### PR TITLE
Auto verify pca.st and pcast.pocketcasts.net hosts

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -102,7 +102,7 @@
                         android:host="*"
                         android:scheme="pktc"/>
             </intent-filter>
-            <intent-filter>
+            <intent-filter android:autoVerify="true">
                 <action android:name="android.intent.action.VIEW"/>
                 <category android:name="android.intent.category.DEFAULT"/>
                 <category android:name="android.intent.category.BROWSABLE"/>
@@ -110,7 +110,7 @@
                     android:host="pca.st"
                     android:scheme="https"/>
             </intent-filter>
-            <intent-filter>
+            <intent-filter android:autoVerify="true">
                 <action android:name="android.intent.action.VIEW"/>
                 <category android:name="android.intent.category.DEFAULT"/>
                 <category android:name="android.intent.category.BROWSABLE"/>


### PR DESCRIPTION
## Description

Add auto verification to our sharing URL hosts. This allows to open them automatically by our app.

Internal ref: p1720591839992879-slack-C029BMW150R

## Testing Instructions

Code review should be enough. Note that this works only with `release` variant at the moment because our debug variants are not verified correctly on the server due to wrong hash.

## Screenshots or Screencast 

![Screenshot_20240710_114638](https://github.com/Automattic/pocket-casts-android/assets/30936061/c3f3378d-23a6-49b9-bf8a-80298740eb11)

## Checklist
- [x] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [x] ~Any jetpack compose components I added or changed are covered by compose previews~
- [x] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] ~with different themes~
- [x] ~with a landscape orientation~
- [x] ~with the device set to have a large display and font size~
- [x] ~for accessibility with TalkBack~