### PR TITLE
Add missing auto play track events

### DIFF
--- a/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
+++ b/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
@@ -389,6 +389,7 @@ enum class AnalyticsEvent(val key: String) {
     PODCAST_SHARED("podcast_shared"),
 
     /* Auto Play */
+    AUTOPLAY_STARTED("autoplay_started"),
     AUTOPLAY_FINISHED_LAST_EPISODE("autoplay_finished_last_episode"),
 
     /* Episode Details */

--- a/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
+++ b/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
@@ -388,6 +388,9 @@ enum class AnalyticsEvent(val key: String) {
     EPISODE_REMOVED_FROM_UP_NEXT("episode_removed_from_up_next"),
     PODCAST_SHARED("podcast_shared"),
 
+    /* Auto Play */
+    AUTOPLAY_FINISHED_LAST_EPISODE("autoplay_finished_last_episode"),
+
     /* Episode Details */
     EPISODE_DETAIL_SHOWN("episode_detail_shown"),
     EPISODE_DETAIL_DISMISSED("episode_detail_dismissed"),

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
@@ -1392,12 +1392,13 @@ open class PlaybackManager @Inject constructor(
         }
 
         // If no matches found, play the latest episode on Android Automotive to avoid the player stopping
-        return when (Util.getAppPlatform(application)) {
-            AppPlatform.Automotive -> episodeManager.findLatestEpisodeToPlay()
-
-            AppPlatform.Phone,
-            AppPlatform.WearOs,
-            -> null
+        when (Util.getAppPlatform(application)) {
+            AppPlatform.Automotive -> return episodeManager.findLatestEpisodeToPlay()
+            AppPlatform.WearOs -> return null
+            AppPlatform.Phone -> {
+                analyticsTracker.track(AnalyticsEvent.AUTOPLAY_FINISHED_LAST_EPISODE, mapOf("episode_source" to settings.lastAutoPlaySource.value))
+                return null
+            }
         }
     }
 

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
@@ -204,6 +204,7 @@ open class PlaybackManager @Inject constructor(
     private var syncTimerDisposable: Disposable? = null
     private var lastWarnedPlayedEpisodeUuid: String? = null
     private var lastPlayedEpisodeUuid: String? = null
+    private var lastTrackedAutoPlaySource: AutoPlaySource? = null
 
     private val resumptionHelper = ResumptionHelper(settings)
 
@@ -1356,6 +1357,7 @@ open class PlaybackManager @Inject constructor(
         if (nextEpisode == null) {
             nextEpisode = autoLoadEpisode(autoPlay)
             if (nextEpisode == null) {
+                lastTrackedAutoPlaySource = null
                 stop()
                 shutdown()
             }
@@ -1365,15 +1367,23 @@ open class PlaybackManager @Inject constructor(
     }
 
     private suspend fun autoSelectNextEpisode(): BaseEpisode? {
+        var episodeSource = settings.lastAutoPlaySource.value.toString().lowercase()
+
         val allEpisodes: List<BaseEpisode> = when (val autoSource = settings.lastAutoPlaySource.value) {
             is AutoPlaySource.Downloads -> episodeManager.observeDownloadEpisodes().asFlow().firstOrNull()
             is AutoPlaySource.Files -> cloudFilesManager.sortedCloudFiles.firstOrNull()
             is AutoPlaySource.Starred -> episodeManager.observeStarredEpisodes().asFlow().firstOrNull()
             // First check if it is a podcast uuid, then check if it is from a filter
-            is AutoPlaySource.PodcastOrFilter -> podcastManager.findPodcastByUuid(autoSource.uuid)
-                ?.let { podcast -> autoPlayOrderForPodcastEpisodes(podcast) }
-                ?: playlistManager.findByUuidSync(autoSource.uuid)
-                    ?.let { playlist -> playlistManager.findEpisodes(playlist, episodeManager, this) }
+            is AutoPlaySource.PodcastOrFilter -> {
+                episodeSource = "podcast"
+                podcastManager.findPodcastByUuid(autoSource.uuid)
+                    ?.let { podcast -> autoPlayOrderForPodcastEpisodes(podcast) }
+                    ?: playlistManager.findByUuidSync(autoSource.uuid)
+                        ?.let { playlist ->
+                            episodeSource = "filter"
+                            playlistManager.findEpisodes(playlist, episodeManager, this)
+                        }
+            }
             is AutoPlaySource.None -> null
         } ?: emptyList()
 
@@ -1387,6 +1397,10 @@ open class PlaybackManager @Inject constructor(
         for (episodeUuid in episodeUuidsSlice) {
             val episode = episodeManager.findEpisodeByUuid(episodeUuid) ?: continue
             if (!episode.isArchived && !episode.isFinished) {
+                if (lastTrackedAutoPlaySource != settings.lastAutoPlaySource.value) {
+                    analyticsTracker.track(AnalyticsEvent.AUTOPLAY_STARTED, mapOf("episode_source" to episodeSource))
+                    lastTrackedAutoPlaySource = settings.lastAutoPlaySource.value
+                }
                 return episode
             }
         }
@@ -1396,7 +1410,7 @@ open class PlaybackManager @Inject constructor(
             AppPlatform.Automotive -> return episodeManager.findLatestEpisodeToPlay()
             AppPlatform.WearOs -> return null
             AppPlatform.Phone -> {
-                analyticsTracker.track(AnalyticsEvent.AUTOPLAY_FINISHED_LAST_EPISODE, mapOf("episode_source" to settings.lastAutoPlaySource.value))
+                analyticsTracker.track(AnalyticsEvent.AUTOPLAY_FINISHED_LAST_EPISODE, mapOf("episode_source" to episodeSource))
                 return null
             }
         }


### PR DESCRIPTION
## Description
This adds `autoplay_started` and `autoplay_finished_last_episode` track events
- `autoplay_started`: whenever an autoplay session starts
- `autoplay_finished_last_episode`: when the last episode of a playlist finishes playing

Fixes #2372

## Testing Instructions
1. Go to settings -> General -> Enable `AutoPlay` toggle
2. Have some episodes starred
3. Go to Profile -> Starred
4. Play episodes from this list (Make sure you have empty Up next)
5. Scroll to finish the episode
6. The auto play will add an episode from the starred list
7. ✅ Ensure 🔵 `Tracked: autoplay_started, Properties: {"episode_source":"starred"` is triggered
8. Play the last episode from the starred list
9. Finish this episode
10. ✅ Ensure 🔵 `Tracked: autoplay_finished_last_episode, Properties: {"episode_source":"starred"` is triggered

You can repeat this test for filter list, download, podcast and file list if you wanted

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack
