### PR TITLE
Transcripts - Style cues into paragraphs

### DIFF
--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/transcripts/TranscriptPage.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/transcripts/TranscriptPage.kt
@@ -16,6 +16,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.MaterialTheme
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -26,6 +27,7 @@ import androidx.compose.ui.unit.dp
 import androidx.media3.common.util.UnstableApi
 import au.com.shiftyjelly.pocketcasts.compose.components.TextH30
 import au.com.shiftyjelly.pocketcasts.compose.components.TextP40
+import au.com.shiftyjelly.pocketcasts.compose.loading.LoadingView
 import au.com.shiftyjelly.pocketcasts.compose.theme
 import au.com.shiftyjelly.pocketcasts.localization.R
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
@@ -44,11 +46,18 @@ fun TranscriptPage(
     val state = viewModel.uiState.collectAsState()
     when (state.value) {
         is UiState.Empty -> Unit
-        is UiState.Success -> {
-            val successState = state.value as UiState.Success
+
+        is UiState.TranscriptFound -> {
+            val transcriptFoundState = state.value as UiState.TranscriptFound
+            val colors = DefaultColors(theme, transcriptFoundState.podcastAndEpisode?.podcast)
+            LoadingView(Modifier.background(colors.backgroundColor()))
+        }
+
+        is UiState.TranscriptLoaded -> {
+            val loadedState = state.value as UiState.TranscriptLoaded
             TranscriptContent(
-                state = successState,
-                colors = DefaultColors(theme, successState.podcast),
+                state = loadedState,
+                colors = DefaultColors(theme, loadedState.podcastAndEpisode?.podcast),
             )
         }
 
@@ -56,16 +65,20 @@ fun TranscriptPage(
             val errorState = state.value as UiState.Error
             TranscriptError(
                 state = errorState,
-                colors = DefaultColors(theme, errorState.podcast),
+                colors = DefaultColors(theme, errorState.podcastAndEpisode?.podcast),
             )
         }
+    }
+
+    LaunchedEffect(Unit) {
+        viewModel.parseAndLoadTranscript()
     }
 }
 
 @OptIn(UnstableApi::class)
 @Composable
 private fun TranscriptContent(
-    state: UiState.Success,
+    state: UiState.TranscriptLoaded,
     colors: DefaultColors,
 ) {
     LazyColumn(

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/transcripts/TranscriptPage.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/transcripts/TranscriptPage.kt
@@ -10,7 +10,6 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
@@ -86,12 +85,13 @@ private fun TranscriptContent(
             .background(colors.backgroundColor())
             .fillMaxSize(),
     ) {
-        items(state.cues) { cues ->
+        items(state.cuesWithTimingSubtitle.eventTimeCount) { index ->
+            val time = state.cuesWithTimingSubtitle.getEventTime(index)
             TextP40(
-                text = cues.startTimeUs.microseconds.format(),
+                text = time.microseconds.format(),
                 color = colors.textColor(),
             )
-            cues.cues.forEach {
+            state.cuesWithTimingSubtitle.getCues(time).forEach {
                 TextP40(
                     text = it.text.toString(),
                     color = colors.textColor(),

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/transcripts/TranscriptViewModel.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/transcripts/TranscriptViewModel.kt
@@ -17,7 +17,6 @@ import au.com.shiftyjelly.pocketcasts.repositories.podcast.TranscriptsManager
 import au.com.shiftyjelly.pocketcasts.utils.UrlUtil
 import com.google.common.collect.ImmutableList
 import dagger.hilt.android.lifecycle.HiltViewModel
-import java.util.regex.Pattern
 import javax.inject.Inject
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -30,9 +29,9 @@ import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
-// TODO: [Transcript] Modify SpeakerRegex for non english languages
-private val SpeakerRegex = Pattern.compile("Speaker \\d*: ")
-private val NewLineRegex = Pattern.compile("\\.$")
+// TODO: [Transcript] Modify regex for non english languages
+private val SpeakerRegex = """Speaker \d+: """.toRegex()
+private val NewLineRegex = """[.?!]$""".toRegex()
 
 @kotlin.OptIn(ExperimentalCoroutinesApi::class)
 @OptIn(UnstableApi::class)
@@ -125,8 +124,8 @@ class TranscriptViewModel @Inject constructor(
         cuesWithTiming.cues.map { cue ->
             val cueBuilder = cue.buildUpon()
             val newText = cue.text.toString()
-                .replace(SpeakerRegex.toRegex(), "")
-                .replace(NewLineRegex.toRegex(), ".\n\n")
+                .replace(SpeakerRegex, "")
+                .replace(NewLineRegex, "${cue.text.toString().last()}\n\n")
             cueBuilder.setText(newText)
             cueBuilder.build()
         }

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/transcripts/TranscriptViewModel.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/transcripts/TranscriptViewModel.kt
@@ -6,6 +6,7 @@ import androidx.lifecycle.viewModelScope
 import androidx.media3.common.Format
 import androidx.media3.common.util.UnstableApi
 import androidx.media3.extractor.text.CuesWithTiming
+import androidx.media3.extractor.text.CuesWithTimingSubtitle
 import androidx.media3.extractor.text.SubtitleParser
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.to.Transcript
@@ -68,7 +69,7 @@ class TranscriptViewModel @Inject constructor(
                     UiState.TranscriptLoaded(
                         transcript = transcript,
                         podcastAndEpisode = podcastAndEpisode,
-                        cues = result,
+                        cuesWithTimingSubtitle = result,
                     )
                 } catch (e: UnsupportedOperationException) {
                     UiState.Error(TranscriptError.NotSupported(transcript.type), podcastAndEpisode)
@@ -96,7 +97,7 @@ class TranscriptViewModel @Inject constructor(
                     element?.let { result.add(it) }
                 }
             }
-            result.build()
+            CuesWithTimingSubtitle(result.build())
         }
     }
 
@@ -121,7 +122,7 @@ class TranscriptViewModel @Inject constructor(
         data class TranscriptLoaded(
             override val podcastAndEpisode: PodcastAndEpisode? = null,
             override val transcript: Transcript,
-            val cues: List<CuesWithTiming> = emptyList(),
+            val cuesWithTimingSubtitle: CuesWithTimingSubtitle,
         ) : UiState()
 
         data class Error(

--- a/modules/features/player/src/test/java/au/com/shiftyjelly/pocketcasts/player/view/transcripts/TranscriptViewModelTest.kt
+++ b/modules/features/player/src/test/java/au/com/shiftyjelly/pocketcasts/player/view/transcripts/TranscriptViewModelTest.kt
@@ -114,27 +114,37 @@ class TranscriptViewModelTest {
     }
 
     @Test
-    fun `new line added to dot at the end of cue text`() = runTest {
+    fun `new line added after period, exclamation mark, or question mark at end of cue text`() = runTest {
         whenever(transcriptsManager.observerTranscriptForEpisode(any())).thenReturn(flowOf(transcript))
         whenever(subtitleParserFactory.supportsFormat(any())).thenReturn(true)
         initViewModel()
-        val cuesWithTiming = CuesWithTiming(listOf(Cue.Builder().setText("Text.").build()), 0L, 0L)
+        val cuesWithTiming = CuesWithTiming(
+            listOf(
+                Cue.Builder().setText("Text.").build(),
+                Cue.Builder().setText("Text!").build(),
+                Cue.Builder().setText("Text?").build(),
+            ),
+            0L,
+            0L,
+        )
 
         val result = viewModel.modifiedCues(cuesWithTiming)
 
         assertTrue(result[0].text == "Text.\n\n")
+        assertTrue(result[1].text == "Text!\n\n")
+        assertTrue(result[2].text == "Text?\n\n")
     }
 
     @Test
-    fun `new line not added to dot in middle of the cue text`() = runTest {
+    fun `new line not added after period, exclamation mark, or question mark in middle of the cue text`() = runTest {
         whenever(transcriptsManager.observerTranscriptForEpisode(any())).thenReturn(flowOf(transcript))
         whenever(subtitleParserFactory.supportsFormat(any())).thenReturn(true)
         initViewModel()
-        val cuesWithTiming = CuesWithTiming(listOf(Cue.Builder().setText("Text1. Text2.").build()), 0L, 0L)
+        val cuesWithTiming = CuesWithTiming(listOf(Cue.Builder().setText("Text1.!? Text2").build()), 0L, 0L)
 
         val result = viewModel.modifiedCues(cuesWithTiming)
 
-        assertTrue(result[0].text == "Text1. Text2.\n\n")
+        assertTrue(result[0].text == "Text1.!? Text2")
     }
 
     @OptIn(ExperimentalCoroutinesApi::class)

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/loading/LoadingView.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/loading/LoadingView.kt
@@ -15,10 +15,12 @@ import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import com.airbnb.android.showkase.annotation.ShowkaseComposable
 
 @Composable
-fun LoadingView() {
+fun LoadingView(
+    modifier: Modifier = Modifier,
+) {
     Box(
         contentAlignment = Alignment.Center,
-        modifier = Modifier.fillMaxSize(),
+        modifier = modifier.fillMaxSize(),
     ) {
         CircularProgressIndicator(
             modifier = Modifier

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/TranscriptsManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/TranscriptsManagerImpl.kt
@@ -14,10 +14,10 @@ class TranscriptsManagerImpl @Inject constructor(
         episodeUuid: String,
         transcripts: List<Transcript>,
     ) {
+        if (transcripts.isEmpty()) return
+        transcriptDao.deleteForEpisode(episodeUuid)
         findBestTranscript(transcripts)?.let { bestTranscript ->
             transcriptDao.insert(bestTranscript)
-        } ?: run {
-            transcriptDao.deleteForEpisode(episodeUuid)
         }
     }
 

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/TranscriptsManagerImplTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/TranscriptsManagerImplTest.kt
@@ -7,6 +7,7 @@ import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Test
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 
 class TranscriptsManagerImplTest {
@@ -59,16 +60,13 @@ class TranscriptsManagerImplTest {
     }
 
     @Test
-    fun `updateTranscripts deletes existing transcript when no transcript is available`() = runTest {
-        val transcripts1 = listOf(
-            Transcript("1", "url_1", "application/srt"),
-            Transcript("1", "url_2", "text/vtt"),
-        )
+    fun `updateTranscripts deletes existing transcript when new transcript is available`() = runTest {
+        val transcripts1 = listOf(Transcript("1", "url_1", "application/srt"))
         transcriptsManager.updateTranscripts("1", transcripts1)
 
-        val transcripts2 = emptyList<Transcript>()
+        val transcripts2 = listOf(Transcript("1", "url_2", "text/vtt"))
         transcriptsManager.updateTranscripts("1", transcripts2)
 
-        verify(transcriptDao).deleteForEpisode("1")
+        verify(transcriptDao, times(2)).deleteForEpisode("1")
     }
 }


### PR DESCRIPTION
## Description
This styles cues into paragraphs.

** I also refactored the code so the transcript is parsed only when the `Transcript` tab is selected. 

## Testing Instructions
1. Play an episode from "Cautionary Tales" (https://pcast.pocketcasts.net/8zpmjiru)
2. Open full screen player
3. Go to the `Transcript` tab
4. ✅ Notice that the transcript is styled as paragraphs

## Screenshots or Screencast 
<img width=250 src="https://github.com/Automattic/pocket-casts-android/assets/1405144/8842ad65-895d-4d6a-ad85-166fc8ce8ff9"/>


## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
