### PR TITLE
Refactor shortcuts deep linking

### DIFF
--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/deeplink/DeepLinkFactoryTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/deeplink/DeepLinkFactoryTest.kt
@@ -1,6 +1,7 @@
 package au.com.shiftyjelly.pocketcasts.deeplink
 
 import android.content.Intent
+import android.content.Intent.ACTION_VIEW
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
@@ -186,5 +187,50 @@ class DeepLinkFactoryTest {
         val deepLink = factory.create(intent)
 
         assertEquals(ShowEpisodeDeepLink("Episode ID", "Podcast ID", sourceView = null), deepLink)
+    }
+
+    @Test
+    fun showPodcasts() {
+        val intent = Intent()
+            .setAction(ACTION_VIEW)
+            .putExtra("launch-page", "podcasts")
+
+        val deepLink = factory.create(intent)
+
+        assertEquals(ShowPodcastsDeepLink, deepLink)
+    }
+
+    @Test
+    fun showDiscover() {
+        val intent = Intent()
+            .setAction(ACTION_VIEW)
+            .putExtra("launch-page", "search")
+
+        val deepLink = factory.create(intent)
+
+        assertEquals(ShowDiscoverDeepLink, deepLink)
+    }
+
+    @Test
+    fun showUpNext() {
+        val intent = Intent()
+            .setAction(ACTION_VIEW)
+            .putExtra("launch-page", "upnext")
+
+        val deepLink = factory.create(intent)
+
+        assertEquals(ShowUpNextDeepLink, deepLink)
+    }
+
+    @Test
+    fun showFilter() {
+        val intent = Intent()
+            .setAction(ACTION_VIEW)
+            .putExtra("launch-page", "playlist")
+            .putExtra("playlist-id", 10L)
+
+        val deepLink = factory.create(intent)
+
+        assertEquals(ShowFilterDeepLink(filterId = 10), deepLink)
     }
 }

--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/deeplink/ShowPageDeepLinkTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/deeplink/ShowPageDeepLinkTest.kt
@@ -1,0 +1,46 @@
+package au.com.shiftyjelly.pocketcasts.deeplink
+
+import android.content.Intent.ACTION_VIEW
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class ShowPageDeepLinkTest {
+    private val context = InstrumentationRegistry.getInstrumentation().context
+
+    @Test
+    fun createShowPodcastsIntent() {
+        val intent = ShowPodcastsDeepLink.toIntent(context)
+
+        assertEquals(ACTION_VIEW, intent.action)
+        assertEquals("podcasts", intent.getStringExtra("launch-page"))
+    }
+
+    @Test
+    fun createShowDiscoverIntent() {
+        val intent = ShowDiscoverDeepLink.toIntent(context)
+
+        assertEquals(ACTION_VIEW, intent.action)
+        assertEquals("search", intent.getStringExtra("launch-page"))
+    }
+
+    @Test
+    fun createShowUpNextIntent() {
+        val intent = ShowUpNextDeepLink.toIntent(context)
+
+        assertEquals(ACTION_VIEW, intent.action)
+        assertEquals("upnext", intent.getStringExtra("launch-page"))
+    }
+
+    @Test
+    fun createShowFilterIntent() {
+        val intent = ShowFilterDeepLink(filterId = 15L).toIntent(context)
+
+        assertEquals(ACTION_VIEW, intent.action)
+        assertEquals("playlist", intent.getStringExtra("launch-page"))
+        assertEquals(15L, intent.getLongExtra("playlist-id", -1L))
+    }
+}

--- a/modules/services/deeplink/src/main/kotlin/au/com/shiftyjelly/pocketcasts/deeplink/DeepLink.kt
+++ b/modules/services/deeplink/src/main/kotlin/au/com/shiftyjelly/pocketcasts/deeplink/DeepLink.kt
@@ -2,6 +2,7 @@ package au.com.shiftyjelly.pocketcasts.deeplink
 
 import android.content.Context
 import android.content.Intent
+import android.content.Intent.ACTION_VIEW
 import au.com.shiftyjelly.pocketcasts.deeplink.DeepLink.Companion.ACTION_OPEN_ADD_BOOKMARK
 import au.com.shiftyjelly.pocketcasts.deeplink.DeepLink.Companion.ACTION_OPEN_BOOKMARK
 import au.com.shiftyjelly.pocketcasts.deeplink.DeepLink.Companion.ACTION_OPEN_CHANGE_BOOKMARK_TITLE
@@ -11,7 +12,9 @@ import au.com.shiftyjelly.pocketcasts.deeplink.DeepLink.Companion.ACTION_OPEN_EP
 import au.com.shiftyjelly.pocketcasts.deeplink.DeepLink.Companion.ACTION_OPEN_PODCAST
 import au.com.shiftyjelly.pocketcasts.deeplink.DeepLink.Companion.EXTRA_BOOKMARK_UUID
 import au.com.shiftyjelly.pocketcasts.deeplink.DeepLink.Companion.EXTRA_EPISODE_UUID
+import au.com.shiftyjelly.pocketcasts.deeplink.DeepLink.Companion.EXTRA_FILTER_ID
 import au.com.shiftyjelly.pocketcasts.deeplink.DeepLink.Companion.EXTRA_NOTIFICATION_TAG
+import au.com.shiftyjelly.pocketcasts.deeplink.DeepLink.Companion.EXTRA_PAGE
 import au.com.shiftyjelly.pocketcasts.deeplink.DeepLink.Companion.EXTRA_PODCAST_UUID
 import au.com.shiftyjelly.pocketcasts.deeplink.DeepLink.Companion.EXTRA_SOURCE_VIEW
 
@@ -32,6 +35,8 @@ sealed interface DeepLink {
         const val EXTRA_EPISODE_UUID = "episode_uuid"
         const val EXTRA_SOURCE_VIEW = "source_view"
         const val EXTRA_NOTIFICATION_TAG = "NOTIFICATION_TAG"
+        const val EXTRA_PAGE = "launch-page"
+        const val EXTRA_FILTER_ID = "playlist-id"
     }
 }
 
@@ -94,6 +99,35 @@ data class ShowEpisodeDeepLink(
         .putExtra(EXTRA_EPISODE_UUID, episodeUuid)
         .putExtra(EXTRA_PODCAST_UUID, podcastUuid)
         .putExtra(EXTRA_SOURCE_VIEW, sourceView)
+}
+
+sealed interface ShowPageDeepLink : DeepLink {
+    val pageId: String
+
+    override fun toIntent(context: Context) = context.launcherIntent
+        .setAction(ACTION_VIEW)
+        .putExtra(EXTRA_PAGE, pageId)
+}
+
+data object ShowPodcastsDeepLink : ShowPageDeepLink {
+    override val pageId = "podcasts"
+}
+
+data object ShowDiscoverDeepLink : ShowPageDeepLink {
+    override val pageId = "search"
+}
+
+data object ShowUpNextDeepLink : ShowPageDeepLink {
+    override val pageId = "upnext"
+}
+
+data class ShowFilterDeepLink(
+    val filterId: Long,
+) : ShowPageDeepLink {
+    override val pageId = "playlist"
+
+    override fun toIntent(context: Context) = super.toIntent(context)
+        .putExtra(EXTRA_FILTER_ID, filterId)
 }
 
 private val Context.launcherIntent get() = requireNotNull(packageManager.getLaunchIntentForPackage(packageName)) {

--- a/modules/services/deeplink/src/main/kotlin/au/com/shiftyjelly/pocketcasts/deeplink/DeepLinkFactory.kt
+++ b/modules/services/deeplink/src/main/kotlin/au/com/shiftyjelly/pocketcasts/deeplink/DeepLinkFactory.kt
@@ -1,6 +1,7 @@
 package au.com.shiftyjelly.pocketcasts.deeplink
 
 import android.content.Intent
+import android.content.Intent.ACTION_VIEW
 import au.com.shiftyjelly.pocketcasts.deeplink.DeepLink.Companion.ACTION_OPEN_ADD_BOOKMARK
 import au.com.shiftyjelly.pocketcasts.deeplink.DeepLink.Companion.ACTION_OPEN_BOOKMARK
 import au.com.shiftyjelly.pocketcasts.deeplink.DeepLink.Companion.ACTION_OPEN_CHANGE_BOOKMARK_TITLE
@@ -10,6 +11,8 @@ import au.com.shiftyjelly.pocketcasts.deeplink.DeepLink.Companion.ACTION_OPEN_EP
 import au.com.shiftyjelly.pocketcasts.deeplink.DeepLink.Companion.ACTION_OPEN_PODCAST
 import au.com.shiftyjelly.pocketcasts.deeplink.DeepLink.Companion.EXTRA_BOOKMARK_UUID
 import au.com.shiftyjelly.pocketcasts.deeplink.DeepLink.Companion.EXTRA_EPISODE_UUID
+import au.com.shiftyjelly.pocketcasts.deeplink.DeepLink.Companion.EXTRA_FILTER_ID
+import au.com.shiftyjelly.pocketcasts.deeplink.DeepLink.Companion.EXTRA_PAGE
 import au.com.shiftyjelly.pocketcasts.deeplink.DeepLink.Companion.EXTRA_PODCAST_UUID
 import au.com.shiftyjelly.pocketcasts.deeplink.DeepLink.Companion.EXTRA_SOURCE_VIEW
 import timber.log.Timber
@@ -23,6 +26,7 @@ class DeepLinkFactory {
         DeleteBookmarkAdapter(),
         ShowPodcastAdapter(),
         ShowEpisodeAdapter(),
+        ShowPageAdapter(),
     )
 
     fun create(intent: Intent): DeepLink? {
@@ -123,5 +127,19 @@ private class ShowEpisodeAdapter : DeepLinkAdapter {
     private companion object {
         // We match on this pattern to handle notification intents that add numbers to actions for pending intents
         private val ACTION_REGEX = ("^" + ACTION_OPEN_EPISODE + """\d*$""").toRegex()
+    }
+}
+
+private class ShowPageAdapter : DeepLinkAdapter {
+    override fun create(intent: Intent) = if (intent.action == ACTION_VIEW) {
+        when (intent.getStringExtra(EXTRA_PAGE)) {
+            "podcasts" -> ShowPodcastsDeepLink
+            "search" -> ShowDiscoverDeepLink
+            "upnext" -> ShowUpNextDeepLink
+            "playlist" -> ShowFilterDeepLink(filterId = intent.getLongExtra(EXTRA_FILTER_ID, -1))
+            else -> null
+        }
+    } else {
+        null
     }
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/shortcuts/PocketCastsShortcuts.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/shortcuts/PocketCastsShortcuts.kt
@@ -2,11 +2,11 @@ package au.com.shiftyjelly.pocketcasts.repositories.shortcuts
 
 import android.annotation.TargetApi
 import android.content.Context
-import android.content.Intent
 import android.content.pm.ShortcutInfo
 import android.content.pm.ShortcutManager
 import android.graphics.drawable.Icon
 import android.os.Build
+import au.com.shiftyjelly.pocketcasts.deeplink.ShowFilterDeepLink
 import au.com.shiftyjelly.pocketcasts.repositories.extensions.shortcutDrawableId
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.PlaylistManager
 import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
@@ -15,10 +15,6 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 
 object PocketCastsShortcuts {
-
-    const val INTENT_EXTRA_PAGE = "launch-page"
-    const val INTENT_EXTRA_PLAYLIST_ID = "playlist-id"
-
     /**
      * Icon shortcuts
      * - Podcasts
@@ -51,10 +47,8 @@ object PocketCastsShortcuts {
             LogBuffer.i(PocketCastsShortcuts::class.java.simpleName, "Shortcut update from ${source.value}, top filter title: ${topPlaylist.title}")
 
             if (shortcutManager.dynamicShortcuts.isEmpty() || force) {
-                val filterIntent = context.packageManager.getLaunchIntentForPackage(context.packageName) ?: return@launch
-                filterIntent.action = Intent.ACTION_VIEW
-                filterIntent.putExtra(INTENT_EXTRA_PAGE, "playlist")
-                filterIntent.putExtra(INTENT_EXTRA_PLAYLIST_ID, topPlaylist.id)
+                val filterId = topPlaylist.id ?: return@launch
+                val filterIntent = ShowFilterDeepLink(filterId).toIntent(context)
 
                 val playlistTitle = topPlaylist.title.ifEmpty { "Top filter" }
 


### PR DESCRIPTION
## Description

> [!note]
> This will be a series of PRs that move deep linking to a separate module that can be tested. The goal is to address #2405 but I don't want to do it blindly without having tests in order to not introduce regressions to deep linking.

This PR migrates opening app from shortcut deep linking to the new module.

## Testing Instructions

Test opening the app using different shortcuts.

## Checklist
- [x] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [x] ~Any jetpack compose components I added or changed are covered by compose previews~
- [x] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~