### PR TITLE
Remove on-the-fly caching

### DIFF
--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/ExoPlayerHelper.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/ExoPlayerHelper.kt
@@ -41,14 +41,10 @@ class ExoPlayerHelper @Inject constructor(
     fun getSimpleCache(): SimpleCache? {
         if (
             simpleCache == null &&
-            (FeatureFlag.isEnabled(Feature.CACHE_PLAYING_EPISODE) || FeatureFlag.isEnabled(Feature.CACHE_ENTIRE_PLAYING_EPISODE))
+            FeatureFlag.isEnabled(Feature.CACHE_ENTIRE_PLAYING_EPISODE)
         ) {
             val cacheDir = File(context.cacheDir, CACHE_DIR_NAME)
-            val cacheSizeInBytes = if (settings.cacheEntirePlayingEpisode.value) {
-                settings.getExoPlayerCacheEntirePlayingEpisodeSizeInMB()
-            } else {
-                settings.getExoPlayerCacheSizeInMB()
-            } * 1024 * 1024L
+            val cacheSizeInBytes = settings.getExoPlayerCacheEntirePlayingEpisodeSizeInMB() * 1024 * 1024L
             simpleCache = try {
                 if (BuildConfig.DEBUG) Timber.d("ExoPlayer cache initialized")
                 SimpleCache(

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/SimplePlayer.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/SimplePlayer.kt
@@ -283,16 +283,17 @@ class SimplePlayer(
         } ?: return
 
         val sourceFactory = exoPlayerHelper.getSimpleCache()?.let { cache ->
-            if (location is EpisodeLocation.Stream && !isDownloading) {
+            if (location is EpisodeLocation.Stream &&
+                !isDownloading &&
+                settings.cacheEntirePlayingEpisode.value
+            ) {
                 val cacheDataSourceFactory = CacheDataSource.Factory()
                     .setUpstreamDataSourceFactory(httpDataSourceFactory)
                     .setFlags(CacheDataSource.FLAG_IGNORE_CACHE_ON_ERROR)
                     .setCache(cache)
+                    .setCacheWriteDataSinkFactory(null) // Disable on-the-fly caching
 
-                if (settings.cacheEntirePlayingEpisode.value) {
-                    cacheDataSourceFactory.setCacheWriteDataSinkFactory(null) // Disable on-the-fly caching
-                    CacheWorker.startCachingEntireEpisode(context, location.uri, episodeUuid)
-                }
+                CacheWorker.startCachingEntireEpisode(context, location.uri, episodeUuid)
 
                 cacheDataSourceFactory
             } else {

--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/Feature.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/Feature.kt
@@ -67,14 +67,6 @@ enum class Feature(
         hasFirebaseRemoteFlag = true,
         hasDevToggle = true,
     ),
-    CACHE_PLAYING_EPISODE( // Used for on-the-fly caching
-        key = "cache_playing_episode_enabled",
-        title = "Cache playing episode",
-        defaultValue = true,
-        tier = FeatureTier.Free,
-        hasFirebaseRemoteFlag = true,
-        hasDevToggle = true,
-    ),
     CATEGORIES_REDESIGN(
         key = "CATEGORIES_REDESIGN",
         title = "Podcasts by category shown in discover view",

--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/providers/FirebaseRemoteFeatureProvider.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/providers/FirebaseRemoteFeatureProvider.kt
@@ -24,10 +24,6 @@ class FirebaseRemoteFeatureProvider @Inject constructor(
                 .getString(FirebaseConfig.SLUMBER_STUDIOS_YEARLY_PROMO_CODE)
                 .isNotEmpty()
 
-        Feature.CACHE_PLAYING_EPISODE ->
-            firebaseRemoteConfig
-                .getLong(FirebaseConfig.EXOPLAYER_CACHE_SIZE_IN_MB) > 0
-
         Feature.CACHE_ENTIRE_PLAYING_EPISODE ->
             firebaseRemoteConfig
                 .getLong(FirebaseConfig.EXOPLAYER_CACHE_ENTIRE_PLAYING_EPISODE_SIZE_IN_MB) > 0


### PR DESCRIPTION
## Description
This removes intermediate (on-the-fly) caching feature.  It wasn't sufficient to disable it remotely if the advanced setting for caching playing episode was toggled off. In this scenario, intermediate caching would still be active with cache size zero.

> [!WARNING]
> Targets 7.67

## Testing Instructions
Caching entire playing episode should still work as before (https://github.com/Automattic/pocket-casts-android/pull/2380). 

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
