### PR TITLE
Fix episode sharing action when using multi-selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 7.67
 -----
 *   Bug Fixes
+    *   Fix sharing episodes when using multi-selection
+        ([#2376](https://github.com/Automattic/pocket-casts-android/pull/2376))
     *   Fix deselected chapters not synced correctly between different platforms
         ([#2357](https://github.com/Automattic/pocket-casts-android/pull/2357))
     *   Adds download episode action button to shelf list in Now Playing

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/FilterEpisodeListFragment.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/FilterEpisodeListFragment.kt
@@ -453,6 +453,7 @@ class FilterEpisodeListFragment : BaseFragment() {
         itemTouchHelper.attachToRecyclerView(recyclerView)
 
         val multiSelectToolbar = binding.multiSelectToolbar
+        multiSelectHelper.context = requireActivity()
         multiSelectHelper.source = SourceView.FILTERS
         multiSelectHelper.isMultiSelectingLive.observe(viewLifecycleOwner) { isMultiSelecting ->
             if (!multiSelectLoaded) {

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastFragment.kt
@@ -748,6 +748,7 @@ class PodcastFragment : BaseFragment(), Toolbar.OnMenuItemClickListener {
             adapter?.notifyDataSetChanged()
         }
         coordinatorLayout = (activity as FragmentHostListener).snackBarView()
+        context = requireActivity()
         source = SourceView.PODCAST_SCREEN
         listener = object : MultiSelectHelper.Listener<T> {
             override fun multiSelectSelectNone() {


### PR DESCRIPTION
## Description

`Context` was never set when multi-selecting episodes from a podcast details or a filter episode list. This prevented episodes from being shared.

## Testing Instructions

1. Open any podcast.
2. Long press to select a single episode.
3. Tap on overflow menu in the toolbar.
4. Tap on share.
5. A bottom share dialog should appear.
6. Go to any filter.
4. Long press to select a single episode.
5. Tap on overflow menu in the toolbar.
9. Tap on share.
10. A bottom share dialog should appear.

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [x] ~Any jetpack compose components I added or changed are covered by compose previews~
- [x] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] ~with different themes~
- [x] ~with a landscape orientation~
- [x] ~with the device set to have a large display and font size~
- [x] ~for accessibility with TalkBack~
