### PR TITLE
Add properties to `bookmark_created ` track event

### DIFF
--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/bookmark/BookmarkManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/bookmark/BookmarkManagerImpl.kt
@@ -6,6 +6,7 @@ import au.com.shiftyjelly.pocketcasts.analytics.SourceView
 import au.com.shiftyjelly.pocketcasts.models.db.AppDatabase
 import au.com.shiftyjelly.pocketcasts.models.entity.BaseEpisode
 import au.com.shiftyjelly.pocketcasts.models.entity.Bookmark
+import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.models.type.SyncStatus
 import au.com.shiftyjelly.pocketcasts.preferences.model.BookmarksSortTypeDefault
 import au.com.shiftyjelly.pocketcasts.preferences.model.BookmarksSortTypeForPodcast
@@ -63,9 +64,15 @@ class BookmarkManagerImpl @Inject constructor(
             syncStatus = SyncStatus.NOT_SYNCED,
         )
         bookmarkDao.insert(bookmark)
+        val podcastUuid = if (episode is PodcastEpisode) episode.podcastOrSubstituteUuid else "user_file"
         analyticsTracker.track(
             AnalyticsEvent.BOOKMARK_CREATED,
-            mapOf("source" to creationSource.analyticsValue),
+            mapOf(
+                "source" to creationSource.analyticsValue,
+                "time" to addedAtMs,
+                "episode_uuid" to episode.uuid,
+                "podcast_uuid" to podcastUuid,
+            ),
         )
         return bookmark
     }


### PR DESCRIPTION
## Description
- Adds `time`, `episode_uuid` and `podcast_uuid` properties to `bookmark_created`
- See: https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?gid=0#gid=0&range=A564

Fixes #2371 

## Testing Instructions
1. Log with a premium account
2. Add Bookmark to a episode
3. ✅ Ensure `🔵 Tracked: bookmark_created, Properties: {"source":"player","time":1718813261779,"episode_uuid":"{episode_uuid}","podcast_uuid":"{podcast_uuid}"` is tracked
4. Go to Profile and add a mp3 file
5. Play the file and add a bookmark
6. ✅ Ensure  `🔵 Tracked: bookmark_created, Properties: {"source":"player","time":1718813283979,"episode_uuid":"{episode_uuid}","podcast_uuid":"user_file"`

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack
