### PR TITLE
Add more constraints for playing episode caching

### DIFF
--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/CacheWorker.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/CacheWorker.kt
@@ -95,6 +95,7 @@ class CacheWorker @AssistedInject constructor(
             WorkManager.getInstance(context).cancelAllWorkByTag(CACHE_WORKER_TAG)
             val constraints = Constraints.Builder()
                 .setRequiredNetworkType(NetworkType.UNMETERED)
+                .setRequiresStorageNotLow(true)
                 .build()
 
             val cacheWorkRequest = OneTimeWorkRequest.Builder(CacheWorker::class.java)

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/CastPlayer.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/CastPlayer.kt
@@ -69,6 +69,8 @@ class CastPlayer(val context: Context, override val onPlayerEvent: (Player, Play
     override val name: String
         get() = "Cast"
 
+    override var isDownloading: Boolean = false
+
     override val episodeUuid: String?
         get() = episode?.uuid
 

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/LocalPlayer.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/LocalPlayer.kt
@@ -34,6 +34,8 @@ abstract class LocalPlayer(override val onPlayerEvent: (Player, PlayerEvent) -> 
     override val url: String?
         get() = (episodeLocation as? EpisodeLocation.Stream)?.uri
 
+    override var isDownloading: Boolean = false
+
     override val filePath: String?
         get() = (episodeLocation as? EpisodeLocation.Downloaded)?.filePath
 
@@ -185,6 +187,7 @@ abstract class LocalPlayer(override val onPlayerEvent: (Player, PlayerEvent) -> 
     override fun setEpisode(episode: BaseEpisode) {
         this.episodeUuid = episode.uuid
         this.isHLS = episode.isHLS
+        this.isDownloading = episode.isDownloading
         episodeLocation = if (episode.isDownloaded) {
             EpisodeLocation.Downloaded(episode.downloadedFilePath)
         } else {

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/Player.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/Player.kt
@@ -18,6 +18,7 @@ interface Player {
     val url: String?
     val episodeUuid: String?
     val name: String
+    var isDownloading: Boolean
     val onPlayerEvent: (Player, PlayerEvent) -> Unit
 
     suspend fun load(currentPositionMs: Int)

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/SimplePlayer.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/SimplePlayer.kt
@@ -283,7 +283,7 @@ class SimplePlayer(
         } ?: return
 
         val sourceFactory = exoPlayerHelper.getSimpleCache()?.let { cache ->
-            if (location is EpisodeLocation.Stream) {
+            if (location is EpisodeLocation.Stream && !isDownloading) {
                 val cacheDataSourceFactory = CacheDataSource.Factory()
                     .setUpstreamDataSourceFactory(httpDataSourceFactory)
                     .setFlags(CacheDataSource.FLAG_IGNORE_CACHE_ON_ERROR)


### PR DESCRIPTION
## Description

This disables playing episode caching if
- it is downloading
- storage is less

## Testing Instructions

1. Delete cache directory if it exists at `/data/data/au.com.shiftyjelly.pocketcasts.debug/cache/pocketcasts-exoplayer-cache`
2. Open a podcast and long-press an episode
3. Tap download from the top bar (multi-select) menu 
4. Play the episode
5. ✅ Notice that the episode is not cached in Device Explorer at `/data/data/au.com.shiftyjelly.pocketcasts.debug/cache/pocketcasts-exoplayer-cache`
6. Smoke test that episode can be cast properly

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
