### PR TITLE
Migrate search and assistant deep linking

### DIFF
--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/deeplink/DeepLinkFactoryTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/deeplink/DeepLinkFactoryTest.kt
@@ -1,10 +1,12 @@
 package au.com.shiftyjelly.pocketcasts.deeplink
 
+import android.app.SearchManager
 import android.content.Intent
 import android.content.Intent.ACTION_SEND
 import android.content.Intent.ACTION_VIEW
 import android.content.Intent.EXTRA_STREAM
 import android.net.Uri
+import android.provider.MediaStore.INTENT_ACTION_MEDIA_PLAY_FROM_SEARCH
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import kotlin.time.Duration.Companion.seconds
 import org.junit.Assert.assertEquals
@@ -822,5 +824,36 @@ class DeepLinkFactoryTest {
         val deepLink = factory.create(intent)
 
         assertEquals(ShowPodcastFromUrlDeepLink("https://podcast.com"), deepLink)
+    }
+
+    @Test
+    fun playFromSearch() {
+        val intent = Intent()
+            .setAction(INTENT_ACTION_MEDIA_PLAY_FROM_SEARCH)
+            .putExtra(SearchManager.QUERY, "Search term")
+
+        val deepLink = factory.create(intent)
+
+        assertEquals(PlayFromSearchDeepLink("Search term"), deepLink)
+    }
+
+    @Test
+    fun assistant1() {
+        val intent = Intent()
+            .putExtra("extra_accl_intent", true)
+
+        val deepLink = factory.create(intent)
+
+        assertEquals(AssistantDeepLink, deepLink)
+    }
+
+    @Test
+    fun assistant2() {
+        val intent = Intent()
+            .putExtra("handled_by_nga", true)
+
+        val deepLink = factory.create(intent)
+
+        assertEquals(AssistantDeepLink, deepLink)
     }
 }

--- a/modules/services/deeplink/src/main/kotlin/au/com/shiftyjelly/pocketcasts/deeplink/DeepLink.kt
+++ b/modules/services/deeplink/src/main/kotlin/au/com/shiftyjelly/pocketcasts/deeplink/DeepLink.kt
@@ -178,6 +178,12 @@ data class OpmlImportDeepLink(
     val uri: Uri,
 ) : DeepLink
 
+data class PlayFromSearchDeepLink(
+    val query: String,
+) : DeepLink
+
+data object AssistantDeepLink : DeepLink
+
 private val Context.launcherIntent get() = requireNotNull(packageManager.getLaunchIntentForPackage(packageName)) {
     "Missing launcher intent for $packageName"
 }

--- a/modules/services/deeplink/src/main/kotlin/au/com/shiftyjelly/pocketcasts/deeplink/DeepLinkFactory.kt
+++ b/modules/services/deeplink/src/main/kotlin/au/com/shiftyjelly/pocketcasts/deeplink/DeepLinkFactory.kt
@@ -1,10 +1,12 @@
 package au.com.shiftyjelly.pocketcasts.deeplink
 
+import android.app.SearchManager
 import android.content.Intent
 import android.content.Intent.ACTION_SEND
 import android.content.Intent.ACTION_VIEW
 import android.content.Intent.EXTRA_STREAM
 import android.net.Uri
+import android.provider.MediaStore.INTENT_ACTION_MEDIA_PLAY_FROM_SEARCH
 import androidx.core.content.IntentCompat
 import au.com.shiftyjelly.pocketcasts.deeplink.BuildConfig.SERVER_LIST_HOST
 import au.com.shiftyjelly.pocketcasts.deeplink.BuildConfig.SERVER_SHORT_URL
@@ -52,6 +54,8 @@ class DeepLinkFactory(
         ShareLinkAdapter(shareHost),
         OpmlAdapter(listOf(listHost, shareHost)),
         PodcastUrlSchemeAdapter(listOf(listHost, shareHost)),
+        PlayFromSearchAdapter(),
+        AssistantAdapter(),
     )
 
     fun create(intent: Intent): DeepLink? {
@@ -455,5 +459,26 @@ private class PodcastUrlSchemeAdapter(
             "subscribeonandroid.com",
             "www.subscribeonandroid.com",
         )
+    }
+}
+
+private class PlayFromSearchAdapter : DeepLinkAdapter {
+    override fun create(intent: Intent): DeepLink? {
+        val query = intent.extras?.getString(SearchManager.QUERY)
+        return if (intent.action == INTENT_ACTION_MEDIA_PLAY_FROM_SEARCH && !query.isNullOrBlank()) {
+            PlayFromSearchDeepLink(query)
+        } else {
+            null
+        }
+    }
+}
+
+private class AssistantAdapter : DeepLinkAdapter {
+    override fun create(intent: Intent): DeepLink? {
+        return if (intent.extras?.getBoolean("extra_accl_intent", false) == true || intent.extras?.getBoolean("handled_by_nga", false) == true) {
+            AssistantDeepLink
+        } else {
+            null
+        }
     }
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/MediaSessionManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/MediaSessionManager.kt
@@ -1,6 +1,5 @@
 package au.com.shiftyjelly.pocketcasts.repositories.playback
 
-import android.app.SearchManager
 import android.content.ComponentName
 import android.content.Context
 import android.content.Intent
@@ -809,9 +808,8 @@ class MediaSessionManager(
         }
     }
 
-    fun playFromSearchExternal(extras: Bundle) {
-        val searchTerm = extras.getString(SearchManager.QUERY) ?: return
-        performPlayFromSearch(searchTerm)
+    fun playFromSearchExternal(query: String) {
+        performPlayFromSearch(query)
     }
 
     /**


### PR DESCRIPTION
## Description

This PR migrates last two deep links to the new module.

## Testing Instructions

Code review should be enough.

## Checklist
- [x] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [x] ~Any jetpack compose components I added or changed are covered by compose previews~
- [x] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~