### PR TITLE
Fix sharing null time marks in episode

### DIFF
--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/SharePodcastHelper.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/SharePodcastHelper.kt
@@ -45,7 +45,7 @@ data class SharePodcastHelper(
         val host = Settings.SERVER_SHORT_URL
         var url = ""
         episode?.let {
-            val timeMarker = listOfNotNull(start, end).takeIf { it.isNotEmpty() }?.joinToString(prefix = "?t=", separator = ",") { it.inWholeSeconds.toString() }
+            val timeMarker = listOfNotNull(start, end).takeIf { it.isNotEmpty() }?.joinToString(prefix = "?t=", separator = ",") { it.inWholeSeconds.toString() }.orEmpty()
             url = "$host/episode/${it.uuid}$timeMarker"
         } ?: run {
             url = "$host/podcast/${podcast.uuid}"


### PR DESCRIPTION
## Description

While refactoring sharing in #2385 I made an error where `null` would be used instead of an empty string when sharing episodes. This resulted in links like `https://pca.st/episode/c510a66f-f9c0-45c8-bca2-8c0cc1d5f055null`.

## Testing Instructions

1. Share an episode.
2. Notice that the link doesn't contain `null` at the end

## Checklist
- [x] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] ~I have considered whether it makes sense to add tests for my changes~
- [x] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [x] ~Any jetpack compose components I added or changed are covered by compose previews~
- [x] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] ~with different themes~
- [x] ~with a landscape orientation~
- [x] ~with the device set to have a large display and font size~
- [x] ~for accessibility with TalkBack~
