### PR TITLE
Transcripts - Parse and save transcript metadata for episode

### DIFF
--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/models/db/AppDatabaseTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/models/db/AppDatabaseTest.kt
@@ -163,6 +163,7 @@ class AppDatabaseTest {
                 AppDatabase.MIGRATION_94_95,
                 AppDatabase.MIGRATION_95_96,
                 AppDatabase.MIGRATION_96_97,
+                AppDatabase.MIGRATION_97_98,
             )
             .build()
         // close the database and release any stream resources when the test finishes

--- a/modules/services/model/schemas/au.com.shiftyjelly.pocketcasts.models.db.AppDatabase/97.json
+++ b/modules/services/model/schemas/au.com.shiftyjelly.pocketcasts.models.db.AppDatabase/97.json
@@ -2,7 +2,7 @@
   "formatVersion": 1,
   "database": {
     "version": 97,
-    "identityHash": "37a4f5b7c63a9efd4556ce5e373033df",
+    "identityHash": "42021750d762130733c983144099e35b",
     "entities": [
       {
         "tableName": "bump_stats",
@@ -1729,12 +1729,61 @@
         },
         "indices": [],
         "foreignKeys": []
+      },
+      {
+        "tableName": "episode_transcript",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`episode_uuid` TEXT NOT NULL, `url` TEXT NOT NULL, `type` TEXT NOT NULL, `language` TEXT, PRIMARY KEY(`episode_uuid`, `url`))",
+        "fields": [
+          {
+            "fieldPath": "episodeUuid",
+            "columnName": "episode_uuid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "language",
+            "columnName": "language",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "episode_uuid",
+            "url"
+          ]
+        },
+        "indices": [
+          {
+            "name": "transcript_episode_uuid_index",
+            "unique": false,
+            "columnNames": [
+              "episode_uuid"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `transcript_episode_uuid_index` ON `${TABLE_NAME}` (`episode_uuid`)"
+          }
+        ],
+        "foreignKeys": []
       }
     ],
     "views": [],
     "setupQueries": [
       "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
-      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '37a4f5b7c63a9efd4556ce5e373033df')"
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '42021750d762130733c983144099e35b')"
     ]
   }
 }

--- a/modules/services/model/schemas/au.com.shiftyjelly.pocketcasts.models.db.AppDatabase/98.json
+++ b/modules/services/model/schemas/au.com.shiftyjelly.pocketcasts.models.db.AppDatabase/98.json
@@ -1,8 +1,8 @@
 {
   "formatVersion": 1,
   "database": {
-    "version": 97,
-    "identityHash": "37a4f5b7c63a9efd4556ce5e373033df",
+    "version": 98,
+    "identityHash": "42021750d762130733c983144099e35b",
     "entities": [
       {
         "tableName": "bump_stats",
@@ -1729,12 +1729,61 @@
         },
         "indices": [],
         "foreignKeys": []
+      },
+      {
+        "tableName": "episode_transcript",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`episode_uuid` TEXT NOT NULL, `url` TEXT NOT NULL, `type` TEXT NOT NULL, `language` TEXT, PRIMARY KEY(`episode_uuid`, `url`))",
+        "fields": [
+          {
+            "fieldPath": "episodeUuid",
+            "columnName": "episode_uuid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "language",
+            "columnName": "language",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "episode_uuid",
+            "url"
+          ]
+        },
+        "indices": [
+          {
+            "name": "transcript_episode_uuid_index",
+            "unique": false,
+            "columnNames": [
+              "episode_uuid"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `transcript_episode_uuid_index` ON `${TABLE_NAME}` (`episode_uuid`)"
+          }
+        ],
+        "foreignKeys": []
       }
     ],
     "views": [],
     "setupQueries": [
       "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
-      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '37a4f5b7c63a9efd4556ce5e373033df')"
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '42021750d762130733c983144099e35b')"
     ]
   }
 }

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/AppDatabase.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/AppDatabase.kt
@@ -85,7 +85,7 @@ import au.com.shiftyjelly.pocketcasts.localization.R as LR
         TrendingPodcast::class,
         Transcript::class,
     ],
-    version = 97,
+    version = 98,
     exportSchema = true,
     autoMigrations = [
         AutoMigration(from = 81, to = 82, spec = AppDatabase.Companion.DeleteSilenceRemovedMigration::class),

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/AppDatabase.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/AppDatabase.kt
@@ -42,6 +42,7 @@ import au.com.shiftyjelly.pocketcasts.models.db.dao.PlaylistDao
 import au.com.shiftyjelly.pocketcasts.models.db.dao.PodcastDao
 import au.com.shiftyjelly.pocketcasts.models.db.dao.PodcastRatingsDao
 import au.com.shiftyjelly.pocketcasts.models.db.dao.SearchHistoryDao
+import au.com.shiftyjelly.pocketcasts.models.db.dao.TranscriptDao
 import au.com.shiftyjelly.pocketcasts.models.db.dao.UpNextChangeDao
 import au.com.shiftyjelly.pocketcasts.models.db.dao.UpNextDao
 import au.com.shiftyjelly.pocketcasts.models.db.dao.UserEpisodeDao
@@ -60,6 +61,7 @@ import au.com.shiftyjelly.pocketcasts.models.entity.UpNextChange
 import au.com.shiftyjelly.pocketcasts.models.entity.UpNextEpisode
 import au.com.shiftyjelly.pocketcasts.models.entity.UserEpisode
 import au.com.shiftyjelly.pocketcasts.models.to.DbChapter
+import au.com.shiftyjelly.pocketcasts.models.to.Transcript
 import java.io.File
 import java.util.Arrays
 import java.util.Date
@@ -81,6 +83,7 @@ import au.com.shiftyjelly.pocketcasts.localization.R as LR
         PodcastRatings::class,
         DbChapter::class,
         TrendingPodcast::class,
+        Transcript::class,
     ],
     version = 97,
     exportSchema = true,
@@ -123,6 +126,7 @@ abstract class AppDatabase : RoomDatabase() {
     abstract fun podcastRatingsDao(): PodcastRatingsDao
     abstract fun bookmarkDao(): BookmarkDao
     abstract fun chapterDao(): ChapterDao
+    abstract fun transcriptDao(): TranscriptDao
 
     fun databaseFiles() =
         openHelper.readableDatabase.path?.let {
@@ -806,6 +810,21 @@ abstract class AppDatabase : RoomDatabase() {
             database.execSQL("CREATE INDEX up_next_episode_episodeUuid ON up_next_episodes(episodeUuid)")
         }
 
+        val MIGRATION_97_98 = addMigration(97, 98) { database ->
+            database.execSQL(
+                """
+                    CREATE TABLE episode_transcript(
+                        episode_uuid TEXT NOT NULL, 
+                        url TEXT NOT NULL,
+                        type TEXT NOT NULL,
+                        language TEXT,
+                        PRIMARY KEY (episode_uuid, url)
+                    )
+                """.trimIndent(),
+            )
+            database.execSQL("CREATE INDEX transcript_episode_uuid_index ON episode_transcript(episode_uuid)")
+        }
+
         fun addMigrations(databaseBuilder: Builder<AppDatabase>, context: Context) {
             databaseBuilder.addMigrations(
                 addMigration(1, 2) { },
@@ -1193,6 +1212,7 @@ abstract class AppDatabase : RoomDatabase() {
                 MIGRATION_94_95,
                 MIGRATION_95_96,
                 MIGRATION_96_97,
+                MIGRATION_97_98,
             )
         }
 

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/TranscriptDao.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/TranscriptDao.kt
@@ -1,0 +1,16 @@
+package au.com.shiftyjelly.pocketcasts.models.db.dao
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import au.com.shiftyjelly.pocketcasts.models.to.Transcript
+
+@Dao
+abstract class TranscriptDao {
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    abstract fun insert(transcript: Transcript)
+
+    @Query("DELETE FROM episode_transcript WHERE episode_uuid IS :episodeUuid")
+    abstract suspend fun deleteForEpisode(episodeUuid: String)
+}

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/di/ModelModule.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/di/ModelModule.kt
@@ -5,6 +5,7 @@ import au.com.shiftyjelly.pocketcasts.models.db.AppDatabase
 import au.com.shiftyjelly.pocketcasts.models.db.dao.ChapterDao
 import au.com.shiftyjelly.pocketcasts.models.db.dao.EpisodeDao
 import au.com.shiftyjelly.pocketcasts.models.db.dao.PodcastDao
+import au.com.shiftyjelly.pocketcasts.models.db.dao.TranscriptDao
 import au.com.shiftyjelly.pocketcasts.models.db.dao.UpNextDao
 import dagger.Module
 import dagger.Provides
@@ -30,4 +31,7 @@ object ModelModule {
 
     @Provides
     fun providePodcastDao(database: AppDatabase): PodcastDao = database.podcastDao()
+
+    @Provides
+    fun provideTranscriptDao(database: AppDatabase): TranscriptDao = database.transcriptDao()
 }

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/to/Transcript.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/to/Transcript.kt
@@ -1,0 +1,8 @@
+package au.com.shiftyjelly.pocketcasts.models.to
+
+data class Transcript(
+    val episodeUuid: String,
+    val url: String,
+    val type: String,
+    val language: String? = null,
+)

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/to/Transcript.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/to/Transcript.kt
@@ -1,8 +1,19 @@
 package au.com.shiftyjelly.pocketcasts.models.to
 
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.Index
+
+@Entity(
+    tableName = "episode_transcript",
+    primaryKeys = ["episode_uuid", "url"],
+    indices = [
+        Index(name = "transcript_episode_uuid_index", value = ["episode_uuid"]),
+    ],
+)
 data class Transcript(
-    val episodeUuid: String,
-    val url: String,
-    val type: String,
-    val language: String? = null,
+    @ColumnInfo(name = "episode_uuid") val episodeUuid: String,
+    @ColumnInfo(name = "url") val url: String,
+    @ColumnInfo(name = "type") val type: String,
+    @ColumnInfo(name = "language") val language: String? = null,
 )

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/di/RepositoryModule.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/di/RepositoryModule.kt
@@ -34,6 +34,8 @@ import au.com.shiftyjelly.pocketcasts.repositories.podcast.PlaylistManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.PlaylistManagerImpl
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManagerImpl
+import au.com.shiftyjelly.pocketcasts.repositories.podcast.TranscriptsManager
+import au.com.shiftyjelly.pocketcasts.repositories.podcast.TranscriptsManagerImpl
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.UserEpisodeManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.UserEpisodeManagerImpl
 import au.com.shiftyjelly.pocketcasts.repositories.ratings.RatingsManager
@@ -172,4 +174,7 @@ abstract class RepositoryModule {
 
     @Binds
     abstract fun provideNovaLauncherManager(novaLauncherManagerImpl: NovaLauncherManagerImpl): NovaLauncherManager
+
+    @Binds
+    abstract fun provideTranscriptsManager(transcriptsManagerImpl: TranscriptsManagerImpl): TranscriptsManager
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/TranscriptsManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/TranscriptsManager.kt
@@ -4,6 +4,7 @@ import au.com.shiftyjelly.pocketcasts.models.to.Transcript
 
 interface TranscriptsManager {
     suspend fun updateTranscripts(
+        episodeUuid: String,
         transcripts: List<Transcript>,
     )
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/TranscriptsManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/TranscriptsManager.kt
@@ -1,0 +1,9 @@
+package au.com.shiftyjelly.pocketcasts.repositories.podcast
+
+import au.com.shiftyjelly.pocketcasts.models.to.Transcript
+
+interface TranscriptsManager {
+    suspend fun updateTranscripts(
+        transcripts: List<Transcript>,
+    )
+}

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/TranscriptsManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/TranscriptsManagerImpl.kt
@@ -1,16 +1,23 @@
 package au.com.shiftyjelly.pocketcasts.repositories.podcast
 
 import androidx.annotation.VisibleForTesting
+import au.com.shiftyjelly.pocketcasts.models.db.dao.TranscriptDao
 import au.com.shiftyjelly.pocketcasts.models.to.Transcript
 import javax.inject.Inject
 
-class TranscriptsManagerImpl @Inject constructor() : TranscriptsManager {
+class TranscriptsManagerImpl @Inject constructor(
+    private val transcriptDao: TranscriptDao,
+) : TranscriptsManager {
     private val supportedFormats = listOf(TranscriptFormat.SRT, TranscriptFormat.VTT)
 
     override suspend fun updateTranscripts(
+        episodeUuid: String,
         transcripts: List<Transcript>,
     ) {
-        findBestTranscript(transcripts)?.let { // TODO: Save into database
+        findBestTranscript(transcripts)?.let { bestTranscript ->
+            transcriptDao.insert(bestTranscript)
+        } ?: run {
+            transcriptDao.deleteForEpisode(episodeUuid)
         }
     }
 

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/TranscriptsManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/TranscriptsManagerImpl.kt
@@ -1,0 +1,32 @@
+package au.com.shiftyjelly.pocketcasts.repositories.podcast
+
+import androidx.annotation.VisibleForTesting
+import au.com.shiftyjelly.pocketcasts.models.to.Transcript
+import javax.inject.Inject
+
+class TranscriptsManagerImpl @Inject constructor() : TranscriptsManager {
+    private val supportedFormats = listOf(TranscriptFormat.SRT, TranscriptFormat.VTT)
+
+    override suspend fun updateTranscripts(
+        transcripts: List<Transcript>,
+    ) {
+        findBestTranscript(transcripts)?.let { // TODO: Save into database
+        }
+    }
+
+    @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
+    fun findBestTranscript(availableTranscripts: List<Transcript>): Transcript? {
+        for (format in supportedFormats) {
+            val transcript = availableTranscripts.firstOrNull { it.type == format.mimeType }
+            if (transcript != null) {
+                return transcript
+            }
+        }
+        return availableTranscripts.firstOrNull()
+    }
+}
+
+enum class TranscriptFormat(val mimeType: String) {
+    SRT("application/srt"),
+    VTT("text/vtt"),
+}

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/shownotes/ShowNotesProcessor.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/shownotes/ShowNotesProcessor.kt
@@ -81,7 +81,7 @@ class ShowNotesProcessor @Inject constructor(
             ?.firstOrNull { it.uuid == episodeUuid }
             ?.transcripts
             ?.mapNotNull { it.takeIf { it.url != null && it.type != null }?.toTranscript(episodeUuid) }
-        transcripts?.let { transcriptsManager.updateTranscripts(it) }
+        transcripts?.let { transcriptsManager.updateTranscripts(episodeUuid, it) }
     }
 
     private fun ShowNotesChapter.toChapter(episodeUuid: String) = Chapter(

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/shownotes/ShowNotesProcessor.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/shownotes/ShowNotesProcessor.kt
@@ -1,12 +1,17 @@
 package au.com.shiftyjelly.pocketcasts.repositories.shownotes
 
+import au.com.shiftyjelly.pocketcasts.models.to.Transcript
 import au.com.shiftyjelly.pocketcasts.repositories.di.ApplicationScope
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.ChapterManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.ImageUrlUpdate
+import au.com.shiftyjelly.pocketcasts.repositories.podcast.TranscriptsManager
 import au.com.shiftyjelly.pocketcasts.servers.podcast.PodcastCacheServer
 import au.com.shiftyjelly.pocketcasts.servers.podcast.ShowNotesChapter
 import au.com.shiftyjelly.pocketcasts.servers.podcast.ShowNotesResponse
+import au.com.shiftyjelly.pocketcasts.servers.podcast.ShowNotesTranscript
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
 import javax.inject.Inject
 import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.CoroutineScope
@@ -18,12 +23,16 @@ class ShowNotesProcessor @Inject constructor(
     @ApplicationScope private val scope: CoroutineScope,
     private val episodeManager: EpisodeManager,
     private val chapterManager: ChapterManager,
+    private val transcriptsManager: TranscriptsManager,
     private val service: PodcastCacheServer,
 ) {
-    fun process(episodeUuidForChapterUrl: String, showNotes: ShowNotesResponse) {
+    fun process(episodeUuid: String, showNotes: ShowNotesResponse) {
         updateImageUrls(showNotes)
-        updateChapters(episodeUuidForChapterUrl, showNotes)
-        updateChapterFromLink(episodeUuidForChapterUrl, showNotes)
+        updateChapters(episodeUuid, showNotes)
+        updateChapterFromLink(episodeUuid, showNotes)
+        if (FeatureFlag.isEnabled(Feature.TRANSCRIPTS)) {
+            updateTranscripts(episodeUuid, showNotes)
+        }
     }
 
     private fun updateImageUrls(showNotes: ShowNotesResponse) = scope.launch {
@@ -67,6 +76,14 @@ class ShowNotesProcessor @Inject constructor(
         newChapters?.let { chapterManager.updateChapters(episodeUuid, it) }
     }
 
+    private fun updateTranscripts(episodeUuid: String, showNotes: ShowNotesResponse) = scope.launch {
+        val transcripts = showNotes.podcast?.episodes
+            ?.firstOrNull { it.uuid == episodeUuid }
+            ?.transcripts
+            ?.mapNotNull { it.takeIf { it.url != null && it.type != null }?.toTranscript(episodeUuid) }
+        transcripts?.let { transcriptsManager.updateTranscripts(it) }
+    }
+
     private fun ShowNotesChapter.toChapter(episodeUuid: String) = Chapter(
         episodeUuid = episodeUuid,
         startTimeMs = startTime.seconds.inWholeMilliseconds,
@@ -75,5 +92,12 @@ class ShowNotesProcessor @Inject constructor(
         imageUrl = image,
         url = url,
         isEmbedded = false,
+    )
+
+    private fun ShowNotesTranscript.toTranscript(episodeUuid: String) = Transcript(
+        episodeUuid = episodeUuid,
+        url = requireNotNull(url),
+        type = requireNotNull(type),
+        language = language,
     )
 }

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/TranscriptsManagerImplTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/TranscriptsManagerImplTest.kt
@@ -1,0 +1,45 @@
+package au.com.shiftyjelly.pocketcasts.repositories.podcast
+
+import au.com.shiftyjelly.pocketcasts.models.to.Transcript
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class TranscriptsManagerImplTest {
+    private val transcriptsManager = TranscriptsManagerImpl()
+
+    @Test
+    fun `findBestTranscript returns first supported transcript`() = runTest {
+        val transcripts = listOf(
+            Transcript("1", "url_0", "un-supported"),
+            Transcript("1", "url_1", "application/srt"),
+            Transcript("1", "url_2", "text/vtt"),
+
+            )
+        val result = transcriptsManager.findBestTranscript(transcripts)
+
+        assertEquals(transcripts[1], result)
+    }
+
+    @Test
+    fun `findBestTranscript returns null when no transcripts available`() = runTest {
+        val transcripts = emptyList<Transcript>()
+
+        val result = transcriptsManager.findBestTranscript(transcripts)
+
+        assertNull(result)
+    }
+
+    @Test
+    fun `findBestTranscript returns first un-supported transcript when no other transcript is supported`() = runTest {
+        val transcripts = listOf(
+            Transcript("1", "url_1", "un-supported"),
+            Transcript("1", "url_2", "un-supported"),
+        )
+
+        val result = transcriptsManager.findBestTranscript(transcripts)
+
+        assertEquals(transcripts[0], result)
+    }
+}

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/shownotes/ShowNotesProcessTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/shownotes/ShowNotesProcessTest.kt
@@ -1,14 +1,17 @@
 package au.com.shiftyjelly.pocketcasts.repositories.shownotes
 
+import au.com.shiftyjelly.pocketcasts.models.to.Transcript
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.ChapterManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.ImageUrlUpdate
+import au.com.shiftyjelly.pocketcasts.repositories.podcast.TranscriptsManager
 import au.com.shiftyjelly.pocketcasts.servers.podcast.PodcastCacheServer
 import au.com.shiftyjelly.pocketcasts.servers.podcast.RawChaptersResponse
 import au.com.shiftyjelly.pocketcasts.servers.podcast.ShowNotesChapter
 import au.com.shiftyjelly.pocketcasts.servers.podcast.ShowNotesEpisode
 import au.com.shiftyjelly.pocketcasts.servers.podcast.ShowNotesPodcast
 import au.com.shiftyjelly.pocketcasts.servers.podcast.ShowNotesResponse
+import au.com.shiftyjelly.pocketcasts.servers.podcast.ShowNotesTranscript
 import au.com.shiftyjelly.pocketcasts.sharedtest.MainCoroutineRule
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
@@ -29,11 +32,12 @@ class ShowNotesProcessTest {
 
     private val episodeManager = mock<EpisodeManager>()
     private val chapterManager = mock<ChapterManager>()
+    private val transcriptsManager = mock<TranscriptsManager>()
     private val service = mock<PodcastCacheServer>()
 
     @Test
     fun `update episodes with image URLs`() = runTest(coroutineRule.testDispatcher) {
-        val processor = ShowNotesProcessor(this, episodeManager, chapterManager, service)
+        val processor = ShowNotesProcessor(this, episodeManager, chapterManager, transcriptsManager, service)
         val episodeWithImage1 = ShowNotesEpisode(
             uuid = "episode_uuid1",
             showNotes = "show_notes1",
@@ -79,7 +83,7 @@ class ShowNotesProcessTest {
 
     @Test
     fun `update episodes with chapters`() = runTest(coroutineRule.testDispatcher) {
-        val processor = ShowNotesProcessor(this, episodeManager, chapterManager, service)
+        val processor = ShowNotesProcessor(this, episodeManager, chapterManager, transcriptsManager, service)
         val episodeWithChapters1 = ShowNotesEpisode(
             uuid = "episode-id-1",
             chapters = listOf(
@@ -148,7 +152,7 @@ class ShowNotesProcessTest {
 
     @Test
     fun `update episodes with no chapters`() = runTest(coroutineRule.testDispatcher) {
-        val processor = ShowNotesProcessor(this, episodeManager, chapterManager, service)
+        val processor = ShowNotesProcessor(this, episodeManager, chapterManager, transcriptsManager, service)
         val episodeWithNoChapters = ShowNotesEpisode(
             uuid = "episode-id",
             chapters = emptyList(),
@@ -167,7 +171,7 @@ class ShowNotesProcessTest {
 
     @Test
     fun `update episodes without chapters`() = runTest(coroutineRule.testDispatcher) {
-        val processor = ShowNotesProcessor(this, episodeManager, chapterManager, service)
+        val processor = ShowNotesProcessor(this, episodeManager, chapterManager, transcriptsManager, service)
         val episodeWithNoChapters = ShowNotesEpisode(
             uuid = "episode-id",
             chapters = null,
@@ -186,7 +190,7 @@ class ShowNotesProcessTest {
 
     @Test
     fun `update episode with chapters from URL when chapters are null`() = runTest(coroutineRule.testDispatcher) {
-        val processor = ShowNotesProcessor(this, episodeManager, chapterManager, service)
+        val processor = ShowNotesProcessor(this, episodeManager, chapterManager, transcriptsManager, service)
         val episode = ShowNotesEpisode(
             uuid = "episode-id",
             chaptersUrl = "url",
@@ -240,7 +244,7 @@ class ShowNotesProcessTest {
 
     @Test
     fun `update episode with chapters from URL when chapters are empty`() = runTest(coroutineRule.testDispatcher) {
-        val processor = ShowNotesProcessor(this, episodeManager, chapterManager, service)
+        val processor = ShowNotesProcessor(this, episodeManager, chapterManager, transcriptsManager, service)
         val episode = ShowNotesEpisode(
             uuid = "episode-id",
             chaptersUrl = "url",
@@ -294,7 +298,7 @@ class ShowNotesProcessTest {
 
     @Test
     fun `use direct chapters when there is less URL chapters`() = runTest(coroutineRule.testDispatcher) {
-        val processor = ShowNotesProcessor(this, episodeManager, chapterManager, service)
+        val processor = ShowNotesProcessor(this, episodeManager, chapterManager, transcriptsManager, service)
         val episode = ShowNotesEpisode(
             uuid = "episode-id",
             chapters = listOf(
@@ -343,7 +347,7 @@ class ShowNotesProcessTest {
 
     @Test
     fun `use URL chapters when there is less direct chapters`() = runTest(coroutineRule.testDispatcher) {
-        val processor = ShowNotesProcessor(this, episodeManager, chapterManager, service)
+        val processor = ShowNotesProcessor(this, episodeManager, chapterManager, transcriptsManager, service)
         val episode = ShowNotesEpisode(
             uuid = "episode-id",
             chapters = listOf(
@@ -392,7 +396,7 @@ class ShowNotesProcessTest {
 
     @Test
     fun `fetch chapters only for specified episode`() = runTest(coroutineRule.testDispatcher) {
-        val processor = ShowNotesProcessor(this, episodeManager, chapterManager, service)
+        val processor = ShowNotesProcessor(this, episodeManager, chapterManager, transcriptsManager, service)
         val episode1 = ShowNotesEpisode(
             uuid = "episode-id-1",
             chaptersUrl = "url1",
@@ -412,5 +416,100 @@ class ShowNotesProcessTest {
 
         verifyBlocking(service) { getShowNotesChapters("url1") }
         verifyBlocking(service, never()) { getShowNotesChapters("url2") }
+    }
+
+    @Test
+    fun `update episodes with transcripts having url and type`() = runTest(coroutineRule.testDispatcher) {
+        val processor = ShowNotesProcessor(this, episodeManager, chapterManager, transcriptsManager, service)
+        val episodeWithTranscripts1 = ShowNotesEpisode(
+            uuid = "episode-id",
+            transcripts = listOf(
+                ShowNotesTranscript(
+                    url = "Url 1",
+                    type = "Type 1",
+                    language = "Language 1",
+                ),
+                ShowNotesTranscript(
+                    url = "Url 2",
+                    type = "Type 2",
+                    language = "Language 2",
+                ),
+            ),
+        )
+        val showNotes = ShowNotesResponse(
+            podcast = ShowNotesPodcast(
+                uuid = "podcast-id",
+                episodes = listOf(
+                    episodeWithTranscripts1,
+                ),
+            ),
+        )
+
+        processor.process("episode-id", showNotes)
+
+        val expected1 = listOf(
+            Transcript(
+                episodeUuid = "episode-id",
+                url = "Url 1",
+                type = "Type 1",
+                language = "Language 1",
+            ),
+            Transcript(
+                episodeUuid = "episode-id",
+                url = "Url 2",
+                type = "Type 2",
+                language = "Language 2",
+            ),
+        )
+        verify(transcriptsManager).updateTranscripts(expected1)
+    }
+
+    @Test
+    fun `update episodes with transcripts without url or type`() = runTest(coroutineRule.testDispatcher) {
+        val processor = ShowNotesProcessor(this, episodeManager, chapterManager, transcriptsManager, service)
+        val episodeWithTranscripts2 = ShowNotesEpisode(
+            uuid = "episode-id",
+            transcripts = listOf(
+                ShowNotesTranscript(
+                    url = "Url",
+                ),
+                ShowNotesTranscript(
+                    type = "Type",
+                ),
+            ),
+        )
+        val showNotes = ShowNotesResponse(
+            podcast = ShowNotesPodcast(
+                uuid = "podcast-id",
+                episodes = listOf(
+                    episodeWithTranscripts2,
+                ),
+            ),
+        )
+        processor.process("episode-id", showNotes)
+
+        val expected2 = emptyList<Transcript>()
+        verify(transcriptsManager).updateTranscripts(expected2)
+    }
+
+    @Test
+    fun `update episodes without transcripts`() = runTest(coroutineRule.testDispatcher) {
+        val processor = ShowNotesProcessor(this, episodeManager, chapterManager, transcriptsManager, service)
+        val episodeWithTranscripts = ShowNotesEpisode(
+            uuid = "episode-id",
+            transcripts = null,
+        )
+        val showNotes = ShowNotesResponse(
+            podcast = ShowNotesPodcast(
+                uuid = "podcast-id",
+                episodes = listOf(
+                    episodeWithTranscripts,
+                ),
+            ),
+        )
+        processor.process("episode-id", showNotes)
+
+        val expected2 = emptyList<Transcript>()
+        verify(transcriptsManager, never()).updateTranscripts(expected2)
     }
 }

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/shownotes/ShowNotesProcessTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/shownotes/ShowNotesProcessTest.kt
@@ -461,7 +461,7 @@ class ShowNotesProcessTest {
                 language = "Language 2",
             ),
         )
-        verify(transcriptsManager).updateTranscripts(expected1)
+        verify(transcriptsManager).updateTranscripts("episode-id", expected1)
     }
 
     @Test
@@ -489,7 +489,7 @@ class ShowNotesProcessTest {
         processor.process("episode-id", showNotes)
 
         val expected2 = emptyList<Transcript>()
-        verify(transcriptsManager).updateTranscripts(expected2)
+        verify(transcriptsManager).updateTranscripts("episode-id", expected2)
     }
 
     @Test
@@ -510,6 +510,6 @@ class ShowNotesProcessTest {
         processor.process("episode-id", showNotes)
 
         val expected2 = emptyList<Transcript>()
-        verify(transcriptsManager, never()).updateTranscripts(expected2)
+        verify(transcriptsManager, never()).updateTranscripts("episode-id", expected2)
     }
 }

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/podcast/ShowNotesResponse.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/podcast/ShowNotesResponse.kt
@@ -25,6 +25,7 @@ data class ShowNotesEpisode(
     @Json(name = "image") val image: String? = null,
     @Json(name = "chapters") val chapters: List<ShowNotesChapter>? = null,
     @Json(name = "chapters_url") val chaptersUrl: String? = null,
+    @Json(name = "transcripts") val transcripts: List<ShowNotesTranscript>? = null,
 )
 
 @JsonClass(generateAdapter = true)
@@ -39,4 +40,11 @@ data class ShowNotesChapter(
 @JsonClass(generateAdapter = true)
 data class RawChaptersResponse(
     @Json(name = "chapters") val chapters: List<ShowNotesChapter>? = null,
+)
+
+@JsonClass(generateAdapter = true)
+data class ShowNotesTranscript(
+    @Json(name = "url") val url: String? = null,
+    @Json(name = "type") val type: String? = null,
+    @Json(name = "language") val language: String? = null,
 )


### PR DESCRIPTION
## Description

This parses transcripts tag for an episode in the show notes endpoint and saves the best transcript metadata in the database.


## Testing Instructions

#### Test.1 
1. Check that `Transcripts` feature flag is enabled
2. Add a break point at line 84 of `ShowNotesProcessor.kt` 
3. Play an episode from "Cautionary Tales" (https://pcast.pocketcasts.net/8zpmjiru)
4. ✅ Notice that the breakpoint is hit and all transcripts for the playing episode are parsed
5. Continue from breakpoint
6. ✅ Notice that the best transcript metadata of the supported [SRT, VTT] formats or the first available transcript (with not null URL and type) is inserted into db.

#### Test.2
Smoke test db migration

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
