### PR TITLE
Add sharing clips option

### DIFF
--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/ShareFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/ShareFragment.kt
@@ -14,6 +14,8 @@ import au.com.shiftyjelly.pocketcasts.player.viewmodel.PlayerViewModel
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.SharePodcastHelper
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.SharePodcastHelper.ShareType
 import au.com.shiftyjelly.pocketcasts.ui.helper.StatusBarColor
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
 import au.com.shiftyjelly.pocketcasts.views.extensions.applyColor
 import au.com.shiftyjelly.pocketcasts.views.fragments.BaseDialogFragment
 import com.google.android.material.bottomsheet.BottomSheetBehavior
@@ -101,10 +103,14 @@ class ShareFragment : BaseDialogFragment() {
             }
             close()
         }
+        binding.buttonShareClip.setOnClickListener {
+            close()
+        }
 
         binding.sharePodcast.isVisible = podcast != null
         binding.shareEpisode.isVisible = episode != null
         binding.shareCurrentPosition.isVisible = episode != null
+        binding.shareClip.isVisible = FeatureFlag.isEnabled(Feature.SHARE_CLIPS) && episode is PodcastEpisode
         binding.openFileIn.isVisible = episode != null && episode.isDownloaded
 
         return binding.root

--- a/modules/features/player/src/main/res/layout/fragment_share.xml
+++ b/modules/features/player/src/main/res/layout/fragment_share.xml
@@ -34,10 +34,17 @@
             tools:ignore="MissingConstraints" />
 
         <androidx.constraintlayout.widget.Group
+            android:id="@+id/shareClip"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            app:constraint_referenced_ids="separator3,labelShareClip,buttonShareClip"
+            tools:ignore="MissingConstraints" />
+
+        <androidx.constraintlayout.widget.Group
             android:id="@+id/openFileIn"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            app:constraint_referenced_ids="separator3,labelOpenFileIn,buttonOpenFileIn"
+            app:constraint_referenced_ids="separator4,labelOpenFileIn,buttonOpenFileIn"
             tools:ignore="MissingConstraints" />
 
         <View
@@ -156,6 +163,41 @@
             app:layout_constraintTop_toBottomOf="@+id/labelShareCurrentPosition" />
 
         <TextView
+            android:id="@+id/labelShareClip"
+            style="@style/DarkSubtitle1"
+            android:layout_width="wrap_content"
+            android:layout_height="64dp"
+            android:layout_marginStart="32dp"
+            android:gravity="center_vertical"
+            android:importantForAccessibility="no"
+            android:text="@string/podcast_share_clip"
+            android:textColor="?attr/player_contrast_01"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/separator3" />
+
+        <View
+            android:id="@+id/buttonShareClip"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            android:background="?attr/selectableItemBackground"
+            android:clickable="true"
+            android:contentDescription="@string/podcast_share_clip"
+            android:focusable="true"
+            app:layout_constraintBottom_toBottomOf="@+id/labelShareClip"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="@+id/labelShareClip" />
+
+        <View
+            android:id="@+id/separator4"
+            android:layout_width="0dp"
+            android:layout_height="@dimen/divider_height"
+            android:background="?attr/player_contrast_05"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/labelShareClip" />
+
+        <TextView
             android:id="@+id/labelOpenFileIn"
             style="@style/DarkSubtitle1"
             android:layout_width="wrap_content"
@@ -166,7 +208,7 @@
             android:text="@string/podcast_share_open_file_in"
             android:textColor="?attr/player_contrast_01"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/separator3" />
+            app:layout_constraintTop_toBottomOf="@+id/separator4" />
 
         <View
             android:id="@+id/buttonOpenFileIn"

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -570,6 +570,7 @@ up    <string name="player_sleep_in_one_chapter">Sleeping in 1 chapter</string>
     <string name="podcast_share_current_position">Current position</string>
     <string name="podcast_share_episode">Share episode</string>
     <string name="podcast_share_open_file_in">Open file in&#x2026;</string>
+    <string name="podcast_share_clip">Clip</string>
     <string name="podcast_show_archived" translatable="false">@string/show_archived</string>
     <string name="podcast_sort_episodes">Sort episodes</string>
     <string name="podcast_subscribed">Subscribed</string>

--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/Feature.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/Feature.kt
@@ -115,6 +115,14 @@ enum class Feature(
         hasFirebaseRemoteFlag = false,
         hasDevToggle = true,
     ),
+    SHARE_CLIPS(
+        key = "share_clip",
+        title = "Share episode clips",
+        defaultValue = BuildConfig.DEBUG,
+        tier = FeatureTier.Free,
+        hasFirebaseRemoteFlag = false,
+        hasDevToggle = true,
+    ),
     ;
 
     companion object {

--- a/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/dialog/ShareDialog.kt
+++ b/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/dialog/ShareDialog.kt
@@ -9,6 +9,8 @@ import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.SharePodcastHelper
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.SharePodcastHelper.ShareType
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 class ShareDialog(
@@ -82,6 +84,12 @@ class ShareDialog(
                     ).showShareDialogDirect()
                 },
             )
+            if (FeatureFlag.isEnabled(Feature.SHARE_CLIPS)) {
+                dialog.addCheckedOption(
+                    titleId = LR.string.podcast_share_clip,
+                    click = {},
+                )
+            }
             if (episode.isDownloaded) {
                 dialog.addCheckedOption(
                     titleId = LR.string.podcast_share_open_file_in,


### PR DESCRIPTION
## Description

Introduction of a feature flag and entry points to the sharing clip feature.

## Testing Instructions

1. Play a podcast episode.
2. Use share action from the shelf.
3. You should see `Clip` option.
4. Go to `Beta features` and disable `Share episode clips`.
5. Use share action from the shelf.
6. You shouldn't see `Clip` option.

## Screenshots or Screencast 

| Podcast details | Episode details |
| - | - |
| ![Screenshot_20240619-095041](https://github.com/Automattic/pocket-casts-android/assets/30936061/3787f5a8-6510-4ee1-9405-06692645aff4) | ![Screenshot_20240619-095056](https://github.com/Automattic/pocket-casts-android/assets/30936061/f35fe168-5000-45dc-8fcd-c3479881f68a) |

## Checklist
- [x] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] ~Any jetpack compose components I added or changed are covered by compose previews~
- [x] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] ~with different themes~
- [x] ~with a landscape orientation~
- [x] ~with the device set to have a large display and font size~
- [x] for accessibility with TalkBack
