### PR TITLE
Improve logs and refactor focus changes

### DIFF
--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/FocusManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/FocusManager.kt
@@ -137,13 +137,14 @@ class FocusManager(
     }
 
     override fun onAudioFocusChange(focusChange: Int) {
-        LogBuffer.i(LogBuffer.TAG_PLAYBACK, "On audio focus change: ${androidAudioFocusToString(focusChange)}")
+        val focusString = androidAudioFocusToString(focusChange)
+        LogBuffer.i(LogBuffer.TAG_PLAYBACK, "On audio focus change: $focusString")
         when (focusChange) {
             in GAIN_FOCUS_LIST -> {
                 // if not transient only let it resume within 2 minutes
                 val shouldResume = (isLostTransient || System.currentTimeMillis() < timeFocusLost + 120000) && !deviceRemovedWhileFocusLost
                 audioFocus = AUDIO_FOCUSED
-                LogBuffer.i(LogBuffer.TAG_PLAYBACK, "Focus gained. Should resume: $shouldResume. Device removed: $deviceRemovedWhileFocusLost.")
+                LogBuffer.i(LogBuffer.TAG_PLAYBACK, "Audio focus gained. Should resume: $shouldResume. Device removed: $deviceRemovedWhileFocusLost.")
                 focusChangeListener.onFocusGain(shouldResume)
             }
             in LOSS_FOCUS_LIST -> {
@@ -155,11 +156,12 @@ class FocusManager(
                 }
                 timeFocusLost = System.currentTimeMillis()
                 deviceRemovedWhileFocusLost = false
-                LogBuffer.i(LogBuffer.TAG_PLAYBACK, "Focus lost.")
-                focusChangeListener.onFocusLoss(canDuck(), isLostTransient)
+                val playOverNotification = canDuck()
+                LogBuffer.i(LogBuffer.TAG_PLAYBACK, "Audio focus lost. Play over notification: $playOverNotification, is transient: $isLostTransient")
+                focusChangeListener.onFocusLoss(playOverNotification, isLostTransient)
             }
             else -> {
-                LogBuffer.i(LogBuffer.TAG_PLAYBACK, "Unknown focus change.")
+                LogBuffer.i(LogBuffer.TAG_PLAYBACK, "Unexpected audio focus change: $focusString.")
             }
         }
     }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/FocusManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/FocusManager.kt
@@ -29,12 +29,25 @@ open class FocusManager(private val settings: Settings, context: Context?) : Aud
 
         // we have full audio focus
         private const val AUDIO_FOCUSED = 3
+
+        private val GAIN_FOCUS_LIST = listOf(
+            AudioManager.AUDIOFOCUS_GAIN,
+            AudioManager.AUDIOFOCUS_GAIN_TRANSIENT,
+            AudioManager.AUDIOFOCUS_GAIN_TRANSIENT_MAY_DUCK,
+            AudioManager.AUDIOFOCUS_GAIN_TRANSIENT_EXCLUSIVE,
+        )
+
+        private val LOSS_FOCUS_LIST = listOf(
+            AudioManager.AUDIOFOCUS_LOSS,
+            AudioManager.AUDIOFOCUS_LOSS_TRANSIENT,
+            AudioManager.AUDIOFOCUS_LOSS_TRANSIENT_CAN_DUCK,
+        )
     }
 
     private val audioManager: AudioManager? = if (context == null) null else context.getSystemService(Context.AUDIO_SERVICE) as AudioManager
 
     // track if another app has stolen audio focus
-    private var audioFocus: Int = 0
+    private var audioFocus: Int = AUDIO_NO_FOCUS_NO_DUCK
 
     // track when the time lost as we don't want to resume if it has been too long
     private var timeFocusLost: Long = 0
@@ -119,40 +132,30 @@ open class FocusManager(private val settings: Settings, context: Context?) : Aud
     }
 
     override fun onAudioFocusChange(focusChange: Int) {
-        // map to our own focus status
-        if (focusChange == AudioManager.AUDIOFOCUS_GAIN ||
-            focusChange == AudioManager.AUDIOFOCUS_GAIN_TRANSIENT ||
-            focusChange == AudioManager.AUDIOFOCUS_GAIN_TRANSIENT_MAY_DUCK ||
-            focusChange == AudioManager.AUDIOFOCUS_GAIN_TRANSIENT_EXCLUSIVE
-        ) {
-            // focus gained
-            // if not transient only let it resume within 2 minutes
-            val shouldResume = (isLostTransient || System.currentTimeMillis() < timeFocusLost + 120000) && !deviceRemovedWhileFocusLost
-            audioFocus = AUDIO_FOCUSED
-            LogBuffer.i(LogBuffer.TAG_PLAYBACK, "Focus gained, should resume $shouldResume. Device removed: $deviceRemovedWhileFocusLost")
-            focusChangeListener?.onFocusGain(shouldResume)
-        } else if (focusChange == AudioManager.AUDIOFOCUS_LOSS ||
-            focusChange == AudioManager.AUDIOFOCUS_LOSS_TRANSIENT ||
-            focusChange == AudioManager.AUDIOFOCUS_LOSS_TRANSIENT_CAN_DUCK
-        ) {
-            // focus lost
-            if (focusChange == AudioManager.AUDIOFOCUS_LOSS) {
-                audioFocus = AUDIO_NO_FOCUS_NO_DUCK
-            } else if (isFocused) {
-                if (focusChange == AudioManager.AUDIOFOCUS_LOSS_TRANSIENT) {
-                    audioFocus = AUDIO_NO_FOCUS_NO_DUCK_TRANSIENT
-                } else if (focusChange == AudioManager.AUDIOFOCUS_LOSS_TRANSIENT_CAN_DUCK) {
-                    audioFocus = AUDIO_NO_FOCUS_CAN_DUCK_TRANSIENT
+        LogBuffer.i(LogBuffer.TAG_PLAYBACK, "On audio focus change: ${androidAudioFocusToString(focusChange)}")
+        when (focusChange) {
+            in GAIN_FOCUS_LIST -> {
+                // if not transient only let it resume within 2 minutes
+                val shouldResume = (isLostTransient || System.currentTimeMillis() < timeFocusLost + 120000) && !deviceRemovedWhileFocusLost
+                audioFocus = AUDIO_FOCUSED
+                LogBuffer.i(LogBuffer.TAG_PLAYBACK, "Focus gained. Should resume: $shouldResume. Device removed: $deviceRemovedWhileFocusLost.")
+                focusChangeListener?.onFocusGain(shouldResume)
+            }
+            in LOSS_FOCUS_LIST -> {
+                audioFocus = when {
+                    focusChange == AudioManager.AUDIOFOCUS_LOSS -> AUDIO_NO_FOCUS_NO_DUCK
+                    isFocused && focusChange == AudioManager.AUDIOFOCUS_LOSS_TRANSIENT -> AUDIO_NO_FOCUS_NO_DUCK_TRANSIENT
+                    isFocused && focusChange == AudioManager.AUDIOFOCUS_LOSS_TRANSIENT_CAN_DUCK -> AUDIO_NO_FOCUS_CAN_DUCK_TRANSIENT
+                    else -> audioFocus
                 }
-            } // if already paused with a focus lost don't then allow the sound to play ducked
-            timeFocusLost = System.currentTimeMillis()
-            deviceRemovedWhileFocusLost = false
-            LogBuffer.i(LogBuffer.TAG_PLAYBACK, "Focus lost. AUDIOFOCUS_LOSS: %s AUDIOFOCUS_LOSS_TRANSIENT: %s AUDIOFOCUS_LOSS_TRANSIENT_CAN_DUCK: %s", focusChange == AudioManager.AUDIOFOCUS_LOSS, focusChange == AudioManager.AUDIOFOCUS_LOSS_TRANSIENT, focusChange == AudioManager.AUDIOFOCUS_LOSS_TRANSIENT_CAN_DUCK)
-            focusChangeListener?.onFocusLoss(canDuck(), isLostTransient)
-        } else if (focusChange == AudioManager.AUDIOFOCUS_REQUEST_FAILED) {
-            focusChangeListener?.onFocusRequestFailed()
-        } else {
-            Timber.w("onAudioFocusChange: Ignoring unsupported focusChange: %d", focusChange)
+                timeFocusLost = System.currentTimeMillis()
+                deviceRemovedWhileFocusLost = false
+                LogBuffer.i(LogBuffer.TAG_PLAYBACK, "Focus lost.")
+                focusChangeListener?.onFocusLoss(canDuck(), isLostTransient)
+            }
+            else -> {
+                LogBuffer.i(LogBuffer.TAG_PLAYBACK, "Unknown focus change.")
+            }
         }
     }
 
@@ -239,5 +242,17 @@ open class FocusManager(private val settings: Settings, context: Context?) : Aud
         }
 
         return typeString
+    }
+
+    private fun androidAudioFocusToString(focus: Int) = when (focus) {
+        AudioManager.AUDIOFOCUS_NONE -> "AUDIOFOCUS_NONE"
+        AudioManager.AUDIOFOCUS_GAIN -> "AUDIOFOCUS_GAIN"
+        AudioManager.AUDIOFOCUS_GAIN_TRANSIENT -> "AUDIOFOCUS_GAIN_TRANSIENT"
+        AudioManager.AUDIOFOCUS_GAIN_TRANSIENT_MAY_DUCK -> "AUDIOFOCUS_GAIN_TRANSIENT_MAY_DUCK"
+        AudioManager.AUDIOFOCUS_GAIN_TRANSIENT_EXCLUSIVE -> "AUDIOFOCUS_GAIN_TRANSIENT_EXCLUSIVE"
+        AudioManager.AUDIOFOCUS_LOSS -> "AUDIOFOCUS_LOSS"
+        AudioManager.AUDIOFOCUS_LOSS_TRANSIENT -> "AUDIOFOCUS_LOSS_TRANSIENT"
+        AudioManager.AUDIOFOCUS_LOSS_TRANSIENT_CAN_DUCK -> "AUDIOFOCUS_LOSS_TRANSIENT_CAN_DUCK"
+        else -> "AUDIO_FOCUS_UNKNOWN($focus)"
     }
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
@@ -160,13 +160,9 @@ open class PlaybackManager @Inject constructor(
     override val coroutineContext: CoroutineContext
         get() = Dispatchers.Default
 
-    private val focusManager: FocusManager by lazy {
-        FocusManager(settings, application).apply {
-            focusChangeListener = this@PlaybackManager
-        }
-    }
-    private var audioNoisyManager =
-        AudioNoisyManager(application)
+    private val focusManager = FocusManager(application, settings, this)
+
+    private var audioNoisyManager = AudioNoisyManager(application)
 
     private val bookmarkTonePlayer: MediaPlayer by lazy {
         MediaPlayer().apply {


### PR DESCRIPTION
## Description

This improves logs for audio focus feature and does a minor refactor.

Internal ref: p1720364784529929-slack-C02A333D8LQ

## Testing Instructions

1. Play an episode.
2. Trigger audio focus change in some other app like Google Maps giving directions.
3. Audio should duck volume or stop depending on your local settings.


## Checklist
- [x] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] ~I have considered whether it makes sense to add tests for my changes~
- [x] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [x] ~Any jetpack compose components I added or changed are covered by compose previews~
- [x] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~