### PR TITLE
Sync trending podcasts with Nova

### DIFF
--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/models/db/PodcastDaoTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/models/db/PodcastDaoTest.kt
@@ -310,7 +310,7 @@ class PodcastDaoTest {
         }
         podcastDao.replaceAllTrendingPodcasts(trendingPodcasts)
 
-        val podcasts = podcastDao.getNovaLauncherTrendingPodcasts()
+        val podcasts = podcastDao.getNovaLauncherTrendingPodcasts(limit = 100)
 
         val expected = List(65) {
             NovaLauncherTrendingPodcast("id-$it", "title-$it")
@@ -319,7 +319,19 @@ class PodcastDaoTest {
     }
 
     @Test
-    fun doNotIncludeTrendingPodcastsThatAreTrendingForNovaLauncher() = runTest {
+    fun limitTrendingPodcastsForNovaLauncher() = runTest {
+        val trendingPodcasts = List(65) {
+            TrendingPodcast("id-$it", "title-$it")
+        }
+        podcastDao.replaceAllTrendingPodcasts(trendingPodcasts)
+
+        val podcasts = podcastDao.getNovaLauncherTrendingPodcasts(limit = 5)
+
+        assertEquals(5, podcasts.size)
+    }
+
+    @Test
+    fun doNotIncludeTrendingPodcastsThatAreSubscribedForNovaLauncher() = runTest {
         val trendingPodcasts = listOf(
             TrendingPodcast("id-1", "title-1"),
             TrendingPodcast("id-2", "title-2"),
@@ -329,7 +341,7 @@ class PodcastDaoTest {
         podcastDao.insert(Podcast("id-1", isSubscribed = true))
         podcastDao.insert(Podcast("id-2", isSubscribed = false))
 
-        val podcasts = podcastDao.getNovaLauncherTrendingPodcasts()
+        val podcasts = podcastDao.getNovaLauncherTrendingPodcasts(limit = 100)
 
         val expected = listOf(
             NovaLauncherTrendingPodcast("id-2", "title-2"),

--- a/modules/features/nova/src/main/kotlin/au/com/shiftyjelly/pocketcasts/nova/CatalogFactory.kt
+++ b/modules/features/nova/src/main/kotlin/au/com/shiftyjelly/pocketcasts/nova/CatalogFactory.kt
@@ -3,6 +3,7 @@ package au.com.shiftyjelly.pocketcasts.nova
 import android.content.Context
 import au.com.shiftyjelly.pocketcasts.analytics.SourceView
 import au.com.shiftyjelly.pocketcasts.models.entity.NovaLauncherSubscribedPodcast
+import au.com.shiftyjelly.pocketcasts.models.entity.NovaLauncherTrendingPodcast
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import io.branch.engage.conduit.source.ApplePodcastCategory
 import io.branch.engage.conduit.source.Image
@@ -30,12 +31,32 @@ internal class CatalogFactory(
             },
         )
 
+    fun trendingPodcasts(data: List<NovaLauncherTrendingPodcast>) = PodcastSeriesCatalog("TrendingPodcasts")
+        .setLabel(context.getString(LR.string.nova_launcher_trending))
+        .setPreferredAspectRatio(1, 1)
+        .addAllItems(
+            data.mapIndexed { index, podcast ->
+                PodcastSeries(podcast.id)
+                    .setRank(index.toLong()) // Our queries sort podcasts in a desired order.
+                    .setOpensDirectlyTo(podcast.intent)
+                    .setName(podcast.title)
+                    .setIcon(Image.WebUrl(podcast.coverUrl, 1 to 1))
+            },
+        )
+
     private val NovaLauncherSubscribedPodcast.coverUrl get() = "${Settings.SERVER_STATIC_URL}/discover/images/webp/960/$id.webp"
 
     private val NovaLauncherSubscribedPodcast.intent get() = context.launcherIntent
         .setAction(Settings.INTENT_OPEN_APP_PODCAST_UUID)
         .putExtra(Settings.PODCAST_UUID, id)
         .putExtra(Settings.SOURCE_VIEW, SourceView.NOVA_LAUNCHER_SUBSCRIBED_PODCASTS.analyticsValue)
+
+    private val NovaLauncherTrendingPodcast.coverUrl get() = "${Settings.SERVER_STATIC_URL}/discover/images/webp/960/$id.webp"
+
+    private val NovaLauncherTrendingPodcast.intent get() = context.launcherIntent
+        .setAction(Settings.INTENT_OPEN_APP_PODCAST_UUID)
+        .putExtra(Settings.PODCAST_UUID, id)
+        .putExtra(Settings.SOURCE_VIEW, SourceView.NOVA_LAUNCHER_TRENDING_PODCASTS.analyticsValue)
 
     private val Context.launcherIntent get() = requireNotNull(packageManager.getLaunchIntentForPackage(packageName)) {
         "Missing launcher intent for $packageName"

--- a/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/SourceView.kt
+++ b/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/SourceView.kt
@@ -24,6 +24,7 @@ enum class SourceView(val analyticsValue: String) {
     NOTIFICATION("notification"),
     NOTIFICATION_BOOKMARK("notification_bookmark"),
     NOVA_LAUNCHER_SUBSCRIBED_PODCASTS("nova_launcher_subscribed_podcasts"),
+    NOVA_LAUNCHER_TRENDING_PODCASTS("nova_launcher_trending_podcasts"),
     ONBOARDING_RECOMMENDATIONS("onboarding_recommendations"),
     ONBOARDING_RECOMMENDATIONS_SEARCH("onboarding_recommendations_search"),
     PLAYER("player"),

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/PodcastDao.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/PodcastDao.kt
@@ -451,9 +451,11 @@ abstract class PodcastDao {
           LEFT JOIN podcasts AS podcast ON podcast.uuid = trending_podcast.uuid 
         WHERE 
           IFNULL(podcast.subscribed, 0) IS 0
+        LIMIT
+          :limit
         """,
     )
-    abstract suspend fun getNovaLauncherTrendingPodcasts(): List<NovaLauncherTrendingPodcast>
+    abstract suspend fun getNovaLauncherTrendingPodcasts(limit: Int): List<NovaLauncherTrendingPodcast>
 
     @Query(
         """

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/nova/NovaLauncherManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/nova/NovaLauncherManager.kt
@@ -9,7 +9,7 @@ import au.com.shiftyjelly.pocketcasts.models.entity.NovaLauncherTrendingPodcast
 interface NovaLauncherManager {
     suspend fun getSubscribedPodcasts(limit: Int): List<NovaLauncherSubscribedPodcast>
     suspend fun getRecentlyPlayedPodcasts(): List<NovaLauncherRecentlyPlayedPodcast>
-    suspend fun getTrendingPodcasts(): List<NovaLauncherTrendingPodcast>
+    suspend fun getTrendingPodcasts(limit: Int): List<NovaLauncherTrendingPodcast>
     suspend fun getNewEpisodes(): List<NovaLauncherNewEpisode>
     suspend fun getInProgressEpisodes(): List<NovaLauncherInProgressEpisode>
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/nova/NovaLauncherManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/nova/NovaLauncherManagerImpl.kt
@@ -10,9 +10,9 @@ class NovaLauncherManagerImpl @Inject constructor(
     private val episodeDao: EpisodeDao,
     private val settings: Settings,
 ) : NovaLauncherManager {
-    override suspend fun getSubscribedPodcasts(limit: Int) = podcastDao.getNovaLauncherSubscribedPodcasts(settings.podcastsSortType.value, limit = limit)
+    override suspend fun getSubscribedPodcasts(limit: Int) = podcastDao.getNovaLauncherSubscribedPodcasts(settings.podcastsSortType.value, limit)
     override suspend fun getRecentlyPlayedPodcasts() = podcastDao.getNovaLauncherRecentlyPlayedPodcasts()
-    override suspend fun getTrendingPodcasts() = podcastDao.getNovaLauncherTrendingPodcasts()
+    override suspend fun getTrendingPodcasts(limit: Int) = podcastDao.getNovaLauncherTrendingPodcasts(limit)
     override suspend fun getNewEpisodes() = episodeDao.getNovaLauncherNewEpisodes()
     override suspend fun getInProgressEpisodes() = episodeDao.getNovaLauncherInProgressEpisodes()
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
@@ -583,6 +583,7 @@ open class PlaybackManager @Inject constructor(
             SourceView.SEARCH,
             SourceView.SEARCH_RESULTS,
             SourceView.NOVA_LAUNCHER_SUBSCRIBED_PODCASTS,
+            SourceView.NOVA_LAUNCHER_TRENDING_PODCASTS,
             -> null
 
             SourceView.MEDIA_BUTTON_BROADCAST_SEARCH_ACTION,


### PR DESCRIPTION
## Description

This PR syncs trending podcasts with Nova Launcher.

## Testing Instructions

1. Install Nova Launcher from this link: p1718205443795369-slack-C028JAG44VD
2. Open Nova Launcher. You don't have to set it as a default launcher app but make sure you can use it.
3. Install Pocket Casts.
4. Open the app and go to Discover tab to see trending podcasts.
6. Minimize the app.
7. You should see logs similar to these ones.
```
BgTask: NovaLauncherOneOffSyncWorker (Worker ID: 4c6d16ca-381f-48e0-ac25-068a3260e01f) - Enqueued Nova Launcher one-off sync
BgTask: NovaLauncherOneOffSyncWorker (Worker ID: 4c6d16ca-381f-48e0-ac25-068a3260e01f) - Staring Nova Launcher sync
BgTask: NovaLauncherOneOffSyncWorker (Worker ID: 4c6d16ca-381f-48e0-ac25-068a3260e01f) - Nova Launcher sync complete. Success: [Subscribed podcasts: 75, Trending podcasts: 25]
```
8. If you notice the message below in the logs. Maximize and minimize the app again. It can happen if Nova fails to fetch verification signatures.
```
Nova Launcher sync failed
java.lang.SecurityException: Failed to verify Source calling package au.com.shiftyjelly.pocketcasts.debug
```
9. On Nova's home screen swipe to the left to open the panel.
10. Scroll down until you see `Trending` card.
11. The card should enlist at most 25 podcasts that are trending. They should not contain podcasts that you're subscribed to.
12. Tapping on podcasts should open them in the app and should track `podcast_screen_shown` with `nova_launcher_trending_podcasts` source.

## Checklist
- [x] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [x] ~Any jetpack compose components I added or changed are covered by compose previews~
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] ~with different themes~
- [x] ~with a landscape orientation~
- [x] ~with the device set to have a large display and font size~
- [x] ~for accessibility with TalkBack~