### PR TITLE
Task/upload files crash fix

### DIFF
--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/cloud/AddFileActivity.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/cloud/AddFileActivity.kt
@@ -1,7 +1,6 @@
 package au.com.shiftyjelly.pocketcasts.profile.cloud
 
-import android.Manifest.permission.INTERNET
-import android.Manifest.permission.WRITE_EXTERNAL_STORAGE
+import android.Manifest.permission.READ_EXTERNAL_STORAGE
 import android.app.Activity
 import android.content.ActivityNotFoundException
 import android.content.Context
@@ -90,8 +89,7 @@ private const val EXTRA_EXISTING_EPISODE_UUID = "fileUUID"
 private const val EXTRA_FILE_CHOOSER = "filechooser"
 private const val STATE_LAUNCHED_FILE_CHOOSER = "LAUNCHED_FILE_CHOOSER"
 private const val STATE_DATAURI = "DATAURI"
-private const val WRITE_STORAGE_PERMISSION_REQUEST_CODE = 50
-private const val INTERNET_PERMISSION_REQUEST_CODE = 51
+private const val READ_STORAGE_PERMISSION_REQUEST_CODE = 50
 
 @AndroidEntryPoint
 class AddFileActivity :
@@ -469,18 +467,11 @@ class AddFileActivity :
         }
     }
 
-    private fun requestInternetPermission() {
+    private fun requestReadExternalStoragePermission() {
         ActivityCompat.requestPermissions(
             this,
-            arrayOf(INTERNET),
-            INTERNET_PERMISSION_REQUEST_CODE,
-        )
-    }
-    private fun requestWriteExternalStoragePermission() {
-        ActivityCompat.requestPermissions(
-            this,
-            arrayOf(WRITE_EXTERNAL_STORAGE),
-            WRITE_STORAGE_PERMISSION_REQUEST_CODE,
+            arrayOf(READ_EXTERNAL_STORAGE),
+            READ_STORAGE_PERMISSION_REQUEST_CODE,
         )
     }
 
@@ -504,11 +495,8 @@ class AddFileActivity :
             if (!(intentType.startsWith("audio/") || intentType.startsWith("video/"))) {
                 return
             }
-            if (!permissionIsGranted(WRITE_EXTERNAL_STORAGE)) {
-                requestWriteExternalStoragePermission()
-            }
-            if (!permissionIsGranted(INTERNET)) {
-                requestInternetPermission()
+            if (!permissionIsGranted(READ_EXTERNAL_STORAGE)) {
+                requestReadExternalStoragePermission()
             }
             launch(Dispatchers.IO) {
                 val userEpisode = UserEpisode(uuid = uuid, publishedDate = Date(), fileType = intent.type)


### PR DESCRIPTION
## Description
<!-- Please include a summary of what this PR is changing and why these changes are needed. -->
This PR fixes file uploading crash. I have tried to reproduce this crash but I was unsuccessful after numerous attempts. Although after going through the logs, the crash was a permission error specifically for `WRITE_EXTERNAL_STORAGE` and `INTERNET` permissions. The `WRITE_EXTERNAL_STORAGE` was causing the `FileNotFoundException` and `INTERNET` permissions caused a connection error leading to a `StorageFileLoadException`. 
The PR adds checks to confirm that the permissions have been enabled and request permissions if they are not enabled. 


Fixes #2285 
## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Tap on the Filters tab -->
<!-- 2. Tap on a filter -->
<!-- 3. etc. -->

## Screenshots or Screencast 
<!-- if applicable -->
1. Sign in 
2. Go to profile 
3. Click files 
4. Add a new file

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [X] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
