### PR TITLE
Discover - Update carousel title size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
         ([#2357](https://github.com/Automattic/pocket-casts-android/pull/2357))
     *   Adds download episode action button to shelf list in Now Playing
         ([#2325](https://github.com/Automattic/pocket-casts-android/pull/2325))
+    *   Updates carousel title size
+        ([#2389](https://github.com/Automattic/pocket-casts-android/pull/2389))
 
 7.66
 -----

--- a/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/CarouselItemViewHolder.kt
+++ b/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/CarouselItemViewHolder.kt
@@ -56,23 +56,21 @@ class CarouselItemViewHolder(val theme: Theme, itemView: View) : RecyclerView.Vi
         lblTagline.chipBackgroundColor = ColorStateList.valueOf(ThemeColor.contrast04(theme.activeTheme))
     }
 
-    var podcast: DiscoverPodcast? = null
-        set(value) {
-            field = value
-            if (value != null) {
-                imageRequestFactory.createForPodcast(value.uuid).loadInto(imageView)
-                lblTitle.text = value.title
-                lblTitle.setTextColor(ThemeColor.contrast01(theme.activeTheme))
-                lblSubtitle.text = value.author
-                lblSubtitle.setTextColor(ThemeColor.contrast03(theme.activeTheme))
-                setBackingGradient(value.color)
-                btnSubscribe.updateSubscribeButtonIcon(
-                    subscribed = value.isSubscribed,
-                    colorSubscribed = UR.attr.contrast_02,
-                    colorUnsubscribed = UR.attr.contrast_02,
-                )
-            } else {
-                reset()
-            }
+    fun setPodcast(podcast: DiscoverPodcast?) {
+        if (podcast != null) {
+            imageRequestFactory.createForPodcast(podcast.uuid).loadInto(imageView)
+            lblSubtitle.setTextColor(ThemeColor.contrast03(theme.activeTheme))
+            setBackingGradient(podcast.color)
+            btnSubscribe.updateSubscribeButtonIcon(
+                subscribed = podcast.isSubscribed,
+                colorSubscribed = UR.attr.contrast_02,
+                colorUnsubscribed = UR.attr.contrast_02,
+            )
+            lblTitle.text = podcast.title
+            lblTitle.setTextColor(ThemeColor.contrast01(theme.activeTheme))
+            lblSubtitle.text = podcast.author
+        } else {
+            reset()
         }
+    }
 }

--- a/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/CarouselItemViewHolder.kt
+++ b/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/CarouselItemViewHolder.kt
@@ -2,12 +2,14 @@ package au.com.shiftyjelly.pocketcasts.discover.view
 
 import android.content.res.ColorStateList
 import android.text.TextUtils
+import android.util.TypedValue
 import android.view.View
 import android.widget.ImageButton
 import android.widget.ImageView
 import android.widget.TextView
 import androidx.annotation.ColorInt
 import androidx.core.view.isVisible
+import androidx.core.widget.TextViewCompat
 import androidx.recyclerview.widget.RecyclerView
 import au.com.shiftyjelly.pocketcasts.discover.R
 import au.com.shiftyjelly.pocketcasts.discover.extensions.updateSubscribeButtonIcon
@@ -22,6 +24,7 @@ import java.util.Locale
 import au.com.shiftyjelly.pocketcasts.ui.R as UR
 
 class CarouselItemViewHolder(val theme: Theme, itemView: View) : RecyclerView.ViewHolder(itemView) {
+
     private val cardBack: View = itemView.findViewById(R.id.cardBack)
     private val imageView: ImageView = itemView.findViewById(R.id.imageView)
     private val lblTitle: TextView = itemView.findViewById(R.id.lblTitle)
@@ -56,7 +59,7 @@ class CarouselItemViewHolder(val theme: Theme, itemView: View) : RecyclerView.Vi
         lblTagline.chipBackgroundColor = ColorStateList.valueOf(ThemeColor.contrast04(theme.activeTheme))
     }
 
-    fun setPodcast(podcast: DiscoverPodcast?) {
+    fun setPodcast(podcast: DiscoverPodcast?, isRankedList: Boolean = false) {
         if (podcast != null) {
             imageRequestFactory.createForPodcast(podcast.uuid).loadInto(imageView)
             lblSubtitle.setTextColor(ThemeColor.contrast03(theme.activeTheme))
@@ -69,6 +72,16 @@ class CarouselItemViewHolder(val theme: Theme, itemView: View) : RecyclerView.Vi
             lblTitle.text = podcast.title
             lblTitle.setTextColor(ThemeColor.contrast01(theme.activeTheme))
             lblSubtitle.text = podcast.author
+
+            if (!isRankedList) {
+                TextViewCompat.setAutoSizeTextTypeUniformWithConfiguration(
+                    lblTitle,
+                    18,
+                    24,
+                    1,
+                    TypedValue.COMPLEX_UNIT_SP,
+                )
+            }
         } else {
             reset()
         }

--- a/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/CarouselListRowAdapter.kt
+++ b/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/CarouselListRowAdapter.kt
@@ -48,7 +48,7 @@ internal class CarouselListRowAdapter(var pillText: String?, val theme: Theme, v
             } else {
                 pillText
             }
-            holder.podcast = podcast
+            holder.setPodcast(podcast)
 
             holder.setTaglineText(tagLineText)
             holder.itemView.setOnClickListener {
@@ -90,7 +90,7 @@ internal class CarouselListRowAdapter(var pillText: String?, val theme: Theme, v
                 }
             }
         } else {
-            holder.podcast = null
+            holder.setPodcast(null)
         }
     }
 

--- a/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/CarouselListRowAdapter.kt
+++ b/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/CarouselListRowAdapter.kt
@@ -41,14 +41,14 @@ internal class CarouselListRowAdapter(var pillText: String?, val theme: Theme, v
 
     override fun onBindViewHolder(holder: CarouselItemViewHolder, position: Int) {
         val podcast = getItem(position)
+        val context = holder.itemView.context
         if (podcast is DiscoverPodcast) {
-            val context = holder.itemView.context
             val tagLineText = if (podcast.isSponsored) {
                 context.getString(LR.string.discover_sponsored)
             } else {
                 pillText
             }
-            holder.setPodcast(podcast)
+            holder.setPodcast(podcast = podcast)
 
             holder.setTaglineText(tagLineText)
             holder.itemView.setOnClickListener {
@@ -90,7 +90,7 @@ internal class CarouselListRowAdapter(var pillText: String?, val theme: Theme, v
                 }
             }
         } else {
-            holder.setPodcast(null)
+            holder.setPodcast(podcast = null)
         }
     }
 

--- a/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/RankedListAdapter.kt
+++ b/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/RankedListAdapter.kt
@@ -40,7 +40,7 @@ class RankedListAdapter(
         }
         when (holder) {
             is CarouselItemViewHolder -> {
-                holder.setPodcast(podcast)
+                holder.setPodcast(podcast = podcast, isRankedList = true)
                 holder.setRanking("1")
                 holder.itemView.setOnClickListener {
                     onPodcastClick(podcast)

--- a/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/RankedListAdapter.kt
+++ b/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/RankedListAdapter.kt
@@ -40,7 +40,7 @@ class RankedListAdapter(
         }
         when (holder) {
             is CarouselItemViewHolder -> {
-                holder.podcast = podcast
+                holder.setPodcast(podcast)
                 holder.setRanking("1")
                 holder.itemView.setOnClickListener {
                     onPodcastClick(podcast)

--- a/modules/features/discover/src/main/res/layout-h560dp/item_carousel.xml
+++ b/modules/features/discover/src/main/res/layout-h560dp/item_carousel.xml
@@ -54,14 +54,17 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 style="@style/DarkH2"
-                android:maxLines="2"
+                android:ellipsize="end"
+                android:maxLines="3"
                 tools:text="Only A Game"/>
             <TextView
                 android:id="@+id/lblSubtitle"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 style="@style/DarkBody2"
-                android:layout_marginBottom="8dp"
+                android:ellipsize="end"
+                android:maxLines="2"
+                android:layout_marginBottom="4dp"
                 tools:text="wbur"/>
         </LinearLayout>
     </LinearLayout>

--- a/modules/features/discover/src/main/res/layout/item_carousel.xml
+++ b/modules/features/discover/src/main/res/layout/item_carousel.xml
@@ -54,7 +54,8 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 style="@style/DarkH2"
-                android:maxLines="2"
+                android:maxLines="3"
+                android:ellipsize="end"
                 tools:text="Only A Game"/>
             <TextView
                 android:id="@+id/lblSubtitle"


### PR DESCRIPTION
## Description
-  Increase maxLine to 3 and add ellipsize="end" for discover carousel title
- Updates font size if the title size is longer than 35 characters 

See: p1718908711900259/1718869041.638049-slack-C04DRL2839S

## Testing Instructions
Run the app in `debug`, go to discover and check the carousel featured podcasts. Check the title and subtitle and make sure they display without issues

## Screenshots or Screencast 

| Phone | Small Phone |
|--------|--------|
| <img src="https://github.com/Automattic/pocket-casts-android/assets/42220351/d9532160-2df9-4a6a-946e-7ff883f06914" width="400"> | <img src="https://github.com/Automattic/pocket-casts-android/assets/42220351/129a8a2b-0ec9-4f78-a8b9-fc8e69d01444" width="400"> | 


| Tablet |
|--------|
| ![tablet](https://github.com/Automattic/pocket-casts-android/assets/42220351/17fdab10-48ee-4108-905e-094a56feb2b7) | 






## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack