### PR TITLE
Share clip links

### DIFF
--- a/modules/features/clip/src/main/kotlin/au/com/shiftyjelly/pocketcasts/clip/ShareClipPage.kt
+++ b/modules/features/clip/src/main/kotlin/au/com/shiftyjelly/pocketcasts/clip/ShareClipPage.kt
@@ -39,6 +39,7 @@ internal fun ShareClipPage(
     podcastTitle: String,
     useEpisodeArtwork: Boolean,
     clipColors: ClipColors,
+    onClip: () -> Unit,
     onPlayClick: () -> Unit,
     onPauseClick: () -> Unit,
     onClose: () -> Unit,
@@ -92,7 +93,7 @@ internal fun ShareClipPage(
             )
             RowButton(
                 text = stringResource(LR.string.podcast_share_clip),
-                onClick = { },
+                onClick = onClip,
                 colors = ButtonDefaults.buttonColors(backgroundColor = clipColors.buttonColor),
                 textColor = clipColors.buttonTextColor,
                 elevation = null,
@@ -135,6 +136,7 @@ fun ShareClipPagePreview() = ShareClipPage(
     podcastTitle = "Podcast title",
     useEpisodeArtwork = true,
     clipColors = ClipColors(Color(0xFF9BF6FF)),
+    onClip = {},
     onPlayClick = {},
     onPauseClick = {},
     onClose = {},

--- a/modules/features/clip/src/main/kotlin/au/com/shiftyjelly/pocketcasts/clip/ShareClipViewModel.kt
+++ b/modules/features/clip/src/main/kotlin/au/com/shiftyjelly/pocketcasts/clip/ShareClipViewModel.kt
@@ -2,6 +2,7 @@ package au.com.shiftyjelly.pocketcasts.clip
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
@@ -27,13 +28,13 @@ class ShareClipViewModel @AssistedInject constructor(
 
     val uiState = combine(
         episodeManager.observeByUuid(episodeUuid),
-        podcastManager.observePodcastByEpisodeUuid(episodeUuid).map { it.title },
+        podcastManager.observePodcastByEpisodeUuid(episodeUuid),
         settings.artworkConfiguration.flow.map { it.useEpisodeArtwork },
         clipPlayer.isPlayingState,
-        transform = { episode, podcastTitle, useEpisodeArtwork, isPlaying ->
+        transform = { episode, podcast, useEpisodeArtwork, isPlaying ->
             UiState(
                 episode = episode,
-                podcastTitle = podcastTitle,
+                podcast = podcast,
                 useEpisodeArtwork = useEpisodeArtwork,
                 isPlaying = isPlaying,
             )
@@ -54,8 +55,8 @@ class ShareClipViewModel @AssistedInject constructor(
 
     data class UiState(
         val episode: PodcastEpisode? = null,
+        val podcast: Podcast? = null,
         val clipRange: Clip.Range = Clip.Range(15.seconds, 30.seconds),
-        val podcastTitle: String = "",
         val useEpisodeArtwork: Boolean = false,
         val isPlaying: Boolean = false,
     ) {

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/ShareFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/ShareFragment.kt
@@ -24,6 +24,7 @@ import com.google.android.material.bottomsheet.BottomSheetDialog
 import dagger.hilt.android.AndroidEntryPoint
 import io.reactivex.disposables.Disposable
 import javax.inject.Inject
+import kotlin.time.Duration.Companion.seconds
 
 @AndroidEntryPoint
 class ShareFragment : BaseDialogFragment() {
@@ -54,6 +55,7 @@ class ShareFragment : BaseDialogFragment() {
                     podcast,
                     null,
                     null,
+                    null,
                     requireContext(),
                     ShareType.PODCAST,
                     SourceView.PLAYER,
@@ -68,6 +70,7 @@ class ShareFragment : BaseDialogFragment() {
                     podcast,
                     episode,
                     null,
+                    null,
                     requireContext(),
                     ShareType.EPISODE,
                     SourceView.PLAYER,
@@ -81,7 +84,8 @@ class ShareFragment : BaseDialogFragment() {
                 SharePodcastHelper(
                     podcast,
                     episode,
-                    episode.playedUpTo,
+                    episode.playedUpTo.seconds,
+                    null,
                     requireContext(),
                     ShareType.CURRENT_TIME,
                     SourceView.PLAYER,
@@ -95,7 +99,8 @@ class ShareFragment : BaseDialogFragment() {
                 SharePodcastHelper(
                     podcast,
                     episode,
-                    episode.playedUpTo,
+                    episode.playedUpTo.seconds,
+                    null,
                     requireContext(),
                     ShareType.EPISODE_FILE,
                     SourceView.PLAYER,

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/BookmarksViewModel.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/BookmarksViewModel.kt
@@ -40,6 +40,7 @@ import au.com.shiftyjelly.pocketcasts.views.multiselect.MultiSelectBookmarksHelp
 import au.com.shiftyjelly.pocketcasts.views.multiselect.MultiSelectHelper
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
+import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.cancelChildren
@@ -279,7 +280,8 @@ class BookmarksViewModel
                         SharePodcastHelper(
                             podcast,
                             episode,
-                            bookmark.timeSecs.toDouble(),
+                            bookmark.timeSecs.seconds,
+                            null,
                             context,
                             ShareType.BOOKMARK_TIME,
                             sourceView,

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastFragment.kt
@@ -968,6 +968,7 @@ class PodcastFragment : BaseFragment(), Toolbar.OnMenuItemClickListener {
                 podcast,
                 null,
                 null,
+                null,
                 context,
                 SharePodcastHelper.ShareType.PODCAST,
                 SourceView.PODCAST_SCREEN,

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/PodcastViewModel.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/PodcastViewModel.kt
@@ -56,6 +56,7 @@ import io.reactivex.schedulers.Schedulers
 import javax.inject.Inject
 import kotlin.coroutines.CoroutineContext
 import kotlin.math.min
+import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -429,7 +430,8 @@ class PodcastViewModel
                     SharePodcastHelper(
                         podcast,
                         episode,
-                        bookmark.timeSecs.toDouble(),
+                        bookmark.timeSecs.seconds,
+                        null,
                         context,
                         ShareType.BOOKMARK_TIME,
                         SourceView.PODCAST_SCREEN,

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/SharePodcastHelper.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/SharePodcastHelper.kt
@@ -23,6 +23,7 @@ import java.io.File
 import java.io.FileOutputStream
 import java.io.IOException
 import kotlin.math.round
+import kotlin.time.Duration
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -32,7 +33,8 @@ import au.com.shiftyjelly.pocketcasts.localization.R as LR
 data class SharePodcastHelper(
     val podcast: Podcast, // Share just a podcast.
     val episode: PodcastEpisode? = null, // Share an episode of a podcast.
-    val upToInSeconds: Double? = null, // Share a position in an episode of a podcast.
+    val start: Duration? = null, // Share start position in an episode of a podcast.
+    val end: Duration? = null, // Share end position in an episode of a podcast.
     val context: Context,
     private val shareType: ShareType,
     private val source: SourceView,
@@ -44,10 +46,7 @@ data class SharePodcastHelper(
         val host = Settings.SERVER_SHORT_URL
         var url = ""
         episode?.let {
-            var timeMarker = ""
-            upToInSeconds?.let {
-                timeMarker = "?t=${round(it).toInt()}"
-            }
+            val timeMarker = listOfNotNull(start, end).takeIf { it.isNotEmpty() }?.joinToString(prefix = "?t=", separator = ",") { it.inWholeSeconds.toString() }
             url = "$host/episode/${it.uuid}$timeMarker"
         } ?: run {
             url = "$host/podcast/${podcast.uuid}"

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/SharePodcastHelper.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/SharePodcastHelper.kt
@@ -22,7 +22,6 @@ import coil.imageLoader
 import java.io.File
 import java.io.FileOutputStream
 import java.io.IOException
-import kotlin.math.round
 import kotlin.time.Duration
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -128,6 +127,7 @@ data class SharePodcastHelper(
         EPISODE("episode"),
         EPISODE_FILE("episode_file"),
         CURRENT_TIME("current_time"),
+        CLIP("clip"),
         BOOKMARK_TIME("bookmark_time"),
     }
 }

--- a/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/dialog/ShareDialog.kt
+++ b/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/dialog/ShareDialog.kt
@@ -11,6 +11,7 @@ import au.com.shiftyjelly.pocketcasts.repositories.podcast.SharePodcastHelper
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.SharePodcastHelper.ShareType
 import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
 import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
+import kotlin.time.Duration.Companion.seconds
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 class ShareDialog(
@@ -48,6 +49,7 @@ class ShareDialog(
                         podcast,
                         null,
                         null,
+                        null,
                         context,
                         ShareType.PODCAST,
                         sourceView,
@@ -64,6 +66,7 @@ class ShareDialog(
                         podcast,
                         episode,
                         null,
+                        null,
                         context,
                         ShareType.EPISODE,
                         sourceView,
@@ -77,7 +80,8 @@ class ShareDialog(
                     SharePodcastHelper(
                         podcast,
                         episode,
-                        episode.playedUpTo,
+                        episode.playedUpTo.seconds,
+                        null,
                         context,
                         ShareType.CURRENT_TIME,
                         sourceView,
@@ -100,7 +104,8 @@ class ShareDialog(
                         SharePodcastHelper(
                             podcast,
                             episode,
-                            episode.playedUpTo,
+                            episode.playedUpTo.seconds,
+                            null,
                             context,
                             ShareType.EPISODE_FILE,
                             sourceView,


### PR DESCRIPTION
## Description

This PR implements clip link sharing.

## Testing Instructions

### Regressions

Smoke test sharing podcast, episode, position, bookmarks, etc.

### Feature

1. Tap on share icon on any episode and select `Clip`.
2. Tap on `Clip` button.
3. You should see share dialog.
4. Share the link somewhere.
5. Open that link in the browser on your computer.
6. A clip player should open in the web.

## Screenshots or Screencast 

https://github.com/Automattic/pocket-casts-android/assets/30936061/3cc5e362-d73d-40cb-9569-759460d70ca2

## Checklist
- [x] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] ~with different themes~
- [x] ~with a landscape orientation~
- [x] ~with the device set to have a large display and font size~
- [x] for accessibility with TalkBack
