### PR TITLE
Update simple cache init condition

### DIFF
--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/ExoPlayerHelper.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/ExoPlayerHelper.kt
@@ -39,7 +39,10 @@ class ExoPlayerHelper @Inject constructor(
     @OptIn(UnstableApi::class)
     @Synchronized
     fun getSimpleCache(): SimpleCache? {
-        if (FeatureFlag.isEnabled(Feature.CACHE_PLAYING_EPISODE) && simpleCache == null) {
+        if (
+            simpleCache == null &&
+            (FeatureFlag.isEnabled(Feature.CACHE_PLAYING_EPISODE) || FeatureFlag.isEnabled(Feature.CACHE_ENTIRE_PLAYING_EPISODE))
+        ) {
             val cacheDir = File(context.cacheDir, CACHE_DIR_NAME)
             val cacheSizeInBytes = if (settings.cacheEntirePlayingEpisode.value) {
                 settings.getExoPlayerCacheEntirePlayingEpisodeSizeInMB()

--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/Feature.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/Feature.kt
@@ -67,7 +67,7 @@ enum class Feature(
         hasFirebaseRemoteFlag = true,
         hasDevToggle = true,
     ),
-    CACHE_PLAYING_EPISODE(
+    CACHE_PLAYING_EPISODE( // Used for on-the-fly caching
         key = "cache_playing_episode_enabled",
         title = "Cache playing episode",
         defaultValue = true,


### PR DESCRIPTION
## Description
This updates `SimpleCache` init condition to give us the flexibility to turn off on-the-fly caching remotely while keeping the entire episode caching enabled. 

## Testing Instructions

Just a code review should be sufficient.

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
