### PR TITLE
Add `filter_options_modal_option_tapped` event

### DIFF
--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/FilterEpisodeListFragment.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/FilterEpisodeListFragment.kt
@@ -243,23 +243,28 @@ class FilterEpisodeListFragment : BaseFragment() {
         toolbar.setOnMenuItemClickListener { item ->
             when (item?.itemId) {
                 R.id.menu_delete -> {
+                    analyticsTracker.track(AnalyticsEvent.FILTER_OPTIONS_MODAL_OPTION_TAPPED, mapOf("option" to "delete_filter"))
                     showDeleteConfirmation()
                     true
                 }
                 R.id.menu_playall -> {
+                    analyticsTracker.track(AnalyticsEvent.FILTER_OPTIONS_MODAL_OPTION_TAPPED, mapOf("option" to "play_all"))
                     val firstEpisode = viewModel.episodesList.value?.firstOrNull() ?: return@setOnMenuItemClickListener true
                     playAllFromHereWarning(firstEpisode, isFirstEpisode = true)
                     true
                 }
                 R.id.menu_sortby -> {
+                    analyticsTracker.track(AnalyticsEvent.FILTER_OPTIONS_MODAL_OPTION_TAPPED, mapOf("option" to "sort_by"))
                     showSortOptions()
                     true
                 }
                 R.id.menu_options -> {
+                    analyticsTracker.track(AnalyticsEvent.FILTER_OPTIONS_MODAL_OPTION_TAPPED, mapOf("option" to "filter_options"))
                     showFilterSettings()
                     true
                 }
                 R.id.menu_downloadall -> {
+                    analyticsTracker.track(AnalyticsEvent.FILTER_OPTIONS_MODAL_OPTION_TAPPED, mapOf("option" to "download_all"))
                     downloadAll()
                     true
                 }

--- a/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
+++ b/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
@@ -280,6 +280,7 @@ enum class AnalyticsEvent(val key: String) {
     FILTER_SHOWN("filter_shown"),
     FILTER_SORT_BY_CHANGED("filter_sort_by_changed"),
     FILTER_UPDATED("filter_updated"),
+    FILTER_OPTIONS_MODAL_OPTION_TAPPED("filter_options_modal_option_tapped"),
 
     /* Discover */
     DISCOVER_SHOWN("discover_shown"),


### PR DESCRIPTION
## Description
Adds `filter_options_modal_option_tapped` for when tap on ellipse menu in filter screen

Fixes #2344

## Testing Instructions
1. Go to filters tab
2. Create a filter
3. Tap on the filter
4. Tap on the ellipse menu
5. Tap on the options and make sure you see the `filter_options_modal_option_tapped` event with the `option`

See the examples:

> 🔵 Tracked: filter_options_modal_option_tapped, Properties: {"option":"sort_by"}
🔵 Tracked: filter_options_modal_option_tapped, Properties: {"option":"play_all"}
🔵 Tracked: filter_options_modal_option_tapped, Properties: {"option":"download_all"}
🔵 Tracked: filter_options_modal_option_tapped, Properties: {"option":"filter_options"}
🔵 Tracked: filter_options_modal_option_tapped, Properties: {"option":"delete_filter"}


## Screenshot

| Filter Menu |
|--------|
| <img width="223" alt="image" src="https://github.com/Automattic/pocket-casts-android/assets/42220351/ff7ae4ae-2334-46c5-8418-9ba73368ff10"> |
| <img width="224" alt="image" src="https://github.com/Automattic/pocket-casts-android/assets/42220351/0ace5ccb-6277-4c07-a2be-af3ef252e658"> | 







## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack
