### PR TITLE
Revert #2286 in order to avoid Search Term gets cleared when scrolled off-screen issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,6 @@
     *   Optimize writing large no. of podcast episodes into DB
         ([#2324](https://github.com/Automattic/pocket-casts-android/pull/2324))
 *   Bug Fixes
-    *   Fix: Search Term Persists When Navigating to Different Podcast Page
-        ([#2286](https://github.com/Automattic/pocket-casts-android/pull/2286))
     *   Fix: Subscribe button is highlighted in green instead of gray in the carousel
         ([#2278](https://github.com/Automattic/pocket-casts-android/pull/2278))
     *   Fix: Flickering when double-tapping an item in the tab bar

--- a/metadata/release_notes.txt
+++ b/metadata/release_notes.txt
@@ -9,8 +9,6 @@
     *   Optimize writing large no. of podcast episodes into DB
         ([#2324](https://github.com/Automattic/pocket-casts-android/pull/2324))
 *   Bug Fixes
-    *   Fix: Search Term Persists When Navigating to Different Podcast Page
-        ([#2286](https://github.com/Automattic/pocket-casts-android/pull/2286))
     *   Fix: Subscribe button is highlighted in green instead of gray in the carousel
         ([#2278](https://github.com/Automattic/pocket-casts-android/pull/2278))
     *   Fix: Flickering when double-tapping an item in the tab bar

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/EpisodeSearchView.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/EpisodeSearchView.kt
@@ -5,7 +5,6 @@ import android.text.Editable
 import android.text.TextWatcher
 import android.util.AttributeSet
 import android.view.LayoutInflater
-import android.view.View
 import android.widget.EditText
 import android.widget.FrameLayout
 import android.widget.ImageButton
@@ -52,7 +51,9 @@ class EpisodeSearchView @JvmOverloads constructor(context: Context, attrs: Attri
         }
         searchText.addTextChangedListener(textChangeListener)
         cancelSearchBtn.setOnClickListener {
-            cancelSearch()
+            searchText.setText("")
+            searchText.clearFocus()
+            UiUtil.hideKeyboard(searchText)
         }
 
         // Stops the focus search going to a detached row and causing a crash
@@ -60,18 +61,5 @@ class EpisodeSearchView @JvmOverloads constructor(context: Context, attrs: Attri
             UiUtil.hideKeyboard(searchText)
             true
         }
-    }
-
-    override fun onWindowVisibilityChanged(visibility: Int) {
-        super.onWindowVisibilityChanged(visibility)
-        if (visibility != View.VISIBLE) {
-            cancelSearch()
-        }
-    }
-
-    private fun cancelSearch() {
-        searchText.setText("")
-        searchText.clearFocus()
-        UiUtil.hideKeyboard(searchText)
     }
 }


### PR DESCRIPTION
## Description
<!-- Please include a summary of what this PR is changing and why these changes are needed. -->
- This PR reverts https://github.com/Automattic/pocket-casts-android/pull/2286 while was tying to fix https://github.com/Automattic/pocket-casts-android/issues/1320. This PR introduced another issue: https://github.com/Automattic/pocket-casts-android/issues/2352


Fixes #2352

## Testing Instructions
- Follow the steps from #2352 and make sure you can't reproduce this issue anymore

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack
