### PR TITLE
Wear app: Bring back email login for debug build

### DIFF
--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/MainActivity.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/MainActivity.kt
@@ -332,6 +332,9 @@ fun WearApp(
 
         authenticationNavGraph(
             navController = navController,
+            onEmailSignInSuccess = {
+                navController.navigate(LoggingInScreen.route)
+            },
             googleSignInSuccessScreen = { googleSignInAccount ->
                 LoggingInScreen(
                     avatarUrl = googleSignInAccount?.photoUrl?.toString(),

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/authentication/AuthenticationNavGraph.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/authentication/AuthenticationNavGraph.kt
@@ -1,3 +1,4 @@
+@file:Suppress("DEPRECATION")
 package au.com.shiftyjelly.pocketcasts.wear.ui.authentication
 
 import androidx.compose.runtime.Composable
@@ -5,6 +6,7 @@ import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.compose.navigation
 import com.google.android.gms.auth.api.signin.GoogleSignInAccount
+import com.google.android.horologist.compose.navscaffold.NavScaffoldViewModel
 import com.google.android.horologist.compose.navscaffold.composable
 import com.google.android.horologist.compose.navscaffold.scrollable
 
@@ -14,10 +16,12 @@ private object AuthenticationNavRoutes {
     const val loginScreen = "login_screen"
     const val loginWithGoogle = "login_with_google"
     const val loginWithPhone = "login_with_phone"
+    const val loginWithEmail = "login_with_email"
 }
 
 fun NavGraphBuilder.authenticationNavGraph(
     navController: NavController,
+    onEmailSignInSuccess: () -> Unit,
     googleSignInSuccessScreen: @Composable (GoogleSignInAccount?) -> Unit,
 ) {
     navigation(startDestination = AuthenticationNavRoutes.loginScreen, route = authenticationSubGraph) {
@@ -31,6 +35,17 @@ fun NavGraphBuilder.authenticationNavGraph(
                 onLoginWithPhoneClick = {
                     navController.navigate(AuthenticationNavRoutes.loginWithPhone)
                 },
+                onLoginWithEmailClick = {
+                    navController.navigate(AuthenticationNavRoutes.loginWithEmail)
+                },
+            )
+        }
+
+        @Suppress("DEPRECATION")
+        scrollable(AuthenticationNavRoutes.loginWithEmail) {
+            it.viewModel.timeTextMode = NavScaffoldViewModel.TimeTextMode.Off
+            LoginWithEmailScreen(
+                onSignInSuccess = onEmailSignInSuccess
             )
         }
 

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/authentication/AuthenticationNavGraph.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/authentication/AuthenticationNavGraph.kt
@@ -1,4 +1,5 @@
 @file:Suppress("DEPRECATION")
+
 package au.com.shiftyjelly.pocketcasts.wear.ui.authentication
 
 import androidx.compose.runtime.Composable
@@ -45,7 +46,7 @@ fun NavGraphBuilder.authenticationNavGraph(
         scrollable(AuthenticationNavRoutes.loginWithEmail) {
             it.viewModel.timeTextMode = NavScaffoldViewModel.TimeTextMode.Off
             LoginWithEmailScreen(
-                onSignInSuccess = onEmailSignInSuccess
+                onSignInSuccess = onEmailSignInSuccess,
             )
         }
 

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/authentication/LoginScreen.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/authentication/LoginScreen.kt
@@ -16,6 +16,7 @@ fun LoginScreen(
     columnState: ScalingLazyColumnState,
     onLoginWithGoogleClick: () -> Unit,
     onLoginWithPhoneClick: () -> Unit,
+    onLoginWithEmailClick: () -> Unit,
 ) {
     val viewModel = hiltViewModel<LoginViewModel>()
 
@@ -46,6 +47,18 @@ fun LoginScreen(
                 onClick = {
                     viewModel.onPhoneLoginClicked()
                     onLoginWithPhoneClick()
+                },
+            )
+        }
+
+        item {
+            Chip(
+                labelId = LR.string.log_in_with_email,
+                colors = ChipDefaults.secondaryChipColors(),
+                icon = DrawableResPaintable(IR.drawable.ic_email_white_24dp),
+                onClick = {
+                    viewModel.onEmailLoginClicked()
+                    onLoginWithEmailClick()
                 },
             )
         }

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/authentication/LoginScreen.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/authentication/LoginScreen.kt
@@ -3,6 +3,7 @@ package au.com.shiftyjelly.pocketcasts.wear.ui.authentication
 import androidx.compose.runtime.Composable
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.wear.compose.material.ChipDefaults
+import au.com.shiftyjelly.pocketcasts.compose.BuildConfig
 import au.com.shiftyjelly.pocketcasts.compose.CallOnce
 import com.google.android.horologist.compose.layout.ScalingLazyColumn
 import com.google.android.horologist.compose.layout.ScalingLazyColumnState
@@ -51,16 +52,18 @@ fun LoginScreen(
             )
         }
 
-        item {
-            Chip(
-                labelId = LR.string.log_in_with_email,
-                colors = ChipDefaults.secondaryChipColors(),
-                icon = DrawableResPaintable(IR.drawable.ic_email_white_24dp),
-                onClick = {
-                    viewModel.onEmailLoginClicked()
-                    onLoginWithEmailClick()
-                },
-            )
+        if (BuildConfig.DEBUG) {
+            item {
+                Chip(
+                    labelId = LR.string.log_in_with_email,
+                    colors = ChipDefaults.secondaryChipColors(),
+                    icon = DrawableResPaintable(IR.drawable.ic_email_white_24dp),
+                    onClick = {
+                        viewModel.onEmailLoginClicked()
+                        onLoginWithEmailClick()
+                    },
+                )
+            }
         }
     }
 }

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/authentication/LoginWithEmailScreen.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/authentication/LoginWithEmailScreen.kt
@@ -1,0 +1,138 @@
+package au.com.shiftyjelly.pocketcasts.wear.ui.authentication
+
+import android.app.RemoteInput
+import android.content.Intent
+import android.os.Bundle
+import android.view.inputmethod.EditorInfo
+import androidx.activity.compose.ManagedActivityResultLauncher
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.ActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.livedata.observeAsState
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.wear.input.RemoteInputIntentHelper
+import androidx.wear.input.wearableExtender
+import au.com.shiftyjelly.pocketcasts.account.viewmodel.SignInState
+import au.com.shiftyjelly.pocketcasts.account.viewmodel.SignInViewModel
+import au.com.shiftyjelly.pocketcasts.wear.ui.component.ErrorScreen
+import au.com.shiftyjelly.pocketcasts.wear.ui.component.LoadingSpinner
+import au.com.shiftyjelly.pocketcasts.localization.R as LR
+
+@Composable
+fun LoginWithEmailScreen(
+    onSignInSuccess: () -> Unit,
+) {
+
+    val viewModel = hiltViewModel<SignInViewModel>()
+    val signInState by viewModel.signInState.observeAsState()
+    val email by viewModel.email.observeAsState()
+    val password by viewModel.password.observeAsState()
+
+    var loading by remember { mutableStateOf(false) }
+
+    when (signInState) {
+        null,
+        SignInState.Empty -> {
+            loading = false
+
+            if (email.isNullOrBlank()) {
+                val label = stringResource(LR.string.enter_email)
+                val launcher = getLauncher { viewModel.updateEmail(it) }
+                LaunchedEffect(Unit) {
+                    launchRemoteInput(label, launcher)
+                }
+            } else if (password.isNullOrEmpty()) {
+                val label = stringResource(LR.string.enter_password)
+                val launcher = getLauncher {
+                    viewModel.updatePassword(it)
+                }
+                LaunchedEffect(Unit) {
+                    launchRemoteInput(label, launcher)
+                }
+            } else {
+                viewModel.signIn()
+            }
+        }
+
+        SignInState.Loading -> {
+            loading = true
+        }
+
+        is SignInState.Success -> {
+            LaunchedEffect(Unit) {
+                onSignInSuccess()
+            }
+        }
+
+        is SignInState.Failure -> {
+            loading = false
+            val currentState = signInState as? SignInState.Failure
+            val message = currentState?.message
+                ?: stringResource(
+                    currentState?.errors?.last()?.message
+                        ?: LR.string.error_login_failed
+                )
+            ErrorScreen(message)
+        }
+    }
+
+    if (loading) {
+        Loading()
+    }
+}
+
+@Composable
+private fun Loading() {
+    Box(
+        contentAlignment = Alignment.Center,
+        modifier = Modifier.fillMaxSize(),
+    ) {
+        LoadingSpinner(Modifier.size(36.dp))
+    }
+}
+
+private const val key = "key"
+
+@Composable
+private fun getLauncher(onResult: (String) -> Unit) =
+    rememberLauncherForActivityResult(ActivityResultContracts.StartActivityForResult()) {
+        it.data?.let { data ->
+            val results: Bundle = RemoteInput.getResultsFromIntent(data)
+            results.getCharSequence(key)?.let { chars ->
+                onResult(chars.toString())
+            }
+        }
+    }
+
+private fun launchRemoteInput(
+    label: String,
+    launcher: ManagedActivityResultLauncher<Intent, ActivityResult>,
+) {
+    val remoteInputs: List<RemoteInput> = listOf(
+        RemoteInput.Builder(key)
+            .setLabel(label)
+            .wearableExtender {
+                setEmojisAllowed(false)
+                setInputActionType(EditorInfo.IME_ACTION_DONE)
+            }
+            .build()
+    )
+
+    val intent: Intent = RemoteInputIntentHelper.createActionRemoteInputIntent()
+    RemoteInputIntentHelper.putRemoteInputsExtra(intent, remoteInputs)
+
+    launcher.launch(intent)
+}

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/authentication/LoginWithEmailScreen.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/authentication/LoginWithEmailScreen.kt
@@ -35,7 +35,6 @@ import au.com.shiftyjelly.pocketcasts.localization.R as LR
 fun LoginWithEmailScreen(
     onSignInSuccess: () -> Unit,
 ) {
-
     val viewModel = hiltViewModel<SignInViewModel>()
     val signInState by viewModel.signInState.observeAsState()
     val email by viewModel.email.observeAsState()
@@ -45,7 +44,8 @@ fun LoginWithEmailScreen(
 
     when (signInState) {
         null,
-        SignInState.Empty -> {
+        SignInState.Empty,
+        -> {
             loading = false
 
             if (email.isNullOrBlank()) {
@@ -83,7 +83,7 @@ fun LoginWithEmailScreen(
             val message = currentState?.message
                 ?: stringResource(
                     currentState?.errors?.last()?.message
-                        ?: LR.string.error_login_failed
+                        ?: LR.string.error_login_failed,
                 )
             ErrorScreen(message)
         }
@@ -128,7 +128,7 @@ private fun launchRemoteInput(
                 setEmojisAllowed(false)
                 setInputActionType(EditorInfo.IME_ACTION_DONE)
             }
-            .build()
+            .build(),
     )
 
     val intent: Intent = RemoteInputIntentHelper.createActionRemoteInputIntent()


### PR DESCRIPTION
## Description

It isn't easy to login on emulators for testing. This brings back login with an email option (which was removed in https://github.com/Automattic/pocket-casts-android/pull/1357) for debug builds.

## Testing Instructions

### Debug build
1. Install debug/ debugProd build on Wear emulator
2. Tap login
3. ✅  Notice you can see Log in with email option
4. Login using a paid account
5. ✅  Login should be successful

### Release build
1. Install the release build on Wear emulator
2. Tap login
3. ✅  Notice you do not see Log in with email option


## Screenshots or Screencast 
Debug | Release
---|---
![debug](https://github.com/Automattic/pocket-casts-android/assets/1405144/3e4bcb24-cdf6-40cd-ab0e-bed76848ba00)| ![release](https://github.com/Automattic/pocket-casts-android/assets/1405144/36b1c2c8-eb79-483c-a248-17fbe0e4d484)


## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
