### PR TITLE
Refactor PC website deep linking

### DIFF
--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/deeplink/DeepLinkFactoryTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/deeplink/DeepLinkFactoryTest.kt
@@ -2,6 +2,7 @@ package au.com.shiftyjelly.pocketcasts.deeplink
 
 import android.content.Intent
 import android.content.Intent.ACTION_VIEW
+import android.net.Uri
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
@@ -10,7 +11,9 @@ import org.junit.runner.RunWith
 
 @RunWith(AndroidJUnit4::class)
 class DeepLinkFactoryTest {
-    private val factory = DeepLinkFactory()
+    private val factory = DeepLinkFactory(
+        webBaseHost = "pocketcasts.com",
+    )
 
     @Test
     fun downloads() {
@@ -232,5 +235,16 @@ class DeepLinkFactoryTest {
         val deepLink = factory.create(intent)
 
         assertEquals(ShowFilterDeepLink(filterId = 10), deepLink)
+    }
+
+    @Test
+    fun pocketCastsWebsiteDeepLink() {
+        val intent = Intent()
+            .setAction(ACTION_VIEW)
+            .setData(Uri.parse("https://pocketcasts.com"))
+
+        val deepLink = factory.create(intent)
+
+        assertEquals(PocketCastsWebsiteDeepLink, deepLink)
     }
 }

--- a/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
+++ b/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
@@ -55,6 +55,7 @@ import au.com.shiftyjelly.pocketcasts.deeplink.DeepLink.Companion.EXTRA_PAGE
 import au.com.shiftyjelly.pocketcasts.deeplink.DeepLinkFactory
 import au.com.shiftyjelly.pocketcasts.deeplink.DeleteBookmarkDeepLink
 import au.com.shiftyjelly.pocketcasts.deeplink.DownloadsDeepLink
+import au.com.shiftyjelly.pocketcasts.deeplink.PocketCastsWebsiteDeepLink
 import au.com.shiftyjelly.pocketcasts.deeplink.ShowBookmarkDeepLink
 import au.com.shiftyjelly.pocketcasts.deeplink.ShowDiscoverDeepLink
 import au.com.shiftyjelly.pocketcasts.deeplink.ShowEpisodeDeepLink
@@ -1291,12 +1292,12 @@ class MainActivity :
                             }
                         }
                     }
+                    is PocketCastsWebsiteDeepLink -> {
+                        // Do nothing when the user goes to https://pocketcasts.com/get it should either open the play store or the user's app
+                    }
                 }
             } else if (action == Intent.ACTION_VIEW) {
-                if (IntentUtil.isPocketCastsWebsite(intent)) {
-                    // when the user goes to https://pocketcasts.com/get it should either open the play store or the user's app
-                    return
-                } else if (IntentUtil.isPodloveUrl(intent)) {
+                if (IntentUtil.isPodloveUrl(intent)) {
                     openPodcastUrl(IntentUtil.getPodloveUrl(intent))
                     return
                 } else if (IntentUtil.isSonosAppLinkUrl(intent)) {

--- a/modules/services/deeplink/src/main/kotlin/au/com/shiftyjelly/pocketcasts/deeplink/DeepLink.kt
+++ b/modules/services/deeplink/src/main/kotlin/au/com/shiftyjelly/pocketcasts/deeplink/DeepLink.kt
@@ -132,6 +132,8 @@ data class ShowFilterDeepLink(
         .putExtra(EXTRA_FILTER_ID, filterId)
 }
 
+data object PocketCastsWebsiteDeepLink : DeepLink
+
 private val Context.launcherIntent get() = requireNotNull(packageManager.getLaunchIntentForPackage(packageName)) {
     "Missing launcher intent for $packageName"
 }

--- a/modules/services/deeplink/src/main/kotlin/au/com/shiftyjelly/pocketcasts/deeplink/DeepLink.kt
+++ b/modules/services/deeplink/src/main/kotlin/au/com/shiftyjelly/pocketcasts/deeplink/DeepLink.kt
@@ -19,8 +19,6 @@ import au.com.shiftyjelly.pocketcasts.deeplink.DeepLink.Companion.EXTRA_PODCAST_
 import au.com.shiftyjelly.pocketcasts.deeplink.DeepLink.Companion.EXTRA_SOURCE_VIEW
 
 sealed interface DeepLink {
-    fun toIntent(context: Context): Intent
-
     companion object {
         const val ACTION_OPEN_DOWNLOADS = "INTENT_OPEN_APP_DOWNLOADING"
         const val ACTION_OPEN_ADD_BOOKMARK = "INTENT_OPEN_APP_ADD_BOOKMARK"
@@ -40,12 +38,16 @@ sealed interface DeepLink {
     }
 }
 
-data object DownloadsDeepLink : DeepLink {
+sealed interface IntentableDeepLink : DeepLink {
+    fun toIntent(context: Context): Intent
+}
+
+data object DownloadsDeepLink : IntentableDeepLink {
     override fun toIntent(context: Context) = context.launcherIntent
         .setAction(ACTION_OPEN_DOWNLOADS)
 }
 
-data object AddBookmarkDeepLink : DeepLink {
+data object AddBookmarkDeepLink : IntentableDeepLink {
     override fun toIntent(context: Context) = context.launcherIntent
         .setAction(ACTION_OPEN_ADD_BOOKMARK)
         .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
@@ -53,7 +55,7 @@ data object AddBookmarkDeepLink : DeepLink {
 
 data class ChangeBookmarkTitleDeepLink(
     val bookmarkUuid: String,
-) : DeepLink {
+) : IntentableDeepLink {
     override fun toIntent(context: Context) = context.launcherIntent
         .setAction(ACTION_OPEN_CHANGE_BOOKMARK_TITLE)
         .putExtra(EXTRA_BOOKMARK_UUID, bookmarkUuid)
@@ -62,7 +64,7 @@ data class ChangeBookmarkTitleDeepLink(
 
 data class ShowBookmarkDeepLink(
     val bookmarkUuid: String,
-) : DeepLink {
+) : IntentableDeepLink {
     override fun toIntent(context: Context) = context.launcherIntent
         .setAction(ACTION_OPEN_BOOKMARK)
         .putExtra(EXTRA_BOOKMARK_UUID, bookmarkUuid)
@@ -71,7 +73,7 @@ data class ShowBookmarkDeepLink(
 
 data class DeleteBookmarkDeepLink(
     val bookmarkUuid: String,
-) : DeepLink {
+) : IntentableDeepLink {
     override fun toIntent(context: Context) = context.launcherIntent
         .setAction(ACTION_OPEN_DELETE_BOOKMARK)
         .putExtra(EXTRA_BOOKMARK_UUID, bookmarkUuid)
@@ -81,7 +83,7 @@ data class DeleteBookmarkDeepLink(
 data class ShowPodcastDeepLink(
     val podcastUuid: String,
     val sourceView: String?,
-) : DeepLink {
+) : IntentableDeepLink {
     override fun toIntent(context: Context) = context.launcherIntent
         .setAction(ACTION_OPEN_PODCAST)
         .putExtra(EXTRA_PODCAST_UUID, podcastUuid)
@@ -92,7 +94,7 @@ data class ShowEpisodeDeepLink(
     val episodeUuid: String,
     val podcastUuid: String?,
     val sourceView: String?,
-) : DeepLink {
+) : IntentableDeepLink {
     override fun toIntent(context: Context) = context.launcherIntent
         .setAction(ACTION_OPEN_EPISODE)
         .addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP)
@@ -101,7 +103,7 @@ data class ShowEpisodeDeepLink(
         .putExtra(EXTRA_SOURCE_VIEW, sourceView)
 }
 
-sealed interface ShowPageDeepLink : DeepLink {
+sealed interface ShowPageDeepLink : IntentableDeepLink {
     val pageId: String
 
     override fun toIntent(context: Context) = context.launcherIntent

--- a/modules/services/deeplink/src/main/kotlin/au/com/shiftyjelly/pocketcasts/deeplink/DeepLinkFactory.kt
+++ b/modules/services/deeplink/src/main/kotlin/au/com/shiftyjelly/pocketcasts/deeplink/DeepLinkFactory.kt
@@ -2,6 +2,7 @@ package au.com.shiftyjelly.pocketcasts.deeplink
 
 import android.content.Intent
 import android.content.Intent.ACTION_VIEW
+import au.com.shiftyjelly.pocketcasts.deeplink.BuildConfig.WEB_BASE_HOST
 import au.com.shiftyjelly.pocketcasts.deeplink.DeepLink.Companion.ACTION_OPEN_ADD_BOOKMARK
 import au.com.shiftyjelly.pocketcasts.deeplink.DeepLink.Companion.ACTION_OPEN_BOOKMARK
 import au.com.shiftyjelly.pocketcasts.deeplink.DeepLink.Companion.ACTION_OPEN_CHANGE_BOOKMARK_TITLE
@@ -17,7 +18,9 @@ import au.com.shiftyjelly.pocketcasts.deeplink.DeepLink.Companion.EXTRA_PODCAST_
 import au.com.shiftyjelly.pocketcasts.deeplink.DeepLink.Companion.EXTRA_SOURCE_VIEW
 import timber.log.Timber
 
-class DeepLinkFactory {
+class DeepLinkFactory(
+    private val webBaseHost: String = WEB_BASE_HOST,
+) {
     private val adapters = listOf(
         DownloadsAdapter(),
         AddBookmarkAdapter(),
@@ -27,6 +30,7 @@ class DeepLinkFactory {
         ShowPodcastAdapter(),
         ShowEpisodeAdapter(),
         ShowPageAdapter(),
+        PocketCastsWebsiteAdapter(webBaseHost),
     )
 
     fun create(intent: Intent): DeepLink? {
@@ -139,6 +143,16 @@ private class ShowPageAdapter : DeepLinkAdapter {
             "playlist" -> ShowFilterDeepLink(filterId = intent.getLongExtra(EXTRA_FILTER_ID, -1))
             else -> null
         }
+    } else {
+        null
+    }
+}
+
+private class PocketCastsWebsiteAdapter(
+    private val webBaseHost: String,
+) : DeepLinkAdapter {
+    override fun create(intent: Intent) = if (intent.action == ACTION_VIEW && intent.data?.host == webBaseHost) {
+        PocketCastsWebsiteDeepLink
     } else {
         null
     }

--- a/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/helper/IntentUtil.kt
+++ b/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/helper/IntentUtil.kt
@@ -7,7 +7,6 @@ import android.net.Uri
 import android.widget.Toast
 import androidx.appcompat.app.AlertDialog
 import au.com.shiftyjelly.pocketcasts.localization.R
-import au.com.shiftyjelly.pocketcasts.preferences.BuildConfig
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.utils.FileUtil
 import java.io.File
@@ -18,10 +17,6 @@ import java.util.regex.Matcher
 import timber.log.Timber
 
 object IntentUtil {
-
-    fun isPocketCastsWebsite(intent: Intent): Boolean {
-        return intent.data?.host == BuildConfig.WEB_BASE_HOST
-    }
 
     fun isPodloveUrl(intent: Intent): Boolean {
         val scheme = intent.scheme


### PR DESCRIPTION
## Description

> [!note]
> This will be a series of PRs that move deep linking to a separate module that can be tested. The goal is to address #2405 but I don't want to do it blindly without having tests in order to not introduce regressions to deep linking.

This PR migrates opening app with PC website in data deep linking to the new module.

## Testing Instructions

1. Execute `adb shell am start -n au.com.shiftyjelly.pocketcasts.debug/au.com.shiftyjelly.pocketcasts.ui.MainActivity -a android.intent.action.VIEW -d "https://pocketcasts.com"`.
2. App should simply open.

## Checklist
- [x] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [x] ~Any jetpack compose components I added or changed are covered by compose previews~
- [x] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~