### PR TITLE
Configure threshold for negative seek on sync using Firebase remote config

### DIFF
--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
@@ -405,6 +405,7 @@ interface Settings {
     fun getSleepTimerDeviceShakeThreshold(): Long
     fun getRefreshPodcastsBatchSize(): Long
     fun getExoPlayerCacheSizeInMB(): Long
+    fun getPlaybackEpisodePositionChangedOnSyncThresholdSecs(): Long
 
     val podcastGroupingDefault: UserSetting<PodcastGrouping>
 

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
@@ -944,6 +944,10 @@ class SettingsImpl @Inject constructor(
         return firebaseRemoteConfig.getLong(FirebaseConfig.EXOPLAYER_CACHE_SIZE_IN_MB)
     }
 
+    override fun getPlaybackEpisodePositionChangedOnSyncThresholdSecs(): Long {
+        return firebaseRemoteConfig.getLong(FirebaseConfig.PLAYBACK_EPISODE_POSITION_CHANGED_ON_SYNC_THRESHOLD_SECS)
+    }
+
     private fun getRemoteConfigLong(key: String): Long {
         val value = firebaseRemoteConfig.getLong(key)
         return if (value == 0L) (FirebaseConfig.defaults[key] as? Long ?: 0L) else value

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/PodcastSyncProcess.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/PodcastSyncProcess.kt
@@ -1057,7 +1057,8 @@ class PodcastSyncProcess(
 
                 // don't update if times are very close
                 val currentUpTo = episode.playedUpTo
-                if (playedUpTo < currentUpTo - 5 || playedUpTo > currentUpTo + 2) {
+                val negativeSeekThresholdSecs = settings.getPlaybackEpisodePositionChangedOnSyncThresholdSecs()
+                if (playedUpTo < currentUpTo - negativeSeekThresholdSecs || playedUpTo > currentUpTo + 2) {
                     episode.playedUpTo = playedUpTo
                     episode.playedUpToModified = null
                     if (episodeInPlayer) {

--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/config/FirebaseConfig.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/config/FirebaseConfig.kt
@@ -14,6 +14,7 @@ object FirebaseConfig {
     const val SLEEP_TIMER_DEVICE_SHAKE_THRESHOLD = "sleep_timer_device_shake_threshold"
     const val REFRESH_PODCASTS_BATCH_SIZE = "refresh_podcasts_batch_size"
     const val EXOPLAYER_CACHE_SIZE_IN_MB = "exoplayer_cache_size_in_mb"
+    const val PLAYBACK_EPISODE_POSITION_CHANGED_ON_SYNC_THRESHOLD_SECS = "playback_episode_position_changed_on_sync_threshold_secs"
     val defaults = mapOf(
         PERIODIC_SAVE_TIME_MS to 60000L,
         PLAYER_RELEASE_TIME_OUT_MS to 500L,
@@ -23,6 +24,7 @@ object FirebaseConfig {
         SLEEP_TIMER_DEVICE_SHAKE_THRESHOLD to 30L,
         REFRESH_PODCASTS_BATCH_SIZE to 200L,
         EXOPLAYER_CACHE_SIZE_IN_MB to if (BuildConfig.DEBUG) 100L else 0L,
+        PLAYBACK_EPISODE_POSITION_CHANGED_ON_SYNC_THRESHOLD_SECS to 5L,
     ) + Feature.values()
         .filter { it.hasFirebaseRemoteFlag }
         .associate { it.key to it.defaultValue }


### PR DESCRIPTION
## Description

The threshold to track negative seek on sync (for the currently paused episode) was set to 5 secs in PR #2292. Looking at early tracks for `playback_episode_position_changed_on_sync`, 99% of values are under 60 secs. This PR gets this threshold value from Firebase remote config, allowing us to experiment with the value. 

## Testing Instructions

I updated threshold from 5 to 10 secs in Firebase remote config and tested that the value is properly fetched in the release build:

![image](https://github.com/Automattic/pocket-casts-android/assets/1405144/787a211c-b269-4cfc-acde-2b021d9f5f9e)


It should be sufficient to just code-review the changes.


## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
