### PR TITLE
QuickFix: Help keyboard resize issue

### DIFF
--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/ChangeEmailFragment.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/ChangeEmailFragment.kt
@@ -5,7 +5,6 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.view.WindowManager
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.livedata.observeAsState
 import androidx.compose.ui.platform.ComposeView
@@ -18,6 +17,8 @@ import au.com.shiftyjelly.pocketcasts.account.viewmodel.ChangeEmailViewModel
 import au.com.shiftyjelly.pocketcasts.account.viewmodel.DoneViewModel
 import au.com.shiftyjelly.pocketcasts.compose.AppThemeWithBackground
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
+import au.com.shiftyjelly.pocketcasts.ui.extensions.setupKeyboardModePan
+import au.com.shiftyjelly.pocketcasts.ui.extensions.setupKeyboardModeResize
 import au.com.shiftyjelly.pocketcasts.ui.helper.FragmentHostListener
 import au.com.shiftyjelly.pocketcasts.utils.extensions.pxToDp
 import au.com.shiftyjelly.pocketcasts.views.fragments.BaseFragment
@@ -78,17 +79,14 @@ class ChangeEmailFragment : BaseFragment() {
         }
     }
 
-    @Suppress("DEPRECATION")
     override fun onAttach(context: Context) {
         super.onAttach(context)
-        // hack: enable scrolling upon keyboard
-        activity?.window?.setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_ADJUST_RESIZE)
+        setupKeyboardModeResize()
     }
 
     override fun onDetach() {
         super.onDetach()
-        // hack: enable scrolling upon keyboard
-        activity?.window?.setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_ADJUST_PAN)
+        setupKeyboardModePan()
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/CreateFilterContainerFragment.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/CreateFilterContainerFragment.kt
@@ -6,7 +6,6 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.view.WindowManager
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentManager
 import androidx.fragment.app.activityViewModels
@@ -19,6 +18,8 @@ import au.com.shiftyjelly.pocketcasts.filters.databinding.FragmentCreateContaine
 import au.com.shiftyjelly.pocketcasts.models.entity.Playlist
 import au.com.shiftyjelly.pocketcasts.ui.extensions.getThemeColor
 import au.com.shiftyjelly.pocketcasts.ui.extensions.getTintedDrawable
+import au.com.shiftyjelly.pocketcasts.ui.extensions.setupKeyboardModePan
+import au.com.shiftyjelly.pocketcasts.ui.extensions.setupKeyboardModeResize
 import au.com.shiftyjelly.pocketcasts.ui.extensions.themeColors
 import au.com.shiftyjelly.pocketcasts.ui.helper.ColorUtils
 import au.com.shiftyjelly.pocketcasts.ui.helper.FragmentHostListener
@@ -170,17 +171,14 @@ class CreateFilterContainerFragment : BaseFragment() {
         _binding = null
     }
 
-    @Suppress("deprecation")
     override fun onAttach(context: Context) {
         super.onAttach(context)
-        // hack: enable scrolling upon keyboard
-        activity?.window?.setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_ADJUST_RESIZE)
+        setupKeyboardModeResize()
     }
 
     override fun onDetach() {
         super.onDetach()
-        // hack: enable scrolling upon keyboard
-        activity?.window?.setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_ADJUST_PAN)
+        setupKeyboardModePan()
 
         if (!playlistSaved) {
             viewModel.clearNewFilter()

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/HelpFragment.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/HelpFragment.kt
@@ -2,6 +2,7 @@ package au.com.shiftyjelly.pocketcasts.settings
 
 import android.annotation.SuppressLint
 import android.content.ActivityNotFoundException
+import android.content.Context
 import android.content.Intent
 import android.net.Uri
 import android.os.Bundle
@@ -31,6 +32,8 @@ import au.com.shiftyjelly.pocketcasts.repositories.subscription.SubscriptionMana
 import au.com.shiftyjelly.pocketcasts.repositories.support.Support
 import au.com.shiftyjelly.pocketcasts.settings.status.StatusFragment
 import au.com.shiftyjelly.pocketcasts.settings.viewmodel.HelpViewModel
+import au.com.shiftyjelly.pocketcasts.ui.extensions.setupKeyboardModePan
+import au.com.shiftyjelly.pocketcasts.ui.extensions.setupKeyboardModeResize
 import au.com.shiftyjelly.pocketcasts.ui.helper.FragmentHostListener
 import au.com.shiftyjelly.pocketcasts.views.extensions.findToolbar
 import au.com.shiftyjelly.pocketcasts.views.extensions.setup
@@ -133,6 +136,17 @@ class HelpFragment : BaseFragment(), HasBackstack, Toolbar.OnMenuItemClickListen
         }
 
         return view
+    }
+
+    @Suppress("DEPRECATION")
+    override fun onAttach(context: Context) {
+        super.onAttach(context)
+        setupKeyboardModeResize()
+    }
+
+    override fun onDetach() {
+        super.onDetach()
+        setupKeyboardModePan()
     }
 
     override fun onMenuItemClick(item: MenuItem): Boolean =

--- a/modules/services/ui/src/main/java/au/com/shiftyjelly/pocketcasts/ui/extensions/Fragment.kt
+++ b/modules/services/ui/src/main/java/au/com/shiftyjelly/pocketcasts/ui/extensions/Fragment.kt
@@ -2,6 +2,7 @@ package au.com.shiftyjelly.pocketcasts.ui.extensions
 
 import android.content.Intent
 import android.net.Uri
+import android.view.WindowManager
 import androidx.fragment.app.Fragment
 import timber.log.Timber
 
@@ -11,4 +12,13 @@ fun Fragment.openUrl(url: String) {
     } catch (e: Exception) {
         Timber.e(e)
     }
+}
+
+@Suppress("DEPRECATION")
+fun Fragment.setupKeyboardModeResize() {
+    activity?.window?.setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_ADJUST_RESIZE)
+}
+
+fun Fragment.setupKeyboardModePan() {
+    activity?.window?.setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_ADJUST_PAN)
 }


### PR DESCRIPTION
## Description
This fixes help screen keyboard resize issue.

## Testing Instructions
1. Open Help & feedback screen in the Profile tab
2. Tap red Help button
3. ✅ Notice that screen resizes based on keyboard size

## Screenshots or Screencast 

https://github.com/user-attachments/assets/f338c0c2-84db-44e7-8be4-27d24ec4d8bd


## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
