### PR TITLE
[Give rating] Fix star color

### DIFF
--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/components/ratings/StarRatingView.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/components/ratings/StarRatingView.kt
@@ -75,7 +75,7 @@ private fun Content(
     ) {
         Stars(
             stars = state.stars,
-            color = MaterialTheme.theme.colors.filter03,
+            color = MaterialTheme.theme.colors.primaryUi05Selected,
         )
 
         if (!state.noRatings) {


### PR DESCRIPTION
## Description
- Fix the start color for give rating view to match with figma designs
- See: p1719920946149709/1719846426.918249-slack-C077XU4GF9D

Fixes #2428

## Testing Instructions
- Check the star color for all themes

## Screenshots or Screencast 

| Before |
|--------|
| <img src="https://github.com/Automattic/pocket-casts-android/assets/42220351/48c142a0-072b-4fb3-9a82-64ebcd6d3007" width="300"> | 


### After this change

| ![image (1)](https://github.com/Automattic/pocket-casts-android/assets/42220351/1a3c09ea-841a-43e1-967b-f70dc19735ed) | ![image (2)](https://github.com/Automattic/pocket-casts-android/assets/42220351/0a9b2a27-91f9-4e12-a70d-3e79ba49357e) |
|:---:|:---:|
| ![image (3)](https://github.com/Automattic/pocket-casts-android/assets/42220351/a843658f-53ce-493c-b34b-ee756fe57090) | ![image (4)](https://github.com/Automattic/pocket-casts-android/assets/42220351/3e16ac39-a3c7-47e4-afca-87a14a9e1b20) |
| ![image (5)](https://github.com/Automattic/pocket-casts-android/assets/42220351/34cffcb9-d678-46c5-8e39-b98e96c3fc90) | ![image (6)](https://github.com/Automattic/pocket-casts-android/assets/42220351/80236b7c-d77f-4873-8f31-e325ff54cd94) |
| ![image (7)](https://github.com/Automattic/pocket-casts-android/assets/42220351/959840b6-4c62-4b32-9434-c588151554f1) | ![image (8)](https://github.com/Automattic/pocket-casts-android/assets/42220351/a7dcf5f8-bc93-48ea-8023-ad6bc7630915) |
| ![image (9)](https://github.com/Automattic/pocket-casts-android/assets/42220351/e4c766ff-69ba-4b8b-969f-2413aa092c52) | ![image (10)](https://github.com/Automattic/pocket-casts-android/assets/42220351/1844cd0d-0ebf-428e-b09d-d6ef4de67879) |






## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack