### PR TITLE
Track `up_next_shown ` when tapping on navigation bar

### DIFF
--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/UpNextFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/UpNextFragment.kt
@@ -190,6 +190,9 @@ class UpNextFragment : BaseFragment(), UpNextListener, UpNextTouchCallback.ItemT
         val binding = FragmentUpnextBinding.inflate(themedInflater, container, false).also {
             realBinding = it
         }
+        if (upNextSource == UpNextSource.UP_NEXT_TAB) {
+            analyticsTracker.track(AnalyticsEvent.UP_NEXT_SHOWN, mapOf("source" to "tab_bar"))
+        }
         return binding.root
     }
 


### PR DESCRIPTION
## Description
- This PR fires `up_next_shown` event with `tab_bar` source when tapping on navigation bar 
- NOTE: Both discover and up next navigation bar button should trigger these `up_next_shown` and `discover_shown` events once, but due the opened issue we have https://github.com/Automattic/pocket-casts-android/issues/2149 we are recreating the fragment every time we tap on navigation bar so the event will be fired every time the navigation is tapped

Fixes #2363

## Testing Instructions
1. Open the app
2. Tap on Up Next bottom navigation bar button
3. ✅ Ensure `🔵 Tracked: up_next_shown, Properties: {"source":"tab_bar"` is tracked


## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
