### PR TITLE
[Dependency Analysis] Add Android Gradle Plugin

### DIFF
--- a/.buildkite/schedules/dependency-analysis.yml
+++ b/.buildkite/schedules/dependency-analysis.yml
@@ -1,0 +1,23 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/buildkite/pipeline-schema/main/schema.json
+---
+
+# Nodes with values to reuse in the pipeline.
+common_params:
+  # Common plugin settings to use with the `plugins` key.
+  - &common_plugins
+    - automattic/bash-cache#2.11.0
+
+agents:
+  queue: "android"
+
+steps:
+  - label: "dependency analysis"
+    command: |
+      echo "--- 📊 Analyzing"
+      ./gradlew buildHealth
+    plugins: *common_plugins
+    artifact_paths:
+      - "build/reports/dependency-analysis/build-health-report.*"
+    notify:
+      - slack: "#android-core-notifs"
+        if: build.state == "failed"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -27,6 +27,7 @@ plugins {
     alias(libs.plugins.kotlin.parcelize) apply false
     alias(libs.plugins.measure.builds)
     alias(libs.plugins.protobuf) apply false
+    alias(libs.plugins.dependency.analysis)
 }
 
 apply(from = rootProject.file("dependencies.gradle.kts"))

--- a/gradle.properties
+++ b/gradle.properties
@@ -24,3 +24,6 @@ org.gradle.daemon=true
 org.gradle.jvmargs=-Xmx8048M
 org.gradle.parallel=true
 org.gradle.caching=true
+
+# Dependency Analysis Plugin
+dependency.analysis.android.ignored.variants=release

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -25,6 +25,7 @@ compose = "2024.02.00" # uses compose version 1.6.1, see https://developer.andro
 # @keep
 # Compose to Kotlin Compatibility Map: https://developer.android.com/jetpack/androidx/releases/compose-kotlin
 compose-kotlin-compiler = "1.5.9"
+dependency-analysis = "1.28.0"
 espresso = "3.4.0"
 firebase = "30.5.0"
 glance = "1.0.0"
@@ -430,6 +431,7 @@ work = [
 aboutlibraries = { id = "com.mikepenz.aboutlibraries.plugin", version.ref = "aboutlibraries" }
 android-application = { id = "com.android.application", version.ref = "android-application" }
 android-library = { id = "com.android.library", version.ref = "android-application" }
+dependency-analysis = { id = "com.autonomousapps.dependency-analysis", version.ref = "dependency-analysis" }
 google-services = { id = "com.google.gms.google-services", version.ref = "google-services" }
 hilt = { id = "com.google.dagger.hilt.android", version.ref = "hilt" }
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }


### PR DESCRIPTION
Project Thread: paaHJt-6yU-p2
Required By: [BuildkiteCI#466](https://github.com/Automattic/buildkite-ci/pull/466)

This PR adds the dependency analysis Android Gradle plugin to this project, for dependency analysis purposes.

## Description
<!-- Please include a summary of what this PR is changing and why these changes are needed. -->

For now, only the main `buildHealth` task is going to be utilized and produce data once every week on CI (see this [commit](https://github.com/Automattic/pocket-casts-android/pull/2433/commits/176e2b5e39726205f7ad702c4a51fc1541e0e446) and [this](https://github.com/Automattic/buildkite-ci/pull/466) PR). Amongst other, this data will include the following:

- Number of modules (`projectCount`)
- Unused dependencies which should be removed (`unusedCount`)
- Transitive dependencies which should be declared directly (`undeclaredCount`)
- Existing dependencies which should be modified to be as indicated (`misDeclaredCount`)
- Dependencies which could be compile-only (`compileOnlyCount`)
- Dependencies which should be removed or changed to runtime-only (`runtimeOnlyCount`)

Afterward, this data will get collected from CI and uploaded to our Apps Metrics infrastructure, for visualization and alerting purposes.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Tap on the Filters tab -->
<!-- 2. Tap on a filter -->
<!-- 3. etc. -->

1. Local: Run the `./gradlew buildHealth` task and verify that under the root level `build/reports/dependency-analysis` folder you get the below 2 reports both, in JSON and text format:
    - `build-health-report.json`
    - `build-health-report.txt`
2. CI: Using the `New Build` 🟢 CI button for [PCAndroid](https://buildkite.com/automattic/pocket-casts-android/), test this standalone dependency analysis job (see form below). Then:
    - When CI starts, make sure that adding `/meta-data` to that CI build's URL ([example](https://buildkite.com/automattic/pocket-casts-android/builds/7133/meta-data)) will give you one extra meta-data, the `pipeline_file` one, with a value of `schedules/dependency-analysis.yml` (see screenshot below):
    - When CI completes, make sure that the below 2 CI artifacts are available both, in JSON and text format:
        - `build/reports/dependency-analysis/build-health-report.json`
        - `build/reports/dependency-analysis/build-health-report.txt`
3. REST: Using the Buildkite's REST API you could query for this type of builds, using the [meta-data](https://buildkite.com/docs/apis/rest-api/builds#list-all-builds) query parameter, and see that the result is the expect one. Use this query: `https://api.buildkite.com/v2/organizations/automattic/pipelines/pocket-casts-android/builds?meta_data[pipeline_file]=schedules/dependency-analysis.yml`

![image](https://github.com/Automattic/pocket-casts-android/assets/9729923/18121317-792d-4e98-9595-2b2d82926232)

![image](https://github.com/Automattic/pocket-casts-android/assets/9729923/745abbea-c981-44c1-810f-8254c9b52259)

## Checklist (`N/A`)

#### I have tested any UI changes... (`N/A`)