### PR TITLE
Add `source ` to `episode_download_finished `

### DIFF
--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/FilterEpisodeListViewModel.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/FilterEpisodeListViewModel.kt
@@ -144,7 +144,7 @@ class FilterEpisodeListViewModel @Inject constructor(
         val trimmedList = episodes.subList(0, min(MAX_DOWNLOAD_ALL, episodes.count()))
         launch {
             trimmedList.forEach {
-                downloadManager.addEpisodeToQueue(it, "filter download all", fireEvent = false, fireToast = false)
+                downloadManager.addEpisodeToQueue(it, "filter download all", fireEvent = false, fireToast = false, source = SourceView.FILTERS)
             }
         }
     }

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/PlayerViewModel.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/PlayerViewModel.kt
@@ -515,7 +515,7 @@ class PlayerViewModel @Inject constructor(
             deleteEpisodeFile(episode, removeFromUpNext = episode.episodeStatus == EpisodeStatusEnum.DOWNLOADED)
         } else {
             launch {
-                DownloadHelper.manuallyDownloadEpisodeNow(episode, "Player shelf", downloadManager, episodeManager, fireToast = true)
+                DownloadHelper.manuallyDownloadEpisodeNow(episode, "Player shelf", downloadManager, episodeManager, fireToast = true, source = source)
             }
         }
     }

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/helper/PlayButtonListener.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/helper/PlayButtonListener.kt
@@ -110,7 +110,7 @@ class PlayButtonListener @Inject constructor(
                     } else {
                         it.autoDownloadStatus = PodcastEpisode.AUTO_DOWNLOAD_STATUS_MANUALLY_DOWNLOADED
                     }
-                    downloadManager.addEpisodeToQueue(it, "play button", fireEvent = true, fireToast = false)
+                    downloadManager.addEpisodeToQueue(it, "play button", fireEvent = true, fireToast = false, source = source)
                     episodeAnalytics.trackEvent(
                         AnalyticsEvent.EPISODE_DOWNLOAD_QUEUED,
                         source = source,

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/episode/EpisodeFragmentViewModel.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/episode/EpisodeFragmentViewModel.kt
@@ -97,7 +97,7 @@ class EpisodeFragmentViewModel @Inject constructor(
                 if (episode != null) {
                     Maybe.just(episode)
                 } else {
-                    episodeManager.downloadMissingEpisode(episodeUuid, podcastUuid, PodcastEpisode(uuid = episodeUuid, publishedDate = Date()), podcastManager, downloadMetaData = true).flatMap { missingEpisode ->
+                    episodeManager.downloadMissingEpisode(episodeUuid, podcastUuid, PodcastEpisode(uuid = episodeUuid, publishedDate = Date()), podcastManager, downloadMetaData = true, source = source).flatMap { missingEpisode ->
                         if (missingEpisode is PodcastEpisode) {
                             Maybe.just(missingEpisode)
                         } else {
@@ -192,7 +192,7 @@ class EpisodeFragmentViewModel @Inject constructor(
                     analyticsEvent = AnalyticsEvent.EPISODE_DOWNLOAD_CANCELLED
                 } else if (!it.isDownloaded) {
                     it.autoDownloadStatus = PodcastEpisode.AUTO_DOWNLOAD_STATUS_MANUAL_OVERRIDE_WIFI
-                    downloadManager.addEpisodeToQueue(it, "episode card", fireEvent = true, fireToast = false)
+                    downloadManager.addEpisodeToQueue(it, "episode card", fireEvent = true, fireToast = false, source = source)
                     analyticsEvent = AnalyticsEvent.EPISODE_DOWNLOAD_QUEUED
                 }
                 episodeManager.clearPlaybackError(episode)

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/PodcastViewModel.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/PodcastViewModel.kt
@@ -377,7 +377,7 @@ class PodcastViewModel
         val trimmedList = episodes.subList(0, min(Settings.MAX_DOWNLOAD, episodes.count()))
         launch {
             trimmedList.forEach {
-                downloadManager.addEpisodeToQueue(it, "podcast download all", fireEvent = false, fireToast = false)
+                downloadManager.addEpisodeToQueue(it, "podcast download all", fireEvent = false, fireToast = false, source = SourceView.PODCAST_SCREEN)
             }
         }
     }

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/cloud/CloudBottomSheetViewModel.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/cloud/CloudBottomSheetViewModel.kt
@@ -100,7 +100,7 @@ class CloudBottomSheetViewModel @Inject constructor(
 
     fun download(episode: UserEpisode) {
         viewModelScope.launch(Dispatchers.Default) {
-            DownloadHelper.manuallyDownloadEpisodeNow(episode, "cloud bottom sheet", downloadManager, episodeManager)
+            DownloadHelper.manuallyDownloadEpisodeNow(episode, "cloud bottom sheet", downloadManager, episodeManager, source = source)
         }
     }
 

--- a/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/EpisodeAnalytics.kt
+++ b/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/EpisodeAnalytics.kt
@@ -21,7 +21,7 @@ class EpisodeAnalytics @Inject constructor(
         analyticsTracker.track(event, AnalyticsProp.sourceAndUuidMap(source, uuid))
     }
 
-    fun trackEvent(event: AnalyticsEvent, uuid: String) {
+    fun trackEvent(event: AnalyticsEvent, uuid: String, source: SourceView? = null) {
         if (event == AnalyticsEvent.EPISODE_DOWNLOAD_FINISHED || event == AnalyticsEvent.EPISODE_DOWNLOAD_FAILED) {
             if (downloadEpisodeUuidQueue.contains(uuid)) {
                 downloadEpisodeUuidQueue.remove(uuid)
@@ -36,7 +36,11 @@ class EpisodeAnalytics @Inject constructor(
             }
         }
 
-        analyticsTracker.track(event, AnalyticsProp.uuidMap(uuid))
+        if (source != null) {
+            analyticsTracker.track(event, AnalyticsProp.sourceAndUuidMap(source, uuid))
+        } else {
+            analyticsTracker.track(event, AnalyticsProp.uuidMap(uuid))
+        }
     }
 
     fun trackEvent(

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/download/DownloadHelper.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/download/DownloadHelper.kt
@@ -17,8 +17,8 @@ object DownloadHelper {
         from: String,
         downloadManager: DownloadManager,
         episodeManager: EpisodeManager,
-        fireToast: Boolean = false,
         source: SourceView,
+        fireToast: Boolean = false,
     ) {
         if (episode.isDownloaded) {
             return

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/download/DownloadHelper.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/download/DownloadHelper.kt
@@ -1,5 +1,6 @@
 package au.com.shiftyjelly.pocketcasts.repositories.download
 
+import au.com.shiftyjelly.pocketcasts.analytics.SourceView
 import au.com.shiftyjelly.pocketcasts.models.entity.BaseEpisode
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.models.type.EpisodeStatusEnum
@@ -11,7 +12,14 @@ import kotlinx.coroutines.runBlocking
 
 object DownloadHelper {
 
-    fun manuallyDownloadEpisodeNow(episode: BaseEpisode, from: String, downloadManager: DownloadManager, episodeManager: EpisodeManager, fireToast: Boolean = false) {
+    fun manuallyDownloadEpisodeNow(
+        episode: BaseEpisode,
+        from: String,
+        downloadManager: DownloadManager,
+        episodeManager: EpisodeManager,
+        fireToast: Boolean = false,
+        source: SourceView,
+    ) {
         if (episode.isDownloaded) {
             return
         }
@@ -19,10 +27,10 @@ object DownloadHelper {
         runBlocking {
             episodeManager.updateAutoDownloadStatus(episode, PodcastEpisode.AUTO_DOWNLOAD_STATUS_MANUALLY_DOWNLOADED)
         }
-        downloadManager.addEpisodeToQueue(episode, from, fireEvent = true, fireToast = fireToast)
+        downloadManager.addEpisodeToQueue(episode, from, fireEvent = true, fireToast = fireToast, source = source)
     }
 
-    fun addAutoDownloadedEpisodeToQueue(episode: BaseEpisode, from: String, downloadManager: DownloadManager, episodeManager: EpisodeManager) {
+    fun addAutoDownloadedEpisodeToQueue(episode: BaseEpisode, from: String, downloadManager: DownloadManager, episodeManager: EpisodeManager, source: SourceView) {
         if (episode.isDownloaded || episode.episodeStatus == EpisodeStatusEnum.DOWNLOAD_FAILED) {
             if (episode.episodeStatus == EpisodeStatusEnum.DOWNLOAD_FAILED) {
                 LogBuffer.i(LogBuffer.TAG_BACKGROUND_TASKS, "Not autodownloading ${episode.title} from $from because it has already failed.")
@@ -33,7 +41,7 @@ object DownloadHelper {
         runBlocking {
             episodeManager.updateAutoDownloadStatus(episode, PodcastEpisode.AUTO_DOWNLOAD_STATUS_AUTO_DOWNLOADED)
         }
-        downloadManager.addEpisodeToQueue(episode, from, fireEvent = true, fireToast = false)
+        downloadManager.addEpisodeToQueue(episode, from, fireEvent = true, fireToast = false, source = source)
     }
 
     fun removeEpisodeFromQueue(episode: BaseEpisode, from: String, downloadManager: DownloadManager) {

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/download/DownloadManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/download/DownloadManager.kt
@@ -2,6 +2,7 @@ package au.com.shiftyjelly.pocketcasts.repositories.download
 
 import android.content.Context
 import androidx.core.app.NotificationCompat
+import au.com.shiftyjelly.pocketcasts.analytics.SourceView
 import au.com.shiftyjelly.pocketcasts.models.entity.BaseEpisode
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
@@ -20,7 +21,7 @@ interface DownloadManager {
     fun setup(episodeManager: EpisodeManager, podcastManager: PodcastManager, playlistManager: PlaylistManager, playbackManager: PlaybackManager)
     fun beginMonitoringWorkManager(context: Context)
     fun hasPendingOrRunningDownloads(): Boolean
-    fun addEpisodeToQueue(episode: BaseEpisode, from: String, fireEvent: Boolean, fireToast: Boolean)
+    fun addEpisodeToQueue(episode: BaseEpisode, from: String, fireEvent: Boolean, fireToast: Boolean, source: SourceView)
     fun removeEpisodeFromQueue(episode: BaseEpisode, from: String)
     fun stopAllDownloads()
     suspend fun getRequirementsAndSetStatusAsync(episode: BaseEpisode): NetworkRequirements

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/download/DownloadManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/download/DownloadManagerImpl.kt
@@ -15,6 +15,7 @@ import androidx.work.WorkManager
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
 import au.com.shiftyjelly.pocketcasts.analytics.EpisodeAnalytics
 import au.com.shiftyjelly.pocketcasts.analytics.EpisodeDownloadError
+import au.com.shiftyjelly.pocketcasts.analytics.SourceView
 import au.com.shiftyjelly.pocketcasts.models.entity.BaseEpisode
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.models.entity.UserEpisode
@@ -279,7 +280,7 @@ class DownloadManagerImpl @Inject constructor(
     private val addDownloadMutex = Mutex()
 
     // We only want to be able to queue one download at a time
-    override fun addEpisodeToQueue(episode: BaseEpisode, from: String, fireEvent: Boolean, fireToast: Boolean) {
+    override fun addEpisodeToQueue(episode: BaseEpisode, from: String, fireEvent: Boolean, fireToast: Boolean, source: SourceView) {
         launch(downloadsCoroutineContext) {
             addDownloadMutex.withLock {
                 val updatedEpisode = episodeManager.findEpisodeByUuid(episode.uuid) ?: return@launch // Get the latest episode so we can check if it's downloaded

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/UpNextQueueImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/UpNextQueueImpl.kt
@@ -1,6 +1,7 @@
 package au.com.shiftyjelly.pocketcasts.repositories.playback
 
 import android.content.Context
+import au.com.shiftyjelly.pocketcasts.analytics.SourceView
 import au.com.shiftyjelly.pocketcasts.models.db.AppDatabase
 import au.com.shiftyjelly.pocketcasts.models.entity.BaseEpisode
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
@@ -319,7 +320,7 @@ class UpNextQueueImpl @Inject constructor(
 
     private fun downloadIfPossible(episode: BaseEpisode, downloadManager: DownloadManager) {
         if (settings.autoDownloadUpNext.value) {
-            DownloadHelper.addAutoDownloadedEpisodeToQueue(episode, "up next auto download", downloadManager, episodeManager)
+            DownloadHelper.addAutoDownloadedEpisodeToQueue(episode, "up next auto download", downloadManager, episodeManager, source = SourceView.UP_NEXT)
         }
     }
 

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManager.kt
@@ -113,7 +113,7 @@ interface EpisodeManager {
     /** Utility methods  */
     suspend fun countEpisodes(): Int
     fun countEpisodesWhere(queryAfterWhere: String): Int
-    fun downloadMissingEpisode(episodeUuid: String, podcastUuid: String, skeletonEpisode: PodcastEpisode, podcastManager: PodcastManager, downloadMetaData: Boolean): Maybe<BaseEpisode>
+    fun downloadMissingEpisode(episodeUuid: String, podcastUuid: String, skeletonEpisode: PodcastEpisode, podcastManager: PodcastManager, downloadMetaData: Boolean, source: SourceView): Maybe<BaseEpisode>
 
     fun deleteEpisodes(episodes: List<PodcastEpisode>, playbackManager: PlaybackManager)
     fun unarchiveAllInList(episodes: List<PodcastEpisode>)

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManagerImpl.kt
@@ -1002,7 +1002,7 @@ class EpisodeManagerImpl @Inject constructor(
     /**
      * Try downloading the episode if it is missing. If the server doesn't know about it insert the skeleton episode.
      */
-    override fun downloadMissingEpisode(episodeUuid: String, podcastUuid: String, skeletonEpisode: PodcastEpisode, podcastManager: PodcastManager, downloadMetaData: Boolean): Maybe<BaseEpisode> {
+    override fun downloadMissingEpisode(episodeUuid: String, podcastUuid: String, skeletonEpisode: PodcastEpisode, podcastManager: PodcastManager, downloadMetaData: Boolean, source: SourceView): Maybe<BaseEpisode> {
         return episodeDao.existsRx(episodeUuid)
             .flatMapMaybe { episodeExists ->
                 if (episodeExists || podcastUuid == Podcast.userPodcast.uuid) {
@@ -1016,7 +1016,7 @@ class EpisodeManagerImpl @Inject constructor(
                         podcastManager.findPodcastByUuidRx(podcastUuid).zipWith(findByUuidRx(episodeUuid))
                     }.flatMap { (podcast, episode) ->
                         if (podcast.isAutoDownloadNewEpisodes) {
-                            DownloadHelper.addAutoDownloadedEpisodeToQueue(episode, "download missing episode", downloadManager, this)
+                            DownloadHelper.addAutoDownloadedEpisodeToQueue(episode, "download missing episode", downloadManager, episodeManager = this, source = source)
                         }
                         return@flatMap Maybe.just(episode)
                     }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PlaylistManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PlaylistManagerImpl.kt
@@ -2,6 +2,7 @@ package au.com.shiftyjelly.pocketcasts.repositories.podcast
 
 import android.content.Context
 import android.os.Build
+import au.com.shiftyjelly.pocketcasts.analytics.SourceView
 import au.com.shiftyjelly.pocketcasts.models.db.AppDatabase
 import au.com.shiftyjelly.pocketcasts.models.entity.Playlist
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
@@ -329,7 +330,7 @@ class PlaylistManagerImpl @Inject constructor(
                     return@forEach
                 }
 
-                DownloadHelper.addAutoDownloadedEpisodeToQueue(episode, "playlist " + playlist.title, downloadManager, episodeManager)
+                DownloadHelper.addAutoDownloadedEpisodeToQueue(episode, "playlist " + playlist.title, downloadManager, episodeManager, source = SourceView.PODCAST_LIST)
             }
         }
     }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PodcastManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PodcastManagerImpl.kt
@@ -1,6 +1,7 @@
 package au.com.shiftyjelly.pocketcasts.repositories.podcast
 
 import android.content.Context
+import au.com.shiftyjelly.pocketcasts.analytics.SourceView
 import au.com.shiftyjelly.pocketcasts.models.db.AppDatabase
 import au.com.shiftyjelly.pocketcasts.models.db.helper.TopPodcast
 import au.com.shiftyjelly.pocketcasts.models.entity.Folder
@@ -757,7 +758,7 @@ class PodcastManagerImpl @Inject constructor(
                 continue
             }
 
-            DownloadHelper.addAutoDownloadedEpisodeToQueue(episode, "podcast auto download " + episode.podcastUuid, downloadManager, episodeManager)
+            DownloadHelper.addAutoDownloadedEpisodeToQueue(episode, "podcast auto download " + episode.podcastUuid, downloadManager, episodeManager, source = SourceView.UNKNOWN)
             uuidToAdded[episodeUuid] = java.lang.Boolean.TRUE
         }
     }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/UserEpisodeManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/UserEpisodeManager.kt
@@ -399,7 +399,7 @@ class UserEpisodeManagerImpl @Inject constructor(
                 if (settings.cloudAutoDownload.value && subscriptionManager.getCachedStatus() is SubscriptionStatus.Paid) {
                     userEpisodeDao.updateAutoDownloadStatus(PodcastEpisode.AUTO_DOWNLOAD_STATUS_AUTO_DOWNLOADED, newEpisode.uuid)
                     newEpisode.autoDownloadStatus = PodcastEpisode.AUTO_DOWNLOAD_STATUS_AUTO_DOWNLOADED
-                    downloadManager.addEpisodeToQueue(newEpisode, "cloud files sync", fireEvent = false, fireToast = false)
+                    downloadManager.addEpisodeToQueue(newEpisode, "cloud files sync", fireEvent = false, fireToast = false, source = SourceView.UNKNOWN)
                 }
             }
         }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/NotificationBroadcastReceiver.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/NotificationBroadcastReceiver.kt
@@ -115,7 +115,7 @@ class NotificationBroadcastReceiver : BroadcastReceiver(), CoroutineScope {
     private fun downloadEpisode(episodeUuid: String) {
         launch {
             episodeManager.findEpisodeByUuid(episodeUuid)?.let { episode ->
-                DownloadHelper.manuallyDownloadEpisodeNow(episode, "download from intent", downloadManager, episodeManager)
+                DownloadHelper.manuallyDownloadEpisodeNow(episode, "download from intent", downloadManager, episodeManager, source = source)
             }
         }
     }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/UpNextSyncJob.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/UpNextSyncJob.kt
@@ -8,6 +8,7 @@ import android.app.job.JobService
 import android.content.ComponentName
 import android.content.Context
 import android.os.SystemClock
+import au.com.shiftyjelly.pocketcasts.analytics.SourceView
 import au.com.shiftyjelly.pocketcasts.models.db.AppDatabase
 import au.com.shiftyjelly.pocketcasts.models.db.dao.UpNextChangeDao
 import au.com.shiftyjelly.pocketcasts.models.entity.BaseEpisode
@@ -213,7 +214,7 @@ class UpNextSyncJob : JobService() {
                     userEpisodeManager.downloadMissingUserEpisode(episodeUuid, placeholderTitle = responseEpisode.title, placeholderPublished = responseEpisode.published?.parseIsoDate()).toObservable()
                 } else {
                     val skeletonEpisode = responseEpisode.toSkeletonEpisode(podcastUuid)
-                    episodeManager.downloadMissingEpisode(episodeUuid, podcastUuid, skeletonEpisode, podcastManager, false).toObservable()
+                    episodeManager.downloadMissingEpisode(episodeUuid, podcastUuid, skeletonEpisode, podcastManager, false, source = SourceView.UP_NEXT).toObservable()
                 }
             }
         }

--- a/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/helper/WarningsHelper.kt
+++ b/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/helper/WarningsHelper.kt
@@ -119,7 +119,7 @@ class WarningsHelper @Inject constructor(
                     if (!waitForWifi) {
                         it.autoDownloadStatus = PodcastEpisode.AUTO_DOWNLOAD_STATUS_MANUAL_OVERRIDE_WIFI
                     }
-                    downloadManager.addEpisodeToQueue(it, from, fireEvent = true, fireToast = false)
+                    downloadManager.addEpisodeToQueue(it, from, fireEvent = true, fireToast = false, source = SourceView.UNKNOWN)
                     launch {
                         episodeManager.unarchive(it)
                     }

--- a/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/multiselect/MultiSelectEpisodesHelper.kt
+++ b/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/multiselect/MultiSelectEpisodesHelper.kt
@@ -314,7 +314,7 @@ class MultiSelectEpisodesHelper @Inject constructor(
         val trimmedList = list.subList(0, min(Settings.MAX_DOWNLOAD, selectedList.count())).toList()
         ConfirmationDialog.downloadWarningDialog(list.count(), resources) {
             trimmedList.forEach {
-                downloadManager.addEpisodeToQueue(it, "podcast download all", fireEvent = false, fireToast = false)
+                downloadManager.addEpisodeToQueue(it, "podcast download all", fireEvent = false, fireToast = false, source = source)
             }
             episodeAnalytics.trackBulkEvent(AnalyticsEvent.EPISODE_BULK_DOWNLOAD_QUEUED, source, trimmedList)
             val snackText = resources.getStringPlural(trimmedList.size, LR.string.download_queued_singular, LR.string.download_queued_plural)

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/episode/EpisodeViewModel.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/episode/EpisodeViewModel.kt
@@ -283,7 +283,7 @@ class EpisodeViewModel @Inject constructor(
             } else if (!episode.isDownloaded) {
                 episode.autoDownloadStatus =
                     PodcastEpisode.AUTO_DOWNLOAD_STATUS_MANUAL_OVERRIDE_WIFI
-                downloadManager.addEpisodeToQueue(episode, fromString, fireEvent = true, fireToast = false)
+                downloadManager.addEpisodeToQueue(episode, fromString, fireEvent = true, fireToast = false, source = sourceView)
 
                 episodeAnalytics.trackEvent(
                     event = AnalyticsEvent.EPISODE_DOWNLOAD_QUEUED,


### PR DESCRIPTION
## Description
- 9a68697a53e053b4dcdd059709d7724921321446 : Refactor `addEpisodeToQueue` method to receive `source` as parameter
-  a70e64a663e74b675ebe1412018dab3e438aa952 : Add `source` to `episode_download_finished` event

Fixes #1039

## Testing Instructions
- Try to download episodes from different sources such as `filters`, `starred`, `podcasts`, etc and ensure `🔵 Tracked: episode_download_finished` with `source`

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack
