### PR TITLE
Migrate sharing to deep link module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 7.69
 -----
-
+*   Bug Fixes
+    *   Links to episodes with playback position shared from the app are now correctly recognized.
+        ([#2471](https://github.com/Automattic/pocket-casts-android/pull/2471))
 
 7.68
 -----

--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/deeplink/NativeShareDeepLinkTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/deeplink/NativeShareDeepLinkTest.kt
@@ -1,0 +1,24 @@
+package au.com.shiftyjelly.pocketcasts.deeplink
+
+import android.net.Uri
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class NativeShareDeepLinkTest {
+    @Test
+    fun sharePathWithSinglePathSegment() {
+        val deepLink = NativeShareDeepLink(Uri.parse("https://hello.com/segment"))
+
+        assertEquals("/social/share/show/segment", deepLink.sharePath)
+    }
+
+    @Test
+    fun sharePathWithMultiplePathSegment() {
+        val deepLink = NativeShareDeepLink(Uri.parse("https://hello.com/segment1/segment2"))
+
+        assertEquals("/segment1/segment2", deepLink.sharePath)
+    }
+}

--- a/automotive/src/main/java/au/com/shiftyjelly/pocketcasts/AutomotiveSettingsActivity.kt
+++ b/automotive/src/main/java/au/com/shiftyjelly/pocketcasts/AutomotiveSettingsActivity.kt
@@ -128,7 +128,8 @@ class AutomotiveSettingsActivity : AppCompatActivity(), FragmentHostListener {
         source: EpisodeViewSource,
         podcastUuid: String?,
         forceDark: Boolean,
-        timestamp: Duration?,
+        startTimestamp: Duration?,
+        endTimestamp: Duration?,
     ) {
     }
 

--- a/modules/features/nova/src/main/kotlin/au/com/shiftyjelly/pocketcasts/nova/CatalogFactory.kt
+++ b/modules/features/nova/src/main/kotlin/au/com/shiftyjelly/pocketcasts/nova/CatalogFactory.kt
@@ -178,9 +178,5 @@ internal class CatalogFactory(
         sourceView = source.value,
     ).toIntent(context)
 
-    private val Context.launcherIntent get() = requireNotNull(packageManager.getLaunchIntentForPackage(packageName)) {
-        "Missing launcher intent for $packageName"
-    }
-
     private fun ApplePodcastCategory.Companion.fromCategories(categories: String) = categories.split('\n').mapNotNull(ApplePodcastCategory::valueOfSafe)
 }

--- a/modules/services/deeplink/src/main/kotlin/au/com/shiftyjelly/pocketcasts/deeplink/DeepLink.kt
+++ b/modules/services/deeplink/src/main/kotlin/au/com/shiftyjelly/pocketcasts/deeplink/DeepLink.kt
@@ -18,6 +18,7 @@ import au.com.shiftyjelly.pocketcasts.deeplink.DeepLink.Companion.EXTRA_NOTIFICA
 import au.com.shiftyjelly.pocketcasts.deeplink.DeepLink.Companion.EXTRA_PAGE
 import au.com.shiftyjelly.pocketcasts.deeplink.DeepLink.Companion.EXTRA_PODCAST_UUID
 import au.com.shiftyjelly.pocketcasts.deeplink.DeepLink.Companion.EXTRA_SOURCE_VIEW
+import kotlin.time.Duration
 
 sealed interface DeepLink {
     companion object {
@@ -95,6 +96,8 @@ data class ShowEpisodeDeepLink(
     val episodeUuid: String,
     val podcastUuid: String?,
     val sourceView: String?,
+    val startTimestamp: Duration? = null,
+    val endTimestamp: Duration? = null,
 ) : IntentableDeepLink {
     override fun toIntent(context: Context) = context.launcherIntent
         .setAction(ACTION_OPEN_EPISODE)
@@ -157,6 +160,19 @@ data object UpgradeAccountDeepLink : DeepLink
 data class PromoCodeDeepLink(
     val code: String,
 ) : DeepLink
+
+data class NativeShareDeepLink(
+    val uri: Uri,
+    val startTimestamp: Duration? = null,
+    val endTimestamp: Duration? = null,
+) : DeepLink {
+    val sharePath get() = buildString {
+        if (uri.pathSegments.size == 1) {
+            append("/social/share/show")
+        }
+        append(uri.path)
+    }
+}
 
 private val Context.launcherIntent get() = requireNotNull(packageManager.getLaunchIntentForPackage(packageName)) {
     "Missing launcher intent for $packageName"

--- a/modules/services/deeplink/src/main/kotlin/au/com/shiftyjelly/pocketcasts/deeplink/SharingUrlTimestampParser.kt
+++ b/modules/services/deeplink/src/main/kotlin/au/com/shiftyjelly/pocketcasts/deeplink/SharingUrlTimestampParser.kt
@@ -1,4 +1,4 @@
-package au.com.shiftyjelly.pocketcasts.utils
+package au.com.shiftyjelly.pocketcasts.deeplink
 
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.hours
@@ -6,7 +6,7 @@ import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Duration.Companion.seconds
 
-class SharingUrlTimestampParser {
+internal class SharingUrlTimestampParser {
     companion object {
         val intervalPattern = Regex("""^(\d+\.?\d*)$""")
         val hmsPattern = Regex("""^(?:(\d+)h)?(?:(0?[0-5]?\d)m)?(?:(0?[0-5]?\d)s)?$""")

--- a/modules/services/deeplink/src/test/kotlin/au/com/shiftyjelly/pocketcasts/deeplink/SharingUrlTimestampParserTest.kt
+++ b/modules/services/deeplink/src/test/kotlin/au/com/shiftyjelly/pocketcasts/deeplink/SharingUrlTimestampParserTest.kt
@@ -1,4 +1,4 @@
-package au.com.shiftyjelly.pocketcasts.utils
+package au.com.shiftyjelly.pocketcasts.deeplink
 
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.hours

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
@@ -105,7 +105,6 @@ interface Settings {
         const val AUTO_ARCHIVE_INCLUDE_STARRED = "autoArchiveIncludeStarred"
 
         const val INTENT_OPEN_APP_NEW_EPISODES = "INTENT_OPEN_APP_NEW_EPISODES"
-        const val INTENT_LINK_PROMO_CODE = "pktc://redeem/promo/"
 
         const val LOG_TAG_AUTO = "PocketCastsAuto"
 

--- a/modules/services/ui/src/main/java/au/com/shiftyjelly/pocketcasts/ui/helper/FragmentHostListener.kt
+++ b/modules/services/ui/src/main/java/au/com/shiftyjelly/pocketcasts/ui/helper/FragmentHostListener.kt
@@ -31,7 +31,8 @@ interface FragmentHostListener {
         source: EpisodeViewSource,
         podcastUuid: String?,
         forceDark: Boolean,
-        timestamp: Duration? = null,
+        startTimestamp: Duration? = null,
+        endTimestamp: Duration? = null,
     )
     fun lockPlayerBottomSheet(locked: Boolean)
     fun updateSystemColors()

--- a/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/helper/IntentUtil.kt
+++ b/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/helper/IntentUtil.kt
@@ -7,7 +7,6 @@ import android.net.Uri
 import android.widget.Toast
 import androidx.appcompat.app.AlertDialog
 import au.com.shiftyjelly.pocketcasts.localization.R
-import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.utils.FileUtil
 import java.io.File
 import java.io.UnsupportedEncodingException
@@ -16,16 +15,6 @@ import java.util.Arrays
 import timber.log.Timber
 
 object IntentUtil {
-
-    fun isShareLink(intent: Intent): Boolean {
-        val scheme = intent.scheme
-        return scheme != null && scheme == "pktc" && intent.data != null && intent.data?.path != null
-    }
-
-    fun isNativeShareLink(intent: Intent): Boolean {
-        val scheme = intent.scheme
-        return scheme != null && scheme in listOf("http", "https") && intent.data != null && intent.data?.host in listOf("pca.st", "pcast.pocketcasts.net")
-    }
 
     fun webViewShouldOverrideUrl(url: String?, context: Context): Boolean {
         var urlFound: String = url ?: return true
@@ -126,16 +115,6 @@ object IntentUtil {
 
     fun getUrl(intent: Intent): String? {
         return if (intent.data != null && intent.data.toString().isNotBlank()) intent.data.toString() else null
-    }
-
-    fun isPromoCodeIntent(intent: Intent): Boolean {
-        val scheme = intent.scheme
-        if (scheme == null || scheme != "pktc") {
-            return false
-        }
-
-        val uri = Uri.parse(Settings.INTENT_LINK_PROMO_CODE)
-        return uri.host == intent.data?.host && intent.data?.pathSegments?.firstOrNull() == uri.pathSegments.first()
     }
 
     fun openWebPage(url: String): Intent {


### PR DESCRIPTION
## Description

This PR migrates sharing deep linking to the new module. It also fixes a bug with incorrect link recognition.

I didn't update changelog yet because the changelog file isn't ready yet for `7.69`. I'll update it once we release new beta.

Closes #2405

## Testing Instructions

### Migration

Do regression tests of opening links in mobile app that are shared from web app and from mobile app.

### Bug fix

1. Play an episode.
2. Share the episode from current position.
3. Open the link using the app.
4. App should recognize episode and the playback timestamp.
5. Share clip link to the episode.
6. Open the link using the mobile app.
7. App should open embedded web view clip player.

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [x] ~Any jetpack compose components I added or changed are covered by compose previews~
- [x] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~