### PR TITLE
Refactor open podcast deep linking

### DIFF
--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/deeplink/DeepLinkFactoryTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/deeplink/DeepLinkFactoryTest.kt
@@ -91,4 +91,37 @@ class DeepLinkFactoryTest {
 
         assertNull(deepLink)
     }
+
+    @Test
+    fun showPodcast() {
+        val intent = Intent()
+            .setAction("INTENT_OPEN_APP_PODCAST_UUID")
+            .putExtra("podcast_uuid", "Podcast ID")
+            .putExtra("source_view", "Source View")
+
+        val deepLink = factory.create(intent)
+
+        assertEquals(ShowPodcastDeepLink("Podcast ID", "Source View"), deepLink)
+    }
+
+    @Test
+    fun showPodcastWithoutPodcastId() {
+        val intent = Intent()
+            .setAction("INTENT_OPEN_APP_PODCAST_UUID")
+
+        val deepLink = factory.create(intent)
+
+        assertNull(deepLink)
+    }
+
+    @Test
+    fun showPodcastWithoutSourceView() {
+        val intent = Intent()
+            .setAction("INTENT_OPEN_APP_PODCAST_UUID")
+            .putExtra("podcast_uuid", "Podcast ID")
+
+        val deepLink = factory.create(intent)
+
+        assertEquals(ShowPodcastDeepLink("Podcast ID", sourceView = null), deepLink)
+    }
 }

--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/deeplink/ShowPodcastDeepLinkTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/deeplink/ShowPodcastDeepLinkTest.kt
@@ -1,0 +1,21 @@
+package au.com.shiftyjelly.pocketcasts.deeplink
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class ShowPodcastDeepLinkTest {
+    private val context = InstrumentationRegistry.getInstrumentation().context
+
+    @Test
+    fun createShowPodcastIntent() {
+        val intent = ShowPodcastDeepLink("Podcast ID", "Source View").toIntent(context)
+
+        assertEquals("INTENT_OPEN_APP_PODCAST_UUID", intent.action)
+        assertEquals("Podcast ID", intent.getStringExtra("podcast_uuid"))
+        assertEquals("Source View", intent.getStringExtra("source_view"))
+    }
+}

--- a/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
+++ b/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
@@ -55,6 +55,7 @@ import au.com.shiftyjelly.pocketcasts.deeplink.DeepLinkFactory
 import au.com.shiftyjelly.pocketcasts.deeplink.DeleteBookmarkDeepLink
 import au.com.shiftyjelly.pocketcasts.deeplink.DownloadsDeepLink
 import au.com.shiftyjelly.pocketcasts.deeplink.ShowBookmarkDeepLink
+import au.com.shiftyjelly.pocketcasts.deeplink.ShowPodcastDeepLink
 import au.com.shiftyjelly.pocketcasts.discover.view.DiscoverFragment
 import au.com.shiftyjelly.pocketcasts.endofyear.StoriesFragment
 import au.com.shiftyjelly.pocketcasts.endofyear.StoriesFragment.StoriesSource
@@ -1256,10 +1257,9 @@ class MainActivity :
                         viewModel.deleteBookmark(deepLink.bookmarkUuid)
                         notificationHelper.removeNotification(intent.extras, Settings.NotificationId.BOOKMARK.value)
                     }
-                }
-            } else if (action == Settings.INTENT_OPEN_APP_PODCAST_UUID) {
-                intent.getStringExtra(PODCAST_UUID)?.let {
-                    openPodcastPage(it, intent.getStringExtra(SOURCE_VIEW))
+                    is ShowPodcastDeepLink -> {
+                        openPodcastPage(deepLink.podcastUuid, deepLink.sourceView)
+                    }
                 }
             } else if (action == Settings.INTENT_OPEN_APP_EPISODE_UUID) {
                 intent.getStringExtra(EPISODE_UUID)?.let {

--- a/modules/features/nova/build.gradle.kts
+++ b/modules/features/nova/build.gradle.kts
@@ -21,6 +21,7 @@ dependencies {
     implementation("io.branch.engage:conduit-source:0.2.3-pocketcasts.9@aar") { isTransitive = true }
 
     implementation(project(":modules:services:analytics"))
+    implementation(project(":modules:services:deeplink"))
     implementation(project(":modules:services:localization"))
     implementation(project(":modules:services:model"))
     implementation(project(":modules:services:repositories"))

--- a/modules/features/nova/src/main/kotlin/au/com/shiftyjelly/pocketcasts/nova/CatalogFactory.kt
+++ b/modules/features/nova/src/main/kotlin/au/com/shiftyjelly/pocketcasts/nova/CatalogFactory.kt
@@ -2,6 +2,7 @@ package au.com.shiftyjelly.pocketcasts.nova
 
 import android.content.Context
 import au.com.shiftyjelly.pocketcasts.analytics.SourceView
+import au.com.shiftyjelly.pocketcasts.deeplink.ShowPodcastDeepLink
 import au.com.shiftyjelly.pocketcasts.models.entity.NovaLauncherInProgressEpisode
 import au.com.shiftyjelly.pocketcasts.models.entity.NovaLauncherNewEpisode
 import au.com.shiftyjelly.pocketcasts.models.entity.NovaLauncherQueueEpisode
@@ -159,10 +160,10 @@ internal class CatalogFactory(
 
     private fun podcastCover(podcastId: String) = "${Settings.SERVER_STATIC_URL}/discover/images/webp/960/$podcastId.webp"
 
-    private fun openPodcastIntent(podcastId: String, sourceView: SourceView) = context.launcherIntent
-        .setAction(Settings.INTENT_OPEN_APP_PODCAST_UUID)
-        .putExtra(Settings.PODCAST_UUID, podcastId)
-        .putExtra(Settings.SOURCE_VIEW, sourceView.analyticsValue)
+    private fun openPodcastIntent(podcastId: String, sourceView: SourceView) = ShowPodcastDeepLink(
+        podcastUuid = podcastId,
+        sourceView = sourceView.analyticsValue,
+    ).toIntent(context)
 
     private fun openPodcastEpisodeIntent(episodeId: String, podcastId: String, source: EpisodeViewSource) = context.launcherIntent
         .setAction(Settings.INTENT_OPEN_APP_EPISODE_UUID)

--- a/modules/services/deeplink/src/main/kotlin/au/com/shiftyjelly/pocketcasts/deeplink/DeepLink.kt
+++ b/modules/services/deeplink/src/main/kotlin/au/com/shiftyjelly/pocketcasts/deeplink/DeepLink.kt
@@ -7,8 +7,11 @@ import au.com.shiftyjelly.pocketcasts.deeplink.DeepLink.Companion.ACTION_OPEN_BO
 import au.com.shiftyjelly.pocketcasts.deeplink.DeepLink.Companion.ACTION_OPEN_CHANGE_BOOKMARK_TITLE
 import au.com.shiftyjelly.pocketcasts.deeplink.DeepLink.Companion.ACTION_OPEN_DELETE_BOOKMARK
 import au.com.shiftyjelly.pocketcasts.deeplink.DeepLink.Companion.ACTION_OPEN_DOWNLOADS
+import au.com.shiftyjelly.pocketcasts.deeplink.DeepLink.Companion.ACTION_OPEN_PODCAST
 import au.com.shiftyjelly.pocketcasts.deeplink.DeepLink.Companion.EXTRA_BOOKMARK_UUID
 import au.com.shiftyjelly.pocketcasts.deeplink.DeepLink.Companion.EXTRA_NOTIFICATION_TAG
+import au.com.shiftyjelly.pocketcasts.deeplink.DeepLink.Companion.EXTRA_PODCAST_UUID
+import au.com.shiftyjelly.pocketcasts.deeplink.DeepLink.Companion.EXTRA_SOURCE_VIEW
 
 sealed interface DeepLink {
     fun toIntent(context: Context): Intent
@@ -19,8 +22,11 @@ sealed interface DeepLink {
         const val ACTION_OPEN_CHANGE_BOOKMARK_TITLE = "INTENT_OPEN_APP_CHANGE_BOOKMARK_TITLE"
         const val ACTION_OPEN_BOOKMARK = "INTENT_OPEN_APP_VIEW_BOOKMARKS"
         const val ACTION_OPEN_DELETE_BOOKMARK = "INTENT_OPEN_APP_DELETE_BOOKMARK"
+        const val ACTION_OPEN_PODCAST = "INTENT_OPEN_APP_PODCAST_UUID"
 
         const val EXTRA_BOOKMARK_UUID = "bookmark_uuid"
+        const val EXTRA_PODCAST_UUID = "podcast_uuid"
+        const val EXTRA_SOURCE_VIEW = "source_view"
         const val EXTRA_NOTIFICATION_TAG = "NOTIFICATION_TAG"
     }
 }
@@ -61,6 +67,16 @@ data class DeleteBookmarkDeepLink(
         .setAction(ACTION_OPEN_DELETE_BOOKMARK)
         .putExtra(EXTRA_BOOKMARK_UUID, bookmarkUuid)
         .putExtra(EXTRA_NOTIFICATION_TAG, "${EXTRA_BOOKMARK_UUID}_$bookmarkUuid")
+}
+
+data class ShowPodcastDeepLink(
+    val podcastUuid: String,
+    val sourceView: String?,
+) : DeepLink {
+    override fun toIntent(context: Context) = context.launcherIntent
+        .setAction(ACTION_OPEN_PODCAST)
+        .putExtra(EXTRA_PODCAST_UUID, podcastUuid)
+        .putExtra(EXTRA_SOURCE_VIEW, sourceView)
 }
 
 private val Context.launcherIntent get() = requireNotNull(packageManager.getLaunchIntentForPackage(packageName)) {

--- a/modules/services/deeplink/src/main/kotlin/au/com/shiftyjelly/pocketcasts/deeplink/DeepLinkFactory.kt
+++ b/modules/services/deeplink/src/main/kotlin/au/com/shiftyjelly/pocketcasts/deeplink/DeepLinkFactory.kt
@@ -6,7 +6,10 @@ import au.com.shiftyjelly.pocketcasts.deeplink.DeepLink.Companion.ACTION_OPEN_BO
 import au.com.shiftyjelly.pocketcasts.deeplink.DeepLink.Companion.ACTION_OPEN_CHANGE_BOOKMARK_TITLE
 import au.com.shiftyjelly.pocketcasts.deeplink.DeepLink.Companion.ACTION_OPEN_DELETE_BOOKMARK
 import au.com.shiftyjelly.pocketcasts.deeplink.DeepLink.Companion.ACTION_OPEN_DOWNLOADS
+import au.com.shiftyjelly.pocketcasts.deeplink.DeepLink.Companion.ACTION_OPEN_PODCAST
 import au.com.shiftyjelly.pocketcasts.deeplink.DeepLink.Companion.EXTRA_BOOKMARK_UUID
+import au.com.shiftyjelly.pocketcasts.deeplink.DeepLink.Companion.EXTRA_PODCAST_UUID
+import au.com.shiftyjelly.pocketcasts.deeplink.DeepLink.Companion.EXTRA_SOURCE_VIEW
 import timber.log.Timber
 
 class DeepLinkFactory {
@@ -16,6 +19,7 @@ class DeepLinkFactory {
         ChangeBookmarkTitleAdapter(),
         ShowBookmarkAdapter(),
         DeleteBookmarkAdapter(),
+        ShowPodcastAdapter(),
     )
 
     fun create(intent: Intent): DeepLink? {
@@ -82,6 +86,19 @@ private class ShowBookmarkAdapter : DeepLinkAdapter {
 private class DeleteBookmarkAdapter : DeepLinkAdapter {
     override fun create(intent: Intent) = if (intent.action == ACTION_OPEN_DELETE_BOOKMARK) {
         intent.getStringExtra(EXTRA_BOOKMARK_UUID)?.let(::DeleteBookmarkDeepLink)
+    } else {
+        null
+    }
+}
+
+private class ShowPodcastAdapter : DeepLinkAdapter {
+    override fun create(intent: Intent) = if (intent.action == ACTION_OPEN_PODCAST) {
+        intent.getStringExtra(EXTRA_PODCAST_UUID)?.let { podcastUuid ->
+            ShowPodcastDeepLink(
+                podcastUuid = podcastUuid,
+                sourceView = intent.getStringExtra(EXTRA_SOURCE_VIEW),
+            )
+        }
     } else {
         null
     }

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
@@ -105,7 +105,6 @@ interface Settings {
         const val AUTO_ARCHIVE_INCLUDE_STARRED = "autoArchiveIncludeStarred"
 
         const val INTENT_OPEN_APP_NEW_EPISODES = "INTENT_OPEN_APP_NEW_EPISODES"
-        const val INTENT_OPEN_APP_PODCAST_UUID = "INTENT_OPEN_APP_PODCAST_UUID"
         const val INTENT_OPEN_APP_EPISODE_UUID = "INTENT_OPEN_APP_EPISODE_UUID"
         const val INTENT_LINK_CLOUD_FILES = "pktc://cloudfiles"
         const val INTENT_LINK_UPGRADE = "pktc://upgrade"


### PR DESCRIPTION
## Description

> [!note]
> This will be a series of PRs that move deep linking to a separate module that can be tested. The goal is to address #2405 but I don't want to do it blindly without having tests in order to not introduce regressions to deep linking.

This PR migrates opening podcast deep linking to the new module.

## Testing Instructions

1. Subscribe to [The Daily](https://pca.st/thedaily).
2. Close the app.
3. Execute `adb shell am start -n au.com.shiftyjelly.pocketcasts.debug/au.com.shiftyjelly.pocketcasts.ui.MainActivity -a INTENT_OPEN_APP_PODCAST_UUID -e podcast_uuid 4eb5b260-c933-0134-10da-25324e2a541d`.
4. The Daily podcast page should open.

## Checklist
- [x] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [x] ~Any jetpack compose components I added or changed are covered by compose previews~
- [x] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~