### PR TITLE
Attempt to fix app freezing when writing several podcast episodes to WAL 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 *   Health
     *   Increase target SDK version to 34 
         ([#2279](https://github.com/Automattic/pocket-casts-android/pull/2279))
+    *   Optimize writing large no. of podcast episodes into DB
+        ([#2324](https://github.com/Automattic/pocket-casts-android/pull/2324))
 *   Bug Fixes
     *   Fix: Search Term Persists When Navigating to Different Podcast Page
         ([#2286](https://github.com/Automattic/pocket-casts-android/pull/2286))

--- a/modules/features/podcasts/src/main/res/layout/adapter_episode.xml
+++ b/modules/features/podcasts/src/main/res/layout/adapter_episode.xml
@@ -184,6 +184,7 @@
                 android:src="@drawable/ic_upnext"
                 android:layout_gravity="center"
                 android:layout_marginEnd="4dp"
+                android:visibility="gone"
                 app:tint="?attr/support_01" />
             <ImageView
                 android:id="@+id/imgIcon"
@@ -202,6 +203,7 @@
                 android:src="@drawable/ic_bookmark"
                 android:layout_gravity="center"
                 android:layout_marginEnd="4dp"
+                android:visibility="gone"
                 app:tint="?attr/support_05" />
             <au.com.shiftyjelly.pocketcasts.views.component.ProgressCircleView
                 android:id="@+id/progressCircle"

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManagerImpl.kt
@@ -837,7 +837,9 @@ class EpisodeManagerImpl @Inject constructor(
             }
         }
         if (addedEpisodes.isNotEmpty()) {
-            episodeDao.insertAll(addedEpisodes)
+            addedEpisodes.chunked(250).forEach { chunkedEpisodes ->
+                episodeDao.insertAll(chunkedEpisodes)
+            }
         }
 
         if (episodes.isNotEmpty()) {

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/SubscribeManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/SubscribeManager.kt
@@ -197,10 +197,10 @@ class SubscribeManager @Inject constructor(
     private fun subscribeInsertEpisodes(podcast: Podcast): Completable {
         // insert the episodes
         return Completable.fromAction {
-                podcast.episodes.chunked(250).forEach { episodes ->
-                    episodeDao.insertAll(episodes)
-                }
+            podcast.episodes.chunked(250).forEach { episodes ->
+                episodeDao.insertAll(episodes)
             }
+        }
             // make sure the podcast has the latest episode uuid
             .andThen(updateLatestEpisodeUuid(podcast.uuid))
     }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/SubscribeManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/SubscribeManager.kt
@@ -196,7 +196,11 @@ class SubscribeManager @Inject constructor(
 
     private fun subscribeInsertEpisodes(podcast: Podcast): Completable {
         // insert the episodes
-        return Completable.fromAction { episodeDao.insertAll(podcast.episodes) }
+        return Completable.fromAction {
+                podcast.episodes.chunked(250).forEach { episodes ->
+                    episodeDao.insertAll(episodes)
+                }
+            }
             // make sure the podcast has the latest episode uuid
             .andThen(updateLatestEpisodeUuid(podcast.uuid))
     }

--- a/modules/services/views/src/main/res/layout/view_file_status_icons.xml
+++ b/modules/services/views/src/main/res/layout/view_file_status_icons.xml
@@ -42,6 +42,7 @@
         android:src="@drawable/ic_bookmark"
         android:layout_gravity="center"
         android:layout_marginEnd="4dp"
+        android:visibility="gone"
         app:tint="?attr/support_05" />
 
     <au.com.shiftyjelly.pocketcasts.views.component.ProgressCircleView
@@ -49,7 +50,8 @@
         android:layout_width="16dp"
         android:layout_height="16dp"
         android:layout_gravity="center"
-        android:layout_marginEnd="4dp" />
+        android:layout_marginEnd="4dp"
+        android:visibility="gone" />
 
     <ProgressBar
         android:id="@+id/progressBar"
@@ -57,7 +59,8 @@
         android:layout_width="16dp"
         android:layout_height="16dp"
         android:layout_gravity="center"
-        android:layout_marginEnd="4dp" />
+        android:layout_marginEnd="4dp"
+        android:visibility="gone" />
 
     <TextView
         android:id="@+id/lblStatus"


### PR DESCRIPTION
## Description

Attempt to fix: #2291

A podcast may have several episodes (can be even more than 2000). Writing all of them into a database in a single transaction may grow WAL size substantially, and shrinking it can lead to unexpected ANR as noticed in https://github.com/Automattic/pocket-casts-android/issues/2291.

This PR inserts podcast episodes in chunks to reduce chances of UI locking at the time of automatic checkpoint to shrink WAL file.

I also set initial visibility to false for episode row icons like bookmarks in f00eb9c8699204549e7c34e8cbc352b470295e0c to minimize icon flashing between tab switches.

## Testing Instructions

#### Test: How to reproduce?
1. Switch to `main` branch
2. Fresh install the app while being connected to adb 
3. Search for `truncating` in the logs
4. Login with an account having podcasts with lots of (> ~500) episodes. You can use the account in the secret store with secret_id: 12050.
5. Tap `Filters` tab
6. Select a filter
7. Toggle between `Filters` tab and any other tab (like `Discover`) so that quick read operations are performed while podcast episodes are written in the database
8. Notice in the logs: ```/data/user/0/au.com.shiftyjelly.pocketcasts.debug/databases/pocketcasts-wal <xxx> bytes: Bigger than 1048576; truncating```
9. During this time, UI may be blocked as shown in the video in issue: #2291


#### Test: Fix
1. Switch to this PR branch
2. Repeat steps 2-7 from above
3. Notice no such logs are shown: ```/data/user/0/au.com.shiftyjelly.pocketcasts.debug/databases/pocketcasts-wal <xxx> bytes: Bigger than 1048576; truncating``` for the above steps


## Screenshots or Screencast 

Before (main branch)


https://github.com/Automattic/pocket-casts-android/assets/1405144/5059b1fa-b1a6-47b2-a039-d25e353aa8b5



After (PR branch)


https://github.com/Automattic/pocket-casts-android/assets/1405144/b0034f7f-3010-493e-9b0f-a99ec3cc15d7




## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
