### PR TITLE
Revert playback speed label taps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 *   Updates:
     *   Update Give rating view to include the average rating
         ([#2421](https://github.com/Automattic/pocket-casts-android/pull/2421))
+*   Bug Fixes
+    *   Fix playback speed label tap behavior
+        ([#2439](https://github.com/Automattic/pocket-casts-android/pull/2439))
 
 7.67
 -----

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/EffectsFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/EffectsFragment.kt
@@ -232,13 +232,8 @@ class EffectsFragment : BaseDialogFragment(), CompoundButton.OnCheckedChangeList
             binding.btnClear.id -> viewModel.clearPodcastEffects(podcast)
             binding.lblSpeed.id -> {
                 when (effects.playbackSpeed) {
-                    in 0.0..<1.05 -> changePlaybackSpeed(effects, podcast, 1.5)
-                    in 1.05..<1.55 -> changePlaybackSpeed(effects, podcast, 2.0)
-                    in 1.55..<2.05 -> changePlaybackSpeed(effects, podcast, 2.5)
-                    in 2.05..<2.55 -> changePlaybackSpeed(effects, podcast, 3.0)
-                    in 2.55..<3.05 -> changePlaybackSpeed(effects, podcast, 3.5)
-                    in 3.05..<3.55 -> changePlaybackSpeed(effects, podcast, 4.0)
-                    in 3.55..<4.05 -> changePlaybackSpeed(effects, podcast, 1.5)
+                    1.0 -> changePlaybackSpeed(effects, podcast, 1.5)
+                    1.5 -> changePlaybackSpeed(effects, podcast, 2.0)
                     else -> changePlaybackSpeed(effects, podcast, 1.0)
                 }
             }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/MediaSessionManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/MediaSessionManager.kt
@@ -462,6 +462,26 @@ class MediaSessionManager(
                             in 2.75..<2.85 -> IR.drawable.auto_2_8
                             in 2.85..<2.95 -> IR.drawable.auto_2_9
                             in 2.95..<3.05 -> IR.drawable.auto_3
+                            in 3.05..<3.15 -> IR.drawable.auto_3_1
+                            in 3.15..<3.25 -> IR.drawable.auto_3_2
+                            in 3.25..<3.35 -> IR.drawable.auto_3_3
+                            in 3.35..<3.45 -> IR.drawable.auto_3_4
+                            in 3.45..<3.55 -> IR.drawable.auto_3_5
+                            in 3.55..<3.65 -> IR.drawable.auto_3_6
+                            in 3.65..<3.75 -> IR.drawable.auto_3_7
+                            in 3.75..<3.85 -> IR.drawable.auto_3_8
+                            in 3.85..<3.95 -> IR.drawable.auto_3_9
+                            in 3.95..<4.05 -> IR.drawable.auto_4
+                            in 4.05..<4.15 -> IR.drawable.auto_4_1
+                            in 4.15..<4.25 -> IR.drawable.auto_4_2
+                            in 4.25..<4.35 -> IR.drawable.auto_4_3
+                            in 4.35..<4.45 -> IR.drawable.auto_4_4
+                            in 4.45..<4.55 -> IR.drawable.auto_4_5
+                            in 4.55..<4.65 -> IR.drawable.auto_4_6
+                            in 4.65..<4.75 -> IR.drawable.auto_4_7
+                            in 4.75..<4.85 -> IR.drawable.auto_4_8
+                            in 4.85..<4.95 -> IR.drawable.auto_4_9
+                            in 4.95..<5.05 -> IR.drawable.auto_5
                             else -> IR.drawable.auto_1
                         }
 

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/MediaSessionManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/MediaSessionManager.kt
@@ -462,26 +462,6 @@ class MediaSessionManager(
                             in 2.75..<2.85 -> IR.drawable.auto_2_8
                             in 2.85..<2.95 -> IR.drawable.auto_2_9
                             in 2.95..<3.05 -> IR.drawable.auto_3
-                            in 3.05..<3.15 -> IR.drawable.auto_3_1
-                            in 3.15..<3.25 -> IR.drawable.auto_3_2
-                            in 3.25..<3.35 -> IR.drawable.auto_3_3
-                            in 3.35..<3.45 -> IR.drawable.auto_3_4
-                            in 3.45..<3.55 -> IR.drawable.auto_3_5
-                            in 3.55..<3.65 -> IR.drawable.auto_3_6
-                            in 3.65..<3.75 -> IR.drawable.auto_3_7
-                            in 3.75..<3.85 -> IR.drawable.auto_3_8
-                            in 3.85..<3.95 -> IR.drawable.auto_3_9
-                            in 3.95..<4.05 -> IR.drawable.auto_4
-                            in 4.05..<4.15 -> IR.drawable.auto_4_1
-                            in 4.15..<4.25 -> IR.drawable.auto_4_2
-                            in 4.25..<4.35 -> IR.drawable.auto_4_3
-                            in 4.35..<4.45 -> IR.drawable.auto_4_4
-                            in 4.45..<4.55 -> IR.drawable.auto_4_5
-                            in 4.55..<4.65 -> IR.drawable.auto_4_6
-                            in 4.65..<4.75 -> IR.drawable.auto_4_7
-                            in 4.75..<4.85 -> IR.drawable.auto_4_8
-                            in 4.85..<4.95 -> IR.drawable.auto_4_9
-                            in 4.95..<5.05 -> IR.drawable.auto_5
                             else -> IR.drawable.auto_1
                         }
 
@@ -773,18 +753,8 @@ class MediaSessionManager(
                 in 1.40..<1.60 -> 1.6
                 in 1.60..<1.80 -> 1.8
                 in 1.80..<2.00 -> 2.0
-                in 2.00..<2.20 -> 2.2
-                in 2.20..<2.40 -> 2.4
-                in 2.40..<2.60 -> 2.6
-                in 2.60..<2.80 -> 2.8
-                in 2.80..<3.00 -> 3.0
-                in 3.00..<3.20 -> 3.2
-                in 3.20..<3.40 -> 3.4
-                in 3.40..<3.60 -> 3.6
-                in 3.60..<3.80 -> 3.8
-                in 3.80..<4.00 -> 4.0
-                in 4.00..<5.00 -> 5.0
-                in 5.00..<5.05 -> 0.6
+                in 2.00..<3.00 -> 3.0
+                in 3.00..<3.05 -> 0.6
                 else -> 1.0
             }
 


### PR DESCRIPTION
## Description

The recent change to add 5x playback speed changed the behaviour of tapping the speed label. We have received lots of negative user feedback, so until we figure out a better way, this will restore the original functionality. 

Fixes https://github.com/Automattic/pocket-casts-android/issues/2427

## Testing Instructions
1. Play an episode
2. Open the full screen player
3. Tap on the effects icon
4. Tap the + button to increase the speed to 1.2
5. Tap the speed label
6. ✅ Verify the speed returns to 1x
7. Tap the speed label
8. ✅ Verify the speed changes to 1.5x
9. Tap the speed label
8. ✅ Verify the speed changes to 2x 
Tap the speed label
8. ✅ Verify the speed changes to 1x 

## Screencast 

https://github.com/Automattic/pocket-casts-android/assets/308331/c52697a0-88a8-4965-b6a4-301eef0cd5c2
