### PR TITLE
[Give rating] Update restriction to rate

### DIFF
--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/GiveRatingViewModel.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/GiveRatingViewModel.kt
@@ -29,6 +29,10 @@ class GiveRatingViewModel @Inject constructor(
     private val userManager: UserManager,
 ) : ViewModel() {
 
+    companion object {
+        const val NUMBER_OF_EPISODES_LISTENED_REQUIRED_TO_RATE = 2
+    }
+
     sealed class State {
         data object Loading : State()
         data class Loaded(
@@ -74,7 +78,7 @@ class GiveRatingViewModel @Inject constructor(
                 withContext(Dispatchers.IO) {
                     val playedEpisodesFromPodcast = podcastManager.findPlayedEpisodesFrom(podcastUuid)
 
-                    if (playedEpisodesFromPodcast.isEmpty()) {
+                    if (playedEpisodesFromPodcast.size < NUMBER_OF_EPISODES_LISTENED_REQUIRED_TO_RATE) {
                         _state.value = State.NotAllowedToRate(podcastUuid)
                     } else {
                         val podcast = podcastManager.findPodcastByUuidSuspend(podcastUuid)

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/GiveRatingViewModel.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/GiveRatingViewModel.kt
@@ -76,9 +76,9 @@ class GiveRatingViewModel @Inject constructor(
                 onUserSignedOut()
             } else if (signInState is SignInState.SignedIn) {
                 withContext(Dispatchers.IO) {
-                    val playedEpisodesFromPodcast = podcastManager.findPlayedEpisodesFrom(podcastUuid)
+                    val countPlayedEpisodes = podcastManager.countPlayedEpisodes(podcastUuid)
 
-                    if (playedEpisodesFromPodcast.size < NUMBER_OF_EPISODES_LISTENED_REQUIRED_TO_RATE) {
+                    if (countPlayedEpisodes < NUMBER_OF_EPISODES_LISTENED_REQUIRED_TO_RATE) {
                         _state.value = State.NotAllowedToRate(podcastUuid)
                     } else {
                         val podcast = podcastManager.findPodcastByUuidSuspend(podcastUuid)

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/EpisodeDao.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/EpisodeDao.kt
@@ -46,7 +46,7 @@ abstract class EpisodeDao {
     @Query("SELECT * FROM podcast_episodes WHERE uuid IN (:episodeUuids)")
     abstract suspend fun findByUuids(episodeUuids: List<String>): List<PodcastEpisode>
 
-    @Query("SELECT * FROM podcast_episodes WHERE podcast_id = :podcastUuid AND played_up_to != 0.0")
+    @Query("SELECT * FROM podcast_episodes WHERE podcast_id = :podcastUuid AND played_up_to > (duration / 2)")
     abstract suspend fun findPlayedEpisodesFrom(podcastUuid: String): List<PodcastEpisode>
 
     @Query("SELECT * FROM podcast_episodes WHERE uuid = :uuid")

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/EpisodeDao.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/EpisodeDao.kt
@@ -46,8 +46,8 @@ abstract class EpisodeDao {
     @Query("SELECT * FROM podcast_episodes WHERE uuid IN (:episodeUuids)")
     abstract suspend fun findByUuids(episodeUuids: List<String>): List<PodcastEpisode>
 
-    @Query("SELECT * FROM podcast_episodes WHERE podcast_id = :podcastUuid AND played_up_to > (duration / 2)")
-    abstract suspend fun findPlayedEpisodesFrom(podcastUuid: String): List<PodcastEpisode>
+    @Query("SELECT count(*) FROM podcast_episodes WHERE podcast_id = :podcastUuid AND played_up_to > (duration / 2)")
+    abstract suspend fun countPlayedEpisodes(podcastUuid: String): Int
 
     @Query("SELECT * FROM podcast_episodes WHERE uuid = :uuid")
     abstract fun findByUuidRx(uuid: String): Maybe<PodcastEpisode>

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PodcastManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PodcastManager.kt
@@ -151,7 +151,7 @@ interface PodcastManager {
 
     suspend fun findRandomPodcasts(limit: Int): List<Podcast>
 
-    suspend fun findPlayedEpisodesFrom(podcastUuid: String): List<PodcastEpisode>
+    suspend fun countPlayedEpisodes(podcastUuid: String): Int
 
     suspend fun updateArchiveSettings(uuid: String, enable: Boolean, afterPlaying: AutoArchiveAfterPlaying, inactive: AutoArchiveInactive)
     suspend fun updateArchiveAfterPlaying(uuid: String, value: AutoArchiveAfterPlaying)

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PodcastManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PodcastManagerImpl.kt
@@ -834,7 +834,7 @@ class PodcastManagerImpl @Inject constructor(
         podcastDao.updateArchiveEpisodeLimit(uuid, value)
     }
 
-    override suspend fun findPlayedEpisodesFrom(podcastUuid: String): List<PodcastEpisode> {
-        return episodeDao.findPlayedEpisodesFrom(podcastUuid)
+    override suspend fun countPlayedEpisodes(podcastUuid: String): Int {
+        return episodeDao.countPlayedEpisodes(podcastUuid)
     }
 }


### PR DESCRIPTION
## Description
- Update restriction to rate

```
Episode listened: played_up_to is greater than half the duration
Podcast listened: at least two episodes "listened" (based on above criteria)
``` 

- See: p1720130797705289/1720101621.153249-slack-C077XU4GF9D
- See: https://github.com/Automattic/pocket-casts-sync-api/pull/987
- See: p1720101621153249-slack-C077XU4GF9D

Fixes #2457

## Testing Instructions
Have `GIVE_RATINGS` feature flag enabled

1. Open a podcast that you did not listen any episode
2. Tap `Rate` button
3. ✅ Ensure you can't rate
4. Listen any episode from this podcast. Seek to almost the end of the episode 
5. Repeat the same step 4 for another episode
6. Try to rate again this podcast
7. ✅ Ensure you can rate

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack