### PR TITLE
Remove flickering when double-tapping an item in the tab bar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
         ([#2286](https://github.com/Automattic/pocket-casts-android/pull/2286))
     *   Fix: Subscribe button is highlighted in green instead of gray in the carousel
         ([#2278](https://github.com/Automattic/pocket-casts-android/pull/2278))
+    *   Fix: Flickering when double-tapping an item in the tab bar
+        ([#2326](https://github.com/Automattic/pocket-casts-android/pull/2326))    
 *   Updates:
     *   Playback speed can now be changed up to 5x.
         ([#1645](https://github.com/Automattic/pocket-casts-android/pull/1645))

--- a/modules/features/navigation/src/main/java/au/com/shiftyjelly/pocketcasts/navigation/BottomNavigator.kt
+++ b/modules/features/navigation/src/main/java/au/com/shiftyjelly/pocketcasts/navigation/BottomNavigator.kt
@@ -90,7 +90,7 @@ open class BottomNavigator internal constructor() : ViewModel() {
                 if (resetRootFragmentSubject.hasObservers() && tabstackAndFragmentManagerInSync) {
                     resetRootFragmentSubject.onNext(currentFragment!!)
                 } else {
-                    reset(tab, true)
+                    reset(tab, false)
                 }
             } else {
                 reset(tab, false)


### PR DESCRIPTION
## Description
- This removes the flickering when taps on the current selected navigation tab bar
- See the video in https://github.com/Automattic/pocket-casts-android/issues/2149

Fixes #2149 

## Testing Instructions
1. Open the app
2. Tap on the current selected navigation item bar
3. ✅ Ensure you don't see the flickering anymore

## Screenshots or Screencast 
[Screen_recording_20240610_125111.webm](https://github.com/Automattic/pocket-casts-android/assets/42220351/ae8c6272-5a8b-4c7e-b9f5-c250b9c99d17)


## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack
