### PR TITLE
Revert PR 2326

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,9 +16,7 @@
         ([#2324](https://github.com/Automattic/pocket-casts-android/pull/2324))
 *   Bug Fixes
     *   Fix: Subscribe button is highlighted in green instead of gray in the carousel
-        ([#2278](https://github.com/Automattic/pocket-casts-android/pull/2278))
-    *   Fix: Flickering when double-tapping an item in the tab bar
-        ([#2326](https://github.com/Automattic/pocket-casts-android/pull/2326))    
+        ([#2278](https://github.com/Automattic/pocket-casts-android/pull/2278)) 
 *   Updates:
     *   Playback speed can now be changed up to 5x.
         ([#1645](https://github.com/Automattic/pocket-casts-android/pull/1645))

--- a/metadata/release_notes.txt
+++ b/metadata/release_notes.txt
@@ -11,8 +11,6 @@
 *   Bug Fixes
     *   Fix: Subscribe button is highlighted in green instead of gray in the carousel
         ([#2278](https://github.com/Automattic/pocket-casts-android/pull/2278))
-    *   Fix: Flickering when double-tapping an item in the tab bar
-        ([#2326](https://github.com/Automattic/pocket-casts-android/pull/2326))    
 *   Updates:
     *   Playback speed can now be changed up to 5x.
         ([#1645](https://github.com/Automattic/pocket-casts-android/pull/1645))

--- a/modules/features/navigation/src/main/java/au/com/shiftyjelly/pocketcasts/navigation/BottomNavigator.kt
+++ b/modules/features/navigation/src/main/java/au/com/shiftyjelly/pocketcasts/navigation/BottomNavigator.kt
@@ -90,7 +90,7 @@ open class BottomNavigator internal constructor() : ViewModel() {
                 if (resetRootFragmentSubject.hasObservers() && tabstackAndFragmentManagerInSync) {
                     resetRootFragmentSubject.onNext(currentFragment!!)
                 } else {
-                    reset(tab, false)
+                    reset(tab, true)
                 }
             } else {
                 reset(tab, false)


### PR DESCRIPTION
## Description
- Due the feedbacks we received [here](https://github.com/Automattic/pocket-casts-android/pull/2326) we decided to revert  
https://github.com/Automattic/pocket-casts-android/pull/2326 and come with another solution later


Internal ref: p1718627578962219/1718626748.174429-slack-C028JAG44VD



## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [ ] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack