### PR TITLE
Configure default value for cache playing episode advanced setting

### DIFF
--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
@@ -196,7 +196,7 @@ class SettingsImpl @Inject constructor(
 
     override val cacheEntirePlayingEpisode = UserSetting.CacheEntirePlayingEpisodePref(
         sharedPrefKey = "cacheEntirePlayingEpisode",
-        defaultValue = false,
+        defaultValue = firebaseRemoteConfig.getBoolean(FirebaseConfig.EXOPLAYER_CACHE_ENTIRE_PLAYING_EPISODE_SETTING_DEFAULT),
         sharedPrefs = sharedPreferences,
     )
 

--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/config/FirebaseConfig.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/config/FirebaseConfig.kt
@@ -15,7 +15,9 @@ object FirebaseConfig {
     const val REFRESH_PODCASTS_BATCH_SIZE = "refresh_podcasts_batch_size"
     const val EXOPLAYER_CACHE_SIZE_IN_MB = "exoplayer_cache_size_in_mb"
     const val EXOPLAYER_CACHE_ENTIRE_PLAYING_EPISODE_SIZE_IN_MB = "exoplayer_cache_entire_playing_episode_size_in_mb"
+    const val EXOPLAYER_CACHE_ENTIRE_PLAYING_EPISODE_SETTING_DEFAULT = "exoplayer_cache_entire_playing_episode_setting_default"
     const val PLAYBACK_EPISODE_POSITION_CHANGED_ON_SYNC_THRESHOLD_SECS = "playback_episode_position_changed_on_sync_threshold_secs"
+
     val defaults = mapOf(
         PERIODIC_SAVE_TIME_MS to 60000L,
         PLAYER_RELEASE_TIME_OUT_MS to 500L,
@@ -26,6 +28,7 @@ object FirebaseConfig {
         REFRESH_PODCASTS_BATCH_SIZE to 200L,
         EXOPLAYER_CACHE_SIZE_IN_MB to if (BuildConfig.DEBUG) 100L else 0L,
         EXOPLAYER_CACHE_ENTIRE_PLAYING_EPISODE_SIZE_IN_MB to if (BuildConfig.DEBUG) 500L else 0L,
+        EXOPLAYER_CACHE_ENTIRE_PLAYING_EPISODE_SETTING_DEFAULT to true,
         PLAYBACK_EPISODE_POSITION_CHANGED_ON_SYNC_THRESHOLD_SECS to 5L,
     ) + Feature.values()
         .filter { it.hasFirebaseRemoteFlag }


### PR DESCRIPTION
## Description
This configures default value for cache playing episode advanced setting using remote config.

## Testing Instructions

1. Change `FirebaseModule.setMinimumFetchIntervalInSeconds(..)` to 5 secs
2. Install release build
3. Open the app and wait for 5 secs
4. Go to Profile -> Settings -> Advanced 
5. ✅ Notice that cache playing episode setting is enabled
6. Uninstall the app

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
