### PR TITLE
[Give rating] Add tracks

### DIFF
--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/components/ratings/GiveRatingFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/components/ratings/GiveRatingFragment.kt
@@ -1,5 +1,6 @@
 package au.com.shiftyjelly.pocketcasts.podcasts.view.components.ratings
 
+import android.content.DialogInterface
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
@@ -8,7 +9,8 @@ import android.widget.Toast
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.platform.ComposeView
 import androidx.core.os.bundleOf
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.fragment.app.viewModels
+import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
 import au.com.shiftyjelly.pocketcasts.compose.AppThemeWithBackground
 import au.com.shiftyjelly.pocketcasts.podcasts.viewmodel.GiveRatingViewModel
 import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingFlow
@@ -23,6 +25,8 @@ import au.com.shiftyjelly.pocketcasts.localization.R as LR
 private const val ARG_PODCAST_UUID = "podcastUuid"
 
 class GiveRatingFragment : BaseDialogFragment() {
+
+    private val viewModel: GiveRatingViewModel by viewModels()
 
     companion object {
         fun newInstance(podcastUuid: String) = GiveRatingFragment().apply {
@@ -45,7 +49,6 @@ class GiveRatingFragment : BaseDialogFragment() {
 
         setContent {
             AppThemeWithBackground(theme.activeTheme) {
-                val viewModel = hiltViewModel<GiveRatingViewModel>()
                 val coroutineScope = rememberCoroutineScope()
                 val context = requireContext()
 
@@ -81,6 +84,14 @@ class GiveRatingFragment : BaseDialogFragment() {
                     },
                 )
             }
+        }
+    }
+
+    override fun onDismiss(dialog: DialogInterface) {
+        val state = viewModel.state.value
+
+        if (state is GiveRatingViewModel.State.Loaded) {
+            viewModel.trackOnDismissed(AnalyticsEvent.RATING_SCREEN_DISMISSED)
         }
     }
 

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/components/ratings/GiveRatingFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/components/ratings/GiveRatingFragment.kt
@@ -92,6 +92,8 @@ class GiveRatingFragment : BaseDialogFragment() {
 
         if (state is GiveRatingViewModel.State.Loaded) {
             viewModel.trackOnDismissed(AnalyticsEvent.RATING_SCREEN_DISMISSED)
+        } else if (state is GiveRatingViewModel.State.NotAllowedToRate) {
+            viewModel.trackOnDismissed(AnalyticsEvent.NOT_ALLOWED_TO_RATE_SCREEN_DISMISSED)
         }
     }
 

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/components/ratings/GiveRatingNotAllowedToRateScreen.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/components/ratings/GiveRatingNotAllowedToRateScreen.kt
@@ -18,8 +18,8 @@ import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import au.com.shiftyjelly.pocketcasts.compose.CallOnce
 import au.com.shiftyjelly.pocketcasts.compose.bars.NavigationButton
 import au.com.shiftyjelly.pocketcasts.compose.bars.NavigationIconButton
 import au.com.shiftyjelly.pocketcasts.compose.buttons.RowButton
@@ -34,9 +34,14 @@ import au.com.shiftyjelly.pocketcasts.podcasts.viewmodel.GiveRatingViewModel
 fun GiveRatingNotAllowedToRate(
     state: GiveRatingViewModel.State.NotAllowedToRate,
     onDismiss: () -> Unit,
+    viewModel: GiveRatingViewModel,
 ) {
     val configuration = LocalConfiguration.current
     val isLandscape = configuration.orientation == Configuration.ORIENTATION_LANDSCAPE
+
+    CallOnce {
+        viewModel.trackOnNotAllowedToRateScreenShown(state.podcastUuid)
+    }
 
     Box(
         modifier = Modifier.fillMaxSize(),
@@ -99,16 +104,4 @@ fun GiveRatingNotAllowedToRate(
                 .padding(16.dp),
         )
     }
-}
-
-@Preview(showBackground = true)
-@Composable
-fun GiveRatingNotAllowedToRatePreview() {
-    val state = GiveRatingViewModel.State.NotAllowedToRate(
-        podcastUuid = "sample-podcast-uuid",
-    )
-    GiveRatingNotAllowedToRate(
-        state = state,
-        onDismiss = {},
-    )
 }

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/components/ratings/GiveRatingPage.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/components/ratings/GiveRatingPage.kt
@@ -28,7 +28,7 @@ fun GiveRatingPage(
     when (val currentState = state) {
         is GiveRatingViewModel.State.Loaded -> GiveRatingScreen(
             state = currentState,
-            setRating = viewModel::setRating,
+            viewModel = viewModel,
             submitRating = submitRating,
             onDismiss = onDismiss,
         )

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/components/ratings/GiveRatingPage.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/components/ratings/GiveRatingPage.kt
@@ -34,6 +34,7 @@ fun GiveRatingPage(
         )
         is GiveRatingViewModel.State.Loading -> GiveRatingLoadingScreen()
         is GiveRatingViewModel.State.NotAllowedToRate -> GiveRatingNotAllowedToRate(
+            viewModel = viewModel,
             state = currentState,
             onDismiss = onDismiss,
         )

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/components/ratings/GiveRatingScreen.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/components/ratings/GiveRatingScreen.kt
@@ -20,6 +20,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import au.com.shiftyjelly.pocketcasts.compose.CallOnce
 import au.com.shiftyjelly.pocketcasts.compose.bars.NavigationButton
 import au.com.shiftyjelly.pocketcasts.compose.bars.NavigationIconButton
 import au.com.shiftyjelly.pocketcasts.compose.buttons.RowButton
@@ -32,13 +33,17 @@ import au.com.shiftyjelly.pocketcasts.podcasts.viewmodel.starsToRating
 
 @Composable
 fun GiveRatingScreen(
+    viewModel: GiveRatingViewModel,
     state: GiveRatingViewModel.State.Loaded,
-    setRating: (Double) -> Unit,
     submitRating: () -> Unit,
     onDismiss: () -> Unit,
 ) {
     val configuration = LocalConfiguration.current
     val isLandscape = configuration.orientation == Configuration.ORIENTATION_LANDSCAPE
+
+    CallOnce {
+        viewModel.trackOnGiveRatingScreenShown(state.podcastUuid)
+    }
 
     Box(
         modifier = Modifier.fillMaxSize(),
@@ -75,7 +80,7 @@ fun GiveRatingScreen(
 
                 SwipeableStars(
                     initialRate = state.previousRate?.let { starsToRating(it) },
-                    onStarsChanged = setRating,
+                    onStarsChanged = viewModel::setRating,
                     modifier = Modifier
                         .height(48.dp)
                         .padding(horizontal = 16.dp),

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/GiveRatingViewModel.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/GiveRatingViewModel.kt
@@ -4,6 +4,8 @@ import android.content.Context
 import android.widget.Toast
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
+import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTracker
 import au.com.shiftyjelly.pocketcasts.models.to.SignInState
 import au.com.shiftyjelly.pocketcasts.podcasts.viewmodel.GiveRatingViewModel.State.Loaded.Stars
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
@@ -26,6 +28,7 @@ class GiveRatingViewModel @Inject constructor(
     private val podcastManager: PodcastManager,
     private val userManager: UserManager,
     private val ratingManager: RatingsManager,
+    private val analyticsTracker: AnalyticsTracker,
 ) : ViewModel() {
 
     companion object {
@@ -151,6 +154,10 @@ class GiveRatingViewModel @Inject constructor(
             throw IllegalStateException("Cannot set stars when state is not Loaded")
         }
         _state.value = stateValue.copy(_currentSelectedRate = stars)
+    }
+
+    fun trackOnGiveRatingScreenShown(uuid: String) {
+        analyticsTracker.track(AnalyticsEvent.RATING_SCREEN_SHOWN, mapOf("uuid" to uuid))
     }
 }
 

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/GiveRatingViewModel.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/GiveRatingViewModel.kt
@@ -140,6 +140,12 @@ class GiveRatingViewModel @Inject constructor(
         shouldTrackDismissedEvent = false
 
         val stars = (state.value as State.Loaded).currentSelectedRate
+
+        analyticsTracker.track(
+            AnalyticsEvent.RATING_SCREEN_SUBMIT_TAPPED,
+            mapOf("uuid" to (state.value as State.Loaded).podcastUuid, "stars" to starsToRating(stars)),
+        )
+
         val result = ratingManager.submitPodcastRating(podcastUuid, starsToRating(stars))
 
         if (result is PodcastRatingResult.Success) {

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/GiveRatingViewModel.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/GiveRatingViewModel.kt
@@ -31,6 +31,8 @@ class GiveRatingViewModel @Inject constructor(
     private val analyticsTracker: AnalyticsTracker,
 ) : ViewModel() {
 
+    private var shouldTrackDismissedEvent = false
+
     companion object {
         const val TAG = "GiveRating"
         const val NUMBER_OF_EPISODES_LISTENED_REQUIRED_TO_RATE = 2
@@ -135,6 +137,8 @@ class GiveRatingViewModel @Inject constructor(
             return
         }
 
+        shouldTrackDismissedEvent = false
+
         val stars = (state.value as State.Loaded).currentSelectedRate
         val result = ratingManager.submitPodcastRating(podcastUuid, starsToRating(stars))
 
@@ -157,7 +161,14 @@ class GiveRatingViewModel @Inject constructor(
     }
 
     fun trackOnGiveRatingScreenShown(uuid: String) {
+        shouldTrackDismissedEvent = true
         analyticsTracker.track(AnalyticsEvent.RATING_SCREEN_SHOWN, mapOf("uuid" to uuid))
+    }
+
+    fun trackOnDismissed(event: AnalyticsEvent) {
+        if (shouldTrackDismissedEvent) {
+            analyticsTracker.track(event)
+        }
     }
 }
 

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/GiveRatingViewModel.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/GiveRatingViewModel.kt
@@ -165,6 +165,11 @@ class GiveRatingViewModel @Inject constructor(
         analyticsTracker.track(AnalyticsEvent.RATING_SCREEN_SHOWN, mapOf("uuid" to uuid))
     }
 
+    fun trackOnNotAllowedToRateScreenShown(uuid: String) {
+        shouldTrackDismissedEvent = true
+        analyticsTracker.track(AnalyticsEvent.NOT_ALLOWED_TO_RATE_SCREEN_SHOWN, mapOf("uuid" to uuid))
+    }
+
     fun trackOnDismissed(event: AnalyticsEvent) {
         if (shouldTrackDismissedEvent) {
             analyticsTracker.track(event)

--- a/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
+++ b/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
@@ -588,6 +588,7 @@ enum class AnalyticsEvent(val key: String) {
 
     /* Ratings */
     RATING_STARS_TAPPED("rating_stars_tapped"),
+    RATING_SCREEN_SHOWN("rating_screen_shown"),
 
     /* Wear Main List Screen */
     WEAR_MAIN_LIST_SHOWN("wear_main_list_shown"),

--- a/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
+++ b/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
@@ -592,6 +592,7 @@ enum class AnalyticsEvent(val key: String) {
     RATING_SCREEN_DISMISSED("rating_screen_dismissed"),
     NOT_ALLOWED_TO_RATE_SCREEN_SHOWN("not_allowed_to_rate_screen_shown"),
     NOT_ALLOWED_TO_RATE_SCREEN_DISMISSED("not_allowed_to_rate_screen_dismissed"),
+    RATING_SCREEN_SUBMIT_TAPPED("rating_screen_submit_tapped"),
 
     /* Wear Main List Screen */
     WEAR_MAIN_LIST_SHOWN("wear_main_list_shown"),

--- a/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
+++ b/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
@@ -589,6 +589,7 @@ enum class AnalyticsEvent(val key: String) {
     /* Ratings */
     RATING_STARS_TAPPED("rating_stars_tapped"),
     RATING_SCREEN_SHOWN("rating_screen_shown"),
+    RATING_SCREEN_DISMISSED("rating_screen_dismissed"),
 
     /* Wear Main List Screen */
     WEAR_MAIN_LIST_SHOWN("wear_main_list_shown"),

--- a/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
+++ b/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
@@ -590,6 +590,8 @@ enum class AnalyticsEvent(val key: String) {
     RATING_STARS_TAPPED("rating_stars_tapped"),
     RATING_SCREEN_SHOWN("rating_screen_shown"),
     RATING_SCREEN_DISMISSED("rating_screen_dismissed"),
+    NOT_ALLOWED_TO_RATE_SCREEN_SHOWN("not_allowed_to_rate_screen_shown"),
+    NOT_ALLOWED_TO_RATE_SCREEN_DISMISSED("not_allowed_to_rate_screen_dismissed"),
 
     /* Wear Main List Screen */
     WEAR_MAIN_LIST_SHOWN("wear_main_list_shown"),


### PR DESCRIPTION
## Description
- This PR adds tracks events for rating screen

<img width="1482" alt="image" src="https://github.com/Automattic/pocket-casts-android/assets/42220351/f5b396ea-893d-4dbc-b942-ae8384ad08fd">



Fixes #2446

## Testing Instructions
1. Open a podcast that you did not listened any episode before
2. Tap on podcast image to open more details
3. Tap on `Rate` button
4. Ensure 🔵 Tracked: rating_stars_tapped is tracked
5. ✅ Ensure 🔵 Tracked: not_allowed_to_rate_screen_shown is tracked
6. Dismiss this screen
7. ✅ Ensure 🔵 Tracked: not_allowed_to_rate_screen_dismissed is tracked
8. Listen some episodes from this podcast
9. ✅ Ensure 🔵 Tracked: rating_stars_tapped is tracked
10. ✅ Ensure 🔵 Tracked: rating_screen_shown is tracked
11. Dismiss this screen
12. ✅ Ensure 🔵 Tracked: rating_screen_dismissed is tracked
13. Back to the rating screen again and submit a rate
14. ✅ Ensure 🔵 Tracked: rating_screen_submit_tapped is tracked

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
