### PR TITLE
Update Privacy Track event name

### DIFF
--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/privacy/PrivacyFragment.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/privacy/PrivacyFragment.kt
@@ -56,7 +56,7 @@ class PrivacyFragment : BaseFragment() {
         savedInstanceState: Bundle?,
     ): View {
         if (!viewModel.isFragmentChangingConfigurations) {
-            analyticsTracker.track(AnalyticsEvent.PRIVACY_SETTINGS_SHOWN)
+            analyticsTracker.track(AnalyticsEvent.PRIVACY_SHOWN)
         }
         return ComposeView(requireContext()).apply {
             setContent {

--- a/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
+++ b/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
@@ -254,7 +254,7 @@ enum class AnalyticsEvent(val key: String) {
     PLAYBACK_EPISODE_POSITION_CHANGED_ON_SYNC("playback_episode_position_changed_on_sync"),
 
     /* Privacy */
-    PRIVACY_SETTINGS_SHOWN("privacy_settings_shown"),
+    PRIVACY_SHOWN("privacy_shown"),
     ANALYTICS_OPT_IN("analytics_opt_in"),
     ANALYTICS_OPT_OUT("analytics_opt_out"),
     SETTINGS_SHOW_PRIVACY_POLICY("settings_show_privacy_policy"),


### PR DESCRIPTION
## Description
- Updates privacy track event name to match with the one listed in our `Pocket Casts Tracking Plan` spreadsheet

- Fixes #2360 

## Testing Instructions
- Code review should be enough


## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
