### PR TITLE
[Give rating] Update Give rating view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 7.68
 -----
-
+*   Updates:
+    *   Update Give rating view to include the average rating
+        ([#2421](https://github.com/Automattic/pocket-casts-android/pull/2421))
 
 7.67
 -----

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/components/ratings/StarRatingView.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/components/ratings/StarRatingView.kt
@@ -3,6 +3,7 @@ package au.com.shiftyjelly.pocketcasts.podcasts.view.components.ratings
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.Icon
 import androidx.compose.material.MaterialTheme
@@ -12,6 +13,8 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.dp
@@ -20,6 +23,7 @@ import au.com.shiftyjelly.pocketcasts.compose.AppThemeWithBackground
 import au.com.shiftyjelly.pocketcasts.compose.components.TextP40
 import au.com.shiftyjelly.pocketcasts.compose.preview.ThemePreviewParameterProvider
 import au.com.shiftyjelly.pocketcasts.compose.theme
+import au.com.shiftyjelly.pocketcasts.localization.R
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastRatings
 import au.com.shiftyjelly.pocketcasts.podcasts.viewmodel.PodcastRatingsViewModel
 import au.com.shiftyjelly.pocketcasts.podcasts.viewmodel.PodcastRatingsViewModel.RatingState
@@ -63,22 +67,29 @@ private fun Content(
 
     Row(
         modifier = Modifier
-            .padding(horizontal = 14.dp, vertical = 4.dp)
-            .clickable { onClick() },
-        horizontalArrangement = Arrangement.Start,
+            .padding(horizontal = 14.dp, vertical = 4.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {
         Stars(
             stars = state.stars,
             color = MaterialTheme.theme.colors.filter03,
+            onClick = onClick,
         )
 
         state.total?.let {
             TextP40(
                 text = "(${it.abbreviated})",
-                modifier = Modifier.padding(start = 6.dp),
+                modifier = Modifier.padding(start = 6.dp).clickable { onClick() },
             )
         }
+
+        Spacer(modifier = Modifier.weight(1f))
+
+        TextP40(
+            text = stringResource(R.string.rate_button),
+            fontWeight = FontWeight.W400,
+            modifier = Modifier.clickable { onClick() },
+        )
     }
 }
 
@@ -86,8 +97,13 @@ private fun Content(
 private fun Stars(
     stars: List<Star>,
     color: Color,
+    onClick: () -> Unit,
 ) {
-    Row(horizontalArrangement = Arrangement.Start) {
+    Row(
+        horizontalArrangement = Arrangement.Start,
+        modifier = Modifier.clickable { onClick() },
+
+    ) {
         stars.forEach { star ->
             Icon(
                 imageVector = star.icon,

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/components/ratings/StarRatingView.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/components/ratings/StarRatingView.kt
@@ -75,7 +75,7 @@ private fun Content(
 
         state.total?.let {
             TextP40(
-                text = it.abbreviated,
+                text = "(${it.abbreviated})",
                 modifier = Modifier.padding(start = 6.dp),
             )
         }

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/components/ratings/StarRatingView.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/components/ratings/StarRatingView.kt
@@ -1,6 +1,5 @@
 package au.com.shiftyjelly.pocketcasts.podcasts.view.components.ratings
 
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -68,23 +67,22 @@ private fun Content(
     state: RatingState.Loaded,
     onClick: () -> Unit,
 ) {
+    val verticalPadding = if (FeatureFlag.isEnabled(Feature.GIVE_RATINGS)) 8.dp else 18.dp
+
     Row(
-        modifier = Modifier
-            .padding(horizontal = 16.dp, vertical = 18.dp),
+        modifier = Modifier.padding(horizontal = 16.dp, vertical = verticalPadding),
         verticalAlignment = Alignment.CenterVertically,
     ) {
         Stars(
             stars = state.stars,
             color = MaterialTheme.theme.colors.filter03,
-            onClick = onClick,
         )
 
         if (!state.noRatings) {
             TextP40(
                 text = state.roundedAverage,
                 modifier = Modifier
-                    .padding(start = 4.dp)
-                    .clickable { onClick() },
+                    .padding(start = 4.dp),
                 fontWeight = FontWeight.W700,
             )
         }
@@ -92,8 +90,7 @@ private fun Content(
         TextP40(
             text = if (state.noRatings) stringResource(R.string.no_ratings) else "(${state.total?.abbreviated})",
             modifier = Modifier
-                .padding(start = 4.dp)
-                .clickable { onClick() },
+                .padding(start = 4.dp),
         )
 
         Spacer(modifier = Modifier.weight(1f))
@@ -122,12 +119,9 @@ private fun Content(
 private fun Stars(
     stars: List<Star>,
     color: Color,
-    onClick: () -> Unit,
 ) {
     Row(
         horizontalArrangement = Arrangement.Start,
-        modifier = Modifier.clickable { onClick() },
-
     ) {
         stars.forEach { star ->
             Icon(

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/components/ratings/StarRatingView.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/components/ratings/StarRatingView.kt
@@ -63,8 +63,6 @@ private fun Content(
     state: RatingState.Loaded,
     onClick: () -> Unit,
 ) {
-    if (state.noRatings) return
-
     Row(
         modifier = Modifier
             .padding(horizontal = 14.dp, vertical = 4.dp),
@@ -76,18 +74,18 @@ private fun Content(
             onClick = onClick,
         )
 
-        state.total?.let {
-            TextP40(
-                text = "(${it.abbreviated})",
-                modifier = Modifier.padding(start = 6.dp).clickable { onClick() },
-            )
-        }
+        TextP40(
+            text = if (state.noRatings) stringResource(R.string.no_ratings) else "(${state.total?.abbreviated})",
+            modifier = Modifier
+                .padding(start = 6.dp)
+                .clickable { onClick() },
+        )
 
         Spacer(modifier = Modifier.weight(1f))
 
         TextP40(
             text = stringResource(R.string.rate_button),
-            fontWeight = FontWeight.W400,
+            fontWeight = FontWeight.W500,
             modifier = Modifier.clickable { onClick() },
         )
     }

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/components/ratings/StarRatingView.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/components/ratings/StarRatingView.kt
@@ -30,6 +30,8 @@ import au.com.shiftyjelly.pocketcasts.podcasts.viewmodel.PodcastRatingsViewModel
 import au.com.shiftyjelly.pocketcasts.podcasts.viewmodel.PodcastRatingsViewModel.Star
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import au.com.shiftyjelly.pocketcasts.utils.extensions.abbreviated
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
 import java.util.UUID
 
 @Composable
@@ -93,11 +95,13 @@ private fun Content(
 
         Spacer(modifier = Modifier.weight(1f))
 
-        TextP40(
-            text = stringResource(R.string.rate_button),
-            fontWeight = FontWeight.W500,
-            modifier = Modifier.clickable { onClick() },
-        )
+        if (FeatureFlag.isEnabled(Feature.GIVE_RATINGS)) {
+            TextP40(
+                text = stringResource(R.string.rate_button),
+                fontWeight = FontWeight.W500,
+                modifier = Modifier.clickable { onClick() },
+            )
+        }
     }
 }
 

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/components/ratings/StarRatingView.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/components/ratings/StarRatingView.kt
@@ -74,10 +74,20 @@ private fun Content(
             onClick = onClick,
         )
 
+        if (!state.noRatings) {
+            TextP40(
+                text = state.roundedAverage,
+                modifier = Modifier
+                    .padding(start = 4.dp)
+                    .clickable { onClick() },
+                fontWeight = FontWeight.W700,
+            )
+        }
+
         TextP40(
             text = if (state.noRatings) stringResource(R.string.no_ratings) else "(${state.total?.abbreviated})",
             modifier = Modifier
-                .padding(start = 6.dp)
+                .padding(start = 4.dp)
                 .clickable { onClick() },
         )
 

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/components/ratings/StarRatingView.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/components/ratings/StarRatingView.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.padding
+import androidx.compose.material.ButtonDefaults
 import androidx.compose.material.Icon
 import androidx.compose.material.MaterialTheme
 import androidx.compose.runtime.Composable
@@ -18,8 +19,10 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import androidx.fragment.app.FragmentManager
 import au.com.shiftyjelly.pocketcasts.compose.AppThemeWithBackground
+import au.com.shiftyjelly.pocketcasts.compose.buttons.RowOutlinedButton
 import au.com.shiftyjelly.pocketcasts.compose.components.TextP40
 import au.com.shiftyjelly.pocketcasts.compose.preview.ThemePreviewParameterProvider
 import au.com.shiftyjelly.pocketcasts.compose.theme
@@ -96,10 +99,20 @@ private fun Content(
         Spacer(modifier = Modifier.weight(1f))
 
         if (FeatureFlag.isEnabled(Feature.GIVE_RATINGS)) {
-            TextP40(
+            RowOutlinedButton(
                 text = stringResource(R.string.rate_button),
+                onClick = { onClick() },
+                includePadding = false,
+                fontSize = 16.sp,
+                textPadding = 0.dp,
                 fontWeight = FontWeight.W500,
-                modifier = Modifier.clickable { onClick() },
+                border = null,
+                fullWidth = false,
+                colors = ButtonDefaults.outlinedButtonColors(
+                    backgroundColor = Color.Transparent,
+                    contentColor = MaterialTheme.theme.colors.primaryText01,
+                ),
+                modifier = Modifier.padding(top = 2.dp, bottom = 2.dp),
             )
         }
     }

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/components/ratings/StarRatingView.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/components/ratings/StarRatingView.kt
@@ -65,7 +65,7 @@ private fun Content(
 ) {
     Row(
         modifier = Modifier
-            .padding(horizontal = 14.dp, vertical = 4.dp),
+            .padding(horizontal = 16.dp, vertical = 18.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {
         Stars(

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/PodcastRatingsViewModel.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/PodcastRatingsViewModel.kt
@@ -89,7 +89,7 @@ class PodcastRatingsViewModel
     }
 
     sealed class RatingState {
-        object Loading : RatingState()
+        data object Loading : RatingState()
 
         data class Loaded(
             private val ratings: PodcastRatings,
@@ -130,7 +130,7 @@ class PodcastRatingsViewModel
             }
         }
 
-        object Error : RatingState()
+        data object Error : RatingState()
     }
 
     enum class Star(val icon: ImageVector) {

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/PodcastRatingsViewModel.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/PodcastRatingsViewModel.kt
@@ -104,6 +104,12 @@ class PodcastRatingsViewModel
 
             val stars: List<Star> = starsList()
 
+            val roundedAverage: String
+                get() {
+                    val rating = average ?: 0.0
+                    return (Math.round(rating * 10) / 10.0).toString()
+                }
+
             private fun starsList(): List<Star> {
                 val rating = average ?: 0.0
                 // truncate the floating points off without rounding

--- a/modules/features/podcasts/src/main/res/layout/view_podcast_header_bottom.xml
+++ b/modules/features/podcasts/src/main/res/layout/view_podcast_header_bottom.xml
@@ -43,7 +43,7 @@
 
     <androidx.compose.ui.platform.ComposeView
         android:id="@+id/ratings"
-        android:layout_width="0dp"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/category"/>

--- a/modules/features/podcasts/src/main/res/layout/view_podcast_header_bottom.xml
+++ b/modules/features/podcasts/src/main/res/layout/view_podcast_header_bottom.xml
@@ -48,13 +48,25 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/category"/>
 
+    <View
+        android:id="@+id/divider"
+        android:layout_width="match_parent"
+        android:layout_height="@dimen/divider_height"
+        android:background="?attr/primary_ui_05"
+        android:layout_marginEnd="16dp"
+        android:layout_marginStart="16dp"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/ratings"
+        />
+
     <TextView
         android:id="@+id/description"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_marginEnd="16dp"
         android:layout_marginStart="16dp"
-        android:layout_marginTop="18dp"
+        android:layout_marginTop="12dp"
         android:autoLink="all"
         android:includeFontPadding="false"
         android:lineSpacingMultiplier="1.3"
@@ -62,7 +74,7 @@
         android:textColor="?attr/primary_text_01"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/ratings"
+        app:layout_constraintTop_toBottomOf="@+id/divider"
         tools:text="@tools:sample/lorem/random" />
 
     <TextView

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/buttons/RowOutlinedButton.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/buttons/RowOutlinedButton.kt
@@ -23,8 +23,10 @@ import androidx.compose.ui.graphics.vector.rememberVectorPainter
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.TextUnit
 import androidx.compose.ui.unit.dp
 import au.com.shiftyjelly.pocketcasts.compose.AppThemeWithBackground
@@ -48,8 +50,10 @@ fun RowOutlinedButton(
     colors: ButtonColors = ButtonDefaults.outlinedButtonColors(),
     disableScale: Boolean = false,
     textIcon: Painter? = null,
+    textPadding: Dp = 6.dp,
     fontFamily: FontFamily? = null,
     fontSize: TextUnit? = null,
+    fontWeight: FontWeight? = null,
     leadingIcon: Painter? = null,
     tintIcon: Boolean = true,
     onClick: () -> Unit,
@@ -88,8 +92,9 @@ fun RowOutlinedButton(
                         color = colors.contentColor(enabled = true).value,
                         textAlign = TextAlign.Center,
                         fontFamily = fontFamily,
+                        fontWeight = fontWeight,
                         fontSize = if (disableScale) fontSize?.value?.nonScaledSp else fontSize,
-                        modifier = Modifier.padding(6.dp),
+                        modifier = Modifier.padding(textPadding),
                     )
                 }
             }

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -614,6 +614,7 @@ up    <string name="player_sleep_in_one_chapter">Sleeping in 1 chapter</string>
     <string name="podcast_log_in_to_rate">You must log in to leave a rating</string>
     <string name="podcast_submit_rating_no_internet">No internet connection found. Please connect to the internet to submit a rating.</string>
     <string name="rate_button">Rate</string>
+    <string name="no_ratings">No ratings</string>
 
     <!-- Episodes -->
 

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -608,8 +608,12 @@ up    <string name="player_sleep_in_one_chapter">Sleeping in 1 chapter</string>
     <string name="podcast_season_x">Season %d</string>
     <string name="podcast_refresh_artwork">Refresh artwork</string>
     <string name="podcast_rate">Rate %s</string>
+
+    <!-- Give Rating -->
+
     <string name="podcast_log_in_to_rate">You must log in to leave a rating</string>
     <string name="podcast_submit_rating_no_internet">No internet connection found. Please connect to the internet to submit a rating.</string>
+    <string name="rate_button">Rate</string>
 
     <!-- Episodes -->
 


### PR DESCRIPTION
## Description
- This PR includes some UI updates to match with the latest UI proposal -> pdeCcb-3ic-p2#comment-2763
- Adds the `Rate` button to open the give rating screen
- Adds the average rating button
- Adds divider below of give rating view
- Makes Rate button as single entry point for the next screen
- See [Figma](https://www.figma.com/design/sQk9KlwngN1g8iJbQGAMva/Ratings-%26-Reviews?node-id=1-2&t=dR66g9ZWgwViot63-0)

> [!NOTE]  
> I noticed that the stars are yellow in the current implementation, but in Figma they are gray. I am waiting for someone to confirm this here p1719846426918249-slack-C077XU4GF9D . I will address it to another PR

Fixes #2418
Fixes #2419
Fixes #2420

## Testing Instructions

| Before |
|--------|
| <img src="https://github.com/Automattic/pocket-casts-android/assets/42220351/e0425f46-e284-463d-a837-ad0942ac5c29" width="300"> | 


### With Give Ratings beta feature flag enabled
1. Go to Discover and open a podcast, for example `The Daily`
2. Tap on the podcast image to open more details
3. ✅ Ensure that has the rate button
4. Tap on rate button
5. ✅ Ensure 🔵 Tracked: rating_stars_tapped is tracked

<img src="https://github.com/Automattic/pocket-casts-android/assets/42220351/34f367b5-eb68-46e1-8552-67805aa4bc1e" width="300">


### No rating
1. git apply [set_no_rating.patch](https://github.com/user-attachments/files/16055829/set_no_rating.patch)
2. Open `The Daily` podcast
3. Ensure you see `No Rating` label

<img src="https://github.com/Automattic/pocket-casts-android/assets/42220351/4f1eb6f9-b28d-4bfb-900d-6748162fb461" width="300">

### With Give Ratings beta feature flag disabled
1. Go to Discover and open a podcast, for example `The Daily`
2. Tap on the podcast image to open more details
3. ✅ Ensure that rate button is not visible

<img src="https://github.com/Automattic/pocket-casts-android/assets/42220351/ef1d7947-1f9e-4b7a-a806-aa69703df0be" width="300">


## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack