### PR TITLE
Refactor promo code deep linking

### DIFF
--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/deeplink/DeepLinkFactoryTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/deeplink/DeepLinkFactoryTest.kt
@@ -512,4 +512,48 @@ class DeepLinkFactoryTest {
 
         assertEquals(UpgradeAccountDeepLink, deepLink)
     }
+
+    @Test
+    fun promoCode() {
+        val intent = Intent()
+            .setAction(ACTION_VIEW)
+            .setData(Uri.parse("pktc://redeem/promo/ABC-123"))
+
+        val deepLink = factory.create(intent)
+
+        assertEquals(PromoCodeDeepLink("ABC-123"), deepLink)
+    }
+
+    @Test
+    fun promoCodeWithLongPath() {
+        val intent = Intent()
+            .setAction(ACTION_VIEW)
+            .setData(Uri.parse("pktc://redeem/promo/with/some/long/path/ABC-123"))
+
+        val deepLink = factory.create(intent)
+
+        assertEquals(PromoCodeDeepLink("ABC-123"), deepLink)
+    }
+
+    @Test
+    fun promoCodeWithoutPromoPath() {
+        val intent = Intent()
+            .setAction(ACTION_VIEW)
+            .setData(Uri.parse("pktc://redeem/ABC-123"))
+
+        val deepLink = factory.create(intent)
+
+        assertNull(deepLink)
+    }
+
+    @Test
+    fun promoCodeWithoutCode() {
+        val intent = Intent()
+            .setAction(ACTION_VIEW)
+            .setData(Uri.parse("pktc://redeem/promo/"))
+
+        val deepLink = factory.create(intent)
+
+        assertNull(deepLink)
+    }
 }

--- a/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
+++ b/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
@@ -57,6 +57,7 @@ import au.com.shiftyjelly.pocketcasts.deeplink.DeepLinkFactory
 import au.com.shiftyjelly.pocketcasts.deeplink.DeleteBookmarkDeepLink
 import au.com.shiftyjelly.pocketcasts.deeplink.DownloadsDeepLink
 import au.com.shiftyjelly.pocketcasts.deeplink.PocketCastsWebsiteDeepLink
+import au.com.shiftyjelly.pocketcasts.deeplink.PromoCodeDeepLink
 import au.com.shiftyjelly.pocketcasts.deeplink.ShareListDeepLink
 import au.com.shiftyjelly.pocketcasts.deeplink.ShowBookmarkDeepLink
 import au.com.shiftyjelly.pocketcasts.deeplink.ShowDiscoverDeepLink
@@ -1318,12 +1319,12 @@ class MainActivity :
                     is UpgradeAccountDeepLink -> {
                         showAccountUpgradeNowDialog(shouldClose = true)
                     }
+                    is PromoCodeDeepLink -> {
+                        openPromoCode(deepLink.code)
+                    }
                 }
             } else if (action == Intent.ACTION_VIEW) {
-                if (IntentUtil.isPromoCodeIntent(intent)) {
-                    openPromoCode(intent)
-                    return
-                } else if (IntentUtil.isShareLink(intent)) { // Must go last, catches all pktc links
+                if (IntentUtil.isShareLink(intent)) { // Must go last, catches all pktc links
                     openSharingUrl(intent)
                     return
                 } else if (IntentUtil.isNativeShareLink(intent)) {
@@ -1560,13 +1561,9 @@ class MainActivity :
     }
 
     @Suppress("DEPRECATION")
-    private fun openPromoCode(intent: Intent) {
-        val code = intent.data?.lastPathSegment
-
-        if (code != null) {
-            val accountIntent = AccountActivity.promoCodeInstance(this, code)
-            startActivityForResult(accountIntent, PROMOCODE_REQUEST_CODE)
-        }
+    private fun openPromoCode(code: String) {
+        val accountIntent = AccountActivity.promoCodeInstance(this, code)
+        startActivityForResult(accountIntent, PROMOCODE_REQUEST_CODE)
     }
 
     private fun showUpgradedFromPromoCode(description: String) {

--- a/modules/services/deeplink/src/main/kotlin/au/com/shiftyjelly/pocketcasts/deeplink/DeepLink.kt
+++ b/modules/services/deeplink/src/main/kotlin/au/com/shiftyjelly/pocketcasts/deeplink/DeepLink.kt
@@ -154,6 +154,10 @@ data object CloudFilesDeepLink : IntentableDeepLink {
 
 data object UpgradeAccountDeepLink : DeepLink
 
+data class PromoCodeDeepLink(
+    val code: String,
+) : DeepLink
+
 private val Context.launcherIntent get() = requireNotNull(packageManager.getLaunchIntentForPackage(packageName)) {
     "Missing launcher intent for $packageName"
 }

--- a/modules/services/deeplink/src/main/kotlin/au/com/shiftyjelly/pocketcasts/deeplink/DeepLinkFactory.kt
+++ b/modules/services/deeplink/src/main/kotlin/au/com/shiftyjelly/pocketcasts/deeplink/DeepLinkFactory.kt
@@ -42,6 +42,7 @@ class DeepLinkFactory(
         AppleAdapter(),
         CloudFilesAdapter(),
         UpdageAccountAdapter(),
+        PromoCodeAdapter(),
     )
 
     fun create(intent: Intent): DeepLink? {
@@ -289,6 +290,20 @@ private class UpdageAccountAdapter : DeepLinkAdapter {
 
         return if (intent.action == ACTION_VIEW && scheme == "pktc" && host == "upgrade") {
             UpgradeAccountDeepLink
+        } else {
+            null
+        }
+    }
+}
+
+private class PromoCodeAdapter : DeepLinkAdapter {
+    override fun create(intent: Intent): DeepLink? {
+        val uriData = intent.data
+        val dataString = uriData?.toString().orEmpty()
+        val pathSegments = uriData?.pathSegments.orEmpty()
+
+        return if (intent.action == ACTION_VIEW && dataString.startsWith("pktc://redeem/promo") && pathSegments.size >= 2) {
+            PromoCodeDeepLink(pathSegments.last())
         } else {
             null
         }


### PR DESCRIPTION
## Description

> [!note]
> This will be a series of PRs that move deep linking to a separate module that can be tested. The goal is to address #2405 but I don't want to do it blindly without having tests in order to not introduce regressions to deep linking.

This PR migrates deep linking promo codes to the new module.

## Testing Instructions

1. Execute `adb shell am start -n au.com.shiftyjelly.pocketcasts.debug/au.com.shiftyjelly.pocketcasts.ui.MainActivity -a android.intent.action.VIEW -d "pktc://redeem/promo/111222333"`.
2. App should open with the promo code flow.

## Checklist
- [x] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [x] ~Any jetpack compose components I added or changed are covered by compose previews~
- [x] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~