### PR TITLE
Fix sync logging

### DIFF
--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/PodcastSyncProcess.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/PodcastSyncProcess.kt
@@ -125,9 +125,9 @@ class PodcastSyncProcess(
             return Completable.complete()
         }
 
-        val lasSyncTimeString = settings.getLastModified()
-        val lastSyncTime = runCatching { Instant.parse(lasSyncTimeString) }
-            .onFailure { Timber.e(it, "Could not convert lastModified String to Long: $lasSyncTimeString") }
+        val lastSyncTimeString = settings.getLastModified()
+        val lastSyncTime = runCatching { Instant.parse(lastSyncTimeString) }
+            .onFailure { Timber.e(it, "Could not convert lastModified String to Long: $lastSyncTimeString") }
             .getOrDefault(Instant.EPOCH)
 
         val downloadObservable = if (lastSyncTime == Instant.EPOCH) {
@@ -360,7 +360,7 @@ class PodcastSyncProcess(
         return podcastManager.subscribeToPodcastRx(podcastUuid = podcastUuid, sync = false)
             .flatMap { podcast -> updatePodcastSyncValues(podcast, podcastResponse).toSingleDefault(podcast) }
             .toMaybe()
-            .doOnError { LogBuffer.e(LogBuffer.TAG_BACKGROUND_TASKS, "Could not import server podcast $podcastResponse.uuid", it) }
+            .doOnError { LogBuffer.e(LogBuffer.TAG_BACKGROUND_TASKS, it, "Could not import server podcast %s", podcastUuid) }
             .onErrorComplete()
     }
 
@@ -904,7 +904,7 @@ class PodcastSyncProcess(
                     podcastManager.updatePodcast(podcast)
                 }
                 .toMaybe()
-                .doOnError { LogBuffer.e(LogBuffer.TAG_BACKGROUND_TASKS, "Could not import server podcast $podcastUuid", it) }
+                .doOnError { LogBuffer.e(LogBuffer.TAG_BACKGROUND_TASKS, it, "Could not import server podcast  %s", podcastUuid) }
                 .onErrorComplete()
         } else {
             return Maybe.empty<Podcast>()


### PR DESCRIPTION
I've made a small change to fix the sync logging. I noticed while testing in staging that my sync data has a production podcast UUID, which causes a sync error. The logging method has the message and exception parameters arranged the wrong way.

The error goes from:
<img width="886" alt="Screenshot 2024-07-04 at 12 04 14 PM" src="https://github.com/Automattic/pocket-casts-android/assets/308331/0583b529-5d46-4029-9fdf-544889ed6265">

to this
<img width="757" alt="Screenshot 2024-07-04 at 12 20 15 PM" src="https://github.com/Automattic/pocket-casts-android/assets/308331/09a8836b-b716-42b9-9995-f6664733d98b">

I also fixed a small typo.

## Testing Instructions

Reading the code and checking that sync still works is probably enough testing. But you could manually throw an exception if you wanted to check the line runs.
