### PR TITLE
[Give Rating] Let the user rate a podcast that has only one episode

### DIFF
--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/GiveRatingViewModel.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/GiveRatingViewModel.kt
@@ -80,7 +80,12 @@ class GiveRatingViewModel @Inject constructor(
                     val countPlayedEpisodes = podcastManager.countPlayedEpisodes(podcastUuid)
 
                     if (countPlayedEpisodes < NUMBER_OF_EPISODES_LISTENED_REQUIRED_TO_RATE) {
-                        _state.value = State.NotAllowedToRate(podcastUuid)
+                        val episodes = podcastManager.countEpisodesByPodcast(podcastUuid)
+                        if (episodes == 1 && countPlayedEpisodes == 1) {
+                            onSuccess() // This is the case an user wants to rate a podcast that has only one episode.
+                        } else {
+                            _state.value = State.NotAllowedToRate(podcastUuid)
+                        }
                     } else {
                         onSuccess()
                     }

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/EpisodeDao.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/EpisodeDao.kt
@@ -49,6 +49,9 @@ abstract class EpisodeDao {
     @Query("SELECT count(*) FROM podcast_episodes WHERE podcast_id = :podcastUuid AND played_up_to > (duration / 2)")
     abstract suspend fun countPlayedEpisodes(podcastUuid: String): Int
 
+    @Query("SELECT count(*) FROM podcast_episodes WHERE podcast_id = :podcastUuid")
+    abstract suspend fun countEpisodesByPodcast(podcastUuid: String): Int
+
     @Query("SELECT * FROM podcast_episodes WHERE uuid = :uuid")
     abstract fun findByUuidRx(uuid: String): Maybe<PodcastEpisode>
 

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PodcastManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PodcastManager.kt
@@ -152,6 +152,7 @@ interface PodcastManager {
     suspend fun findRandomPodcasts(limit: Int): List<Podcast>
 
     suspend fun countPlayedEpisodes(podcastUuid: String): Int
+    suspend fun countEpisodesByPodcast(podcastUuid: String): Int
 
     suspend fun updateArchiveSettings(uuid: String, enable: Boolean, afterPlaying: AutoArchiveAfterPlaying, inactive: AutoArchiveInactive)
     suspend fun updateArchiveAfterPlaying(uuid: String, value: AutoArchiveAfterPlaying)

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PodcastManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PodcastManagerImpl.kt
@@ -837,4 +837,8 @@ class PodcastManagerImpl @Inject constructor(
     override suspend fun countPlayedEpisodes(podcastUuid: String): Int {
         return episodeDao.countPlayedEpisodes(podcastUuid)
     }
+
+    override suspend fun countEpisodesByPodcast(podcastUuid: String): Int {
+        return episodeDao.countEpisodesByPodcast(podcastUuid)
+    }
 }


### PR DESCRIPTION
## Description
- This PR handles an edge case that the user wants to rate a podcast that has only one episode. For this case, if the user listened this episode, we will let them to rate.
- See: p1720619863257859/1720578266.711749-slack-C077XU4GF9D

Fixes #2488

## Testing Instructions
Have `GIVE_RATINGS` feature flag enabled

1. Run the app
2. Open discover 
3. Add RSS https://anchor.fm/s/f68090c0/podcast/rss that has only episode
4. Do not listen to the episode
5. Try to rate
6. ✅ Ensure you can't rate
7. Listen to the episode (scroll to almost the end)
8. ✅ Ensure you can rate the podcast

### Regression
- Make sure the restriction still works for podcasts that has more than 1 episode: https://github.com/Automattic/pocket-casts-android/pull/2461

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack