### PR TITLE
Refactor Podlove podcast deep linking

### DIFF
--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/deeplink/DeepLinkFactoryTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/deeplink/DeepLinkFactoryTest.kt
@@ -247,4 +247,81 @@ class DeepLinkFactoryTest {
 
         assertEquals(PocketCastsWebsiteDeepLink, deepLink)
     }
+
+    @Test
+    fun podloveHttps() {
+        val intent = Intent()
+            .setAction(ACTION_VIEW)
+            .setData(Uri.parse("pktc://subscribehttps/mypodcast.com/rss/123"))
+
+        val deepLink = factory.create(intent)
+
+        assertEquals(ShowPodcastFromUrlDeepLink("https://mypodcast.com/rss/123"), deepLink)
+    }
+
+    @Test
+    fun podloveHttpsWithParams() {
+        val intent = Intent()
+            .setAction(ACTION_VIEW)
+            .setData(Uri.parse("pktc://subscribehttps/mypodcast.com/rss/123?someKey=someValue"))
+
+        val deepLink = factory.create(intent)
+
+        assertEquals(ShowPodcastFromUrlDeepLink("https://mypodcast.com/rss/123?someKey=someValue"), deepLink)
+    }
+
+    @Test
+    fun podloveHttp() {
+        val intent = Intent()
+            .setAction(ACTION_VIEW)
+            .setData(Uri.parse("pktc://subscribe/mypodcast.com/rss/123"))
+
+        val deepLink = factory.create(intent)
+
+        assertEquals(ShowPodcastFromUrlDeepLink("http://mypodcast.com/rss/123"), deepLink)
+    }
+
+    @Test
+    fun podloveHttpWithParams() {
+        val intent = Intent()
+            .setAction(ACTION_VIEW)
+            .setData(Uri.parse("pktc://subscribe/mypodcast.com/rss/123?someKey=someValue"))
+
+        val deepLink = factory.create(intent)
+
+        assertEquals(ShowPodcastFromUrlDeepLink("http://mypodcast.com/rss/123?someKey=someValue"), deepLink)
+    }
+
+    @Test
+    fun podloveWithWrongScheme() {
+        val intent = Intent()
+            .setAction(ACTION_VIEW)
+            .setData(Uri.parse("https://subscribehttps/mypodcast.com/rss/123"))
+
+        val deepLink = factory.create(intent)
+
+        assertNull(deepLink)
+    }
+
+    @Test
+    fun podloveWithWrongHost() {
+        val intent = Intent()
+            .setAction(ACTION_VIEW)
+            .setData(Uri.parse("pktc://subscribehttp/mypodcast.com/rss/123"))
+
+        val deepLink = factory.create(intent)
+
+        assertNull(deepLink)
+    }
+
+    @Test
+    fun podloveWithShortPath() {
+        val intent = Intent()
+            .setAction(ACTION_VIEW)
+            .setData(Uri.parse("pktc://subscribe/aa"))
+
+        val deepLink = factory.create(intent)
+
+        assertNull(deepLink)
+    }
 }

--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/views/helper/IntentUtilTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/views/helper/IntentUtilTest.kt
@@ -1,7 +1,6 @@
 package au.com.shiftyjelly.pocketcasts.views.helper
 
 import android.content.Intent
-import android.net.Uri
 import org.junit.Assert.assertEquals
 import org.junit.Test
 
@@ -21,45 +20,5 @@ class IntentUtilTest {
         assertEquals(Intent.ACTION_VIEW, intent.action)
         assertEquals("http", intent.data?.scheme)
         assertEquals("www.google.com", intent.data?.host)
-    }
-
-    @Test
-    fun testSubscribeUrlWithParams() {
-        val intent = Intent(Intent.ACTION_VIEW)
-        val url = "pktc://subscribe/mypodcast.memberfulcontent.com/rss/6618?someKey=someValue"
-        intent.data = Uri.parse(url)
-
-        val parsed = IntentUtil.getPodloveUrl(intent)
-        assertEquals("http://mypodcast.memberfulcontent.com/rss/6618?someKey=someValue", parsed)
-    }
-
-    @Test
-    fun testSubscribeUrlWithoutParams() {
-        val intent = Intent(Intent.ACTION_VIEW)
-        val url = "pktc://subscribe/mypodcast.com/rss/123"
-        intent.data = Uri.parse(url)
-
-        val parsed = IntentUtil.getPodloveUrl(intent)
-        assertEquals("http://mypodcast.com/rss/123", parsed)
-    }
-
-    @Test
-    fun testSubscribeUrlWithParamsHttps() {
-        val intent = Intent(Intent.ACTION_VIEW)
-        val url = "pktc://subscribehttps/mypodcast.memberfulcontent.com/rss/6618?someKey=someValue"
-        intent.data = Uri.parse(url)
-
-        val parsed = IntentUtil.getPodloveUrl(intent)
-        assertEquals("https://mypodcast.memberfulcontent.com/rss/6618?someKey=someValue", parsed)
-    }
-
-    @Test
-    fun testSubscribeUrlWithoutParamsHttps() {
-        val intent = Intent(Intent.ACTION_VIEW)
-        val url = "pktc://subscribehttps/mypodcast.com/rss/123"
-        intent.data = Uri.parse(url)
-
-        val parsed = IntentUtil.getPodloveUrl(intent)
-        assertEquals("https://mypodcast.com/rss/123", parsed)
     }
 }

--- a/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
+++ b/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
@@ -61,6 +61,7 @@ import au.com.shiftyjelly.pocketcasts.deeplink.ShowDiscoverDeepLink
 import au.com.shiftyjelly.pocketcasts.deeplink.ShowEpisodeDeepLink
 import au.com.shiftyjelly.pocketcasts.deeplink.ShowFilterDeepLink
 import au.com.shiftyjelly.pocketcasts.deeplink.ShowPodcastDeepLink
+import au.com.shiftyjelly.pocketcasts.deeplink.ShowPodcastFromUrlDeepLink
 import au.com.shiftyjelly.pocketcasts.deeplink.ShowPodcastsDeepLink
 import au.com.shiftyjelly.pocketcasts.deeplink.ShowUpNextDeepLink
 import au.com.shiftyjelly.pocketcasts.discover.view.DiscoverFragment
@@ -1295,12 +1296,12 @@ class MainActivity :
                     is PocketCastsWebsiteDeepLink -> {
                         // Do nothing when the user goes to https://pocketcasts.com/get it should either open the play store or the user's app
                     }
+                    is ShowPodcastFromUrlDeepLink -> {
+                        openPodcastUrl(deepLink.url)
+                    }
                 }
             } else if (action == Intent.ACTION_VIEW) {
-                if (IntentUtil.isPodloveUrl(intent)) {
-                    openPodcastUrl(IntentUtil.getPodloveUrl(intent))
-                    return
-                } else if (IntentUtil.isSonosAppLinkUrl(intent)) {
+                if (IntentUtil.isSonosAppLinkUrl(intent)) {
                     startActivityForResult(
                         SonosAppLinkActivity.buildIntent(intent, this),
                         SonosAppLinkActivity.SONOS_APP_ACTIVITY_RESULT,

--- a/modules/services/deeplink/src/main/kotlin/au/com/shiftyjelly/pocketcasts/deeplink/DeepLink.kt
+++ b/modules/services/deeplink/src/main/kotlin/au/com/shiftyjelly/pocketcasts/deeplink/DeepLink.kt
@@ -134,6 +134,10 @@ data class ShowFilterDeepLink(
 
 data object PocketCastsWebsiteDeepLink : DeepLink
 
+data class ShowPodcastFromUrlDeepLink(
+    val url: String,
+) : DeepLink
+
 private val Context.launcherIntent get() = requireNotNull(packageManager.getLaunchIntentForPackage(packageName)) {
     "Missing launcher intent for $packageName"
 }

--- a/modules/services/deeplink/src/main/kotlin/au/com/shiftyjelly/pocketcasts/deeplink/DeepLinkFactory.kt
+++ b/modules/services/deeplink/src/main/kotlin/au/com/shiftyjelly/pocketcasts/deeplink/DeepLinkFactory.kt
@@ -31,6 +31,7 @@ class DeepLinkFactory(
         ShowEpisodeAdapter(),
         ShowPageAdapter(),
         PocketCastsWebsiteAdapter(webBaseHost),
+        PodloveAdapter(),
     )
 
     fun create(intent: Intent): DeepLink? {
@@ -155,5 +156,23 @@ private class PocketCastsWebsiteAdapter(
         PocketCastsWebsiteDeepLink
     } else {
         null
+    }
+}
+
+private class PodloveAdapter : DeepLinkAdapter {
+    override fun create(intent: Intent): DeepLink? {
+        val uriData = intent.dataString.orEmpty()
+        val groupValues = PODLOVE_REGEX.matchEntire(uriData)?.groupValues
+
+        return if (intent.action == ACTION_VIEW && groupValues != null) {
+            val scheme = if (groupValues[1] == "subscribe") "http" else "https"
+            ShowPodcastFromUrlDeepLink("$scheme://${groupValues[2]}")
+        } else {
+            null
+        }
+    }
+
+    private companion object {
+        private val PODLOVE_REGEX = """^pktc://(subscribe|subscribehttps)/(.{3,})$""".toRegex()
     }
 }

--- a/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/helper/IntentUtil.kt
+++ b/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/helper/IntentUtil.kt
@@ -18,16 +18,6 @@ import timber.log.Timber
 
 object IntentUtil {
 
-    fun isPodloveUrl(intent: Intent): Boolean {
-        val scheme = intent.scheme
-        if (scheme == null || scheme != "pktc" || intent.data == null || intent.data?.host == null) {
-            return false
-        }
-
-        val host = intent.data?.host
-        return host == "subscribe" || host == "subscribehttps"
-    }
-
     fun isSonosAppLinkUrl(intent: Intent): Boolean {
         val scheme = intent.scheme
         if (scheme == null || scheme != "pktc" || intent.data == null || intent.data?.host == null) {
@@ -36,20 +26,6 @@ object IntentUtil {
 
         val host = intent.data?.host
         return host == "applink"
-    }
-
-    fun getPodloveUrl(intent: Intent): String? {
-        val uri = intent.data ?: return null
-        var path = uri.path ?: return null
-        if (path.startsWith("/")) {
-            path = path.replaceFirst(Matcher.quoteReplacement("/").toRegex(), "")
-        }
-        if (path.length < 3) {
-            return null
-        }
-        val host = uri.host
-        val params = uri.encodedQuery
-        return (if (host == "subscribehttps") "https" else "http") + "://" + path + if (!params.isNullOrEmpty()) "?${uri.encodedQuery}" else ""
     }
 
     fun isShareLink(intent: Intent): Boolean {


### PR DESCRIPTION
## Description

> [!note]
> This will be a series of PRs that move deep linking to a separate module that can be tested. The goal is to address #2405 but I don't want to do it blindly without having tests in order to not introduce regressions to deep linking.

This PR migrates Podlove subscription deep linking to the new module.

## Testing Instructions

1. Execute `adb shell am start -n au.com.shiftyjelly.pocketcasts.debug/au.com.shiftyjelly.pocketcasts.ui.MainActivity -a android.intent.action.VIEW -d "pktc://subscribehttps/v4-feed-test.podlove.org/feed/"`.
2. App should open and load [Podlove Test](https://pca.st/RKAS) podcast.

## Checklist
- [x] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [x] ~Any jetpack compose components I added or changed are covered by compose previews~
- [x] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~