### PR TITLE
Play clips on clip page

### DIFF
--- a/modules/features/clip/build.gradle.kts
+++ b/modules/features/clip/build.gradle.kts
@@ -18,6 +18,7 @@ android {
 }
 
 dependencies {
+    implementation(project(":modules:services:analytics"))
     implementation(project(":modules:services:compose"))
     implementation(project(":modules:services:images"))
     implementation(project(":modules:services:localization"))
@@ -27,4 +28,6 @@ dependencies {
     implementation(project(":modules:services:ui"))
     implementation(project(":modules:services:utils"))
     implementation(project(":modules:services:views"))
+
+    testImplementation(project(":modules:services:sharedtest"))
 }

--- a/modules/features/clip/src/main/kotlin/au/com/shiftyjelly/pocketcasts/clip/Clip.kt
+++ b/modules/features/clip/src/main/kotlin/au/com/shiftyjelly/pocketcasts/clip/Clip.kt
@@ -1,0 +1,14 @@
+package au.com.shiftyjelly.pocketcasts.clip
+
+import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
+import kotlin.time.Duration
+
+data class Clip(
+    val episode: PodcastEpisode,
+    val range: Range,
+) {
+    data class Range(
+        val start: Duration,
+        val end: Duration,
+    )
+}

--- a/modules/features/clip/src/main/kotlin/au/com/shiftyjelly/pocketcasts/clip/ClipCard.kt
+++ b/modules/features/clip/src/main/kotlin/au/com/shiftyjelly/pocketcasts/clip/ClipCard.kt
@@ -17,7 +17,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.luminance
 import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.style.TextAlign
@@ -28,7 +27,6 @@ import au.com.shiftyjelly.pocketcasts.compose.components.TextH40
 import au.com.shiftyjelly.pocketcasts.compose.components.TextH70
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.repositories.images.PocketCastsImageRequestFactory.PlaceholderType
-import au.com.shiftyjelly.pocketcasts.ui.helper.ColorUtils
 import au.com.shiftyjelly.pocketcasts.utils.extensions.toLocalizedFormatMediumStyle
 import com.airbnb.android.showkase.annotation.ShowkaseComposable
 import java.sql.Date
@@ -40,16 +38,15 @@ internal fun ClipCard(
     episode: PodcastEpisode,
     podcastTitle: String,
     useEpisodeArtwork: Boolean,
-    baseColor: Color,
+    clipColors: ClipColors,
     modifier: Modifier = Modifier,
 ) {
     val backgroundGradient = Brush.verticalGradient(
         listOf(
-            ColorUtils.changeHsvValue(baseColor, 1.25f),
-            ColorUtils.changeHsvValue(baseColor, 0.75f),
+            clipColors.cardTop,
+            clipColors.cardBottom,
         ),
     )
-    val textColor = if (baseColor.luminance() < 0.5f) Color.White else Color.Black
     Column(
         horizontalAlignment = Alignment.CenterHorizontally,
         modifier = modifier.background(backgroundGradient, RoundedCornerShape(12.dp)),
@@ -76,14 +73,14 @@ internal fun ClipCard(
         ) {
             TextH70(
                 text = episode.publishedDate.toLocalizedFormatMediumStyle(),
-                color = textColor.copy(alpha = 0.5f),
+                color = clipColors.cardTextColor.copy(alpha = 0.5f),
             )
             Spacer(
                 modifier = Modifier.height(6.dp),
             )
             TextH40(
                 text = episode.title,
-                color = textColor,
+                color = clipColors.cardTextColor,
                 maxLines = 2,
                 textAlign = TextAlign.Center,
             )
@@ -92,7 +89,7 @@ internal fun ClipCard(
             )
             TextH70(
                 text = podcastTitle,
-                color = textColor.copy(alpha = 0.5f),
+                color = clipColors.cardTextColor.copy(alpha = 0.5f),
                 maxLines = 1,
             )
         }
@@ -148,5 +145,5 @@ private fun ClipCardPreview(
     ),
     podcastTitle = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.",
     useEpisodeArtwork = true,
-    baseColor = baseColor,
+    clipColors = ClipColors(baseColor),
 )

--- a/modules/features/clip/src/main/kotlin/au/com/shiftyjelly/pocketcasts/clip/ClipColors.kt
+++ b/modules/features/clip/src/main/kotlin/au/com/shiftyjelly/pocketcasts/clip/ClipColors.kt
@@ -1,0 +1,23 @@
+package au.com.shiftyjelly.pocketcasts.clip
+
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.luminance
+import au.com.shiftyjelly.pocketcasts.ui.helper.ColorUtils
+
+internal data class ClipColors(
+    val baseColor: Color,
+) {
+    val backgroundColor = ColorUtils.changeHsvValue(baseColor, factor = 0.4f)
+    val backgroundTextColor = if (backgroundColor.luminance() < 0.5f) Color.White else Color.Black
+
+    val buttonColor = if (backgroundColor.luminance() < 0.25) {
+        ColorUtils.changeHsvValue(baseColor, 1.25f)
+    } else {
+        baseColor
+    }
+    val buttonTextColor = if (buttonColor.luminance() < 0.5f) Color.White else Color.Black
+
+    val cardTop = ColorUtils.changeHsvValue(baseColor, 1.25f)
+    val cardBottom = ColorUtils.changeHsvValue(baseColor, 0.75f)
+    val cardTextColor = if (baseColor.luminance() < 0.5f) Color.White else Color.Black
+}

--- a/modules/features/clip/src/main/kotlin/au/com/shiftyjelly/pocketcasts/clip/ClipModule.kt
+++ b/modules/features/clip/src/main/kotlin/au/com/shiftyjelly/pocketcasts/clip/ClipModule.kt
@@ -1,0 +1,34 @@
+package au.com.shiftyjelly.pocketcasts.clip
+
+import android.content.Context
+import androidx.annotation.OptIn
+import androidx.media3.common.util.UnstableApi
+import androidx.media3.database.StandaloneDatabaseProvider
+import androidx.media3.datasource.cache.LeastRecentlyUsedCacheEvictor
+import androidx.media3.datasource.cache.SimpleCache
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
+import dagger.hilt.components.SingletonComponent
+import java.io.File
+import javax.inject.Qualifier
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+object ClipModule {
+    @Provides
+    @Singleton
+    @ClipSimpleCache
+    @OptIn(UnstableApi::class)
+    fun simpleCache(@ApplicationContext context: Context) = SimpleCache(
+        File(context.cacheDir, "pocketcasts-exoplayer-clips-cache"),
+        LeastRecentlyUsedCacheEvictor(25 * 1024 * 1024L),
+        StandaloneDatabaseProvider(context),
+    )
+}
+
+@Qualifier
+@Retention(AnnotationRetention.BINARY)
+annotation class ClipSimpleCache

--- a/modules/features/clip/src/main/kotlin/au/com/shiftyjelly/pocketcasts/clip/ClipPlayer.kt
+++ b/modules/features/clip/src/main/kotlin/au/com/shiftyjelly/pocketcasts/clip/ClipPlayer.kt
@@ -1,0 +1,105 @@
+package au.com.shiftyjelly.pocketcasts.clip
+
+import android.content.Context
+import androidx.annotation.OptIn
+import androidx.media3.common.MediaItem
+import androidx.media3.common.MediaItem.ClippingConfiguration
+import androidx.media3.common.PlaybackException
+import androidx.media3.common.Player
+import androidx.media3.common.util.UnstableApi
+import androidx.media3.datasource.DefaultDataSource
+import androidx.media3.datasource.DefaultHttpDataSource
+import androidx.media3.exoplayer.ExoPlayer
+import androidx.media3.exoplayer.source.DefaultMediaSourceFactory
+import androidx.media3.exoplayer.source.MediaSource
+import androidx.media3.extractor.DefaultExtractorsFactory
+import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
+import javax.inject.Inject
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+
+interface ClipPlayer {
+    val isPlayingState: StateFlow<Boolean>
+
+    val errors: Flow<Exception>
+
+    fun play(clip: Clip)
+
+    fun stop()
+
+    fun release()
+
+    class Factory @Inject constructor(
+        private val playbackManager: PlaybackManager,
+    ) {
+        @OptIn(UnstableApi::class)
+        fun create(context: Context): ClipPlayer {
+            val httpSourceFactory = DefaultHttpDataSource.Factory()
+                .setUserAgent("Pocket Casts")
+                .setAllowCrossProtocolRedirects(true)
+            val dataSourceFactory = DefaultDataSource.Factory(context, httpSourceFactory)
+            val extractorsFactory = DefaultExtractorsFactory().setConstantBitrateSeekingEnabled(true)
+            val mediaSourceFactory = DefaultMediaSourceFactory(dataSourceFactory, extractorsFactory)
+            val exoPlayer = ExoPlayer.Builder(context).build()
+            return ExoPlayerClipPlayer(exoPlayer, mediaSourceFactory, playbackManager)
+        }
+    }
+}
+
+private class ExoPlayerClipPlayer(
+    private val exoPlayer: ExoPlayer,
+    private val mediaSourceFactory: MediaSource.Factory,
+    private val playbackManager: PlaybackManager,
+) : ClipPlayer {
+    override val isPlayingState = MutableStateFlow(false)
+    override val errors = MutableSharedFlow<Exception>()
+
+    init {
+        exoPlayer.addListener(object : Player.Listener {
+            override fun onPlaybackStateChanged(playbackState: Int) {
+                super.onPlaybackStateChanged(playbackState)
+            }
+
+            override fun onIsPlayingChanged(isPlaying: Boolean) {
+                isPlayingState.value = isPlaying
+            }
+
+            override fun onPlayerError(error: PlaybackException) {
+                errors.tryEmit(error)
+            }
+        })
+    }
+
+    @OptIn(UnstableApi::class)
+    override fun play(clip: Clip) {
+        if (exoPlayer.isLoading) {
+            return
+        }
+        playbackManager.pause()
+        exoPlayer.stop()
+        exoPlayer.setMediaSource(mediaSourceFactory.createMediaSource(clip.toMediaItem()))
+        exoPlayer.prepare()
+        exoPlayer.play()
+    }
+
+    override fun stop() {
+        exoPlayer.stop()
+    }
+
+    override fun release() {
+        exoPlayer.stop()
+        exoPlayer.release()
+    }
+
+    private fun Clip.toMediaItem() = MediaItem.Builder()
+        .setUri(episode.let { if (it.isDownloaded) it.downloadedFilePath else it.downloadUrl })
+        .setClippingConfiguration(
+            ClippingConfiguration.Builder()
+                .setStartPositionMs(range.start.inWholeMilliseconds)
+                .setEndPositionMs(range.end.inWholeMilliseconds)
+                .build(),
+        )
+        .build()
+}

--- a/modules/features/clip/src/main/kotlin/au/com/shiftyjelly/pocketcasts/clip/ClipSelector.kt
+++ b/modules/features/clip/src/main/kotlin/au/com/shiftyjelly/pocketcasts/clip/ClipSelector.kt
@@ -1,21 +1,38 @@
 package au.com.shiftyjelly.pocketcasts.clip
 
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import au.com.shiftyjelly.pocketcasts.compose.components.TextH30
 import com.airbnb.android.showkase.annotation.ShowkaseComposable
+import au.com.shiftyjelly.pocketcasts.images.R as IR
+import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 @Composable
 fun ClipSelector(
+    isPlaying: Boolean,
+    onPlayClick: () -> Unit,
+    onPauseClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Row(
@@ -24,16 +41,55 @@ fun ClipSelector(
         modifier = modifier
             .fillMaxWidth()
             .height(72.dp)
-            .background(Color.Magenta),
+            .background(Color(0x476B6B6B), RoundedCornerShape(topStart = 8.dp, bottomStart = 8.dp)),
     ) {
-        TextH30(
-            text = "SELECTOR PLACEHOLDER",
-            color = Color.White,
+        Image(
+            painter = painterResource(if (isPlaying) IR.drawable.ic_widget_pause else IR.drawable.ic_widget_play),
+            contentDescription = stringResource(if (isPlaying) LR.string.pause else LR.string.play),
+            colorFilter = ColorFilter.tint(Color.White),
+            modifier = Modifier
+                .size(72.dp)
+                .clickable {
+                    if (isPlaying) onPauseClick() else onPlayClick()
+                }
+                .padding(16.dp),
         )
+        Box(
+            contentAlignment = Alignment.Center,
+            modifier = Modifier
+                .padding(vertical = 6.dp)
+                .fillMaxSize()
+                .background(Color.Magenta),
+        ) {
+            TextH30(
+                text = "SELECTOR PLACEHOLDER",
+                color = Color.White,
+            )
+        }
     }
 }
 
-@ShowkaseComposable(name = "ClipSelector", group = "Clip")
-@Preview(name = "ClipSelector")
+@ShowkaseComposable(name = "ClipSelector", group = "Clip", styleName = "Light")
+@Preview(name = "ClipSelectorLight", showBackground = true, backgroundColor = 0xFF3E6266)
 @Composable
-fun ClipSelectorPreview() = ClipSelector()
+fun ClipSelectorLightPreview() = ClipSelectorPreview()
+
+@ShowkaseComposable(name = "ClipSelector", group = "Clip", styleName = "Dark")
+@Preview(name = "ClipSelectorDark", showBackground = true, backgroundColor = 0xFF0E1A17)
+@Composable
+fun ClipSelectorDarkPreview() = ClipSelectorPreview()
+
+@Composable
+private fun ClipSelectorPreview() = Column {
+    ClipSelector(
+        isPlaying = false,
+        onPlayClick = {},
+        onPauseClick = {},
+    )
+    Spacer(modifier = Modifier.height(32.dp))
+    ClipSelector(
+        isPlaying = true,
+        onPlayClick = {},
+        onPauseClick = {},
+    )
+}

--- a/modules/features/clip/src/main/kotlin/au/com/shiftyjelly/pocketcasts/clip/ClipSelector.kt
+++ b/modules/features/clip/src/main/kotlin/au/com/shiftyjelly/pocketcasts/clip/ClipSelector.kt
@@ -3,6 +3,7 @@ package au.com.shiftyjelly.pocketcasts.clip
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -14,13 +15,17 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.ripple.rememberRipple
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import au.com.shiftyjelly.pocketcasts.compose.components.TextH30
@@ -29,8 +34,9 @@ import au.com.shiftyjelly.pocketcasts.images.R as IR
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 @Composable
-fun ClipSelector(
+internal fun ClipSelector(
     isPlaying: Boolean,
+    clipColors: ClipColors,
     onPlayClick: () -> Unit,
     onPauseClick: () -> Unit,
     modifier: Modifier = Modifier,
@@ -49,9 +55,14 @@ fun ClipSelector(
             colorFilter = ColorFilter.tint(Color.White),
             modifier = Modifier
                 .size(72.dp)
-                .clickable {
-                    if (isPlaying) onPauseClick() else onPlayClick()
-                }
+                .clip(RoundedCornerShape(topStart = 8.dp, bottomStart = 8.dp))
+                .clickable(
+                    interactionSource = remember { MutableInteractionSource() },
+                    indication = rememberRipple(color = clipColors.baseColor),
+                    onClickLabel = stringResource(if (isPlaying) LR.string.pause else LR.string.play),
+                    role = Role.Button,
+                    onClick = if (isPlaying) onPauseClick else onPlayClick,
+                )
                 .padding(16.dp),
         )
         Box(
@@ -59,11 +70,11 @@ fun ClipSelector(
             modifier = Modifier
                 .padding(vertical = 6.dp)
                 .fillMaxSize()
-                .background(Color.Magenta),
+                .background(clipColors.backgroundColor),
         ) {
             TextH30(
                 text = "SELECTOR PLACEHOLDER",
-                color = Color.White,
+                color = clipColors.backgroundTextColor,
             )
         }
     }
@@ -72,23 +83,27 @@ fun ClipSelector(
 @ShowkaseComposable(name = "ClipSelector", group = "Clip", styleName = "Light")
 @Preview(name = "ClipSelectorLight", showBackground = true, backgroundColor = 0xFF3E6266)
 @Composable
-fun ClipSelectorLightPreview() = ClipSelectorPreview()
+fun ClipSelectorLightPreview() = ClipSelectorPreview(Color(0xFF9BF6FF))
 
 @ShowkaseComposable(name = "ClipSelector", group = "Clip", styleName = "Dark")
 @Preview(name = "ClipSelectorDark", showBackground = true, backgroundColor = 0xFF0E1A17)
 @Composable
-fun ClipSelectorDarkPreview() = ClipSelectorPreview()
+fun ClipSelectorDarkPreview() = ClipSelectorPreview(Color(0xFF152622))
 
 @Composable
-private fun ClipSelectorPreview() = Column {
+private fun ClipSelectorPreview(
+    color: Color,
+) = Column {
     ClipSelector(
         isPlaying = false,
+        clipColors = ClipColors(color),
         onPlayClick = {},
         onPauseClick = {},
     )
     Spacer(modifier = Modifier.height(32.dp))
     ClipSelector(
         isPlaying = true,
+        clipColors = ClipColors(color),
         onPlayClick = {},
         onPauseClick = {},
     )

--- a/modules/features/clip/src/main/kotlin/au/com/shiftyjelly/pocketcasts/clip/ShareClipFragment.kt
+++ b/modules/features/clip/src/main/kotlin/au/com/shiftyjelly/pocketcasts/clip/ShareClipFragment.kt
@@ -22,6 +22,7 @@ import au.com.shiftyjelly.pocketcasts.utils.parceler.ColorParceler
 import au.com.shiftyjelly.pocketcasts.views.fragments.BaseDialogFragment
 import dagger.hilt.android.AndroidEntryPoint
 import dagger.hilt.android.lifecycle.withCreationCallback
+import javax.inject.Inject
 import kotlinx.parcelize.Parcelize
 import kotlinx.parcelize.TypeParceler
 
@@ -32,10 +33,13 @@ class ShareClipFragment : BaseDialogFragment() {
     private val viewModel by viewModels<ShareClipViewModel>(
         extrasProducer = {
             defaultViewModelCreationExtras.withCreationCallback<ShareClipViewModel.Factory> { factory ->
-                factory.create(args.episodeUuid)
+                factory.create(args.episodeUuid, clipPlayerFactory.create(requireActivity().applicationContext))
             }
         },
     )
+
+    @Inject
+    lateinit var clipPlayerFactory: ClipPlayer.Factory
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -47,9 +51,12 @@ class ShareClipFragment : BaseDialogFragment() {
 
             ShareClipPage(
                 episode = state.episode,
+                isPlaying = state.isPlaying,
                 podcastTitle = state.podcastTitle,
                 useEpisodeArtwork = state.useEpisodeArtwork,
                 baseColor = args.baseColor,
+                onPlayClick = { viewModel.playClip() },
+                onPauseClick = { viewModel.stopClip() },
                 onClose = { dismiss() },
             )
         }

--- a/modules/features/clip/src/main/kotlin/au/com/shiftyjelly/pocketcasts/clip/ShareClipFragment.kt
+++ b/modules/features/clip/src/main/kotlin/au/com/shiftyjelly/pocketcasts/clip/ShareClipFragment.kt
@@ -17,7 +17,6 @@ import androidx.core.os.BundleCompat
 import androidx.core.os.bundleOf
 import androidx.core.view.WindowInsetsControllerCompat
 import androidx.fragment.app.viewModels
-import au.com.shiftyjelly.pocketcasts.ui.helper.ColorUtils
 import au.com.shiftyjelly.pocketcasts.utils.parceler.ColorParceler
 import au.com.shiftyjelly.pocketcasts.views.fragments.BaseDialogFragment
 import dagger.hilt.android.AndroidEntryPoint
@@ -29,6 +28,8 @@ import kotlinx.parcelize.TypeParceler
 @AndroidEntryPoint
 class ShareClipFragment : BaseDialogFragment() {
     private val args get() = requireNotNull(arguments?.let { BundleCompat.getParcelable(it, NEW_INSTANCE_ARG, Args::class.java) })
+
+    private val clipColors get() = ClipColors(args.baseColor)
 
     private val viewModel by viewModels<ShareClipViewModel>(
         extrasProducer = {
@@ -46,6 +47,7 @@ class ShareClipFragment : BaseDialogFragment() {
         container: ViewGroup?,
         savedInstanceState: Bundle?,
     ) = ComposeView(requireActivity()).apply {
+        val clipColors = clipColors
         setContent {
             val state by viewModel.uiState.collectAsState()
 
@@ -54,7 +56,7 @@ class ShareClipFragment : BaseDialogFragment() {
                 isPlaying = state.isPlaying,
                 podcastTitle = state.podcastTitle,
                 useEpisodeArtwork = state.useEpisodeArtwork,
-                baseColor = args.baseColor,
+                clipColors = clipColors,
                 onPlayClick = { viewModel.playClip() },
                 onPauseClick = { viewModel.stopClip() },
                 onClose = { dismiss() },
@@ -64,16 +66,16 @@ class ShareClipFragment : BaseDialogFragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        val backgroundColor = ColorUtils.changeHsvValue(args.baseColor, factor = 0.4f)
-        val argbColor = backgroundColor.toArgb()
+        val clipColors = clipColors
+        val argbColor = clipColors.backgroundColor.toArgb()
 
         requireActivity().window?.let { activityWindow ->
             activityWindow.statusBarColor = argbColor
-            WindowInsetsControllerCompat(activityWindow, activityWindow.decorView).isAppearanceLightStatusBars = backgroundColor.luminance() > 0.5f
+            WindowInsetsControllerCompat(activityWindow, activityWindow.decorView).isAppearanceLightStatusBars = clipColors.backgroundColor.luminance() > 0.5f
         }
         requireDialog().window?.let { dialogWindow ->
             dialogWindow.navigationBarColor = argbColor
-            WindowInsetsControllerCompat(dialogWindow, dialogWindow.decorView).isAppearanceLightNavigationBars = backgroundColor.luminance() > 0.5f
+            WindowInsetsControllerCompat(dialogWindow, dialogWindow.decorView).isAppearanceLightNavigationBars = clipColors.backgroundColor.luminance() > 0.5f
         }
         bottomSheetView()?.backgroundTintList = ColorStateList.valueOf(argbColor)
     }

--- a/modules/features/clip/src/main/kotlin/au/com/shiftyjelly/pocketcasts/clip/ShareClipPage.kt
+++ b/modules/features/clip/src/main/kotlin/au/com/shiftyjelly/pocketcasts/clip/ShareClipPage.kt
@@ -37,9 +37,12 @@ import au.com.shiftyjelly.pocketcasts.localization.R as LR
 @Composable
 internal fun ShareClipPage(
     episode: PodcastEpisode?,
+    isPlaying: Boolean,
     podcastTitle: String,
     useEpisodeArtwork: Boolean,
     baseColor: Color,
+    onPlayClick: () -> Unit,
+    onPauseClick: () -> Unit,
     onClose: () -> Unit,
 ) {
     val backgroundColor = ColorUtils.changeHsvValue(baseColor, factor = 0.4f)
@@ -81,6 +84,9 @@ internal fun ShareClipPage(
             }
 
             ClipSelector(
+                isPlaying = isPlaying,
+                onPlayClick = onPlayClick,
+                onPauseClick = onPauseClick,
                 modifier = Modifier.padding(horizontal = 16.dp),
             )
             Spacer(
@@ -132,8 +138,11 @@ fun ShareClipPagePreview() = ShareClipPage(
         publishedDate = Date.from(Instant.parse("2024-12-03T10:15:30.00Z")),
         title = "Episode title",
     ),
+    isPlaying = false,
     podcastTitle = "Podcast title",
     useEpisodeArtwork = true,
     baseColor = Color(0xFF9BF6FF),
+    onPlayClick = {},
+    onPauseClick = {},
     onClose = {},
 )

--- a/modules/features/clip/src/main/kotlin/au/com/shiftyjelly/pocketcasts/clip/ShareClipPage.kt
+++ b/modules/features/clip/src/main/kotlin/au/com/shiftyjelly/pocketcasts/clip/ShareClipPage.kt
@@ -19,7 +19,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.luminance
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
@@ -27,7 +26,6 @@ import androidx.compose.ui.unit.dp
 import au.com.shiftyjelly.pocketcasts.compose.buttons.RowButton
 import au.com.shiftyjelly.pocketcasts.compose.components.TextH30
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
-import au.com.shiftyjelly.pocketcasts.ui.helper.ColorUtils
 import com.airbnb.android.showkase.annotation.ShowkaseComposable
 import java.sql.Date
 import java.time.Instant
@@ -40,18 +38,17 @@ internal fun ShareClipPage(
     isPlaying: Boolean,
     podcastTitle: String,
     useEpisodeArtwork: Boolean,
-    baseColor: Color,
+    clipColors: ClipColors,
     onPlayClick: () -> Unit,
     onPauseClick: () -> Unit,
     onClose: () -> Unit,
 ) {
-    val backgroundColor = ColorUtils.changeHsvValue(baseColor, factor = 0.4f)
     Box {
         Column(
             horizontalAlignment = Alignment.CenterHorizontally,
             modifier = Modifier
                 .fillMaxSize()
-                .background(backgroundColor),
+                .background(clipColors.backgroundColor),
         ) {
             Spacer(
                 modifier = Modifier.weight(0.5f),
@@ -59,7 +56,7 @@ internal fun ShareClipPage(
 
             TextH30(
                 text = stringResource(LR.string.podcast_create_clip),
-                color = if (backgroundColor.luminance() < 0.5f) Color.White else Color.Black,
+                color = clipColors.backgroundTextColor,
             )
 
             Spacer(
@@ -75,7 +72,7 @@ internal fun ShareClipPage(
                         episode = episode,
                         podcastTitle = podcastTitle,
                         useEpisodeArtwork = useEpisodeArtwork,
-                        baseColor = baseColor,
+                        clipColors = clipColors,
                     )
                 }
                 Spacer(
@@ -92,16 +89,11 @@ internal fun ShareClipPage(
             Spacer(
                 modifier = Modifier.height(16.dp),
             )
-            val buttonColor = if (backgroundColor.luminance() < 0.25) {
-                ColorUtils.changeHsvValue(baseColor, 1.25f)
-            } else {
-                baseColor
-            }
             RowButton(
                 text = stringResource(LR.string.podcast_share_clip),
                 onClick = { },
-                colors = ButtonDefaults.buttonColors(backgroundColor = buttonColor),
-                textColor = if (buttonColor.luminance() < 0.5f) Color.White else Color.Black,
+                colors = ButtonDefaults.buttonColors(backgroundColor = clipColors.buttonColor),
+                textColor = clipColors.buttonTextColor,
                 elevation = null,
                 includePadding = false,
                 modifier = Modifier
@@ -141,7 +133,7 @@ fun ShareClipPagePreview() = ShareClipPage(
     isPlaying = false,
     podcastTitle = "Podcast title",
     useEpisodeArtwork = true,
-    baseColor = Color(0xFF9BF6FF),
+    clipColors = ClipColors(Color(0xFF9BF6FF)),
     onPlayClick = {},
     onPauseClick = {},
     onClose = {},

--- a/modules/features/clip/src/main/kotlin/au/com/shiftyjelly/pocketcasts/clip/ShareClipPage.kt
+++ b/modules/features/clip/src/main/kotlin/au/com/shiftyjelly/pocketcasts/clip/ShareClipPage.kt
@@ -82,6 +82,7 @@ internal fun ShareClipPage(
 
             ClipSelector(
                 isPlaying = isPlaying,
+                clipColors = clipColors,
                 onPlayClick = onPlayClick,
                 onPauseClick = onPauseClick,
                 modifier = Modifier.padding(horizontal = 16.dp),

--- a/modules/features/clip/src/test/kotlin/au/com/shiftyjelly/pocketcasts/clip/FakeClipPlayer.kt
+++ b/modules/features/clip/src/test/kotlin/au/com/shiftyjelly/pocketcasts/clip/FakeClipPlayer.kt
@@ -1,0 +1,24 @@
+package au.com.shiftyjelly.pocketcasts.clip
+
+import app.cash.turbine.Turbine
+import app.cash.turbine.plusAssign
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+
+class FakeClipPlayer : ClipPlayer {
+    override val isPlayingState = MutableStateFlow(false)
+    override val errors = MutableSharedFlow<Exception>()
+
+    val clips = Turbine<Clip>()
+
+    override fun play(clip: Clip) {
+        clips += clip
+        isPlayingState.value = true
+    }
+
+    override fun stop() {
+        isPlayingState.value = false
+    }
+
+    override fun release() = Unit
+}

--- a/modules/features/clip/src/test/kotlin/au/com/shiftyjelly/pocketcasts/clip/ShareClipViewModelTest.kt
+++ b/modules/features/clip/src/test/kotlin/au/com/shiftyjelly/pocketcasts/clip/ShareClipViewModelTest.kt
@@ -1,0 +1,80 @@
+package au.com.shiftyjelly.pocketcasts.clip
+
+import app.cash.turbine.test
+import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
+import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
+import au.com.shiftyjelly.pocketcasts.preferences.Settings
+import au.com.shiftyjelly.pocketcasts.preferences.UserSetting
+import au.com.shiftyjelly.pocketcasts.preferences.model.ArtworkConfiguration
+import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
+import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
+import au.com.shiftyjelly.pocketcasts.sharedtest.MainCoroutineRule
+import java.util.Date
+import junit.framework.TestCase.assertTrue
+import kotlin.time.Duration.Companion.seconds
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+
+@ExperimentalCoroutinesApi
+class ShareClipViewModelTest {
+    @get:Rule
+    val coroutineRule = MainCoroutineRule()
+
+    private val clipPlayer = FakeClipPlayer()
+    private val episodeManager = mock<EpisodeManager>()
+    private val podcastManager = mock<PodcastManager>()
+    private val settings = mock<Settings>()
+
+    private val episode = PodcastEpisode(uuid = "episode-id", publishedDate = Date())
+    private val podcast = Podcast(uuid = "podcast-id", title = "Podcast Title")
+
+    private val episodeFlow = MutableStateFlow(episode)
+    private val podcastFlow = MutableStateFlow(podcast)
+
+    private lateinit var viewModel: ShareClipViewModel
+
+    @Before
+    fun setUp() {
+        whenever(episodeManager.observeByUuid("episode-id")).thenReturn(episodeFlow)
+        whenever(podcastManager.observePodcastByEpisodeUuid("episode-id")).thenReturn(podcastFlow)
+        val artworkSetting = mock<UserSetting<ArtworkConfiguration>>()
+        whenever(artworkSetting.flow).thenReturn(MutableStateFlow(ArtworkConfiguration(useEpisodeArtwork = true)))
+        whenever(settings.artworkConfiguration).thenReturn(artworkSetting)
+
+        viewModel = ShareClipViewModel(
+            "episode-id",
+            clipPlayer,
+            episodeManager,
+            podcastManager,
+            settings,
+        )
+    }
+
+    @Test
+    fun `play clip`() = runTest {
+        viewModel.playClip()
+
+        assertEquals(Clip(episode, Clip.Range(15.seconds, 30.seconds)), clipPlayer.clips.awaitItem())
+    }
+
+    @Test
+    fun `update play state`() = runTest {
+        viewModel.uiState.test {
+            assertFalse(awaitItem().isPlaying)
+
+            viewModel.playClip()
+            assertTrue(awaitItem().isPlaying)
+
+            viewModel.stopClip()
+            assertFalse(awaitItem().isPlaying)
+        }
+    }
+}


### PR DESCRIPTION
## Description

This adds playback to the clip page. Since there is currently no start and end selection implemented the clip is using 15 seconds and 30 seconds as respective timestamps.

I wasn't sure how to provide the best implementation for clip playback. I decided to opt-in for a second instance of `ExoPlayer` that is used temporarily only for this screen. I can't use what we already use in our main player for couple of reasons:
* Our app isn't modularized in a way that would allow that.
* `SimplePlayer` is not a singleton and can have different `ExoPlayer` instances.
* I'm afraid that `SimplePlayer` is too coupled with other things and reusing it would cause some side effects.
* `SimplePlayer` uses for configuration things like `ProgressiveMediaSource` that prevent playing clips.

## Testing Instructions

1. Play a not downloaded podcast episode.
2. Share it and select `Clip` option.
3. Playing the clip should pause the player playback.
4. Pausing and playing the clip again should restart the clip from the beginning.
5. Playing the clip again after it finishes should be possible.
6. Minimizing the clip share page should stop the clip playback.
7. Test the same thing for a downloaded episode.

## Screenshots or Screencast 

https://github.com/Automattic/pocket-casts-android/assets/30936061/22804acf-6e82-426c-8c6c-386faf22cf68

## Checklist
- [x] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] ~with different themes~
- [x] ~with a landscape orientation~
- [x] ~with the device set to have a large display and font size~
- [x] ~for accessibility with TalkBack~
