### PR TITLE
Add `chapter_link_clicked` event

### DIFF
--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/chapters/ChaptersFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/chapters/ChaptersFragment.kt
@@ -20,6 +20,7 @@ import androidx.core.os.bundleOf
 import androidx.fragment.app.viewModels
 import au.com.shiftyjelly.pocketcasts.compose.AppThemeWithBackground
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
+import au.com.shiftyjelly.pocketcasts.models.to.Chapter
 import au.com.shiftyjelly.pocketcasts.player.view.PlayerContainerFragment
 import au.com.shiftyjelly.pocketcasts.player.view.chapters.ChaptersViewModel.Mode.Episode
 import au.com.shiftyjelly.pocketcasts.player.view.chapters.ChaptersViewModel.Mode.Player
@@ -109,11 +110,12 @@ class ChaptersFragment : BaseFragment() {
         }
     }
 
-    private fun openChapterUrl(url: String) {
+    private fun openChapterUrl(chapter: Chapter) {
         try {
-            startActivity(Intent(Intent.ACTION_VIEW).setData(url.toUri()))
+            viewModel.trackChapterLinkTap(chapter)
+            startActivity(Intent(Intent.ACTION_VIEW).setData(chapter.url.toString().toUri()))
         } catch (_: Throwable) {
-            UiUtil.displayAlertError(requireContext(), getString(LR.string.player_open_url_failed, url), null)
+            UiUtil.displayAlertError(requireContext(), getString(LR.string.player_open_url_failed, chapter.url.toString()), null)
         }
     }
 

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/chapters/ChaptersPage.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/chapters/ChaptersPage.kt
@@ -22,7 +22,7 @@ fun ChaptersPage(
     totalChaptersCount: Int,
     onSelectionChange: (Boolean, Chapter) -> Unit,
     onChapterClick: (Chapter) -> Unit,
-    onUrlClick: (String) -> Unit,
+    onUrlClick: (Chapter) -> Unit,
     onSkipChaptersClick: (Boolean) -> Unit,
     isTogglingChapters: Boolean,
     showSubscriptionIcon: Boolean,
@@ -54,7 +54,7 @@ fun ChaptersPage(
                 selectedCount = selectedCount,
                 onSelectionChange = onSelectionChange,
                 onClick = { onChapterClick(state.chapter) },
-                onUrlClick = { onUrlClick(state.chapter.url.toString()) },
+                onUrlClick = { onUrlClick(state.chapter) },
                 modifier = Modifier.animateItemPlacement(),
             )
             if (index < chapters.lastIndex) {

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/chapters/ChaptersViewModel.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/chapters/ChaptersViewModel.kt
@@ -138,6 +138,26 @@ class ChaptersViewModel @AssistedInject constructor(
         viewModelScope.launch { _scrollToChapter.emit(chapter) }
     }
 
+    fun trackChapterLinkTap(chapter: Chapter) {
+        viewModelScope.launch(ioDispatcher) {
+            val episodeId = when (mode) {
+                is Mode.Episode -> mode.episodeId
+                is Mode.Player -> playbackManager.playbackStateFlow.first().episodeUuid
+            }
+
+            episodeManager.findEpisodeByUuid(episodeId)?.let { episode ->
+                tracker.track(
+                    AnalyticsEvent.CHAPTER_LINK_CLICKED,
+                    mapOf(
+                        "chapter_title" to chapter.title,
+                        "episode_uuid" to episodeId,
+                        "podcast_uuid" to episode.podcastOrSubstituteUuid,
+                    ),
+                )
+            }
+        }
+    }
+
     private fun createUiState(
         playbackState: PlaybackState,
         episode: BaseEpisode,

--- a/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
+++ b/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
@@ -614,6 +614,7 @@ enum class AnalyticsEvent(val key: String) {
     DESELECT_CHAPTERS_CHAPTER_SELECTED("deselect_chapters_chapter_selected"),
     DESELECT_CHAPTERS_CHAPTER_DESELECTED("deselect_chapters_chapter_deselected"),
     PLAYBACK_CHAPTER_SKIPPED("playback_chapter_skipped"),
+    CHAPTER_LINK_CLICKED("chapter_link_clicked"),
 
     /* Widgets */
     WIDGET_INSTALLED("widget_installed"),


### PR DESCRIPTION
## Description
- Adds `chapter_link_clicked` event when taps on chapter link

Fixes #2374

## Testing Instructions
1. Log with a premium account
2. Go to a podcast that has chapters, such as `The Changelog: Software Development, Open Source`
3. Open the `Chapters` tab
4. Tap on the chapter URL link icon (see screenshot below)
5. ✅ Ensure `🔵 Tracked: chapter_link_clicked, Properties: {"chapter_title":"name","episode_uuid":"uuid","podcast_uuid": "uuid"`
6. Go to the podcast page
7. Tap on an episode to open the episode detail screen
8. Go to `Chapters tab`
9.  ✅ Ensure `🔵 Tracked: chapter_link_clicked, Properties: {"chapter_title":"name","episode_uuid":"uuid","podcast_uuid": "uuid"`

## Screenshots or Screencast 

| Chapter link |
|--------|
| <img src="https://github.com/Automattic/pocket-casts-android/assets/42220351/47108c3e-a446-4264-8377-4437cc33d50b" width="400"> |




## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack
