### PR TITLE
Rename both track name event and property for Headphone Controls

### DIFF
--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/HeadphoneControlsSettingsPageViewModel.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/HeadphoneControlsSettingsPageViewModel.kt
@@ -74,8 +74,8 @@ class HeadphoneControlsSettingsPageViewModel @Inject constructor(
 
     fun onConfirmationSoundChanged(playConfirmationSound: Boolean) {
         analyticsTracker.track(
-            AnalyticsEvent.SETTINGS_HEADPHONE_CONTROLS_BOOKMARK_CONFIRMATION_SOUND,
-            mapOf("value" to playConfirmationSound),
+            AnalyticsEvent.SETTINGS_HEADPHONE_CONTROLS_BOOKMARK_SOUND_TOGGLED,
+            mapOf("enabled" to playConfirmationSound),
         )
     }
 

--- a/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
+++ b/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
@@ -511,7 +511,7 @@ enum class AnalyticsEvent(val key: String) {
     SETTINGS_HEADPHONE_CONTROLS_SHOWN("settings_headphone_controls_shown"),
     SETTINGS_HEADPHONE_CONTROLS_NEXT_CHANGED("settings_headphone_controls_next_changed"),
     SETTINGS_HEADPHONE_CONTROLS_PREVIOUS_CHANGED("settings_headphone_controls_previous_changed"),
-    SETTINGS_HEADPHONE_CONTROLS_BOOKMARK_CONFIRMATION_SOUND("settings_headphone_controls_bookmark_confirmation_sound"),
+    SETTINGS_HEADPHONE_CONTROLS_BOOKMARK_SOUND_TOGGLED("settings_headphone_controls_bookmark_sound_toggled"),
 
     /* Settings - Help */
     SETTINGS_HELP_SHOWN("settings_help_shown"),


### PR DESCRIPTION
## Description
- Rename `settings_headphone_controls_bookmark_confirmation_sound` to `settings_headphone_controls_bookmark_sound_toggled`
- Rename the property from value to enabled

This was a pending task we had in Track Events doc for Android

Fixes #2350

## Testing Instructions
1. Log with a premium account
2. Go to Profile tab - > Settings -> Headphone Controls
3. Set Add Bookmark as next or previous action
4. Toggle the Bookmark confirmation sound
5. ✅ Ensure 🔵 Tracked: `settings_headphone_controls_bookmark_sound_toggled, Properties: {"enabled"` is tracked


## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [ ] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
