### PR TITLE
Sync in progress episodes with Nova

### DIFF
--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/models/db/EpisodeDaoTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/models/db/EpisodeDaoTest.kt
@@ -488,7 +488,7 @@ class EpisodeDaoTest {
                 number = 11,
                 playingStatus = EpisodePlayingStatus.IN_PROGRESS,
                 publishedDate = Date(0),
-                lastPlaybackInteraction = 74211,
+                lastPlaybackInteraction = 74,
             ),
             PodcastEpisode(
                 uuid = "id-2",
@@ -499,7 +499,7 @@ class EpisodeDaoTest {
                 season = 7,
                 number = null,
                 playingStatus = EpisodePlayingStatus.IN_PROGRESS,
-                publishedDate = Date(2000),
+                publishedDate = Date(2),
                 lastPlaybackInteraction = 0,
             ),
             PodcastEpisode(
@@ -511,13 +511,13 @@ class EpisodeDaoTest {
                 season = null,
                 number = 399,
                 playingStatus = EpisodePlayingStatus.IN_PROGRESS,
-                publishedDate = Date(3412),
+                publishedDate = Date(3),
                 lastPlaybackInteraction = null,
             ),
         )
         episodeDao.insertAll(episodes)
 
-        val inProgressEpisodes = episodeDao.getNovaLauncherInProgressEpisodes()
+        val inProgressEpisodes = episodeDao.getNovaLauncherInProgressEpisodes(limit = 100)
 
         val expected = listOf(
             NovaLauncherInProgressEpisode(
@@ -563,25 +563,25 @@ class EpisodeDaoTest {
             PodcastEpisode(
                 uuid = "id-1",
                 playingStatus = EpisodePlayingStatus.IN_PROGRESS,
-                publishedDate = Date(2000),
-                lastPlaybackInteraction = 1000,
+                publishedDate = Date(2),
+                lastPlaybackInteraction = 1,
             ),
             PodcastEpisode(
                 uuid = "id-2",
                 playingStatus = EpisodePlayingStatus.IN_PROGRESS,
-                publishedDate = Date(3000),
+                publishedDate = Date(3),
                 lastPlaybackInteraction = null,
             ),
             PodcastEpisode(
                 uuid = "id-3",
                 playingStatus = EpisodePlayingStatus.IN_PROGRESS,
-                publishedDate = Date(1000),
-                lastPlaybackInteraction = 3000,
+                publishedDate = Date(1),
+                lastPlaybackInteraction = 3,
             ),
         )
         episodeDao.insertAll(episodes)
 
-        val inProgressEpisodes = episodeDao.getNovaLauncherInProgressEpisodes()
+        val inProgressEpisodes = episodeDao.getNovaLauncherInProgressEpisodes(limit = 100)
 
         val expected = listOf(
             NovaLauncherInProgressEpisode(
@@ -622,7 +622,7 @@ class EpisodeDaoTest {
     }
 
     @Test
-    fun limitNovaLauncherInProgressEpisodesTo500Episodes() = runTest {
+    fun limitNovaLauncherInProgressEpisodes() = runTest {
         val episodes = List(550) {
             PodcastEpisode(
                 uuid = "id-$it",
@@ -632,9 +632,9 @@ class EpisodeDaoTest {
         }
         episodeDao.insertAll(episodes)
 
-        val inProgressEpisodes = episodeDao.getNovaLauncherInProgressEpisodes()
+        val inProgressEpisodes = episodeDao.getNovaLauncherInProgressEpisodes(limit = 20)
 
-        assertEquals(500, inProgressEpisodes.size)
+        assertEquals(20, inProgressEpisodes.size)
     }
 
     @Test
@@ -655,7 +655,7 @@ class EpisodeDaoTest {
         )
         episodeDao.insertAll(episodes)
 
-        val inProgressEpisodes = episodeDao.getNovaLauncherInProgressEpisodes()
+        val inProgressEpisodes = episodeDao.getNovaLauncherInProgressEpisodes(limit = 100)
 
         val expected = listOf(
             NovaLauncherInProgressEpisode(
@@ -694,7 +694,7 @@ class EpisodeDaoTest {
         )
         episodeDao.insertAll(episodes)
 
-        val inProgressEpisodes = episodeDao.getNovaLauncherInProgressEpisodes()
+        val inProgressEpisodes = episodeDao.getNovaLauncherInProgressEpisodes(limit = 100)
 
         val expected = listOf(
             NovaLauncherInProgressEpisode(

--- a/modules/features/nova/src/main/kotlin/au/com/shiftyjelly/pocketcasts/nova/CatalogFactory.kt
+++ b/modules/features/nova/src/main/kotlin/au/com/shiftyjelly/pocketcasts/nova/CatalogFactory.kt
@@ -2,6 +2,7 @@ package au.com.shiftyjelly.pocketcasts.nova
 
 import android.content.Context
 import au.com.shiftyjelly.pocketcasts.analytics.SourceView
+import au.com.shiftyjelly.pocketcasts.models.entity.NovaLauncherInProgressEpisode
 import au.com.shiftyjelly.pocketcasts.models.entity.NovaLauncherNewEpisode
 import au.com.shiftyjelly.pocketcasts.models.entity.NovaLauncherSubscribedPodcast
 import au.com.shiftyjelly.pocketcasts.models.entity.NovaLauncherTrendingPodcast
@@ -67,6 +68,25 @@ internal class CatalogFactory(
             },
         )
 
+    fun inProgressEpisodes(data: List<NovaLauncherInProgressEpisode>) = PodcastEpisodeCatalog("ContinueListening")
+        .setLabel(context.getString(LR.string.nova_launcher_continue_listening))
+        .setPreferredAspectRatio(1, 1)
+        .addAllItems(
+            data.mapIndexed { index, episode ->
+                PodcastEpisode(episode.id)
+                    .setRank(index.toLong()) // Our queries sort episodes in a desired order.
+                    .setOpensDirectlyTo(episode.intent)
+                    .setLastUsedTimestamp(episode.lastUsedTimestamp)
+                    .setName(episode.title)
+                    .setIcon(Image.WebUrl(episode.coverUrl, 1 to 1))
+                    .setSeasonNumber(episode.seasonNumber)
+                    .setEpisodeNumber(episode.episodeNumber)
+                    .setReleaseTimestamp(episode.releaseTimestamp)
+                    .setLengthSeconds(episode.duration)
+                    .setCurrentPositionSeconds(episode.currentPosition)
+            },
+        )
+
     private val NovaLauncherSubscribedPodcast.coverUrl get() = "${Settings.SERVER_STATIC_URL}/discover/images/webp/960/$id.webp"
 
     private val NovaLauncherSubscribedPodcast.intent get() = context.launcherIntent
@@ -88,6 +108,14 @@ internal class CatalogFactory(
         .putExtra(Settings.EPISODE_UUID, id)
         .putExtra(Settings.PODCAST_UUID, podcastId)
         .putExtra(Settings.SOURCE_VIEW, EpisodeViewSource.NOVA_LAUNCHER_NEW_RELEASES.value)
+
+    private val NovaLauncherInProgressEpisode.intent get() = context.launcherIntent
+        .setAction(Settings.INTENT_OPEN_APP_EPISODE_UUID)
+        .putExtra(Settings.EPISODE_UUID, id)
+        .putExtra(Settings.PODCAST_UUID, podcastId)
+        .putExtra(Settings.SOURCE_VIEW, EpisodeViewSource.NOVA_LAUNCHER_IN_PROGRESS.value)
+
+    private val NovaLauncherInProgressEpisode.coverUrl get() = "${Settings.SERVER_STATIC_URL}/discover/images/webp/960/$podcastId.webp"
 
     private val Context.launcherIntent get() = requireNotNull(packageManager.getLaunchIntentForPackage(packageName)) {
         "Missing launcher intent for $packageName"

--- a/modules/features/nova/src/main/kotlin/au/com/shiftyjelly/pocketcasts/nova/NovaLauncherSyncWorker.kt
+++ b/modules/features/nova/src/main/kotlin/au/com/shiftyjelly/pocketcasts/nova/NovaLauncherSyncWorker.kt
@@ -48,11 +48,13 @@ internal class NovaLauncherSyncWorker @AssistedInject constructor(
                 val subscribedPodcasts = async { catalogFactory.subscribedPodcasts(manager.getSubscribedPodcasts(limit = 200)) }
                 val trendingPodcasts = async { catalogFactory.trendingPodcasts(manager.getTrendingPodcasts(limit = 25)) }
                 val newEpisodes = async { catalogFactory.newEpisodes(manager.getNewEpisodes(limit = 25)) }
+                val inProgressEpisodes = async { catalogFactory.inProgressEpisodes(manager.getInProgressEpisodes(limit = 25)) }
 
                 val catalogSubmission = CatalogSubmission()
                     .setUserLibrary(listOf(subscribedPodcasts.await()))
                     .setTrending(listOf(trendingPodcasts.await()))
                     .setUserLibraryNew(listOf(newEpisodes.await()))
+                    .setContinue(listOf(inProgressEpisodes.await()))
 
                 val isDataSubmitted = BranchDynamicData.getOrInit(applicationContext).submit(catalogSubmission).isSuccess
 
@@ -60,6 +62,7 @@ internal class NovaLauncherSyncWorker @AssistedInject constructor(
                     SubmissionResult("Subscribed podcasts", subscribedPodcasts.await().size),
                     SubmissionResult("Trending podcasts", trendingPodcasts.await().size),
                     SubmissionResult("New episodes", newEpisodes.await().size),
+                    SubmissionResult("In progress episodes", inProgressEpisodes.await().size),
                 )
 
                 logInfo("Nova Launcher sync complete. ${if (isDataSubmitted) "Success" else "Failure"}: $results")

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/EpisodeDao.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/EpisodeDao.kt
@@ -582,9 +582,8 @@ abstract class EpisodeDao {
           episode.played_up_to AS current_position,
           episode.season AS season_number,
           episode.number AS episode_number,
-          -- Divide by 1000 to convert milliseconds that we store to seconds that Nova Launcher expects
-          episode.published_date / 1000 AS release_timestamp,
-          episode.last_playback_interaction_date / 1000 AS last_used_timestamp
+          episode.published_date AS release_timestamp,
+          episode.last_playback_interaction_date AS last_used_timestamp
         FROM
           podcast_episodes AS episode
         WHERE
@@ -594,8 +593,10 @@ abstract class EpisodeDao {
         ORDER BY
           episode.last_playback_interaction_date DESC
         LIMIT
-          500
+          :limit
         """,
     )
-    abstract suspend fun getNovaLauncherInProgressEpisodes(): List<NovaLauncherInProgressEpisode>
+    abstract suspend fun getNovaLauncherInProgressEpisodes(
+        limit: Int,
+    ): List<NovaLauncherInProgressEpisode>
 }

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/type/EpisodeViewSource.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/type/EpisodeViewSource.kt
@@ -12,6 +12,7 @@ enum class EpisodeViewSource(val value: String) {
     NOTIFICATION("notification"),
     NOTIFICATION_BOOKMARK("notification_bookmark"),
     NOVA_LAUNCHER_NEW_RELEASES("nova_launcher_new_releases"),
+    NOVA_LAUNCHER_IN_PROGRESS("nova_launcher_in_progress"),
     SEARCH("search"),
     SEARCH_HISTORY("search_history"),
     NOW_PLAYING("now_playing"),

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/nova/NovaLauncherManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/nova/NovaLauncherManager.kt
@@ -11,5 +11,5 @@ interface NovaLauncherManager {
     suspend fun getRecentlyPlayedPodcasts(): List<NovaLauncherRecentlyPlayedPodcast>
     suspend fun getTrendingPodcasts(limit: Int): List<NovaLauncherTrendingPodcast>
     suspend fun getNewEpisodes(limit: Int): List<NovaLauncherNewEpisode>
-    suspend fun getInProgressEpisodes(): List<NovaLauncherInProgressEpisode>
+    suspend fun getInProgressEpisodes(limit: Int): List<NovaLauncherInProgressEpisode>
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/nova/NovaLauncherManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/nova/NovaLauncherManagerImpl.kt
@@ -14,5 +14,5 @@ class NovaLauncherManagerImpl @Inject constructor(
     override suspend fun getRecentlyPlayedPodcasts() = podcastDao.getNovaLauncherRecentlyPlayedPodcasts()
     override suspend fun getTrendingPodcasts(limit: Int) = podcastDao.getNovaLauncherTrendingPodcasts(limit)
     override suspend fun getNewEpisodes(limit: Int) = episodeDao.getNovaLauncherNewEpisodes(limit)
-    override suspend fun getInProgressEpisodes() = episodeDao.getNovaLauncherInProgressEpisodes()
+    override suspend fun getInProgressEpisodes(limit: Int) = episodeDao.getNovaLauncherInProgressEpisodes(limit)
 }


### PR DESCRIPTION
## Description

This PR syncs in progress episodes with Nova Launcher.

## Testing Instructions

1. Install Nova Launcher from this link: p1718205443795369-slack-C028JAG44VD
2. Open Nova Launcher. You don't have to set it as a default launcher app but make sure you can use it.
3. Install Pocket Casts.
4. Have some episodes played but not finished.
6. Minimize the app.
7. You should see logs similar to these ones.
```
BgTask: NovaLauncherOneOffSyncWorker (Worker ID: 136bdd40-f9a4-450b-ac6c-c9eaa3f00370) - Enqueued Nova Launcher one-off sync
BgTask: NovaLauncherOneOffSyncWorker (Worker ID: 136bdd40-f9a4-450b-ac6c-c9eaa3f00370) - Staring Nova Launcher sync
BgTask: NovaLauncherOneOffSyncWorker (Worker ID: 136bdd40-f9a4-450b-ac6c-c9eaa3f00370) - Nova Launcher sync complete. Success: [Subscribed podcasts: 75, Trending podcasts: 25, New episodes: 25, In progress episodes: 14]
```
8. If you notice the message below in the logs. Maximize and minimize the app again. It can happen if Nova fails to fetch verification signatures.
```
Nova Launcher sync failed
java.lang.SecurityException: Failed to verify Source calling package au.com.shiftyjelly.pocketcasts.debug
```
9. On Nova's home screen swipe to the left to open the panel.
10. Scroll down until you see `Continue Listening` card.
11. The card should enlist at most 25 episodes that are in progress. They should contain only episodes that are not archived.
12. Tap on any of the episodes.
13. You should see `episode_detail_shown` event with `nova_launcher_in_progress` and the episode details should open.
14. Mark the episode as played.
15. Minimize the app and wait for Nova to sync with the app.
16. You should no longer see the episode you've just played in the `Continue Listening` card.
17. Tap on a different episode.
18. Archive it in the app.
19. Minimize the app and wait for Nova to sync with the app.
20. You should no longer see the episode you've just archived in the `Continue Listening` card.

## Checklist
- [x] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [x] ~Any jetpack compose components I added or changed are covered by compose previews~
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] ~with different themes~
- [x] ~with a landscape orientation~
- [x] ~with the device set to have a large display and font size~
- [x] ~for accessibility with TalkBack~