### PR TITLE
Refactor Apple deep linking

### DIFF
--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/deeplink/DeepLinkFactoryTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/deeplink/DeepLinkFactoryTest.kt
@@ -468,4 +468,26 @@ class DeepLinkFactoryTest {
 
         assertNull(deepLink)
     }
+
+    @Test
+    fun iTunes() {
+        val intent = Intent()
+            .setAction(ACTION_VIEW)
+            .setData(Uri.parse("https://itunes.apple.com/some/podcast"))
+
+        val deepLink = factory.create(intent)
+
+        assertEquals(ShowPodcastFromUrlDeepLink("https://itunes.apple.com/some/podcast"), deepLink)
+    }
+
+    @Test
+    fun applePodcasts() {
+        val intent = Intent()
+            .setAction(ACTION_VIEW)
+            .setData(Uri.parse("https://podcasts.apple.com/some/podcast"))
+
+        val deepLink = factory.create(intent)
+
+        assertEquals(ShowPodcastFromUrlDeepLink("https://podcasts.apple.com/some/podcast"), deepLink)
+    }
 }

--- a/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
+++ b/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
@@ -1312,10 +1312,7 @@ class MainActivity :
                     }
                 }
             } else if (action == Intent.ACTION_VIEW) {
-                if (IntentUtil.isItunesLink(intent)) {
-                    openPodcastUrl(IntentUtil.getUrl(intent))
-                    return
-                } else if (IntentUtil.isCloudFilesIntent(intent)) {
+                if (IntentUtil.isCloudFilesIntent(intent)) {
                     openCloudFiles()
                     return
                 } else if (IntentUtil.isUpgradeIntent(intent)) {

--- a/modules/services/deeplink/src/main/kotlin/au/com/shiftyjelly/pocketcasts/deeplink/DeepLinkFactory.kt
+++ b/modules/services/deeplink/src/main/kotlin/au/com/shiftyjelly/pocketcasts/deeplink/DeepLinkFactory.kt
@@ -39,6 +39,7 @@ class DeepLinkFactory(
         ShareListAdapter(listHost),
         ShareListNativeAdapter(),
         SubscribeOnAndroidAdapter(),
+        AppleAdapter(),
     )
 
     fun create(intent: Intent): DeepLink? {
@@ -245,6 +246,19 @@ private class SubscribeOnAndroidAdapter : DeepLinkAdapter {
             path != null
         ) {
             ShowPodcastFromUrlDeepLink("$scheme://$path")
+        } else {
+            null
+        }
+    }
+}
+
+private class AppleAdapter : DeepLinkAdapter {
+    override fun create(intent: Intent): DeepLink? {
+        val uriData = intent.data
+        val host = uriData?.host
+
+        return if (intent.action == ACTION_VIEW && host in listOf("itunes.apple.com", "podcasts.apple.com") && uriData != null) {
+            ShowPodcastFromUrlDeepLink(uriData.toString())
         } else {
             null
         }

--- a/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/helper/IntentUtil.kt
+++ b/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/helper/IntentUtil.kt
@@ -128,10 +128,6 @@ object IntentUtil {
         return if (intent.data != null && intent.data.toString().isNotBlank()) intent.data.toString() else null
     }
 
-    fun isItunesLink(intent: Intent): Boolean {
-        return intent.data?.host == "itunes.apple.com" || intent.data?.host == "podcasts.apple.com"
-    }
-
     fun isCloudFilesIntent(intent: Intent): Boolean {
         val scheme = intent.scheme
         if (scheme == null || scheme != "pktc") {


### PR DESCRIPTION
## Description

> [!note]
> This will be a series of PRs that move deep linking to a separate module that can be tested. The goal is to address #2405 but I don't want to do it blindly without having tests in order to not introduce regressions to deep linking.

This PR migrates Apple deep linking to the new module.

## Testing Instructions

1. Execute `adb shell am start -n au.com.shiftyjelly.pocketcasts.debug/au.com.shiftyjelly.pocketcasts.ui.MainActivity -a android.intent.action.VIEW -d "https://itunes.apple.com/us/podcast/within-reason/id1458675168"`.
2. App should open and load `Within Reason` podcast.
3. Close the app.
4. Execute `adb shell am start -n au.com.shiftyjelly.pocketcasts.debug/au.com.shiftyjelly.pocketcasts.ui.MainActivity -a android.intent.action.VIEW -d "https://podcasts.apple.com/us/podcast/within-reason/id1458675168"`.
5. App should open and load `Within Reason` podcast.

## Checklist
- [x] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [x] ~Any jetpack compose components I added or changed are covered by compose previews~
- [x] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~