### PR TITLE
Refactor subscribe on Android deep linking

### DIFF
--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/deeplink/DeepLinkFactoryTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/deeplink/DeepLinkFactoryTest.kt
@@ -424,4 +424,48 @@ class DeepLinkFactoryTest {
 
         assertEquals(ShareListDeepLink("/path/to/list"), deepLink)
     }
+
+    @Test
+    fun subscribeOnAndroid() {
+        val intent = Intent()
+            .setAction(ACTION_VIEW)
+            .setData(Uri.parse("https://subscribeonandroid.com/blubrry.com/feed/podcast/"))
+
+        val deepLink = factory.create(intent)
+
+        assertEquals(ShowPodcastFromUrlDeepLink("https://blubrry.com/feed/podcast/"), deepLink)
+    }
+
+    @Test
+    fun subscribeOnAndroidHttp() {
+        val intent = Intent()
+            .setAction(ACTION_VIEW)
+            .setData(Uri.parse("http://subscribeonandroid.com/blubrry.com/feed/podcast/"))
+
+        val deepLink = factory.create(intent)
+
+        assertEquals(ShowPodcastFromUrlDeepLink("http://blubrry.com/feed/podcast/"), deepLink)
+    }
+
+    @Test
+    fun subscribeOnAndroidWithWwwHost() {
+        val intent = Intent()
+            .setAction(ACTION_VIEW)
+            .setData(Uri.parse("https://www.subscribeonandroid.com/blubrry.com/feed/podcast/"))
+
+        val deepLink = factory.create(intent)
+
+        assertEquals(ShowPodcastFromUrlDeepLink("https://blubrry.com/feed/podcast/"), deepLink)
+    }
+
+    @Test
+    fun subscribeOnAndroidWithTooShortPath() {
+        val intent = Intent()
+            .setAction(ACTION_VIEW)
+            .setData(Uri.parse("https://subscribeonandroid.com/bl"))
+
+        val deepLink = factory.create(intent)
+
+        assertNull(deepLink)
+    }
 }

--- a/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
+++ b/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
@@ -1312,10 +1312,7 @@ class MainActivity :
                     }
                 }
             } else if (action == Intent.ACTION_VIEW) {
-                if (IntentUtil.isSubscribeOnAndroidUrl(intent)) {
-                    openPodcastUrl(IntentUtil.getSubscribeOnAndroidUrl(intent))
-                    return
-                } else if (IntentUtil.isItunesLink(intent)) {
+                if (IntentUtil.isItunesLink(intent)) {
                     openPodcastUrl(IntentUtil.getUrl(intent))
                     return
                 } else if (IntentUtil.isCloudFilesIntent(intent)) {

--- a/modules/services/deeplink/src/main/kotlin/au/com/shiftyjelly/pocketcasts/deeplink/DeepLinkFactory.kt
+++ b/modules/services/deeplink/src/main/kotlin/au/com/shiftyjelly/pocketcasts/deeplink/DeepLinkFactory.kt
@@ -17,6 +17,7 @@ import au.com.shiftyjelly.pocketcasts.deeplink.DeepLink.Companion.EXTRA_FILTER_I
 import au.com.shiftyjelly.pocketcasts.deeplink.DeepLink.Companion.EXTRA_PAGE
 import au.com.shiftyjelly.pocketcasts.deeplink.DeepLink.Companion.EXTRA_PODCAST_UUID
 import au.com.shiftyjelly.pocketcasts.deeplink.DeepLink.Companion.EXTRA_SOURCE_VIEW
+import au.com.shiftyjelly.pocketcasts.deeplink.PodloveAdapter.Companion.PODLOVE_REGEX
 import timber.log.Timber
 
 class DeepLinkFactory(
@@ -37,6 +38,7 @@ class DeepLinkFactory(
         SonosAdapter(),
         ShareListAdapter(listHost),
         ShareListNativeAdapter(),
+        SubscribeOnAndroidAdapter(),
     )
 
     fun create(intent: Intent): DeepLink? {
@@ -223,6 +225,26 @@ private class ShareListNativeAdapter : DeepLinkAdapter {
 
         return if (intent.action == ACTION_VIEW && scheme == "pktc" && host == "sharelist" && path != null) {
             ShareListDeepLink(path)
+        } else {
+            null
+        }
+    }
+}
+
+// http://subscribeonandroid.com/geeknewscentral.com/podcast.xml
+private class SubscribeOnAndroidAdapter : DeepLinkAdapter {
+    override fun create(intent: Intent): DeepLink? {
+        val uriData = intent.data
+        val scheme = uriData?.scheme
+        val host = uriData?.host
+        val path = uriData?.path?.replaceFirst("/", "")?.takeIf { it.length >= 3 }
+
+        return if (intent.action == ACTION_VIEW &&
+            scheme in listOf("http", "https") &&
+            host in listOf("subscribeonandroid.com", "www.subscribeonandroid.com") &&
+            path != null
+        ) {
+            ShowPodcastFromUrlDeepLink("$scheme://$path")
         } else {
             null
         }

--- a/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/helper/IntentUtil.kt
+++ b/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/helper/IntentUtil.kt
@@ -13,7 +13,6 @@ import java.io.File
 import java.io.UnsupportedEncodingException
 import java.net.URLDecoder
 import java.util.Arrays
-import java.util.regex.Matcher
 import timber.log.Timber
 
 object IntentUtil {
@@ -26,33 +25,6 @@ object IntentUtil {
     fun isNativeShareLink(intent: Intent): Boolean {
         val scheme = intent.scheme
         return scheme != null && scheme in listOf("http", "https") && intent.data != null && intent.data?.host in listOf("pca.st", "pcast.pocketcasts.net")
-    }
-
-    // http://subscribeonandroid.com/geeknewscentral.com/podcast.xml
-    fun isSubscribeOnAndroidUrl(intent: Intent): Boolean {
-        val scheme = intent.scheme
-        if (scheme == null || !(scheme == "http" || scheme == "https")) {
-            return false
-        }
-
-        if (intent.data == null || intent.data?.host == null) {
-            return false
-        }
-        val host = intent.data?.host
-        return host == "subscribeonandroid.com" || host == "www.subscribeonandroid.com"
-    }
-
-    fun getSubscribeOnAndroidUrl(intent: Intent): String? {
-        val uri = intent.data ?: return null
-        var path = uri.path ?: return null
-        if (path.startsWith("/")) {
-            path = path.replaceFirst(Matcher.quoteReplacement("/").toRegex(), "")
-        }
-        if (path.length < 3) {
-            return null
-        }
-        val scheme = intent.scheme
-        return "$scheme://$path"
     }
 
     fun webViewShouldOverrideUrl(url: String?, context: Context): Boolean {


### PR DESCRIPTION
## Description

> [!note]
> This will be a series of PRs that move deep linking to a separate module that can be tested. The goal is to address #2405 but I don't want to do it blindly without having tests in order to not introduce regressions to deep linking.

This PR migrates subscribe on Android deep linking to the new module.

## Testing Instructions

1. Execute `adb shell am start -n au.com.shiftyjelly.pocketcasts.debug/au.com.shiftyjelly.pocketcasts.ui.MainActivity -a android.intent.action.VIEW -d "https://subscribeonandroid.com/blubrry.com/feed/podcast/"`.
2. App should open and load `Podcast Insider` podcast.

## Checklist
- [x] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [x] ~Any jetpack compose components I added or changed are covered by compose previews~
- [x] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~