### PR TITLE
[Dependency Update] Update `a8c-ci-toolkit` to 3.4.2

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,12 +1,6 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/buildkite/pipeline-schema/main/schema.json
 ---
 
-# Nodes with values to reuse in the pipeline.
-common_params:
-  # Common plugin settings to use with the `plugins` key.
-  - &common_plugins
-    - automattic/a8c-ci-toolkit#3.4.2
-
 agents:
   queue: "android"
 
@@ -14,7 +8,7 @@ steps:
   - label: "Gradle Wrapper Validation"
     command: |
       validate_gradle_wrapper
-    plugins: *common_plugins
+    plugins: [$CI_TOOLKIT]
 
   # Wait for Gradle Wrapper to be validated before running any other jobs
   - wait
@@ -35,7 +29,7 @@ steps:
         command: |
           echo "--- 🧹 Linting"
           ./gradlew lintDebug
-        plugins: *common_plugins
+        plugins: [$CI_TOOLKIT]
         artifact_paths:
           - "**/build/reports/lint-results*.*"
 
@@ -43,13 +37,13 @@ steps:
     command: |
       echo "--- 🧪 Testing"
       ./gradlew testDebugUnitTest
-    plugins: *common_plugins
+    plugins: [$CI_TOOLKIT]
 
   - label: 'Spotless formatting check'
     command: |
       echo "--- 🔎 Checking formatting with Spotless"
       ./gradlew spotlessCheck
-    plugins: *common_plugins
+    plugins: [$CI_TOOLKIT]
 
   - label: "Instrumented tests"
     command: |
@@ -59,7 +53,7 @@ steps:
       bundle exec fastlane run configure_apply
       echo "--- 🧪 Testing"
       bundle exec fastlane build_and_instrumented_test
-    plugins: *common_plugins
+    plugins: [$CI_TOOLKIT]
     artifact_paths:
       - "**/build/instrumented-tests/**/*"
 
@@ -71,6 +65,6 @@ steps:
       bundle exec fastlane run configure_apply
       echo "--- ⚙️ Building release variant"
       ./gradlew assembleRelease -PskipSentryProguardMappingUpload=true
-    plugins: *common_plugins
+    plugins: [$CI_TOOLKIT]
     artifact_paths:
       - "**/build/outputs/apk/**/*"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -5,7 +5,7 @@
 common_params:
   # Common plugin settings to use with the `plugins` key.
   - &common_plugins
-    - automattic/bash-cache#2.11.0
+    - automattic/a8c-ci-toolkit#3.4.2
 
 agents:
   queue: "android"

--- a/.buildkite/release-builds.yml
+++ b/.buildkite/release-builds.yml
@@ -4,12 +4,6 @@
 # This pipeline is meant to be run via the Buildkite API, and is
 # only used for release builds
 
-# Nodes with values to reuse in the pipeline.
-common_params:
-  # Common plugin settings to use with the `plugins` key.
-  - &common_plugins
-    - automattic/a8c-ci-toolkit#3.4.2
-
 agents:
   queue: "android"
 
@@ -18,7 +12,7 @@ steps:
     command: |
       validate_gradle_wrapper
     priority: 1
-    plugins: *common_plugins
+    plugins: [$CI_TOOLKIT]
 
   # Wait for Gradle Wrapper to be validated before running any other jobs
   - wait
@@ -26,6 +20,6 @@ steps:
   - label: "🛠 Release Build"
     command: ".buildkite/commands/release-build.sh"
     priority: 1
-    plugins: *common_plugins
+    plugins: [$CI_TOOLKIT]
     notify:
       - slack: "#build-and-ship"

--- a/.buildkite/release-builds.yml
+++ b/.buildkite/release-builds.yml
@@ -8,7 +8,7 @@
 common_params:
   # Common plugin settings to use with the `plugins` key.
   - &common_plugins
-    - automattic/bash-cache#2.11.0
+    - automattic/a8c-ci-toolkit#3.4.2
 
 agents:
   queue: "android"

--- a/.buildkite/schedules/dependency-analysis.yml
+++ b/.buildkite/schedules/dependency-analysis.yml
@@ -1,12 +1,6 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/buildkite/pipeline-schema/main/schema.json
 ---
 
-# Nodes with values to reuse in the pipeline.
-common_params:
-  # Common plugin settings to use with the `plugins` key.
-  - &common_plugins
-    - automattic/a8c-ci-toolkit#3.4.2
-
 agents:
   queue: "android"
 
@@ -15,7 +9,7 @@ steps:
     command: |
       echo "--- 📊 Analyzing"
       ./gradlew buildHealth
-    plugins: *common_plugins
+    plugins: [$CI_TOOLKIT]
     artifact_paths:
       - "build/reports/dependency-analysis/build-health-report.*"
     notify:

--- a/.buildkite/schedules/dependency-analysis.yml
+++ b/.buildkite/schedules/dependency-analysis.yml
@@ -5,7 +5,7 @@
 common_params:
   # Common plugin settings to use with the `plugins` key.
   - &common_plugins
-    - automattic/bash-cache#2.11.0
+    - automattic/a8c-ci-toolkit#3.4.2
 
 agents:
   queue: "android"

--- a/.buildkite/shared-pipeline-vars
+++ b/.buildkite/shared-pipeline-vars
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+ # This file is `source`'d before calling `buildkite-agent pipeline upload`, and can be used
+ # to set up some variables that will be interpolated in the `.yml` pipeline before uploading it.
+
+ export CI_TOOLKIT="automattic/a8c-ci-toolkit#3.4.2"


### PR DESCRIPTION
## Description
<!-- Please include a summary of what this PR is changing and why these changes are needed. -->

This PR updates `a8c-ci-toolkit` to [3.4.2](https://github.com/Automattic/a8c-ci-toolkit-buildkite-plugin/releases/tag/3.4.2). To be more specific, this PR actually also migrates from the old `bash-cache` to the new `a8c-ci-toolkit` naming convention ([context](https://github.com/Automattic/pocket-casts-android/pull/2433#discussion_r1664015761)).

FYI: The breaking change in `3.0.0` is due to removing the `nvm_install` command, but this repo doesn't use that anywhere anyway. As such, it is safe to apply this update.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Tap on the Filters tab -->
<!-- 2. Tap on a filter -->
<!-- 3. etc. -->

- Make sure CI is green (🟢).

## Checklist (`N/A`)

#### I have tested any UI changes... (`N/A`)