### PR TITLE
Do not interact with playback manager on the main thread

### DIFF
--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/episode/EpisodeFragmentViewModel.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/episode/EpisodeFragmentViewModel.kt
@@ -306,7 +306,7 @@ class EpisodeFragmentViewModel @Inject constructor(
         episode: BaseEpisode,
         timestamp: Duration,
     ) {
-        viewModelScope.launch(NonCancellable) {
+        viewModelScope.launch(Dispatchers.IO + NonCancellable) {
             playbackManager.playNowSync(episode, sourceView = source)
             playbackManager.seekToTimeMsSuspend(timestamp.toInt(DurationUnit.MILLISECONDS))
         }


### PR DESCRIPTION
## Description

In #2479 I aligned clip playback with iOS. However in doing so I introduced a potential crash because `PlaybackManager` suspending methods are not thread safe. This should be fixed in the manager but doing it there right now is a too far reaching task.

The crash doesn't happen always. In my testing it happened mainly during cold starts.

```
java.lang.IllegalStateException: Cannot access database on the main thread since it may potentially lock the UI for a long period of time.
	at androidx.room.RoomDatabase.assertNotMainThread(RoomDatabase.kt:444)
	at androidx.room.SharedSQLiteStatement.assertNotMainThread(SharedSQLiteStatement.kt:52)
	at androidx.room.SharedSQLiteStatement.acquire(SharedSQLiteStatement.kt:74)
	at au.com.shiftyjelly.pocketcasts.models.db.dao.EpisodeDao_Impl.updatePlayedUpToIfChanged(EpisodeDao_Impl.java:1353)
	at au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManagerImpl.updatePlayedUpTo(EpisodeManagerImpl.kt:236)
	at au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager.updateCurrentPositionInDatabase(PlaybackManager.kt:2219)
	at au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager.seekToTimeMsInternal(PlaybackManager.kt:862)
	at au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager.seekToTimeMsSuspend(PlaybackManager.kt:832)
	at au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager.seekToTimeMsSuspend$default(PlaybackManager.kt:831)
	at au.com.shiftyjelly.pocketcasts.podcasts.view.episode.EpisodeFragmentViewModel$playAtTimestamp$1.invokeSuspend(EpisodeFragmentViewModel.kt:311)
	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
	at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:104)
	at android.os.Handler.handleCallback(Handler.java:959)
	at android.os.Handler.dispatchMessage(Handler.java:100)
	at android.os.Looper.loopOnce(Looper.java:232)
	at android.os.Looper.loop(Looper.java:317)
	at android.app.ActivityThread.main(ActivityThread.java:8592)
	at java.lang.reflect.Method.invoke(Native Method)
	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:580)
	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:878)
	Suppressed: kotlinx.coroutines.internal.DiagnosticCoroutineContextException: [StandaloneCoroutine{Cancelling}@4780cbf, Dispatchers.Main.immediate]
```

## Testing Instructions

1. Have the app processed killed.
2. Run `adb shell am start -n au.com.shiftyjelly.pocketcasts.debug/au.com.shiftyjelly.pocketcasts.ui.MainActivity -a android.intent.action.VIEW -d "https://pca.st/episode/c510a66f-f9c0-45c8-bca2-8c0cc1d5f055?t=1327"`.
3. Tap on the play button.
4. App should not crash and the episode should play.

## Checklist
- [x] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] ~I have considered whether it makes sense to add tests for my changes~
- [x] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [x] ~Any jetpack compose components I added or changed are covered by compose previews~
- [x] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~