### PR TITLE
Cache playing episode feature flag + advanced setting

### DIFF
--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/AdvancedSettingsPage.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/AdvancedSettingsPage.kt
@@ -30,6 +30,8 @@ import au.com.shiftyjelly.pocketcasts.compose.preview.ThemePreviewParameterProvi
 import au.com.shiftyjelly.pocketcasts.compose.theme
 import au.com.shiftyjelly.pocketcasts.settings.viewmodel.AdvancedSettingsViewModel
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 /**
@@ -94,9 +96,12 @@ fun AdvancedSettingsView(
             }
             item {
                 SettingSection(
-                    heading = stringResource(LR.string.settings_storage_section_heading_seek_accuracy),
+                    heading = stringResource(LR.string.settings_advanced_heading_playback),
                     indent = false,
                 ) {
+                    if (FeatureFlag.isEnabled(Feature.CACHE_ENTIRE_PLAYING_EPISODE)) {
+                        CacheEntirePlayingEpisodeRow(state.cacheEntirePlayingEpisodeState)
+                    }
                     PrioritizeSeekAccuracydRow(state.prioritizeSeekAccuracyState)
                 }
             }
@@ -140,6 +145,24 @@ private fun PrioritizeSeekAccuracydRow(
     )
 }
 
+@Composable
+private fun CacheEntirePlayingEpisodeRow(
+    state: AdvancedSettingsViewModel.State.CacheEntirePlayingEpisodeState,
+    modifier: Modifier = Modifier,
+) {
+    SettingRow(
+        primaryText = stringResource(LR.string.settings_advanced_cache_entire_playing_episode),
+        secondaryText = stringResource(LR.string.settings_advanced_cache_entire_playing_episode_summary),
+        toggle = SettingRowToggle.Switch(state.isChecked),
+        indent = false,
+        modifier = modifier.toggleable(
+            value = state.isChecked,
+            role = Role.Switch,
+            onValueChange = { state.onCheckedChange(it) },
+        ),
+    )
+}
+
 @Preview(showBackground = true)
 @Composable
 private fun AdvancedSettingsPreview(
@@ -154,6 +177,10 @@ private fun AdvancedSettingsPreview(
                     onCheckedChange = {},
                 ),
                 prioritizeSeekAccuracyState = AdvancedSettingsViewModel.State.PrioritizeSeekAccuracyState(
+                    isChecked = true,
+                    onCheckedChange = {},
+                ),
+                cacheEntirePlayingEpisodeState = AdvancedSettingsViewModel.State.CacheEntirePlayingEpisodeState(
                     isChecked = true,
                     onCheckedChange = {},
                 ),

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/viewmodel/AdvancedSettingsViewModel.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/viewmodel/AdvancedSettingsViewModel.kt
@@ -49,6 +49,17 @@ class AdvancedSettingsViewModel
                 )
             },
         ),
+        cacheEntirePlayingEpisodeState = State.CacheEntirePlayingEpisodeState(
+            isChecked = settings.cacheEntirePlayingEpisode.value,
+            onCheckedChange = {
+                settings.cacheEntirePlayingEpisode.set(it, updateModifiedAt = false)
+                updateCacheEntirePlayingEpisodeState()
+                analyticsTracker.track(
+                    AnalyticsEvent.SETTINGS_ADVANCED_CACHE_ENTIRE_PLAYING_EPISODE,
+                    mapOf("enabled" to it),
+                )
+            },
+        ),
     )
 
     private fun onSyncOnMeteredCheckedChange(isChecked: Boolean) {
@@ -75,6 +86,14 @@ class AdvancedSettingsViewModel
         )
     }
 
+    private fun updateCacheEntirePlayingEpisodeState() {
+        mutableState.value = mutableState.value.copy(
+            cacheEntirePlayingEpisodeState = mutableState.value.cacheEntirePlayingEpisodeState.copy(
+                isChecked = settings.cacheEntirePlayingEpisode.value,
+            ),
+        )
+    }
+
     fun onShown() {
         analyticsTracker.track(AnalyticsEvent.SETTINGS_ADVANCED_SHOWN)
     }
@@ -82,6 +101,7 @@ class AdvancedSettingsViewModel
     data class State(
         val backgroundSyncOnMeteredState: BackgroundSyncOnMeteredState,
         val prioritizeSeekAccuracyState: PrioritizeSeekAccuracyState,
+        val cacheEntirePlayingEpisodeState: CacheEntirePlayingEpisodeState,
     ) {
 
         data class BackgroundSyncOnMeteredState(
@@ -91,6 +111,11 @@ class AdvancedSettingsViewModel
         )
 
         data class PrioritizeSeekAccuracyState(
+            val isChecked: Boolean,
+            val onCheckedChange: (Boolean) -> Unit,
+        )
+
+        data class CacheEntirePlayingEpisodeState(
             val isChecked: Boolean,
             val onCheckedChange: (Boolean) -> Unit,
         )

--- a/modules/features/settings/src/test/java/au/com/shiftyjelly/pocketcasts/settings/viewmodel/AdvancedSettingsViewModelTest.kt
+++ b/modules/features/settings/src/test/java/au/com/shiftyjelly/pocketcasts/settings/viewmodel/AdvancedSettingsViewModelTest.kt
@@ -39,6 +39,7 @@ class AdvancedSettingsViewModelTest {
         whenever(settings.syncOnMeteredNetwork()).thenReturn(false)
         whenever(settings.backgroundRefreshPodcasts).thenReturn(UserSetting.Mock(true, mock()))
         whenever(settings.prioritizeSeekAccuracy).thenReturn(UserSetting.Mock(false, mock()))
+        whenever(settings.cacheEntirePlayingEpisode).thenReturn(UserSetting.Mock(false, mock()))
         viewModel = AdvancedSettingsViewModel(
             settings,
             analyticsTracker,
@@ -50,5 +51,6 @@ class AdvancedSettingsViewModelTest {
     fun `verify settings methods initialize the viewModel state correctly`() {
         TestCase.assertEquals(viewModel.state.value.backgroundSyncOnMeteredState.isChecked, false)
         TestCase.assertEquals(viewModel.state.value.prioritizeSeekAccuracyState.isChecked, false)
+        TestCase.assertEquals(viewModel.state.value.cacheEntirePlayingEpisodeState.isChecked, false)
     }
 }

--- a/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
+++ b/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
@@ -557,6 +557,7 @@ enum class AnalyticsEvent(val key: String) {
     SETTINGS_ADVANCED_SHOWN("settings_advanced_shown"),
     SETTINGS_ADVANCED_SYNC_ON_METERED("settings_advanced_sync_on_metered"),
     SETTINGS_ADVANCED_PRIORITIZE_SEEK_ACCURACY("settings_advanced_prioritize_seek_accuracy"),
+    SETTINGS_ADVANCED_CACHE_ENTIRE_PLAYING_EPISODE("settings_advanced_cache_entire_playing_episode"),
 
     /* Search */
     SEARCH_SHOWN("search_shown"),

--- a/modules/services/localization/src/main/res/values-de/strings.xml
+++ b/modules/services/localization/src/main/res/values-de/strings.xml
@@ -15,7 +15,6 @@ Language: de
     <string name="settings_general_sleep_timer">Schlummerfunktion</string>
     <string name="settings_advanced_prioritize_seek_accuracy_summary">Durch die Priorisierung der Suchgenauigkeit kann die Reaktionsfähigkeit der Suche erheblich verlangsamt werden, was bei Pocket Casts zu einem höheren Datenverbrauch führen kann.</string>
     <string name="settings_advanced_prioritize_seek_accuracy">Suchgenauigkeit priorisieren</string>
-    <string name="settings_storage_section_heading_seek_accuracy">Suchgenauigkeit</string>
     <string name="settings_import_opml_succeeded_message">OPML-Import erfolgreich</string>
     <string name="settings_import_opml_import_failed_message">Aus der angegebenen OPML-Datei konnten keine Podcasts importiert werden.</string>
     <string name="nova_launcher_recently_played">Zuletzt abgespielt</string>

--- a/modules/services/localization/src/main/res/values-es-rMX/strings.xml
+++ b/modules/services/localization/src/main/res/values-es-rMX/strings.xml
@@ -15,7 +15,6 @@ Language: es
     <string name="settings_general_sleep_timer">Temporizador</string>
     <string name="settings_advanced_prioritize_seek_accuracy_summary">Priorizar la precisión en la búsqueda puede ralentizar significativamente la capacidad de respuesta de la búsqueda y hacer que Pocket Casts consuma más datos.</string>
     <string name="settings_advanced_prioritize_seek_accuracy">Priorizando la precisión en la búsqueda</string>
-    <string name="settings_storage_section_heading_seek_accuracy">Precisión en la búsqueda</string>
     <string name="settings_import_opml_succeeded_message">Importación de OPML realizada correctamente.</string>
     <string name="settings_import_opml_import_failed_message">No se pueden importar los podcasts del archivo OPML que has especificado.</string>
     <string name="nova_launcher_recently_played">Reproducido recientemente</string>

--- a/modules/services/localization/src/main/res/values-es/strings.xml
+++ b/modules/services/localization/src/main/res/values-es/strings.xml
@@ -15,7 +15,6 @@ Language: es
     <string name="settings_general_sleep_timer">Temporizador</string>
     <string name="settings_advanced_prioritize_seek_accuracy_summary">Priorizar la precisión en la búsqueda puede ralentizar significativamente la capacidad de respuesta de la búsqueda y hacer que Pocket Casts consuma más datos.</string>
     <string name="settings_advanced_prioritize_seek_accuracy">Priorizando la precisión en la búsqueda</string>
-    <string name="settings_storage_section_heading_seek_accuracy">Precisión en la búsqueda</string>
     <string name="settings_import_opml_succeeded_message">Importación de OPML realizada correctamente.</string>
     <string name="settings_import_opml_import_failed_message">No se pueden importar los podcasts del archivo OPML que has especificado.</string>
     <string name="nova_launcher_recently_played">Reproducido recientemente</string>

--- a/modules/services/localization/src/main/res/values-fr-rCA/strings.xml
+++ b/modules/services/localization/src/main/res/values-fr-rCA/strings.xml
@@ -15,7 +15,6 @@ Language: fr
     <string name="settings_general_sleep_timer">Mise en veille</string>
     <string name="settings_advanced_prioritize_seek_accuracy_summary">Privilégier la précision de la recherche peut ralentir considérablement la réactivité de la fonction de recherche et accroître la quantité de données consommées par Pocket Casts.</string>
     <string name="settings_advanced_prioritize_seek_accuracy">Privilégier la précision de la recherche</string>
-    <string name="settings_storage_section_heading_seek_accuracy">Précision de la recherche</string>
     <string name="settings_import_opml_succeeded_message">Importation OPML réussie.</string>
     <string name="settings_import_opml_import_failed_message">Impossible d’importer des podcasts à partir du fichier OPML indiqué.</string>
     <string name="nova_launcher_recently_played">Lectures récentes</string>

--- a/modules/services/localization/src/main/res/values-fr/strings.xml
+++ b/modules/services/localization/src/main/res/values-fr/strings.xml
@@ -15,7 +15,6 @@ Language: fr
     <string name="settings_general_sleep_timer">Mise en veille</string>
     <string name="settings_advanced_prioritize_seek_accuracy_summary">Privilégier la précision de la recherche peut ralentir considérablement la réactivité de la fonction de recherche et accroître la quantité de données consommées par Pocket Casts.</string>
     <string name="settings_advanced_prioritize_seek_accuracy">Privilégier la précision de la recherche</string>
-    <string name="settings_storage_section_heading_seek_accuracy">Précision de la recherche</string>
     <string name="settings_import_opml_succeeded_message">Importation OPML réussie.</string>
     <string name="settings_import_opml_import_failed_message">Impossible d’importer des podcasts à partir du fichier OPML indiqué.</string>
     <string name="nova_launcher_recently_played">Lectures récentes</string>

--- a/modules/services/localization/src/main/res/values-it/strings.xml
+++ b/modules/services/localization/src/main/res/values-it/strings.xml
@@ -15,7 +15,6 @@ Language: it
     <string name="settings_general_sleep_timer">Autospegnimento</string>
     <string name="settings_advanced_prioritize_seek_accuracy_summary">Dare priorità alla precisione della ricerca può rallentarne in modo significativo la reattività e comportare un maggiore consumo di dati da parte di Pocket Casts.</string>
     <string name="settings_advanced_prioritize_seek_accuracy">Dare priorità alla precisione della ricerca</string>
-    <string name="settings_storage_section_heading_seek_accuracy">Precisione della ricerca</string>
     <string name="settings_import_opml_succeeded_message">Importazione di OPML completata.</string>
     <string name="settings_import_opml_import_failed_message">Impossibile importare i podcast dal file OPML specificato.</string>
     <string name="nova_launcher_recently_played">Ascoltati di recente</string>

--- a/modules/services/localization/src/main/res/values-ja/strings.xml
+++ b/modules/services/localization/src/main/res/values-ja/strings.xml
@@ -15,7 +15,6 @@ Language: ja_JP
     <string name="settings_general_sleep_timer">スリープタイマー</string>
     <string name="settings_advanced_prioritize_seek_accuracy_summary">探索の精度を優先すると、探索の応答性が大幅に低下し、Pocket Casts のデータ消費が増える可能性があります。</string>
     <string name="settings_advanced_prioritize_seek_accuracy">探索の精度を優先</string>
-    <string name="settings_storage_section_heading_seek_accuracy">探索の精度</string>
     <string name="settings_import_opml_succeeded_message">OPML をインポートできました。</string>
     <string name="settings_import_opml_import_failed_message">指定した OPML ファイルからポッドキャストをインポートできません。</string>
     <string name="nova_launcher_recently_played">最近再生済み</string>

--- a/modules/services/localization/src/main/res/values-ko/strings.xml
+++ b/modules/services/localization/src/main/res/values-ko/strings.xml
@@ -15,7 +15,6 @@ Language: ko_KR
     <string name="settings_general_sleep_timer">절전 타이머</string>
     <string name="settings_advanced_prioritize_seek_accuracy_summary">검색 정확도를 우선시하면 검색 응답 속도가 크게 느려지고 Pocket Casts에서 더 많은 데이터를 사용합니다.</string>
     <string name="settings_advanced_prioritize_seek_accuracy">검색 정확도 우선</string>
-    <string name="settings_storage_section_heading_seek_accuracy">검색 정확도</string>
     <string name="settings_import_opml_succeeded_message">OPML 가져오기에 성공했습니다.</string>
     <string name="settings_import_opml_import_failed_message">지정하신 OPML 파일에서 팟캐스트를 가져올 수 없습니다.</string>
     <string name="nova_launcher_recently_played">최근 재생됨</string>

--- a/modules/services/localization/src/main/res/values-nl/strings.xml
+++ b/modules/services/localization/src/main/res/values-nl/strings.xml
@@ -13,7 +13,6 @@ Language: nl
     <string name="settings_general_sleep_timer">Slaaptimer</string>
     <string name="settings_advanced_prioritize_seek_accuracy_summary">De nauwkeurigheid van zoekopdrachten prioriteren kan de responsiviteit vertragen en ervoor zorgen dat Pocket Casts meer gegevens verbruikt.</string>
     <string name="settings_advanced_prioritize_seek_accuracy">Zoeknauwkeurigheid prioriteren</string>
-    <string name="settings_storage_section_heading_seek_accuracy">Zoeknauwkeurigheid</string>
     <string name="settings_import_opml_succeeded_message">Importeren van OPML is gelukt.</string>
     <string name="settings_import_opml_import_failed_message">Kan geen podcasts importeren via het OPML-bestand dat je hebt opgegeven.</string>
     <string name="nova_launcher_recently_played">Recent afgespeeld</string>

--- a/modules/services/localization/src/main/res/values-pt-rBR/strings.xml
+++ b/modules/services/localization/src/main/res/values-pt-rBR/strings.xml
@@ -15,7 +15,6 @@ Language: pt_BR
     <string name="settings_general_sleep_timer">Temporizador</string>
     <string name="settings_advanced_prioritize_seek_accuracy_summary">Priorizar a precisão da busca pode diminuir significativamente a capacidade de resposta da busca e fazer com que o Pocket Casts consuma mais dados.</string>
     <string name="settings_advanced_prioritize_seek_accuracy">Priorizar a precisão da busca</string>
-    <string name="settings_storage_section_heading_seek_accuracy">Precisão da busca</string>
     <string name="settings_import_opml_succeeded_message">Importação de OPML bem-sucedida.</string>
     <string name="settings_import_opml_import_failed_message">Não é possível importar podcasts do arquivo OPML que você especificou.</string>
     <string name="nova_launcher_recently_played">Reproduzido recentemente</string>

--- a/modules/services/localization/src/main/res/values-ru/strings.xml
+++ b/modules/services/localization/src/main/res/values-ru/strings.xml
@@ -15,7 +15,6 @@ Language: ru
     <string name="settings_general_sleep_timer">Таймер сна</string>
     <string name="settings_advanced_prioritize_seek_accuracy_summary">Указание точности поиска в качестве приоритета может значительно замедлить его скорость отклика и привести к тому, что Pocket Casts станет потреблять больше данных.</string>
     <string name="settings_advanced_prioritize_seek_accuracy">Приоритет точности при поиске</string>
-    <string name="settings_storage_section_heading_seek_accuracy">Точность при поиске</string>
     <string name="settings_import_opml_succeeded_message">Файлы OPML импортированы.</string>
     <string name="settings_import_opml_import_failed_message">Не удаётся импортировать подкасты из указанного вами файла OPML.</string>
     <string name="nova_launcher_recently_played">Недавно воспроизведённые</string>

--- a/modules/services/localization/src/main/res/values-sv/strings.xml
+++ b/modules/services/localization/src/main/res/values-sv/strings.xml
@@ -15,7 +15,6 @@ Language: sv_SE
     <string name="settings_general_sleep_timer">Sömntimer</string>
     <string name="settings_advanced_prioritize_seek_accuracy_summary">Att prioritera sökprecision kan bromsa svarstiden för sökningar avsevärt och göra att Pocket Casts konsumerar mer data.</string>
     <string name="settings_advanced_prioritize_seek_accuracy">Prioritera sökprecision</string>
-    <string name="settings_storage_section_heading_seek_accuracy">Sökprecision</string>
     <string name="settings_import_opml_succeeded_message">OPML-importen har genomförts.</string>
     <string name="settings_import_opml_import_failed_message">Det gick inte att importera podcasts från den angivna OPML-filen.</string>
     <string name="nova_launcher_recently_played">Senast spelade</string>

--- a/modules/services/localization/src/main/res/values-zh-rTW/strings.xml
+++ b/modules/services/localization/src/main/res/values-zh-rTW/strings.xml
@@ -15,7 +15,6 @@ Language: zh_TW
     <string name="settings_general_sleep_timer">睡眠計時器</string>
     <string name="settings_advanced_prioritize_seek_accuracy_summary">若將搜尋精確度設為優先，會大幅降低搜尋靈敏度，導致 Pocket Casts 消耗更多資料。</string>
     <string name="settings_advanced_prioritize_seek_accuracy">將搜尋精確度設為優先</string>
-    <string name="settings_storage_section_heading_seek_accuracy">搜尋精確度</string>
     <string name="settings_import_opml_succeeded_message">已成功匯入 OPML。</string>
     <string name="settings_import_opml_import_failed_message">無法從你指定的 OPML 檔案匯入 Podcast。</string>
     <string name="nova_launcher_recently_played">最近播放</string>

--- a/modules/services/localization/src/main/res/values-zh/strings.xml
+++ b/modules/services/localization/src/main/res/values-zh/strings.xml
@@ -15,7 +15,6 @@ Language: zh_CN
     <string name="settings_general_sleep_timer">睡眠计时器</string>
     <string name="settings_advanced_prioritize_seek_accuracy_summary">提高搜索准确性的优先级会大幅降低搜索响应速度，并增加 Pocket Casts 的数据消耗量。</string>
     <string name="settings_advanced_prioritize_seek_accuracy">提高搜索准确性的优先级</string>
-    <string name="settings_storage_section_heading_seek_accuracy">搜索准确性</string>
     <string name="settings_import_opml_succeeded_message">OPML 导入成功。</string>
     <string name="settings_import_opml_import_failed_message">无法从您指定的 OPML 文件导入播客。</string>
     <string name="nova_launcher_recently_played">最近播放</string>

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -1289,7 +1289,7 @@ up    <string name="player_sleep_in_one_chapter">Sleeping in 1 chapter</string>
     <string name="settings_storage_move_podcasts">Moving podcasts&#x2026;</string>
     <string name="settings_storage_section_heading_usage">Usage</string>
     <string name="settings_storage_section_heading_mobile_data">Mobile Data</string>
-    <string name="settings_storage_section_heading_seek_accuracy">Seek Accuracy</string>
+    <string name="settings_storage_section_heading_playback">Playback</string>
     <string name="settings_storage_size_free">%s free</string>
     <string name="settings_storage_sorry">Sorry</string>
     <string name="settings_storage_store_on">Store podcasts on</string>
@@ -1488,10 +1488,13 @@ up    <string name="player_sleep_in_one_chapter">Sleeping in 1 chapter</string>
     <string name="settings_open_on_phone">Open on phone</string>
     <string name="settings_could_not_open_on_phone">Unable to open on phone</string>
 
+    <string name="settings_advanced_heading_playback">Playback</string>
     <string name="settings_advanced_sync_on_metered">Sync on Metered Networks</string>
     <string name="settings_advanced_sync_on_metered_summary">Permits automatic background sync on metered networks. This is enabled by default and has no effect if background refresh is turned off.</string>
     <string name="settings_advanced_prioritize_seek_accuracy">Prioritizing seek accuracy</string>
     <string name="settings_advanced_prioritize_seek_accuracy_summary">Prioritizing seek accuracy can significantly slow down seek responsiveness and cause Pocket Casts to consume more data.</string>
+    <string name="settings_advanced_cache_entire_playing_episode">Cache playing episode</string>
+    <string name="settings_advanced_cache_entire_playing_episode_summary">Entire playing episode is cached on an unmetered network to minimize streaming while playing. The episode is automatically removed from cache when the cache size limit is reached.</string>
     <!-- Used in a button meaning that the user understood the message. -->
     <string name="whats_new_got_it_button">Got it</string>
     <!-- Button title to upgrade to Plus. Don't translate "Plus" -->

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -65,6 +65,7 @@
     <string name="pause">Pause</string>
     <string name="pause_episode">Pause episode</string>
     <string name="play">Play</string>
+    <string name="playback">Playback</string>
     <string name="play_all">Play all</string>
     <string name="play_all_from_here">Play all from here</string>
     <string name="play_episode">Play episode</string>
@@ -1289,7 +1290,7 @@ up    <string name="player_sleep_in_one_chapter">Sleeping in 1 chapter</string>
     <string name="settings_storage_move_podcasts">Moving podcasts&#x2026;</string>
     <string name="settings_storage_section_heading_usage">Usage</string>
     <string name="settings_storage_section_heading_mobile_data">Mobile Data</string>
-    <string name="settings_storage_section_heading_playback">Playback</string>
+    <string name="settings_storage_section_heading_playback" translatable="false">@string/playback</string>
     <string name="settings_storage_size_free">%s free</string>
     <string name="settings_storage_sorry">Sorry</string>
     <string name="settings_storage_store_on">Store podcasts on</string>
@@ -1488,7 +1489,7 @@ up    <string name="player_sleep_in_one_chapter">Sleeping in 1 chapter</string>
     <string name="settings_open_on_phone">Open on phone</string>
     <string name="settings_could_not_open_on_phone">Unable to open on phone</string>
 
-    <string name="settings_advanced_heading_playback">Playback</string>
+    <string name="settings_advanced_heading_playback" translatable="false">@string/playback</string>
     <string name="settings_advanced_sync_on_metered">Sync on Metered Networks</string>
     <string name="settings_advanced_sync_on_metered_summary">Permits automatic background sync on metered networks. This is enabled by default and has no effect if background refresh is turned off.</string>
     <string name="settings_advanced_prioritize_seek_accuracy">Prioritizing seek accuracy</string>

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
@@ -288,6 +288,7 @@ interface Settings {
     val backgroundRefreshPodcasts: UserSetting<Boolean>
     val podcastsSortType: UserSetting<PodcastsSortType>
     val prioritizeSeekAccuracy: UserSetting<Boolean>
+    val cacheEntirePlayingEpisode: UserSetting<Boolean>
 
     fun setSelectPodcastsSortType(sortType: PodcastsSortType)
     fun getSelectPodcastsSortType(): PodcastsSortType

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
@@ -194,6 +194,12 @@ class SettingsImpl @Inject constructor(
         sharedPrefs = sharedPreferences,
     )
 
+    override val cacheEntirePlayingEpisode = UserSetting.BoolPref(
+        sharedPrefKey = "cacheEntirePlayingEpisode",
+        defaultValue = false,
+        sharedPrefs = sharedPreferences,
+    )
+
     override fun setSelectPodcastsSortType(sortType: PodcastsSortType) {
         sharedPreferences.edit().apply {
             putString(Settings.PREFERENCE_SELECT_PODCAST_LIBRARY_SORT, sortType.clientId.toString())

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
@@ -194,7 +194,7 @@ class SettingsImpl @Inject constructor(
         sharedPrefs = sharedPreferences,
     )
 
-    override val cacheEntirePlayingEpisode = UserSetting.BoolPref(
+    override val cacheEntirePlayingEpisode = UserSetting.CacheEntirePlayingEpisodePref(
         sharedPrefKey = "cacheEntirePlayingEpisode",
         defaultValue = false,
         sharedPrefs = sharedPreferences,

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/UserSetting.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/UserSetting.kt
@@ -2,6 +2,8 @@ package au.com.shiftyjelly.pocketcasts.preferences
 
 import android.annotation.SuppressLint
 import android.content.SharedPreferences
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
 import java.time.Clock
 import java.time.Instant
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -71,7 +73,7 @@ abstract class UserSetting<T>(
         }
     }
 
-    class BoolPref(
+    open class BoolPref(
         sharedPrefKey: String,
         private val defaultValue: Boolean,
         sharedPrefs: SharedPreferences,
@@ -271,6 +273,20 @@ abstract class UserSetting<T>(
             intValue.toString()
         },
     )
+
+    // This returns shared pref value only if CACHE_ENTIRE_PLAYING_EPISODE feature flag is enabled, otherwise returns always false
+    class CacheEntirePlayingEpisodePref(
+        sharedPrefKey: String,
+        private val defaultValue: Boolean,
+        sharedPrefs: SharedPreferences,
+    ) : BoolPref(sharedPrefKey, defaultValue, sharedPrefs) {
+
+        override fun get() = if (FeatureFlag.isEnabled(Feature.CACHE_ENTIRE_PLAYING_EPISODE)) {
+            sharedPrefs.getBoolean(sharedPrefKey, defaultValue)
+        } else {
+            false
+        }
+    }
 
     // This manual mock is needed to avoid problems when accessing a lazily initialized UserSetting::flow
     // from a mocked Settings class

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/ExoPlayerHelper.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/ExoPlayerHelper.kt
@@ -15,7 +15,7 @@ import java.io.File
 import timber.log.Timber
 
 @OptIn(UnstableApi::class)
-object ExoPlayerCacheUtil {
+object ExoPlayerHelper {
     private const val CACHE_DIR_NAME = "pocketcasts-exoplayer-cache"
     private var simpleCache: SimpleCache? = null
 

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlayerFactoryImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlayerFactoryImpl.kt
@@ -3,14 +3,13 @@ package au.com.shiftyjelly.pocketcasts.repositories.playback
 import android.content.Context
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.repositories.user.StatsManager
-import com.automattic.android.tracks.crashlogging.CrashLogging
 import dagger.hilt.android.qualifiers.ApplicationContext
 import javax.inject.Inject
 
 class PlayerFactoryImpl @Inject constructor(
     private val settings: Settings,
     private val statsManager: StatsManager,
-    private val crashLogging: CrashLogging,
+    private val exoPlayerHelper: ExoPlayerHelper,
     @ApplicationContext private val context: Context,
 ) : PlayerFactory {
 
@@ -22,6 +21,6 @@ class PlayerFactoryImpl @Inject constructor(
     }
 
     override fun createSimplePlayer(onPlayerEvent: (Player, PlayerEvent) -> Unit): Player {
-        return SimplePlayer(settings, statsManager, context, crashLogging, onPlayerEvent)
+        return SimplePlayer(settings, statsManager, context, exoPlayerHelper, onPlayerEvent)
     }
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/SimplePlayer.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/SimplePlayer.kt
@@ -33,7 +33,6 @@ import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.repositories.user.StatsManager
 import au.com.shiftyjelly.pocketcasts.utils.Util
 import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
-import com.automattic.android.tracks.crashlogging.CrashLogging
 import java.io.File
 import java.util.concurrent.TimeUnit
 import kotlinx.coroutines.Dispatchers
@@ -44,7 +43,7 @@ class SimplePlayer(
     val settings: Settings,
     val statsManager: StatsManager,
     val context: Context,
-    val crashLogging: CrashLogging,
+    private val exoPlayerHelper: ExoPlayerHelper,
     override val onPlayerEvent: (au.com.shiftyjelly.pocketcasts.repositories.playback.Player, PlayerEvent) -> Unit,
 ) : LocalPlayer(onPlayerEvent) {
     private val reducedBufferManufacturers = listOf("mercedes-benz")
@@ -286,11 +285,7 @@ class SimplePlayer(
             }
         } ?: return
 
-        val sourceFactory = ExoPlayerCacheUtil.getSimpleCache(
-            context = context,
-            cacheSizeInMB = settings.getExoPlayerCacheSizeInMB(),
-            crashLogging = crashLogging,
-        )?.let { cache ->
+        val sourceFactory = exoPlayerHelper.getSimpleCache()?.let { cache ->
             if (location is EpisodeLocation.Stream) {
                 CacheDataSource.Factory()
                     .setCache(cache)

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/SimplePlayer.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/SimplePlayer.kt
@@ -250,9 +250,7 @@ class SimplePlayer(
 
         addVideoListener(player)
 
-        val httpDataSourceFactory = DefaultHttpDataSource.Factory()
-            .setUserAgent("Pocket Casts")
-            .setAllowCrossProtocolRedirects(true)
+        val httpDataSourceFactory = exoPlayerHelper.getDataSourceFactory()
         val dataSourceFactory = DefaultDataSource.Factory(context, httpDataSourceFactory)
         val extractorsFactory = DefaultExtractorsFactory()
             .setConstantBitrateSeekingEnabled(true)
@@ -287,9 +285,10 @@ class SimplePlayer(
 
         val sourceFactory = exoPlayerHelper.getSimpleCache()?.let { cache ->
             if (location is EpisodeLocation.Stream) {
-                CacheDataSource.Factory()
-                    .setCache(cache)
-                    .setUpstreamDataSourceFactory(httpDataSourceFactory)
+                exoPlayerHelper.getCacheDataSourceFactory(
+                    httpDataSourceFactory,
+                    cache,
+                )
             } else {
                 dataSourceFactory
             }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/SimplePlayer.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/SimplePlayer.kt
@@ -17,8 +17,6 @@ import androidx.media3.common.Tracks
 import androidx.media3.common.VideoSize
 import androidx.media3.common.util.UnstableApi
 import androidx.media3.datasource.DefaultDataSource
-import androidx.media3.datasource.DefaultHttpDataSource
-import androidx.media3.datasource.cache.CacheDataSource
 import androidx.media3.exoplayer.DefaultLoadControl
 import androidx.media3.exoplayer.ExoPlayer
 import androidx.media3.exoplayer.hls.HlsMediaSource

--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/Feature.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/Feature.kt
@@ -115,6 +115,14 @@ enum class Feature(
         hasFirebaseRemoteFlag = false,
         hasDevToggle = true,
     ),
+    CACHE_ENTIRE_PLAYING_EPISODE(
+        key = "cache_entire_playing_episode",
+        title = "Cache entire playing episode",
+        defaultValue = BuildConfig.DEBUG,
+        tier = FeatureTier.Free,
+        hasFirebaseRemoteFlag = false,
+        hasDevToggle = true,
+    ),
     ;
 
     companion object {


### PR DESCRIPTION
## Description

This is a preparatory PR  that

1. Adds feature flag for caching the entire streaming episode to minimize streaming while playing (this is different from on-the-fly caching introduced earlier).
2. Adds advanced setting if the above feature flag is enabled (it is disabled by default, we can revisit the default state, and summary text later).
3. Extracts data source factory to helper singleton so that they can be reused later to cache entire episode.

## Testing Instructions
1. Install the app
2. Go to `Profile` -> `Settings`-> `Advanced`
3. ✅ Notice there is an advanced setting to enable caching the playing episode 
4. Toggle the setting
5. ✅ Notice that `settings_advanced_cache_entire_playing_episode` is tracked
6. Go to `Profile` -> `Settings`->  `Beta features` 
7. ✅ Disable "Cache entire playing episode" feature
8. Go to `Profile` -> `Settings`-> `Advanced`
9. ✅ Notice there is no advanced setting to enable caching the playing episode 

## Screenshots or Screencast 
<img width=200 src="https://github.com/Automattic/pocket-casts-android/assets/1405144/71d31b79-7046-41dd-bfdf-469125d67faf"/>


## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
