### PR TITLE
Improve zooming feature of the timeline

### DIFF
--- a/modules/features/clip/src/main/kotlin/au/com/shiftyjelly/pocketcasts/clip/ClipSelector.kt
+++ b/modules/features/clip/src/main/kotlin/au/com/shiftyjelly/pocketcasts/clip/ClipSelector.kt
@@ -173,6 +173,7 @@ private fun BoxWithConstraintsScope.ClipTimeline(
     }
 
     LazyRow(
+        horizontalArrangement = Arrangement.spacedBy(state.spaceWidthDp),
         verticalAlignment = Alignment.CenterVertically,
         state = state.listState,
         modifier = Modifier
@@ -204,7 +205,10 @@ private fun BoxWithConstraintsScope.ClipTimeline(
                 )
             },
     ) {
-        items(episodeDuration.inWholeSeconds.toInt().ceilDiv(state.secondsPerTick) + 1) { index ->
+        items(
+            count = episodeDuration.inWholeSeconds.toInt().ceilDiv(state.secondsPerTick) + 1,
+            key = { index -> index },
+        ) { index ->
             val heightIndex = when (index % 10) {
                 0 -> largeTickHeight
                 5 -> mediumTickHeight
@@ -212,7 +216,6 @@ private fun BoxWithConstraintsScope.ClipTimeline(
             }
             Box(
                 modifier = Modifier
-                    .padding(end = state.spaceWidthDp)
                     .width(state.tickWidthDp)
                     .height(heightIndex)
                     .background(clipColors.timelineTick),


### PR DESCRIPTION
## Description

Previously zooming tipping point for switching tick resolution was hardcoded to 5. But it didn't account for minor ticks which contribute to overall space between major ticks. This PR addresses this issue.

## Testing Instructions

Smoke test zooming of clip timeline.

## Checklist
- [x] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] ~I have considered whether it makes sense to add tests for my changes~
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] ~with different themes~
- [x] ~with a landscape orientation~
- [x] ~with the device set to have a large display and font size~
- [x] ~for accessibility with TalkBack~
