### PR TITLE
Revert PR #2325

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 *   Updates:
     *   Update Give rating view to include the average rating
         ([#2421](https://github.com/Automattic/pocket-casts-android/pull/2421))
+    *   Removes download button from shelf list in Now Playing
+        ([#2493](https://github.com/Automattic/pocket-casts-android/pull/2493))
 *   Bug Fixes
     *   Fix playback speed label tap behavior
         ([#2439](https://github.com/Automattic/pocket-casts-android/pull/2439))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@
         ([#2376](https://github.com/Automattic/pocket-casts-android/pull/2376))
     *   Fix deselected chapters not synced correctly between different platforms
         ([#2357](https://github.com/Automattic/pocket-casts-android/pull/2357))
+    *   Adds download episode action button to shelf list in Now Playing
+        ([#2325](https://github.com/Automattic/pocket-casts-android/pull/2325))
     *    Updates carousel title size
          ([#2401](https://github.com/Automattic/pocket-casts-android/pull/2401))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,8 +21,6 @@
         ([#2376](https://github.com/Automattic/pocket-casts-android/pull/2376))
     *   Fix deselected chapters not synced correctly between different platforms
         ([#2357](https://github.com/Automattic/pocket-casts-android/pull/2357))
-    *   Adds download episode action button to shelf list in Now Playing
-        ([#2325](https://github.com/Automattic/pocket-casts-android/pull/2325))
     *    Updates carousel title size
          ([#2401](https://github.com/Automattic/pocket-casts-android/pull/2401))
 

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/FilterEpisodeListViewModel.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/FilterEpisodeListViewModel.kt
@@ -144,7 +144,7 @@ class FilterEpisodeListViewModel @Inject constructor(
         val trimmedList = episodes.subList(0, min(MAX_DOWNLOAD_ALL, episodes.count()))
         launch {
             trimmedList.forEach {
-                downloadManager.addEpisodeToQueue(it, "filter download all", fireEvent = false, fireToast = false, source = SourceView.FILTERS)
+                downloadManager.addEpisodeToQueue(it, "filter download all", fireEvent = false, source = SourceView.FILTERS)
             }
         }
     }

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/ShelfBottomSheet.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/ShelfBottomSheet.kt
@@ -188,10 +188,6 @@ class ShelfBottomSheet : BaseDialogFragment() {
                 openUrl(settings.getReportViolationUrl())
             }
 
-            ShelfItem.Downloading -> {
-                // do nothing
-            }
-
             ShelfItem.RemoveDownloaded -> {
                 playerViewModel.removeDownload()
                 Toast.makeText(context, episode_was_removed, Toast.LENGTH_LONG).show()

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/ShelfBottomSheet.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/ShelfBottomSheet.kt
@@ -15,7 +15,6 @@ import androidx.recyclerview.widget.LinearLayoutManager
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTracker
 import au.com.shiftyjelly.pocketcasts.analytics.SourceView
-import au.com.shiftyjelly.pocketcasts.localization.R.string.episode_queued_for_download
 import au.com.shiftyjelly.pocketcasts.localization.R.string.episode_was_removed
 import au.com.shiftyjelly.pocketcasts.player.databinding.FragmentShelfBottomSheetBinding
 import au.com.shiftyjelly.pocketcasts.player.view.ShelfFragment.Companion.AnalyticsProp
@@ -36,7 +35,6 @@ import au.com.shiftyjelly.pocketcasts.views.fragments.BaseDialogFragment
 import com.google.android.gms.cast.framework.CastButtonFactory
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
-import kotlinx.coroutines.launch
 
 @AndroidEntryPoint
 class ShelfBottomSheet : BaseDialogFragment() {
@@ -188,13 +186,6 @@ class ShelfBottomSheet : BaseDialogFragment() {
 
             ShelfItem.Report -> {
                 openUrl(settings.getReportViolationUrl())
-            }
-
-            ShelfItem.Download -> {
-                Toast.makeText(context, episode_queued_for_download, Toast.LENGTH_SHORT).show()
-                launch {
-                    playerViewModel.downloadCurrentlyPlaying()
-                }
             }
 
             ShelfItem.Downloading -> {

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/ShelfBottomSheet.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/ShelfBottomSheet.kt
@@ -8,14 +8,12 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.widget.Toast
 import androidx.core.os.bundleOf
 import androidx.fragment.app.activityViewModels
 import androidx.recyclerview.widget.LinearLayoutManager
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTracker
 import au.com.shiftyjelly.pocketcasts.analytics.SourceView
-import au.com.shiftyjelly.pocketcasts.localization.R.string.episode_was_removed
 import au.com.shiftyjelly.pocketcasts.player.databinding.FragmentShelfBottomSheetBinding
 import au.com.shiftyjelly.pocketcasts.player.view.ShelfFragment.Companion.AnalyticsProp
 import au.com.shiftyjelly.pocketcasts.player.viewmodel.PlayerViewModel
@@ -186,11 +184,6 @@ class ShelfBottomSheet : BaseDialogFragment() {
 
             ShelfItem.Report -> {
                 openUrl(settings.getReportViolationUrl())
-            }
-
-            ShelfItem.RemoveDownloaded -> {
-                playerViewModel.removeDownload()
-                Toast.makeText(context, episode_was_removed, Toast.LENGTH_LONG).show()
             }
         }
         analyticsTracker.track(

--- a/modules/features/player/src/main/res/layout/adapter_shelf_item.xml
+++ b/modules/features/player/src/main/res/layout/adapter_shelf_item.xml
@@ -11,8 +11,8 @@
 
     <ImageView
         android:id="@+id/imgIcon"
-        android:layout_width="24dp"
-        android:layout_height="24dp"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
         android:layout_marginStart="16dp"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/helper/PlayButtonListener.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/helper/PlayButtonListener.kt
@@ -110,7 +110,7 @@ class PlayButtonListener @Inject constructor(
                     } else {
                         it.autoDownloadStatus = PodcastEpisode.AUTO_DOWNLOAD_STATUS_MANUALLY_DOWNLOADED
                     }
-                    downloadManager.addEpisodeToQueue(it, "play button", fireEvent = true, fireToast = false, source = source)
+                    downloadManager.addEpisodeToQueue(it, "play button", fireEvent = true, source = source)
                     episodeAnalytics.trackEvent(
                         AnalyticsEvent.EPISODE_DOWNLOAD_QUEUED,
                         source = source,

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/episode/EpisodeFragmentViewModel.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/episode/EpisodeFragmentViewModel.kt
@@ -192,7 +192,7 @@ class EpisodeFragmentViewModel @Inject constructor(
                     analyticsEvent = AnalyticsEvent.EPISODE_DOWNLOAD_CANCELLED
                 } else if (!it.isDownloaded) {
                     it.autoDownloadStatus = PodcastEpisode.AUTO_DOWNLOAD_STATUS_MANUAL_OVERRIDE_WIFI
-                    downloadManager.addEpisodeToQueue(it, "episode card", fireEvent = true, fireToast = false, source = source)
+                    downloadManager.addEpisodeToQueue(it, "episode card", fireEvent = true, source = source)
                     analyticsEvent = AnalyticsEvent.EPISODE_DOWNLOAD_QUEUED
                 }
                 episodeManager.clearPlaybackError(episode)

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/PodcastViewModel.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/PodcastViewModel.kt
@@ -378,7 +378,7 @@ class PodcastViewModel
         val trimmedList = episodes.subList(0, min(Settings.MAX_DOWNLOAD, episodes.count()))
         launch {
             trimmedList.forEach {
-                downloadManager.addEpisodeToQueue(it, "podcast download all", fireEvent = false, fireToast = false, source = SourceView.PODCAST_SCREEN)
+                downloadManager.addEpisodeToQueue(it, "podcast download all", fireEvent = false, source = SourceView.PODCAST_SCREEN)
             }
         }
     }

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -9,7 +9,6 @@
     <string name="empty" translatable="false" />
 
     <string name="account">Account</string>
-    <string name="remove_downloaded_file">Remove downloaded file</string>
     <string name="add_bookmark">Add bookmark</string>
     <string name="add_bookmark_title">Add Bookmark</string>
     <string name="bookmark_added">Bookmark \"%s\" added</string>
@@ -235,8 +234,6 @@
     <string name="download_warning_title">Download All</string>
     <string name="download_warning_limit_summary">Bulk downloads are limited to %1$d.</string>
 
-    <string name="episode_was_removed">Episode was removed</string>
-    <string name="episode_queued_for_download">Episode queued for download</string>
     <string name="download_queued_singular">1 episode queued for download</string>
     <string name="download_queued_plural">%1$d episodes queued for download</string>
 
@@ -253,7 +250,6 @@
     <string name="download_warning_on_wifi_summary">Downloading this episode will use data.</string>
     <string name="download_warning_on_wifi_button">Download now</string>
     <string name="download_warning_on_wifi_later" translatable="false">@string/queue_for_later</string>
-    <string name="download_completed_for_episode">Download completed for %1$s</string>
 
     <string name="profile_cloud_upload_warning_title_on_wifi" translatable="false">@string/youre_not_on_wifi</string>
     <string name="profile_cloud_upload_warning_title_metered_wifi" translatable="false">@string/youre_on_metered_wifi</string>

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/model/ShelfItem.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/model/ShelfItem.kt
@@ -66,13 +66,6 @@ enum class ShelfItem(
         iconId = { IR.drawable.ic_bookmark },
         analyticsValue = "add_bookmark",
     ),
-    Download(
-        id = "download",
-        titleId = { LR.string.download },
-        iconId = { IR.drawable.ic_download },
-        showIf = { it is PodcastEpisode && !it.isDownloaded && !it.isDownloading },
-        analyticsValue = "download",
-    ),
     Downloading(
         id = "downloading",
         titleId = { LR.string.episode_downloading },

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/model/ShelfItem.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/model/ShelfItem.kt
@@ -66,13 +66,6 @@ enum class ShelfItem(
         iconId = { IR.drawable.ic_bookmark },
         analyticsValue = "add_bookmark",
     ),
-    RemoveDownloaded(
-        id = "remove_downloaded",
-        titleId = { LR.string.remove_downloaded_file },
-        iconId = { IR.drawable.ic_downloaded },
-        showIf = { it is PodcastEpisode && it.isDownloaded },
-        analyticsValue = "remove_downloaded_file",
-    ),
     Archive(
         id = "archive",
         titleId = { if (it is UserEpisode) LR.string.delete else LR.string.archive },

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/model/ShelfItem.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/model/ShelfItem.kt
@@ -66,13 +66,6 @@ enum class ShelfItem(
         iconId = { IR.drawable.ic_bookmark },
         analyticsValue = "add_bookmark",
     ),
-    Downloading(
-        id = "downloading",
-        titleId = { LR.string.episode_downloading },
-        iconId = { IR.drawable.ic_download },
-        showIf = { it is PodcastEpisode && it.isDownloading },
-        analyticsValue = "downloading",
-    ),
     RemoveDownloaded(
         id = "remove_downloaded",
         titleId = { LR.string.remove_downloaded_file },

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/download/DownloadHelper.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/download/DownloadHelper.kt
@@ -18,7 +18,6 @@ object DownloadHelper {
         downloadManager: DownloadManager,
         episodeManager: EpisodeManager,
         source: SourceView,
-        fireToast: Boolean = false,
     ) {
         if (episode.isDownloaded) {
             return
@@ -27,7 +26,7 @@ object DownloadHelper {
         runBlocking {
             episodeManager.updateAutoDownloadStatus(episode, PodcastEpisode.AUTO_DOWNLOAD_STATUS_MANUALLY_DOWNLOADED)
         }
-        downloadManager.addEpisodeToQueue(episode, from, fireEvent = true, fireToast = fireToast, source = source)
+        downloadManager.addEpisodeToQueue(episode, from, fireEvent = true, source = source)
     }
 
     fun addAutoDownloadedEpisodeToQueue(episode: BaseEpisode, from: String, downloadManager: DownloadManager, episodeManager: EpisodeManager, source: SourceView) {
@@ -41,7 +40,7 @@ object DownloadHelper {
         runBlocking {
             episodeManager.updateAutoDownloadStatus(episode, PodcastEpisode.AUTO_DOWNLOAD_STATUS_AUTO_DOWNLOADED)
         }
-        downloadManager.addEpisodeToQueue(episode, from, fireEvent = true, fireToast = false, source = source)
+        downloadManager.addEpisodeToQueue(episode, from, fireEvent = true, source = source)
     }
 
     fun removeEpisodeFromQueue(episode: BaseEpisode, from: String, downloadManager: DownloadManager) {

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/download/DownloadManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/download/DownloadManager.kt
@@ -21,7 +21,7 @@ interface DownloadManager {
     fun setup(episodeManager: EpisodeManager, podcastManager: PodcastManager, playlistManager: PlaylistManager, playbackManager: PlaybackManager)
     fun beginMonitoringWorkManager(context: Context)
     fun hasPendingOrRunningDownloads(): Boolean
-    fun addEpisodeToQueue(episode: BaseEpisode, from: String, fireEvent: Boolean, fireToast: Boolean, source: SourceView)
+    fun addEpisodeToQueue(episode: BaseEpisode, from: String, fireEvent: Boolean, source: SourceView)
     fun removeEpisodeFromQueue(episode: BaseEpisode, from: String)
     fun stopAllDownloads()
     suspend fun getRequirementsAndSetStatusAsync(episode: BaseEpisode): NetworkRequirements

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/download/DownloadManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/download/DownloadManagerImpl.kt
@@ -282,7 +282,7 @@ class DownloadManagerImpl @Inject constructor(
     private val addDownloadMutex = Mutex()
 
     // We only want to be able to queue one download at a time
-    override fun addEpisodeToQueue(episode: BaseEpisode, from: String, fireEvent: Boolean, fireToast: Boolean, source: SourceView) {
+    override fun addEpisodeToQueue(episode: BaseEpisode, from: String, fireEvent: Boolean, source: SourceView) {
         updateSource(source)
 
         launch(downloadsCoroutineContext) {
@@ -303,7 +303,7 @@ class DownloadManagerImpl @Inject constructor(
                 LogBuffer.i(LogBuffer.TAG_BACKGROUND_TASKS, "Added episode to downloads. ${episode.uuid} podcast: ${(episode as? PodcastEpisode)?.podcastUuid} from: $from")
                 val networkRequirements = getRequirementsAndSetStatusAsync(episode)
                 episodeManager.updateLastDownloadAttemptDate(episode)
-                addWorkManagerTask(episode, networkRequirements, fireToast)
+                addWorkManagerTask(episode, networkRequirements)
             }
 
             updateNotification()
@@ -330,7 +330,7 @@ class DownloadManagerImpl @Inject constructor(
         }
     }
 
-    private suspend fun addWorkManagerTask(episode: BaseEpisode, networkRequirements: NetworkRequirements, fireToast: Boolean) {
+    private suspend fun addWorkManagerTask(episode: BaseEpisode, networkRequirements: NetworkRequirements) {
         try {
             val constraints = Constraints.Builder()
                 .setRequiredNetworkType(networkRequirements.toWorkManagerEnum())
@@ -339,7 +339,6 @@ class DownloadManagerImpl @Inject constructor(
 
             val downloadTask = run {
                 val downloadData = Data.Builder()
-                    .putBoolean(DownloadEpisodeTask.FIRE_TOAST, fireToast)
                     .putString(DownloadEpisodeTask.INPUT_EPISODE_UUID, episode.uuid)
                     .putString(DownloadEpisodeTask.INPUT_PATH_TO_SAVE_TO, DownloadHelper.pathForEpisode(episode, fileStorage))
                     .putString(DownloadEpisodeTask.INPUT_TEMP_PATH, DownloadHelper.tempPathForEpisode(episode, fileStorage))

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/download/task/DownloadEpisodeTask.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/download/task/DownloadEpisodeTask.kt
@@ -8,11 +8,10 @@ import android.os.Build
 import android.system.ErrnoException
 import android.system.OsConstants
 import android.util.Log
-import android.widget.Toast
 import androidx.hilt.work.HiltWorker
-import androidx.work.CoroutineWorker
 import androidx.work.Data
 import androidx.work.ForegroundInfo
+import androidx.work.Worker
 import androidx.work.WorkerParameters
 import au.com.shiftyjelly.pocketcasts.analytics.EpisodeDownloadError
 import au.com.shiftyjelly.pocketcasts.models.entity.BaseEpisode
@@ -57,10 +56,8 @@ import kotlin.coroutines.resumeWithException
 import kotlin.coroutines.suspendCoroutine
 import kotlin.time.DurationUnit
 import kotlin.time.TimeSource
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.rx2.await
-import kotlinx.coroutines.withContext
 import okhttp3.Call
 import okhttp3.Callback
 import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
@@ -81,7 +78,7 @@ class DownloadEpisodeTask @AssistedInject constructor(
     var userEpisodeManager: UserEpisodeManager,
     @DownloadCallFactory private val callFactory: Call.Factory,
     @DownloadRequestBuilder private val requestBuilderProvider: Provider<Request.Builder>,
-) : CoroutineWorker(context, params) {
+) : Worker(context, params) {
 
     companion object {
         private const val MAX_RETRIES = 5
@@ -120,7 +117,6 @@ class DownloadEpisodeTask @AssistedInject constructor(
     private val episodeUUID: String? = inputData.getString(INPUT_EPISODE_UUID)
     private val pathToSaveTo: String? = inputData.getString(INPUT_PATH_TO_SAVE_TO)
     private val tempDownloadPath: String? = inputData.getString(INPUT_TEMP_PATH)
-    private val fireToast: Boolean = inputData.getBoolean(FIRE_TOAST, false)
 
     private var bytesDownloadedSoFar: Long = 0
     private var bytesRemaining: Long = 0
@@ -128,7 +124,7 @@ class DownloadEpisodeTask @AssistedInject constructor(
     private val timeSource = TimeSource.Monotonic
     private val startTimestamp = timeSource.markNow()
 
-    override suspend fun doWork(): Result {
+    override fun doWork(): Result {
         if (isStopped) {
             LogBuffer.i(LogBuffer.TAG_BACKGROUND_TASKS, "Cancelling execution of $episodeUUID download because we are already stopped")
             return Result.failure(failureData())
@@ -174,11 +170,6 @@ class DownloadEpisodeTask @AssistedInject constructor(
                     }
                 }
 
-                if (fireToast) {
-                    withContext(Dispatchers.Main) {
-                        Toast.makeText(context, context.getString(LR.string.download_completed_for_episode, episode.title), Toast.LENGTH_SHORT).show()
-                    }
-                }
                 LogBuffer.i(LogBuffer.TAG_BACKGROUND_TASKS, "Downloaded episode ${episode.title} ${episode.uuid}")
 
                 Result.success(outputData)

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/UserEpisodeManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/UserEpisodeManager.kt
@@ -399,7 +399,7 @@ class UserEpisodeManagerImpl @Inject constructor(
                 if (settings.cloudAutoDownload.value && subscriptionManager.getCachedStatus() is SubscriptionStatus.Paid) {
                     userEpisodeDao.updateAutoDownloadStatus(PodcastEpisode.AUTO_DOWNLOAD_STATUS_AUTO_DOWNLOADED, newEpisode.uuid)
                     newEpisode.autoDownloadStatus = PodcastEpisode.AUTO_DOWNLOAD_STATUS_AUTO_DOWNLOADED
-                    downloadManager.addEpisodeToQueue(newEpisode, "cloud files sync", fireEvent = false, fireToast = false, source = SourceView.UNKNOWN)
+                    downloadManager.addEpisodeToQueue(newEpisode, "cloud files sync", fireEvent = false, source = SourceView.UNKNOWN)
                 }
             }
         }

--- a/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/helper/WarningsHelper.kt
+++ b/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/helper/WarningsHelper.kt
@@ -119,7 +119,7 @@ class WarningsHelper @Inject constructor(
                     if (!waitForWifi) {
                         it.autoDownloadStatus = PodcastEpisode.AUTO_DOWNLOAD_STATUS_MANUAL_OVERRIDE_WIFI
                     }
-                    downloadManager.addEpisodeToQueue(it, from, fireEvent = true, fireToast = false, source = SourceView.UNKNOWN)
+                    downloadManager.addEpisodeToQueue(it, from, fireEvent = true, source = SourceView.UNKNOWN)
                     launch {
                         episodeManager.unarchive(it)
                     }

--- a/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/multiselect/MultiSelectEpisodesHelper.kt
+++ b/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/multiselect/MultiSelectEpisodesHelper.kt
@@ -314,7 +314,7 @@ class MultiSelectEpisodesHelper @Inject constructor(
         val trimmedList = list.subList(0, min(Settings.MAX_DOWNLOAD, selectedList.count())).toList()
         ConfirmationDialog.downloadWarningDialog(list.count(), resources) {
             trimmedList.forEach {
-                downloadManager.addEpisodeToQueue(it, "podcast download all", fireEvent = false, fireToast = false, source = source)
+                downloadManager.addEpisodeToQueue(it, "podcast download all", fireEvent = false, source = source)
             }
             episodeAnalytics.trackBulkEvent(AnalyticsEvent.EPISODE_BULK_DOWNLOAD_QUEUED, source, trimmedList)
             val snackText = resources.getStringPlural(trimmedList.size, LR.string.download_queued_singular, LR.string.download_queued_plural)

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/episode/EpisodeViewModel.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/episode/EpisodeViewModel.kt
@@ -283,7 +283,7 @@ class EpisodeViewModel @Inject constructor(
             } else if (!episode.isDownloaded) {
                 episode.autoDownloadStatus =
                     PodcastEpisode.AUTO_DOWNLOAD_STATUS_MANUAL_OVERRIDE_WIFI
-                downloadManager.addEpisodeToQueue(episode, fromString, fireEvent = true, fireToast = false, source = sourceView)
+                downloadManager.addEpisodeToQueue(episode, fromString, fireEvent = true, source = sourceView)
 
                 episodeAnalytics.trackEvent(
                     event = AnalyticsEvent.EPISODE_DOWNLOAD_QUEUED,


### PR DESCRIPTION
## Description
- Reverts https://github.com/Automattic/pocket-casts-android/pull/2325

Closes #2477

## Testing Instructions
1. Install a version of the app that contains the download button as shelf item. For example: 3ed768730322da4f1c495b3f021e803631cf7503
2. Install the app from this branch
3. Play an episode
4. Open the Now Playing
5. Tap on the 3 dots
6. ✅ Make sure the app does not crash
7. ✅ Make sure the download button is not visible in shelf


## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
