### PR TITLE
Sync recently played podcasts with Nova

### DIFF
--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/models/db/PodcastDaoTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/models/db/PodcastDaoTest.kt
@@ -13,7 +13,6 @@ import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.models.entity.TrendingPodcast
 import au.com.shiftyjelly.pocketcasts.models.type.PodcastsSortType
-import au.com.shiftyjelly.pocketcasts.utils.extensions.timeSecs
 import java.time.Instant
 import java.time.temporal.ChronoUnit
 import java.util.Date
@@ -357,40 +356,43 @@ class PodcastDaoTest {
         val interactionDate3 = Date.from(Instant.now().minus(3, ChronoUnit.DAYS))
         podcastDao.insert(Podcast(uuid = "id-1", title = "title-1", isSubscribed = true))
         episodeDao.insert(PodcastEpisode(uuid = "id-1", publishedDate = Date(0), podcastUuid = "id-1", lastPlaybackInteraction = interactionDate1.time))
-        episodeDao.insert(PodcastEpisode(uuid = "id-2", publishedDate = Date(2000), podcastUuid = "id-1", lastPlaybackInteraction = null))
-        episodeDao.insert(PodcastEpisode(uuid = "id-3", publishedDate = Date(1000), podcastUuid = "id-1", lastPlaybackInteraction = 13000))
+        episodeDao.insert(PodcastEpisode(uuid = "id-2", publishedDate = Date(2), podcastUuid = "id-1", lastPlaybackInteraction = null))
+        episodeDao.insert(PodcastEpisode(uuid = "id-3", publishedDate = Date(1), podcastUuid = "id-1", lastPlaybackInteraction = 13000))
 
         podcastDao.insert(Podcast(uuid = "id-2", title = "title-2", isSubscribed = false))
-        episodeDao.insert(PodcastEpisode(uuid = "id-4", publishedDate = Date(5000), podcastUuid = "id-2", lastPlaybackInteraction = 0))
-        episodeDao.insert(PodcastEpisode(uuid = "id-5", publishedDate = Date(4000), podcastUuid = "id-2", lastPlaybackInteraction = 20000))
-        episodeDao.insert(PodcastEpisode(uuid = "id-6", publishedDate = Date(3000), podcastUuid = "id-2", lastPlaybackInteraction = interactionDate2.time))
+        episodeDao.insert(PodcastEpisode(uuid = "id-4", publishedDate = Date(5), podcastUuid = "id-2", lastPlaybackInteraction = 0))
+        episodeDao.insert(PodcastEpisode(uuid = "id-5", publishedDate = Date(4), podcastUuid = "id-2", lastPlaybackInteraction = 20))
+        episodeDao.insert(PodcastEpisode(uuid = "id-6", publishedDate = Date(3), podcastUuid = "id-2", lastPlaybackInteraction = interactionDate2.time))
 
         podcastDao.insert(Podcast(uuid = "id-3", title = "title-3", isSubscribed = true))
-        episodeDao.insert(PodcastEpisode(uuid = "id-7", publishedDate = Date(12000), podcastUuid = "id-3", lastPlaybackInteraction = interactionDate3.time))
+        episodeDao.insert(PodcastEpisode(uuid = "id-7", publishedDate = Date(12), podcastUuid = "id-3", lastPlaybackInteraction = interactionDate3.time))
 
-        val podcasts = podcastDao.getNovaLauncherRecentlyPlayedPodcasts()
+        val podcasts = podcastDao.getNovaLauncherRecentlyPlayedPodcasts(limit = 100)
 
         val expected = listOf(
             NovaLauncherRecentlyPlayedPodcast(
                 id = "id-1",
                 title = "title-1",
+                categories = "",
                 initialReleaseTimestamp = 0,
                 latestReleaseTimestamp = 2,
-                lastUsedTimestamp = interactionDate1.timeSecs(),
+                lastUsedTimestamp = interactionDate1.time,
             ),
             NovaLauncherRecentlyPlayedPodcast(
                 id = "id-2",
                 title = "title-2",
+                categories = "",
                 initialReleaseTimestamp = 3,
                 latestReleaseTimestamp = 5,
-                lastUsedTimestamp = interactionDate2.timeSecs(),
+                lastUsedTimestamp = interactionDate2.time,
             ),
             NovaLauncherRecentlyPlayedPodcast(
                 id = "id-3",
                 title = "title-3",
+                categories = "",
                 initialReleaseTimestamp = 12,
                 latestReleaseTimestamp = 12,
-                lastUsedTimestamp = interactionDate3.timeSecs(),
+                lastUsedTimestamp = interactionDate3.time,
             ),
         )
         assertEquals(expected, podcasts)
@@ -407,15 +409,16 @@ class PodcastDaoTest {
 
         podcastDao.insert(Podcast(uuid = "id-3", title = "title-3"))
 
-        val podcasts = podcastDao.getNovaLauncherRecentlyPlayedPodcasts()
+        val podcasts = podcastDao.getNovaLauncherRecentlyPlayedPodcasts(limit = 100)
 
         val expected = listOf(
             NovaLauncherRecentlyPlayedPodcast(
                 id = "id-1",
                 title = "title-1",
+                categories = "",
                 initialReleaseTimestamp = 0,
                 latestReleaseTimestamp = 0,
-                lastUsedTimestamp = interactionDate.timeSecs(),
+                lastUsedTimestamp = interactionDate.time,
             ),
         )
         assertEquals(expected, podcasts)
@@ -435,44 +438,47 @@ class PodcastDaoTest {
         podcastDao.insert(Podcast(uuid = "id-3", title = "title-3"))
         episodeDao.insert(PodcastEpisode(uuid = "id-3", publishedDate = Date(0), podcastUuid = "id-3", lastPlaybackInteraction = interactionDate3.time))
 
-        val podcasts = podcastDao.getNovaLauncherRecentlyPlayedPodcasts()
+        val podcasts = podcastDao.getNovaLauncherRecentlyPlayedPodcasts(limit = 100)
 
         val expected = listOf(
             NovaLauncherRecentlyPlayedPodcast(
                 id = "id-2",
                 title = "title-2",
+                categories = "",
                 initialReleaseTimestamp = 0,
                 latestReleaseTimestamp = 0,
-                lastUsedTimestamp = interactionDate2.timeSecs(),
+                lastUsedTimestamp = interactionDate2.time,
             ),
             NovaLauncherRecentlyPlayedPodcast(
                 id = "id-3",
                 title = "title-3",
+                categories = "",
                 initialReleaseTimestamp = 0,
                 latestReleaseTimestamp = 0,
-                lastUsedTimestamp = interactionDate3.timeSecs(),
+                lastUsedTimestamp = interactionDate3.time,
             ),
             NovaLauncherRecentlyPlayedPodcast(
                 id = "id-1",
                 title = "title-1",
+                categories = "",
                 initialReleaseTimestamp = 0,
                 latestReleaseTimestamp = 0,
-                lastUsedTimestamp = interactionDate1.timeSecs(),
+                lastUsedTimestamp = interactionDate1.time,
             ),
         )
         assertEquals(expected, podcasts)
     }
 
     @Test
-    fun limitNovaLauncherRecentlyPlayedPodcastsTo200Podcasts() = runTest {
+    fun limitNovaLauncherRecentlyPlayedPodcasts() = runTest {
         List(250) {
             podcastDao.insert(Podcast(uuid = "id-$it"))
             episodeDao.insert(PodcastEpisode(uuid = "id-$it", podcastUuid = "id-$it", publishedDate = Date(), lastPlaybackInteraction = Date().time))
         }
 
-        val inProgressEpisodes = podcastDao.getNovaLauncherRecentlyPlayedPodcasts()
+        val inProgressEpisodes = podcastDao.getNovaLauncherRecentlyPlayedPodcasts(limit = 100)
 
-        assertEquals(200, inProgressEpisodes.size)
+        assertEquals(100, inProgressEpisodes.size)
     }
 
     @Test
@@ -485,15 +491,37 @@ class PodcastDaoTest {
         podcastDao.insert(Podcast(uuid = "id-2", title = "title-2", isSubscribed = false))
         episodeDao.insert(PodcastEpisode(uuid = "id-2", publishedDate = Date(0), podcastUuid = "id-2", lastPlaybackInteraction = interactionDate2.time))
 
-        val podcasts = podcastDao.getNovaLauncherRecentlyPlayedPodcasts()
+        val podcasts = podcastDao.getNovaLauncherRecentlyPlayedPodcasts(limit = 100)
 
         val expected = listOf(
             NovaLauncherRecentlyPlayedPodcast(
                 id = "id-2",
                 title = "title-2",
+                categories = "",
                 initialReleaseTimestamp = 0,
                 latestReleaseTimestamp = 0,
-                lastUsedTimestamp = interactionDate2.timeSecs(),
+                lastUsedTimestamp = interactionDate2.time,
+            ),
+        )
+        assertEquals(expected, podcasts)
+    }
+
+    @Test
+    fun includeCategoriesForNovaLauncherRecentlyPlayedPodcasts() = runTest {
+        val interactionDate1 = Date.from(Instant.now().minus(1, ChronoUnit.DAYS))
+        podcastDao.insert(Podcast(uuid = "id-1", title = "title-1", podcastCategory = "category1"))
+        episodeDao.insert(PodcastEpisode(uuid = "id-1", publishedDate = Date(0), podcastUuid = "id-1", lastPlaybackInteraction = interactionDate1.time))
+
+        val podcasts = podcastDao.getNovaLauncherRecentlyPlayedPodcasts(limit = 100)
+
+        val expected = listOf(
+            NovaLauncherRecentlyPlayedPodcast(
+                id = "id-1",
+                title = "title-1",
+                categories = "category1",
+                initialReleaseTimestamp = 0,
+                latestReleaseTimestamp = 0,
+                lastUsedTimestamp = interactionDate1.time,
             ),
         )
         assertEquals(expected, podcasts)

--- a/modules/features/nova/src/main/kotlin/au/com/shiftyjelly/pocketcasts/nova/CatalogFactory.kt
+++ b/modules/features/nova/src/main/kotlin/au/com/shiftyjelly/pocketcasts/nova/CatalogFactory.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import au.com.shiftyjelly.pocketcasts.analytics.SourceView
 import au.com.shiftyjelly.pocketcasts.models.entity.NovaLauncherInProgressEpisode
 import au.com.shiftyjelly.pocketcasts.models.entity.NovaLauncherNewEpisode
+import au.com.shiftyjelly.pocketcasts.models.entity.NovaLauncherRecentlyPlayedPodcast
 import au.com.shiftyjelly.pocketcasts.models.entity.NovaLauncherSubscribedPodcast
 import au.com.shiftyjelly.pocketcasts.models.entity.NovaLauncherTrendingPodcast
 import au.com.shiftyjelly.pocketcasts.models.type.EpisodeViewSource
@@ -21,6 +22,23 @@ internal class CatalogFactory(
 ) {
     fun subscribedPodcasts(data: List<NovaLauncherSubscribedPodcast>) = PodcastSeriesCatalog("SubscribedPodcasts")
         .setLabel(context.getString(LR.string.nova_launcher_subscribed_podcasts))
+        .setPreferredAspectRatio(1, 1)
+        .addAllItems(
+            data.mapIndexed { index, podcast ->
+                PodcastSeries(podcast.id)
+                    .setRank(index.toLong()) // Our queries sort podcasts in a desired order.
+                    .setOpensDirectlyTo(podcast.intent)
+                    .setName(podcast.title)
+                    .setIcon(Image.WebUrl(podcast.coverUrl, 1 to 1))
+                    .setLastUsedTimestamp(podcast.lastUsedTimestamp)
+                    .setOriginalReleaseTimestamp(podcast.initialReleaseTimestamp)
+                    .setLatestReleaseTimestamp(podcast.latestReleaseTimestamp)
+                    .addAllCategories(ApplePodcastCategory.fromCategories(podcast.categories))
+            },
+        )
+
+    fun recentlyPlayedPodcasts(data: List<NovaLauncherRecentlyPlayedPodcast>) = PodcastSeriesCatalog("RecentlyPlayed")
+        .setLabel(context.getString(LR.string.nova_launcher_recently_played))
         .setPreferredAspectRatio(1, 1)
         .addAllItems(
             data.mapIndexed { index, podcast ->
@@ -93,6 +111,13 @@ internal class CatalogFactory(
         .setAction(Settings.INTENT_OPEN_APP_PODCAST_UUID)
         .putExtra(Settings.PODCAST_UUID, id)
         .putExtra(Settings.SOURCE_VIEW, SourceView.NOVA_LAUNCHER_SUBSCRIBED_PODCASTS.analyticsValue)
+
+    private val NovaLauncherRecentlyPlayedPodcast.coverUrl get() = "${Settings.SERVER_STATIC_URL}/discover/images/webp/960/$id.webp"
+
+    private val NovaLauncherRecentlyPlayedPodcast.intent get() = context.launcherIntent
+        .setAction(Settings.INTENT_OPEN_APP_PODCAST_UUID)
+        .putExtra(Settings.PODCAST_UUID, id)
+        .putExtra(Settings.SOURCE_VIEW, SourceView.NOVA_LAUNCHER_RECENTLY_PLAYED.analyticsValue)
 
     private val NovaLauncherTrendingPodcast.coverUrl get() = "${Settings.SERVER_STATIC_URL}/discover/images/webp/960/$id.webp"
 

--- a/modules/features/nova/src/main/kotlin/au/com/shiftyjelly/pocketcasts/nova/NovaLauncherSyncWorker.kt
+++ b/modules/features/nova/src/main/kotlin/au/com/shiftyjelly/pocketcasts/nova/NovaLauncherSyncWorker.kt
@@ -46,12 +46,14 @@ internal class NovaLauncherSyncWorker @AssistedInject constructor(
         return coroutineScope {
             try {
                 val subscribedPodcasts = async { catalogFactory.subscribedPodcasts(manager.getSubscribedPodcasts(limit = 200)) }
+                val recentlyPlayedPodcasts = async { catalogFactory.recentlyPlayedPodcasts(manager.getRecentlyPlayedPodcasts(limit = 200)) }
                 val trendingPodcasts = async { catalogFactory.trendingPodcasts(manager.getTrendingPodcasts(limit = 25)) }
                 val newEpisodes = async { catalogFactory.newEpisodes(manager.getNewEpisodes(limit = 25)) }
                 val inProgressEpisodes = async { catalogFactory.inProgressEpisodes(manager.getInProgressEpisodes(limit = 25)) }
 
                 val catalogSubmission = CatalogSubmission()
                     .setUserLibrary(listOf(subscribedPodcasts.await()))
+                    .setUsageHistory(listOf(recentlyPlayedPodcasts.await()))
                     .setTrending(listOf(trendingPodcasts.await()))
                     .setUserLibraryNew(listOf(newEpisodes.await()))
                     .setContinue(listOf(inProgressEpisodes.await()))
@@ -60,6 +62,7 @@ internal class NovaLauncherSyncWorker @AssistedInject constructor(
 
                 val results = listOf(
                     SubmissionResult("Subscribed podcasts", subscribedPodcasts.await().size),
+                    SubmissionResult("Recently played podcasts", recentlyPlayedPodcasts.await().size),
                     SubmissionResult("Trending podcasts", trendingPodcasts.await().size),
                     SubmissionResult("New episodes", newEpisodes.await().size),
                     SubmissionResult("In progress episodes", inProgressEpisodes.await().size),

--- a/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/SourceView.kt
+++ b/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/SourceView.kt
@@ -23,6 +23,7 @@ enum class SourceView(val analyticsValue: String) {
     MULTI_SELECT("multi_select"),
     NOTIFICATION("notification"),
     NOTIFICATION_BOOKMARK("notification_bookmark"),
+    NOVA_LAUNCHER_RECENTLY_PLAYED("nova_launcher_recently_played"),
     NOVA_LAUNCHER_SUBSCRIBED_PODCASTS("nova_launcher_subscribed_podcasts"),
     NOVA_LAUNCHER_TRENDING_PODCASTS("nova_launcher_trending_podcasts"),
     ONBOARDING_RECOMMENDATIONS("onboarding_recommendations"),

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/PodcastDao.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/PodcastDao.kt
@@ -461,21 +461,24 @@ abstract class PodcastDao {
         """
         SELECT 
           podcasts.uuid AS id, 
-          podcasts.title AS title, 
-          -- Divide by 1000 to convert milliseconds that we store to seconds that Nova Launcher expects
-          (SELECT MIN(podcast_episodes.published_date) / 1000 FROM podcast_episodes WHERE podcasts.uuid IS podcast_episodes.podcast_id) AS initial_release_timestamp, 
-          (SELECT MAX(podcast_episodes.published_date) / 1000 FROM podcast_episodes WHERE podcasts.uuid IS podcast_episodes.podcast_id) AS latest_release_timestamp,
-          (SELECT MAX(podcast_episodes.last_playback_interaction_date) / 1000 FROM podcast_episodes WHERE podcasts.uuid IS podcast_episodes.podcast_id) AS last_used_timestamp
+          podcasts.title AS title,
+          podcasts.podcast_category AS podcast_category,
+          (SELECT MIN(podcast_episodes.published_date) FROM podcast_episodes WHERE podcasts.uuid IS podcast_episodes.podcast_id) AS initial_release_timestamp, 
+          (SELECT MAX(podcast_episodes.published_date) FROM podcast_episodes WHERE podcasts.uuid IS podcast_episodes.podcast_id) AS latest_release_timestamp,
+          (SELECT MAX(podcast_episodes.last_playback_interaction_date) FROM podcast_episodes WHERE podcasts.uuid IS podcast_episodes.podcast_id) AS last_used_timestamp
         FROM 
           podcasts
         WHERE
         -- Select only episodes that were used at most 2 months ago
-          last_used_timestamp * 1000 >= (:currentTime - 5184000000)
+          last_used_timestamp >= (:currentTime - 5184000000)
         ORDER BY
           last_used_timestamp DESC
         LIMIT
-          200
+          :limit
         """,
     )
-    abstract suspend fun getNovaLauncherRecentlyPlayedPodcasts(currentTime: Long = System.currentTimeMillis()): List<NovaLauncherRecentlyPlayedPodcast>
+    abstract suspend fun getNovaLauncherRecentlyPlayedPodcasts(
+        limit: Int,
+        currentTime: Long = System.currentTimeMillis(),
+    ): List<NovaLauncherRecentlyPlayedPodcast>
 }

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/entity/NovaLauncherRecentlyPlayedPodcast.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/entity/NovaLauncherRecentlyPlayedPodcast.kt
@@ -5,6 +5,7 @@ import androidx.room.ColumnInfo
 data class NovaLauncherRecentlyPlayedPodcast(
     @ColumnInfo(name = "id") val id: String,
     @ColumnInfo(name = "title") val title: String,
+    @ColumnInfo(name = "podcast_category") val categories: String,
     @ColumnInfo(name = "initial_release_timestamp") val initialReleaseTimestamp: Long?,
     @ColumnInfo(name = "latest_release_timestamp") val latestReleaseTimestamp: Long?,
     @ColumnInfo(name = "last_used_timestamp") val lastUsedTimestamp: Long,

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/nova/NovaLauncherManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/nova/NovaLauncherManager.kt
@@ -8,7 +8,7 @@ import au.com.shiftyjelly.pocketcasts.models.entity.NovaLauncherTrendingPodcast
 
 interface NovaLauncherManager {
     suspend fun getSubscribedPodcasts(limit: Int): List<NovaLauncherSubscribedPodcast>
-    suspend fun getRecentlyPlayedPodcasts(): List<NovaLauncherRecentlyPlayedPodcast>
+    suspend fun getRecentlyPlayedPodcasts(limit: Int): List<NovaLauncherRecentlyPlayedPodcast>
     suspend fun getTrendingPodcasts(limit: Int): List<NovaLauncherTrendingPodcast>
     suspend fun getNewEpisodes(limit: Int): List<NovaLauncherNewEpisode>
     suspend fun getInProgressEpisodes(limit: Int): List<NovaLauncherInProgressEpisode>

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/nova/NovaLauncherManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/nova/NovaLauncherManagerImpl.kt
@@ -11,7 +11,7 @@ class NovaLauncherManagerImpl @Inject constructor(
     private val settings: Settings,
 ) : NovaLauncherManager {
     override suspend fun getSubscribedPodcasts(limit: Int) = podcastDao.getNovaLauncherSubscribedPodcasts(settings.podcastsSortType.value, limit)
-    override suspend fun getRecentlyPlayedPodcasts() = podcastDao.getNovaLauncherRecentlyPlayedPodcasts()
+    override suspend fun getRecentlyPlayedPodcasts(limit: Int) = podcastDao.getNovaLauncherRecentlyPlayedPodcasts(limit)
     override suspend fun getTrendingPodcasts(limit: Int) = podcastDao.getNovaLauncherTrendingPodcasts(limit)
     override suspend fun getNewEpisodes(limit: Int) = episodeDao.getNovaLauncherNewEpisodes(limit)
     override suspend fun getInProgressEpisodes(limit: Int) = episodeDao.getNovaLauncherInProgressEpisodes(limit)

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
@@ -582,6 +582,7 @@ open class PlaybackManager @Inject constructor(
             SourceView.BOTTOM_SHELF,
             SourceView.SEARCH,
             SourceView.SEARCH_RESULTS,
+            SourceView.NOVA_LAUNCHER_RECENTLY_PLAYED,
             SourceView.NOVA_LAUNCHER_SUBSCRIBED_PODCASTS,
             SourceView.NOVA_LAUNCHER_TRENDING_PODCASTS,
             -> null


### PR DESCRIPTION
## Description

This PR syncs recently played podcasts with Nova Launcher.

## Testing Instructions

1. Install Nova Launcher from this link: p1718205443795369-slack-C028JAG44VD
2. Open Nova Launcher. You don't have to set it as a default launcher app but make sure you can use it.
3. Install Pocket Casts.
4. Have some podcasts that you listened to in the past 2 months.
6. Minimize the app.
7. You should see logs similar to these ones.
```
BgTask: NovaLauncherOneOffSyncWorker (Worker ID: 3ef6ed87-82ab-4def-ab64-f4ad062cb244) - Enqueued Nova Launcher one-off sync
BgTask: NovaLauncherOneOffSyncWorker (Worker ID: 3ef6ed87-82ab-4def-ab64-f4ad062cb244) - Staring Nova Launcher sync
BgTask: NovaLauncherOneOffSyncWorker (Worker ID: 3ef6ed87-82ab-4def-ab64-f4ad062cb244) - Nova Launcher sync complete. Success: [Subscribed podcasts: 75, Recently played podcasts: 36, Trending podcasts: 25, New episodes: 25, In progress episodes: 14]
```
8. If you notice the message below in the logs. Maximize and minimize the app again. It can happen if Nova fails to fetch verification signatures.
```
Nova Launcher sync failed
java.lang.SecurityException: Failed to verify Source calling package au.com.shiftyjelly.pocketcasts.debug
```
9. On Nova's home screen swipe to the left to open the panel.
10. Scroll down until you see `Recently Played` card.
11. The card should enlist at most 200 podcasts that you've listened to in the past 60 days.
12. Tap on any of the podcasts.
13. You should see `podcast_screen_shown` event with `nova_launcher_recently_played` and the episode details should open.

## Checklist
- [x] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [x] ~Any jetpack compose components I added or changed are covered by compose previews~
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] ~with different themes~
- [x] ~with a landscape orientation~
- [x] ~with the device set to have a large display and font size~
- [x] ~for accessibility with TalkBack~