### PR TITLE
Refactor cloud files deep linking

### DIFF
--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/deeplink/CloudFilesDeepLinkTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/deeplink/CloudFilesDeepLinkTest.kt
@@ -1,0 +1,22 @@
+package au.com.shiftyjelly.pocketcasts.deeplink
+
+import android.content.Intent.ACTION_VIEW
+import android.net.Uri
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class CloudFilesDeepLinkTest {
+    private val context = InstrumentationRegistry.getInstrumentation().context
+
+    @Test
+    fun createIntent() {
+        val intent = CloudFilesDeepLink.toIntent(context)
+
+        assertEquals(ACTION_VIEW, intent.action)
+        assertEquals(Uri.parse("pktc://cloudfiles"), intent.data)
+    }
+}

--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/deeplink/DeepLinkFactoryTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/deeplink/DeepLinkFactoryTest.kt
@@ -490,4 +490,15 @@ class DeepLinkFactoryTest {
 
         assertEquals(ShowPodcastFromUrlDeepLink("https://podcasts.apple.com/some/podcast"), deepLink)
     }
+
+    @Test
+    fun cloudFiles() {
+        val intent = Intent()
+            .setAction(ACTION_VIEW)
+            .setData(Uri.parse("pktc://cloudfiles"))
+
+        val deepLink = factory.create(intent)
+
+        assertEquals(CloudFilesDeepLink, deepLink)
+    }
 }

--- a/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
+++ b/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
@@ -51,6 +51,7 @@ import au.com.shiftyjelly.pocketcasts.analytics.SourceView
 import au.com.shiftyjelly.pocketcasts.databinding.ActivityMainBinding
 import au.com.shiftyjelly.pocketcasts.deeplink.AddBookmarkDeepLink
 import au.com.shiftyjelly.pocketcasts.deeplink.ChangeBookmarkTitleDeepLink
+import au.com.shiftyjelly.pocketcasts.deeplink.CloudFilesDeepLink
 import au.com.shiftyjelly.pocketcasts.deeplink.DeepLink.Companion.EXTRA_PAGE
 import au.com.shiftyjelly.pocketcasts.deeplink.DeepLinkFactory
 import au.com.shiftyjelly.pocketcasts.deeplink.DeleteBookmarkDeepLink
@@ -1310,12 +1311,12 @@ class MainActivity :
                     is ShareListDeepLink -> {
                         addFragment(ShareListIncomingFragment.newInstance(deepLink.path))
                     }
+                    is CloudFilesDeepLink -> {
+                        openCloudFiles()
+                    }
                 }
             } else if (action == Intent.ACTION_VIEW) {
-                if (IntentUtil.isCloudFilesIntent(intent)) {
-                    openCloudFiles()
-                    return
-                } else if (IntentUtil.isUpgradeIntent(intent)) {
+                if (IntentUtil.isUpgradeIntent(intent)) {
                     showAccountUpgradeNowDialog(shouldClose = true)
                     return
                 } else if (IntentUtil.isPromoCodeIntent(intent)) {

--- a/modules/features/profile/build.gradle.kts
+++ b/modules/features/profile/build.gradle.kts
@@ -30,6 +30,7 @@ dependencies {
     implementation(project(":modules:services:analytics"))
     implementation(project(":modules:services:compose"))
     implementation(project(":modules:services:crashlogging"))
+    implementation(project(":modules:services:deeplink"))
     implementation(project(":modules:services:images"))
     implementation(project(":modules:services:localization"))
     implementation(project(":modules:services:model"))

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/cloud/AddFileActivity.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/cloud/AddFileActivity.kt
@@ -36,6 +36,7 @@ import androidx.media3.extractor.mp3.Mp3Extractor
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import au.com.shiftyjelly.pocketcasts.account.onboarding.OnboardingActivity
+import au.com.shiftyjelly.pocketcasts.deeplink.CloudFilesDeepLink
 import au.com.shiftyjelly.pocketcasts.models.entity.UserEpisode
 import au.com.shiftyjelly.pocketcasts.models.to.SignInState
 import au.com.shiftyjelly.pocketcasts.models.to.SubscriptionStatus
@@ -511,8 +512,7 @@ class AddFileActivity :
                     if (isFileChooserMode) {
                         finish()
                     } else {
-                        val intent = Intent(Intent.ACTION_VIEW, Uri.parse(Settings.INTENT_LINK_CLOUD_FILES))
-                        startActivity(intent)
+                        startActivity(CloudFilesDeepLink.toIntent(this@AddFileActivity))
                         finish()
                     }
                 }

--- a/modules/services/deeplink/src/main/kotlin/au/com/shiftyjelly/pocketcasts/deeplink/DeepLink.kt
+++ b/modules/services/deeplink/src/main/kotlin/au/com/shiftyjelly/pocketcasts/deeplink/DeepLink.kt
@@ -3,6 +3,7 @@ package au.com.shiftyjelly.pocketcasts.deeplink
 import android.content.Context
 import android.content.Intent
 import android.content.Intent.ACTION_VIEW
+import android.net.Uri
 import au.com.shiftyjelly.pocketcasts.deeplink.DeepLink.Companion.ACTION_OPEN_ADD_BOOKMARK
 import au.com.shiftyjelly.pocketcasts.deeplink.DeepLink.Companion.ACTION_OPEN_BOOKMARK
 import au.com.shiftyjelly.pocketcasts.deeplink.DeepLink.Companion.ACTION_OPEN_CHANGE_BOOKMARK_TITLE
@@ -145,6 +146,11 @@ data class SonosDeepLink(
 data class ShareListDeepLink(
     val path: String,
 ) : DeepLink
+
+data object CloudFilesDeepLink : IntentableDeepLink {
+    override fun toIntent(context: Context) = Intent(ACTION_VIEW)
+        .setData(Uri.parse("pktc://cloudfiles"))
+}
 
 private val Context.launcherIntent get() = requireNotNull(packageManager.getLaunchIntentForPackage(packageName)) {
     "Missing launcher intent for $packageName"

--- a/modules/services/deeplink/src/main/kotlin/au/com/shiftyjelly/pocketcasts/deeplink/DeepLinkFactory.kt
+++ b/modules/services/deeplink/src/main/kotlin/au/com/shiftyjelly/pocketcasts/deeplink/DeepLinkFactory.kt
@@ -40,6 +40,7 @@ class DeepLinkFactory(
         ShareListNativeAdapter(),
         SubscribeOnAndroidAdapter(),
         AppleAdapter(),
+        CloudFilesAdapter(),
     )
 
     fun create(intent: Intent): DeepLink? {
@@ -259,6 +260,20 @@ private class AppleAdapter : DeepLinkAdapter {
 
         return if (intent.action == ACTION_VIEW && host in listOf("itunes.apple.com", "podcasts.apple.com") && uriData != null) {
             ShowPodcastFromUrlDeepLink(uriData.toString())
+        } else {
+            null
+        }
+    }
+}
+
+private class CloudFilesAdapter : DeepLinkAdapter {
+    override fun create(intent: Intent): DeepLink? {
+        val uriData = intent.data
+        val scheme = uriData?.scheme
+        val host = uriData?.host
+
+        return if (intent.action == ACTION_VIEW && scheme == "pktc" && host == "cloudfiles") {
+            CloudFilesDeepLink
         } else {
             null
         }

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
@@ -105,7 +105,6 @@ interface Settings {
         const val AUTO_ARCHIVE_INCLUDE_STARRED = "autoArchiveIncludeStarred"
 
         const val INTENT_OPEN_APP_NEW_EPISODES = "INTENT_OPEN_APP_NEW_EPISODES"
-        const val INTENT_LINK_CLOUD_FILES = "pktc://cloudfiles"
         const val INTENT_LINK_UPGRADE = "pktc://upgrade"
         const val INTENT_LINK_PROMO_CODE = "pktc://redeem/promo/"
 

--- a/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/helper/IntentUtil.kt
+++ b/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/helper/IntentUtil.kt
@@ -128,15 +128,6 @@ object IntentUtil {
         return if (intent.data != null && intent.data.toString().isNotBlank()) intent.data.toString() else null
     }
 
-    fun isCloudFilesIntent(intent: Intent): Boolean {
-        val scheme = intent.scheme
-        if (scheme == null || scheme != "pktc") {
-            return false
-        }
-
-        return Uri.parse(Settings.INTENT_LINK_CLOUD_FILES).host == intent.data?.host
-    }
-
     fun isUpgradeIntent(intent: Intent): Boolean {
         val scheme = intent.scheme
         if (scheme == null || scheme != "pktc") {


### PR DESCRIPTION
## Description

> [!note]
> This will be a series of PRs that move deep linking to a separate module that can be tested. The goal is to address #2405 but I don't want to do it blindly without having tests in order to not introduce regressions to deep linking.

This PR migrates cloud files deep linking to the new module.

## Testing Instructions

1. Go to your file manager and find an audio file.
2. Share it to Pocket Casts.
3. Add the file in Pocket Casts.
4. App should open Files page.

## Checklist
- [x] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [x] ~Any jetpack compose components I added or changed are covered by compose previews~
- [x] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~