### PR TITLE
Redesign sharing actions

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -76,6 +76,7 @@ dependencies {
     implementation(project(":modules:features:search"))
     implementation(project(":modules:features:settings"))
     implementation(project(":modules:features:shared"))
+    implementation(project(":modules:features:sharing"))
     implementation(project(":modules:features:taskerplugin"))
     implementation(project(":modules:features:widgets"))
     implementation(project(":modules:features:nova"))

--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/sharing/ShareActionsTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/sharing/ShareActionsTest.kt
@@ -1,0 +1,326 @@
+package au.com.shiftyjelly.pocketcasts.sharing
+
+import android.content.Context
+import android.content.Intent
+import android.content.Intent.ACTION_SEND
+import android.content.Intent.EXTRA_INTENT
+import android.content.Intent.EXTRA_STREAM
+import android.content.Intent.EXTRA_TEXT
+import android.content.Intent.EXTRA_TITLE
+import android.content.Intent.FLAG_GRANT_READ_URI_PERMISSION
+import android.net.Uri
+import androidx.core.content.IntentCompat
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
+import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTracker
+import au.com.shiftyjelly.pocketcasts.analytics.SourceView
+import au.com.shiftyjelly.pocketcasts.analytics.Tracker
+import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
+import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
+import au.com.shiftyjelly.pocketcasts.sharedtest.MainCoroutineRule
+import au.com.shiftyjelly.pocketcasts.utils.FileUtil
+import java.io.File
+import java.util.Date
+import kotlin.time.Duration.Companion.seconds
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+@OptIn(ExperimentalCoroutinesApi::class)
+class ShareActionsTest {
+    @get:Rule
+    val coroutineRule = MainCoroutineRule()
+
+    private val context = InstrumentationRegistry.getInstrumentation().targetContext
+
+    private val shareStarter = TestShareStarter()
+
+    private val tracker = TestTracker()
+
+    private val actions = ShareActions(
+        context = context,
+        scope = CoroutineScope(coroutineRule.testDispatcher),
+        tracker = AnalyticsTracker.test(tracker, isEnabled = true),
+        source = SourceView.BOTTOM_SHELF,
+        hostUrl = "https://pca.st",
+        shareStarter = shareStarter,
+    )
+
+    @Test
+    fun sharePodcast() = runTest {
+        actions.sharePodcast(
+            podcast = Podcast(uuid = "podcast-uuid", title = "Podcast Title"),
+        ).join()
+
+        val intent = shareStarter.shareIntent
+
+        assertEquals(ACTION_SEND, intent.action)
+        assertEquals("text/plain", intent.type)
+        assertEquals("https://pca.st/podcast/podcast-uuid", intent.getStringExtra(EXTRA_TEXT))
+        assertEquals("Podcast Title", intent.getStringExtra(EXTRA_TITLE))
+        assertEquals(FLAG_GRANT_READ_URI_PERMISSION, intent.flags and FLAG_GRANT_READ_URI_PERMISSION)
+    }
+
+    @Test
+    fun shareEpisode() = runTest {
+        actions.shareEpisode(
+            podcast = Podcast(uuid = "podcast-uuid", title = "Podcast Title"),
+            episode = PodcastEpisode(uuid = "episode-uuid", title = "Episode Title", publishedDate = Date()),
+        ).join()
+
+        val intent = shareStarter.shareIntent
+
+        assertEquals(ACTION_SEND, intent.action)
+        assertEquals("text/plain", intent.type)
+        assertEquals("https://pca.st/episode/episode-uuid", intent.getStringExtra(EXTRA_TEXT))
+        assertEquals("Episode Title", intent.getStringExtra(EXTRA_TITLE))
+        assertEquals(FLAG_GRANT_READ_URI_PERMISSION, intent.flags and FLAG_GRANT_READ_URI_PERMISSION)
+    }
+
+    @Test
+    fun shareEpisodePosition() = runTest {
+        actions.shareEpisodePosition(
+            podcast = Podcast(uuid = "podcast-uuid", title = "Podcast Title"),
+            episode = PodcastEpisode(uuid = "episode-uuid", title = "Episode Title", publishedDate = Date()),
+            start = 25.seconds,
+        ).join()
+
+        val intent = shareStarter.shareIntent
+
+        assertEquals(ACTION_SEND, intent.action)
+        assertEquals("text/plain", intent.type)
+        assertEquals("https://pca.st/episode/episode-uuid?t=25", intent.getStringExtra(EXTRA_TEXT))
+        assertEquals("Episode Title", intent.getStringExtra(EXTRA_TITLE))
+        assertEquals(FLAG_GRANT_READ_URI_PERMISSION, intent.flags and FLAG_GRANT_READ_URI_PERMISSION)
+    }
+
+    @Test
+    fun shareBookmark() = runTest {
+        actions.shareBookmark(
+            podcast = Podcast(uuid = "podcast-uuid", title = "Podcast Title"),
+            episode = PodcastEpisode(uuid = "episode-uuid", title = "Episode Title", publishedDate = Date()),
+            start = 25.seconds,
+        ).join()
+
+        val intent = shareStarter.shareIntent
+
+        assertEquals(ACTION_SEND, intent.action)
+        assertEquals("text/plain", intent.type)
+        assertEquals("https://pca.st/episode/episode-uuid?t=25", intent.getStringExtra(EXTRA_TEXT))
+        assertEquals("Episode Title", intent.getStringExtra(EXTRA_TITLE))
+        assertEquals(FLAG_GRANT_READ_URI_PERMISSION, intent.flags and FLAG_GRANT_READ_URI_PERMISSION)
+    }
+
+    @Test
+    fun shareClipLink() = runTest {
+        actions.shareClipLink(
+            podcast = Podcast(uuid = "podcast-uuid", title = "Podcast Title"),
+            episode = PodcastEpisode(uuid = "episode-uuid", title = "Episode Title", publishedDate = Date()),
+            start = 25.seconds,
+            end = 85.seconds,
+        ).join()
+
+        val intent = shareStarter.shareIntent
+
+        assertEquals(ACTION_SEND, intent.action)
+        assertEquals("text/plain", intent.type)
+        assertEquals("https://pca.st/episode/episode-uuid?t=25,85", intent.getStringExtra(EXTRA_TEXT))
+        assertEquals("Episode Title", intent.getStringExtra(EXTRA_TITLE))
+        assertEquals(FLAG_GRANT_READ_URI_PERMISSION, intent.flags and FLAG_GRANT_READ_URI_PERMISSION)
+    }
+
+    @Test
+    fun shareEpisodeFile() = runTest {
+        val file = File(context.cacheDir, "file.mp3")
+
+        actions.shareEpisodeFile(
+            episode = PodcastEpisode(uuid = "episode-uuid", title = "Episode Title", downloadedFilePath = file.path, fileType = "audio/mp3", publishedDate = Date()),
+        ).join()
+
+        val intent = shareStarter.shareIntent
+
+        assertEquals(ACTION_SEND, intent.action)
+        assertEquals("audio/mp3", intent.type)
+        assertEquals(FileUtil.getUriForFile(context, file), IntentCompat.getParcelableExtra(intent, EXTRA_STREAM, Uri::class.java))
+    }
+
+    @Test
+    fun sharePodcastAnalytics() = runTest {
+        actions.sharePodcast(
+            podcast = Podcast(uuid = "podcast-uuid", title = "Podcast Title"),
+        )
+
+        val (event, properties) = tracker.events.single()
+
+        assertEquals(AnalyticsEvent.PODCAST_SHARED, event)
+        assertEquals(
+            mapOf(
+                "source" to SourceView.BOTTOM_SHELF.analyticsValue,
+                "type" to "podcast",
+            ),
+            properties,
+        )
+    }
+
+    @Test
+    fun shareEpisodeAnalytics() = runTest {
+        actions.shareEpisode(
+            podcast = Podcast(uuid = "podcast-uuid", title = "Podcast Title"),
+            episode = PodcastEpisode(uuid = "episode-uuid", title = "Episode Title", publishedDate = Date()),
+        )
+
+        val (event, properties) = tracker.events.single()
+
+        assertEquals(AnalyticsEvent.PODCAST_SHARED, event)
+        assertEquals(
+            mapOf(
+                "source" to SourceView.BOTTOM_SHELF.analyticsValue,
+                "type" to "episode",
+            ),
+            properties,
+        )
+    }
+
+    @Test
+    fun shareEpisodePositionAnalytics() = runTest {
+        actions.shareEpisodePosition(
+            podcast = Podcast(uuid = "podcast-uuid", title = "Podcast Title"),
+            episode = PodcastEpisode(uuid = "episode-uuid", title = "Episode Title", publishedDate = Date()),
+            start = 25.seconds,
+        )
+
+        val (event, properties) = tracker.events.single()
+
+        assertEquals(AnalyticsEvent.PODCAST_SHARED, event)
+        assertEquals(
+            mapOf(
+                "source" to SourceView.BOTTOM_SHELF.analyticsValue,
+                "type" to "current_time",
+            ),
+            properties,
+        )
+    }
+
+    @Test
+    fun shareBookmarkAnalytics() = runTest {
+        actions.shareBookmark(
+            podcast = Podcast(uuid = "podcast-uuid", title = "Podcast Title"),
+            episode = PodcastEpisode(uuid = "episode-uuid", title = "Episode Title", publishedDate = Date()),
+            start = 25.seconds,
+        )
+
+        val (event, properties) = tracker.events.single()
+
+        assertEquals(AnalyticsEvent.PODCAST_SHARED, event)
+        assertEquals(
+            mapOf(
+                "source" to SourceView.BOTTOM_SHELF.analyticsValue,
+                "type" to "bookmark_time",
+            ),
+            properties,
+        )
+    }
+
+    @Test
+    fun shareClipLinkAnalytics() = runTest {
+        actions.shareClipLink(
+            podcast = Podcast(uuid = "podcast-uuid", title = "Podcast Title"),
+            episode = PodcastEpisode(uuid = "episode-uuid", title = "Episode Title", publishedDate = Date()),
+            start = 25.seconds,
+            end = 85.seconds,
+        )
+
+        val (event, properties) = tracker.events.single()
+
+        assertEquals(AnalyticsEvent.PODCAST_SHARED, event)
+        assertEquals(
+            mapOf(
+                "source" to SourceView.BOTTOM_SHELF.analyticsValue,
+                "type" to "clip_link",
+            ),
+            properties,
+        )
+    }
+
+    @Test
+    fun shareEpisodeFileAnalytics() = runTest {
+        val file = File(context.cacheDir, "file.mp3")
+
+        actions.shareEpisodeFile(
+            episode = PodcastEpisode(uuid = "episode-uuid", title = "Episode Title", downloadedFilePath = file.path, fileType = "audio/mp3", publishedDate = Date()),
+        )
+
+        val (event, properties) = tracker.events.single()
+
+        assertEquals(AnalyticsEvent.PODCAST_SHARED, event)
+        assertEquals(
+            mapOf(
+                "source" to SourceView.BOTTOM_SHELF.analyticsValue,
+                "type" to "episode_file",
+            ),
+            properties,
+        )
+    }
+
+    @Test
+    fun trackSharingWithPodcastScreenSource() = runTest {
+        val actions = ShareActions(
+            context = context,
+            scope = CoroutineScope(coroutineRule.testDispatcher),
+            tracker = AnalyticsTracker.test(tracker, isEnabled = true),
+            source = SourceView.PODCAST_SCREEN,
+            hostUrl = "https://pca.st",
+            shareStarter = shareStarter,
+        )
+
+        actions.sharePodcast(
+            podcast = Podcast(uuid = "podcast-uuid", title = "Podcast Title"),
+        )
+
+        val (event1, properties1) = tracker.events[0]
+
+        assertEquals(AnalyticsEvent.PODCAST_SHARED, event1)
+        assertEquals(
+            mapOf(
+                "source" to SourceView.PODCAST_SCREEN.analyticsValue,
+                "type" to "podcast",
+            ),
+            properties1,
+        )
+
+        val (event2, properties2) = tracker.events[1]
+
+        assertEquals(AnalyticsEvent.PODCAST_SCREEN_SHARE_TAPPED, event2)
+        assertEquals(emptyMap<String, Any>(), properties2)
+    }
+
+    private class TestShareStarter : ShareStarter {
+        private var _intent: Intent? = null
+        val shareIntent get() = requireNotNull(IntentCompat.getParcelableExtra(requireNotNull(_intent), EXTRA_INTENT, Intent::class.java))
+
+        override fun start(context: Context, intent: Intent) {
+            _intent = intent
+        }
+    }
+
+    private class TestTracker : Tracker {
+        private val _trackedEvents = mutableListOf<Pair<AnalyticsEvent, Map<String, Any>>>()
+        val events get() = _trackedEvents.toList()
+
+        override fun track(event: AnalyticsEvent, properties: Map<String, Any>) {
+            _trackedEvents.add(event to properties)
+        }
+
+        override fun refreshMetadata() = Unit
+
+        override fun flush() = Unit
+
+        override fun clearAllData() = Unit
+    }
+}

--- a/modules/features/sharing/build.gradle.kts
+++ b/modules/features/sharing/build.gradle.kts
@@ -1,0 +1,31 @@
+plugins {
+    alias(libs.plugins.android.library)
+    alias(libs.plugins.kotlin.android)
+    alias(libs.plugins.ksp)
+    alias(libs.plugins.hilt)
+    alias(libs.plugins.kotlin.parcelize)
+}
+
+apply(from = "${project.rootDir}/base.gradle")
+
+android {
+    namespace = "au.com.shiftyjelly.pocketcasts.sharing"
+    buildFeatures {
+        buildConfig = true
+        viewBinding = false
+        compose = true
+    }
+}
+
+dependencies {
+    implementation(project(":modules:services:analytics"))
+    implementation(project(":modules:services:compose"))
+    implementation(project(":modules:services:localization"))
+    implementation(project(":modules:services:model"))
+    implementation(project(":modules:services:repositories"))
+    implementation(project(":modules:services:ui"))
+    implementation(project(":modules:services:utils"))
+    implementation(project(":modules:services:views"))
+
+    implementation(project(":modules:features:clip"))
+}

--- a/modules/features/sharing/lint-baseline.xml
+++ b/modules/features/sharing/lint-baseline.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<issues format="6" by="lint 8.4.1" type="baseline" client="gradle" dependencies="false" name="AGP (8.4.1)" variant="all" version="8.4.1">
+
+</issues>

--- a/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/ShareActions.kt
+++ b/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/ShareActions.kt
@@ -1,0 +1,205 @@
+package au.com.shiftyjelly.pocketcasts.sharing
+
+import android.content.ClipData
+import android.content.Context
+import android.content.Intent
+import android.content.Intent.ACTION_SEND
+import android.content.Intent.EXTRA_STREAM
+import android.content.Intent.EXTRA_TEXT
+import android.content.Intent.EXTRA_TITLE
+import android.content.Intent.FLAG_ACTIVITY_NEW_TASK
+import android.content.Intent.FLAG_GRANT_READ_URI_PERMISSION
+import android.graphics.Bitmap
+import android.os.Build
+import androidx.core.graphics.drawable.toBitmap
+import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
+import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTracker
+import au.com.shiftyjelly.pocketcasts.analytics.SourceView
+import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
+import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
+import au.com.shiftyjelly.pocketcasts.repositories.di.ApplicationScope
+import au.com.shiftyjelly.pocketcasts.repositories.images.PocketCastsImageRequestFactory
+import au.com.shiftyjelly.pocketcasts.sharing.BuildConfig.SERVER_SHORT_URL
+import au.com.shiftyjelly.pocketcasts.utils.FileUtil
+import coil.executeBlocking
+import coil.imageLoader
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedFactory
+import dagger.assisted.AssistedInject
+import dagger.hilt.android.qualifiers.ApplicationContext
+import java.io.File
+import java.io.FileOutputStream
+import kotlin.time.Duration
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import au.com.shiftyjelly.pocketcasts.localization.R as LR
+
+class ShareActions(
+    private val context: Context,
+    private val scope: CoroutineScope,
+    private val tracker: AnalyticsTracker,
+    private val source: SourceView,
+    private val hostUrl: String,
+    private val shareStarter: ShareStarter,
+) {
+    @AssistedInject constructor(
+        @Assisted sourceView: SourceView,
+        @ApplicationContext context: Context,
+        @ApplicationScope scope: CoroutineScope,
+        analyticsTracker: AnalyticsTracker,
+    ) : this(
+        context = context,
+        scope = scope,
+        tracker = analyticsTracker,
+        source = sourceView,
+        hostUrl = SERVER_SHORT_URL,
+        shareStarter = ShareStarter { ctx, intent -> ctx.startActivity(intent) },
+    )
+
+    private val imageRequestFactory = PocketCastsImageRequestFactory(context, isDarkTheme = false).smallSize()
+
+    fun sharePodcast(podcast: Podcast): Job {
+        trackSharing(Type.Podcast)
+        return shareUrl(
+            url = "$hostUrl/podcast/${podcast.uuid}",
+            title = podcast.title,
+            podcast = podcast,
+        )
+    }
+
+    fun shareEpisode(podcast: Podcast, episode: PodcastEpisode): Job {
+        trackSharing(Type.Episode)
+        return shareUrl(
+            url = episodeUrl(episode, start = null, end = null),
+            title = episode.title,
+            podcast = podcast,
+        )
+    }
+
+    fun shareEpisodePosition(podcast: Podcast, episode: PodcastEpisode, start: Duration): Job {
+        trackSharing(Type.EpisodeTimestamp)
+        return shareUrl(
+            url = episodeUrl(episode, start, end = null),
+            title = episode.title,
+            podcast = podcast,
+        )
+    }
+
+    fun shareBookmark(podcast: Podcast, episode: PodcastEpisode, start: Duration): Job {
+        trackSharing(Type.BookmarkTimestamp)
+        return shareUrl(
+            url = episodeUrl(episode, start, end = null),
+            title = episode.title,
+            podcast = podcast,
+        )
+    }
+
+    fun shareClipLink(podcast: Podcast, episode: PodcastEpisode, start: Duration, end: Duration): Job {
+        trackSharing(Type.ClipLink)
+        return shareUrl(
+            url = episodeUrl(episode, start, end),
+            title = episode.title,
+            podcast = podcast,
+        )
+    }
+
+    fun shareEpisodeFile(episode: PodcastEpisode): Job {
+        trackSharing(Type.EpisodeFile)
+        return scope.launch(Dispatchers.Main) {
+            runCatching {
+                episode.downloadedFilePath?.let(::File)?.let { file ->
+                    val intent = Intent(ACTION_SEND)
+                        .setType(episode.fileType)
+                        .setExtraStream(file)
+                    shareStarter.start(context, intent.toChooserIntent())
+                }
+            }
+        }
+    }
+
+    private fun episodeUrl(episode: PodcastEpisode, start: Duration?, end: Duration?): String {
+        val timeMarker = listOfNotNull(start, end).takeIf { it.isNotEmpty() }?.joinToString(prefix = "?t=", separator = ",") { it.inWholeSeconds.toString() }.orEmpty()
+        return "$hostUrl/episode/${episode.uuid}$timeMarker"
+    }
+
+    private fun shareUrl(
+        url: String,
+        title: String,
+        podcast: Podcast,
+    ) = scope.launch(Dispatchers.Main) {
+        runCatching {
+            val intent = createUrlShareIntent(url, title, podcast)
+            shareStarter.start(context, intent.toChooserIntent())
+        }
+    }
+
+    private fun Intent.toChooserIntent() = Intent
+        .createChooser(this, context.getString(LR.string.podcasts_share_via))
+        .addFlags(FLAG_ACTIVITY_NEW_TASK)
+
+    private suspend fun createUrlShareIntent(
+        url: String,
+        title: String,
+        podcast: Podcast,
+    ) = Intent(Intent.ACTION_SEND)
+        .setType("text/plain")
+        .putExtra(EXTRA_TEXT, url)
+        .putExtra(EXTRA_TITLE, title)
+        .addFlags(FLAG_GRANT_READ_URI_PERMISSION)
+        .setPodcastCover(podcast)
+
+    private suspend fun Intent.setPodcastCover(podcast: Podcast): Intent {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            val coverUri = getPodcastCoverUri(podcast)
+            if (coverUri != null) {
+                clipData = ClipData.newRawUri(null, coverUri)
+            }
+        }
+        return this
+    }
+
+    private suspend fun Intent.setExtraStream(file: File) = putExtra(EXTRA_STREAM, FileUtil.createUriWithReadPermissions(context, file, this))
+
+    private suspend fun getPodcastCoverUri(podcast: Podcast) = runCatching {
+        withContext(Dispatchers.IO) {
+            val request = imageRequestFactory.create(podcast)
+            context.imageLoader.executeBlocking(request).drawable?.toBitmap()?.let { bitmap ->
+                val imageFile = File(context.cacheDir, "share_podcast_thumbnail.jpg")
+                FileOutputStream(imageFile).use { bitmap.compress(Bitmap.CompressFormat.JPEG, 100, it) }
+                FileUtil.getUriForFile(context, imageFile)
+            }
+        }
+    }.getOrNull()
+
+    private fun trackSharing(type: Type) {
+        tracker.track(
+            AnalyticsEvent.PODCAST_SHARED,
+            mapOf(
+                "source" to source.analyticsValue,
+                "type" to type.analyticsValue,
+            ),
+        )
+        if (source == SourceView.PODCAST_SCREEN && type == Type.Podcast) {
+            tracker.track(AnalyticsEvent.PODCAST_SCREEN_SHARE_TAPPED)
+        }
+    }
+
+    private enum class Type(
+        val analyticsValue: String,
+    ) {
+        Podcast("podcast"),
+        Episode("episode"),
+        EpisodeTimestamp("current_time"),
+        EpisodeFile("episode_file"),
+        BookmarkTimestamp("bookmark_time"),
+        ClipLink("clip_link"),
+    }
+
+    @AssistedFactory
+    interface Factory {
+        fun create(source: SourceView): ShareActions
+    }
+}

--- a/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/ShareStarter.kt
+++ b/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/ShareStarter.kt
@@ -1,0 +1,8 @@
+package au.com.shiftyjelly.pocketcasts.sharing
+
+import android.content.Context
+import android.content.Intent
+
+fun interface ShareStarter {
+    fun start(context: Context, intent: Intent)
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -53,6 +53,7 @@ include(":modules:features:profile")
 include(":modules:features:search")
 include(":modules:features:settings")
 include(":modules:features:shared")
+include(":modules:features:sharing")
 include(":modules:features:taskerplugin")
 include(":modules:features:widgets")
 


### PR DESCRIPTION
## Description

Currently our sharing is split into multiple different classes that are hard to use and are not tested - `SharePodcastHelper`, `ShareDialog`, `ShareFragment`. This PR introduces a new classes that will be used for all sharing. I'll replace the old ones in the following PRs.

There will be a small change to analytics for podcast sharing. Previously it didn't send `podcast_share` event. More infor here: p1721652688414179-slack-C029BMLUGRX

## Testing Instructions

Code review and green tests are enough since this code is not used yet.

## Checklist
- [x] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [x] ~Any jetpack compose components I added or changed are covered by compose previews~
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.