### PR TITLE
Add landscape orientation for clip sharing

### DIFF
--- a/modules/features/clip/src/main/kotlin/au/com/shiftyjelly/pocketcasts/clip/HorizontalClipCard.kt
+++ b/modules/features/clip/src/main/kotlin/au/com/shiftyjelly/pocketcasts/clip/HorizontalClipCard.kt
@@ -1,0 +1,123 @@
+package au.com.shiftyjelly.pocketcasts.clip
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalInspectionMode
+import androidx.compose.ui.res.pluralStringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import au.com.shiftyjelly.pocketcasts.compose.components.EpisodeImage
+import au.com.shiftyjelly.pocketcasts.compose.components.TextH40
+import au.com.shiftyjelly.pocketcasts.compose.components.TextH70
+import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
+import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
+import au.com.shiftyjelly.pocketcasts.repositories.images.PocketCastsImageRequestFactory.PlaceholderType
+import com.airbnb.android.showkase.annotation.ShowkaseComposable
+import java.sql.Date
+import java.time.Instant
+import au.com.shiftyjelly.pocketcasts.localization.R as LR
+
+@Composable
+internal fun HorizontalClipCard(
+    episode: PodcastEpisode,
+    podcast: Podcast,
+    episodeCount: Int,
+    useEpisodeArtwork: Boolean,
+    clipColors: ClipColors,
+    modifier: Modifier = Modifier,
+) {
+    val backgroundGradient = Brush.verticalGradient(
+        listOf(
+            clipColors.cardTop,
+            clipColors.cardBottom,
+        ),
+    )
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = modifier
+            .background(backgroundGradient, RoundedCornerShape(12.dp))
+            .padding(24.dp),
+    ) {
+        EpisodeImage(
+            episode = episode,
+            useEpisodeArtwork = useEpisodeArtwork,
+            placeholderType = if (LocalInspectionMode.current) PlaceholderType.Large else PlaceholderType.None,
+            modifier = Modifier.clip(RoundedCornerShape(8.dp)),
+        )
+        Spacer(
+            modifier = Modifier.width(18.dp),
+        )
+        Column(
+            verticalArrangement = Arrangement.Center,
+        ) {
+            TextH70(
+                text = podcast.title,
+                color = clipColors.cardTextColor.copy(alpha = 0.5f),
+                maxLines = 1,
+            )
+            Spacer(
+                modifier = Modifier.height(6.dp),
+            )
+            TextH40(
+                text = episode.title,
+                color = clipColors.cardTextColor,
+                maxLines = 1,
+            )
+            Spacer(
+                modifier = Modifier.height(6.dp),
+            )
+            TextH70(
+                text = listOfNotNull(
+                    pluralStringResource(LR.plurals.episode_count, count = episodeCount, episodeCount),
+                    podcast.displayableFrequency(LocalContext.current.resources),
+                ).joinToString(" · "),
+                color = clipColors.cardTextColor.copy(alpha = 0.5f),
+            )
+        }
+    }
+}
+
+@ShowkaseComposable(name = "HorizontalClipCard", group = "Clip", styleName = "Light")
+@Preview(name = "HorizontalClipCardLight")
+@Composable
+fun HorizontalClipCardLightPreview() = HorizontalClipCardPreview(Color(0xFF9BF6FF))
+
+@ShowkaseComposable(name = "HorizontalClipCard", group = "Clip", styleName = "Dark")
+@Preview(name = "HorizontalClipCardDark")
+@Composable
+fun HorizontalClipCardDarkPreview() = HorizontalClipCardPreview(Color(0xFF152622))
+
+@Composable
+private fun HorizontalClipCardPreview(
+    baseColor: Color,
+) = HorizontalClipCard(
+    episode = PodcastEpisode(
+        uuid = "episode-id",
+        podcastUuid = "podcast-id",
+        publishedDate = Date.from(Instant.parse("2024-12-03T10:15:30.00Z")),
+        title = "Nobis sapiente fugit vitae. Iusto magnam nam nam et odio. Debitis cupiditate officiis et. Sit quia in voluptate sit voluptatem magni.",
+    ),
+    podcast = Podcast(
+        uuid = "podcast-id",
+        title = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.",
+        episodeFrequency = "monthly",
+    ),
+    episodeCount = 120,
+    useEpisodeArtwork = true,
+    clipColors = ClipColors(baseColor),
+    modifier = Modifier.height(172.dp),
+)

--- a/modules/features/clip/src/main/kotlin/au/com/shiftyjelly/pocketcasts/clip/ShareClipFragment.kt
+++ b/modules/features/clip/src/main/kotlin/au/com/shiftyjelly/pocketcasts/clip/ShareClipFragment.kt
@@ -60,8 +60,9 @@ class ShareClipFragment : BaseDialogFragment() {
 
             ShareClipPage(
                 episode = state.episode,
-                isPlaying = state.isPlaying,
                 podcast = state.podcast,
+                episodeCount = state.episodeCount,
+                isPlaying = state.isPlaying,
                 useEpisodeArtwork = state.useEpisodeArtwork,
                 clipColors = clipColors,
                 onPlayClick = { viewModel.playClip() },

--- a/modules/features/clip/src/main/kotlin/au/com/shiftyjelly/pocketcasts/clip/ShareClipFragment.kt
+++ b/modules/features/clip/src/main/kotlin/au/com/shiftyjelly/pocketcasts/clip/ShareClipFragment.kt
@@ -61,7 +61,7 @@ class ShareClipFragment : BaseDialogFragment() {
             ShareClipPage(
                 episode = state.episode,
                 isPlaying = state.isPlaying,
-                podcastTitle = state.podcast?.title.orEmpty(),
+                podcast = state.podcast,
                 useEpisodeArtwork = state.useEpisodeArtwork,
                 clipColors = clipColors,
                 onPlayClick = { viewModel.playClip() },

--- a/modules/features/clip/src/main/kotlin/au/com/shiftyjelly/pocketcasts/clip/ShareClipPage.kt
+++ b/modules/features/clip/src/main/kotlin/au/com/shiftyjelly/pocketcasts/clip/ShareClipPage.kt
@@ -264,82 +264,25 @@ private fun HorizontalClipPage(
 @ShowkaseComposable(name = "ShareClipPageVertical", group = "Clip")
 @Preview(name = "ShareClipPageVertical")
 @Composable
-fun ShareClipPageVerticalPreview() = ShareClipPage(
-    episode = PodcastEpisode(
-        uuid = "episode-id",
-        podcastUuid = "podcast-id",
-        publishedDate = Date.from(Instant.parse("2024-12-03T10:15:30.00Z")),
-        title = "Episode title",
-    ),
-    podcast = Podcast(
-        uuid = "podcast-id",
-        title = "Podcast title",
-        episodeFrequency = "monthly",
-    ),
-    episodeCount = 120,
-    isPlaying = false,
-    useEpisodeArtwork = true,
-    clipColors = ClipColors(Color(0xFF931B17)),
-    onClip = {},
-    onPlayClick = {},
-    onPauseClick = {},
-    onClose = {},
-)
+fun ShareClipPageVerticalPreview() = ShareClipPagePreview()
 
 @ShowkaseComposable(name = "ShareClipVerticalSmallPage", group = "Clip")
 @Preview(name = "ShareClipVerticalSmallPage", device = "spec:width=360dp,height=640dp,dpi=320,orientation=portrait")
 @Composable
-fun ShareClipPageVerticalSmallPreview() = ShareClipPage(
-    episode = PodcastEpisode(
-        uuid = "episode-id",
-        podcastUuid = "podcast-id",
-        publishedDate = Date.from(Instant.parse("2024-12-03T10:15:30.00Z")),
-        title = "Episode title",
-    ),
-    podcast = Podcast(
-        uuid = "podcast-id",
-        title = "Podcast title",
-        episodeFrequency = "monthly",
-    ),
-    episodeCount = 120,
-    isPlaying = false,
-    useEpisodeArtwork = true,
-    clipColors = ClipColors(Color(0xFF931B17)),
-    onClip = {},
-    onPlayClick = {},
-    onPauseClick = {},
-    onClose = {},
-)
+fun ShareClipPageVerticalSmallPreview() = ShareClipPagePreview()
 
 @ShowkaseComposable(name = "ShareClipHorizontalPage", group = "Clip")
 @Preview(name = "ShareClipHorizontalPage", device = "spec:width=420dp,height=900dp,dpi=420,orientation=landscape")
 @Composable
-fun ShareClipPageHorizontalPreview() = ShareClipPage(
-    episode = PodcastEpisode(
-        uuid = "episode-id",
-        podcastUuid = "podcast-id",
-        publishedDate = Date.from(Instant.parse("2024-12-03T10:15:30.00Z")),
-        title = "Episode title",
-    ),
-    podcast = Podcast(
-        uuid = "podcast-id",
-        title = "Podcast title",
-        episodeFrequency = "monthly",
-    ),
-    episodeCount = 120,
-    isPlaying = false,
-    useEpisodeArtwork = true,
-    clipColors = ClipColors(Color(0xFF931B17)),
-    onClip = {},
-    onPlayClick = {},
-    onPauseClick = {},
-    onClose = {},
-)
+fun ShareClipPageHorizontalPreview() = ShareClipPagePreview()
 
 @ShowkaseComposable(name = "ShareClipHorizontalSmallPage", group = "Clip")
 @Preview(name = "ShareClipHorizontalSmallPage", device = "spec:width=360dp,height=640dp,dpi=320,orientation=landscape")
 @Composable
-fun ShareClipPageHorizontalSmallPreview() = ShareClipPage(
+fun ShareClipPageHorizontalSmallPreview() = ShareClipPagePreview()
+
+@Composable
+private fun ShareClipPagePreview() = ShareClipPage(
     episode = PodcastEpisode(
         uuid = "episode-id",
         podcastUuid = "podcast-id",

--- a/modules/features/clip/src/main/kotlin/au/com/shiftyjelly/pocketcasts/clip/ShareClipPage.kt
+++ b/modules/features/clip/src/main/kotlin/au/com/shiftyjelly/pocketcasts/clip/ShareClipPage.kt
@@ -1,26 +1,32 @@
 package au.com.shiftyjelly.pocketcasts.clip
 
+import android.content.res.Configuration
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.material.ButtonDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import au.com.shiftyjelly.pocketcasts.compose.buttons.RowButton
@@ -45,8 +51,44 @@ internal fun ShareClipPage(
     onPlayClick: () -> Unit,
     onPauseClick: () -> Unit,
     onClose: () -> Unit,
+) = when (LocalConfiguration.current.orientation) {
+    Configuration.ORIENTATION_LANDSCAPE -> HorizontalClipPage(
+        episode = episode,
+        podcast = podcast,
+        episodeCount = episodeCount,
+        isPlaying = isPlaying,
+        useEpisodeArtwork = useEpisodeArtwork,
+        clipColors = clipColors,
+        onClip = onClip,
+        onPlayClick = onPlayClick,
+        onPauseClick = onPauseClick,
+        onClose = onClose,
+    )
+    else -> VerticalClipPage(
+        episode = episode,
+        podcast = podcast,
+        isPlaying = isPlaying,
+        useEpisodeArtwork = useEpisodeArtwork,
+        clipColors = clipColors,
+        onClip = onClip,
+        onPlayClick = onPlayClick,
+        onPauseClick = onPauseClick,
+        onClose = onClose,
+    )
+}
+
+@Composable
+private fun VerticalClipPage(
+    episode: PodcastEpisode?,
+    podcast: Podcast?,
+    isPlaying: Boolean,
+    useEpisodeArtwork: Boolean,
+    clipColors: ClipColors,
+    onClip: () -> Unit,
+    onPlayClick: () -> Unit,
+    onPauseClick: () -> Unit,
+    onClose: () -> Unit,
 ) = Box {
-    println(episodeCount)
     Column(
         horizontalAlignment = Alignment.CenterHorizontally,
         modifier = Modifier
@@ -123,10 +165,106 @@ internal fun ShareClipPage(
     }
 }
 
-@ShowkaseComposable(name = "ShareClipPage", group = "Clip")
-@Preview(name = "ShareClipPage")
 @Composable
-fun ShareClipPagePreview() = ShareClipPage(
+private fun HorizontalClipPage(
+    episode: PodcastEpisode?,
+    podcast: Podcast?,
+    episodeCount: Int,
+    isPlaying: Boolean,
+    useEpisodeArtwork: Boolean,
+    clipColors: ClipColors,
+    onClip: () -> Unit,
+    onPlayClick: () -> Unit,
+    onPauseClick: () -> Unit,
+    onClose: () -> Unit,
+) {
+    Box(
+        contentAlignment = Alignment.TopEnd,
+        modifier = Modifier
+            .fillMaxSize()
+            .background(clipColors.backgroundColor),
+    ) {
+        Row {
+            Column(
+                verticalArrangement = Arrangement.Center,
+                horizontalAlignment = Alignment.End,
+                modifier = Modifier
+                    .weight(1f)
+                    .fillMaxHeight()
+                    .padding(start = 32.dp),
+            ) {
+                if (episode != null && podcast != null) {
+                    BoxWithConstraints {
+                        HorizontalClipCard(
+                            episode = episode,
+                            podcast = podcast,
+                            episodeCount = episodeCount,
+                            useEpisodeArtwork = useEpisodeArtwork,
+                            clipColors = clipColors,
+                            modifier = Modifier
+                                .width(minOf(maxWidth, 360.dp))
+                                .height(180.dp),
+                        )
+                    }
+                }
+            }
+            Spacer(
+                modifier = Modifier.width(12.dp),
+            )
+            Column(
+                verticalArrangement = Arrangement.Center,
+                horizontalAlignment = Alignment.Start,
+                modifier = Modifier
+                    .weight(1f)
+                    .fillMaxHeight()
+                    .padding(end = 32.dp),
+            ) {
+                ClipSelector(
+                    isPlaying = isPlaying,
+                    clipColors = clipColors,
+                    onPlayClick = onPlayClick,
+                    onPauseClick = onPauseClick,
+                    modifier = Modifier.padding(horizontal = 16.dp),
+                )
+                Spacer(
+                    modifier = Modifier.height(16.dp),
+                )
+                RowButton(
+                    text = stringResource(LR.string.podcast_share_clip),
+                    onClick = onClip,
+                    colors = ButtonDefaults.buttonColors(backgroundColor = clipColors.buttonColor),
+                    textColor = clipColors.buttonTextColor,
+                    elevation = null,
+                    includePadding = false,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .heightIn(min = 56.dp)
+                        .padding(horizontal = 16.dp),
+                )
+            }
+        }
+        TextH30(
+            text = stringResource(LR.string.podcast_create_clip),
+            color = clipColors.backgroundTextColor,
+            textAlign = TextAlign.Center,
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(top = 28.dp),
+        )
+        Image(
+            painter = painterResource(IR.drawable.ic_close_sheet),
+            contentDescription = stringResource(LR.string.close),
+            modifier = Modifier
+                .clickable(onClick = onClose)
+                .padding(top = 24.dp, end = 16.dp),
+        )
+    }
+}
+
+@ShowkaseComposable(name = "ShareClipPageVertical", group = "Clip")
+@Preview(name = "ShareClipPageVertical")
+@Composable
+fun ShareClipPageVerticalPreview() = ShareClipPage(
     episode = PodcastEpisode(
         uuid = "episode-id",
         podcastUuid = "podcast-id",
@@ -135,13 +273,88 @@ fun ShareClipPagePreview() = ShareClipPage(
     ),
     podcast = Podcast(
         uuid = "podcast-id",
-        title = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.",
+        title = "Podcast title",
         episodeFrequency = "monthly",
     ),
     episodeCount = 120,
     isPlaying = false,
     useEpisodeArtwork = true,
-    clipColors = ClipColors(Color(0xFF9BF6FF)),
+    clipColors = ClipColors(Color(0xFF931B17)),
+    onClip = {},
+    onPlayClick = {},
+    onPauseClick = {},
+    onClose = {},
+)
+
+@ShowkaseComposable(name = "ShareClipVerticalSmallPage", group = "Clip")
+@Preview(name = "ShareClipVerticalSmallPage", device = "spec:width=360dp,height=640dp,dpi=320,orientation=portrait")
+@Composable
+fun ShareClipPageVerticalSmallPreview() = ShareClipPage(
+    episode = PodcastEpisode(
+        uuid = "episode-id",
+        podcastUuid = "podcast-id",
+        publishedDate = Date.from(Instant.parse("2024-12-03T10:15:30.00Z")),
+        title = "Episode title",
+    ),
+    podcast = Podcast(
+        uuid = "podcast-id",
+        title = "Podcast title",
+        episodeFrequency = "monthly",
+    ),
+    episodeCount = 120,
+    isPlaying = false,
+    useEpisodeArtwork = true,
+    clipColors = ClipColors(Color(0xFF931B17)),
+    onClip = {},
+    onPlayClick = {},
+    onPauseClick = {},
+    onClose = {},
+)
+
+@ShowkaseComposable(name = "ShareClipHorizontalPage", group = "Clip")
+@Preview(name = "ShareClipHorizontalPage", device = "spec:width=420dp,height=900dp,dpi=420,orientation=landscape")
+@Composable
+fun ShareClipPageHorizontalPreview() = ShareClipPage(
+    episode = PodcastEpisode(
+        uuid = "episode-id",
+        podcastUuid = "podcast-id",
+        publishedDate = Date.from(Instant.parse("2024-12-03T10:15:30.00Z")),
+        title = "Episode title",
+    ),
+    podcast = Podcast(
+        uuid = "podcast-id",
+        title = "Podcast title",
+        episodeFrequency = "monthly",
+    ),
+    episodeCount = 120,
+    isPlaying = false,
+    useEpisodeArtwork = true,
+    clipColors = ClipColors(Color(0xFF931B17)),
+    onClip = {},
+    onPlayClick = {},
+    onPauseClick = {},
+    onClose = {},
+)
+
+@ShowkaseComposable(name = "ShareClipHorizontalSmallPage", group = "Clip")
+@Preview(name = "ShareClipHorizontalSmallPage", device = "spec:width=360dp,height=640dp,dpi=320,orientation=landscape")
+@Composable
+fun ShareClipPageHorizontalSmallPreview() = ShareClipPage(
+    episode = PodcastEpisode(
+        uuid = "episode-id",
+        podcastUuid = "podcast-id",
+        publishedDate = Date.from(Instant.parse("2024-12-03T10:15:30.00Z")),
+        title = "Episode title",
+    ),
+    podcast = Podcast(
+        uuid = "podcast-id",
+        title = "Podcast title",
+        episodeFrequency = "monthly",
+    ),
+    episodeCount = 120,
+    isPlaying = false,
+    useEpisodeArtwork = true,
+    clipColors = ClipColors(Color(0xFF931B17)),
     onClip = {},
     onPlayClick = {},
     onPauseClick = {},

--- a/modules/features/clip/src/main/kotlin/au/com/shiftyjelly/pocketcasts/clip/ShareClipPage.kt
+++ b/modules/features/clip/src/main/kotlin/au/com/shiftyjelly/pocketcasts/clip/ShareClipPage.kt
@@ -69,7 +69,7 @@ internal fun ShareClipPage(
                     contentAlignment = Alignment.Center,
                     modifier = Modifier.padding(horizontal = 50.dp),
                 ) {
-                    ClipCard(
+                    VerticalClipCard(
                         episode = episode,
                         podcastTitle = podcastTitle,
                         useEpisodeArtwork = useEpisodeArtwork,

--- a/modules/features/clip/src/main/kotlin/au/com/shiftyjelly/pocketcasts/clip/ShareClipPage.kt
+++ b/modules/features/clip/src/main/kotlin/au/com/shiftyjelly/pocketcasts/clip/ShareClipPage.kt
@@ -37,6 +37,7 @@ import au.com.shiftyjelly.pocketcasts.localization.R as LR
 internal fun ShareClipPage(
     episode: PodcastEpisode?,
     podcast: Podcast?,
+    episodeCount: Int,
     isPlaying: Boolean,
     useEpisodeArtwork: Boolean,
     clipColors: ClipColors,
@@ -44,82 +45,81 @@ internal fun ShareClipPage(
     onPlayClick: () -> Unit,
     onPauseClick: () -> Unit,
     onClose: () -> Unit,
-) {
-    Box {
-        Column(
-            horizontalAlignment = Alignment.CenterHorizontally,
-            modifier = Modifier
-                .fillMaxSize()
-                .background(clipColors.backgroundColor),
-        ) {
-            Spacer(
-                modifier = Modifier.weight(0.5f),
-            )
+) = Box {
+    println(episodeCount)
+    Column(
+        horizontalAlignment = Alignment.CenterHorizontally,
+        modifier = Modifier
+            .fillMaxSize()
+            .background(clipColors.backgroundColor),
+    ) {
+        Spacer(
+            modifier = Modifier.weight(0.5f),
+        )
 
-            TextH30(
-                text = stringResource(LR.string.podcast_create_clip),
-                color = clipColors.backgroundTextColor,
-            )
+        TextH30(
+            text = stringResource(LR.string.podcast_create_clip),
+            color = clipColors.backgroundTextColor,
+        )
 
+        Spacer(
+            modifier = Modifier.weight(1f),
+        )
+
+        if (episode != null && podcast != null) {
+            Box(
+                contentAlignment = Alignment.Center,
+                modifier = Modifier.padding(horizontal = 50.dp),
+            ) {
+                VerticalClipCard(
+                    episode = episode,
+                    podcast = podcast,
+                    useEpisodeArtwork = useEpisodeArtwork,
+                    clipColors = clipColors,
+                )
+            }
             Spacer(
                 modifier = Modifier.weight(1f),
             )
-
-            if (episode != null && podcast != null) {
-                Box(
-                    contentAlignment = Alignment.Center,
-                    modifier = Modifier.padding(horizontal = 50.dp),
-                ) {
-                    VerticalClipCard(
-                        episode = episode,
-                        podcast = podcast,
-                        useEpisodeArtwork = useEpisodeArtwork,
-                        clipColors = clipColors,
-                    )
-                }
-                Spacer(
-                    modifier = Modifier.weight(1f),
-                )
-            }
-
-            ClipSelector(
-                isPlaying = isPlaying,
-                clipColors = clipColors,
-                onPlayClick = onPlayClick,
-                onPauseClick = onPauseClick,
-                modifier = Modifier.padding(horizontal = 16.dp),
-            )
-            Spacer(
-                modifier = Modifier.height(16.dp),
-            )
-            RowButton(
-                text = stringResource(LR.string.podcast_share_clip),
-                onClick = onClip,
-                colors = ButtonDefaults.buttonColors(backgroundColor = clipColors.buttonColor),
-                textColor = clipColors.buttonTextColor,
-                elevation = null,
-                includePadding = false,
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .heightIn(min = 56.dp)
-                    .padding(horizontal = 16.dp),
-            )
         }
-        Row(
-            verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.End,
+
+        ClipSelector(
+            isPlaying = isPlaying,
+            clipColors = clipColors,
+            onPlayClick = onPlayClick,
+            onPauseClick = onPauseClick,
+            modifier = Modifier.padding(horizontal = 16.dp),
+        )
+        Spacer(
+            modifier = Modifier.height(16.dp),
+        )
+        RowButton(
+            text = stringResource(LR.string.podcast_share_clip),
+            onClick = onClip,
+            colors = ButtonDefaults.buttonColors(backgroundColor = clipColors.buttonColor),
+            textColor = clipColors.buttonTextColor,
+            elevation = null,
+            includePadding = false,
             modifier = Modifier
                 .fillMaxWidth()
-                .wrapContentHeight(),
-        ) {
-            Image(
-                painter = painterResource(IR.drawable.ic_close_sheet),
-                contentDescription = stringResource(LR.string.close),
-                modifier = Modifier
-                    .padding(top = 16.dp, end = 16.dp)
-                    .clickable(onClick = onClose),
-            )
-        }
+                .heightIn(min = 56.dp)
+                .padding(horizontal = 16.dp),
+        )
+    }
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.End,
+        modifier = Modifier
+            .fillMaxWidth()
+            .wrapContentHeight(),
+    ) {
+        Image(
+            painter = painterResource(IR.drawable.ic_close_sheet),
+            contentDescription = stringResource(LR.string.close),
+            modifier = Modifier
+                .padding(top = 16.dp, end = 16.dp)
+                .clickable(onClick = onClose),
+        )
     }
 }
 
@@ -138,6 +138,7 @@ fun ShareClipPagePreview() = ShareClipPage(
         title = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.",
         episodeFrequency = "monthly",
     ),
+    episodeCount = 120,
     isPlaying = false,
     useEpisodeArtwork = true,
     clipColors = ClipColors(Color(0xFF9BF6FF)),

--- a/modules/features/clip/src/main/kotlin/au/com/shiftyjelly/pocketcasts/clip/ShareClipPage.kt
+++ b/modules/features/clip/src/main/kotlin/au/com/shiftyjelly/pocketcasts/clip/ShareClipPage.kt
@@ -25,6 +25,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import au.com.shiftyjelly.pocketcasts.compose.buttons.RowButton
 import au.com.shiftyjelly.pocketcasts.compose.components.TextH30
+import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import com.airbnb.android.showkase.annotation.ShowkaseComposable
 import java.sql.Date
@@ -35,8 +36,8 @@ import au.com.shiftyjelly.pocketcasts.localization.R as LR
 @Composable
 internal fun ShareClipPage(
     episode: PodcastEpisode?,
+    podcast: Podcast?,
     isPlaying: Boolean,
-    podcastTitle: String,
     useEpisodeArtwork: Boolean,
     clipColors: ClipColors,
     onClip: () -> Unit,
@@ -64,14 +65,14 @@ internal fun ShareClipPage(
                 modifier = Modifier.weight(1f),
             )
 
-            if (episode != null) {
+            if (episode != null && podcast != null) {
                 Box(
                     contentAlignment = Alignment.Center,
                     modifier = Modifier.padding(horizontal = 50.dp),
                 ) {
                     VerticalClipCard(
                         episode = episode,
-                        podcastTitle = podcastTitle,
+                        podcast = podcast,
                         useEpisodeArtwork = useEpisodeArtwork,
                         clipColors = clipColors,
                     )
@@ -132,8 +133,12 @@ fun ShareClipPagePreview() = ShareClipPage(
         publishedDate = Date.from(Instant.parse("2024-12-03T10:15:30.00Z")),
         title = "Episode title",
     ),
+    podcast = Podcast(
+        uuid = "podcast-id",
+        title = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.",
+        episodeFrequency = "monthly",
+    ),
     isPlaying = false,
-    podcastTitle = "Podcast title",
     useEpisodeArtwork = true,
     clipColors = ClipColors(Color(0xFF9BF6FF)),
     onClip = {},

--- a/modules/features/clip/src/main/kotlin/au/com/shiftyjelly/pocketcasts/clip/ShareClipViewModel.kt
+++ b/modules/features/clip/src/main/kotlin/au/com/shiftyjelly/pocketcasts/clip/ShareClipViewModel.kt
@@ -29,12 +29,14 @@ class ShareClipViewModel @AssistedInject constructor(
     val uiState = combine(
         episodeManager.observeByUuid(episodeUuid),
         podcastManager.observePodcastByEpisodeUuid(episodeUuid),
+        podcastManager.observeEpisodeCountByEpisodeUuid(episodeUuid),
         settings.artworkConfiguration.flow.map { it.useEpisodeArtwork },
         clipPlayer.isPlayingState,
-        transform = { episode, podcast, useEpisodeArtwork, isPlaying ->
+        transform = { episode, podcast, episodeCount, useEpisodeArtwork, isPlaying ->
             UiState(
                 episode = episode,
                 podcast = podcast,
+                episodeCount = episodeCount,
                 useEpisodeArtwork = useEpisodeArtwork,
                 isPlaying = isPlaying,
             )
@@ -56,6 +58,7 @@ class ShareClipViewModel @AssistedInject constructor(
     data class UiState(
         val episode: PodcastEpisode? = null,
         val podcast: Podcast? = null,
+        val episodeCount: Int = 0,
         val clipRange: Clip.Range = Clip.Range(15.seconds, 30.seconds),
         val useEpisodeArtwork: Boolean = false,
         val isPlaying: Boolean = false,

--- a/modules/features/clip/src/main/kotlin/au/com/shiftyjelly/pocketcasts/clip/VerticalClipCard.kt
+++ b/modules/features/clip/src/main/kotlin/au/com/shiftyjelly/pocketcasts/clip/VerticalClipCard.kt
@@ -34,7 +34,7 @@ import java.time.Instant
 import au.com.shiftyjelly.pocketcasts.images.R as IR
 
 @Composable
-internal fun ClipCard(
+internal fun VerticalClipCard(
     episode: PodcastEpisode,
     podcastTitle: String,
     useEpisodeArtwork: Boolean,
@@ -123,20 +123,20 @@ internal fun ClipCard(
     }
 }
 
-@ShowkaseComposable(name = "ClipCard", group = "Clip", styleName = "Light")
-@Preview(name = "ClipCardLight")
+@ShowkaseComposable(name = "VerticalClipCard", group = "Clip", styleName = "Light")
+@Preview(name = "VerticalClipCardLight")
 @Composable
-fun ClipCardLightPreview() = ClipCardPreview(Color(0xFF9BF6FF))
+fun VerticalClipCardLightPreview() = VerticalClipCardPreview(Color(0xFF9BF6FF))
 
-@ShowkaseComposable(name = "ClipCard", group = "Clip", styleName = "Dark")
-@Preview(name = "ClipCardDark")
+@ShowkaseComposable(name = "VerticalClipCard", group = "Clip", styleName = "Dark")
+@Preview(name = "VerticalClipCardDark")
 @Composable
-fun ClipCardDarkPreview() = ClipCardPreview(Color(0xFF152622))
+fun VerticalClipCardDarkPreview() = VerticalClipCardPreview(Color(0xFF152622))
 
 @Composable
-private fun ClipCardPreview(
+private fun VerticalClipCardPreview(
     baseColor: Color,
-) = ClipCard(
+) = VerticalClipCard(
     episode = PodcastEpisode(
         uuid = "episode-id",
         podcastUuid = "podcast-id",

--- a/modules/features/clip/src/main/kotlin/au/com/shiftyjelly/pocketcasts/clip/VerticalClipCard.kt
+++ b/modules/features/clip/src/main/kotlin/au/com/shiftyjelly/pocketcasts/clip/VerticalClipCard.kt
@@ -25,6 +25,7 @@ import androidx.compose.ui.unit.dp
 import au.com.shiftyjelly.pocketcasts.compose.components.EpisodeImage
 import au.com.shiftyjelly.pocketcasts.compose.components.TextH40
 import au.com.shiftyjelly.pocketcasts.compose.components.TextH70
+import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.repositories.images.PocketCastsImageRequestFactory.PlaceholderType
 import au.com.shiftyjelly.pocketcasts.utils.extensions.toLocalizedFormatMediumStyle
@@ -36,7 +37,7 @@ import au.com.shiftyjelly.pocketcasts.images.R as IR
 @Composable
 internal fun VerticalClipCard(
     episode: PodcastEpisode,
-    podcastTitle: String,
+    podcast: Podcast,
     useEpisodeArtwork: Boolean,
     clipColors: ClipColors,
     modifier: Modifier = Modifier,
@@ -88,7 +89,7 @@ internal fun VerticalClipCard(
                 modifier = Modifier.height(6.dp),
             )
             TextH70(
-                text = podcastTitle,
+                text = podcast.title,
                 color = clipColors.cardTextColor.copy(alpha = 0.5f),
                 maxLines = 1,
             )
@@ -143,7 +144,10 @@ private fun VerticalClipCardPreview(
         publishedDate = Date.from(Instant.parse("2024-12-03T10:15:30.00Z")),
         title = "Nobis sapiente fugit vitae. Iusto magnam nam nam et odio. Debitis cupiditate officiis et. Sit quia in voluptate sit voluptatem magni.",
     ),
-    podcastTitle = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.",
+    podcast = Podcast(
+        uuid = "podcast-id",
+        title = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.",
+    ),
     useEpisodeArtwork = true,
     clipColors = ClipColors(baseColor),
 )

--- a/modules/features/clip/src/test/kotlin/au/com/shiftyjelly/pocketcasts/clip/ShareClipViewModelTest.kt
+++ b/modules/features/clip/src/test/kotlin/au/com/shiftyjelly/pocketcasts/clip/ShareClipViewModelTest.kt
@@ -14,6 +14,7 @@ import junit.framework.TestCase.assertTrue
 import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -36,15 +37,13 @@ class ShareClipViewModelTest {
     private val episode = PodcastEpisode(uuid = "episode-id", publishedDate = Date())
     private val podcast = Podcast(uuid = "podcast-id", title = "Podcast Title")
 
-    private val episodeFlow = MutableStateFlow(episode)
-    private val podcastFlow = MutableStateFlow(podcast)
-
     private lateinit var viewModel: ShareClipViewModel
 
     @Before
     fun setUp() {
-        whenever(episodeManager.observeByUuid("episode-id")).thenReturn(episodeFlow)
-        whenever(podcastManager.observePodcastByEpisodeUuid("episode-id")).thenReturn(podcastFlow)
+        whenever(episodeManager.observeByUuid("episode-id")).thenReturn(flowOf(episode))
+        whenever(podcastManager.observePodcastByEpisodeUuid("episode-id")).thenReturn(flowOf(podcast))
+        whenever(podcastManager.observeEpisodeCountByEpisodeUuid("episode-id")).thenReturn(flowOf(10))
         val artworkSetting = mock<UserSetting<ArtworkConfiguration>>()
         whenever(artworkSetting.flow).thenReturn(MutableStateFlow(ArtworkConfiguration(useEpisodeArtwork = true)))
         whenever(settings.artworkConfiguration).thenReturn(artworkSetting)

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -182,6 +182,10 @@
 
     <string name="episodes_singular">1 episode</string>
     <string name="episodes_plural">%d episodes</string>
+    <plurals name="episode_count">
+        <item quantity="one">%d episode</item>
+        <item quantity="other">%d episodes</item>
+    </plurals>
     <string name="empty_play_state">Pick an episode to begin</string>
 
     <string name="seconds_label">Seconds</string>

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/PodcastDao.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/PodcastDao.kt
@@ -249,6 +249,9 @@ abstract class PodcastDao {
         return countByUuid(uuid) != 0
     }
 
+    @Query("SELECT COUNT(*) FROM podcast_episodes WHERE podcast_id IS :podcastUuid")
+    abstract fun episodeCount(podcastUuid: String): Flow<Int>
+
     fun existsRx(uuid: String): Single<Boolean> {
         return Single.fromCallable { exists(uuid) }
     }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PodcastManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PodcastManager.kt
@@ -55,6 +55,7 @@ interface PodcastManager {
     fun findPodcastsAutodownload(): List<Podcast>
 
     fun exists(podcastUuid: String): Boolean
+    fun observeEpisodeCountByEpisodeUuid(uuid: String): Flow<Int>
 
     /** Add methods  */
     fun subscribeToPodcast(podcastUuid: String, sync: Boolean)

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PodcastManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PodcastManagerImpl.kt
@@ -190,6 +190,15 @@ class PodcastManagerImpl @Inject constructor(
         return podcastDao.exists(podcastUuid)
     }
 
+    override fun observeEpisodeCountByEpisodeUuid(uuid: String): Flow<Int> {
+        return flow {
+            val episode = episodeDao.findByUuid(uuid)
+            if (episode != null) {
+                emitAll(podcastDao.episodeCount(episode.podcastUuid))
+            }
+        }
+    }
+
     override fun refreshPodcastsIfRequired(fromLog: String) {
         // if it's been more than 5 minutes since the last refresh, do another one
         val lastUpdateTime = settings.getLastRefreshTime()


### PR DESCRIPTION
## Description

This PR adds landscape view to the clip sharing.

Designs: [Figma](https://www.figma.com/design/HR2vcQrWcS0scsolKZBitg/Sharing?node-id=2889-14798&t=6MYRnxAe5EbwWA7O-4)

Implemented padding is a little bit different to accommodate for small devices.

## Testing Instructions

1. Start clip sharing in landscape orientation.
2. Verify designs.
3. You can smoke test if clip playback and sharing still work.

## Screenshots or Screencast 

| A | B | small |
| - | - | - |
| ![Screenshot_20240620-142449](https://github.com/Automattic/pocket-casts-android/assets/30936061/e4a1177e-84a5-44aa-bb60-8b826fbbfd93) | ![Screenshot_20240620-142245](https://github.com/Automattic/pocket-casts-android/assets/30936061/c976114d-c9c8-4cd9-986c-f41fabf409de) | ![small](https://github.com/Automattic/pocket-casts-android/assets/30936061/844c3a29-1c81-493a-a2ab-69cfdc3c2b56) |

## Checklist
- [x] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] ~with different themes~
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack
