### PR TITLE
Add `sso_started` track event

### DIFF
--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/GoogleSignInButtonViewModel.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/GoogleSignInButtonViewModel.kt
@@ -56,6 +56,8 @@ class GoogleSignInButtonViewModel @Inject constructor(
         onError: suspend () -> Unit,
     ) {
         if (flow != null) {
+            analyticsTracker.track(AnalyticsEvent.SSO_STARTED, mapOf("source" to "google"))
+
             analyticsTracker.track(
                 AnalyticsEvent.SETUP_ACCOUNT_BUTTON_TAPPED,
                 mapOf(

--- a/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
+++ b/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
@@ -27,6 +27,7 @@ enum class AnalyticsEvent(val key: String) {
     USER_PASSWORD_UPDATED("user_password_updated"),
     USER_EMAIL_UPDATED("user_email_updated"),
     USER_PASSWORD_RESET("user_password_reset"),
+    SSO_STARTED("sso_started"),
     USER_ACCOUNT_CREATED("user_account_created"),
     USER_ACCOUNT_CREATION_FAILED("user_account_creation_failed"),
     USER_SIGNED_OUT("user_signed_out"),


### PR DESCRIPTION
## Description
- Add `sso_started` Track event

Fixes #2366

## Testing Instructions
1. Install the app
2. Tap on `Continue with Google` button
3. ✅ Ensure `🔵 Tracked: sso_started, Properties: {"source":"google"` event is track


## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [ ] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
