### PR TITLE
Add chapters to episode details screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 *   New Features
     *   Adds an option to export the database and preferences from the Help & Feedback view
         ([#2309](https://github.com/Automattic/pocket-casts-android/pull/2309))
+    *   Chapters tab is now accessible from episode details.
+        ([#2318](https://github.com/Automattic/pocket-casts-android/pull/2318))
 *   Health
     *   Increase target SDK version to 34 
         ([#2279](https://github.com/Automattic/pocket-casts-android/pull/2279))

--- a/lint.xml
+++ b/lint.xml
@@ -10,6 +10,7 @@
     <!-- We don't want failures due to outdated dependnecies  -->
     <issue id="GradleDependency" severity="ignore"/>
     <issue id="NewerVersionAvailable" severity="ignore"/>
+    <issue id="AndroidGradlePluginVersion" severity="ignore"/>
 
     <!-- Translations are handled during the release process  -->
     <issue id="MissingTranslation" severity="ignore"/>

--- a/modules/features/player/lint-baseline.xml
+++ b/modules/features/player/lint-baseline.xml
@@ -169,17 +169,6 @@
     <issue
         id="NotifyDataSetChanged"
         message="It will always be more efficient to use more specific change events if you can. Rely on `notifyDataSetChanged` as a last resort."
-        errorLine1="                if (updated) adapter.notifyDataSetChanged()"
-        errorLine2="                             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
-        <location
-            file="src/main/java/au/com/shiftyjelly/pocketcasts/player/view/PlayerContainerFragment.kt"
-            line="177"
-            column="30"/>
-    </issue>
-
-    <issue
-        id="NotifyDataSetChanged"
-        message="It will always be more efficient to use more specific change events if you can. Rely on `notifyDataSetChanged` as a last resort."
         errorLine1="            notifyDataSetChanged()"
         errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~">
         <location

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/chapters/ChaptersFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/chapters/ChaptersFragment.kt
@@ -1,53 +1,52 @@
 package au.com.shiftyjelly.pocketcasts.player.view.chapters
 
-import android.content.ActivityNotFoundException
 import android.content.Intent
-import android.net.Uri
 import android.os.Bundle
+import android.os.Parcelable
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.compose.foundation.lazy.rememberLazyListState
-import androidx.compose.material.Surface
+import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.platform.ComposeView
-import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.platform.LocalView
-import androidx.compose.ui.platform.ViewCompositionStrategy
-import androidx.compose.ui.platform.rememberNestedScrollInteropConnection
-import androidx.fragment.app.activityViewModels
-import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
-import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
-import au.com.shiftyjelly.pocketcasts.compose.AppTheme
-import au.com.shiftyjelly.pocketcasts.models.to.Chapter
+import androidx.core.net.toUri
+import androidx.core.os.BundleCompat
+import androidx.core.os.bundleOf
+import androidx.fragment.app.viewModels
+import au.com.shiftyjelly.pocketcasts.compose.AppThemeWithBackground
+import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.player.view.PlayerContainerFragment
-import au.com.shiftyjelly.pocketcasts.player.view.chapters.ChaptersViewModel.NavigationState
+import au.com.shiftyjelly.pocketcasts.player.view.chapters.ChaptersViewModel.Mode.Episode
+import au.com.shiftyjelly.pocketcasts.player.view.chapters.ChaptersViewModel.Mode.Player
 import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingFlow
 import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingLauncher
 import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingUpgradeSource
-import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
-import au.com.shiftyjelly.pocketcasts.ui.theme.ThemeColor
 import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
 import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureTier
 import au.com.shiftyjelly.pocketcasts.views.fragments.BaseFragment
 import au.com.shiftyjelly.pocketcasts.views.helper.UiUtil
-import com.google.android.material.snackbar.Snackbar
 import dagger.hilt.android.AndroidEntryPoint
-import javax.inject.Inject
+import dagger.hilt.android.lifecycle.withCreationCallback
 import kotlinx.coroutines.delay
-import kotlinx.coroutines.flow.collectLatest
+import kotlinx.parcelize.Parcelize
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 @AndroidEntryPoint
 class ChaptersFragment : BaseFragment() {
+    private val args get() = requireNotNull(arguments?.let { BundleCompat.getParcelable(it, NEW_INSTANCE_ARG, Args::class.java) })
 
-    @Inject lateinit var analyticsTracker: AnalyticsTrackerWrapper
+    private val mode get() = args.episodeId?.let(::Episode) ?: Player
 
-    private val chaptersViewModel: ChaptersViewModel by activityViewModels()
+    private val viewModel by viewModels<ChaptersViewModel>(
+        ownerProducer = { requireParentFragment() },
+        extrasProducer = {
+            defaultViewModelCreationExtras.withCreationCallback<ChaptersViewModel.Factory> { factory ->
+                factory.create(mode)
+            }
+        },
+    )
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -55,83 +54,60 @@ class ChaptersFragment : BaseFragment() {
         savedInstanceState: Bundle?,
     ) = ComposeView(requireContext()).apply {
         setContent {
-            val uiState by chaptersViewModel.uiState.collectAsStateWithLifecycle()
+            val state by viewModel.uiState.collectAsState()
 
-            AppTheme(Theme.ThemeType.DARK) {
-                ChaptersThemeForPlayer(theme, uiState.podcast) {
-                    setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
-
+            AppThemeWithBackground(theme.activeTheme) {
+                ChaptersTheme(state.podcast) {
                     val lazyListState = rememberLazyListState()
-                    val context = LocalContext.current
-                    val currentView = LocalView.current
 
-                    val scrollToChapter by chaptersViewModel.scrollToChapterState.collectAsState()
-                    LaunchedEffect(scrollToChapter) {
-                        scrollToChapter?.let {
+                    ChaptersPage(
+                        lazyListState = lazyListState,
+                        chapters = state.chapters,
+                        showHeader = state.showHeader,
+                        totalChaptersCount = state.chaptersCount,
+                        isTogglingChapters = state.isTogglingChapters,
+                        showSubscriptionIcon = state.showSubscriptionIcon,
+                        onChapterClick = viewModel::playChapter,
+                        onSkipChaptersClick = viewModel::enableTogglingOrUpsell,
+                        onSelectionChange = viewModel::selectChapter,
+                        onUrlClick = ::openChapterUrl,
+                    )
+
+                    LaunchedEffect(Unit) {
+                        viewModel.scrollToChapter.collect {
                             delay(250)
                             lazyListState.animateScrollToItem(it.index - 1)
-
-                            // Need to clear this so that if the user taps on the same chapter a second time we
-                            // still get the scrollTo behavior.
-                            chaptersViewModel.setScrollToChapter(null)
                         }
                     }
 
                     LaunchedEffect(Unit) {
-                        chaptersViewModel
-                            .navigationState
-                            .collectLatest { event ->
-                                when (event) {
-                                    is NavigationState.StartUpsell -> startUpsell()
-                                }
-                            }
+                        viewModel.showPlayer.collect {
+                            showPlayer()
+                        }
                     }
 
                     LaunchedEffect(Unit) {
-                        chaptersViewModel
-                            .snackbarMessage
-                            .collectLatest { message ->
-                                Snackbar.make(currentView, context.getString(message), Snackbar.LENGTH_SHORT)
-                                    .setBackgroundTint(ThemeColor.playerContrast01(Theme.ThemeType.DARK))
-                                    .setTextColor(ThemeColor.playerBackground01(Theme.ThemeType.DARK, theme.playerBackgroundColor(uiState.podcast)))
-                                    .show()
-                            }
-                    }
-
-                    Surface(modifier = Modifier.nestedScroll(rememberNestedScrollInteropConnection())) {
-                        ChaptersPage(
-                            lazyListState = lazyListState,
-                            chapters = uiState.displayChapters,
-                            showHeader = uiState.showHeader,
-                            totalChaptersCount = uiState.totalChaptersCount,
-                            onSelectionChange = { selected, chapter -> chaptersViewModel.onSelectionChange(selected, chapter) },
-                            onChapterClick = ::onChapterClick,
-                            onUrlClick = ::onUrlClick,
-                            onSkipChaptersClick = { chaptersViewModel.onSkipChaptersClick(it) },
-                            isTogglingChapters = uiState.isTogglingChapters,
-                            showSubscriptionIcon = uiState.showSubscriptionIcon,
-                        )
+                        viewModel.showUpsell.collect {
+                            showUpsell()
+                        }
                     }
                 }
             }
         }
     }
 
-    private fun onChapterClick(chapter: Chapter, isPlaying: Boolean) {
-        analyticsTracker.track(AnalyticsEvent.PLAYER_CHAPTER_SELECTED)
-        if (isPlaying) {
-            showPlayer()
-        } else {
-            chaptersViewModel.skipToChapter(chapter)
+    @Composable
+    private fun ChaptersTheme(podcast: Podcast?, content: @Composable () -> Unit) {
+        when (mode) {
+            is Episode -> ChaptersTheme(content)
+            is Player -> ChaptersThemeForPlayer(theme, podcast, content)
         }
     }
 
-    private fun onUrlClick(url: String) {
-        val intent = Intent(Intent.ACTION_VIEW)
-        intent.data = Uri.parse(url)
+    private fun openChapterUrl(url: String) {
         try {
-            startActivity(intent)
-        } catch (e: ActivityNotFoundException) {
+            startActivity(Intent(Intent.ACTION_VIEW).setData(url.toUri()))
+        } catch (_: Throwable) {
             UiUtil.displayAlertError(requireContext(), getString(LR.string.player_open_url_failed, url), null)
         }
     }
@@ -140,13 +116,29 @@ class ChaptersFragment : BaseFragment() {
         (parentFragment as? PlayerContainerFragment)?.openPlayer()
     }
 
-    private fun startUpsell() {
+    private fun showUpsell() {
         val source = OnboardingUpgradeSource.SKIP_CHAPTERS
         val onboardingFlow = OnboardingFlow.Upsell(
             source = source,
-            showPatronOnly = Feature.DESELECT_CHAPTERS.tier == FeatureTier.Patron ||
-                Feature.DESELECT_CHAPTERS.isCurrentlyExclusiveToPatron(),
+            showPatronOnly = Feature.DESELECT_CHAPTERS.tier == FeatureTier.Patron || Feature.DESELECT_CHAPTERS.isCurrentlyExclusiveToPatron(),
         )
-        OnboardingLauncher.openOnboardingFlow(activity, onboardingFlow)
+        OnboardingLauncher.openOnboardingFlow(requireActivity(), onboardingFlow)
+    }
+
+    @Parcelize
+    private class Args(
+        val episodeId: String?,
+    ) : Parcelable
+
+    companion object {
+        private const val NEW_INSTANCE_ARG = "ChaptersFragment2Arg"
+
+        fun forEpisode(episodeUuid: String) = ChaptersFragment().apply {
+            arguments = bundleOf(NEW_INSTANCE_ARG to Args(episodeUuid))
+        }
+
+        fun forPlayer() = ChaptersFragment().apply {
+            arguments = bundleOf(NEW_INSTANCE_ARG to Args(episodeId = null))
+        }
     }
 }

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/chapters/ChaptersFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/chapters/ChaptersFragment.kt
@@ -10,7 +10,10 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.platform.ComposeView
+import androidx.compose.ui.platform.rememberNestedScrollInteropConnection
 import androidx.core.net.toUri
 import androidx.core.os.BundleCompat
 import androidx.core.os.bundleOf
@@ -71,6 +74,7 @@ class ChaptersFragment : BaseFragment() {
                         onSkipChaptersClick = viewModel::enableTogglingOrUpsell,
                         onSelectionChange = viewModel::selectChapter,
                         onUrlClick = ::openChapterUrl,
+                        modifier = Modifier.nestedScroll(rememberNestedScrollInteropConnection()),
                     )
 
                     LaunchedEffect(Unit) {

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/chapters/ChaptersFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/chapters/ChaptersFragment.kt
@@ -26,6 +26,7 @@ import au.com.shiftyjelly.pocketcasts.player.view.chapters.ChaptersViewModel.Mod
 import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingFlow
 import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingLauncher
 import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingUpgradeSource
+import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
 import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureTier
 import au.com.shiftyjelly.pocketcasts.views.fragments.BaseFragment
@@ -59,7 +60,7 @@ class ChaptersFragment : BaseFragment() {
         setContent {
             val state by viewModel.uiState.collectAsState()
 
-            AppThemeWithBackground(theme.activeTheme) {
+            AppThemeWithBackground(mode.themeType) {
                 ChaptersTheme(state.podcast) {
                     val lazyListState = rememberLazyListState()
 
@@ -127,6 +128,11 @@ class ChaptersFragment : BaseFragment() {
             showPatronOnly = Feature.DESELECT_CHAPTERS.tier == FeatureTier.Patron || Feature.DESELECT_CHAPTERS.isCurrentlyExclusiveToPatron(),
         )
         OnboardingLauncher.openOnboardingFlow(requireActivity(), onboardingFlow)
+    }
+
+    private val ChaptersViewModel.Mode.themeType get() = when (this) {
+        is Player -> Theme.ThemeType.DARK
+        is Episode -> theme.activeTheme
     }
 
     @Parcelize

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/chapters/ChaptersPage.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/chapters/ChaptersPage.kt
@@ -21,7 +21,7 @@ fun ChaptersPage(
     showHeader: Boolean,
     totalChaptersCount: Int,
     onSelectionChange: (Boolean, Chapter) -> Unit,
-    onChapterClick: (Chapter, Boolean) -> Unit,
+    onChapterClick: (Chapter) -> Unit,
     onUrlClick: (String) -> Unit,
     onSkipChaptersClick: (Boolean) -> Unit,
     isTogglingChapters: Boolean,
@@ -53,7 +53,7 @@ fun ChaptersPage(
                 isTogglingChapters = isTogglingChapters,
                 selectedCount = selectedCount,
                 onSelectionChange = onSelectionChange,
-                onClick = { onChapterClick(state.chapter, state is ChaptersViewModel.ChapterState.Playing) },
+                onClick = { onChapterClick(state.chapter) },
                 onUrlClick = { onUrlClick(state.chapter.url.toString()) },
                 modifier = Modifier.animateItemPlacement(),
             )

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/chapters/ChaptersViewModel.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/chapters/ChaptersViewModel.kt
@@ -1,10 +1,7 @@
 package au.com.shiftyjelly.pocketcasts.player.view.chapters
 
-import androidx.annotation.VisibleForTesting
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
-import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
 import au.com.shiftyjelly.pocketcasts.models.entity.BaseEpisode
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
@@ -12,271 +9,192 @@ import au.com.shiftyjelly.pocketcasts.models.to.Chapter
 import au.com.shiftyjelly.pocketcasts.models.to.Chapters
 import au.com.shiftyjelly.pocketcasts.models.to.SubscriptionStatus
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
+import au.com.shiftyjelly.pocketcasts.repositories.di.IoDispatcher
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackState
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.ChapterManager
+import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
 import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
 import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
 import au.com.shiftyjelly.pocketcasts.utils.featureflag.UserTier
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedFactory
+import dagger.assisted.AssistedInject
 import dagger.hilt.android.lifecycle.HiltViewModel
-import io.reactivex.Observable
-import io.reactivex.schedulers.Schedulers
-import javax.inject.Inject
-import kotlin.coroutines.CoroutineContext
+import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.asSharedFlow
-import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.rx2.asFlow
-import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
-@HiltViewModel
-class ChaptersViewModel @Inject constructor(
+@HiltViewModel(assistedFactory = ChaptersViewModel.Factory::class)
+class ChaptersViewModel @AssistedInject constructor(
+    @Assisted private val mode: Mode,
     private val chapterManager: ChapterManager,
     private val playbackManager: PlaybackManager,
+    private val episodeManager: EpisodeManager,
     private val settings: Settings,
-    private val analyticsTracker: AnalyticsTrackerWrapper,
-) : ViewModel(), CoroutineScope {
+    @IoDispatcher private val ioDispatcher: CoroutineDispatcher,
+) : ViewModel() {
+    private val isTogglingChapters = MutableStateFlow(false)
 
-    override val coroutineContext: CoroutineContext
-        get() = Dispatchers.Default
+    val uiState = mode.uiStateFlow().stateIn(viewModelScope, SharingStarted.Lazily, UiState())
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    private fun Mode.uiStateFlow() = when (this) {
+        is Mode.Episode -> createUiStateFlow(episodeId)
+        is Mode.Player ->
+            playbackManager.playbackStateFlow
+                .map { it.episodeUuid }
+                .distinctUntilChanged()
+                .flatMapLatest(::createUiStateFlow)
+    }
+
+    private fun createUiStateFlow(episodeId: String) = combine(
+        playbackManager.playbackStateFlow,
+        episodeManager.observeEpisodeByUuid(episodeId),
+        chapterManager.observerChaptersForEpisode(episodeId),
+        settings.cachedSubscriptionStatus.flow,
+        isTogglingChapters,
+        ::createUiState,
+    )
+
+    private var playChapterJob: Job? = null
+
+    private val _showPlayer = MutableSharedFlow<Unit>()
+    val showPlayer = _showPlayer.asSharedFlow()
+
+    fun playChapter(chapter: Chapter) {
+        playChapterJob?.cancel()
+        playChapterJob = viewModelScope.launch(ioDispatcher) {
+            val playbackState = playbackManager.playbackStateFlow.first()
+            val episodeId = when (mode) {
+                is Mode.Episode -> mode.episodeId
+                is Mode.Player -> playbackState.episodeUuid
+            }
+
+            when {
+                playbackState.episodeUuid == episodeId && playbackState.positionMs.milliseconds in chapter -> _showPlayer.emit(Unit)
+                playbackState.episodeUuid == episodeId -> {
+                    playbackManager.skipToChapter(chapter)
+                    if (!playbackState.isPlaying) {
+                        playbackManager.playNowSuspend(episodeId)
+                    }
+                }
+                playbackState.episodeUuid != episodeId -> {
+                    val episode = episodeManager.findEpisodeByUuid(episodeId) ?: return@launch
+                    episode.playedUpToMs = chapter.startTime.inWholeMilliseconds.toInt()
+                    episodeManager.updatePlayedUpTo(episode, chapter.startTime.inWholeSeconds.toDouble(), forceUpdate = true)
+                    playbackManager.playNowSuspend(episode)
+                }
+            }
+        }
+    }
+
+    private val _showUpsell = MutableSharedFlow<Unit>()
+    val showUpsell = _showUpsell.asSharedFlow()
+
+    fun enableTogglingOrUpsell(enable: Boolean) {
+        if (uiState.value.canSkipChapters) {
+            isTogglingChapters.value = enable
+        } else {
+            viewModelScope.launch { _showUpsell.emit(Unit) }
+        }
+    }
+
+    fun selectChapter(select: Boolean, chapter: Chapter) {
+        viewModelScope.launch(ioDispatcher) {
+            val episodeId = when (mode) {
+                is Mode.Episode -> mode.episodeId
+                is Mode.Player -> playbackManager.playbackStateFlow.first().episodeUuid
+            }
+            chapterManager.selectChapter(episodeId, chapter.index, select)
+        }
+    }
+
+    private val _scrollToChapter = MutableSharedFlow<Chapter>()
+    val scrollToChapter = _scrollToChapter.asSharedFlow()
+
+    fun scrollToChapter(chapter: Chapter) {
+        viewModelScope.launch { _scrollToChapter.emit(chapter) }
+    }
+
+    private fun createUiState(
+        playbackState: PlaybackState,
+        episode: BaseEpisode,
+        chapters: Chapters,
+        subscriptionStatus: SubscriptionStatus?,
+        isToggling: Boolean,
+    ) = UiState(
+        podcast = playbackState.podcast,
+        allChapters = chapters.toChapterStates(playbackPosition(playbackState, episode)),
+        isTogglingChapters = isToggling,
+        canSkipChapters = subscriptionStatus.canSkipChapters(),
+        showHeader = FeatureFlag.isEnabled(Feature.DESELECT_CHAPTERS) && episode is PodcastEpisode,
+    )
+
+    private fun playbackPosition(playbackState: PlaybackState, episode: BaseEpisode) = when (mode) {
+        is Mode.Episode -> if (playbackState.episodeUuid == mode.episodeId) {
+            playbackState.positionMs
+        } else {
+            episode.playedUpToMs
+        }
+        is Mode.Player -> playbackState.positionMs
+    }.milliseconds
+
+    private fun Chapters.toChapterStates(playbackPosition: Duration): List<ChapterState> {
+        return getList().map { chapter ->
+            when {
+                playbackPosition in chapter -> ChapterState.Playing(chapter.calculateProgress(playbackPosition), chapter)
+                playbackPosition > chapter.startTime -> ChapterState.Played(chapter)
+                else -> ChapterState.NotPlayed(chapter)
+            }
+        }
+    }
+
+    private fun SubscriptionStatus?.canSkipChapters() = FeatureFlag.isEnabled(Feature.DESELECT_CHAPTERS) &&
+        Feature.isUserEntitled(Feature.DESELECT_CHAPTERS, toUserTier())
+
+    private fun SubscriptionStatus?.toUserTier() = (this as? SubscriptionStatus.Paid)?.tier?.toUserTier() ?: UserTier.Free
 
     data class UiState(
-        val allChapters: List<ChapterState> = emptyList(),
-        val displayChapters: List<ChapterState> = emptyList(),
-        val totalChaptersCount: Int = 0,
-        val isTogglingChapters: Boolean = false,
-        val userTier: UserTier = UserTier.Free,
-        val canSkipChapters: Boolean = false,
         val podcast: Podcast? = null,
-        val episodeUuid: String? = null,
+        private val allChapters: List<ChapterState> = emptyList(),
+        val isTogglingChapters: Boolean = false,
+        val canSkipChapters: Boolean = false,
         val showHeader: Boolean = false,
     ) {
-        val showSubscriptionIcon
-            get() = !isTogglingChapters && !canSkipChapters
+        val chaptersCount = allChapters.size
+        val chapters get() = if (isTogglingChapters) allChapters else allChapters.filter { it.chapter.selected }
+        val showSubscriptionIcon get() = !isTogglingChapters && !canSkipChapters
     }
 
-    sealed class ChapterState {
-        abstract val chapter: Chapter
+    sealed interface ChapterState {
+        val chapter: Chapter
 
-        data class Played(override val chapter: Chapter) : ChapterState()
-        data class Playing(val progress: Float, override val chapter: Chapter) : ChapterState()
-        data class NotPlayed(override val chapter: Chapter) : ChapterState()
+        data class Played(override val chapter: Chapter) : ChapterState
+        data class Playing(val progress: Float, override val chapter: Chapter) : ChapterState
+        data class NotPlayed(override val chapter: Chapter) : ChapterState
     }
 
-    private val _scrollToChapterState = MutableStateFlow<Chapter?>(null)
-    val scrollToChapterState = _scrollToChapterState.asStateFlow()
-
-    fun setScrollToChapter(chapter: Chapter?) {
-        _scrollToChapterState.value = chapter
+    sealed interface Mode {
+        data class Episode(val episodeId: String) : Mode
+        data object Player : Mode
     }
 
-    private val playbackStateObservable: Observable<PlaybackState> = playbackManager.playbackStateRelay
-        .observeOn(Schedulers.io())
-
-    private val _uiState = MutableStateFlow(
-        UiState(
-            userTier = settings.userTier,
-            canSkipChapters = canSkipChapters(settings.userTier),
-        ),
-    )
-    val uiState: StateFlow<UiState>
-        get() = _uiState
-
-    private val _navigationState: MutableSharedFlow<NavigationState> = MutableSharedFlow()
-    val navigationState = _navigationState.asSharedFlow()
-
-    private val _snackbarMessage: MutableSharedFlow<Int> = MutableSharedFlow()
-    val snackbarMessage = _snackbarMessage.asSharedFlow()
-
-    private var numberOfDeselectedChapters = 0
-
-    init {
-        viewModelScope.launch {
-            combine(
-                playbackStateObservable.asFlow(),
-                settings.cachedSubscriptionStatus.flow,
-                this@ChaptersViewModel::combineUiState,
-            )
-                .distinctUntilChanged()
-                .stateIn(viewModelScope)
-                .collectLatest {
-                    _uiState.value = it
-                }
-        }
-    }
-
-    fun skipToChapter(chapter: Chapter) {
-        launch {
-            playbackManager.skipToChapter(chapter)
-        }
-    }
-
-    private fun combineUiState(
-        playbackState: PlaybackState,
-        cachedSubscriptionStatus: SubscriptionStatus?,
-    ): UiState {
-        val chapters = buildChaptersWithState(
-            chapters = playbackState.chapters,
-            playbackPositionMs = playbackState.positionMs,
-        )
-        val currentUserTier = (cachedSubscriptionStatus as? SubscriptionStatus.Paid)?.tier?.toUserTier() ?: UserTier.Free
-        val lastUserTier = _uiState.value.userTier
-        val canSkipChapters = canSkipChapters(currentUserTier)
-        val isTogglingChapters = ((lastUserTier != currentUserTier) && canSkipChapters) || _uiState.value.isTogglingChapters
-
-        return UiState(
-            allChapters = chapters,
-            displayChapters = getFilteredChaptersIfNeeded(
-                chapters = chapters,
-                isTogglingChapters = isTogglingChapters,
-                userTier = currentUserTier,
-            ),
-            totalChaptersCount = chapters.size,
-            isTogglingChapters = isTogglingChapters,
-            userTier = currentUserTier,
-            canSkipChapters = canSkipChapters,
-            podcast = playbackState.podcast,
-            episodeUuid = playbackState.episodeUuid,
-            showHeader = (playbackManager.getCurrentEpisode()?.let { it is PodcastEpisode } ?: false) &&
-                FeatureFlag.isEnabled(Feature.DESELECT_CHAPTERS),
-        )
-    }
-
-    @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
-    fun buildChaptersWithState(
-        chapters: Chapters,
-        playbackPositionMs: Int,
-    ): List<ChapterState> {
-        val chapterStates = mutableListOf<ChapterState>()
-        var currentChapter: Chapter? = null
-        for (chapter in chapters.getList()) {
-            val chapterState = if (currentChapter != null) {
-                // a chapter that hasn't been played
-                ChapterState.NotPlayed(chapter)
-            } else if (playbackPositionMs.milliseconds in chapter) {
-                if (chapter.selected || !FeatureFlag.isEnabled(Feature.DESELECT_CHAPTERS)) {
-                    // the chapter currently playing
-                    currentChapter = chapter
-                    val progress = chapter.calculateProgress(playbackPositionMs.milliseconds)
-                    ChapterState.Playing(chapter = chapter, progress = progress)
-                } else {
-                    ChapterState.NotPlayed(chapter)
-                }
-            } else {
-                // a chapter that has been played
-                ChapterState.Played(chapter)
-            }
-            chapterStates.add(chapterState)
-        }
-        return chapterStates
-    }
-
-    fun onSelectionChange(selected: Boolean, chapter: Chapter) {
-        val uiState = _uiState.value
-        val selectedChapters = uiState.allChapters.filter { it.chapter.selected }
-        if (!selected && selectedChapters.size == 1) {
-            viewModelScope.launch {
-                _snackbarMessage.emit(LR.string.select_one_chapter_message)
-            }
-        } else {
-            uiState.episodeUuid?.let { id ->
-                viewModelScope.launch {
-                    chapterManager.selectChapter(id, chapter.index, selected)
-                    trackChapterSelectionToggled(selected)
-                }
-            }
-        }
-    }
-
-    fun onSkipChaptersClick(checked: Boolean) {
-        if (_uiState.value.canSkipChapters) {
-            _uiState.value = _uiState.value.copy(
-                isTogglingChapters = checked,
-                displayChapters = getFilteredChaptersIfNeeded(
-                    chapters = _uiState.value.allChapters,
-                    isTogglingChapters = checked,
-                    userTier = _uiState.value.userTier,
-                ),
-            )
-            trackSkipChaptersToggled(checked)
-        } else {
-            viewModelScope.launch {
-                _navigationState.emit(NavigationState.StartUpsell)
-            }
-        }
-    }
-
-    private fun getFilteredChaptersIfNeeded(
-        chapters: List<ChapterState>,
-        isTogglingChapters: Boolean,
-        userTier: UserTier,
-    ): List<ChapterState> {
-        val shouldFilterChapters = canSkipChapters(userTier) &&
-            !isTogglingChapters
-
-        return if (shouldFilterChapters) {
-            chapters.filter { it.chapter.selected }
-        } else {
-            chapters
-        }
-    }
-
-    private fun canSkipChapters(userTier: UserTier) = FeatureFlag.isEnabled(Feature.DESELECT_CHAPTERS) &&
-        Feature.isUserEntitled(Feature.DESELECT_CHAPTERS, userTier)
-
-    private fun trackChapterSelectionToggled(selected: Boolean) {
-        val currentEpisode = playbackManager.getCurrentEpisode()
-        analyticsTracker.track(
-            if (selected) {
-                AnalyticsEvent.DESELECT_CHAPTERS_CHAPTER_SELECTED
-            } else {
-                AnalyticsEvent.DESELECT_CHAPTERS_CHAPTER_DESELECTED
-            },
-            Analytics.chapterSelectionToggled(currentEpisode),
-        )
-    }
-
-    private fun trackSkipChaptersToggled(checked: Boolean) {
-        val selectedChaptersCount = _uiState.value.allChapters.filter { it.chapter.selected }.size
-        if (checked) {
-            numberOfDeselectedChapters = selectedChaptersCount
-            analyticsTracker.track(AnalyticsEvent.DESELECT_CHAPTERS_TOGGLED_ON)
-        } else {
-            numberOfDeselectedChapters -= selectedChaptersCount
-            analyticsTracker.track(
-                AnalyticsEvent.DESELECT_CHAPTERS_TOGGLED_OFF,
-                Analytics.skipChaptersToggled(numberOfDeselectedChapters),
-            )
-        }
-    }
-
-    private object Analytics {
-        private const val EPISODE_UUID = "episode_uuid"
-        private const val PODCAST_UUID = "podcast_uuid"
-        private const val NUMBER_OF_DESELECTED_CHAPTERS = "number_of_deselected_chapters"
-        private const val UNKNOWN = "unknown"
-
-        fun chapterSelectionToggled(episode: BaseEpisode?) =
-            mapOf(
-                EPISODE_UUID to (episode?.uuid ?: UNKNOWN),
-                PODCAST_UUID to (episode?.podcastOrSubstituteUuid ?: UNKNOWN),
-            )
-
-        fun skipChaptersToggled(count: Int) =
-            mapOf(NUMBER_OF_DESELECTED_CHAPTERS to count)
-    }
-
-    sealed class NavigationState {
-        data object StartUpsell : NavigationState()
+    @AssistedFactory
+    interface Factory {
+        fun create(mode: Mode): ChaptersViewModel
     }
 }

--- a/modules/features/player/src/test/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/ChaptersViewModelTest.kt
+++ b/modules/features/player/src/test/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/ChaptersViewModelTest.kt
@@ -1,6 +1,7 @@
 package au.com.shiftyjelly.pocketcasts.player.viewmodel
 
 import app.cash.turbine.test
+import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
 import au.com.shiftyjelly.pocketcasts.models.entity.BaseEpisode
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.models.entity.UserEpisode
@@ -56,6 +57,7 @@ class ChaptersViewModelTest {
     private val chapterManager = mock<ChapterManager>()
     private val playbackManager = mock<PlaybackManager>()
     private val episodeManager = mock<EpisodeManager>()
+    private val tracker = mock<AnalyticsTrackerWrapper>()
     private val settings = mock<Settings>()
 
     private val episode = PodcastEpisode(uuid = "id", publishedDate = Date())
@@ -91,6 +93,8 @@ class ChaptersViewModelTest {
         val userSetting = mock<UserSetting<SubscriptionStatus?>>()
         whenever(userSetting.flow).thenReturn(subscriptionStatusFlow)
         whenever(settings.cachedSubscriptionStatus).thenReturn(userSetting)
+        whenever(tracker.getSendUsageStats()).thenReturn(false)
+
         FeatureFlag.setEnabled(Feature.DESELECT_CHAPTERS, true)
 
         chaptersViewModel = ChaptersViewModel(
@@ -99,6 +103,7 @@ class ChaptersViewModelTest {
             playbackManager,
             episodeManager,
             settings,
+            tracker,
             testDispatcher,
         )
     }
@@ -260,6 +265,7 @@ class ChaptersViewModelTest {
             playbackManager,
             episodeManager,
             settings,
+            tracker,
             testDispatcher,
         )
 

--- a/modules/features/player/src/test/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/ChaptersViewModelTest.kt
+++ b/modules/features/player/src/test/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/ChaptersViewModelTest.kt
@@ -1,7 +1,9 @@
 package au.com.shiftyjelly.pocketcasts.player.viewmodel
 
-import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import app.cash.turbine.test
+import au.com.shiftyjelly.pocketcasts.models.entity.BaseEpisode
+import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
+import au.com.shiftyjelly.pocketcasts.models.entity.UserEpisode
 import au.com.shiftyjelly.pocketcasts.models.to.Chapter
 import au.com.shiftyjelly.pocketcasts.models.to.Chapters
 import au.com.shiftyjelly.pocketcasts.models.to.SubscriptionStatus
@@ -9,160 +11,278 @@ import au.com.shiftyjelly.pocketcasts.models.type.SubscriptionPlatform
 import au.com.shiftyjelly.pocketcasts.models.type.SubscriptionTier
 import au.com.shiftyjelly.pocketcasts.models.type.SubscriptionType
 import au.com.shiftyjelly.pocketcasts.player.view.chapters.ChaptersViewModel
+import au.com.shiftyjelly.pocketcasts.player.view.chapters.ChaptersViewModel.Mode
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.preferences.UserSetting
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackState
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.ChapterManager
+import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
 import au.com.shiftyjelly.pocketcasts.sharedtest.InMemoryFeatureFlagRule
 import au.com.shiftyjelly.pocketcasts.sharedtest.MainCoroutineRule
-import au.com.shiftyjelly.pocketcasts.utils.featureflag.UserTier
-import com.jakewharton.rxrelay2.BehaviorRelay
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
 import java.util.Date
 import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
+import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
-import org.junit.runner.RunWith
-import org.mockito.Mock
-import org.mockito.junit.MockitoJUnitRunner
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyBlocking
 import org.mockito.kotlin.whenever
-import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 @ExperimentalCoroutinesApi
-@RunWith(MockitoJUnitRunner::class)
 class ChaptersViewModelTest {
+    private val testDispatcher = UnconfinedTestDispatcher()
 
     @get:Rule
-    val instantTaskExecutorRule = InstantTaskExecutorRule()
-
-    @get:Rule
-    val coroutineRule = MainCoroutineRule()
+    val coroutineRule = MainCoroutineRule(testDispatcher)
 
     @get:Rule
     val featureFlagRule = InMemoryFeatureFlagRule()
 
-    @Mock
-    private lateinit var chapterManager: ChapterManager
+    private val chapterManager = mock<ChapterManager>()
+    private val playbackManager = mock<PlaybackManager>()
+    private val episodeManager = mock<EpisodeManager>()
+    private val settings = mock<Settings>()
 
-    @Mock
-    private lateinit var playbackManager: PlaybackManager
-
-    @Mock
-    private lateinit var settings: Settings
-
-    private val freeSubscriptionStatus = SubscriptionStatus.Free()
-
-    private val paidSubscriptionStatus = SubscriptionStatus.Paid(
-        expiry = Date(),
-        autoRenew = false,
-        index = 0,
-        platform = SubscriptionPlatform.GIFT,
-        tier = SubscriptionTier.PATRON,
-        type = SubscriptionType.PLUS,
+    private val episode = PodcastEpisode(uuid = "id", publishedDate = Date())
+    private val chapters = Chapters(
+        listOf(
+            Chapter("1", 0.milliseconds, 100.milliseconds, selected = true, index = 0),
+            Chapter("2", 101.milliseconds, 200.milliseconds, selected = true, index = 1),
+            Chapter("3", 201.milliseconds, 300.milliseconds, selected = true, index = 2),
+        ),
     )
-    private val cachedSubscriptionStatusFlow: MutableStateFlow<SubscriptionStatus> = MutableStateFlow(freeSubscriptionStatus)
+
+    private val playbackStateFlow = MutableStateFlow(PlaybackState(episodeUuid = "id"))
+    private val episodeFlow = MutableStateFlow<BaseEpisode>(episode)
+    private val chaptersFlow = MutableStateFlow(chapters)
+    private val subscriptionStatusFlow = MutableStateFlow<SubscriptionStatus?>(
+        SubscriptionStatus.Paid(
+            expiry = Date(),
+            autoRenew = false,
+            index = 0,
+            platform = SubscriptionPlatform.GIFT,
+            tier = SubscriptionTier.PATRON,
+            type = SubscriptionType.PLUS,
+        ),
+    )
 
     private lateinit var chaptersViewModel: ChaptersViewModel
 
-    private val chaptersTwoSelectedOneUnselected = Chapters(
-        listOf(
-            Chapter("1", 0.milliseconds, 100.milliseconds, selected = true),
-            Chapter("2", 101.milliseconds, 200.milliseconds, selected = false),
-            Chapter("3", 201.milliseconds, 300.milliseconds, selected = true),
-        ),
-    )
-
-    private val chaptersOneSelectedOneUnselected = Chapters(
-        listOf(
-            Chapter("1", 0.milliseconds, 100.milliseconds, selected = true),
-            Chapter("2", 101.milliseconds, 200.milliseconds, selected = false),
-        ),
-    )
-
-    @Test
-    fun `given user not entitled to feature, when user taps skip chapters, then upsell starts`() = runTest {
-        initViewModel()
-
-        chaptersViewModel.uiState.test {
-            assertFalse(awaitItem().canSkipChapters)
-            chaptersViewModel.navigationState.test {
-                chaptersViewModel.onSkipChaptersClick(true)
-                assertTrue(awaitItem() is ChaptersViewModel.NavigationState.StartUpsell)
-            }
-        }
-    }
-
-    @Test
-    fun `given user entitled to feature, when user taps skip chapters, then upsell does not start`() = runTest {
-        initViewModel()
-
-        chaptersViewModel.uiState.test {
-            assertFalse(awaitItem().canSkipChapters)
-            cachedSubscriptionStatusFlow.value = paidSubscriptionStatus
-            assertTrue(awaitItem().canSkipChapters)
-            chaptersViewModel.navigationState.test {
-                chaptersViewModel.onSkipChaptersClick(true)
-                expectNoEvents()
-            }
-        }
-    }
-
-    @Test
-    fun `given only one chapter unselected, when chapter is unselected, then select at least one chapter message shown`() = runTest {
-        val chapters = initChapters(chaptersOneSelectedOneUnselected)
-        initViewModel(chapters = chapters)
-
-        chaptersViewModel.uiState.test {
-            cachedSubscriptionStatusFlow.value = paidSubscriptionStatus
-            skipItems(2)
-            chaptersViewModel.snackbarMessage.test {
-                chaptersViewModel.onSelectionChange(false, chapters.getList().first { it.selected })
-                assertTrue(awaitItem() == LR.string.select_one_chapter_message)
-            }
-            cancelAndConsumeRemainingEvents()
-        }
-    }
-
-    @Test
-    fun `given more than one chapter unselected, when chapter is unselected, then select at least one chapter message not shown`() = runTest {
-        val chapters = initChapters(chaptersTwoSelectedOneUnselected)
-        initViewModel(chapters = chapters)
-
-        chaptersViewModel.uiState.test {
-            cachedSubscriptionStatusFlow.value = paidSubscriptionStatus
-            skipItems(2)
-            chaptersViewModel.snackbarMessage.test {
-                chaptersViewModel.onSelectionChange(false, chapters.getList().first { it.selected })
-                expectNoEvents()
-            }
-        }
-    }
-
-    private fun initChapters(chapters: Chapters = chaptersTwoSelectedOneUnselected) = chapters
-
-    private fun initViewModel(
-        chapters: Chapters = Chapters(),
-    ) {
-        whenever(playbackManager.playbackStateRelay)
-            .thenReturn(BehaviorRelay.create<PlaybackState>().toSerialized().apply { accept(PlaybackState(chapters = chapters)) })
-        whenever(settings.userTier)
-            .thenReturn(UserTier.Free)
-
+    @Before
+    fun setup() {
+        whenever(playbackManager.playbackStateFlow).thenReturn(playbackStateFlow)
+        whenever(episodeManager.observeEpisodeByUuid("id")).thenReturn(episodeFlow)
+        whenever(chapterManager.observerChaptersForEpisode("id")).thenReturn(chaptersFlow)
         val userSetting = mock<UserSetting<SubscriptionStatus?>>()
-        whenever(userSetting.flow).thenReturn(cachedSubscriptionStatusFlow)
+        whenever(userSetting.flow).thenReturn(subscriptionStatusFlow)
         whenever(settings.cachedSubscriptionStatus).thenReturn(userSetting)
+        FeatureFlag.setEnabled(Feature.DESELECT_CHAPTERS, true)
 
         chaptersViewModel = ChaptersViewModel(
-            chapterManager = chapterManager,
-            playbackManager = playbackManager,
-            settings = settings,
-            analyticsTracker = mock(),
+            Mode.Episode(episode.uuid),
+            chapterManager,
+            playbackManager,
+            episodeManager,
+            settings,
+            testDispatcher,
         )
+    }
+
+    @Test
+    fun `paid user can skip chapters`() = runTest {
+        chaptersViewModel.uiState.test {
+            assertTrue(awaitItem().canSkipChapters)
+        }
+    }
+
+    @Test
+    fun `paid user cant skip chapters if feature is disabled`() = runTest {
+        FeatureFlag.setEnabled(Feature.DESELECT_CHAPTERS, false)
+
+        chaptersViewModel.uiState.test {
+            assertFalse(awaitItem().canSkipChapters)
+        }
+    }
+
+    @Test
+    fun `free user cant skip chapters`() = runTest {
+        subscriptionStatusFlow.value = SubscriptionStatus.Free()
+
+        chaptersViewModel.uiState.test {
+            assertFalse(awaitItem().canSkipChapters)
+        }
+    }
+
+    @Test
+    fun `unknown user cant skip chapters`() = runTest {
+        subscriptionStatusFlow.value = null
+
+        chaptersViewModel.uiState.test {
+            assertFalse(awaitItem().canSkipChapters)
+        }
+    }
+
+    @Test
+    fun `chapters are mapped to their played statuses`() = runTest {
+        playbackStateFlow.update { it.copy(positionMs = 150) }
+
+        chaptersViewModel.uiState.test {
+            val state = awaitItem()
+
+            assertEquals(ChaptersViewModel.ChapterState.Played(chapters.getList()[0]), state.chapters[0])
+            assertEquals(ChaptersViewModel.ChapterState.Playing(progress = 0.4949495f, chapters.getList()[1]), state.chapters[1])
+            assertEquals(ChaptersViewModel.ChapterState.NotPlayed(chapters.getList()[2]), state.chapters[2])
+        }
+    }
+
+    @Test
+    fun `show header for podcast episode`() = runTest {
+        chaptersViewModel.uiState.test {
+            assertTrue(awaitItem().showHeader)
+        }
+    }
+
+    @Test
+    fun `do not show header when feature is disabled`() = runTest {
+        FeatureFlag.setEnabled(Feature.DESELECT_CHAPTERS, false)
+
+        chaptersViewModel.uiState.test {
+            assertFalse(awaitItem().showHeader)
+        }
+    }
+
+    @Test
+    fun `do not show header for user episode`() = runTest {
+        episodeFlow.value = UserEpisode(uuid = "id", publishedDate = Date())
+
+        chaptersViewModel.uiState.test {
+            assertFalse(awaitItem().showHeader)
+        }
+    }
+
+    @Test
+    fun `toggle chapter selection`() = runTest {
+        chaptersViewModel.uiState.test {
+            assertFalse(awaitItem().isTogglingChapters)
+
+            chaptersViewModel.enableTogglingOrUpsell(true)
+            assertTrue(awaitItem().isTogglingChapters)
+
+            chaptersViewModel.enableTogglingOrUpsell(false)
+            assertFalse(awaitItem().isTogglingChapters)
+        }
+    }
+
+    @Test
+    fun `free user cant toggle chapters`() = runTest {
+        subscriptionStatusFlow.value = SubscriptionStatus.Free()
+
+        chaptersViewModel.uiState.test {
+            assertFalse(awaitItem().isTogglingChapters)
+
+            chaptersViewModel.enableTogglingOrUpsell(true)
+            chaptersViewModel.enableTogglingOrUpsell(false)
+
+            expectNoEvents()
+        }
+    }
+
+    @Test
+    fun `select chapter`() = runTest {
+        chaptersViewModel.selectChapter(true, chapters.getList()[1])
+
+        verifyBlocking(chapterManager, times(1)) { selectChapter("id", chapterIndex = 1, true) }
+    }
+
+    @Test
+    fun `deselect chapter`() = runTest {
+        chaptersViewModel.selectChapter(false, chapters.getList()[0])
+
+        verifyBlocking(chapterManager, times(1)) { selectChapter("id", chapterIndex = 0, false) }
+    }
+
+    @Test
+    fun `scroll to chapter`() = runTest {
+        chaptersViewModel.scrollToChapter.test {
+            expectNoEvents()
+
+            chaptersViewModel.scrollToChapter(chapters.getList()[0])
+            assertEquals(chapters.getList()[0], awaitItem())
+
+            chaptersViewModel.scrollToChapter(chapters.getList()[0])
+            assertEquals(chapters.getList()[0], awaitItem())
+
+            chaptersViewModel.scrollToChapter(chapters.getList()[1])
+            assertEquals(chapters.getList()[1], awaitItem())
+        }
+    }
+
+    @Test
+    fun `skip to chapter from current episode while playing`() = runTest {
+        playbackStateFlow.update { it.copy(state = PlaybackState.State.PLAYING) }
+
+        chaptersViewModel.playChapter(chapters.getList()[2])
+
+        verify(playbackManager, times(1)).skipToChapter(chapters.getList()[2])
+        verifyBlocking(playbackManager, never()) { playNowSuspend("id") }
+    }
+
+    @Test
+    fun `skip to and play chapter from current episode while not playing`() = runTest {
+        playbackStateFlow.update { it.copy(state = PlaybackState.State.STOPPED) }
+
+        chaptersViewModel.playChapter(chapters.getList()[2])
+
+        verify(playbackManager, times(1)).skipToChapter(chapters.getList()[2])
+        verifyBlocking(playbackManager, times(1)) { playNowSuspend("id") }
+    }
+
+    @Test
+    fun `play chapter from different episode`() = runTest {
+        chaptersViewModel = ChaptersViewModel(
+            Mode.Episode("id2"),
+            chapterManager,
+            playbackManager,
+            episodeManager,
+            settings,
+            testDispatcher,
+        )
+
+        val episode = PodcastEpisode(uuid = "id2", publishedDate = Date())
+        val chapter = Chapter("Chapter", startTime = 2.seconds, endTime = 3.seconds)
+        whenever(episodeManager.findEpisodeByUuid("id2")).thenReturn(episode)
+
+        chaptersViewModel.playChapter(chapter)
+
+        verify(episodeManager, times(1)).updatePlayedUpTo(episode, chapter.startTime.inWholeSeconds.toDouble(), forceUpdate = true)
+        verifyBlocking(playbackManager, times(1)) { playNowSuspend(episode) }
+    }
+
+    @Test
+    fun `navigate to chapter when tapped on while playing`() = runTest {
+        chaptersViewModel.showPlayer.test {
+            expectNoEvents()
+
+            chaptersViewModel.playChapter(chapters.getList()[0])
+            assertEquals(Unit, awaitItem())
+
+            chaptersViewModel.playChapter(chapters.getList()[0])
+            assertEquals(Unit, awaitItem())
+        }
     }
 }

--- a/modules/features/podcasts/lint-baseline.xml
+++ b/modules/features/podcasts/lint-baseline.xml
@@ -816,7 +816,7 @@
         errorLine2="             ~~~~~~~~~">
         <location
             file="src/main/res/layout/adapter_episode.xml"
-            line="188"
+            line="189"
             column="14"/>
     </issue>
 

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/episode/EpisodeContainerFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/episode/EpisodeContainerFragment.kt
@@ -18,6 +18,8 @@ import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentManager
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
 import androidx.viewpager2.adapter.FragmentStateAdapter
 import androidx.viewpager2.widget.ViewPager2
 import au.com.shiftyjelly.pocketcasts.analytics.SourceView
@@ -25,6 +27,9 @@ import au.com.shiftyjelly.pocketcasts.images.R
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.models.type.EpisodeViewSource
 import au.com.shiftyjelly.pocketcasts.player.view.bookmark.BookmarksFragment
+import au.com.shiftyjelly.pocketcasts.player.view.chapters.ChaptersFragment
+import au.com.shiftyjelly.pocketcasts.player.view.chapters.ChaptersViewModel
+import au.com.shiftyjelly.pocketcasts.player.view.chapters.ChaptersViewModel.Mode.Episode
 import au.com.shiftyjelly.pocketcasts.player.viewmodel.BookmarksViewModel
 import au.com.shiftyjelly.pocketcasts.podcasts.databinding.FragmentEpisodeContainerBinding
 import au.com.shiftyjelly.pocketcasts.podcasts.view.episode.EpisodeFragment.EpisodeFragmentArgs
@@ -37,7 +42,9 @@ import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.google.android.material.bottomsheet.BottomSheetDialog
 import com.google.android.material.tabs.TabLayoutMediator
 import dagger.hilt.android.AndroidEntryPoint
+import dagger.hilt.android.lifecycle.withCreationCallback
 import kotlin.time.Duration
+import kotlinx.coroutines.launch
 import timber.log.Timber
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 import au.com.shiftyjelly.pocketcasts.ui.R as UR
@@ -132,6 +139,13 @@ class EpisodeContainerFragment :
 
     private val viewModel: EpisodeContainerFragmentViewModel by viewModels()
     private val bookmarksViewModel: BookmarksViewModel by viewModels()
+    private val chaptersViewModel by viewModels<ChaptersViewModel>(
+        extrasProducer = {
+            defaultViewModelCreationExtras.withCreationCallback<ChaptersViewModel.Factory> { factory ->
+                factory.create(Episode(episodeUUID))
+            }
+        },
+    )
 
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
         if (!forceDarkTheme || theme.isDarkTheme) {
@@ -221,12 +235,20 @@ class EpisodeContainerFragment :
                 super.onPageSelected(position)
                 btnFav.isVisible = adapter.isDetailsTab(position)
                 btnShare.isVisible = adapter.isDetailsTab(position)
-                viewModel.onPageSelected(position)
+                viewModel.onPageSelected(adapter.pageKey(position))
             }
         })
 
         if (episodeViewSource == EpisodeViewSource.NOTIFICATION_BOOKMARK) {
             openBookmarks()
+        }
+
+        viewLifecycleOwner.lifecycleScope.launch {
+            viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
+                chaptersViewModel.uiState.collect {
+                    adapter.update(addChapters = it.chaptersCount > 0)
+                }
+            }
         }
     }
 
@@ -274,14 +296,35 @@ class EpisodeContainerFragment :
         val indexOfBookmarks: Int
             get() = sections.indexOf(Section.Bookmarks)
 
-        private sealed class Section(@StringRes val titleRes: Int) {
-            data object Details : Section(LR.string.details)
-            data object Bookmarks : Section(LR.string.bookmarks)
+        private sealed class Section(@StringRes val titleRes: Int, val analyticsValue: String) {
+            data object Details : Section(LR.string.details, "details")
+            data object Chapters : Section(LR.string.chapters, "chapters")
+            data object Bookmarks : Section(LR.string.bookmarks, "bookmarks")
         }
 
-        private var sections = mutableListOf<Section>(Section.Details).apply {
-            add(Section.Bookmarks)
-        }.toList()
+        private var sections = listOf(
+            Section.Details,
+            Section.Bookmarks,
+        )
+
+        fun update(addChapters: Boolean) {
+            val currentSections = sections
+            val newSections = buildList {
+                add(Section.Details)
+                if (addChapters) {
+                    add(Section.Chapters)
+                }
+                add(Section.Bookmarks)
+            }
+            if (currentSections != newSections) {
+                sections = newSections
+                if (addChapters) {
+                    notifyItemInserted(1)
+                } else {
+                    notifyItemRemoved(1)
+                }
+            }
+        }
 
         override fun getItemId(position: Int): Long {
             return sections[position].hashCode().toLong()
@@ -307,11 +350,13 @@ class EpisodeContainerFragment :
                     fromListUuid = fromListUuid,
                     forceDark = forceDarkTheme,
                 )
-
                 Section.Bookmarks -> BookmarksFragment.newInstance(
                     sourceView = SourceView.EPISODE_DETAILS,
                     episodeUuid = requireNotNull(episodeUUID),
                     forceDarkTheme = forceDarkTheme,
+                )
+                Section.Chapters -> ChaptersFragment.forEpisode(
+                    episodeUuid = requireNotNull(episodeUUID),
                 )
             }
         }
@@ -320,6 +365,8 @@ class EpisodeContainerFragment :
         fun pageTitle(position: Int): Int {
             return sections[position].titleRes
         }
+
+        fun pageKey(position: Int) = sections[position].analyticsValue
 
         fun isDetailsTab(position: Int) = sections[position] is Section.Details
     }

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/episode/EpisodeContainerFragmentViewModel.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/episode/EpisodeContainerFragmentViewModel.kt
@@ -3,7 +3,6 @@ package au.com.shiftyjelly.pocketcasts.podcasts.view.episode
 import androidx.lifecycle.ViewModel
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTrackerWrapper
-import au.com.shiftyjelly.pocketcasts.podcasts.BuildConfig
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
 
@@ -14,25 +13,12 @@ class EpisodeContainerFragmentViewModel @Inject constructor(
 
     private var initialized = false
 
-    fun onPageSelected(position: Int) {
+    fun onPageSelected(pageKey: String) {
         // Don't track the initial page selection because that is just the screen loading
         if (initialized) {
             analyticsTracker.track(
                 AnalyticsEvent.EPISODE_DETAIL_TAB_CHANGED,
-                mapOf(
-                    "value" to when (position) {
-                        0 -> "details"
-                        1 -> "bookmarks"
-                        else -> {
-                            // This should never happen
-                            if (BuildConfig.DEBUG) {
-                                throw IllegalStateException("Unknown tab position: $position")
-                            } else {
-                                "unknown"
-                            }
-                        }
-                    },
-                ),
+                mapOf("value" to pageKey),
             )
         }
         initialized = true

--- a/modules/services/localization/lint-baseline.xml
+++ b/modules/services/localization/lint-baseline.xml
@@ -1,27 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 8.4.1" type="baseline" client="gradle" dependencies="false" name="AGP (8.4.1)" variant="all" version="8.4.1">
-
-    <issue
-        id="DefaultLocale"
-        message="Implicitly using the default locale is a common source of bugs: Use `String.format(Locale, ...)` instead"
-        errorLine1="        return if (hours > 0) String.format(hoursFormat, hours, min - hours * 60, sec) else String.format(noHoursFormat, min, sec)"
-        errorLine2="                              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
-        <location
-            file="src/main/java/au/com/shiftyjelly/pocketcasts/localization/helper/TimeHelper.kt"
-            line="162"
-            column="31"/>
-    </issue>
-
-    <issue
-        id="DefaultLocale"
-        message="Implicitly using the default locale is a common source of bugs: Use `String.format(Locale, ...)` instead"
-        errorLine1="        return if (hours > 0) String.format(hoursFormat, hours, min - hours * 60, sec) else String.format(noHoursFormat, min, sec)"
-        errorLine2="                                                                                            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
-        <location
-            file="src/main/java/au/com/shiftyjelly/pocketcasts/localization/helper/TimeHelper.kt"
-            line="162"
-            column="93"/>
-    </issue>
+<issues format="6" by="lint 8.2.2" type="baseline" client="gradle" dependencies="false" name="AGP (8.2.2)" variant="all" version="8.2.2">
 
     <issue
         id="MissingDefaultResource"
@@ -52,7 +30,7 @@
         errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values-fr-rCA/strings.xml"
-            line="69"
+            line="68"
             column="5"/>
     </issue>
 
@@ -63,7 +41,7 @@
         errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values-fr/strings.xml"
-            line="69"
+            line="68"
             column="5"/>
     </issue>
 
@@ -74,7 +52,7 @@
         errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values-it/strings.xml"
-            line="69"
+            line="68"
             column="5"/>
     </issue>
 
@@ -85,7 +63,7 @@
         errorLine2="    ^">
         <location
             file="src/main/res/values-es-rMX/strings.xml"
-            line="1674"
+            line="1673"
             column="5"/>
     </issue>
 
@@ -96,7 +74,7 @@
         errorLine2="    ^">
         <location
             file="src/main/res/values-es/strings.xml"
-            line="1674"
+            line="1673"
             column="5"/>
     </issue>
 
@@ -107,7 +85,7 @@
         errorLine2="    ^">
         <location
             file="src/main/res/values-fr-rCA/strings.xml"
-            line="1674"
+            line="1673"
             column="5"/>
     </issue>
 
@@ -118,7 +96,7 @@
         errorLine2="    ^">
         <location
             file="src/main/res/values-fr/strings.xml"
-            line="1674"
+            line="1673"
             column="5"/>
     </issue>
 
@@ -129,7 +107,7 @@
         errorLine2="    ^">
         <location
             file="src/main/res/values-it/strings.xml"
-            line="1674"
+            line="1673"
             column="5"/>
     </issue>
 
@@ -140,7 +118,7 @@
         errorLine2="    ^">
         <location
             file="src/main/res/values-pt-rBR/strings.xml"
-            line="1674"
+            line="1673"
             column="5"/>
     </issue>
 
@@ -151,7 +129,7 @@
         errorLine2="                                                              ^">
         <location
             file="src/main/res/values-de/strings.xml"
-            line="335"
+            line="334"
             column="63"/>
     </issue>
 
@@ -162,7 +140,7 @@
         errorLine2="                                  ^">
         <location
             file="src/main/res/values-es-rMX/strings.xml"
-            line="1581"
+            line="1580"
             column="35"/>
     </issue>
 
@@ -173,7 +151,7 @@
         errorLine2="                                  ^">
         <location
             file="src/main/res/values-es/strings.xml"
-            line="1581"
+            line="1580"
             column="35"/>
     </issue>
 
@@ -657,7 +635,7 @@
         errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="402"
+            line="401"
             column="5"/>
     </issue>
 
@@ -668,7 +646,7 @@
         errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="426"
+            line="425"
             column="5"/>
     </issue>
 
@@ -690,7 +668,7 @@
         errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="446"
+            line="445"
             column="5"/>
     </issue>
 
@@ -712,7 +690,7 @@
         errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="477"
+            line="476"
             column="5"/>
     </issue>
 
@@ -723,7 +701,7 @@
         errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="500"
+            line="499"
             column="5"/>
     </issue>
 
@@ -734,7 +712,7 @@
         errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="501"
+            line="500"
             column="5"/>
     </issue>
 
@@ -745,7 +723,7 @@
         errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="503"
+            line="502"
             column="5"/>
     </issue>
 
@@ -756,7 +734,7 @@
         errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="530"
+            line="529"
             column="5"/>
     </issue>
 
@@ -767,7 +745,7 @@
         errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="545"
+            line="544"
             column="5"/>
     </issue>
 
@@ -778,7 +756,7 @@
         errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="564"
+            line="563"
             column="5"/>
     </issue>
 
@@ -789,7 +767,7 @@
         errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="587"
+            line="586"
             column="5"/>
     </issue>
 
@@ -800,7 +778,7 @@
         errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="622"
+            line="621"
             column="5"/>
     </issue>
 
@@ -811,7 +789,7 @@
         errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="650"
+            line="649"
             column="5"/>
     </issue>
 
@@ -822,7 +800,7 @@
         errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="674"
+            line="673"
             column="5"/>
     </issue>
 
@@ -833,7 +811,7 @@
         errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="715"
+            line="714"
             column="5"/>
     </issue>
 
@@ -855,7 +833,7 @@
         errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="780"
+            line="779"
             column="5"/>
     </issue>
 
@@ -866,7 +844,7 @@
         errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="782"
+            line="781"
             column="5"/>
     </issue>
 
@@ -932,7 +910,7 @@
         errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="1172"
+            line="1171"
             column="5"/>
     </issue>
 
@@ -943,7 +921,7 @@
         errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="1179"
+            line="1178"
             column="5"/>
     </issue>
 
@@ -965,7 +943,7 @@
         errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="1183"
+            line="1182"
             column="5"/>
     </issue>
 
@@ -987,7 +965,7 @@
         errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="1241"
+            line="1240"
             column="5"/>
     </issue>
 
@@ -1031,7 +1009,7 @@
         errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="1276"
+            line="1275"
             column="5"/>
     </issue>
 
@@ -1394,7 +1372,7 @@
         errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="1671"
+            line="1668"
             column="5"/>
     </issue>
 
@@ -1405,7 +1383,7 @@
         errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="1672"
+            line="1669"
             column="5"/>
     </issue>
 
@@ -1416,7 +1394,7 @@
         errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="1676"
+            line="1673"
             column="5"/>
     </issue>
 
@@ -1427,7 +1405,7 @@
         errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="1678"
+            line="1675"
             column="5"/>
     </issue>
 
@@ -1438,7 +1416,7 @@
         errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="1679"
+            line="1676"
             column="5"/>
     </issue>
 
@@ -1449,7 +1427,7 @@
         errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="1683"
+            line="1680"
             column="5"/>
     </issue>
 
@@ -1460,7 +1438,7 @@
         errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="1687"
+            line="1684"
             column="5"/>
     </issue>
 
@@ -1471,7 +1449,7 @@
         errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="1740"
+            line="1737"
             column="5"/>
     </issue>
 
@@ -1482,7 +1460,7 @@
         errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="1851"
+            line="1848"
             column="5"/>
     </issue>
 
@@ -1493,7 +1471,7 @@
         errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="1855"
+            line="1852"
             column="5"/>
     </issue>
 
@@ -1504,264 +1482,200 @@
         errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="1857"
+            line="1854"
             column="5"/>
     </issue>
 
     <issue
         id="StringFormatCount"
-        message="Inconsistent number of arguments in formatting string `half_price_first_year`; found both 0 here and 1 in values/strings.xml"
-        errorLine1="    &lt;string name=&quot;half_price_first_year&quot;>初年度は50% オフ&lt;/string>"
-        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
-        <location
-            file="src/main/res/values-ja/strings.xml"
-            line="69"
-            column="5"/>
+        message="Inconsistent number of arguments in formatting string `half_price_first_year`; found both 1 here and 0 in values-zh-rTW/strings.xml"
+        errorLine1="    &lt;string name=&quot;half_price_first_year&quot;>50% off your first year&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="1070"
-            column="5"
-            message="Conflicting number of arguments (1) here"/>
-    </issue>
-
-    <issue
-        id="StringFormatCount"
-        message="Inconsistent number of arguments in formatting string `half_price_first_year`; found both 0 here and 1 in values/strings.xml"
-        errorLine1="    &lt;string name=&quot;half_price_first_year&quot;>첫해 50% 할인&lt;/string>"
-        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
-        <location
-            file="src/main/res/values-ko/strings.xml"
-            line="69"
+            line="1069"
             column="5"/>
-        <location
-            file="src/main/res/values/strings.xml"
-            line="1070"
-            column="5"
-            message="Conflicting number of arguments (1) here"/>
-    </issue>
-
-    <issue
-        id="StringFormatCount"
-        message="Inconsistent number of arguments in formatting string `half_price_first_year`; found both 0 here and 1 in values/strings.xml"
-        errorLine1="    &lt;string name=&quot;half_price_first_year&quot;>Скидка 50 % на первый год&lt;/string>"
-        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
-        <location
-            file="src/main/res/values-ru/strings.xml"
-            line="69"
-            column="5"/>
-        <location
-            file="src/main/res/values/strings.xml"
-            line="1070"
-            column="5"
-            message="Conflicting number of arguments (1) here"/>
-    </issue>
-
-    <issue
-        id="StringFormatCount"
-        message="Inconsistent number of arguments in formatting string `half_price_first_year`; found both 0 here and 1 in values/strings.xml"
-        errorLine1="    &lt;string name=&quot;half_price_first_year&quot;>首年享五折優惠&lt;/string>"
-        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values-zh-rTW/strings.xml"
-            line="69"
-            column="5"/>
-        <location
-            file="src/main/res/values/strings.xml"
-            line="1070"
+            line="68"
             column="5"
-            message="Conflicting number of arguments (1) here"/>
+            message="Conflicting number of arguments (0) here"/>
     </issue>
 
     <issue
         id="StringFormatCount"
-        message="Inconsistent number of arguments in formatting string `half_price_first_year`; found both 0 here and 1 in values/strings.xml"
-        errorLine1="    &lt;string name=&quot;half_price_first_year&quot;>首年享 5 折优惠&lt;/string>"
-        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
-        <location
-            file="src/main/res/values-zh/strings.xml"
-            line="69"
-            column="5"/>
-        <location
-            file="src/main/res/values/strings.xml"
-            line="1070"
-            column="5"
-            message="Conflicting number of arguments (1) here"/>
-    </issue>
-
-    <issue
-        id="StringFormatCount"
-        message="Inconsistent number of arguments in formatting string `settings_stats_funny_searches`; found both 0 here and 1 in values/strings.xml"
-        errorLine1="    &lt;string name=&quot;settings_stats_funny_searches&quot;>خلال هذه الفترة، تم إجراء %1$ من عمليات بحث غوغل. بازينجا.&lt;/string>"
-        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
-        <location
-            file="src/main/res/values-ar/strings.xml"
-            line="669"
-            column="5"/>
-        <location
-            file="src/main/res/values/strings.xml"
-            line="1369"
-            column="5"
-            message="Conflicting number of arguments (1) here"/>
-    </issue>
-
-    <issue
-        id="StringFormatCount"
-        message="Inconsistent number of arguments in formatting string `settings_stats_funny_air_balloon`; found both 0 here and 1 in values/strings.xml"
-        errorLine1="    &lt;string name=&quot;settings_stats_funny_air_balloon&quot;>خلال هذه الفترة، يمكنك التجول حول العالم %1$ من المرات في منطاد هواء.&lt;/string>"
-        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
-        <location
-            file="src/main/res/values-ar/strings.xml"
-            line="670"
-            column="5"/>
-        <location
-            file="src/main/res/values/strings.xml"
-            line="1368"
-            column="5"
-            message="Conflicting number of arguments (1) here"/>
-    </issue>
-
-    <issue
-        id="StringFormatCount"
-        message="Inconsistent number of arguments in formatting string `settings_stats_funny_laces`; found both 0 here and 1 in values/strings.xml"
-        errorLine1="    &lt;string name=&quot;settings_stats_funny_laces&quot;>خلال هذه الفترة، يمكنك ربط %1$ من أربطة الحذاء. ربما.&lt;/string>"
-        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
-        <location
-            file="src/main/res/values-ar/strings.xml"
-            line="671"
-            column="5"/>
-        <location
-            file="src/main/res/values/strings.xml"
-            line="1367"
-            column="5"
-            message="Conflicting number of arguments (1) here"/>
-    </issue>
-
-    <issue
-        id="StringFormatCount"
-        message="Inconsistent number of arguments in formatting string `settings_stats_funny_air_biscuits`; found both 0 here and 1 in values/strings.xml"
-        errorLine1="    &lt;string name=&quot;settings_stats_funny_air_biscuits&quot;>خلال هذه الفترة، أطلقت %1$ أوقية من الغازات. الإجمالي!&lt;/string>"
-        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
-        <location
-            file="src/main/res/values-ar/strings.xml"
-            line="672"
-            column="5"/>
-        <location
-            file="src/main/res/values/strings.xml"
-            line="1366"
-            column="5"
-            message="Conflicting number of arguments (1) here"/>
-    </issue>
-
-    <issue
-        id="StringFormatCount"
-        message="Inconsistent number of arguments in formatting string `settings_stats_funny_tweets`; found both 0 here and 1 in values/strings.xml"
-        errorLine1="    &lt;string name=&quot;settings_stats_funny_tweets&quot;>خلال هذه الفترة، تم نشر %1$ من التغريدات. توت! توت!&lt;/string>"
-        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
-        <location
-            file="src/main/res/values-ar/strings.xml"
-            line="673"
-            column="5"/>
-        <location
-            file="src/main/res/values/strings.xml"
-            line="1365"
-            column="5"
-            message="Conflicting number of arguments (1) here"/>
-    </issue>
-
-    <issue
-        id="StringFormatCount"
-        message="Inconsistent number of arguments in formatting string `settings_stats_funny_emails`; found both 0 here and 1 in values/strings.xml"
-        errorLine1="    &lt;string name=&quot;settings_stats_funny_emails&quot;>خلال هذه الفترة، تم إرسال %1$ من رسائل البريد الإلكتروني.&lt;/string>"
-        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
-        <location
-            file="src/main/res/values-ar/strings.xml"
-            line="674"
-            column="5"/>
-        <location
-            file="src/main/res/values/strings.xml"
-            line="1364"
-            column="5"
-            message="Conflicting number of arguments (1) here"/>
-    </issue>
-
-    <issue
-        id="StringFormatCount"
-        message="Inconsistent number of arguments in formatting string `settings_stats_funny_sneezed`; found both 0 here and 1 in values/strings.xml"
-        errorLine1="    &lt;string name=&quot;settings_stats_funny_sneezed&quot;>خلال هذه الفترة، عطس رائد فضاء %1$ من المرات. آتشو!&lt;/string>"
-        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
-        <location
-            file="src/main/res/values-ar/strings.xml"
-            line="675"
-            column="5"/>
-        <location
-            file="src/main/res/values/strings.xml"
-            line="1363"
-            column="5"
-            message="Conflicting number of arguments (1) here"/>
-    </issue>
-
-    <issue
-        id="StringFormatCount"
-        message="Inconsistent number of arguments in formatting string `settings_stats_funny_skin`; found both 0 here and 1 in values/strings.xml"
-        errorLine1="    &lt;string name=&quot;settings_stats_funny_skin&quot;>خلال هذه الفترة، قمت بتغيير %1$ من خلايا الجلد. أوف؟&lt;/string>"
+        message="Inconsistent number of arguments in formatting string `settings_stats_funny_babies`; found both 1 here and 0 in values-ar/strings.xml"
+        errorLine1="    &lt;string name=&quot;settings_stats_funny_babies&quot;>During which time %1$,.0f babies were born. Wahhh!&lt;/string>"
         errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
-            file="src/main/res/values-ar/strings.xml"
-            line="676"
-            column="5"/>
-        <location
             file="src/main/res/values/strings.xml"
-            line="1362"
-            column="5"
-            message="Conflicting number of arguments (1) here"/>
-    </issue>
-
-    <issue
-        id="StringFormatCount"
-        message="Inconsistent number of arguments in formatting string `settings_stats_funny_lightning`; found both 0 here and 1 in values/strings.xml"
-        errorLine1="    &lt;string name=&quot;settings_stats_funny_lightning&quot;>خلال هذه الفترة، ضرب البرق %1$ من المرات. بووم.&lt;/string>"
-        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
-        <location
-            file="src/main/res/values-ar/strings.xml"
-            line="677"
+            line="1358"
             column="5"/>
-        <location
-            file="src/main/res/values/strings.xml"
-            line="1361"
-            column="5"
-            message="Conflicting number of arguments (1) here"/>
-    </issue>
-
-    <issue
-        id="StringFormatCount"
-        message="Inconsistent number of arguments in formatting string `settings_stats_funny_blinked`; found both 0 here and 1 in values/strings.xml"
-        errorLine1="    &lt;string name=&quot;settings_stats_funny_blinked&quot;>خلال هذه الفترة، رمشت %1$ من المرات. مرحبًا!&lt;/string>"
-        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
-        <location
-            file="src/main/res/values-ar/strings.xml"
-            line="678"
-            column="5"/>
-        <location
-            file="src/main/res/values/strings.xml"
-            line="1360"
-            column="5"
-            message="Conflicting number of arguments (1) here"/>
-    </issue>
-
-    <issue
-        id="StringFormatCount"
-        message="Inconsistent number of arguments in formatting string `settings_stats_funny_babies`; found both 0 here and 1 in values/strings.xml"
-        errorLine1="    &lt;string name=&quot;settings_stats_funny_babies&quot;>خلال هذه الفترة، تمت ولادة %1$ من الأطفال الرضع. يا إلهي!&lt;/string>"
-        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values-ar/strings.xml"
             line="679"
-            column="5"/>
+            column="5"
+            message="Conflicting number of arguments (0) here"/>
+    </issue>
+
+    <issue
+        id="StringFormatCount"
+        message="Inconsistent number of arguments in formatting string `settings_stats_funny_blinked`; found both 1 here and 0 in values-ar/strings.xml"
+        errorLine1="    &lt;string name=&quot;settings_stats_funny_blinked&quot;>During which time you blinked %1$,.0f times. Heyooo!&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
             line="1359"
+            column="5"/>
+        <location
+            file="src/main/res/values-ar/strings.xml"
+            line="678"
             column="5"
-            message="Conflicting number of arguments (1) here"/>
+            message="Conflicting number of arguments (0) here"/>
+    </issue>
+
+    <issue
+        id="StringFormatCount"
+        message="Inconsistent number of arguments in formatting string `settings_stats_funny_lightning`; found both 1 here and 0 in values-ar/strings.xml"
+        errorLine1="    &lt;string name=&quot;settings_stats_funny_lightning&quot;>During which time lightning struck %1$,.0f times. Boom.&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="1360"
+            column="5"/>
+        <location
+            file="src/main/res/values-ar/strings.xml"
+            line="677"
+            column="5"
+            message="Conflicting number of arguments (0) here"/>
+    </issue>
+
+    <issue
+        id="StringFormatCount"
+        message="Inconsistent number of arguments in formatting string `settings_stats_funny_skin`; found both 1 here and 0 in values-ar/strings.xml"
+        errorLine1="    &lt;string name=&quot;settings_stats_funny_skin&quot;>During which time you shed %1$,.0f skin cells. Ew?&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="1361"
+            column="5"/>
+        <location
+            file="src/main/res/values-ar/strings.xml"
+            line="676"
+            column="5"
+            message="Conflicting number of arguments (0) here"/>
+    </issue>
+
+    <issue
+        id="StringFormatCount"
+        message="Inconsistent number of arguments in formatting string `settings_stats_funny_sneezed`; found both 1 here and 0 in values-ar/strings.xml"
+        errorLine1="    &lt;string name=&quot;settings_stats_funny_sneezed&quot;>During which time an astronaut sneezed %1$,.0f times. Achoo!&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="1362"
+            column="5"/>
+        <location
+            file="src/main/res/values-ar/strings.xml"
+            line="675"
+            column="5"
+            message="Conflicting number of arguments (0) here"/>
+    </issue>
+
+    <issue
+        id="StringFormatCount"
+        message="Inconsistent number of arguments in formatting string `settings_stats_funny_emails`; found both 1 here and 0 in values-ar/strings.xml"
+        errorLine1="    &lt;string name=&quot;settings_stats_funny_emails&quot;>During which time %1$,.0f emails were sent.&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="1363"
+            column="5"/>
+        <location
+            file="src/main/res/values-ar/strings.xml"
+            line="674"
+            column="5"
+            message="Conflicting number of arguments (0) here"/>
+    </issue>
+
+    <issue
+        id="StringFormatCount"
+        message="Inconsistent number of arguments in formatting string `settings_stats_funny_tweets`; found both 1 here and 0 in values-ar/strings.xml"
+        errorLine1="    &lt;string name=&quot;settings_stats_funny_tweets&quot;>During which time %1$,.0f tweets were tooted. Toot! Toot!&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="1364"
+            column="5"/>
+        <location
+            file="src/main/res/values-ar/strings.xml"
+            line="673"
+            column="5"
+            message="Conflicting number of arguments (0) here"/>
+    </issue>
+
+    <issue
+        id="StringFormatCount"
+        message="Inconsistent number of arguments in formatting string `settings_stats_funny_air_biscuits`; found both 1 here and 0 in values-ar/strings.xml"
+        errorLine1="    &lt;string name=&quot;settings_stats_funny_air_biscuits&quot;>During which time you released %1$,.0f oz of air biscuits. Gross!&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="1365"
+            column="5"/>
+        <location
+            file="src/main/res/values-ar/strings.xml"
+            line="672"
+            column="5"
+            message="Conflicting number of arguments (0) here"/>
+    </issue>
+
+    <issue
+        id="StringFormatCount"
+        message="Inconsistent number of arguments in formatting string `settings_stats_funny_laces`; found both 1 here and 0 in values-ar/strings.xml"
+        errorLine1="    &lt;string name=&quot;settings_stats_funny_laces&quot;>During which time you could have tied %1$,.0f shoe laces. Maybe.&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="1366"
+            column="5"/>
+        <location
+            file="src/main/res/values-ar/strings.xml"
+            line="671"
+            column="5"
+            message="Conflicting number of arguments (0) here"/>
+    </issue>
+
+    <issue
+        id="StringFormatCount"
+        message="Inconsistent number of arguments in formatting string `settings_stats_funny_air_balloon`; found both 1 here and 0 in values-ar/strings.xml"
+        errorLine1="    &lt;string name=&quot;settings_stats_funny_air_balloon&quot;>During which time you could have gone around the world %1$,.0f times in an air balloon.&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="1367"
+            column="5"/>
+        <location
+            file="src/main/res/values-ar/strings.xml"
+            line="670"
+            column="5"
+            message="Conflicting number of arguments (0) here"/>
+    </issue>
+
+    <issue
+        id="StringFormatCount"
+        message="Inconsistent number of arguments in formatting string `settings_stats_funny_searches`; found both 1 here and 0 in values-ar/strings.xml"
+        errorLine1="    &lt;string name=&quot;settings_stats_funny_searches&quot;>During which time %1$,.0f Google searches were performed. Bazinga.&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="1368"
+            column="5"/>
+        <location
+            file="src/main/res/values-ar/strings.xml"
+            line="669"
+            column="5"
+            message="Conflicting number of arguments (0) here"/>
     </issue>
 
     <issue

--- a/modules/services/localization/lint-baseline.xml
+++ b/modules/services/localization/lint-baseline.xml
@@ -1,5 +1,27 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 8.2.2" type="baseline" client="gradle" dependencies="false" name="AGP (8.2.2)" variant="all" version="8.2.2">
+<issues format="6" by="lint 8.4.1" type="baseline" client="gradle" dependencies="false" name="AGP (8.4.1)" variant="all" version="8.4.1">
+
+    <issue
+        id="DefaultLocale"
+        message="Implicitly using the default locale is a common source of bugs: Use `String.format(Locale, ...)` instead"
+        errorLine1="        return if (hours > 0) String.format(hoursFormat, hours, min - hours * 60, sec) else String.format(noHoursFormat, min, sec)"
+        errorLine2="                              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/au/com/shiftyjelly/pocketcasts/localization/helper/TimeHelper.kt"
+            line="162"
+            column="31"/>
+    </issue>
+
+    <issue
+        id="DefaultLocale"
+        message="Implicitly using the default locale is a common source of bugs: Use `String.format(Locale, ...)` instead"
+        errorLine1="        return if (hours > 0) String.format(hoursFormat, hours, min - hours * 60, sec) else String.format(noHoursFormat, min, sec)"
+        errorLine2="                                                                                            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/au/com/shiftyjelly/pocketcasts/localization/helper/TimeHelper.kt"
+            line="162"
+            column="93"/>
+    </issue>
 
     <issue
         id="MissingDefaultResource"
@@ -30,7 +52,7 @@
         errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values-fr-rCA/strings.xml"
-            line="68"
+            line="91"
             column="5"/>
     </issue>
 
@@ -41,7 +63,7 @@
         errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values-fr/strings.xml"
-            line="68"
+            line="91"
             column="5"/>
     </issue>
 
@@ -52,7 +74,7 @@
         errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values-it/strings.xml"
-            line="68"
+            line="91"
             column="5"/>
     </issue>
 
@@ -63,7 +85,7 @@
         errorLine2="    ^">
         <location
             file="src/main/res/values-es-rMX/strings.xml"
-            line="1673"
+            line="1696"
             column="5"/>
     </issue>
 
@@ -74,7 +96,7 @@
         errorLine2="    ^">
         <location
             file="src/main/res/values-es/strings.xml"
-            line="1673"
+            line="1696"
             column="5"/>
     </issue>
 
@@ -85,7 +107,7 @@
         errorLine2="    ^">
         <location
             file="src/main/res/values-fr-rCA/strings.xml"
-            line="1673"
+            line="1696"
             column="5"/>
     </issue>
 
@@ -96,7 +118,7 @@
         errorLine2="    ^">
         <location
             file="src/main/res/values-fr/strings.xml"
-            line="1673"
+            line="1696"
             column="5"/>
     </issue>
 
@@ -107,7 +129,7 @@
         errorLine2="    ^">
         <location
             file="src/main/res/values-it/strings.xml"
-            line="1673"
+            line="1696"
             column="5"/>
     </issue>
 
@@ -118,7 +140,7 @@
         errorLine2="    ^">
         <location
             file="src/main/res/values-pt-rBR/strings.xml"
-            line="1673"
+            line="1696"
             column="5"/>
     </issue>
 
@@ -129,7 +151,7 @@
         errorLine2="                                                              ^">
         <location
             file="src/main/res/values-de/strings.xml"
-            line="334"
+            line="357"
             column="63"/>
     </issue>
 
@@ -140,7 +162,7 @@
         errorLine2="                                  ^">
         <location
             file="src/main/res/values-es-rMX/strings.xml"
-            line="1580"
+            line="1603"
             column="35"/>
     </issue>
 
@@ -151,7 +173,7 @@
         errorLine2="                                  ^">
         <location
             file="src/main/res/values-es/strings.xml"
-            line="1580"
+            line="1603"
             column="35"/>
     </issue>
 
@@ -1372,7 +1394,7 @@
         errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="1668"
+            line="1670"
             column="5"/>
     </issue>
 
@@ -1383,7 +1405,7 @@
         errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="1669"
+            line="1671"
             column="5"/>
     </issue>
 
@@ -1394,7 +1416,7 @@
         errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="1673"
+            line="1675"
             column="5"/>
     </issue>
 
@@ -1405,7 +1427,7 @@
         errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="1675"
+            line="1677"
             column="5"/>
     </issue>
 
@@ -1416,7 +1438,7 @@
         errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="1676"
+            line="1678"
             column="5"/>
     </issue>
 
@@ -1427,7 +1449,7 @@
         errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="1680"
+            line="1682"
             column="5"/>
     </issue>
 
@@ -1438,7 +1460,7 @@
         errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="1684"
+            line="1686"
             column="5"/>
     </issue>
 
@@ -1449,7 +1471,7 @@
         errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="1737"
+            line="1739"
             column="5"/>
     </issue>
 
@@ -1460,7 +1482,7 @@
         errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="1848"
+            line="1850"
             column="5"/>
     </issue>
 
@@ -1471,7 +1493,7 @@
         errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="1852"
+            line="1854"
             column="5"/>
     </issue>
 
@@ -1482,200 +1504,264 @@
         errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="1854"
+            line="1856"
             column="5"/>
     </issue>
 
     <issue
         id="StringFormatCount"
-        message="Inconsistent number of arguments in formatting string `half_price_first_year`; found both 1 here and 0 in values-zh-rTW/strings.xml"
-        errorLine1="    &lt;string name=&quot;half_price_first_year&quot;>50% off your first year&lt;/string>"
-        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        message="Inconsistent number of arguments in formatting string `half_price_first_year`; found both 0 here and 1 in values/strings.xml"
+        errorLine1="    &lt;string name=&quot;half_price_first_year&quot;>初年度は50% オフ&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-ja/strings.xml"
+            line="91"
+            column="5"/>
         <location
             file="src/main/res/values/strings.xml"
             line="1069"
+            column="5"
+            message="Conflicting number of arguments (1) here"/>
+    </issue>
+
+    <issue
+        id="StringFormatCount"
+        message="Inconsistent number of arguments in formatting string `half_price_first_year`; found both 0 here and 1 in values/strings.xml"
+        errorLine1="    &lt;string name=&quot;half_price_first_year&quot;>첫해 50% 할인&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-ko/strings.xml"
+            line="91"
             column="5"/>
+        <location
+            file="src/main/res/values/strings.xml"
+            line="1069"
+            column="5"
+            message="Conflicting number of arguments (1) here"/>
+    </issue>
+
+    <issue
+        id="StringFormatCount"
+        message="Inconsistent number of arguments in formatting string `half_price_first_year`; found both 0 here and 1 in values/strings.xml"
+        errorLine1="    &lt;string name=&quot;half_price_first_year&quot;>Скидка 50 % на первый год&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-ru/strings.xml"
+            line="91"
+            column="5"/>
+        <location
+            file="src/main/res/values/strings.xml"
+            line="1069"
+            column="5"
+            message="Conflicting number of arguments (1) here"/>
+    </issue>
+
+    <issue
+        id="StringFormatCount"
+        message="Inconsistent number of arguments in formatting string `half_price_first_year`; found both 0 here and 1 in values/strings.xml"
+        errorLine1="    &lt;string name=&quot;half_price_first_year&quot;>首年享五折優惠&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values-zh-rTW/strings.xml"
-            line="68"
+            line="91"
+            column="5"/>
+        <location
+            file="src/main/res/values/strings.xml"
+            line="1069"
             column="5"
-            message="Conflicting number of arguments (0) here"/>
+            message="Conflicting number of arguments (1) here"/>
     </issue>
 
     <issue
         id="StringFormatCount"
-        message="Inconsistent number of arguments in formatting string `settings_stats_funny_babies`; found both 1 here and 0 in values-ar/strings.xml"
-        errorLine1="    &lt;string name=&quot;settings_stats_funny_babies&quot;>During which time %1$,.0f babies were born. Wahhh!&lt;/string>"
-        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        message="Inconsistent number of arguments in formatting string `half_price_first_year`; found both 0 here and 1 in values/strings.xml"
+        errorLine1="    &lt;string name=&quot;half_price_first_year&quot;>首年享 5 折优惠&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
-            file="src/main/res/values/strings.xml"
-            line="1358"
+            file="src/main/res/values-zh/strings.xml"
+            line="91"
             column="5"/>
         <location
-            file="src/main/res/values-ar/strings.xml"
-            line="679"
+            file="src/main/res/values/strings.xml"
+            line="1069"
             column="5"
-            message="Conflicting number of arguments (0) here"/>
+            message="Conflicting number of arguments (1) here"/>
     </issue>
 
     <issue
         id="StringFormatCount"
-        message="Inconsistent number of arguments in formatting string `settings_stats_funny_blinked`; found both 1 here and 0 in values-ar/strings.xml"
-        errorLine1="    &lt;string name=&quot;settings_stats_funny_blinked&quot;>During which time you blinked %1$,.0f times. Heyooo!&lt;/string>"
-        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
-        <location
-            file="src/main/res/values/strings.xml"
-            line="1359"
-            column="5"/>
-        <location
-            file="src/main/res/values-ar/strings.xml"
-            line="678"
-            column="5"
-            message="Conflicting number of arguments (0) here"/>
-    </issue>
-
-    <issue
-        id="StringFormatCount"
-        message="Inconsistent number of arguments in formatting string `settings_stats_funny_lightning`; found both 1 here and 0 in values-ar/strings.xml"
-        errorLine1="    &lt;string name=&quot;settings_stats_funny_lightning&quot;>During which time lightning struck %1$,.0f times. Boom.&lt;/string>"
-        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
-        <location
-            file="src/main/res/values/strings.xml"
-            line="1360"
-            column="5"/>
-        <location
-            file="src/main/res/values-ar/strings.xml"
-            line="677"
-            column="5"
-            message="Conflicting number of arguments (0) here"/>
-    </issue>
-
-    <issue
-        id="StringFormatCount"
-        message="Inconsistent number of arguments in formatting string `settings_stats_funny_skin`; found both 1 here and 0 in values-ar/strings.xml"
-        errorLine1="    &lt;string name=&quot;settings_stats_funny_skin&quot;>During which time you shed %1$,.0f skin cells. Ew?&lt;/string>"
-        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
-        <location
-            file="src/main/res/values/strings.xml"
-            line="1361"
-            column="5"/>
-        <location
-            file="src/main/res/values-ar/strings.xml"
-            line="676"
-            column="5"
-            message="Conflicting number of arguments (0) here"/>
-    </issue>
-
-    <issue
-        id="StringFormatCount"
-        message="Inconsistent number of arguments in formatting string `settings_stats_funny_sneezed`; found both 1 here and 0 in values-ar/strings.xml"
-        errorLine1="    &lt;string name=&quot;settings_stats_funny_sneezed&quot;>During which time an astronaut sneezed %1$,.0f times. Achoo!&lt;/string>"
-        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
-        <location
-            file="src/main/res/values/strings.xml"
-            line="1362"
-            column="5"/>
-        <location
-            file="src/main/res/values-ar/strings.xml"
-            line="675"
-            column="5"
-            message="Conflicting number of arguments (0) here"/>
-    </issue>
-
-    <issue
-        id="StringFormatCount"
-        message="Inconsistent number of arguments in formatting string `settings_stats_funny_emails`; found both 1 here and 0 in values-ar/strings.xml"
-        errorLine1="    &lt;string name=&quot;settings_stats_funny_emails&quot;>During which time %1$,.0f emails were sent.&lt;/string>"
-        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
-        <location
-            file="src/main/res/values/strings.xml"
-            line="1363"
-            column="5"/>
-        <location
-            file="src/main/res/values-ar/strings.xml"
-            line="674"
-            column="5"
-            message="Conflicting number of arguments (0) here"/>
-    </issue>
-
-    <issue
-        id="StringFormatCount"
-        message="Inconsistent number of arguments in formatting string `settings_stats_funny_tweets`; found both 1 here and 0 in values-ar/strings.xml"
-        errorLine1="    &lt;string name=&quot;settings_stats_funny_tweets&quot;>During which time %1$,.0f tweets were tooted. Toot! Toot!&lt;/string>"
-        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
-        <location
-            file="src/main/res/values/strings.xml"
-            line="1364"
-            column="5"/>
-        <location
-            file="src/main/res/values-ar/strings.xml"
-            line="673"
-            column="5"
-            message="Conflicting number of arguments (0) here"/>
-    </issue>
-
-    <issue
-        id="StringFormatCount"
-        message="Inconsistent number of arguments in formatting string `settings_stats_funny_air_biscuits`; found both 1 here and 0 in values-ar/strings.xml"
-        errorLine1="    &lt;string name=&quot;settings_stats_funny_air_biscuits&quot;>During which time you released %1$,.0f oz of air biscuits. Gross!&lt;/string>"
-        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
-        <location
-            file="src/main/res/values/strings.xml"
-            line="1365"
-            column="5"/>
-        <location
-            file="src/main/res/values-ar/strings.xml"
-            line="672"
-            column="5"
-            message="Conflicting number of arguments (0) here"/>
-    </issue>
-
-    <issue
-        id="StringFormatCount"
-        message="Inconsistent number of arguments in formatting string `settings_stats_funny_laces`; found both 1 here and 0 in values-ar/strings.xml"
-        errorLine1="    &lt;string name=&quot;settings_stats_funny_laces&quot;>During which time you could have tied %1$,.0f shoe laces. Maybe.&lt;/string>"
-        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
-        <location
-            file="src/main/res/values/strings.xml"
-            line="1366"
-            column="5"/>
-        <location
-            file="src/main/res/values-ar/strings.xml"
-            line="671"
-            column="5"
-            message="Conflicting number of arguments (0) here"/>
-    </issue>
-
-    <issue
-        id="StringFormatCount"
-        message="Inconsistent number of arguments in formatting string `settings_stats_funny_air_balloon`; found both 1 here and 0 in values-ar/strings.xml"
-        errorLine1="    &lt;string name=&quot;settings_stats_funny_air_balloon&quot;>During which time you could have gone around the world %1$,.0f times in an air balloon.&lt;/string>"
-        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
-        <location
-            file="src/main/res/values/strings.xml"
-            line="1367"
-            column="5"/>
-        <location
-            file="src/main/res/values-ar/strings.xml"
-            line="670"
-            column="5"
-            message="Conflicting number of arguments (0) here"/>
-    </issue>
-
-    <issue
-        id="StringFormatCount"
-        message="Inconsistent number of arguments in formatting string `settings_stats_funny_searches`; found both 1 here and 0 in values-ar/strings.xml"
-        errorLine1="    &lt;string name=&quot;settings_stats_funny_searches&quot;>During which time %1$,.0f Google searches were performed. Bazinga.&lt;/string>"
-        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
-        <location
-            file="src/main/res/values/strings.xml"
-            line="1368"
-            column="5"/>
+        message="Inconsistent number of arguments in formatting string `settings_stats_funny_searches`; found both 0 here and 1 in values/strings.xml"
+        errorLine1="    &lt;string name=&quot;settings_stats_funny_searches&quot;>خلال هذه الفترة، تم إجراء %1$ من عمليات بحث غوغل. بازينجا.&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values-ar/strings.xml"
             line="669"
+            column="5"/>
+        <location
+            file="src/main/res/values/strings.xml"
+            line="1368"
             column="5"
-            message="Conflicting number of arguments (0) here"/>
+            message="Conflicting number of arguments (1) here"/>
+    </issue>
+
+    <issue
+        id="StringFormatCount"
+        message="Inconsistent number of arguments in formatting string `settings_stats_funny_air_balloon`; found both 0 here and 1 in values/strings.xml"
+        errorLine1="    &lt;string name=&quot;settings_stats_funny_air_balloon&quot;>خلال هذه الفترة، يمكنك التجول حول العالم %1$ من المرات في منطاد هواء.&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-ar/strings.xml"
+            line="670"
+            column="5"/>
+        <location
+            file="src/main/res/values/strings.xml"
+            line="1367"
+            column="5"
+            message="Conflicting number of arguments (1) here"/>
+    </issue>
+
+    <issue
+        id="StringFormatCount"
+        message="Inconsistent number of arguments in formatting string `settings_stats_funny_laces`; found both 0 here and 1 in values/strings.xml"
+        errorLine1="    &lt;string name=&quot;settings_stats_funny_laces&quot;>خلال هذه الفترة، يمكنك ربط %1$ من أربطة الحذاء. ربما.&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-ar/strings.xml"
+            line="671"
+            column="5"/>
+        <location
+            file="src/main/res/values/strings.xml"
+            line="1366"
+            column="5"
+            message="Conflicting number of arguments (1) here"/>
+    </issue>
+
+    <issue
+        id="StringFormatCount"
+        message="Inconsistent number of arguments in formatting string `settings_stats_funny_air_biscuits`; found both 0 here and 1 in values/strings.xml"
+        errorLine1="    &lt;string name=&quot;settings_stats_funny_air_biscuits&quot;>خلال هذه الفترة، أطلقت %1$ أوقية من الغازات. الإجمالي!&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-ar/strings.xml"
+            line="672"
+            column="5"/>
+        <location
+            file="src/main/res/values/strings.xml"
+            line="1365"
+            column="5"
+            message="Conflicting number of arguments (1) here"/>
+    </issue>
+
+    <issue
+        id="StringFormatCount"
+        message="Inconsistent number of arguments in formatting string `settings_stats_funny_tweets`; found both 0 here and 1 in values/strings.xml"
+        errorLine1="    &lt;string name=&quot;settings_stats_funny_tweets&quot;>خلال هذه الفترة، تم نشر %1$ من التغريدات. توت! توت!&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-ar/strings.xml"
+            line="673"
+            column="5"/>
+        <location
+            file="src/main/res/values/strings.xml"
+            line="1364"
+            column="5"
+            message="Conflicting number of arguments (1) here"/>
+    </issue>
+
+    <issue
+        id="StringFormatCount"
+        message="Inconsistent number of arguments in formatting string `settings_stats_funny_emails`; found both 0 here and 1 in values/strings.xml"
+        errorLine1="    &lt;string name=&quot;settings_stats_funny_emails&quot;>خلال هذه الفترة، تم إرسال %1$ من رسائل البريد الإلكتروني.&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-ar/strings.xml"
+            line="674"
+            column="5"/>
+        <location
+            file="src/main/res/values/strings.xml"
+            line="1363"
+            column="5"
+            message="Conflicting number of arguments (1) here"/>
+    </issue>
+
+    <issue
+        id="StringFormatCount"
+        message="Inconsistent number of arguments in formatting string `settings_stats_funny_sneezed`; found both 0 here and 1 in values/strings.xml"
+        errorLine1="    &lt;string name=&quot;settings_stats_funny_sneezed&quot;>خلال هذه الفترة، عطس رائد فضاء %1$ من المرات. آتشو!&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-ar/strings.xml"
+            line="675"
+            column="5"/>
+        <location
+            file="src/main/res/values/strings.xml"
+            line="1362"
+            column="5"
+            message="Conflicting number of arguments (1) here"/>
+    </issue>
+
+    <issue
+        id="StringFormatCount"
+        message="Inconsistent number of arguments in formatting string `settings_stats_funny_skin`; found both 0 here and 1 in values/strings.xml"
+        errorLine1="    &lt;string name=&quot;settings_stats_funny_skin&quot;>خلال هذه الفترة، قمت بتغيير %1$ من خلايا الجلد. أوف؟&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-ar/strings.xml"
+            line="676"
+            column="5"/>
+        <location
+            file="src/main/res/values/strings.xml"
+            line="1361"
+            column="5"
+            message="Conflicting number of arguments (1) here"/>
+    </issue>
+
+    <issue
+        id="StringFormatCount"
+        message="Inconsistent number of arguments in formatting string `settings_stats_funny_lightning`; found both 0 here and 1 in values/strings.xml"
+        errorLine1="    &lt;string name=&quot;settings_stats_funny_lightning&quot;>خلال هذه الفترة، ضرب البرق %1$ من المرات. بووم.&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-ar/strings.xml"
+            line="677"
+            column="5"/>
+        <location
+            file="src/main/res/values/strings.xml"
+            line="1360"
+            column="5"
+            message="Conflicting number of arguments (1) here"/>
+    </issue>
+
+    <issue
+        id="StringFormatCount"
+        message="Inconsistent number of arguments in formatting string `settings_stats_funny_blinked`; found both 0 here and 1 in values/strings.xml"
+        errorLine1="    &lt;string name=&quot;settings_stats_funny_blinked&quot;>خلال هذه الفترة، رمشت %1$ من المرات. مرحبًا!&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-ar/strings.xml"
+            line="678"
+            column="5"/>
+        <location
+            file="src/main/res/values/strings.xml"
+            line="1359"
+            column="5"
+            message="Conflicting number of arguments (1) here"/>
+    </issue>
+
+    <issue
+        id="StringFormatCount"
+        message="Inconsistent number of arguments in formatting string `settings_stats_funny_babies`; found both 0 here and 1 in values/strings.xml"
+        errorLine1="    &lt;string name=&quot;settings_stats_funny_babies&quot;>خلال هذه الفترة، تمت ولادة %1$ من الأطفال الرضع. يا إلهي!&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-ar/strings.xml"
+            line="679"
+            column="5"/>
+        <location
+            file="src/main/res/values/strings.xml"
+            line="1358"
+            column="5"
+            message="Conflicting number of arguments (1) here"/>
     </issue>
 
     <issue

--- a/modules/services/localization/src/main/res/values-de/strings.xml
+++ b/modules/services/localization/src/main/res/values-de/strings.xml
@@ -81,7 +81,6 @@ Language: de
     <string name="whats_new_got_it_button">Verstanden</string>
     <string name="skip_chapters_patron_prompt">Kapitel vorauswählen und mehr mit Pocket Casts Patron</string>
     <string name="skip_chapters_plus_prompt">Kapitel vorauswählen und mehr mit Pocket Casts Plus</string>
-    <string name="select_one_chapter_message">Bitte wähle mindestens ein Kapitel aus</string>
     <string name="number_of_chapters_summary_singular">1 Kapitel • %d versteckt</string>
     <string name="number_of_chapters_summary_plural">%1$d Kapitel • %2$d versteckt</string>
     <string name="single_chapter">1 Kapitel</string>

--- a/modules/services/localization/src/main/res/values-es-rMX/strings.xml
+++ b/modules/services/localization/src/main/res/values-es-rMX/strings.xml
@@ -81,7 +81,6 @@ Language: es
     <string name="whats_new_got_it_button">De acuerdo</string>
     <string name="skip_chapters_patron_prompt">Preselecciona capítulos y haz otros ajustes con Pocket Casts Patron</string>
     <string name="skip_chapters_plus_prompt">Preselecciona capítulos y haz otros ajustes con Pocket Casts Plus</string>
-    <string name="select_one_chapter_message">Selecciona al menos un capítulo</string>
     <string name="number_of_chapters_summary_singular">1 capítulo • %d oculto</string>
     <string name="number_of_chapters_summary_plural">%1$d capítulos • %2$d ocultos</string>
     <string name="single_chapter">1 capítulo</string>

--- a/modules/services/localization/src/main/res/values-es/strings.xml
+++ b/modules/services/localization/src/main/res/values-es/strings.xml
@@ -81,7 +81,6 @@ Language: es
     <string name="whats_new_got_it_button">De acuerdo</string>
     <string name="skip_chapters_patron_prompt">Preselecciona capítulos y haz otros ajustes con Pocket Casts Patron</string>
     <string name="skip_chapters_plus_prompt">Preselecciona capítulos y haz otros ajustes con Pocket Casts Plus</string>
-    <string name="select_one_chapter_message">Selecciona al menos un capítulo</string>
     <string name="number_of_chapters_summary_singular">1 capítulo • %d oculto</string>
     <string name="number_of_chapters_summary_plural">%1$d capítulos • %2$d ocultos</string>
     <string name="single_chapter">1 capítulo</string>

--- a/modules/services/localization/src/main/res/values-fr-rCA/strings.xml
+++ b/modules/services/localization/src/main/res/values-fr-rCA/strings.xml
@@ -81,7 +81,6 @@ Language: fr
     <string name="whats_new_got_it_button">J’ai compris</string>
     <string name="skip_chapters_patron_prompt">Présélectionner des chapitres et plus encore avec Pocket Casts Patron</string>
     <string name="skip_chapters_plus_prompt">Présélectionner des chapitres et plus encore avec Pocket Casts Plus</string>
-    <string name="select_one_chapter_message">Veuillez sélectionner au moins un chapitre</string>
     <string name="number_of_chapters_summary_singular">1 chapitre • %d masqué</string>
     <string name="number_of_chapters_summary_plural">%1$d chapitres • %2$d masqués</string>
     <string name="single_chapter">1 chapitre</string>

--- a/modules/services/localization/src/main/res/values-fr/strings.xml
+++ b/modules/services/localization/src/main/res/values-fr/strings.xml
@@ -81,7 +81,6 @@ Language: fr
     <string name="whats_new_got_it_button">J’ai compris</string>
     <string name="skip_chapters_patron_prompt">Présélectionner des chapitres et plus encore avec Pocket Casts Patron</string>
     <string name="skip_chapters_plus_prompt">Présélectionner des chapitres et plus encore avec Pocket Casts Plus</string>
-    <string name="select_one_chapter_message">Veuillez sélectionner au moins un chapitre</string>
     <string name="number_of_chapters_summary_singular">1 chapitre • %d masqué</string>
     <string name="number_of_chapters_summary_plural">%1$d chapitres • %2$d masqués</string>
     <string name="single_chapter">1 chapitre</string>

--- a/modules/services/localization/src/main/res/values-it/strings.xml
+++ b/modules/services/localization/src/main/res/values-it/strings.xml
@@ -81,7 +81,6 @@ Language: it
     <string name="whats_new_got_it_button">Fatto</string>
     <string name="skip_chapters_patron_prompt">Preseleziona capitoli e altro ancora con Pocket Casts Patron</string>
     <string name="skip_chapters_plus_prompt">Preseleziona capitoli e altro ancora con Pocket Casts Plus</string>
-    <string name="select_one_chapter_message">Seleziona almeno un capitolo</string>
     <string name="number_of_chapters_summary_singular">1 capitolo • %d nascosto</string>
     <string name="number_of_chapters_summary_plural">%1$d capitoli • %2$d nascosto</string>
     <string name="single_chapter">1 capitolo</string>

--- a/modules/services/localization/src/main/res/values-ja/strings.xml
+++ b/modules/services/localization/src/main/res/values-ja/strings.xml
@@ -81,7 +81,6 @@ Language: ja_JP
     <string name="whats_new_got_it_button">OK</string>
     <string name="skip_chapters_patron_prompt">Pocket Casts Patron でチャプターの事前選択やその他の機能を利用</string>
     <string name="skip_chapters_plus_prompt">Pocket Casts Plus でチャプターの事前選択やその他の機能を利用</string>
-    <string name="select_one_chapter_message">チャプターを少なくとも1つ選択してください</string>
     <string name="number_of_chapters_summary_singular">1個のチャプター • %d個が非表示</string>
     <string name="number_of_chapters_summary_plural">%1$d個のチャプター • %2$d個が非表示</string>
     <string name="single_chapter">1個のチャプター</string>

--- a/modules/services/localization/src/main/res/values-ko/strings.xml
+++ b/modules/services/localization/src/main/res/values-ko/strings.xml
@@ -81,7 +81,6 @@ Language: ko_KR
     <string name="whats_new_got_it_button">알겠습니다.</string>
     <string name="skip_chapters_patron_prompt">Pocket Casts Patron으로 챕터 미리 선택 등</string>
     <string name="skip_chapters_plus_prompt">Pocket Casts Plus로 챕터 미리 선택 등</string>
-    <string name="select_one_chapter_message">챕터를 하나 이상 선택하세요.</string>
     <string name="number_of_chapters_summary_singular">1개 챕터 • %d개 숨김</string>
     <string name="number_of_chapters_summary_plural">%1$d개 챕터 • %2$d개 숨김</string>
     <string name="single_chapter">1개 챕터</string>

--- a/modules/services/localization/src/main/res/values-nl/strings.xml
+++ b/modules/services/localization/src/main/res/values-nl/strings.xml
@@ -81,7 +81,6 @@ Language: nl
     <string name="whats_new_got_it_button">Duidelijk</string>
     <string name="skip_chapters_patron_prompt">Selecteer hoofdstukken voor en geniet van extra functies met Pocket Casts Patron</string>
     <string name="skip_chapters_plus_prompt">Selecteer hoofdstukken voor en geniet van extra functies met Pocket Casts Plus</string>
-    <string name="select_one_chapter_message">Please select at least one chapter</string>
     <string name="number_of_chapters_summary_singular">1 hoofdstuk • %d verborgen</string>
     <string name="number_of_chapters_summary_plural">%1$d hoofdstukken • %2$d verborgen</string>
     <string name="single_chapter">1 hoofdstuk</string>

--- a/modules/services/localization/src/main/res/values-pt-rBR/strings.xml
+++ b/modules/services/localization/src/main/res/values-pt-rBR/strings.xml
@@ -81,7 +81,6 @@ Language: pt_BR
     <string name="whats_new_got_it_button">Entendi</string>
     <string name="skip_chapters_patron_prompt">Pré-selecione capítulos e muito mais com o Pocket Casts Patron</string>
     <string name="skip_chapters_plus_prompt">Pré-selecione capítulos e muito mais com o Pocket Casts Plus</string>
-    <string name="select_one_chapter_message">Selecione ao menos um capítulo</string>
     <string name="number_of_chapters_summary_singular">1 capítulo • %d oculto</string>
     <string name="number_of_chapters_summary_plural">%1$d capítulos • %2$d oculto</string>
     <string name="single_chapter">1 capítulo</string>

--- a/modules/services/localization/src/main/res/values-ru/strings.xml
+++ b/modules/services/localization/src/main/res/values-ru/strings.xml
@@ -81,7 +81,6 @@ Language: ru
     <string name="whats_new_got_it_button">Понятно</string>
     <string name="skip_chapters_patron_prompt">Возможность предварительно выбирать главы и множество других функций с Pocket Casts Patron</string>
     <string name="skip_chapters_plus_prompt">Возможность предварительно выбирать главы и множество других функций с Pocket Casts Plus</string>
-    <string name="select_one_chapter_message">Выберите хотя бы одну главу</string>
     <string name="number_of_chapters_summary_singular">1 глава • Скрыто: %d</string>
     <string name="number_of_chapters_summary_plural">Глав: %1$d • Скрыто: %2$d</string>
     <string name="single_chapter">1 глава</string>

--- a/modules/services/localization/src/main/res/values-sv/strings.xml
+++ b/modules/services/localization/src/main/res/values-sv/strings.xml
@@ -81,7 +81,6 @@ Language: sv_SE
     <string name="whats_new_got_it_button">Uppfattat</string>
     <string name="skip_chapters_patron_prompt">Välj kapitel och mer i förväg med Pocket Casts Patron</string>
     <string name="skip_chapters_plus_prompt">Välj kapitel och mer i förväg med Pocket Casts Plus</string>
-    <string name="select_one_chapter_message">Välj minst ett kapitel</string>
     <string name="number_of_chapters_summary_singular">1 kapitel • %d dolda</string>
     <string name="number_of_chapters_summary_plural">%1$d kapitel • %2$d dolda</string>
     <string name="single_chapter">1 kapitel</string>

--- a/modules/services/localization/src/main/res/values-zh-rTW/strings.xml
+++ b/modules/services/localization/src/main/res/values-zh-rTW/strings.xml
@@ -81,7 +81,6 @@ Language: zh_TW
     <string name="whats_new_got_it_button">知道了</string>
     <string name="skip_chapters_patron_prompt">訂閱 Pocket Casts Patron，就能預先選取章節並享有更多功能</string>
     <string name="skip_chapters_plus_prompt">訂閱 Pocket Casts Plus，就能預先選取章節並享有更多功能</string>
-    <string name="select_one_chapter_message">請選取至少一章</string>
     <string name="number_of_chapters_summary_singular">1 個章節 • %d 個章節已隱藏</string>
     <string name="number_of_chapters_summary_plural">%1$d 個章節 • %2$d 個章節已隱藏</string>
     <string name="single_chapter">1 個章節</string>

--- a/modules/services/localization/src/main/res/values-zh/strings.xml
+++ b/modules/services/localization/src/main/res/values-zh/strings.xml
@@ -81,7 +81,6 @@ Language: zh_CN
     <string name="whats_new_got_it_button">知道了</string>
     <string name="skip_chapters_patron_prompt">使用 Pocket Casts Patron，享受预选章节等更多功能</string>
     <string name="skip_chapters_plus_prompt">使用 Pocket Casts Plus，享受预选章节等更多功能</string>
-    <string name="select_one_chapter_message">请至少选择一个章节</string>
     <string name="number_of_chapters_summary_singular">1 个章节 • %d 已隐藏</string>
     <string name="number_of_chapters_summary_plural">%1$d 个章节 • %2$d 已隐藏</string>
     <string name="single_chapter">1 个章节</string>

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -387,7 +387,6 @@ up    <string name="player_sleep_in_one_chapter">Sleeping in 1 chapter</string>
     <!-- %1$d is the number of total chapters. %2$d is the number of hidden chapters. -->
     <string name="number_of_chapters_summary_plural">%1$d chapters &#x2022; %2$d hidden</string>
     <string name="number_of_chapters_summary_singular">1 chapter &#x2022; %d hidden</string>
-    <string name="select_one_chapter_message">Please select at least one chapter</string>
     <string name="skip_chapters_plus_prompt">Preselect chapters and more with Pocket Casts Plus</string>
     <string name="skip_chapters_patron_prompt">Preselect chapters and more with Pocket Casts Patron</string>
 

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
@@ -92,6 +92,7 @@ import kotlin.time.Duration.Companion.milliseconds
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
@@ -190,6 +191,7 @@ open class PlaybackManager @Inject constructor(
     val playbackStateLive: LiveData<PlaybackState> = playbackStateRelay
         .toFlowable(BackpressureStrategy.LATEST)
         .toLiveData()
+    val playbackStateFlow: Flow<PlaybackState> = playbackStateRelay.asFlow()
 
     private var updateCount = 0
     private var resettingPlayer = false


### PR DESCRIPTION
## Description

This PR adds chapters preview to episode details. It also improves couple of other things:
- Data set changes in player container are now applied selectively with appropriate `notifyItemInserted()` and `notifyItemRemoved()`.
- Chapters are now available in player view before playing the episode. They are not extracted beforehand so embedded chapters still require playing but once extracted and saved in the database they will be there before playing.
- I removed snackbar feedback about deselecting last chapter because it is now blocked in the UI.
- `ChaptersViewModel` is now extensively tested.

## Testing Instructions

Test both episode details and player chapters. They should behave almost the same. The only difference is that tapping on an already playing chapter in the episode details doesn't navigate to player. Check if upsell still works.

Test player behavior with tabs. Add to the queue episodes with and without chapters and skip between them. Chapters tab should behave correctly and appear or disappear depending on whether episode has chapters.

## Screenshots or Screencast 

| Light | Dark | Rose | Indigo | Extra dark |
| - | - | - | - | - |
| ![Screenshot_20240606-120624](https://github.com/Automattic/pocket-casts-android/assets/30936061/e7226301-e940-4084-b8bf-f76193ebabea) | ![Screenshot_20240606-120650](https://github.com/Automattic/pocket-casts-android/assets/30936061/92dcf2d9-e138-49a3-b193-c5096c41f849) | ![Screenshot_20240606-120700](https://github.com/Automattic/pocket-casts-android/assets/30936061/0bf050b9-e6a9-43fc-96b0-8a917052e0e6) | ![Screenshot_20240606-120713](https://github.com/Automattic/pocket-casts-android/assets/30936061/38c17ddd-aa89-429f-8ae0-e47509ab09f2) | ![Screenshot_20240606-120727](https://github.com/Automattic/pocket-casts-android/assets/30936061/234b6431-9a79-4e31-90fd-c71f611973d1) |

| Dark Contrast | Light Contrast | Electricity | Classic | Radioactivity |
| - | - | - | - | - |
| ![Screenshot_20240606-120739](https://github.com/Automattic/pocket-casts-android/assets/30936061/59bb556f-bec4-49f3-a576-06984f44377d) | ![Screenshot_20240606-120750](https://github.com/Automattic/pocket-casts-android/assets/30936061/d3e84eee-0b16-48a4-84ce-c0c262d584f9) | ![Screenshot_20240606-120759](https://github.com/Automattic/pocket-casts-android/assets/30936061/f0bbcf80-e4b0-419c-b1cc-5b2de5fc42a9) | ![Screenshot_20240606-120812](https://github.com/Automattic/pocket-casts-android/assets/30936061/814d113c-9f20-47a8-a332-5f562dbec6d8) | ![Screenshot_20240606-120832](https://github.com/Automattic/pocket-casts-android/assets/30936061/5e0d7a8b-1fbc-47ed-9559-a3148e2d8ee3) |

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [x] ~Any jetpack compose components I added or changed are covered by compose previews~
- [x] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] ~with a landscape orientation~
- [x] ~with the device set to have a large display and font size~
- [x] ~for accessibility with TalkBack~
