### PR TITLE
Start clip sharing from the playback position

### DIFF
--- a/app/src/main/java/au/com/shiftyjelly/pocketcasts/di/AppModule.kt
+++ b/app/src/main/java/au/com/shiftyjelly/pocketcasts/di/AppModule.kt
@@ -42,7 +42,7 @@ object AppModule {
     @Provides
     fun shareActionProvider() = object : ShareActionProvider {
         override fun clipAction(podcastEpisode: PodcastEpisode, podcast: Podcast, fragmentManager: FragmentManager) {
-            ShareClipFragment.newInstance(podcastEpisode.uuid, podcast.backgroundColor).show(fragmentManager, "share_clip")
+            ShareClipFragment.newInstance(podcastEpisode, podcast.backgroundColor).show(fragmentManager, "share_clip")
         }
     }
 }

--- a/modules/features/clip/src/main/kotlin/au/com/shiftyjelly/pocketcasts/clip/Clip.kt
+++ b/modules/features/clip/src/main/kotlin/au/com/shiftyjelly/pocketcasts/clip/Clip.kt
@@ -1,14 +1,33 @@
 package au.com.shiftyjelly.pocketcasts.clip
 
+import android.os.Parcelable
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
+import au.com.shiftyjelly.pocketcasts.utils.parceler.DurationParceler
 import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
+import kotlinx.parcelize.Parcelize
+import kotlinx.parcelize.TypeParceler
 
 data class Clip(
     val episode: PodcastEpisode,
     val range: Range,
 ) {
+    @Parcelize
     data class Range(
-        val start: Duration,
-        val end: Duration,
-    )
+        @TypeParceler<Duration, DurationParceler>() val start: Duration,
+        @TypeParceler<Duration, DurationParceler>() val end: Duration,
+    ) : Parcelable {
+        companion object {
+            fun fromPosition(
+                playbackPosition: Duration,
+                episodeDuration: Duration,
+                clipDuration: Duration = 15.seconds,
+            ): Clip.Range {
+                val initialClipStart = (playbackPosition - clipDuration / 2).coerceAtLeast(0.seconds)
+                val clipEnd = (initialClipStart + clipDuration).coerceAtMost(episodeDuration)
+                val clipStart = (clipEnd - clipDuration).coerceAtLeast(0.seconds)
+                return Clip.Range(clipStart, clipEnd)
+            }
+        }
+    }
 }

--- a/modules/features/clip/src/main/kotlin/au/com/shiftyjelly/pocketcasts/clip/ClipSelector.kt
+++ b/modules/features/clip/src/main/kotlin/au/com/shiftyjelly/pocketcasts/clip/ClipSelector.kt
@@ -71,7 +71,7 @@ internal fun ClipSelector(
     onClipStartUpdate: (Duration) -> Unit,
     onClipEndUpdate: (Duration) -> Unit,
     modifier: Modifier = Modifier,
-    state: ClipSelectorState = rememberClipSelectorState(),
+    state: ClipSelectorState = rememberClipSelectorState(firstVisibleItemIndex = 0),
 ) {
     val density = LocalDensity.current
     LaunchedEffect(state.scale) {

--- a/modules/features/clip/src/main/kotlin/au/com/shiftyjelly/pocketcasts/clip/ClipSelectorState.kt
+++ b/modules/features/clip/src/main/kotlin/au/com/shiftyjelly/pocketcasts/clip/ClipSelectorState.kt
@@ -18,16 +18,31 @@ import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
 
 @Composable
-internal fun rememberClipSelectorState() = rememberSaveable(saver = ClipSelectorState.Saver, init = ::ClipSelectorState)
+internal fun rememberClipSelectorState(
+    firstVisibleItemIndex: Int,
+) = rememberSaveable(
+    saver = ClipSelectorState.Saver,
+    init = {
+        ClipSelectorState(
+            firstVisibleItemIndex = firstVisibleItemIndex,
+            firstVisibleItemScrollOffset = 0,
+            scale = 1f,
+            secondsPerTick = 1,
+            itemWidth = 0f,
+            startOffset = 0f,
+            endOffset = 0f,
+        )
+    },
+)
 
 internal class ClipSelectorState(
-    firstVisibleItemIndex: Int = 0,
-    firstVisibleItemScrollOffset: Int = 0,
-    scale: Float = 1f,
-    secondsPerTick: Int = 1,
-    itemWidth: Float = 0f,
-    startOffset: Float = 0f,
-    endOffset: Float = 0f,
+    firstVisibleItemIndex: Int,
+    firstVisibleItemScrollOffset: Int,
+    scale: Float,
+    secondsPerTick: Int,
+    itemWidth: Float,
+    startOffset: Float,
+    endOffset: Float,
 ) {
     val listState = LazyListState(firstVisibleItemIndex, firstVisibleItemScrollOffset)
     val scrollOffset: Float

--- a/modules/features/clip/src/main/kotlin/au/com/shiftyjelly/pocketcasts/clip/ShareClipPage.kt
+++ b/modules/features/clip/src/main/kotlin/au/com/shiftyjelly/pocketcasts/clip/ShareClipPage.kt
@@ -57,7 +57,9 @@ internal fun ShareClipPage(
     onClipEndUpdate: (Duration) -> Unit,
     onClose: () -> Unit,
 ) {
-    val state = rememberClipSelectorState()
+    val state = rememberClipSelectorState(
+        firstVisibleItemIndex = (clipRange.start.inWholeSeconds.toInt() - 10).coerceAtLeast(0),
+    )
     when (LocalConfiguration.current.orientation) {
         Configuration.ORIENTATION_LANDSCAPE -> HorizontalClipPage(
             episode = episode,

--- a/modules/features/clip/src/main/kotlin/au/com/shiftyjelly/pocketcasts/clip/ShareClipViewModel.kt
+++ b/modules/features/clip/src/main/kotlin/au/com/shiftyjelly/pocketcasts/clip/ShareClipViewModel.kt
@@ -22,12 +22,13 @@ import kotlinx.coroutines.flow.stateIn
 @HiltViewModel(assistedFactory = ShareClipViewModel.Factory::class)
 class ShareClipViewModel @AssistedInject constructor(
     @Assisted private val episodeUuid: String,
+    @Assisted initialClipRange: Clip.Range,
     @Assisted private val clipPlayer: ClipPlayer,
     private val episodeManager: EpisodeManager,
     private val podcastManager: PodcastManager,
     private val settings: Settings,
 ) : ViewModel() {
-    private val clipRange = MutableStateFlow(Clip.Range(15.seconds, 30.seconds))
+    private val clipRange = MutableStateFlow(initialClipRange)
 
     val uiState = combine(
         episodeManager.observeByUuid(episodeUuid),
@@ -46,7 +47,7 @@ class ShareClipViewModel @AssistedInject constructor(
                 isPlaying = isPlaying,
             )
         },
-    ).stateIn(viewModelScope, started = SharingStarted.Eagerly, initialValue = UiState())
+    ).stateIn(viewModelScope, started = SharingStarted.Eagerly, initialValue = UiState(clipRange = initialClipRange))
 
     fun playClip() {
         uiState.value.clip?.let(clipPlayer::play)
@@ -83,6 +84,7 @@ class ShareClipViewModel @AssistedInject constructor(
     interface Factory {
         fun create(
             episodeUuid: String,
+            initialClipRange: Clip.Range,
             clipPlayer: ClipPlayer,
         ): ShareClipViewModel
     }

--- a/modules/features/clip/src/test/kotlin/au/com/shiftyjelly/pocketcasts/clip/ClipRangeTest.kt
+++ b/modules/features/clip/src/test/kotlin/au/com/shiftyjelly/pocketcasts/clip/ClipRangeTest.kt
@@ -1,0 +1,61 @@
+package au.com.shiftyjelly.pocketcasts.clip
+
+import kotlin.time.Duration.Companion.seconds
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class ClipRangeTest {
+    @Test
+    fun `create clip range in the middle of playback position`() {
+        val clipRange = Clip.Range.fromPosition(
+            playbackPosition = 10.seconds,
+            episodeDuration = 20.seconds,
+            clipDuration = 10.seconds,
+        )
+
+        assertEquals(Clip.Range(5.seconds, 15.seconds), clipRange)
+    }
+
+    @Test
+    fun `create clip range with default 15 seconds duration`() {
+        val clipRange = Clip.Range.fromPosition(
+            playbackPosition = 12.5.seconds,
+            episodeDuration = 30.seconds,
+        )
+
+        assertEquals(Clip.Range(5.seconds, 20.seconds), clipRange)
+    }
+
+    @Test
+    fun `create clip range with expected start below 0`() {
+        val clipRange = Clip.Range.fromPosition(
+            playbackPosition = 0.seconds,
+            episodeDuration = 20.seconds,
+            clipDuration = 10.seconds,
+        )
+
+        assertEquals(Clip.Range(0.seconds, 10.seconds), clipRange)
+    }
+
+    @Test
+    fun `create clip range with expected end above episode duration`() {
+        val clipRange = Clip.Range.fromPosition(
+            playbackPosition = 20.seconds,
+            episodeDuration = 20.seconds,
+            clipDuration = 10.seconds,
+        )
+
+        assertEquals(Clip.Range(10.seconds, 20.seconds), clipRange)
+    }
+
+    @Test
+    fun `create clip range with too long duration`() {
+        val clipRange = Clip.Range.fromPosition(
+            playbackPosition = 10.seconds,
+            episodeDuration = 20.seconds,
+            clipDuration = 300.seconds,
+        )
+
+        assertEquals(Clip.Range(0.seconds, 20.seconds), clipRange)
+    }
+}

--- a/modules/features/clip/src/test/kotlin/au/com/shiftyjelly/pocketcasts/clip/ShareClipViewModelTest.kt
+++ b/modules/features/clip/src/test/kotlin/au/com/shiftyjelly/pocketcasts/clip/ShareClipViewModelTest.kt
@@ -50,6 +50,7 @@ class ShareClipViewModelTest {
 
         viewModel = ShareClipViewModel(
             "episode-id",
+            Clip.Range(15.seconds, 30.seconds),
             clipPlayer,
             episodeManager,
             podcastManager,

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/ShareFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/ShareFragment.kt
@@ -112,7 +112,7 @@ class ShareFragment : BaseDialogFragment() {
         binding.buttonShareClip.setOnClickListener {
             if (podcast != null && episode is PodcastEpisode) {
                 ShareClipFragment
-                    .newInstance(episode.uuid, podcast.backgroundColor)
+                    .newInstance(episode, podcast.backgroundColor)
                     .show(parentFragmentManager, "share_clip")
             }
             close()


### PR DESCRIPTION
## Description

This PR adds starting clip sharing position. Initial clip is 15 seconds long with the center at the current played up to position. If the clip range would be invalid (start below 0 seconds or end above episode duration) than clip position is adjusted.

## Testing Instructions

1. Play an episode.
2. Start clip sharing.
3. Notice that the initial clip position matches current played up to position and the timeline is scrolled to make it visible.
4. Repeat steps 2 and 3 with some different positions of the player.
5. Clip an episode that has no played up to timestamp.
6. Clip should be between 0 and 15 seconds.
7. Clip an episode that you've played to the end.
8. Clip should be positioned at 15 seconds till the end of this episode.
9. Test that the clip position is not being reset to the initial state due to the configuration changes.

## Checklist
- [x] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [x] ~Any jetpack compose components I added or changed are covered by compose previews~
- [x] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] ~with different themes~
- [x] with a landscape orientation
- [x] ~with the device set to have a large display and font size~
- [x] ~for accessibility with TalkBack~
