### PR TITLE
Transcripts -  Integrate (temporary) UI container to show transcript in the Player

### DIFF
--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/PlayerContainerFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/PlayerContainerFragment.kt
@@ -60,9 +60,11 @@ import au.com.shiftyjelly.pocketcasts.views.R as VR
 
 @AndroidEntryPoint
 class PlayerContainerFragment : BaseFragment(), HasBackstack {
-    @Inject lateinit var settings: Settings
+    @Inject
+    lateinit var settings: Settings
 
-    @Inject lateinit var analyticsTracker: AnalyticsTracker
+    @Inject
+    lateinit var analyticsTracker: AnalyticsTracker
     private val bookmarksViewModel: BookmarksViewModel by viewModels()
 
     lateinit var upNextBottomSheetBehavior: BottomSheetBehavior<View>
@@ -166,17 +168,21 @@ class PlayerContainerFragment : BaseFragment(), HasBackstack {
                         analyticsTracker.track(AnalyticsEvent.PLAYER_TAB_SELECTED, mapOf(TAB_KEY to "now_playing"))
                         FirebaseAnalyticsTracker.nowPlayingOpen()
                     }
+
                     adapter.isNotesTab(position) -> {
                         analyticsTracker.track(AnalyticsEvent.PLAYER_TAB_SELECTED, mapOf(TAB_KEY to "show_notes"))
                         FirebaseAnalyticsTracker.openedPlayerNotes()
                     }
+
                     adapter.isBookmarksTab(position) -> {
                         analyticsTracker.track(AnalyticsEvent.PLAYER_TAB_SELECTED, mapOf(TAB_KEY to "bookmarks"))
                     }
+
                     adapter.isChaptersTab(position) -> {
                         analyticsTracker.track(AnalyticsEvent.PLAYER_TAB_SELECTED, mapOf(TAB_KEY to "chapters"))
                         FirebaseAnalyticsTracker.openedPlayerChapters()
                     }
+
                     else -> {
                         Timber.e("Invalid tab selected")
                     }
@@ -223,8 +229,8 @@ class PlayerContainerFragment : BaseFragment(), HasBackstack {
         if (FeatureFlag.isEnabled(Feature.TRANSCRIPTS)) {
             viewLifecycleOwner.lifecycleScope.launch {
                 viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
-                    transcriptViewModel.uiState.collect {
-                        adapter.updateTranscript(addTranscript = it.transcript != null)
+                    transcriptViewModel.uiState.collect { uiState ->
+                        adapter.updateTranscript(uiState !is TranscriptViewModel.UiState.Empty)
                     }
                 }
             }
@@ -330,11 +336,13 @@ class PlayerContainerFragment : BaseFragment(), HasBackstack {
                 upNextBottomSheetBehavior.state = BottomSheetBehavior.STATE_COLLAPSED
                 true
             }
+
             bookmarksViewModel.multiSelectHelper.isMultiSelecting -> {
                 bookmarksViewModel.multiSelectHelper.closeMultiSelect()
                 binding?.viewPager?.isUserInputEnabled = true
                 true
             }
+
             else -> false
         }
     }
@@ -482,7 +490,8 @@ private class ViewPagerAdapter(fragmentManager: FragmentManager, lifecycle: Life
         }
     }
 
-    @StringRes fun pageTitle(position: Int): Int {
+    @StringRes
+    fun pageTitle(position: Int): Int {
         return sections[position].titleRes
     }
 

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/transcripts/TranscriptFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/transcripts/TranscriptFragment.kt
@@ -3,6 +3,11 @@ package au.com.shiftyjelly.pocketcasts.player.view.transcripts
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.ViewGroup
+import androidx.annotation.OptIn
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
 import androidx.compose.material.Surface
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
@@ -12,10 +17,15 @@ import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.compose.ui.platform.rememberNestedScrollInteropConnection
+import androidx.compose.ui.unit.dp
 import androidx.fragment.app.viewModels
+import androidx.media3.common.util.UnstableApi
 import au.com.shiftyjelly.pocketcasts.compose.AppTheme
 import au.com.shiftyjelly.pocketcasts.views.fragments.BaseFragment
 import dagger.hilt.android.AndroidEntryPoint
+import java.util.Locale
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.microseconds
 
 @AndroidEntryPoint
 class TranscriptFragment : BaseFragment() {
@@ -40,13 +50,31 @@ class TranscriptFragment : BaseFragment() {
         }
     }
 
+    @OptIn(UnstableApi::class)
     @Composable
     fun TranscriptContent(
         viewModel: TranscriptViewModel,
     ) {
         val state = viewModel.uiState.collectAsState()
-        Text(
-            text = "Transcript for episode ${state.value.episodeId} url ${state.value.transcript?.url}",
-        )
+
+        LazyColumn {
+            items(state.value.cues) { cues ->
+                Text(text = cues.startTimeUs.microseconds.format())
+                cues.cues.forEach {
+                    Text(text = it.text.toString())
+                }
+                Spacer(modifier = Modifier.height(16.dp))
+            }
+        }
     }
+}
+
+private fun Duration.format() = toComponents { hours, minutes, seconds, _ ->
+    String.format(
+        Locale.getDefault(),
+        "%02d:%02d:%02d",
+        hours,
+        minutes,
+        seconds,
+    )
 }

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/transcripts/TranscriptFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/transcripts/TranscriptFragment.kt
@@ -3,35 +3,24 @@ package au.com.shiftyjelly.pocketcasts.player.view.transcripts
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.ViewGroup
-import androidx.annotation.OptIn
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.items
 import androidx.compose.material.Surface
-import androidx.compose.material.Text
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.compose.ui.platform.rememberNestedScrollInteropConnection
-import androidx.compose.ui.unit.dp
 import androidx.fragment.app.viewModels
-import androidx.media3.common.util.UnstableApi
 import au.com.shiftyjelly.pocketcasts.compose.AppTheme
+import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import au.com.shiftyjelly.pocketcasts.views.fragments.BaseFragment
 import dagger.hilt.android.AndroidEntryPoint
-import java.util.Locale
-import kotlin.time.Duration
-import kotlin.time.Duration.Companion.microseconds
 
 @AndroidEntryPoint
 class TranscriptFragment : BaseFragment() {
     companion object {
         fun newInstance() = TranscriptFragment()
     }
+
     private val viewModel by viewModels<TranscriptViewModel>({ requireParentFragment() })
 
     override fun onCreateView(
@@ -40,41 +29,15 @@ class TranscriptFragment : BaseFragment() {
         savedInstanceState: Bundle?,
     ) = ComposeView(requireContext()).apply {
         setContent {
-            AppTheme(theme.activeTheme) {
+            AppTheme(Theme.ThemeType.DARK) {
                 setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
-
                 Surface(modifier = Modifier.nestedScroll(rememberNestedScrollInteropConnection())) {
-                    TranscriptContent(viewModel)
+                    TranscriptPage(
+                        viewModel = viewModel,
+                        theme = theme,
+                    )
                 }
             }
         }
     }
-
-    @OptIn(UnstableApi::class)
-    @Composable
-    fun TranscriptContent(
-        viewModel: TranscriptViewModel,
-    ) {
-        val state = viewModel.uiState.collectAsState()
-
-        LazyColumn {
-            items(state.value.cues) { cues ->
-                Text(text = cues.startTimeUs.microseconds.format())
-                cues.cues.forEach {
-                    Text(text = it.text.toString())
-                }
-                Spacer(modifier = Modifier.height(16.dp))
-            }
-        }
-    }
-}
-
-private fun Duration.format() = toComponents { hours, minutes, seconds, _ ->
-    String.format(
-        Locale.getDefault(),
-        "%02d:%02d:%02d",
-        hours,
-        minutes,
-        seconds,
-    )
 }

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/transcripts/TranscriptFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/transcripts/TranscriptFragment.kt
@@ -1,0 +1,52 @@
+package au.com.shiftyjelly.pocketcasts.player.view.transcripts
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.compose.material.Surface
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.nestedscroll.nestedScroll
+import androidx.compose.ui.platform.ComposeView
+import androidx.compose.ui.platform.ViewCompositionStrategy
+import androidx.compose.ui.platform.rememberNestedScrollInteropConnection
+import androidx.fragment.app.viewModels
+import au.com.shiftyjelly.pocketcasts.compose.AppTheme
+import au.com.shiftyjelly.pocketcasts.views.fragments.BaseFragment
+import dagger.hilt.android.AndroidEntryPoint
+
+@AndroidEntryPoint
+class TranscriptFragment : BaseFragment() {
+    companion object {
+        fun newInstance() = TranscriptFragment()
+    }
+    private val viewModel by viewModels<TranscriptViewModel>({ requireParentFragment() })
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?,
+    ) = ComposeView(requireContext()).apply {
+        setContent {
+            AppTheme(theme.activeTheme) {
+                setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
+
+                Surface(modifier = Modifier.nestedScroll(rememberNestedScrollInteropConnection())) {
+                    TranscriptContent(viewModel)
+                }
+            }
+        }
+    }
+
+    @Composable
+    fun TranscriptContent(
+        viewModel: TranscriptViewModel,
+    ) {
+        val state = viewModel.uiState.collectAsState()
+        Text(
+            text = "Transcript for episode ${state.value.episodeId} url ${state.value.transcript?.url}",
+        )
+    }
+}

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/transcripts/TranscriptPage.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/transcripts/TranscriptPage.kt
@@ -1,0 +1,169 @@
+package au.com.shiftyjelly.pocketcasts.player.view.transcripts
+
+import androidx.annotation.OptIn
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.media3.common.util.UnstableApi
+import au.com.shiftyjelly.pocketcasts.compose.components.TextH30
+import au.com.shiftyjelly.pocketcasts.compose.components.TextP40
+import au.com.shiftyjelly.pocketcasts.compose.theme
+import au.com.shiftyjelly.pocketcasts.localization.R
+import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
+import au.com.shiftyjelly.pocketcasts.player.view.transcripts.TranscriptViewModel.TranscriptError
+import au.com.shiftyjelly.pocketcasts.player.view.transcripts.TranscriptViewModel.UiState
+import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
+import java.util.Locale
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.microseconds
+
+@Composable
+fun TranscriptPage(
+    viewModel: TranscriptViewModel,
+    theme: Theme,
+) {
+    val state = viewModel.uiState.collectAsState()
+    when (state.value) {
+        is UiState.Empty -> Unit
+        is UiState.Success -> {
+            val successState = state.value as UiState.Success
+            TranscriptContent(
+                state = successState,
+                colors = DefaultColors(theme, successState.podcast),
+            )
+        }
+
+        is UiState.Error -> {
+            val errorState = state.value as UiState.Error
+            TranscriptError(
+                state = errorState,
+                colors = DefaultColors(theme, errorState.podcast),
+            )
+        }
+    }
+}
+
+@OptIn(UnstableApi::class)
+@Composable
+private fun TranscriptContent(
+    state: UiState.Success,
+    colors: DefaultColors,
+) {
+    LazyColumn(
+        modifier = Modifier
+            .background(colors.backgroundColor())
+            .fillMaxSize(),
+    ) {
+        items(state.cues) { cues ->
+            TextP40(
+                text = cues.startTimeUs.microseconds.format(),
+                color = colors.textColor(),
+            )
+            cues.cues.forEach {
+                TextP40(
+                    text = it.text.toString(),
+                    color = colors.textColor(),
+                )
+            }
+            Spacer(modifier = Modifier.height(16.dp))
+        }
+    }
+}
+
+@Composable
+private fun TranscriptError(
+    state: UiState.Error,
+    colors: DefaultColors,
+) {
+    val errorMessage = when (val error = state.error) {
+        is TranscriptError.NotSupported ->
+            stringResource(R.string.error_transcript_format_not_supported, error.format)
+
+        is TranscriptError.FailedToLoad ->
+            stringResource(R.string.error_transcript_failed_to_load)
+    }
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(colors.backgroundColor())
+            .verticalScroll(rememberScrollState()),
+    ) {
+        Box(
+            modifier = Modifier
+                .padding(16.dp)
+                .background(
+                    color = colors.contentColor(),
+                    shape = RoundedCornerShape(size = 4.dp),
+                ),
+        ) {
+            Column(
+                verticalArrangement = Arrangement.Center,
+                horizontalAlignment = Alignment.CenterHorizontally,
+                modifier = Modifier
+                    .padding(16.dp),
+            ) {
+                TextH30(
+                    text = stringResource(R.string.error),
+                    color = colors.titleColor(),
+                )
+                TextP40(
+                    text = errorMessage,
+                    textAlign = TextAlign.Center,
+                    modifier = Modifier.padding(top = 12.dp),
+                    color = colors.textColor(),
+                )
+            }
+        }
+    }
+}
+
+private fun Duration.format() = toComponents { hours, minutes, seconds, _ ->
+    String.format(
+        Locale.getDefault(),
+        "%02d:%02d:%02d",
+        hours,
+        minutes,
+        seconds,
+    )
+}
+
+private data class DefaultColors(
+    val theme: Theme,
+    val podcast: Podcast?,
+) {
+    @Composable
+    fun backgroundColor() =
+        Color(theme.playerBackgroundColor(podcast))
+
+    @Composable
+    fun contentColor() =
+        MaterialTheme.theme.colors.playerContrast06
+
+    @Composable
+    fun textColor() =
+        MaterialTheme.theme.colors.playerContrast02
+
+    @Composable
+    fun titleColor() =
+        MaterialTheme.theme.colors.playerContrast01
+}

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/transcripts/TranscriptViewModel.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/transcripts/TranscriptViewModel.kt
@@ -1,10 +1,17 @@
 package au.com.shiftyjelly.pocketcasts.player.view.transcripts
 
+import androidx.annotation.OptIn
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import androidx.media3.common.Format
+import androidx.media3.common.util.UnstableApi
+import androidx.media3.extractor.text.CuesWithTiming
+import androidx.media3.extractor.text.SubtitleParser
 import au.com.shiftyjelly.pocketcasts.models.to.Transcript
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.TranscriptsManager
+import au.com.shiftyjelly.pocketcasts.utils.UrlUtil
+import com.google.common.collect.ImmutableList
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -15,13 +22,16 @@ import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 
-@OptIn(ExperimentalCoroutinesApi::class)
+@OptIn(UnstableApi::class)
 @HiltViewModel
 class TranscriptViewModel @Inject constructor(
     private val transcriptsManager: TranscriptsManager,
     playbackManager: PlaybackManager,
+    private val urlUtil: UrlUtil,
+    private val subtitleParserFactory: SubtitleParser.Factory,
 ) : ViewModel() {
 
+    @kotlin.OptIn(ExperimentalCoroutinesApi::class)
     val uiState: StateFlow<UiState> = playbackManager.playbackStateFlow
         .map { it.episodeUuid }
         .distinctUntilChanged()
@@ -31,14 +41,38 @@ class TranscriptViewModel @Inject constructor(
     private fun createUiStateFlow(episodeId: String) =
         transcriptsManager.observerTranscriptForEpisode(episodeId)
             .map { transcript ->
+                val cues = transcript?.let { parseTranscript(it) } ?: emptyList()
                 UiState(
                     transcript = transcript,
                     episodeId = episodeId,
+                    cues = cues,
                 )
             }
+
+    private suspend fun parseTranscript(transcript: Transcript): List<CuesWithTiming> {
+        val format = Format.Builder()
+            .setSampleMimeType(transcript.type)
+            .build()
+        return if (subtitleParserFactory.supportsFormat(format).not()) {
+            emptyList()
+        } else {
+            val result = ImmutableList.builder<CuesWithTiming>()
+            urlUtil.contentBytes(transcript.url)?.let { data ->
+                val parser = subtitleParserFactory.create(format)
+                parser.parse(
+                    data,
+                    SubtitleParser.OutputOptions.allCues(),
+                ) { element: CuesWithTiming? ->
+                    element?.let { result.add(it) }
+                }
+            }
+            return result.build()
+        }
+    }
 
     data class UiState(
         val transcript: Transcript? = null,
         val episodeId: String? = null,
+        val cues: List<CuesWithTiming> = emptyList(),
     )
 }

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/transcripts/TranscriptViewModel.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/transcripts/TranscriptViewModel.kt
@@ -1,0 +1,44 @@
+package au.com.shiftyjelly.pocketcasts.player.view.transcripts
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import au.com.shiftyjelly.pocketcasts.models.to.Transcript
+import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
+import au.com.shiftyjelly.pocketcasts.repositories.podcast.TranscriptsManager
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
+
+@OptIn(ExperimentalCoroutinesApi::class)
+@HiltViewModel
+class TranscriptViewModel @Inject constructor(
+    private val transcriptsManager: TranscriptsManager,
+    playbackManager: PlaybackManager,
+) : ViewModel() {
+
+    val uiState: StateFlow<UiState> = playbackManager.playbackStateFlow
+        .map { it.episodeUuid }
+        .distinctUntilChanged()
+        .flatMapLatest(::createUiStateFlow)
+        .stateIn(viewModelScope, SharingStarted.Lazily, UiState())
+
+    private fun createUiStateFlow(episodeId: String) =
+        transcriptsManager.observerTranscriptForEpisode(episodeId)
+            .map { transcript ->
+                UiState(
+                    transcript = transcript,
+                    episodeId = episodeId,
+                )
+            }
+
+    data class UiState(
+        val transcript: Transcript? = null,
+        val episodeId: String? = null,
+    )
+}

--- a/modules/features/player/src/test/java/au/com/shiftyjelly/pocketcasts/player/view/transcripts/TranscriptViewModelTest.kt
+++ b/modules/features/player/src/test/java/au/com/shiftyjelly/pocketcasts/player/view/transcripts/TranscriptViewModelTest.kt
@@ -1,0 +1,91 @@
+package au.com.shiftyjelly.pocketcasts.player.view.transcripts
+
+import androidx.media3.extractor.text.SubtitleParser
+import app.cash.turbine.test
+import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
+import au.com.shiftyjelly.pocketcasts.models.to.Transcript
+import au.com.shiftyjelly.pocketcasts.player.view.transcripts.TranscriptViewModel.TranscriptError
+import au.com.shiftyjelly.pocketcasts.player.view.transcripts.TranscriptViewModel.UiState
+import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
+import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackState
+import au.com.shiftyjelly.pocketcasts.repositories.podcast.TranscriptsManager
+import au.com.shiftyjelly.pocketcasts.sharedtest.MainCoroutineRule
+import au.com.shiftyjelly.pocketcasts.utils.UrlUtil
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+
+class TranscriptViewModelTest {
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @get:Rule
+    val coroutineRule = MainCoroutineRule()
+
+    private val transcriptsManager: TranscriptsManager = mock()
+    private val playbackManager: PlaybackManager = mock()
+    private val urlUtil: UrlUtil = mock()
+    private val subtitleParserFactory: SubtitleParser.Factory = mock()
+    private val transcript: Transcript = Transcript("episode_id", "url", "type")
+    private val playbackStateFlow = MutableStateFlow(PlaybackState(podcast = Podcast("podcast_id"), episodeUuid = "episode_id"))
+    private lateinit var viewModel: TranscriptViewModel
+
+    @Test
+    fun `given no transcript available, then Empty state is returned`() = runTest {
+        whenever(transcriptsManager.observerTranscriptForEpisode(any())).thenReturn(flowOf(null))
+
+        initViewModel()
+
+        viewModel.uiState.test {
+            assertTrue((awaitItem() is UiState.Empty))
+        }
+    }
+
+    @Test
+    fun `given transcript is available and supported, then Success state is returned`() = runTest {
+        whenever(transcriptsManager.observerTranscriptForEpisode(any())).thenReturn(flowOf(transcript))
+        whenever(subtitleParserFactory.supportsFormat(any())).thenReturn(true)
+
+        initViewModel()
+
+        viewModel.uiState.test {
+            assertEquals(transcript, (awaitItem() as UiState.Success).transcript)
+        }
+    }
+
+    @Test
+    fun `given transcript is not supported, then NotSupported error is returned`() = runTest {
+        whenever(transcriptsManager.observerTranscriptForEpisode(any())).thenReturn(flowOf(transcript))
+        whenever(subtitleParserFactory.supportsFormat(any())).thenReturn(false)
+
+        initViewModel()
+
+        viewModel.uiState.test {
+            assertTrue((awaitItem() as UiState.Error).error is TranscriptError.NotSupported)
+        }
+    }
+
+    @Test
+    fun `given transcript type supported but content not valid, then FailedToLoad error is returned`() = runTest {
+        whenever(transcriptsManager.observerTranscriptForEpisode(any())).thenReturn(flowOf(transcript))
+        whenever(subtitleParserFactory.supportsFormat(any())).thenReturn(true)
+        whenever(urlUtil.contentBytes(any())).thenThrow(RuntimeException())
+
+        initViewModel()
+
+        viewModel.uiState.test {
+            assertTrue((awaitItem() as UiState.Error).error is TranscriptError.FailedToLoad)
+        }
+    }
+
+    private fun initViewModel() {
+        whenever(playbackManager.playbackStateFlow).thenReturn(playbackStateFlow)
+        viewModel = TranscriptViewModel(transcriptsManager, playbackManager, urlUtil, subtitleParserFactory)
+    }
+}

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -104,6 +104,7 @@
     <string name="star_episode">Star episode</string>
     <string name="token_refresh_sign_in_error_title">Sign In Error</string>
     <string name="token_refresh_sign_in_error_description">There was a problem and you\'ve been signed out. Tap here to sign back in.</string>
+    <string name="transcript">Transcript</string>
     <string name="unstar">Unstar</string>
     <string name="unstar_episode">Unstar episode</string>
     <string name="starred">Starred</string>
@@ -344,6 +345,7 @@ up    <string name="player_sleep_in_one_chapter">Sleeping in 1 chapter</string>
     <string name="player_star" translatable="false">@string/star</string>
     <string name="player_tab_bookmarks" translatable="false">@string/bookmarks</string>
     <string name="player_tab_chapters" translatable="false">@string/chapters</string>
+    <string name="player_tab_transcript" translatable="false">@string/transcript</string>
     <string name="player_tab_notes">Details</string>
     <string name="player_tab_playing">Playing</string>
     <string name="player_tab_playing_wide">Now Playing</string>

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -1886,6 +1886,10 @@ up    <string name="player_sleep_in_one_chapter">Sleeping in 1 chapter</string>
     <string name="bookmarks_upsell_instructions_early_access">Get early access to this feature with Pocket&#160;Casts Patron and save timestamps of your favorite episodes. Available for Plus subscribers soon.</string>
     <string name="bookmarks_search_results_not_found">We couldn\'t find any bookmark for that search.</string>
 
+    <!-- Transcripts -->
+    <string name="error_transcript_failed_to_load">Transcript failed to load</string>
+    <string name="error_transcript_format_not_supported">Transcript format not supported: %s</string>
+
     <!--    Tasker Plugin-->
 
     <string name="must_provide_filter_name">Must provide filter name</string>

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/TranscriptDao.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/TranscriptDao.kt
@@ -5,12 +5,17 @@ import androidx.room.Insert
 import androidx.room.OnConflictStrategy
 import androidx.room.Query
 import au.com.shiftyjelly.pocketcasts.models.to.Transcript
+import kotlinx.coroutines.flow.Flow
 
 @Dao
 abstract class TranscriptDao {
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     abstract fun insert(transcript: Transcript)
 
+    @Query("SELECT * FROM episode_transcript WHERE episode_uuid IS :episodeUuid")
+    abstract fun observerTranscriptForEpisode(episodeUuid: String): Flow<Transcript?>
+
     @Query("DELETE FROM episode_transcript WHERE episode_uuid IS :episodeUuid")
     abstract suspend fun deleteForEpisode(episodeUuid: String)
+
 }

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/TranscriptDao.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/TranscriptDao.kt
@@ -17,5 +17,4 @@ abstract class TranscriptDao {
 
     @Query("DELETE FROM episode_transcript WHERE episode_uuid IS :episodeUuid")
     abstract suspend fun deleteForEpisode(episodeUuid: String)
-
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/di/PlayerModule.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/di/PlayerModule.kt
@@ -1,0 +1,49 @@
+package au.com.shiftyjelly.pocketcasts.repositories.di
+
+import androidx.annotation.OptIn
+import androidx.media3.common.Format
+import androidx.media3.common.util.UnstableApi
+import androidx.media3.extractor.text.SubtitleParser
+import androidx.media3.extractor.text.subrip.SubripParser
+import androidx.media3.extractor.text.webvtt.WebvttParser
+import au.com.shiftyjelly.pocketcasts.repositories.podcast.TranscriptFormat
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+
+@Module
+@InstallIn(SingletonComponent::class)
+@OptIn(UnstableApi::class)
+object PlayerModule {
+    @Provides
+    fun providesSubtitleParserFactory(): SubtitleParser.Factory {
+        return object : SubtitleParser.Factory {
+            override fun supportsFormat(format: Format): Boolean {
+                return when (format.sampleMimeType) {
+                    TranscriptFormat.VTT.mimeType,
+                    TranscriptFormat.SRT.mimeType,
+                    -> true
+
+                    else -> false
+                }
+            }
+
+            override fun getCueReplacementBehavior(format: Format): Int {
+                return when (val mimeType = format.sampleMimeType) {
+                    TranscriptFormat.VTT.mimeType -> WebvttParser.CUE_REPLACEMENT_BEHAVIOR
+                    TranscriptFormat.SRT.mimeType -> SubripParser.CUE_REPLACEMENT_BEHAVIOR
+                    else -> throw IllegalArgumentException("Unsupported MIME type: $mimeType")
+                }
+            }
+
+            override fun create(format: Format): SubtitleParser {
+                return when (val mimeType = format.sampleMimeType) {
+                    TranscriptFormat.VTT.mimeType -> WebvttParser()
+                    TranscriptFormat.SRT.mimeType -> SubripParser()
+                    else -> throw IllegalArgumentException("Unsupported MIME type: $mimeType")
+                }
+            }
+        }
+    }
+}

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/TranscriptsManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/TranscriptsManager.kt
@@ -1,10 +1,13 @@
 package au.com.shiftyjelly.pocketcasts.repositories.podcast
 
 import au.com.shiftyjelly.pocketcasts.models.to.Transcript
+import kotlinx.coroutines.flow.Flow
 
 interface TranscriptsManager {
     suspend fun updateTranscripts(
         episodeUuid: String,
         transcripts: List<Transcript>,
     )
+
+    fun observerTranscriptForEpisode(episodeUuid: String): Flow<Transcript?>
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/TranscriptsManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/TranscriptsManagerImpl.kt
@@ -21,6 +21,9 @@ class TranscriptsManagerImpl @Inject constructor(
         }
     }
 
+    override fun observerTranscriptForEpisode(episodeUuid: String) =
+        transcriptDao.observerTranscriptForEpisode(episodeUuid)
+
     @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
     fun findBestTranscript(availableTranscripts: List<Transcript>): Transcript? {
         for (format in supportedFormats) {

--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/UrlUtil.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/UrlUtil.kt
@@ -1,0 +1,24 @@
+package au.com.shiftyjelly.pocketcasts.utils
+
+import java.io.IOException
+import java.io.InputStream
+import java.net.URL
+import javax.inject.Inject
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+class UrlUtil @Inject constructor() {
+    suspend fun contentBytes(url: String) = withContext(Dispatchers.IO) {
+        var inputStream: InputStream? = null
+        var bytes: ByteArray? = null
+        try {
+            inputStream = URL(url).openStream()
+            bytes = inputStream.readBytes()
+        } catch (e: IOException) {
+            e.printStackTrace()
+        } finally {
+            inputStream?.close()
+        }
+        bytes
+    }
+}


### PR DESCRIPTION
## Description
This displays an episode transcript in the player container's "temporary" `Transcripts` tab.

## Testing Instructions

1. Launch the app
2. Play an episode from "Cautionary Tales" (https://pcast.pocketcasts.net/8zpmjiru)
3. Open player tab
4. ✅ Notice there's a new `Transcripts` tab
5. Tap on the `Transcripts` tab
6. ✅ Notice that the episode's transcript is displayed on the tab (ignore all styling)
7. Play an episode that does not have a transcript 
8. ✅ Notice `Transcripts` tab is not shown for the episode

## Screenshots or Screencast 

<image width=250 src="https://github.com/Automattic/pocket-casts-android/assets/1405144/abaf2dc9-6b8a-425a-b50d-1898d790f9c3"/>


## Checklist
-  If this is a user-facing change, I have added an entry in CHANGELOG.md - N/A
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- Any jetpack compose components I added or changed are covered by compose previews - Not added as views are temporary
- I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics. - TBD 
 
#### I have tested any UI changes...  
<!-- If this PR does not contain UI changes, ignore these items -->

(N/A as views are temporary)
- with different themes
- with a landscape orientation
- with the device set to have a large display and font size
- for accessibility with TalkBack
