### PR TITLE
Refactor open episode deep linking

### DIFF
--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/deeplink/DeepLinkFactoryTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/deeplink/DeepLinkFactoryTest.kt
@@ -124,4 +124,67 @@ class DeepLinkFactoryTest {
 
         assertEquals(ShowPodcastDeepLink("Podcast ID", sourceView = null), deepLink)
     }
+
+    @Test
+    fun showEpisode() {
+        val intent = Intent()
+            .setAction("INTENT_OPEN_APP_EPISODE_UUID")
+            .putExtra("episode_uuid", "Episode ID")
+            .putExtra("podcast_uuid", "Podcast ID")
+            .putExtra("source_view", "Source View")
+
+        val deepLink = factory.create(intent)
+
+        assertEquals(ShowEpisodeDeepLink("Episode ID", "Podcast ID", "Source View"), deepLink)
+    }
+
+    // Notifications add numbers to the action to display multiple of them
+    @Test
+    fun showEpisodeWithActionEndingWithNumbers() {
+        val intent = Intent()
+            .setAction("INTENT_OPEN_APP_EPISODE_UUID87123648710")
+            .putExtra("episode_uuid", "Episode ID")
+            .putExtra("podcast_uuid", "Podcast ID")
+            .putExtra("source_view", "Source View")
+
+        val deepLink = factory.create(intent)
+
+        assertEquals(ShowEpisodeDeepLink("Episode ID", "Podcast ID", "Source View"), deepLink)
+    }
+
+    @Test
+    fun showEpisodeWithoutEpisodeId() {
+        val intent = Intent()
+            .setAction("INTENT_OPEN_APP_EPISODE_UUID")
+            .putExtra("podcast_uuid", "Podcast ID")
+            .putExtra("source_view", "Source View")
+
+        val deepLink = factory.create(intent)
+
+        assertNull(deepLink)
+    }
+
+    @Test
+    fun showEpisodeWithoutPodcastId() {
+        val intent = Intent()
+            .setAction("INTENT_OPEN_APP_EPISODE_UUID")
+            .putExtra("episode_uuid", "Episode ID")
+            .putExtra("source_view", "Source View")
+
+        val deepLink = factory.create(intent)
+
+        assertEquals(ShowEpisodeDeepLink("Episode ID", podcastUuid = null, "Source View"), deepLink)
+    }
+
+    @Test
+    fun showEpisodeWithoutSourceView() {
+        val intent = Intent()
+            .setAction("INTENT_OPEN_APP_EPISODE_UUID")
+            .putExtra("episode_uuid", "Episode ID")
+            .putExtra("podcast_uuid", "Podcast ID")
+
+        val deepLink = factory.create(intent)
+
+        assertEquals(ShowEpisodeDeepLink("Episode ID", "Podcast ID", sourceView = null), deepLink)
+    }
 }

--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/deeplink/ShowEpisodeDeepLinkTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/deeplink/ShowEpisodeDeepLinkTest.kt
@@ -1,0 +1,24 @@
+package au.com.shiftyjelly.pocketcasts.deeplink
+
+import android.content.Intent
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class ShowEpisodeDeepLinkTest {
+    private val context = InstrumentationRegistry.getInstrumentation().context
+
+    @Test
+    fun createShowPodcastIntent() {
+        val intent = ShowEpisodeDeepLink("Episode ID", "Podcast ID", "Source View").toIntent(context)
+
+        assertEquals("INTENT_OPEN_APP_EPISODE_UUID", intent.action)
+        assertEquals(Intent.FLAG_ACTIVITY_SINGLE_TOP, intent.flags and Intent.FLAG_ACTIVITY_SINGLE_TOP)
+        assertEquals("Episode ID", intent.getStringExtra("episode_uuid"))
+        assertEquals("Podcast ID", intent.getStringExtra("podcast_uuid"))
+        assertEquals("Source View", intent.getStringExtra("source_view"))
+    }
+}

--- a/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
+++ b/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
@@ -55,6 +55,7 @@ import au.com.shiftyjelly.pocketcasts.deeplink.DeepLinkFactory
 import au.com.shiftyjelly.pocketcasts.deeplink.DeleteBookmarkDeepLink
 import au.com.shiftyjelly.pocketcasts.deeplink.DownloadsDeepLink
 import au.com.shiftyjelly.pocketcasts.deeplink.ShowBookmarkDeepLink
+import au.com.shiftyjelly.pocketcasts.deeplink.ShowEpisodeDeepLink
 import au.com.shiftyjelly.pocketcasts.deeplink.ShowPodcastDeepLink
 import au.com.shiftyjelly.pocketcasts.discover.view.DiscoverFragment
 import au.com.shiftyjelly.pocketcasts.endofyear.StoriesFragment
@@ -82,9 +83,6 @@ import au.com.shiftyjelly.pocketcasts.podcasts.view.podcast.PodcastFragment
 import au.com.shiftyjelly.pocketcasts.podcasts.view.podcasts.PodcastsFragment
 import au.com.shiftyjelly.pocketcasts.podcasts.view.share.ShareListIncomingFragment
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
-import au.com.shiftyjelly.pocketcasts.preferences.Settings.Companion.EPISODE_UUID
-import au.com.shiftyjelly.pocketcasts.preferences.Settings.Companion.PODCAST_UUID
-import au.com.shiftyjelly.pocketcasts.preferences.Settings.Companion.SOURCE_VIEW
 import au.com.shiftyjelly.pocketcasts.profile.ProfileFragment
 import au.com.shiftyjelly.pocketcasts.profile.SubCancelledFragment
 import au.com.shiftyjelly.pocketcasts.profile.TrialFinishedFragment
@@ -1260,27 +1258,15 @@ class MainActivity :
                     is ShowPodcastDeepLink -> {
                         openPodcastPage(deepLink.podcastUuid, deepLink.sourceView)
                     }
+                    is ShowEpisodeDeepLink -> {
+                        openEpisodeDialog(
+                            episodeUuid = deepLink.episodeUuid,
+                            podcastUuid = deepLink.podcastUuid,
+                            source = EpisodeViewSource.fromString(deepLink.sourceView),
+                            forceDark = false,
+                        )
+                    }
                 }
-            } else if (action == Settings.INTENT_OPEN_APP_EPISODE_UUID) {
-                intent.getStringExtra(EPISODE_UUID)?.let {
-                    openEpisodeDialog(
-                        episodeUuid = it,
-                        source = EpisodeViewSource.fromString(intent.getStringExtra(SOURCE_VIEW)),
-                        podcastUuid = intent.getStringExtra(PODCAST_UUID),
-                        forceDark = false,
-                    )
-                }
-            } // new episode notification tapped
-            else if (intent.extras?.containsKey(Settings.INTENT_OPEN_APP_EPISODE_UUID) ?: false) {
-                // intents were being reused for notifications so we had to use the extra to pass action
-                val episodeUuid =
-                    intent.extras?.getString(Settings.INTENT_OPEN_APP_EPISODE_UUID, null)
-                openEpisodeDialog(
-                    episodeUuid = episodeUuid,
-                    source = EpisodeViewSource.NOTIFICATION,
-                    podcastUuid = null,
-                    forceDark = false,
-                )
             } else if (action == Intent.ACTION_VIEW) {
                 val extraPage = intent.extras?.getString(INTENT_EXTRA_PAGE, null)
                 if (extraPage != null) {

--- a/modules/features/nova/src/main/kotlin/au/com/shiftyjelly/pocketcasts/nova/CatalogFactory.kt
+++ b/modules/features/nova/src/main/kotlin/au/com/shiftyjelly/pocketcasts/nova/CatalogFactory.kt
@@ -2,6 +2,7 @@ package au.com.shiftyjelly.pocketcasts.nova
 
 import android.content.Context
 import au.com.shiftyjelly.pocketcasts.analytics.SourceView
+import au.com.shiftyjelly.pocketcasts.deeplink.ShowEpisodeDeepLink
 import au.com.shiftyjelly.pocketcasts.deeplink.ShowPodcastDeepLink
 import au.com.shiftyjelly.pocketcasts.models.entity.NovaLauncherInProgressEpisode
 import au.com.shiftyjelly.pocketcasts.models.entity.NovaLauncherNewEpisode
@@ -165,16 +166,17 @@ internal class CatalogFactory(
         sourceView = sourceView.analyticsValue,
     ).toIntent(context)
 
-    private fun openPodcastEpisodeIntent(episodeId: String, podcastId: String, source: EpisodeViewSource) = context.launcherIntent
-        .setAction(Settings.INTENT_OPEN_APP_EPISODE_UUID)
-        .putExtra(Settings.EPISODE_UUID, episodeId)
-        .putExtra(Settings.PODCAST_UUID, podcastId)
-        .putExtra(Settings.SOURCE_VIEW, source.value)
+    private fun openPodcastEpisodeIntent(episodeId: String, podcastId: String, source: EpisodeViewSource) = ShowEpisodeDeepLink(
+        episodeUuid = episodeId,
+        podcastUuid = podcastId,
+        sourceView = source.value,
+    ).toIntent(context)
 
-    private fun openUserEpisodeIntent(episodeId: String, source: EpisodeViewSource) = context.launcherIntent
-        .setAction(Settings.INTENT_OPEN_APP_EPISODE_UUID)
-        .putExtra(Settings.EPISODE_UUID, episodeId)
-        .putExtra(Settings.SOURCE_VIEW, source.value)
+    private fun openUserEpisodeIntent(episodeId: String, source: EpisodeViewSource) = ShowEpisodeDeepLink(
+        episodeUuid = episodeId,
+        podcastUuid = null,
+        sourceView = source.value,
+    ).toIntent(context)
 
     private val Context.launcherIntent get() = requireNotNull(packageManager.getLaunchIntentForPackage(packageName)) {
         "Missing launcher intent for $packageName"

--- a/modules/services/deeplink/src/main/kotlin/au/com/shiftyjelly/pocketcasts/deeplink/DeepLink.kt
+++ b/modules/services/deeplink/src/main/kotlin/au/com/shiftyjelly/pocketcasts/deeplink/DeepLink.kt
@@ -7,8 +7,10 @@ import au.com.shiftyjelly.pocketcasts.deeplink.DeepLink.Companion.ACTION_OPEN_BO
 import au.com.shiftyjelly.pocketcasts.deeplink.DeepLink.Companion.ACTION_OPEN_CHANGE_BOOKMARK_TITLE
 import au.com.shiftyjelly.pocketcasts.deeplink.DeepLink.Companion.ACTION_OPEN_DELETE_BOOKMARK
 import au.com.shiftyjelly.pocketcasts.deeplink.DeepLink.Companion.ACTION_OPEN_DOWNLOADS
+import au.com.shiftyjelly.pocketcasts.deeplink.DeepLink.Companion.ACTION_OPEN_EPISODE
 import au.com.shiftyjelly.pocketcasts.deeplink.DeepLink.Companion.ACTION_OPEN_PODCAST
 import au.com.shiftyjelly.pocketcasts.deeplink.DeepLink.Companion.EXTRA_BOOKMARK_UUID
+import au.com.shiftyjelly.pocketcasts.deeplink.DeepLink.Companion.EXTRA_EPISODE_UUID
 import au.com.shiftyjelly.pocketcasts.deeplink.DeepLink.Companion.EXTRA_NOTIFICATION_TAG
 import au.com.shiftyjelly.pocketcasts.deeplink.DeepLink.Companion.EXTRA_PODCAST_UUID
 import au.com.shiftyjelly.pocketcasts.deeplink.DeepLink.Companion.EXTRA_SOURCE_VIEW
@@ -23,9 +25,11 @@ sealed interface DeepLink {
         const val ACTION_OPEN_BOOKMARK = "INTENT_OPEN_APP_VIEW_BOOKMARKS"
         const val ACTION_OPEN_DELETE_BOOKMARK = "INTENT_OPEN_APP_DELETE_BOOKMARK"
         const val ACTION_OPEN_PODCAST = "INTENT_OPEN_APP_PODCAST_UUID"
+        const val ACTION_OPEN_EPISODE = "INTENT_OPEN_APP_EPISODE_UUID"
 
         const val EXTRA_BOOKMARK_UUID = "bookmark_uuid"
         const val EXTRA_PODCAST_UUID = "podcast_uuid"
+        const val EXTRA_EPISODE_UUID = "episode_uuid"
         const val EXTRA_SOURCE_VIEW = "source_view"
         const val EXTRA_NOTIFICATION_TAG = "NOTIFICATION_TAG"
     }
@@ -75,6 +79,19 @@ data class ShowPodcastDeepLink(
 ) : DeepLink {
     override fun toIntent(context: Context) = context.launcherIntent
         .setAction(ACTION_OPEN_PODCAST)
+        .putExtra(EXTRA_PODCAST_UUID, podcastUuid)
+        .putExtra(EXTRA_SOURCE_VIEW, sourceView)
+}
+
+data class ShowEpisodeDeepLink(
+    val episodeUuid: String,
+    val podcastUuid: String?,
+    val sourceView: String?,
+) : DeepLink {
+    override fun toIntent(context: Context) = context.launcherIntent
+        .setAction(ACTION_OPEN_EPISODE)
+        .addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP)
+        .putExtra(EXTRA_EPISODE_UUID, episodeUuid)
         .putExtra(EXTRA_PODCAST_UUID, podcastUuid)
         .putExtra(EXTRA_SOURCE_VIEW, sourceView)
 }

--- a/modules/services/deeplink/src/main/kotlin/au/com/shiftyjelly/pocketcasts/deeplink/DeepLinkFactory.kt
+++ b/modules/services/deeplink/src/main/kotlin/au/com/shiftyjelly/pocketcasts/deeplink/DeepLinkFactory.kt
@@ -6,8 +6,10 @@ import au.com.shiftyjelly.pocketcasts.deeplink.DeepLink.Companion.ACTION_OPEN_BO
 import au.com.shiftyjelly.pocketcasts.deeplink.DeepLink.Companion.ACTION_OPEN_CHANGE_BOOKMARK_TITLE
 import au.com.shiftyjelly.pocketcasts.deeplink.DeepLink.Companion.ACTION_OPEN_DELETE_BOOKMARK
 import au.com.shiftyjelly.pocketcasts.deeplink.DeepLink.Companion.ACTION_OPEN_DOWNLOADS
+import au.com.shiftyjelly.pocketcasts.deeplink.DeepLink.Companion.ACTION_OPEN_EPISODE
 import au.com.shiftyjelly.pocketcasts.deeplink.DeepLink.Companion.ACTION_OPEN_PODCAST
 import au.com.shiftyjelly.pocketcasts.deeplink.DeepLink.Companion.EXTRA_BOOKMARK_UUID
+import au.com.shiftyjelly.pocketcasts.deeplink.DeepLink.Companion.EXTRA_EPISODE_UUID
 import au.com.shiftyjelly.pocketcasts.deeplink.DeepLink.Companion.EXTRA_PODCAST_UUID
 import au.com.shiftyjelly.pocketcasts.deeplink.DeepLink.Companion.EXTRA_SOURCE_VIEW
 import timber.log.Timber
@@ -20,6 +22,7 @@ class DeepLinkFactory {
         ShowBookmarkAdapter(),
         DeleteBookmarkAdapter(),
         ShowPodcastAdapter(),
+        ShowEpisodeAdapter(),
     )
 
     fun create(intent: Intent): DeepLink? {
@@ -101,5 +104,24 @@ private class ShowPodcastAdapter : DeepLinkAdapter {
         }
     } else {
         null
+    }
+}
+
+private class ShowEpisodeAdapter : DeepLinkAdapter {
+    override fun create(intent: Intent) = if (ACTION_REGEX.matches(intent.action.orEmpty())) {
+        intent.getStringExtra(EXTRA_EPISODE_UUID)?.let { episodeUuid ->
+            ShowEpisodeDeepLink(
+                episodeUuid = episodeUuid,
+                podcastUuid = intent.getStringExtra(EXTRA_PODCAST_UUID),
+                sourceView = intent.getStringExtra(EXTRA_SOURCE_VIEW),
+            )
+        }
+    } else {
+        null
+    }
+
+    private companion object {
+        // We match on this pattern to handle notification intents that add numbers to actions for pending intents
+        private val ACTION_REGEX = ("^" + ACTION_OPEN_EPISODE + """\d*$""").toRegex()
     }
 }

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
@@ -105,7 +105,6 @@ interface Settings {
         const val AUTO_ARCHIVE_INCLUDE_STARRED = "autoArchiveIncludeStarred"
 
         const val INTENT_OPEN_APP_NEW_EPISODES = "INTENT_OPEN_APP_NEW_EPISODES"
-        const val INTENT_OPEN_APP_EPISODE_UUID = "INTENT_OPEN_APP_EPISODE_UUID"
         const val INTENT_LINK_CLOUD_FILES = "pktc://cloudfiles"
         const val INTENT_LINK_UPGRADE = "pktc://upgrade"
         const val INTENT_LINK_PROMO_CODE = "pktc://redeem/promo/"
@@ -115,12 +114,6 @@ interface Settings {
         const val NOTIFICATIONS_DISABLED_MESSAGE_SHOWN = "notificationsDisabledMessageShown"
 
         const val APP_REVIEW_REQUESTED_DATES = "in_app_review_requested_dates"
-
-        const val PODCAST_UUID = "podcast_uuid"
-
-        const val EPISODE_UUID = "episode_uuid"
-
-        const val SOURCE_VIEW = "source_view"
 
         const val AUTOMOTIVE_CONNECTED_TO_MEDIA_SESSION = "automotive_connected_to_media_session"
     }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/refresh/RefreshPodcastsThread.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/refresh/RefreshPodcastsThread.kt
@@ -17,10 +17,12 @@ import androidx.core.text.HtmlCompat
 import androidx.work.ListenableWorker
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTracker
 import au.com.shiftyjelly.pocketcasts.analytics.SourceView
+import au.com.shiftyjelly.pocketcasts.deeplink.ShowEpisodeDeepLink
 import au.com.shiftyjelly.pocketcasts.localization.BuildConfig
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.models.to.RefreshState
+import au.com.shiftyjelly.pocketcasts.models.type.EpisodeViewSource
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.preferences.model.AutoAddUpNextLimitBehaviour
 import au.com.shiftyjelly.pocketcasts.preferences.model.NewEpisodeNotificationAction
@@ -466,10 +468,12 @@ class RefreshPodcastsThread(
             var intentId = intentId
             val manager = NotificationManagerCompat.from(context)
 
-            val intent = context.packageManager.getLaunchIntentForPackage(context.packageName)?.apply {
-                flags = Intent.FLAG_ACTIVITY_SINGLE_TOP
-                action = (System.currentTimeMillis() + intentId).toString()
-                putExtra(Settings.INTENT_OPEN_APP_EPISODE_UUID, episode.uuid)
+            val intent = ShowEpisodeDeepLink(
+                episodeUuid = episode.uuid,
+                podcastUuid = podcast.uuid,
+                sourceView = EpisodeViewSource.NOTIFICATION.value,
+            ).toIntent(context).apply {
+                action = action + System.currentTimeMillis() + intentId
             }
             val pendingIntent = PendingIntent.getActivity(context, intentId, intent, PendingIntent.FLAG_UPDATE_CURRENT.or(PendingIntent.FLAG_IMMUTABLE))
             intentId += 1


### PR DESCRIPTION
## Description

> [!note]
> This will be a series of PRs that move deep linking to a separate module that can be tested. The goal is to address #2405 but I don't want to do it blindly without having tests in order to not introduce regressions to deep linking.

This PR migrates opening episode deep linking to the new module.

## Testing Instructions

### Regular deep link

1. Subscribe to [The Daily](https://pca.st/thedaily).
2. Close the app.
3. Execute `adb shell am start -n au.com.shiftyjelly.pocketcasts.debug/au.com.shiftyjelly.pocketcasts.ui.MainActivity -a INTENT_OPEN_APP_EPISODE_UUID -e episode_uuid ebc07cd8-10b6-4ca6-bfae-2994ee215012`.
4. A page for [this episode](https://pca.st/34oj7fwg) should open.

### Notifications deep link

1. Subscribe to some podcasts.
2. Enable notifications for them.
3. Trigger new episode notification from the Developer menu.
4. Tapping on notifications should navigate you to episode details.

## Checklist
- [x] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [x] ~Any jetpack compose components I added or changed are covered by compose previews~
- [x] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~