### PR TITLE
[Tooling] Use Android Queue by Default

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,3 +1,6 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/buildkite/pipeline-schema/main/schema.json
+---
+
 # Nodes with values to reuse in the pipeline.
 common_params:
   # Common plugin settings to use with the `plugins` key.

--- a/.buildkite/release-builds.yml
+++ b/.buildkite/release-builds.yml
@@ -1,3 +1,6 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/buildkite/pipeline-schema/main/schema.json
+---
+
 # This pipeline is meant to be run via the Buildkite API, and is
 # only used for release builds
 
@@ -6,6 +9,9 @@ common_params:
   # Common plugin settings to use with the `plugins` key.
   - &common_plugins
     - automattic/bash-cache#2.11.0
+
+agents:
+  queue: "android"
 
 steps:
   - label: "Gradle Wrapper Validation"


### PR DESCRIPTION
Cherry picking https://github.com/Automattic/pocket-casts-android/commit/746f752011c66573535de73575a938e6b026c279 (https://github.com/Automattic/pocket-casts-android/pull/2430) from `trunk`, so that the release branch also uses the `android` queue by default.