### PR TITLE
Refactor Sonos deep linking

### DIFF
--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/deeplink/DeepLinkFactoryTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/deeplink/DeepLinkFactoryTest.kt
@@ -324,4 +324,26 @@ class DeepLinkFactoryTest {
 
         assertNull(deepLink)
     }
+
+    @Test
+    fun sonos() {
+        val intent = Intent()
+            .setAction(ACTION_VIEW)
+            .setData(Uri.parse("pktc://applink?state=hello_world"))
+
+        val deepLink = factory.create(intent)
+
+        assertEquals(SonosDeepLink("hello_world"), deepLink)
+    }
+
+    @Test
+    fun sonosWithoutState() {
+        val intent = Intent()
+            .setAction(ACTION_VIEW)
+            .setData(Uri.parse("pktc://applink"))
+
+        val deepLink = factory.create(intent)
+
+        assertNull(deepLink)
+    }
 }

--- a/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
+++ b/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
@@ -64,6 +64,7 @@ import au.com.shiftyjelly.pocketcasts.deeplink.ShowPodcastDeepLink
 import au.com.shiftyjelly.pocketcasts.deeplink.ShowPodcastFromUrlDeepLink
 import au.com.shiftyjelly.pocketcasts.deeplink.ShowPodcastsDeepLink
 import au.com.shiftyjelly.pocketcasts.deeplink.ShowUpNextDeepLink
+import au.com.shiftyjelly.pocketcasts.deeplink.SonosDeepLink
 import au.com.shiftyjelly.pocketcasts.discover.view.DiscoverFragment
 import au.com.shiftyjelly.pocketcasts.endofyear.StoriesFragment
 import au.com.shiftyjelly.pocketcasts.endofyear.StoriesFragment.StoriesSource
@@ -1299,15 +1300,15 @@ class MainActivity :
                     is ShowPodcastFromUrlDeepLink -> {
                         openPodcastUrl(deepLink.url)
                     }
+                    is SonosDeepLink -> {
+                        startActivityForResult(
+                            SonosAppLinkActivity.buildIntent(deepLink.state, this),
+                            SonosAppLinkActivity.SONOS_APP_ACTIVITY_RESULT,
+                        )
+                    }
                 }
             } else if (action == Intent.ACTION_VIEW) {
-                if (IntentUtil.isSonosAppLinkUrl(intent)) {
-                    startActivityForResult(
-                        SonosAppLinkActivity.buildIntent(intent, this),
-                        SonosAppLinkActivity.SONOS_APP_ACTIVITY_RESULT,
-                    )
-                    return
-                } else if (IntentUtil.isPodcastListShare(intent) || IntentUtil.isPodcastListShareMobile(
+                if (IntentUtil.isPodcastListShare(intent) || IntentUtil.isPodcastListShareMobile(
                         intent,
                     )
                 ) {

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/sonos/SonosAppLinkActivity.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/sonos/SonosAppLinkActivity.kt
@@ -32,7 +32,7 @@ class SonosAppLinkActivity : AppCompatActivity(), CoroutineScope {
 
         fun buildIntent(state: String, context: Context): Intent {
             return Intent(context, SonosAppLinkActivity::class.java).apply {
-                putExtra(SonosAppLinkActivity.SONOS_STATE_EXTRA, state)
+                putExtra(SONOS_STATE_EXTRA, state)
             }
         }
     }

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/sonos/SonosAppLinkActivity.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/sonos/SonosAppLinkActivity.kt
@@ -30,9 +30,9 @@ class SonosAppLinkActivity : AppCompatActivity(), CoroutineScope {
         const val SONOS_APP_ACTIVITY_RESULT = 1007
         const val SONOS_STATE_EXTRA = "state"
 
-        fun buildIntent(intent: Intent, context: Context): Intent {
+        fun buildIntent(state: String, context: Context): Intent {
             return Intent(context, SonosAppLinkActivity::class.java).apply {
-                putExtra(SonosAppLinkActivity.SONOS_STATE_EXTRA, intent.data?.query)
+                putExtra(SonosAppLinkActivity.SONOS_STATE_EXTRA, state)
             }
         }
     }
@@ -107,7 +107,7 @@ class SonosAppLinkActivity : AppCompatActivity(), CoroutineScope {
             val sonosToken = response.accessToken
 
             val code = URLEncoder.encode(sonosToken.value, "UTF-8")
-            val state = sonosState.replace("state=", "")
+            val state = sonosState
 
             val result = Intent().apply {
                 putExtra("code", code)

--- a/modules/services/deeplink/src/main/kotlin/au/com/shiftyjelly/pocketcasts/deeplink/DeepLink.kt
+++ b/modules/services/deeplink/src/main/kotlin/au/com/shiftyjelly/pocketcasts/deeplink/DeepLink.kt
@@ -138,6 +138,10 @@ data class ShowPodcastFromUrlDeepLink(
     val url: String,
 ) : DeepLink
 
+data class SonosDeepLink(
+    val state: String,
+) : DeepLink
+
 private val Context.launcherIntent get() = requireNotNull(packageManager.getLaunchIntentForPackage(packageName)) {
     "Missing launcher intent for $packageName"
 }

--- a/modules/services/deeplink/src/main/kotlin/au/com/shiftyjelly/pocketcasts/deeplink/DeepLinkFactory.kt
+++ b/modules/services/deeplink/src/main/kotlin/au/com/shiftyjelly/pocketcasts/deeplink/DeepLinkFactory.kt
@@ -16,6 +16,7 @@ import au.com.shiftyjelly.pocketcasts.deeplink.DeepLink.Companion.EXTRA_FILTER_I
 import au.com.shiftyjelly.pocketcasts.deeplink.DeepLink.Companion.EXTRA_PAGE
 import au.com.shiftyjelly.pocketcasts.deeplink.DeepLink.Companion.EXTRA_PODCAST_UUID
 import au.com.shiftyjelly.pocketcasts.deeplink.DeepLink.Companion.EXTRA_SOURCE_VIEW
+import au.com.shiftyjelly.pocketcasts.deeplink.PodloveAdapter.Companion.PODLOVE_REGEX
 import timber.log.Timber
 
 class DeepLinkFactory(
@@ -32,6 +33,7 @@ class DeepLinkFactory(
         ShowPageAdapter(),
         PocketCastsWebsiteAdapter(webBaseHost),
         PodloveAdapter(),
+        SonosAdapter(),
     )
 
     fun create(intent: Intent): DeepLink? {
@@ -174,5 +176,20 @@ private class PodloveAdapter : DeepLinkAdapter {
 
     private companion object {
         private val PODLOVE_REGEX = """^pktc://(subscribe|subscribehttps)/(.{3,})$""".toRegex()
+    }
+}
+
+private class SonosAdapter : DeepLinkAdapter {
+    override fun create(intent: Intent): DeepLink? {
+        val uriData = intent.data
+        val scheme = uriData?.scheme
+        val host = uriData?.host
+        val state = uriData?.getQueryParameter("state")
+
+        return if (intent.action == ACTION_VIEW && scheme == "pktc" && host == "applink" && state != null) {
+            SonosDeepLink(state)
+        } else {
+            null
+        }
     }
 }

--- a/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/helper/IntentUtil.kt
+++ b/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/helper/IntentUtil.kt
@@ -18,16 +18,6 @@ import timber.log.Timber
 
 object IntentUtil {
 
-    fun isSonosAppLinkUrl(intent: Intent): Boolean {
-        val scheme = intent.scheme
-        if (scheme == null || scheme != "pktc" || intent.data == null || intent.data?.host == null) {
-            return false
-        }
-
-        val host = intent.data?.host
-        return host == "applink"
-    }
-
     fun isShareLink(intent: Intent): Boolean {
         val scheme = intent.scheme
         return scheme != null && scheme == "pktc" && intent.data != null && intent.data?.path != null


### PR DESCRIPTION
## Description

> [!note]
> This will be a series of PRs that move deep linking to a separate module that can be tested. The goal is to address #2405 but I don't want to do it blindly without having tests in order to not introduce regressions to deep linking.

This PR migrates Sonos deep linking to the new module.

## Testing Instructions

1. Sign in.
2. Close the app.
3. Execute `adb shell am start -n au.com.shiftyjelly.pocketcasts.debug/au.com.shiftyjelly.pocketcasts.ui.MainActivity -a android.intent.action.VIEW -d "pktc://applink?state=hello"`.
4. Connect to Sonos screen should open.

## Checklist
- [x] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [x] ~Any jetpack compose components I added or changed are covered by compose previews~
- [x] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~