### PR TITLE
Refactor bookmark delete deep linking

### DIFF
--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/deeplink/DeepLinkFactoryTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/deeplink/DeepLinkFactoryTest.kt
@@ -70,4 +70,25 @@ class DeepLinkFactoryTest {
 
         assertNull(deepLink)
     }
+
+    @Test
+    fun deleteBookmark() {
+        val intent = Intent()
+            .setAction("INTENT_OPEN_APP_DELETE_BOOKMARK")
+            .putExtra("bookmark_uuid", "bookmark-id")
+
+        val deepLink = factory.create(intent)
+
+        assertEquals(DeleteBookmarkDeepLink("bookmark-id"), deepLink)
+    }
+
+    @Test
+    fun deleteBookmarkWithoutBookmarkUuid() {
+        val intent = Intent()
+            .setAction("INTENT_OPEN_APP_DELETE_BOOKMARK")
+
+        val deepLink = factory.create(intent)
+
+        assertNull(deepLink)
+    }
 }

--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/deeplink/DeleteookmarkDeepLinkTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/deeplink/DeleteookmarkDeepLinkTest.kt
@@ -1,0 +1,21 @@
+package au.com.shiftyjelly.pocketcasts.deeplink
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class DeleteookmarkDeepLinkTest {
+    private val context = InstrumentationRegistry.getInstrumentation().context
+
+    @Test
+    fun createShowBookmarkIntent() {
+        val intent = DeleteBookmarkDeepLink("bookmark-id").toIntent(context)
+
+        assertEquals("INTENT_OPEN_APP_DELETE_BOOKMARK", intent.action)
+        assertEquals("bookmark-id", intent.getStringExtra("bookmark_uuid"))
+        assertEquals("bookmark_uuid_bookmark-id", intent.getStringExtra("NOTIFICATION_TAG"))
+    }
+}

--- a/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
+++ b/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
@@ -52,6 +52,7 @@ import au.com.shiftyjelly.pocketcasts.databinding.ActivityMainBinding
 import au.com.shiftyjelly.pocketcasts.deeplink.AddBookmarkDeepLink
 import au.com.shiftyjelly.pocketcasts.deeplink.ChangeBookmarkTitleDeepLink
 import au.com.shiftyjelly.pocketcasts.deeplink.DeepLinkFactory
+import au.com.shiftyjelly.pocketcasts.deeplink.DeleteBookmarkDeepLink
 import au.com.shiftyjelly.pocketcasts.deeplink.DownloadsDeepLink
 import au.com.shiftyjelly.pocketcasts.deeplink.ShowBookmarkDeepLink
 import au.com.shiftyjelly.pocketcasts.discover.view.DiscoverFragment
@@ -80,7 +81,6 @@ import au.com.shiftyjelly.pocketcasts.podcasts.view.podcast.PodcastFragment
 import au.com.shiftyjelly.pocketcasts.podcasts.view.podcasts.PodcastsFragment
 import au.com.shiftyjelly.pocketcasts.podcasts.view.share.ShareListIncomingFragment
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
-import au.com.shiftyjelly.pocketcasts.preferences.Settings.Companion.BOOKMARK_UUID
 import au.com.shiftyjelly.pocketcasts.preferences.Settings.Companion.EPISODE_UUID
 import au.com.shiftyjelly.pocketcasts.preferences.Settings.Companion.PODCAST_UUID
 import au.com.shiftyjelly.pocketcasts.preferences.Settings.Companion.SOURCE_VIEW
@@ -1252,12 +1252,11 @@ class MainActivity :
                     is ShowBookmarkDeepLink -> {
                         viewModel.viewBookmark(deepLink.bookmarkUuid)
                     }
+                    is DeleteBookmarkDeepLink -> {
+                        viewModel.deleteBookmark(deepLink.bookmarkUuid)
+                        notificationHelper.removeNotification(intent.extras, Settings.NotificationId.BOOKMARK.value)
+                    }
                 }
-            } else if (action == Settings.INTENT_OPEN_APP_DELETE_BOOKMARK) {
-                intent.getStringExtra(BOOKMARK_UUID)?.let {
-                    viewModel.deleteBookmark(it)
-                }
-                notificationHelper.removeNotification(intent.extras, Settings.NotificationId.BOOKMARK.value)
             } else if (action == Settings.INTENT_OPEN_APP_PODCAST_UUID) {
                 intent.getStringExtra(PODCAST_UUID)?.let {
                     openPodcastPage(it, intent.getStringExtra(SOURCE_VIEW))

--- a/modules/services/deeplink/src/main/kotlin/au/com/shiftyjelly/pocketcasts/deeplink/DeepLink.kt
+++ b/modules/services/deeplink/src/main/kotlin/au/com/shiftyjelly/pocketcasts/deeplink/DeepLink.kt
@@ -5,6 +5,7 @@ import android.content.Intent
 import au.com.shiftyjelly.pocketcasts.deeplink.DeepLink.Companion.ACTION_OPEN_ADD_BOOKMARK
 import au.com.shiftyjelly.pocketcasts.deeplink.DeepLink.Companion.ACTION_OPEN_BOOKMARK
 import au.com.shiftyjelly.pocketcasts.deeplink.DeepLink.Companion.ACTION_OPEN_CHANGE_BOOKMARK_TITLE
+import au.com.shiftyjelly.pocketcasts.deeplink.DeepLink.Companion.ACTION_OPEN_DELETE_BOOKMARK
 import au.com.shiftyjelly.pocketcasts.deeplink.DeepLink.Companion.ACTION_OPEN_DOWNLOADS
 import au.com.shiftyjelly.pocketcasts.deeplink.DeepLink.Companion.EXTRA_BOOKMARK_UUID
 import au.com.shiftyjelly.pocketcasts.deeplink.DeepLink.Companion.EXTRA_NOTIFICATION_TAG
@@ -17,6 +18,7 @@ sealed interface DeepLink {
         const val ACTION_OPEN_ADD_BOOKMARK = "INTENT_OPEN_APP_ADD_BOOKMARK"
         const val ACTION_OPEN_CHANGE_BOOKMARK_TITLE = "INTENT_OPEN_APP_CHANGE_BOOKMARK_TITLE"
         const val ACTION_OPEN_BOOKMARK = "INTENT_OPEN_APP_VIEW_BOOKMARKS"
+        const val ACTION_OPEN_DELETE_BOOKMARK = "INTENT_OPEN_APP_DELETE_BOOKMARK"
 
         const val EXTRA_BOOKMARK_UUID = "bookmark_uuid"
         const val EXTRA_NOTIFICATION_TAG = "NOTIFICATION_TAG"
@@ -48,6 +50,15 @@ data class ShowBookmarkDeepLink(
 ) : DeepLink {
     override fun toIntent(context: Context) = context.launcherIntent
         .setAction(ACTION_OPEN_BOOKMARK)
+        .putExtra(EXTRA_BOOKMARK_UUID, bookmarkUuid)
+        .putExtra(EXTRA_NOTIFICATION_TAG, "${EXTRA_BOOKMARK_UUID}_$bookmarkUuid")
+}
+
+data class DeleteBookmarkDeepLink(
+    val bookmarkUuid: String,
+) : DeepLink {
+    override fun toIntent(context: Context) = context.launcherIntent
+        .setAction(ACTION_OPEN_DELETE_BOOKMARK)
         .putExtra(EXTRA_BOOKMARK_UUID, bookmarkUuid)
         .putExtra(EXTRA_NOTIFICATION_TAG, "${EXTRA_BOOKMARK_UUID}_$bookmarkUuid")
 }

--- a/modules/services/deeplink/src/main/kotlin/au/com/shiftyjelly/pocketcasts/deeplink/DeepLinkFactory.kt
+++ b/modules/services/deeplink/src/main/kotlin/au/com/shiftyjelly/pocketcasts/deeplink/DeepLinkFactory.kt
@@ -4,6 +4,7 @@ import android.content.Intent
 import au.com.shiftyjelly.pocketcasts.deeplink.DeepLink.Companion.ACTION_OPEN_ADD_BOOKMARK
 import au.com.shiftyjelly.pocketcasts.deeplink.DeepLink.Companion.ACTION_OPEN_BOOKMARK
 import au.com.shiftyjelly.pocketcasts.deeplink.DeepLink.Companion.ACTION_OPEN_CHANGE_BOOKMARK_TITLE
+import au.com.shiftyjelly.pocketcasts.deeplink.DeepLink.Companion.ACTION_OPEN_DELETE_BOOKMARK
 import au.com.shiftyjelly.pocketcasts.deeplink.DeepLink.Companion.ACTION_OPEN_DOWNLOADS
 import au.com.shiftyjelly.pocketcasts.deeplink.DeepLink.Companion.EXTRA_BOOKMARK_UUID
 import timber.log.Timber
@@ -14,6 +15,7 @@ class DeepLinkFactory {
         AddBookmarkAdapter(),
         ChangeBookmarkTitleAdapter(),
         ShowBookmarkAdapter(),
+        DeleteBookmarkAdapter(),
     )
 
     fun create(intent: Intent): DeepLink? {
@@ -72,6 +74,14 @@ private class ChangeBookmarkTitleAdapter : DeepLinkAdapter {
 private class ShowBookmarkAdapter : DeepLinkAdapter {
     override fun create(intent: Intent) = if (intent.action == ACTION_OPEN_BOOKMARK) {
         intent.getStringExtra(EXTRA_BOOKMARK_UUID)?.let(::ShowBookmarkDeepLink)
+    } else {
+        null
+    }
+}
+
+private class DeleteBookmarkAdapter : DeepLinkAdapter {
+    override fun create(intent: Intent) = if (intent.action == ACTION_OPEN_DELETE_BOOKMARK) {
+        intent.getStringExtra(EXTRA_BOOKMARK_UUID)?.let(::DeleteBookmarkDeepLink)
     } else {
         null
     }

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
@@ -107,7 +107,6 @@ interface Settings {
         const val INTENT_OPEN_APP_NEW_EPISODES = "INTENT_OPEN_APP_NEW_EPISODES"
         const val INTENT_OPEN_APP_PODCAST_UUID = "INTENT_OPEN_APP_PODCAST_UUID"
         const val INTENT_OPEN_APP_EPISODE_UUID = "INTENT_OPEN_APP_EPISODE_UUID"
-        const val INTENT_OPEN_APP_DELETE_BOOKMARK = "INTENT_OPEN_APP_DELETE_BOOKMARK"
         const val INTENT_LINK_CLOUD_FILES = "pktc://cloudfiles"
         const val INTENT_LINK_UPGRADE = "pktc://upgrade"
         const val INTENT_LINK_PROMO_CODE = "pktc://redeem/promo/"
@@ -117,8 +116,6 @@ interface Settings {
         const val NOTIFICATIONS_DISABLED_MESSAGE_SHOWN = "notificationsDisabledMessageShown"
 
         const val APP_REVIEW_REQUESTED_DATES = "in_app_review_requested_dates"
-
-        const val BOOKMARK_UUID = "bookmark_uuid"
 
         const val PODCAST_UUID = "podcast_uuid"
 

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/bookmark/BookmarkHelper.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/bookmark/BookmarkHelper.kt
@@ -10,12 +10,11 @@ import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationManagerCompat
 import au.com.shiftyjelly.pocketcasts.deeplink.AddBookmarkDeepLink
 import au.com.shiftyjelly.pocketcasts.deeplink.ChangeBookmarkTitleDeepLink
+import au.com.shiftyjelly.pocketcasts.deeplink.DeleteBookmarkDeepLink
 import au.com.shiftyjelly.pocketcasts.deeplink.ShowBookmarkDeepLink
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
-import au.com.shiftyjelly.pocketcasts.preferences.Settings.Companion.INTENT_OPEN_APP_DELETE_BOOKMARK
 import au.com.shiftyjelly.pocketcasts.repositories.R
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
-import au.com.shiftyjelly.pocketcasts.repositories.sync.NotificationBroadcastReceiver.Companion.INTENT_EXTRA_NOTIFICATION_TAG
 import au.com.shiftyjelly.pocketcasts.utils.AppPlatform
 import au.com.shiftyjelly.pocketcasts.utils.Util
 import au.com.shiftyjelly.pocketcasts.utils.extensions.isAppForeground
@@ -88,7 +87,7 @@ private fun buildAndShowNotification(
     val deleteAction = NotificationCompat.Action(
         R.drawable.ic_delete_black,
         context.getString(LR.string.bookmark_notification_action_delete_title),
-        buildPendingIntent(context, INTENT_OPEN_APP_DELETE_BOOKMARK, bookmarkUuid),
+        buildPendingIntent(context, DeleteBookmarkDeepLink(bookmarkUuid).toIntent(context)),
     )
 
     val notification = NotificationCompat.Builder(
@@ -115,22 +114,6 @@ private fun buildAndShowNotification(
     } else {
         LogBuffer.e(LogBuffer.TAG_BACKGROUND_TASKS, "Post notification permission not granted.")
     }
-}
-
-private fun buildPendingIntent(
-    context: Context,
-    actionKey: String,
-    bookmarkUuid: String,
-): PendingIntent {
-    val appIntent = context.packageManager
-        .getLaunchIntentForPackage(context.packageName)
-        ?.apply {
-            action = actionKey
-            putExtra(Settings.BOOKMARK_UUID, bookmarkUuid)
-            putExtra(INTENT_EXTRA_NOTIFICATION_TAG, "${Settings.BOOKMARK_UUID}_$bookmarkUuid")
-        }
-
-    return buildPendingIntent(context, appIntent)
 }
 
 private fun buildPendingIntent(


### PR DESCRIPTION
## Description

> [!note]
> This will be a series of PRs that move deep linking to a separate module that can be tested. The goal is to address #2405 but I don't want to do it blindly without having tests in order to not introduce regressions to deep linking.

This PR migrates deleting bookmark deep linking to the new module.

## Testing Instructions

You can test it by assigning `Add bookmark` action to your headphones, and then triggering it while the app is in background and choosing `Delete` option. If you can't test it this way do the following:

1. Create a bookmark.
2. Using app manger find an UUID of a bookmark.
3. Execute `adb shell am start -n au.com.shiftyjelly.pocketcasts.debug/au.com.shiftyjelly.pocketcasts.ui.MainActivity  -a INTENT_OPEN_APP_DELETE_BOOKMARK -e bookmark_uuid <BOOKMARK_UUID>`.
4. The bookmark should be deleted.

## Checklist
- [x] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [x] ~Any jetpack compose components I added or changed are covered by compose previews~
- [x] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~