### PR TITLE
Refactor share list deep linking

### DIFF
--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/deeplink/DeepLinkFactoryTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/deeplink/DeepLinkFactoryTest.kt
@@ -13,6 +13,7 @@ import org.junit.runner.RunWith
 class DeepLinkFactoryTest {
     private val factory = DeepLinkFactory(
         webBaseHost = "pocketcasts.com",
+        listHost = "lists.pocketcasts.com",
     )
 
     @Test
@@ -345,5 +346,82 @@ class DeepLinkFactoryTest {
         val deepLink = factory.create(intent)
 
         assertNull(deepLink)
+    }
+
+    @Test
+    fun shareListHttp() {
+        val intent = Intent()
+            .setAction(ACTION_VIEW)
+            .setData(Uri.parse("http://lists.pocketcasts.com/path/to/list"))
+
+        val deepLink = factory.create(intent)
+
+        assertEquals(ShareListDeepLink("/path/to/list"), deepLink)
+    }
+
+    @Test
+    fun shareListHttps() {
+        val intent = Intent()
+            .setAction(ACTION_VIEW)
+            .setData(Uri.parse("https://lists.pocketcasts.com/path/to/list"))
+
+        val deepLink = factory.create(intent)
+
+        assertEquals(ShareListDeepLink("/path/to/list"), deepLink)
+    }
+
+    @Test
+    fun shareListNative() {
+        val intent = Intent()
+            .setAction(ACTION_VIEW)
+            .setData(Uri.parse("pktc://sharelist/path/to/list"))
+
+        val deepLink = factory.create(intent)
+
+        assertEquals(ShareListDeepLink("/path/to/list"), deepLink)
+    }
+
+    @Test
+    fun shareListWithoutPath() {
+        val intent = Intent()
+            .setAction(ACTION_VIEW)
+            .setData(Uri.parse("https://lists.pocketcasts.com/"))
+
+        val deepLink = factory.create(intent)
+
+        assertNull(deepLink)
+    }
+
+    @Test
+    fun shareListNativeWithoutPath() {
+        val intent = Intent()
+            .setAction(ACTION_VIEW)
+            .setData(Uri.parse("pktc://sharelist/"))
+
+        val deepLink = factory.create(intent)
+
+        assertNull(deepLink)
+    }
+
+    @Test
+    fun shareListWithQuery() {
+        val intent = Intent()
+            .setAction(ACTION_VIEW)
+            .setData(Uri.parse("https://lists.pocketcasts.com/path/to/list?someKey=someValue"))
+
+        val deepLink = factory.create(intent)
+
+        assertEquals(ShareListDeepLink("/path/to/list"), deepLink)
+    }
+
+    @Test
+    fun shareListNativeWithQuery() {
+        val intent = Intent()
+            .setAction(ACTION_VIEW)
+            .setData(Uri.parse("pktc://sharelist/path/to/list?someKey=someValue"))
+
+        val deepLink = factory.create(intent)
+
+        assertEquals(ShareListDeepLink("/path/to/list"), deepLink)
     }
 }

--- a/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
+++ b/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
@@ -56,6 +56,7 @@ import au.com.shiftyjelly.pocketcasts.deeplink.DeepLinkFactory
 import au.com.shiftyjelly.pocketcasts.deeplink.DeleteBookmarkDeepLink
 import au.com.shiftyjelly.pocketcasts.deeplink.DownloadsDeepLink
 import au.com.shiftyjelly.pocketcasts.deeplink.PocketCastsWebsiteDeepLink
+import au.com.shiftyjelly.pocketcasts.deeplink.ShareListDeepLink
 import au.com.shiftyjelly.pocketcasts.deeplink.ShowBookmarkDeepLink
 import au.com.shiftyjelly.pocketcasts.deeplink.ShowDiscoverDeepLink
 import au.com.shiftyjelly.pocketcasts.deeplink.ShowEpisodeDeepLink
@@ -1306,15 +1307,12 @@ class MainActivity :
                             SonosAppLinkActivity.SONOS_APP_ACTIVITY_RESULT,
                         )
                     }
+                    is ShareListDeepLink -> {
+                        addFragment(ShareListIncomingFragment.newInstance(deepLink.path))
+                    }
                 }
             } else if (action == Intent.ACTION_VIEW) {
-                if (IntentUtil.isPodcastListShare(intent) || IntentUtil.isPodcastListShareMobile(
-                        intent,
-                    )
-                ) {
-                    intent.data?.path?.let { addFragment(ShareListIncomingFragment.newInstance(it)) }
-                    return
-                } else if (IntentUtil.isSubscribeOnAndroidUrl(intent)) {
+                if (IntentUtil.isSubscribeOnAndroidUrl(intent)) {
                     openPodcastUrl(IntentUtil.getSubscribeOnAndroidUrl(intent))
                     return
                 } else if (IntentUtil.isItunesLink(intent)) {

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/share/ShareListIncomingFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/share/ShareListIncomingFragment.kt
@@ -44,10 +44,10 @@ class ShareListIncomingFragment : BaseFragment(), ShareListIncomingAdapter.Click
     companion object {
         const val EXTRA_URL = "EXTRA_URL"
 
-        fun newInstance(url: String): ShareListIncomingFragment {
+        fun newInstance(listPath: String): ShareListIncomingFragment {
             return ShareListIncomingFragment().apply {
                 arguments = bundleOf(
-                    EXTRA_URL to url,
+                    EXTRA_URL to listPath,
                 )
             }
         }

--- a/modules/services/deeplink/src/main/kotlin/au/com/shiftyjelly/pocketcasts/deeplink/DeepLink.kt
+++ b/modules/services/deeplink/src/main/kotlin/au/com/shiftyjelly/pocketcasts/deeplink/DeepLink.kt
@@ -142,6 +142,10 @@ data class SonosDeepLink(
     val state: String,
 ) : DeepLink
 
+data class ShareListDeepLink(
+    val path: String,
+) : DeepLink
+
 private val Context.launcherIntent get() = requireNotNull(packageManager.getLaunchIntentForPackage(packageName)) {
     "Missing launcher intent for $packageName"
 }

--- a/modules/services/deeplink/src/main/kotlin/au/com/shiftyjelly/pocketcasts/deeplink/DeepLinkFactory.kt
+++ b/modules/services/deeplink/src/main/kotlin/au/com/shiftyjelly/pocketcasts/deeplink/DeepLinkFactory.kt
@@ -2,6 +2,7 @@ package au.com.shiftyjelly.pocketcasts.deeplink
 
 import android.content.Intent
 import android.content.Intent.ACTION_VIEW
+import au.com.shiftyjelly.pocketcasts.deeplink.BuildConfig.SERVER_LIST_HOST
 import au.com.shiftyjelly.pocketcasts.deeplink.BuildConfig.WEB_BASE_HOST
 import au.com.shiftyjelly.pocketcasts.deeplink.DeepLink.Companion.ACTION_OPEN_ADD_BOOKMARK
 import au.com.shiftyjelly.pocketcasts.deeplink.DeepLink.Companion.ACTION_OPEN_BOOKMARK
@@ -16,11 +17,11 @@ import au.com.shiftyjelly.pocketcasts.deeplink.DeepLink.Companion.EXTRA_FILTER_I
 import au.com.shiftyjelly.pocketcasts.deeplink.DeepLink.Companion.EXTRA_PAGE
 import au.com.shiftyjelly.pocketcasts.deeplink.DeepLink.Companion.EXTRA_PODCAST_UUID
 import au.com.shiftyjelly.pocketcasts.deeplink.DeepLink.Companion.EXTRA_SOURCE_VIEW
-import au.com.shiftyjelly.pocketcasts.deeplink.PodloveAdapter.Companion.PODLOVE_REGEX
 import timber.log.Timber
 
 class DeepLinkFactory(
     private val webBaseHost: String = WEB_BASE_HOST,
+    private val listHost: String = SERVER_LIST_HOST,
 ) {
     private val adapters = listOf(
         DownloadsAdapter(),
@@ -34,6 +35,8 @@ class DeepLinkFactory(
         PocketCastsWebsiteAdapter(webBaseHost),
         PodloveAdapter(),
         SonosAdapter(),
+        ShareListAdapter(listHost),
+        ShareListNativeAdapter(),
     )
 
     fun create(intent: Intent): DeepLink? {
@@ -188,6 +191,38 @@ private class SonosAdapter : DeepLinkAdapter {
 
         return if (intent.action == ACTION_VIEW && scheme == "pktc" && host == "applink" && state != null) {
             SonosDeepLink(state)
+        } else {
+            null
+        }
+    }
+}
+
+private class ShareListAdapter(
+    private val listHost: String,
+) : DeepLinkAdapter {
+    override fun create(intent: Intent): DeepLink? {
+        val uriData = intent.data
+        val scheme = uriData?.scheme
+        val host = uriData?.host
+        val path = uriData?.path?.takeIf { it != "/" }
+
+        return if (intent.action == ACTION_VIEW && scheme in listOf("http", "https") && host == listHost && path != null) {
+            ShareListDeepLink(path)
+        } else {
+            null
+        }
+    }
+}
+
+private class ShareListNativeAdapter : DeepLinkAdapter {
+    override fun create(intent: Intent): DeepLink? {
+        val uriData = intent.data
+        val scheme = uriData?.scheme
+        val host = uriData?.host
+        val path = uriData?.path?.takeIf { it != "/" }
+
+        return if (intent.action == ACTION_VIEW && scheme == "pktc" && host == "sharelist" && path != null) {
+            ShareListDeepLink(path)
         } else {
             null
         }

--- a/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/helper/IntentUtil.kt
+++ b/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/helper/IntentUtil.kt
@@ -152,26 +152,6 @@ object IntentUtil {
         return true
     }
 
-    fun isPodcastListShare(intent: Intent): Boolean {
-        val scheme = intent.scheme
-        if (scheme == null || !(scheme == "http" || scheme == "https")) {
-            return false
-        }
-
-        val host = intent.data?.host
-        return host == "lists.pocketcasts.com"
-    }
-
-    fun isPodcastListShareMobile(intent: Intent): Boolean {
-        val scheme = intent.scheme
-        if (scheme == null || scheme != "pktc") {
-            return false
-        }
-
-        val host = intent.data?.host
-        return host == "sharelist"
-    }
-
     fun getUrl(intent: Intent): String? {
         return if (intent.data != null && intent.data.toString().isNotBlank()) intent.data.toString() else null
     }


### PR DESCRIPTION
## Description

> [!note]
> This will be a series of PRs that move deep linking to a separate module that can be tested. The goal is to address #2405 but I don't want to do it blindly without having tests in order to not introduce regressions to deep linking.

This PR migrates share list  deep linking to the new module.

## Testing Instructions

1. Execute `adb shell am start -n au.com.shiftyjelly.pocketcasts.debug/au.com.shiftyjelly.pocketcasts.ui.MainActivity -a android.intent.action.VIEW -d "https://lists.pocketcasts.com/regularly-scheduled-programming"`.
2. App should open and load `Regularly Scheduled Programming` list.
3. Close the app.
4. Execute `adb shell am start -n au.com.shiftyjelly.pocketcasts.debug/au.com.shiftyjelly.pocketcasts.ui.MainActivity -a android.intent.action.VIEW -d "pktc://sharelist/regularly-scheduled-programming"`.
5. App should open and load `Regularly Scheduled Programming` list.

## Checklist
- [x] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [x] ~Any jetpack compose components I added or changed are covered by compose previews~
- [x] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~