### PR TITLE
Fix: Newsletter event track not tracked when is creating account 

### DIFF
--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/OnboardingWelcomeViewModel.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/OnboardingWelcomeViewModel.kt
@@ -22,6 +22,7 @@ class OnboardingWelcomeViewModel @Inject constructor(
 
     fun updateNewsletter(isChecked: Boolean) {
         _stateFlow.update { it.copy(newsletter = isChecked) }
+        persistNewsletterSelection()
     }
 
     private fun persistNewsletterSelection() {


### PR DESCRIPTION
## Description
This tracks the `newsletter_opt_in_changed ` when creating an account

Fixes #2335 


## Testing Instructions
1. Open the App
2. Sign in
3. Enter email and password to create an account
4. Move to the next screen
5. When you find the screen that contains the newsletter toggle you can enable / disable
6. ✅ Ensure you see 🔵 Tracked: `newsletter_opt_in_changed, Properties: {"source":"welcome_new_account","enabled":true/false` in the logs

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack
