### PR TITLE
Do not play episode automatically when app is opened from a link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 7.69
 -----
+* Updated
+    *   App opened from a link with an episode timestamp no longer starts playing automatically.
+        ([#2479](https://github.com/Automattic/pocket-casts-android/pull/2479))
 *   Bug Fixes
     *   Links to episodes with playback position shared from the app are now correctly recognized.
         ([#2471](https://github.com/Automattic/pocket-casts-android/pull/2471))

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/episode/EpisodeFragmentViewModel.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/episode/EpisodeFragmentViewModel.kt
@@ -43,6 +43,7 @@ import kotlin.time.Duration
 import kotlin.time.DurationUnit
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.rx2.asFlowable
 
@@ -75,13 +76,15 @@ class EpisodeFragmentViewModel @Inject constructor(
     var episode: PodcastEpisode? = null
     var isFragmentChangingConfigurations: Boolean = false
 
+    private var startPlaybackTimestamp: Duration? = null
+
     fun setup(
         episodeUuid: String,
         podcastUuid: String?,
         forceDark: Boolean,
         timestamp: Duration?,
     ) {
-        var playAtTimestamp = timestamp != null
+        startPlaybackTimestamp = timestamp
         val isDarkTheme = forceDark || theme.isDarkTheme
         val progressUpdatesObservable = downloadManager.progressUpdateRelay
             .filter { it.episodeUuid == episodeUuid }
@@ -129,16 +132,7 @@ class EpisodeFragmentViewModel @Inject constructor(
                     zipper,
                 )
             }
-            .doOnNext {
-                if (it is EpisodeFragmentState.Loaded) {
-                    timestamp?.let { timestamp ->
-                        if (!playAtTimestamp) return@let
-                        playAtTimestamp(it.episode, timestamp)
-                        playAtTimestamp = false
-                    }
-                    episode = it.episode
-                }
-            }
+            .doOnNext { if (it is EpisodeFragmentState.Loaded) { episode = it.episode } }
             .onErrorReturn { EpisodeFragmentState.Error(it) }
             .observeOn(AndroidSchedulers.mainThread())
             .subscribeOn(Schedulers.io())
@@ -278,22 +272,30 @@ class EpisodeFragmentViewModel @Inject constructor(
         fromListUuid: String? = null,
     ): Boolean {
         episode?.let { episode ->
-            if (isPlaying.value == true) {
-                playbackManager.pause(sourceView = source)
-                return false
-            } else {
-                fromListUuid?.let {
-                    FirebaseAnalyticsTracker.podcastEpisodePlayedFromList(it, episode.podcastUuid)
-                    analyticsTracker.track(AnalyticsEvent.DISCOVER_LIST_EPISODE_PLAY, mapOf(LIST_ID_KEY to it, PODCAST_ID_KEY to episode.podcastUuid))
+            val timestamp = startPlaybackTimestamp
+            when {
+                isPlaying.value == true -> {
+                    playbackManager.pause(sourceView = source)
+                    return false
                 }
-                playbackManager.playNow(
-                    episode = episode,
-                    forceStream = force,
-                    showedStreamWarning = showedStreamWarning,
-                    sourceView = source,
-                )
-                warningsHelper.showBatteryWarningSnackbarIfAppropriate()
-                return true
+                timestamp != null -> {
+                    startPlaybackTimestamp = null
+                    playAtTimestamp(episode, timestamp)
+                    return true
+                } else -> {
+                    fromListUuid?.let {
+                        FirebaseAnalyticsTracker.podcastEpisodePlayedFromList(it, episode.podcastUuid)
+                        analyticsTracker.track(AnalyticsEvent.DISCOVER_LIST_EPISODE_PLAY, mapOf(LIST_ID_KEY to it, PODCAST_ID_KEY to episode.podcastUuid))
+                    }
+                    playbackManager.playNow(
+                        episode = episode,
+                        forceStream = force,
+                        showedStreamWarning = showedStreamWarning,
+                        sourceView = source,
+                    )
+                    warningsHelper.showBatteryWarningSnackbarIfAppropriate()
+                    return true
+                }
             }
         }
 
@@ -304,13 +306,9 @@ class EpisodeFragmentViewModel @Inject constructor(
         episode: BaseEpisode,
         timestamp: Duration,
     ) {
-        viewModelScope.launch {
-            val shouldLoadOrSwitchEpisode = !playbackManager.isPlaying() ||
-                playbackManager.getCurrentEpisode()?.uuid != episode.uuid
-            if (shouldLoadOrSwitchEpisode) {
-                playbackManager.playNowSync(episode, sourceView = source)
-            }
-            playbackManager.seekToTimeMs(positionMs = timestamp.toInt(DurationUnit.MILLISECONDS))
+        viewModelScope.launch(NonCancellable) {
+            playbackManager.playNowSync(episode, sourceView = source)
+            playbackManager.seekToTimeMsSuspend(timestamp.toInt(DurationUnit.MILLISECONDS))
         }
     }
 


### PR DESCRIPTION
## Description

This PR aligns behavior of opening the app from an episode timestamp link with iOS. Previously we started playback automatically. Now it is started only when user taps play.

Internal ref: p1720591839992879-slack-C029BMW150R

## Testing Instructions

1. Open the app with a bookmark link or an episode at a position link.
2. The episode page should open.
3. Playback for the episode should not start.
4. Tapping on play should start playback at the timestamp position.

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [x] ~Any jetpack compose components I added or changed are covered by compose previews~
- [x] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] ~with different themes~
- [x] ~with a landscape orientation~
- [x] ~with the device set to have a large display and font size~
- [x] ~for accessibility with TalkBack~