### PR TITLE
Address feedbacks for #2438 PR

### DIFF
--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/components/ratings/GiveRatingNotAllowedToRateScreen.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/components/ratings/GiveRatingNotAllowedToRateScreen.kt
@@ -1,5 +1,6 @@
 package au.com.shiftyjelly.pocketcasts.podcasts.view.components.ratings
 
+import android.content.res.Configuration
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
@@ -13,6 +14,7 @@ import androidx.compose.material.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
@@ -33,6 +35,9 @@ fun GiveRatingNotAllowedToRate(
     state: GiveRatingViewModel.State.NotAllowedToRate,
     onDismiss: () -> Unit,
 ) {
+    val configuration = LocalConfiguration.current
+    val isLandscape = configuration.orientation == Configuration.ORIENTATION_LANDSCAPE
+
     Box(
         modifier = Modifier.fillMaxSize(),
     ) {
@@ -48,10 +53,12 @@ fun GiveRatingNotAllowedToRate(
             Column(
                 horizontalAlignment = Alignment.CenterHorizontally,
             ) {
-                PodcastCover(
-                    uuid = state.podcastUuid,
-                    coverWidth = 164.dp,
-                )
+                if (!isLandscape) {
+                    PodcastCover(
+                        uuid = state.podcastUuid,
+                        coverWidth = 164.dp,
+                    )
+                }
 
                 Spacer(Modifier.height(40.dp))
 

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/components/ratings/GiveRatingNotAllowedToRateScreen.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/components/ratings/GiveRatingNotAllowedToRateScreen.kt
@@ -15,6 +15,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import au.com.shiftyjelly.pocketcasts.compose.bars.NavigationButton
 import au.com.shiftyjelly.pocketcasts.compose.bars.NavigationIconButton
@@ -83,4 +84,16 @@ fun GiveRatingNotAllowedToRate(
             ),
         )
     }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun GiveRatingNotAllowedToRatePreview() {
+    val state = GiveRatingViewModel.State.NotAllowedToRate(
+        podcastUuid = "sample-podcast-uuid",
+    )
+    GiveRatingNotAllowedToRate(
+        state = state,
+        onDismiss = {},
+    )
 }

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/components/ratings/GiveRatingNotAllowedToRateScreen.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/components/ratings/GiveRatingNotAllowedToRateScreen.kt
@@ -1,5 +1,6 @@
 package au.com.shiftyjelly.pocketcasts.podcasts.view.components.ratings
 
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
@@ -32,56 +33,63 @@ fun GiveRatingNotAllowedToRate(
     state: GiveRatingViewModel.State.NotAllowedToRate,
     onDismiss: () -> Unit,
 ) {
-    Column(
-        horizontalAlignment = Alignment.CenterHorizontally,
-        modifier = Modifier
-            .fillMaxSize()
-            .verticalScroll(rememberScrollState()),
+    Box(
+        modifier = Modifier.fillMaxSize(),
     ) {
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            modifier = Modifier
+                .fillMaxSize()
+                .verticalScroll(rememberScrollState())
+                .padding(top = 56.dp),
+        ) {
+            Spacer(Modifier.weight(1f))
+
+            Column(
+                horizontalAlignment = Alignment.CenterHorizontally,
+            ) {
+                PodcastCover(
+                    uuid = state.podcastUuid,
+                    coverWidth = 164.dp,
+                )
+
+                Spacer(Modifier.height(40.dp))
+
+                TextH30(
+                    text = stringResource(R.string.not_allowed_to_rate_title),
+                    fontWeight = FontWeight.W600,
+                    textAlign = TextAlign.Center,
+                    modifier = Modifier.padding(horizontal = 16.dp),
+                )
+
+                Spacer(Modifier.height(32.dp))
+
+                TextP40(
+                    text = stringResource(R.string.not_allowed_to_rate_description),
+                    textAlign = TextAlign.Center,
+                    fontWeight = FontWeight.W400,
+                    modifier = Modifier.padding(horizontal = 16.dp),
+                )
+            }
+
+            Spacer(Modifier.weight(1f))
+
+            RowButton(
+                text = stringResource(R.string.done),
+                onClick = onDismiss,
+                colors = ButtonDefaults.buttonColors(
+                    backgroundColor = MaterialTheme.theme.colors.primaryText01,
+                ),
+            )
+        }
+
         NavigationIconButton(
             iconColor = MaterialTheme.theme.colors.primaryText01,
             navigationButton = NavigationButton.Close,
             onNavigationClick = onDismiss,
-            modifier = Modifier.align(Alignment.Start),
-        )
-
-        Spacer(Modifier.weight(1f))
-
-        Column(
-            horizontalAlignment = Alignment.CenterHorizontally,
-        ) {
-            PodcastCover(
-                uuid = state.podcastUuid,
-                coverWidth = 164.dp,
-            )
-
-            Spacer(Modifier.height(40.dp))
-
-            TextH30(
-                text = stringResource(R.string.not_allowed_to_rate_title),
-                fontWeight = FontWeight.W600,
-                textAlign = TextAlign.Center,
-                modifier = Modifier.padding(horizontal = 16.dp),
-            )
-
-            Spacer(Modifier.height(32.dp))
-
-            TextP40(
-                text = stringResource(R.string.not_allowed_to_rate_description),
-                textAlign = TextAlign.Center,
-                fontWeight = FontWeight.W400,
-                modifier = Modifier.padding(horizontal = 16.dp),
-            )
-        }
-
-        Spacer(Modifier.weight(1f))
-
-        RowButton(
-            text = stringResource(R.string.done),
-            onClick = onDismiss,
-            colors = ButtonDefaults.buttonColors(
-                backgroundColor = MaterialTheme.theme.colors.primaryText01,
-            ),
+            modifier = Modifier
+                .align(Alignment.TopStart)
+                .padding(16.dp),
         )
     }
 }

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/components/ratings/GiveRatingNotAllowedToRateScreen.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/components/ratings/GiveRatingNotAllowedToRateScreen.kt
@@ -78,7 +78,7 @@ fun GiveRatingNotAllowedToRate(
         RowButton(
             text = stringResource(R.string.done),
             onClick = onDismiss,
-            colors = ButtonDefaults.outlinedButtonColors(
+            colors = ButtonDefaults.buttonColors(
                 backgroundColor = MaterialTheme.theme.colors.primaryText01,
             ),
         )

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/components/ratings/GiveRatingScreen.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/components/ratings/GiveRatingScreen.kt
@@ -79,7 +79,7 @@ fun GiveRatingScreen(
         RowButton(
             text = stringResource(LR.string.submit),
             onClick = submitRating,
-            colors = ButtonDefaults.outlinedButtonColors(
+            colors = ButtonDefaults.buttonColors(
                 backgroundColor = MaterialTheme.theme.colors.primaryText01,
             ),
         )

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/components/ratings/GiveRatingScreen.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/components/ratings/GiveRatingScreen.kt
@@ -1,5 +1,6 @@
 package au.com.shiftyjelly.pocketcasts.podcasts.view.components.ratings
 
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
@@ -32,56 +33,63 @@ fun GiveRatingScreen(
     submitRating: () -> Unit,
     onDismiss: () -> Unit,
 ) {
-    Column(
-        horizontalAlignment = Alignment.CenterHorizontally,
-        modifier = Modifier
-            .fillMaxSize()
-            .verticalScroll(rememberScrollState()),
+    Box(
+        modifier = Modifier.fillMaxSize(),
     ) {
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            modifier = Modifier
+                .fillMaxSize()
+                .verticalScroll(rememberScrollState())
+                .padding(top = 56.dp),
+        ) {
+            Spacer(Modifier.weight(1f))
+
+            Column(
+                horizontalAlignment = Alignment.CenterHorizontally,
+            ) {
+                PodcastCover(
+                    uuid = state.podcastUuid,
+                    coverWidth = 164.dp,
+                )
+
+                Spacer(Modifier.height(40.dp))
+
+                TextH30(
+                    text = stringResource(LR.string.podcast_rate, state.podcastTitle),
+                    textAlign = TextAlign.Center,
+                    fontWeight = FontWeight.W600,
+                    modifier = Modifier.padding(horizontal = 16.dp),
+                )
+
+                Spacer(Modifier.height(32.dp))
+
+                SwipeableStars(
+                    onStarsChanged = setRating,
+                    modifier = Modifier
+                        .height(48.dp)
+                        .padding(horizontal = 16.dp),
+                )
+            }
+
+            Spacer(Modifier.weight(1f))
+
+            RowButton(
+                text = stringResource(LR.string.submit),
+                onClick = submitRating,
+                colors = ButtonDefaults.buttonColors(
+                    backgroundColor = MaterialTheme.theme.colors.primaryText01,
+                ),
+            )
+        }
+
         NavigationIconButton(
             iconColor = MaterialTheme.theme.colors.primaryText01,
             navigationButton = NavigationButton.Close,
             onNavigationClick = onDismiss,
-            modifier = Modifier.align(Alignment.Start),
-        )
-
-        Spacer(Modifier.weight(1f))
-
-        Column(
-            horizontalAlignment = Alignment.CenterHorizontally,
-        ) {
-            PodcastCover(
-                uuid = state.podcastUuid,
-                coverWidth = 164.dp,
-            )
-
-            Spacer(Modifier.height(40.dp))
-
-            TextH30(
-                text = stringResource(LR.string.podcast_rate, state.podcastTitle),
-                textAlign = TextAlign.Center,
-                fontWeight = FontWeight.W600,
-                modifier = Modifier.padding(horizontal = 16.dp),
-            )
-
-            Spacer(Modifier.height(32.dp))
-
-            SwipeableStars(
-                onStarsChanged = setRating,
-                modifier = Modifier
-                    .height(48.dp)
-                    .padding(horizontal = 16.dp),
-            )
-        }
-
-        Spacer(Modifier.weight(1f))
-
-        RowButton(
-            text = stringResource(LR.string.submit),
-            onClick = submitRating,
-            colors = ButtonDefaults.buttonColors(
-                backgroundColor = MaterialTheme.theme.colors.primaryText01,
-            ),
+            modifier = Modifier
+                .align(Alignment.TopStart)
+                .padding(16.dp),
         )
     }
 }

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/components/ratings/GiveRatingScreen.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/components/ratings/GiveRatingScreen.kt
@@ -1,5 +1,6 @@
 package au.com.shiftyjelly.pocketcasts.podcasts.view.components.ratings
 
+import android.content.res.Configuration
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
@@ -13,6 +14,7 @@ import androidx.compose.material.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
@@ -33,6 +35,9 @@ fun GiveRatingScreen(
     submitRating: () -> Unit,
     onDismiss: () -> Unit,
 ) {
+    val configuration = LocalConfiguration.current
+    val isLandscape = configuration.orientation == Configuration.ORIENTATION_LANDSCAPE
+
     Box(
         modifier = Modifier.fillMaxSize(),
     ) {
@@ -48,10 +53,12 @@ fun GiveRatingScreen(
             Column(
                 horizontalAlignment = Alignment.CenterHorizontally,
             ) {
-                PodcastCover(
-                    uuid = state.podcastUuid,
-                    coverWidth = 164.dp,
-                )
+                if (!isLandscape) {
+                    PodcastCover(
+                        uuid = state.podcastUuid,
+                        coverWidth = 164.dp,
+                    )
+                }
 
                 Spacer(Modifier.height(40.dp))
 


### PR DESCRIPTION
## Description
- This addresses all feedbacks given to https://github.com/Automattic/pocket-casts-android/pull/2438
- Adds Jetpack Compose preview
- Fixes scroll to top
- Changed from `outlinedButtonColors ` to `buttonColors `


## Testing Instructions
See: https://github.com/Automattic/pocket-casts-android/pull/2438

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
