### PR TITLE
Add missing latest episode info to the podcast

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 *   Updates
     *   Episodes shared from the player are updated with the playback status.
         ([#2499](https://github.com/Automattic/pocket-casts-android/pull/2499))
+    *   Improved the podcast refresh performance.
+        ([#2500](https://github.com/Automattic/pocket-casts-android/pull/2500))
 *   New Features
     *   Add an option in your account settings to modify your avatar with Gravatar
         ([#2263](https://github.com/Automattic/pocket-casts-android/pull/2263))

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PodcastManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PodcastManager.kt
@@ -158,4 +158,6 @@ interface PodcastManager {
     suspend fun updateArchiveAfterPlaying(uuid: String, value: AutoArchiveAfterPlaying)
     suspend fun updateArchiveAfterInactive(uuid: String, value: AutoArchiveInactive)
     suspend fun updateArchiveEpisodeLimit(uuid: String, value: AutoArchiveLimit)
+
+    fun updatePodcastLatestEpisode(podcast: Podcast)
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PodcastManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PodcastManagerImpl.kt
@@ -596,12 +596,12 @@ class PodcastManagerImpl @Inject constructor(
     }
 
     // WARNING: only call this when NEW episodes are added, not old ones
-    private fun updateLatestEpisodeUuid(podcastUuid: String) {
+    override fun updatePodcastLatestEpisode(podcast: Podcast) {
         // get the most recent episode details
-        val episode = episodeDao.findLatest(podcastUuid) ?: return
+        val episode = episodeDao.findLatest(podcast.uuid) ?: return
         val latestEpisodeUuid = episode.uuid
         val latestEpisodeDate = episode.publishedDate
-        podcastDao.updateLatestEpisode(episodeUuid = latestEpisodeUuid, publishedDate = latestEpisodeDate, podcastUuid = podcastUuid)
+        podcastDao.updateLatestEpisode(episodeUuid = latestEpisodeUuid, publishedDate = latestEpisodeDate, podcastUuid = podcast.uuid)
     }
 
     override fun addFolderPodcast(podcast: Podcast) {

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/SubscribeManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/SubscribeManager.kt
@@ -232,6 +232,10 @@ class SubscribeManager @Inject constructor(
         podcast.isShowNotifications = foundEpisodes && allSendingNotifications
         podcast.sortPosition = count
         podcast.episodesSortType = if (podcast.episodesSortType.ordinal == 0) EpisodesSortType.EPISODES_SORT_BY_DATE_DESC else podcast.episodesSortType
+        podcast.episodes.firstOrNull()?.let { episode ->
+            podcast.latestEpisodeUuid = episode.uuid
+            podcast.latestEpisodeDate = episode.publishedDate
+        }
         // give the podcasts and episodes the same added date so we can tell which are new episodes or added with podcast when calculating notifications
         podcast.addedDate = Date()
         // copy colors

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/refresh/RefreshPodcastsThread.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/refresh/RefreshPodcastsThread.kt
@@ -317,8 +317,13 @@ class RefreshPodcastsThread(
             }
             episodes = episodeManager.add(episodes, podcast.uuid, downloadMetaData)
 
-            // we now have some new episodes, update the latest episode uuid on the podcast row
-            if (episodes.isNotEmpty()) {
+            if (episodes.isEmpty()) {
+                // the server returned episodes, but none were added to the database. Update the podcast when it doesn't have the latest episode information.
+                if (podcast.latestEpisodeUuid == null) {
+                    podcastManager.updatePodcastLatestEpisode(podcast)
+                }
+            } else {
+                // we now have some new episodes, update the latest episode uuid on the podcast row
                 podcastManager.updateLatestEpisode(podcast, episodes[0])
                 for ((uuid) in episodes) {
                     episodeUuidsAdded.add(uuid)


### PR DESCRIPTION
## Description

When testing the podcast refresh we found that Android wasn't setting the latest episode uuid and publish date on the podcast when first signing in. This would mean that the latest episode uuid would be sent to the server as null. If a new episode was never released, then every time the server would return episodes. This will speed up the refresh for lots of users. Do you think I should add it to the change log?

Parameters before. I have replaced `%2C` with `,` to make it easier to read.

```
podcasts=bb793090-0424-012e-f9a0-00163e1b201c,2743d720-0edf-0133-2204-059c869cc4eb,04364440-031e-012e-f99b-00163e1b201c,4eb5b260-c933-0134-10da-25324e2a541d,b1090430-da7a-0135-9e62-5bb073f92b78
last_episodes=null,null,null,null,null
```

Parameters after

```
podcasts=bb793090-0424-012e-f9a0-00163e1b201c,2743d720-0edf-0133-2204-059c869cc4eb,04364440-031e-012e-f99b-00163e1b201c,4eb5b260-c933-0134-10da-25324e2a541d,b1090430-da7a-0135-9e62-5bb073f92b78
last_episodes=1fb6e853-aabf-4104-b0f7-a98612628234,68cf7e90-303b-4806-bcca-9c54e823b5a3,209753f1-1426-4bd7-952e-d436d8108ad5,1cf06916-3eb6-4f20-b5a6-2116db33007b,0e4601ee-f35b-4196-8932-8900401756e2
```

## Testing Instructions

1. Sign up for a new Pocket Casts account
2. Subscribe to some podcasts
3. Sign out and clear the storage
4. Sign in with the account
5. Filter logcat for last_episodes
6. Go to the Profile tab and tap Refresh
7. ✅ Verify that the episode uuids are not null
