### PR TITLE
Fix: Track `discover_featured_page_changed` event only when Discover is visible

### DIFF
--- a/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/DiscoverAdapter.kt
+++ b/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/DiscoverAdapter.kt
@@ -136,10 +136,16 @@ internal class DiscoverAdapter(
     }
     var onChangeRegion: (() -> Unit)? = null
 
+    private var isFeaturePageTrackingEnabled = true
+
     private val imageRequestFactory = PocketCastsImageRequestFactory(context).smallSize().themed()
 
     init {
         setHasStableIds(true)
+    }
+
+    fun enablePageTracking(enable: Boolean) {
+        isFeaturePageTrackingEnabled = enable
     }
 
     abstract class NetworkLoadableViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
@@ -258,8 +264,12 @@ internal class DiscoverAdapter(
                         recyclerView?.scrollToPosition(nextPosition)
                     }
                     binding.pageIndicatorView.position = nextPosition
+
                     trackSponsoredListImpression(nextPosition)
-                    trackPageChanged(nextPosition)
+
+                    if (isFeaturePageTrackingEnabled) {
+                        trackPageChanged(nextPosition)
+                    }
                 }
             }
 

--- a/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/DiscoverFragment.kt
+++ b/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/DiscoverFragment.kt
@@ -57,7 +57,13 @@ class DiscoverFragment : BaseFragment(), DiscoverAdapter.Listener, RegionSelectF
 
     override fun onPause() {
         super.onPause()
+        adapter?.enablePageTracking(enable = false)
         viewModel.onFragmentPause(activity?.isChangingConfigurations)
+    }
+
+    override fun onResume() {
+        super.onResume()
+        adapter?.enablePageTracking(enable = true)
     }
 
     override fun onPodcastClicked(podcast: DiscoverPodcast, listUuid: String?, isFeatured: Boolean) {


### PR DESCRIPTION
## Description
- `discover_featured_page_changed` track event was being tracked even if the screen was not visible
- See: p1718795716620289/1718795055.315149-slack-C028JAG44VD

Fixes #2379

## Testing Instructions
1. Remove any already installed pocket casts app to have a fresh install
2. Install the app from this branch 
3. ✅ When you see the Log in / Sign in screen, ensure `discover_featured_page_changed` does not continue firing
4. Close the Log in / Sign in screen
5. Go to Discover
6.  ✅ Ensure `discover_featured_page_changed` is tracked
7. Go to another screen
8.  ✅ Ensure `discover_featured_page_changed` is not tracked

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack