### PR TITLE
[Give Rating] Update Rating screen

### DIFF
--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/components/ratings/GiveRatingFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/components/ratings/GiveRatingFragment.kt
@@ -64,12 +64,10 @@ class GiveRatingFragment : BaseDialogFragment() {
                                 dismiss()
                             }
                         },
-                        onFailure = ::exitWithError,
                     )
                 }
 
-                val state = viewModel.state.collectAsState().value
-                when (state) {
+                when (val state = viewModel.state.collectAsState().value) {
                     is GiveRatingViewModel.State.Loaded -> GiveRatingScreen(
                         state = state,
                         onDismiss = ::dismiss,
@@ -84,8 +82,11 @@ class GiveRatingFragment : BaseDialogFragment() {
                             )
                         },
                     )
-                    GiveRatingViewModel.State.Loading -> GiveRatingLoadingScreen()
                     is GiveRatingViewModel.State.NotAllowedToRate -> GiveRatingNotAllowedToRate(state = state, onDismiss = { dismiss() })
+                    is GiveRatingViewModel.State.FailedToRate -> {
+                        exitWithError(state.message)
+                    }
+                    GiveRatingViewModel.State.Loading -> GiveRatingLoadingScreen()
                 }
             }
         }

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/components/ratings/GiveRatingFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/components/ratings/GiveRatingFragment.kt
@@ -85,6 +85,7 @@ class GiveRatingFragment : BaseDialogFragment() {
                         },
                     )
                     GiveRatingViewModel.State.Loading -> GiveRatingLoadingScreen()
+                    is GiveRatingViewModel.State.NotAllowedToRate -> GiveRatingNotAllowedToRate(state = state, onDismiss = { dismiss() })
                 }
             }
         }

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/components/ratings/GiveRatingNotAllowedToRateScreen.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/components/ratings/GiveRatingNotAllowedToRateScreen.kt
@@ -1,0 +1,86 @@
+package au.com.shiftyjelly.pocketcasts.podcasts.view.components.ratings
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.ButtonDefaults
+import androidx.compose.material.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import au.com.shiftyjelly.pocketcasts.compose.bars.NavigationButton
+import au.com.shiftyjelly.pocketcasts.compose.bars.NavigationIconButton
+import au.com.shiftyjelly.pocketcasts.compose.buttons.RowButton
+import au.com.shiftyjelly.pocketcasts.compose.components.PodcastCover
+import au.com.shiftyjelly.pocketcasts.compose.components.TextH30
+import au.com.shiftyjelly.pocketcasts.compose.components.TextP40
+import au.com.shiftyjelly.pocketcasts.compose.theme
+import au.com.shiftyjelly.pocketcasts.localization.R
+import au.com.shiftyjelly.pocketcasts.podcasts.viewmodel.GiveRatingViewModel
+
+@Composable
+fun GiveRatingNotAllowedToRate(
+    state: GiveRatingViewModel.State.NotAllowedToRate,
+    onDismiss: () -> Unit,
+) {
+    Column(
+        horizontalAlignment = Alignment.CenterHorizontally,
+        modifier = Modifier
+            .fillMaxSize()
+            .verticalScroll(rememberScrollState()),
+    ) {
+        NavigationIconButton(
+            iconColor = MaterialTheme.theme.colors.primaryText01,
+            navigationButton = NavigationButton.Close,
+            onNavigationClick = onDismiss,
+            modifier = Modifier.align(Alignment.Start),
+        )
+
+        Spacer(Modifier.weight(1f))
+
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+        ) {
+            PodcastCover(
+                uuid = state.podcastUuid,
+                coverWidth = 164.dp,
+            )
+
+            Spacer(Modifier.height(40.dp))
+
+            TextH30(
+                text = stringResource(R.string.not_allowed_to_rate_title),
+                fontWeight = FontWeight.W600,
+                textAlign = TextAlign.Center,
+                modifier = Modifier.padding(horizontal = 16.dp),
+            )
+
+            Spacer(Modifier.height(32.dp))
+
+            TextP40(
+                text = stringResource(R.string.not_allowed_to_rate_description),
+                textAlign = TextAlign.Center,
+                fontWeight = FontWeight.W400,
+                modifier = Modifier.padding(horizontal = 16.dp),
+            )
+        }
+
+        Spacer(Modifier.weight(1f))
+
+        RowButton(
+            text = stringResource(R.string.done),
+            onClick = onDismiss,
+            colors = ButtonDefaults.outlinedButtonColors(
+                backgroundColor = MaterialTheme.theme.colors.primaryText01,
+            ),
+        )
+    }
+}

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/components/ratings/GiveRatingScreen.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/components/ratings/GiveRatingScreen.kt
@@ -7,11 +7,13 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.ButtonDefaults
 import androidx.compose.material.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import au.com.shiftyjelly.pocketcasts.compose.bars.NavigationButton
@@ -58,6 +60,7 @@ fun GiveRatingScreen(
             TextH30(
                 text = stringResource(LR.string.podcast_rate, state.podcastTitle),
                 textAlign = TextAlign.Center,
+                fontWeight = FontWeight.W600,
                 modifier = Modifier.padding(horizontal = 16.dp),
             )
 
@@ -76,6 +79,9 @@ fun GiveRatingScreen(
         RowButton(
             text = stringResource(LR.string.submit),
             onClick = submitRating,
+            colors = ButtonDefaults.outlinedButtonColors(
+                backgroundColor = MaterialTheme.theme.colors.primaryText01,
+            ),
         )
     }
 }

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/components/ratings/SwipeableStars.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/components/ratings/SwipeableStars.kt
@@ -268,7 +268,7 @@ fun Stars(
                 } else {
                     Icons.Filled.StarBorder
                 },
-                tint = MaterialTheme.theme.colors.primaryIcon01,
+                tint = MaterialTheme.theme.colors.primaryText01,
                 contentDescription = null,
                 modifier = modifier(index)
                     .fillMaxHeight()

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/GiveRatingViewModel.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/GiveRatingViewModel.kt
@@ -30,7 +30,7 @@ class GiveRatingViewModel @Inject constructor(
 ) : ViewModel() {
 
     sealed class State {
-        object Loading : State()
+        data object Loading : State()
         data class Loaded(
             val podcastUuid: String,
             val podcastTitle: String,
@@ -53,6 +53,7 @@ class GiveRatingViewModel @Inject constructor(
                 Five,
             }
         }
+        data class NotAllowedToRate(val podcastUuid: String) : State()
     }
 
     private val _state = MutableStateFlow<State>(State.Loading)

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -615,6 +615,8 @@ up    <string name="player_sleep_in_one_chapter">Sleeping in 1 chapter</string>
     <string name="podcast_submit_rating_no_internet">No internet connection found. Please connect to the internet to submit a rating.</string>
     <string name="rate_button">Rate</string>
     <string name="no_ratings">No ratings</string>
+    <string name="not_allowed_to_rate_title">Please listen to this podcast first</string>
+    <string name="not_allowed_to_rate_description">Only listeners of this podcast can give it a rating. Have a listen to a few episodes and then come back to give your rating. We look forward to hearing what you think!</string>
 
     <!-- Episodes -->
 

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/EpisodeDao.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/EpisodeDao.kt
@@ -46,6 +46,9 @@ abstract class EpisodeDao {
     @Query("SELECT * FROM podcast_episodes WHERE uuid IN (:episodeUuids)")
     abstract suspend fun findByUuids(episodeUuids: List<String>): List<PodcastEpisode>
 
+    @Query("SELECT * FROM podcast_episodes WHERE podcast_id = :podcastUuid AND played_up_to != 0.0")
+    abstract suspend fun findPlayedEpisodesFrom(podcastUuid: String): List<PodcastEpisode>
+
     @Query("SELECT * FROM podcast_episodes WHERE uuid = :uuid")
     abstract fun findByUuidRx(uuid: String): Maybe<PodcastEpisode>
 

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PodcastManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PodcastManager.kt
@@ -151,6 +151,8 @@ interface PodcastManager {
 
     suspend fun findRandomPodcasts(limit: Int): List<Podcast>
 
+    suspend fun findPlayedEpisodesFrom(podcastUuid: String): List<PodcastEpisode>
+
     suspend fun updateArchiveSettings(uuid: String, enable: Boolean, afterPlaying: AutoArchiveAfterPlaying, inactive: AutoArchiveInactive)
     suspend fun updateArchiveAfterPlaying(uuid: String, value: AutoArchiveAfterPlaying)
     suspend fun updateArchiveAfterInactive(uuid: String, value: AutoArchiveInactive)

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PodcastManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PodcastManagerImpl.kt
@@ -833,4 +833,8 @@ class PodcastManagerImpl @Inject constructor(
     override suspend fun updateArchiveEpisodeLimit(uuid: String, value: AutoArchiveLimit) {
         podcastDao.updateArchiveEpisodeLimit(uuid, value)
     }
+
+    override suspend fun findPlayedEpisodesFrom(podcastUuid: String): List<PodcastEpisode> {
+        return episodeDao.findPlayedEpisodesFrom(podcastUuid)
+    }
 }


### PR DESCRIPTION
## Description
- Updates the rating screen to match with the colors proposed in Figma
- Implement the logic to display the not allowed to rate message when the user did not listen any episode from a podcast that is trying to rate
- [Figma](https://www.figma.com/design/sQk9KlwngN1g8iJbQGAMva/Ratings-%26-Reviews?node-id=1-2&t=thV0O4CaLw1UPn0v-0)

Fixes #2434
Fixed #2435

## Testing Instructions

Make sure `GIVE_RATINGS` feature flag is enabled

1. Open a podcast that you did not listen any episode before
2. Tap on `Rate` button
3. ✅ Ensure you see the rating screen with the not allowed to rate messages
4. Listen any episode from this podcast you are trying to rate until `played_up_to` is updated
5. Tap on `Rate` button
6. ✅ Ensure you see the rating screen with the option to rate the podcast

## Screenshots or Screencast 
[Screen_recording_20240703_085955.webm](https://github.com/Automattic/pocket-casts-android/assets/42220351/c56c6004-f65d-4c21-877e-7fbb4fcc3f30)


## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
