### PR TITLE
Use latest Nova SDK to sync subscribed podcasts

### DIFF
--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/models/db/PodcastDaoTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/models/db/PodcastDaoTest.kt
@@ -12,6 +12,7 @@ import au.com.shiftyjelly.pocketcasts.models.entity.NovaLauncherTrendingPodcast
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.models.entity.TrendingPodcast
+import au.com.shiftyjelly.pocketcasts.models.type.PodcastsSortType
 import au.com.shiftyjelly.pocketcasts.utils.extensions.timeSecs
 import java.time.Instant
 import java.time.temporal.ChronoUnit
@@ -121,26 +122,27 @@ class PodcastDaoTest {
     @Test
     fun useCorrectReleaseTimestampsForNovaLauncherSubscribedPodcasts() = runTest {
         podcastDao.insert(Podcast(uuid = "id-1", title = "title-1", isSubscribed = true))
-        episodeDao.insert(PodcastEpisode(uuid = "id-1", publishedDate = Date(0), podcastUuid = "id-1", lastPlaybackInteraction = 10000))
-        episodeDao.insert(PodcastEpisode(uuid = "id-2", publishedDate = Date(2000), podcastUuid = "id-1", lastPlaybackInteraction = null))
-        episodeDao.insert(PodcastEpisode(uuid = "id-3", publishedDate = Date(1000), podcastUuid = "id-1", lastPlaybackInteraction = 13000))
+        episodeDao.insert(PodcastEpisode(uuid = "id-1", publishedDate = Date(0), podcastUuid = "id-1", lastPlaybackInteraction = 10))
+        episodeDao.insert(PodcastEpisode(uuid = "id-2", publishedDate = Date(2), podcastUuid = "id-1", lastPlaybackInteraction = null))
+        episodeDao.insert(PodcastEpisode(uuid = "id-3", publishedDate = Date(1), podcastUuid = "id-1", lastPlaybackInteraction = 13))
 
         podcastDao.insert(Podcast(uuid = "id-2", title = "title-2", isSubscribed = true))
-        episodeDao.insert(PodcastEpisode(uuid = "id-4", publishedDate = Date(5000), podcastUuid = "id-2", lastPlaybackInteraction = 0))
-        episodeDao.insert(PodcastEpisode(uuid = "id-5", publishedDate = Date(4000), podcastUuid = "id-2", lastPlaybackInteraction = 20000))
-        episodeDao.insert(PodcastEpisode(uuid = "id-6", publishedDate = Date(3000), podcastUuid = "id-2", lastPlaybackInteraction = 25000))
+        episodeDao.insert(PodcastEpisode(uuid = "id-4", publishedDate = Date(5), podcastUuid = "id-2", lastPlaybackInteraction = 0))
+        episodeDao.insert(PodcastEpisode(uuid = "id-5", publishedDate = Date(4), podcastUuid = "id-2", lastPlaybackInteraction = 20))
+        episodeDao.insert(PodcastEpisode(uuid = "id-6", publishedDate = Date(3), podcastUuid = "id-2", lastPlaybackInteraction = 25))
 
         podcastDao.insert(Podcast(uuid = "id-3", title = "title-3", isSubscribed = true))
-        episodeDao.insert(PodcastEpisode(uuid = "id-7", publishedDate = Date(12000), podcastUuid = "id-3", lastPlaybackInteraction = 0))
+        episodeDao.insert(PodcastEpisode(uuid = "id-7", publishedDate = Date(12), podcastUuid = "id-3", lastPlaybackInteraction = 0))
 
         podcastDao.insert(Podcast(uuid = "id-4", title = "title-4", isSubscribed = true))
 
-        val podcasts = podcastDao.getNovaLauncherSubscribedPodcasts()
+        val podcasts = podcastDao.getNovaLauncherSubscribedPodcasts(PodcastsSortType.NAME_A_TO_Z, limit = 100)
 
         val expected = listOf(
             NovaLauncherSubscribedPodcast(
                 id = "id-1",
                 title = "title-1",
+                categories = "",
                 initialReleaseTimestamp = 0,
                 latestReleaseTimestamp = 2,
                 lastUsedTimestamp = 13,
@@ -148,6 +150,7 @@ class PodcastDaoTest {
             NovaLauncherSubscribedPodcast(
                 id = "id-2",
                 title = "title-2",
+                categories = "",
                 initialReleaseTimestamp = 3,
                 latestReleaseTimestamp = 5,
                 lastUsedTimestamp = 25,
@@ -155,6 +158,7 @@ class PodcastDaoTest {
             NovaLauncherSubscribedPodcast(
                 id = "id-3",
                 title = "title-3",
+                categories = "",
                 initialReleaseTimestamp = 12,
                 latestReleaseTimestamp = 12,
                 lastUsedTimestamp = 0,
@@ -162,6 +166,7 @@ class PodcastDaoTest {
             NovaLauncherSubscribedPodcast(
                 id = "id-4",
                 title = "title-4",
+                categories = "",
                 initialReleaseTimestamp = null,
                 latestReleaseTimestamp = null,
                 lastUsedTimestamp = null,
@@ -182,18 +187,120 @@ class PodcastDaoTest {
         episodeDao.insert(PodcastEpisode(uuid = "id-5", publishedDate = Date(0), podcastUuid = "id-2"))
         episodeDao.insert(PodcastEpisode(uuid = "id-6", publishedDate = Date(0), podcastUuid = "id-2"))
 
-        val podcasts = podcastDao.getNovaLauncherSubscribedPodcasts()
+        val podcasts = podcastDao.getNovaLauncherSubscribedPodcasts(PodcastsSortType.NAME_A_TO_Z, limit = 100)
 
         val expected = listOf(
             NovaLauncherSubscribedPodcast(
                 id = "id-1",
                 title = "title-1",
+                categories = "",
                 initialReleaseTimestamp = 0,
                 latestReleaseTimestamp = 0,
                 lastUsedTimestamp = null,
             ),
         )
         assertEquals(expected, podcasts)
+    }
+
+    @Test
+    fun includeCategoriesForNovaLauncherSubscribedPodcasts() = runTest {
+        podcastDao.insert(Podcast(uuid = "id-1", title = "title-1", isSubscribed = true, podcastCategory = "category-1"))
+
+        val podcasts = podcastDao.getNovaLauncherSubscribedPodcasts(PodcastsSortType.NAME_A_TO_Z, limit = 100)
+
+        val expected = listOf(
+            NovaLauncherSubscribedPodcast(
+                id = "id-1",
+                title = "title-1",
+                categories = "category-1",
+                initialReleaseTimestamp = null,
+                latestReleaseTimestamp = null,
+                lastUsedTimestamp = null,
+            ),
+        )
+        assertEquals(expected, podcasts)
+    }
+
+    @Test
+    fun sortNovaLauncherSubscribedPodcastsByAddedDate() = runTest {
+        podcastDao.insert(Podcast(uuid = "id-1", title = "title-1", isSubscribed = true, addedDate = Date(3)))
+        podcastDao.insert(Podcast(uuid = "id-2", title = "title-2", isSubscribed = true, addedDate = Date(4)))
+        podcastDao.insert(Podcast(uuid = "id-3", title = "title-3", isSubscribed = true, addedDate = Date(2)))
+        podcastDao.insert(Podcast(uuid = "id-4", title = "title-4", isSubscribed = true, addedDate = Date(1)))
+        podcastDao.insert(Podcast(uuid = "id-5", title = "title-5", isSubscribed = true, addedDate = null))
+
+        val podcastIds = podcastDao.getNovaLauncherSubscribedPodcasts(PodcastsSortType.DATE_ADDED_OLDEST_TO_NEWEST, limit = 100).map { it.id }
+
+        assertEquals(listOf("id-4", "id-3", "id-1", "id-2", "id-5"), podcastIds)
+    }
+
+    @Test
+    fun sortNovaLauncherSubscribedPodcastsByTitle() = runTest {
+        podcastDao.insert(Podcast(uuid = "id-1", title = "title-4", isSubscribed = true))
+        podcastDao.insert(Podcast(uuid = "id-2", title = "title-3", isSubscribed = true))
+        podcastDao.insert(Podcast(uuid = "id-3", title = "title-1", isSubscribed = true))
+        podcastDao.insert(Podcast(uuid = "id-4", title = "title-2", isSubscribed = true))
+
+        val podcastIds = podcastDao.getNovaLauncherSubscribedPodcasts(PodcastsSortType.NAME_A_TO_Z, limit = 100).map { it.id }
+
+        assertEquals(listOf("id-3", "id-4", "id-2", "id-1"), podcastIds)
+    }
+
+    @Test
+    fun sortingNovaLauncherSubscribedPodcastsByTitleOmitsEnglishArticles() = runTest {
+        podcastDao.insert(Podcast(uuid = "id-1", title = "The 1", isSubscribed = true))
+        podcastDao.insert(Podcast(uuid = "id-2", title = "An 2", isSubscribed = true))
+        podcastDao.insert(Podcast(uuid = "id-3", title = "A 3", isSubscribed = true))
+        podcastDao.insert(Podcast(uuid = "id-4", title = "4", isSubscribed = true))
+        podcastDao.insert(Podcast(uuid = "id-5", title = "the 5", isSubscribed = true))
+        podcastDao.insert(Podcast(uuid = "id-6", title = "an 6", isSubscribed = true))
+        podcastDao.insert(Podcast(uuid = "id-7", title = "a 7", isSubscribed = true))
+        podcastDao.insert(Podcast(uuid = "id-8", title = "8", isSubscribed = true))
+
+        val podcastIds = podcastDao.getNovaLauncherSubscribedPodcasts(PodcastsSortType.NAME_A_TO_Z, limit = 100).map { it.id }
+
+        assertEquals(listOf("id-1", "id-2", "id-3", "id-4", "id-5", "id-6", "id-7", "id-8"), podcastIds)
+    }
+
+    @Test
+    fun sortNovaLauncherSubscribedPodcastsByLatestReleaseTimestamp() = runTest {
+        podcastDao.insert(Podcast(uuid = "id-1", title = "title-1", isSubscribed = true))
+        episodeDao.insert(PodcastEpisode(uuid = "id-1", publishedDate = Date(0), podcastUuid = "id-1"))
+
+        podcastDao.insert(Podcast(uuid = "id-2", title = "title-2", isSubscribed = true))
+        episodeDao.insert(PodcastEpisode(uuid = "id-2", publishedDate = Date(100), podcastUuid = "id-2"))
+
+        podcastDao.insert(Podcast(uuid = "id-3", title = "title-3", isSubscribed = true))
+
+        podcastDao.insert(Podcast(uuid = "id-4", title = "title-4", isSubscribed = true))
+        episodeDao.insert(PodcastEpisode(uuid = "id-3", publishedDate = Date(200), podcastUuid = "id-4"))
+
+        val podcastIds = podcastDao.getNovaLauncherSubscribedPodcasts(PodcastsSortType.EPISODE_DATE_NEWEST_TO_OLDEST, limit = 100).map { it.id }
+
+        assertEquals(listOf("id-4", "id-2", "id-1", "id-3"), podcastIds)
+    }
+
+    @Test
+    fun sortNovaLauncherSubscribedPodcastsByCustomSortOrder() = runTest {
+        podcastDao.insert(Podcast(uuid = "id-1", title = "title-1", isSubscribed = true, sortPosition = 3))
+        podcastDao.insert(Podcast(uuid = "id-2", title = "title-2", isSubscribed = true, sortPosition = 1))
+        podcastDao.insert(Podcast(uuid = "id-3", title = "title-3", isSubscribed = true, sortPosition = 2))
+        podcastDao.insert(Podcast(uuid = "id-4", title = "title-4", isSubscribed = true, sortPosition = 4))
+
+        val podcastIds = podcastDao.getNovaLauncherSubscribedPodcasts(PodcastsSortType.DRAG_DROP, limit = 100).map { it.id }
+
+        assertEquals(listOf("id-2", "id-3", "id-1", "id-4"), podcastIds)
+    }
+
+    @Test
+    fun limitNovaLauncherSubscribedPodcasts() = runTest {
+        List(250) {
+            podcastDao.insert(Podcast(uuid = "id-$it", isSubscribed = true))
+        }
+
+        val podcasts = podcastDao.getNovaLauncherSubscribedPodcasts(PodcastsSortType.NAME_A_TO_Z, limit = 60)
+
+        assertEquals(60, podcasts.size)
     }
 
     @Test

--- a/modules/features/nova/build.gradle.kts
+++ b/modules/features/nova/build.gradle.kts
@@ -18,7 +18,7 @@ android {
 
 dependencies {
     // AAR dependencies cannot be resolved with Version Catalogs https://github.com/gradle/gradle/issues/20074
-    implementation("io.branch.engage:conduit-source:0.2.3-pocketcasts.4@aar") { isTransitive = true }
+    implementation("io.branch.engage:conduit-source:0.2.3-pocketcasts.9@aar") { isTransitive = true }
 
     implementation(project(":modules:services:analytics"))
     implementation(project(":modules:services:localization"))

--- a/modules/features/nova/src/main/kotlin/au/com/shiftyjelly/pocketcasts/nova/CatalogFactory.kt
+++ b/modules/features/nova/src/main/kotlin/au/com/shiftyjelly/pocketcasts/nova/CatalogFactory.kt
@@ -2,145 +2,44 @@ package au.com.shiftyjelly.pocketcasts.nova
 
 import android.content.Context
 import au.com.shiftyjelly.pocketcasts.analytics.SourceView
-import au.com.shiftyjelly.pocketcasts.models.entity.NovaLauncherInProgressEpisode
-import au.com.shiftyjelly.pocketcasts.models.entity.NovaLauncherNewEpisode
-import au.com.shiftyjelly.pocketcasts.models.entity.NovaLauncherRecentlyPlayedPodcast
 import au.com.shiftyjelly.pocketcasts.models.entity.NovaLauncherSubscribedPodcast
-import au.com.shiftyjelly.pocketcasts.models.entity.NovaLauncherTrendingPodcast
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
-import io.branch.engage.conduit.source.Catalog
-import io.branch.engage.conduit.source.CatalogItem
-import io.branch.engage.conduit.source.CatalogType
-import io.branch.engage.conduit.source.TypeData
+import io.branch.engage.conduit.source.ApplePodcastCategory
+import io.branch.engage.conduit.source.Image
+import io.branch.engage.conduit.source.PodcastSeries
+import io.branch.engage.conduit.source.PodcastSeriesCatalog
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 internal class CatalogFactory(
     private val context: Context,
 ) {
-    fun subscribedPodcasts(data: List<NovaLauncherSubscribedPodcast>) = Catalog(
-        id = "SubscribedPodcasts",
-        label = context.getString(LR.string.nova_launcher_subscribed_podcasts),
-        items = data.map { podcast ->
-            CatalogItem.Base(
-                id = podcast.id,
-                intent = podcast.intent,
-                lastUsedTimestamp = podcast.lastUsedTimestamp,
-                typeData = TypeData.Podcast(
-                    name = podcast.title,
-                    iconUrl = podcast.coverUrl,
-                    originalReleaseTimestamp = podcast.initialReleaseTimestamp,
-                    latestReleaseTimestamp = podcast.latestReleaseTimestamp,
-                ),
-            )
-        },
-    )
-
-    fun recentlyPlayedPodcasts(data: List<NovaLauncherRecentlyPlayedPodcast>) = Catalog(
-        id = "RecentlyPlayed",
-        label = context.getString(LR.string.nova_launcher_recently_played),
-        type = CatalogType.CONTINUE,
-        items = data.map { podcast ->
-            CatalogItem.Base(
-                id = podcast.id,
-                intent = podcast.intent,
-                lastUsedTimestamp = podcast.lastUsedTimestamp,
-                typeData = TypeData.Podcast(
-                    name = podcast.title,
-                    iconUrl = podcast.coverUrl,
-                    originalReleaseTimestamp = podcast.initialReleaseTimestamp,
-                    latestReleaseTimestamp = podcast.latestReleaseTimestamp,
-                ),
-            )
-        },
-    )
-
-    fun trendingPodcasts(data: List<NovaLauncherTrendingPodcast>) = Catalog(
-        id = "TrendingPodcasts",
-        label = context.getString(LR.string.nova_launcher_trending),
-        type = CatalogType.TRENDING,
-        items = data.map { podcast ->
-            CatalogItem.Base(
-                id = podcast.id,
-                intent = podcast.intent,
-                typeData = TypeData.Podcast(
-                    name = podcast.title,
-                    iconUrl = podcast.coverUrl,
-                    originalReleaseTimestamp = null,
-                    latestReleaseTimestamp = null,
-                ),
-            )
-        },
-    )
-
-    fun newEpisodes(data: List<NovaLauncherNewEpisode>) = Catalog(
-        id = "NewReleases",
-        label = context.getString(LR.string.nova_launcher_new_releases),
-        items = data.map { episode ->
-            CatalogItem.Base(
-                id = episode.id,
-                intent = context.launcherIntent,
-                lastUsedTimestamp = episode.lastUsedTimestamp,
-                typeData = TypeData.PodcastEpisode(
-                    name = episode.title,
-                    iconUrl = episode.coverUrl,
-                    seasonNumber = episode.seasonNumber,
-                    episodeNumber = episode.episodeNumber,
-                    releaseTimestamp = episode.releaseTimestamp,
-                    lengthSeconds = episode.duration,
-                    currentPositionSeconds = episode.currentPosition,
-                ),
-            )
-        },
-    )
-
-    fun inProgressEpisodes(data: List<NovaLauncherInProgressEpisode>) = Catalog(
-        id = "ContinueListening",
-        label = context.getString(LR.string.nova_launcher_continue_listening),
-        type = CatalogType.CONTINUE,
-        items = data.map { episode ->
-            CatalogItem.Base(
-                id = episode.id,
-                intent = context.launcherIntent,
-                lastUsedTimestamp = episode.lastUsedTimestamp,
-                typeData = TypeData.PodcastEpisode(
-                    name = episode.title,
-                    iconUrl = episode.coverUrl,
-                    seasonNumber = episode.seasonNumber,
-                    episodeNumber = episode.episodeNumber,
-                    releaseTimestamp = episode.releaseTimestamp,
-                    lengthSeconds = episode.duration,
-                    currentPositionSeconds = episode.currentPosition,
-                ),
-            )
-        },
-    )
+    fun subscribedPodcasts(data: List<NovaLauncherSubscribedPodcast>) = PodcastSeriesCatalog("SubscribedPodcasts")
+        .setLabel(context.getString(LR.string.nova_launcher_subscribed_podcasts))
+        .setPreferredAspectRatio(1, 1)
+        .addAllItems(
+            data.mapIndexed { index, podcast ->
+                PodcastSeries(podcast.id)
+                    .setRank(index.toLong()) // Our queries sort podcasts in a desired order.
+                    .setOpensDirectlyTo(podcast.intent)
+                    .setName(podcast.title)
+                    .setIcon(Image.WebUrl(podcast.coverUrl, 1 to 1))
+                    .setLastUsedTimestamp(podcast.lastUsedTimestamp)
+                    .setOriginalReleaseTimestamp(podcast.initialReleaseTimestamp)
+                    .setLatestReleaseTimestamp(podcast.latestReleaseTimestamp)
+                    .addAllCategories(ApplePodcastCategory.fromCategories(podcast.categories))
+            },
+        )
 
     private val NovaLauncherSubscribedPodcast.coverUrl get() = "${Settings.SERVER_STATIC_URL}/discover/images/webp/960/$id.webp"
 
     private val NovaLauncherSubscribedPodcast.intent get() = context.launcherIntent
         .setAction(Settings.INTENT_OPEN_APP_PODCAST_UUID)
         .putExtra(Settings.PODCAST_UUID, id)
-        .putExtra(Settings.SOURCE_VIEW, SourceView.NOVA_LAUNCHER.analyticsValue)
-
-    private val NovaLauncherRecentlyPlayedPodcast.coverUrl get() = "${Settings.SERVER_STATIC_URL}/discover/images/webp/960/$id.webp"
-
-    private val NovaLauncherRecentlyPlayedPodcast.intent get() = context.launcherIntent
-        .setAction(Settings.INTENT_OPEN_APP_PODCAST_UUID)
-        .putExtra(Settings.PODCAST_UUID, id)
-        .putExtra(Settings.SOURCE_VIEW, SourceView.NOVA_LAUNCHER.analyticsValue)
-
-    private val NovaLauncherTrendingPodcast.coverUrl get() = "${Settings.SERVER_STATIC_URL}/discover/images/webp/960/$id.webp"
-
-    private val NovaLauncherTrendingPodcast.intent get() = context.launcherIntent
-        .setAction(Settings.INTENT_OPEN_APP_PODCAST_UUID)
-        .putExtra(Settings.PODCAST_UUID, id)
-        .putExtra(Settings.SOURCE_VIEW, SourceView.NOVA_LAUNCHER.analyticsValue)
-
-    private val NovaLauncherNewEpisode.coverUrl get() = "${Settings.SERVER_STATIC_URL}/discover/images/webp/960/$podcastId.webp"
-
-    private val NovaLauncherInProgressEpisode.coverUrl get() = "${Settings.SERVER_STATIC_URL}/discover/images/webp/960/$podcastId.webp"
+        .putExtra(Settings.SOURCE_VIEW, SourceView.NOVA_LAUNCHER_SUBSCRIBED_PODCASTS.analyticsValue)
 
     private val Context.launcherIntent get() = requireNotNull(packageManager.getLaunchIntentForPackage(packageName)) {
         "Missing launcher intent for $packageName"
     }
+
+    private fun ApplePodcastCategory.Companion.fromCategories(categories: String) = categories.split('\n').mapNotNull(ApplePodcastCategory::valueOfSafe)
 }

--- a/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/SourceView.kt
+++ b/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/SourceView.kt
@@ -23,7 +23,7 @@ enum class SourceView(val analyticsValue: String) {
     MULTI_SELECT("multi_select"),
     NOTIFICATION("notification"),
     NOTIFICATION_BOOKMARK("notification_bookmark"),
-    NOVA_LAUNCHER("nova_launcher"),
+    NOVA_LAUNCHER_SUBSCRIBED_PODCASTS("nova_launcher_subscribed_podcasts"),
     ONBOARDING_RECOMMENDATIONS("onboarding_recommendations"),
     ONBOARDING_RECOMMENDATIONS_SEARCH("onboarding_recommendations_search"),
     PLAYER("player"),

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/PodcastDao.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/PodcastDao.kt
@@ -19,6 +19,7 @@ import au.com.shiftyjelly.pocketcasts.models.to.AutoArchiveLimit
 import au.com.shiftyjelly.pocketcasts.models.to.PodcastGrouping
 import au.com.shiftyjelly.pocketcasts.models.type.EpisodeStatusEnum
 import au.com.shiftyjelly.pocketcasts.models.type.EpisodesSortType
+import au.com.shiftyjelly.pocketcasts.models.type.PodcastsSortType
 import au.com.shiftyjelly.pocketcasts.models.type.TrimMode
 import io.reactivex.Completable
 import io.reactivex.Flowable
@@ -409,17 +410,36 @@ abstract class PodcastDao {
         SELECT 
           podcasts.uuid AS id, 
           podcasts.title AS title, 
-          -- Divide by 1000 to convert milliseconds that we store to seconds that Nova Launcher expects
-          (SELECT MIN(podcast_episodes.published_date) / 1000 FROM podcast_episodes WHERE podcasts.uuid IS podcast_episodes.podcast_id) AS initial_release_timestamp, 
-          (SELECT MAX(podcast_episodes.published_date) / 1000 FROM podcast_episodes WHERE podcasts.uuid IS podcast_episodes.podcast_id) AS latest_release_timestamp,
-          (SELECT MAX(podcast_episodes.last_playback_interaction_date) / 1000 FROM podcast_episodes WHERE podcasts.uuid IS podcast_episodes.podcast_id) AS last_used_timestamp
+          podcasts.podcast_category AS podcast_category,
+          (SELECT MIN(podcast_episodes.published_date) FROM podcast_episodes WHERE podcasts.uuid IS podcast_episodes.podcast_id) AS initial_release_timestamp, 
+          (SELECT MAX(podcast_episodes.published_date) FROM podcast_episodes WHERE podcasts.uuid IS podcast_episodes.podcast_id) AS latest_release_timestamp,
+          (SELECT MAX(podcast_episodes.last_playback_interaction_date) FROM podcast_episodes WHERE podcasts.uuid IS podcast_episodes.podcast_id) AS last_used_timestamp
         FROM 
           podcasts 
         WHERE 
           podcasts.subscribed IS NOT 0
+        ORDER BY
+          -- Order by oldest to newest date added
+          CASE WHEN :sortOrder IS 0 THEN IFNULL(podcasts.added_date, 9223372036854775807) END ASC,
+          -- Order by A-Z podcast title
+          CASE WHEN :sortOrder IS 1 THEN (CASE
+            WHEN UPPER(podcasts.title) LIKE 'THE %' THEN SUBSTR(UPPER(podcasts.title), 5)
+            WHEN UPPER(podcasts.title) LIKE 'A %' THEN SUBSTR(UPPER(podcasts.title), 3)
+            WHEN UPPER(podcasts.title) LIKE 'AN %' THEN SUBSTR(UPPER(podcasts.title), 4)
+            ELSE UPPER(podcasts.title)
+          END) END ASC,
+          -- Order by newest to oldest episode
+          CASE WHEN :sortOrder IS 2 THEN (SELECT IFNULL(MAX(podcast_episodes.published_date), 0) FROM podcast_episodes WHERE podcasts.uuid IS podcast_episodes.podcast_id) END DESC,
+          -- Order by drag and drop position
+          CASE WHEN :sortOrder IS 3 THEN IFNULL(podcasts.sort_order, 9223372036854775807) END ASC
+        LIMIT
+          :limit
         """,
     )
-    abstract suspend fun getNovaLauncherSubscribedPodcasts(): List<NovaLauncherSubscribedPodcast>
+    abstract suspend fun getNovaLauncherSubscribedPodcasts(
+        sortOrder: PodcastsSortType,
+        limit: Int,
+    ): List<NovaLauncherSubscribedPodcast>
 
     @Query(
         """

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/entity/NovaLauncherSubscribedPodcast.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/entity/NovaLauncherSubscribedPodcast.kt
@@ -5,6 +5,7 @@ import androidx.room.ColumnInfo
 data class NovaLauncherSubscribedPodcast(
     @ColumnInfo(name = "id") val id: String,
     @ColumnInfo(name = "title") val title: String,
+    @ColumnInfo(name = "podcast_category") val categories: String,
     @ColumnInfo(name = "initial_release_timestamp") val initialReleaseTimestamp: Long?,
     @ColumnInfo(name = "latest_release_timestamp") val latestReleaseTimestamp: Long?,
     @ColumnInfo(name = "last_used_timestamp") val lastUsedTimestamp: Long?,

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/nova/NovaLauncherManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/nova/NovaLauncherManager.kt
@@ -7,7 +7,7 @@ import au.com.shiftyjelly.pocketcasts.models.entity.NovaLauncherSubscribedPodcas
 import au.com.shiftyjelly.pocketcasts.models.entity.NovaLauncherTrendingPodcast
 
 interface NovaLauncherManager {
-    suspend fun getSubscribedPodcasts(): List<NovaLauncherSubscribedPodcast>
+    suspend fun getSubscribedPodcasts(limit: Int): List<NovaLauncherSubscribedPodcast>
     suspend fun getRecentlyPlayedPodcasts(): List<NovaLauncherRecentlyPlayedPodcast>
     suspend fun getTrendingPodcasts(): List<NovaLauncherTrendingPodcast>
     suspend fun getNewEpisodes(): List<NovaLauncherNewEpisode>

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/nova/NovaLauncherManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/nova/NovaLauncherManagerImpl.kt
@@ -2,13 +2,15 @@ package au.com.shiftyjelly.pocketcasts.repositories.nova
 
 import au.com.shiftyjelly.pocketcasts.models.db.dao.EpisodeDao
 import au.com.shiftyjelly.pocketcasts.models.db.dao.PodcastDao
+import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import javax.inject.Inject
 
 class NovaLauncherManagerImpl @Inject constructor(
     private val podcastDao: PodcastDao,
     private val episodeDao: EpisodeDao,
+    private val settings: Settings,
 ) : NovaLauncherManager {
-    override suspend fun getSubscribedPodcasts() = podcastDao.getNovaLauncherSubscribedPodcasts()
+    override suspend fun getSubscribedPodcasts(limit: Int) = podcastDao.getNovaLauncherSubscribedPodcasts(settings.podcastsSortType.value, limit = limit)
     override suspend fun getRecentlyPlayedPodcasts() = podcastDao.getNovaLauncherRecentlyPlayedPodcasts()
     override suspend fun getTrendingPodcasts() = podcastDao.getNovaLauncherTrendingPodcasts()
     override suspend fun getNewEpisodes() = episodeDao.getNovaLauncherNewEpisodes()

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
@@ -582,7 +582,7 @@ open class PlaybackManager @Inject constructor(
             SourceView.BOTTOM_SHELF,
             SourceView.SEARCH,
             SourceView.SEARCH_RESULTS,
-            SourceView.NOVA_LAUNCHER,
+            SourceView.NOVA_LAUNCHER_SUBSCRIBED_PODCASTS,
             -> null
 
             SourceView.MEDIA_BUTTON_BROADCAST_SEARCH_ACTION,


### PR DESCRIPTION
## Description

This PR bumps the Nova SDK and uses latest APIs to sync subscribed podcasts. I removed syncing of all other catalogs to test them separately as I'll migrate to the new SDK.

## Testing Instructions

1. Install Nova Launcher from this link: p1718205443795369-slack-C028JAG44VD
2. Open Nova Launcher. You don't have to set is a default launcher app but make sure you can use it.
3. Install Pocket Casts.
4. Open the app.
5. Subscribe to some podcasts.
6. Minimize the app.
7. You should see logs similar to these ones.
```
BgTask: NovaLauncherOneOffSyncWorker (Worker ID: 1cfb4398-1b4a-4f58-b483-b93dcf370409) - Enqueued Nova Launcher one-off sync
BgTask: NovaLauncherOneOffSyncWorker (Worker ID: 1cfb4398-1b4a-4f58-b483-b93dcf370409) - Staring Nova Launcher sync
BgTask: NovaLauncherOneOffSyncWorker (Worker ID: 1cfb4398-1b4a-4f58-b483-b93dcf370409) - Nova Launcher sync complete. Success: [Subscribed podcasts: 24]
```
8. If you notice the message below in the logs. Maximize and minimize the app again. It can happen if Nova fails to fetch verification signatures.
```
Nova Launcher sync failed
java.lang.SecurityException: Failed to verify Source calling package au.com.shiftyjelly.pocketcasts.debug
```
9. On Nova's home screen swipe to the left to open the panel.
10. Scroll down until you see `Subscribed Podcasts` card.
11. The card should enlist at most 200 podcasts that you're subscribed to. They should be enlisted in the same order you use in Pocket Casts*.
12. Tapping on podcasts should open them in the app and should track `podcast_screen_shown` with `nova_launcher_subscribed_podcasts` source.

*There are some small differences as I do not ignore archived or played episodes so sorting by release date might slightly differ. Also I sort only by single field while home screen presorts everything by release date.

## Checklist
- [x] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [x] ~Any jetpack compose components I added or changed are covered by compose previews~
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] ~with different themes~
- [x] ~with a landscape orientation~
- [x] ~with the device set to have a large display and font size~
- [x] ~for accessibility with TalkBack~