### PR TITLE
Add reimagine sharing entry points

### DIFF
--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/bookmark/BookmarksFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/bookmark/BookmarksFragment.kt
@@ -21,6 +21,7 @@ import androidx.fragment.app.activityViewModels
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.asFlow
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.lifecycle.lifecycleScope
 import au.com.shiftyjelly.pocketcasts.analytics.SourceView
 import au.com.shiftyjelly.pocketcasts.compose.AppTheme
 import au.com.shiftyjelly.pocketcasts.compose.theme
@@ -31,16 +32,22 @@ import au.com.shiftyjelly.pocketcasts.settings.SettingsFragment
 import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingFlow
 import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingLauncher
 import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingUpgradeSource
+import au.com.shiftyjelly.pocketcasts.sharing.ShareActions
+import au.com.shiftyjelly.pocketcasts.sharing.timestamp.ShareEpisodeTimestampFragment
 import au.com.shiftyjelly.pocketcasts.ui.helper.FragmentHostListener
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import au.com.shiftyjelly.pocketcasts.utils.extensions.pxToDp
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
 import au.com.shiftyjelly.pocketcasts.views.R
 import au.com.shiftyjelly.pocketcasts.views.dialog.OptionsDialog
 import au.com.shiftyjelly.pocketcasts.views.fragments.BaseFragment
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
+import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.launch
 import au.com.shiftyjelly.pocketcasts.images.R as IR
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
@@ -70,6 +77,11 @@ class BookmarksFragment : BaseFragment() {
     @Inject
     lateinit var settings: Settings
 
+    @Inject
+    lateinit var shareActionsFactory: ShareActions.Factory
+
+    private lateinit var shareActions: ShareActions
+
     private val sourceView: SourceView
         get() = SourceView.fromString(arguments?.getString(ARG_SOURCE_VIEW))
 
@@ -84,6 +96,11 @@ class BookmarksFragment : BaseFragment() {
             SourceView.PLAYER -> if (Theme.isDark(context)) theme.activeTheme else Theme.ThemeType.DARK
             else -> if (forceDarkTheme && theme.isLightTheme) Theme.ThemeType.DARK else theme.activeTheme
         }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        shareActions = shareActionsFactory.create(sourceView)
+    }
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -200,7 +217,17 @@ class BookmarksFragment : BaseFragment() {
     }
 
     private fun onShareBookmarkClick() {
-        bookmarksViewModel.onShareClicked(parentFragmentManager)
+        lifecycleScope.launch {
+            val (podcast, episode, bookmark) = bookmarksViewModel.getSharedBookmark() ?: return@launch
+            val timestamp = bookmark.timeSecs.seconds
+            if (FeatureFlag.isEnabled(Feature.REIMAGINE_SHARING)) {
+                ShareEpisodeTimestampFragment
+                    .forBookmark(episode, timestamp, podcast.backgroundColor, sourceView)
+                    .show(parentFragmentManager, "share_screen")
+            } else {
+                shareActions.shareBookmark(podcast, episode, timestamp)
+            }
+        }
     }
 
     private fun onEditBookmarkClick() {

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/BookmarksViewModel.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/BookmarksViewModel.kt
@@ -1,6 +1,5 @@
 package au.com.shiftyjelly.pocketcasts.player.viewmodel
 
-import androidx.fragment.app.FragmentManager
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.asFlow
 import androidx.lifecycle.viewModelScope
@@ -11,6 +10,7 @@ import au.com.shiftyjelly.pocketcasts.compose.bookmark.BookmarkRowColors
 import au.com.shiftyjelly.pocketcasts.compose.buttons.TimePlayButtonStyle
 import au.com.shiftyjelly.pocketcasts.models.entity.BaseEpisode
 import au.com.shiftyjelly.pocketcasts.models.entity.Bookmark
+import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.models.to.SubscriptionStatus
 import au.com.shiftyjelly.pocketcasts.player.view.bookmark.BookmarkArguments
@@ -29,7 +29,6 @@ import au.com.shiftyjelly.pocketcasts.repositories.di.IoDispatcher
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
-import au.com.shiftyjelly.pocketcasts.sharing.ShareDialogFragment
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import au.com.shiftyjelly.pocketcasts.utils.extensions.combine
 import au.com.shiftyjelly.pocketcasts.utils.featureflag.BookmarkFeatureControl
@@ -266,18 +265,12 @@ class BookmarksViewModel
         }
     }
 
-    fun onShareClicked(fragmentManager: FragmentManager) {
-        (_uiState.value as? UiState.Loaded)?.let {
-            val bookmark = it.bookmarks.firstOrNull { bookmark -> multiSelectHelper.isSelected(bookmark) }
-            bookmark?.let {
-                viewModelScope.launch {
-                    val podcast = podcastManager.findPodcastByUuidSuspend(bookmark.podcastUuid) ?: return@launch
-                    val episode = episodeManager.findEpisodeByUuid(bookmark.episodeUuid) as? PodcastEpisode ?: return@launch
-                    ShareDialogFragment
-                        .newInstance(podcast, episode, sourceView)
-                        .show(fragmentManager, "share_dialog")
-                }
-            }
+    suspend fun getSharedBookmark(): Triple<Podcast, PodcastEpisode, Bookmark>? {
+        return (_uiState.value as? UiState.Loaded)?.let {
+            val bookmark = it.bookmarks.firstOrNull { bookmark -> multiSelectHelper.isSelected(bookmark) } ?: return null
+            val podcast = podcastManager.findPodcastByUuidSuspend(bookmark.podcastUuid) ?: return null
+            val episode = episodeManager.findEpisodeByUuid(bookmark.episodeUuid) as? PodcastEpisode ?: return null
+            Triple(podcast, episode, bookmark)
         }
     }
 

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/PodcastViewModel.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/PodcastViewModel.kt
@@ -35,7 +35,6 @@ import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.FolderManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
 import au.com.shiftyjelly.pocketcasts.repositories.user.UserManager
-import au.com.shiftyjelly.pocketcasts.sharing.ShareActions
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
 import au.com.shiftyjelly.pocketcasts.views.multiselect.MultiSelectBookmarksHelper
@@ -55,7 +54,6 @@ import io.reactivex.schedulers.Schedulers
 import javax.inject.Inject
 import kotlin.coroutines.CoroutineContext
 import kotlin.math.min
-import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -420,13 +418,11 @@ class PodcastViewModel
         }
     }
 
-    fun onShareBookmarkClick(shareActions: ShareActions) {
-        multiSelectBookmarksHelper.selectedListLive.value?.firstOrNull()?.let { bookmark ->
-            viewModelScope.launch {
-                val podcast = podcastManager.findPodcastByUuidSuspend(bookmark.podcastUuid) ?: return@launch
-                val episode = episodeManager.findEpisodeByUuid(bookmark.episodeUuid) as? PodcastEpisode ?: return@launch
-                shareActions.shareBookmark(podcast, episode, bookmark.timeSecs.seconds)
-            }
+    suspend fun getSharedBookmark(): Triple<Podcast, PodcastEpisode, Bookmark>? {
+        return multiSelectBookmarksHelper.selectedListLive.value?.firstOrNull()?.let { bookmark ->
+            val podcast = podcastManager.findPodcastByUuidSuspend(bookmark.podcastUuid) ?: return null
+            val episode = episodeManager.findEpisodeByUuid(bookmark.episodeUuid) as? PodcastEpisode ?: return null
+            Triple(podcast, episode, bookmark)
         }
     }
 

--- a/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/ShareDialogFragment.kt
+++ b/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/ShareDialogFragment.kt
@@ -38,6 +38,9 @@ import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.models.type.EpisodeStatusEnum
 import au.com.shiftyjelly.pocketcasts.sharing.clip.ShareClipFragment
+import au.com.shiftyjelly.pocketcasts.sharing.episode.ShareEpisodeFragment
+import au.com.shiftyjelly.pocketcasts.sharing.podcast.SharePodcastFragment
+import au.com.shiftyjelly.pocketcasts.sharing.timestamp.ShareEpisodeTimestampFragment
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import au.com.shiftyjelly.pocketcasts.ui.theme.ThemeColor
 import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
@@ -177,7 +180,13 @@ class ShareDialogFragment : BottomSheetDialogFragment() {
                     textColor = textColor,
                     backgroundColor = backgroundColor,
                     onClick = {
-                        lifecycleScope.launch { shareActions.sharePodcast(podcast) }
+                        if (FeatureFlag.isEnabled(Feature.REIMAGINE_SHARING)) {
+                            SharePodcastFragment
+                                .newInstance(podcast, args.source)
+                                .show(parentFragmentManager, "share_screen")
+                        } else {
+                            lifecycleScope.launch { shareActions.sharePodcast(podcast) }
+                        }
                     },
                 ),
             )
@@ -189,7 +198,13 @@ class ShareDialogFragment : BottomSheetDialogFragment() {
                     textColor = textColor,
                     backgroundColor = backgroundColor,
                     onClick = {
-                        lifecycleScope.launch { shareActions.shareEpisode(podcast, episode) }
+                        if (FeatureFlag.isEnabled(Feature.REIMAGINE_SHARING)) {
+                            ShareEpisodeFragment
+                                .newInstance(episode, podcast.backgroundColor, args.source)
+                                .show(parentFragmentManager, "share_screen")
+                        } else {
+                            lifecycleScope.launch { shareActions.shareEpisode(podcast, episode) }
+                        }
                     },
                 ),
             )
@@ -199,11 +214,17 @@ class ShareDialogFragment : BottomSheetDialogFragment() {
                     textColor = textColor,
                     backgroundColor = backgroundColor,
                     onClick = {
-                        lifecycleScope.launch { shareActions.shareEpisodePosition(podcast, episode, episode.playedUpTo.seconds) }
+                        if (FeatureFlag.isEnabled(Feature.REIMAGINE_SHARING)) {
+                            ShareEpisodeTimestampFragment
+                                .forEpisodePosition(episode, podcast.backgroundColor, args.source)
+                                .show(parentFragmentManager, "share_screen")
+                        } else {
+                            lifecycleScope.launch { shareActions.shareEpisodePosition(podcast, episode, episode.playedUpTo.seconds) }
+                        }
                     },
                 ),
             )
-            if (FeatureFlag.isEnabled(Feature.SHARE_CLIPS)) {
+            if (FeatureFlag.isEnabled(Feature.SHARE_CLIPS) && FeatureFlag.isEnabled(Feature.REIMAGINE_SHARING)) {
                 add(
                     shareOption(
                         textId = LR.string.podcast_share_clip,
@@ -212,7 +233,7 @@ class ShareDialogFragment : BottomSheetDialogFragment() {
                         onClick = {
                             ShareClipFragment
                                 .newInstance(episode, podcast.backgroundColor, args.source)
-                                .show(parentFragmentManager, "share_clip")
+                                .show(parentFragmentManager, "share_screen")
                         },
                     ),
                 )

--- a/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/episode/ShareEpisodeFragment.kt
+++ b/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/episode/ShareEpisodeFragment.kt
@@ -1,0 +1,76 @@
+package au.com.shiftyjelly.pocketcasts.sharing.episode
+
+import android.os.Bundle
+import android.os.Parcelable
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.annotation.ColorInt
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material.Text
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.ComposeView
+import androidx.compose.ui.unit.sp
+import androidx.core.os.BundleCompat
+import androidx.core.os.bundleOf
+import au.com.shiftyjelly.pocketcasts.analytics.SourceView
+import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
+import au.com.shiftyjelly.pocketcasts.utils.parceler.ColorParceler
+import au.com.shiftyjelly.pocketcasts.views.fragments.BaseDialogFragment
+import kotlinx.parcelize.Parcelize
+import kotlinx.parcelize.TypeParceler
+
+class ShareEpisodeFragment : BaseDialogFragment() {
+    private val args get() = requireNotNull(arguments?.let { BundleCompat.getParcelable(it, NEW_INSTANCE_ARG, Args::class.java) })
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?,
+    ) = ComposeView(requireActivity()).apply {
+        setContent {
+            Box(
+                contentAlignment = Alignment.Center,
+                modifier = Modifier
+                    .background(Color.Black)
+                    .fillMaxSize(),
+            ) {
+                Text(
+                    text = "Share episode: ${args.episodeUuid}",
+                    fontSize = 24.sp,
+                    color = Color.White,
+                )
+            }
+        }
+    }
+
+    @Parcelize
+    private class Args(
+        val episodeUuid: String,
+        val podcastUuid: String,
+        @TypeParceler<Color, ColorParceler>() val baseColor: Color,
+        val source: SourceView,
+    ) : Parcelable
+
+    companion object {
+        private const val NEW_INSTANCE_ARG = "ShareEpisodeFragmentArgs"
+
+        fun newInstance(
+            episode: PodcastEpisode,
+            @ColorInt baseColor: Int,
+            source: SourceView,
+        ) = ShareEpisodeFragment().apply {
+            arguments = bundleOf(
+                NEW_INSTANCE_ARG to Args(
+                    episodeUuid = episode.uuid,
+                    podcastUuid = episode.podcastUuid,
+                    baseColor = Color(baseColor),
+                    source = source,
+                ),
+            )
+        }
+    }
+}

--- a/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/podcast/SharePodcastFragment.kt
+++ b/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/podcast/SharePodcastFragment.kt
@@ -1,0 +1,72 @@
+package au.com.shiftyjelly.pocketcasts.sharing.podcast
+
+import android.os.Bundle
+import android.os.Parcelable
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material.Text
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.ComposeView
+import androidx.compose.ui.unit.sp
+import androidx.core.os.BundleCompat
+import androidx.core.os.bundleOf
+import au.com.shiftyjelly.pocketcasts.analytics.SourceView
+import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
+import au.com.shiftyjelly.pocketcasts.utils.parceler.ColorParceler
+import au.com.shiftyjelly.pocketcasts.views.fragments.BaseDialogFragment
+import kotlinx.parcelize.Parcelize
+import kotlinx.parcelize.TypeParceler
+
+class SharePodcastFragment : BaseDialogFragment() {
+    private val args get() = requireNotNull(arguments?.let { BundleCompat.getParcelable(it, NEW_INSTANCE_ARG, Args::class.java) })
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?,
+    ) = ComposeView(requireActivity()).apply {
+        setContent {
+            Box(
+                contentAlignment = Alignment.Center,
+                modifier = Modifier
+                    .background(Color.Black)
+                    .fillMaxSize(),
+            ) {
+                Text(
+                    text = "Share podcast: ${args.podcastUuid}",
+                    fontSize = 24.sp,
+                    color = Color.White,
+                )
+            }
+        }
+    }
+
+    @Parcelize
+    private class Args(
+        val podcastUuid: String,
+        @TypeParceler<Color, ColorParceler>() val baseColor: Color,
+        val source: SourceView,
+    ) : Parcelable
+
+    companion object {
+        private const val NEW_INSTANCE_ARG = "SharePodcastFragmentArgs"
+
+        fun newInstance(
+            podcast: Podcast,
+            source: SourceView,
+        ) = SharePodcastFragment().apply {
+            arguments = bundleOf(
+                NEW_INSTANCE_ARG to Args(
+                    podcastUuid = podcast.uuid,
+                    baseColor = Color(podcast.backgroundColor),
+                    source = source,
+                ),
+            )
+        }
+    }
+}

--- a/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/timestamp/ShareEpisodeTimestampFragment.kt
+++ b/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/timestamp/ShareEpisodeTimestampFragment.kt
@@ -1,0 +1,101 @@
+package au.com.shiftyjelly.pocketcasts.sharing.timestamp
+
+import android.os.Bundle
+import android.os.Parcelable
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.annotation.ColorInt
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material.Text
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.ComposeView
+import androidx.compose.ui.unit.sp
+import androidx.core.os.BundleCompat
+import androidx.core.os.bundleOf
+import au.com.shiftyjelly.pocketcasts.analytics.SourceView
+import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
+import au.com.shiftyjelly.pocketcasts.utils.parceler.ColorParceler
+import au.com.shiftyjelly.pocketcasts.utils.parceler.DurationParceler
+import au.com.shiftyjelly.pocketcasts.views.fragments.BaseDialogFragment
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
+import kotlinx.parcelize.Parcelize
+import kotlinx.parcelize.TypeParceler
+
+class ShareEpisodeTimestampFragment : BaseDialogFragment() {
+    private val args get() = requireNotNull(arguments?.let { BundleCompat.getParcelable(it, NEW_INSTANCE_ARG, Args::class.java) })
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?,
+    ) = ComposeView(requireActivity()).apply {
+        setContent {
+            Box(
+                contentAlignment = Alignment.Center,
+                modifier = Modifier
+                    .background(Color.Black)
+                    .fillMaxSize(),
+            ) {
+                Text(
+                    text = "Share ${if (args.shareAsBookmark) "bookmark" else "episode timestamp"}: ${args.episodeUuid}",
+                    fontSize = 24.sp,
+                    color = Color.White,
+                )
+            }
+        }
+    }
+
+    @Parcelize
+    private class Args(
+        val episodeUuid: String,
+        val podcastUuid: String,
+        @TypeParceler<Duration, DurationParceler>() val timestamp: Duration,
+        @TypeParceler<Color, ColorParceler>() val baseColor: Color,
+        val source: SourceView,
+        val shareAsBookmark: Boolean,
+    ) : Parcelable
+
+    companion object {
+        private const val NEW_INSTANCE_ARG = "ShareEpisodeFragmentArgs"
+
+        fun forEpisodePosition(
+            episode: PodcastEpisode,
+            @ColorInt baseColor: Int,
+            source: SourceView,
+        ) = ShareEpisodeTimestampFragment().apply {
+            arguments = bundleOf(
+                NEW_INSTANCE_ARG to Args(
+                    episodeUuid = episode.uuid,
+                    podcastUuid = episode.podcastUuid,
+                    timestamp = episode.playedUpTo.seconds,
+                    baseColor = Color(baseColor),
+                    source = source,
+                    shareAsBookmark = false,
+                ),
+            )
+        }
+
+        fun forBookmark(
+            episode: PodcastEpisode,
+            timestamp: Duration,
+            @ColorInt baseColor: Int,
+            source: SourceView,
+        ) = ShareEpisodeTimestampFragment().apply {
+            arguments = bundleOf(
+                NEW_INSTANCE_ARG to Args(
+                    episodeUuid = episode.uuid,
+                    podcastUuid = episode.podcastUuid,
+                    timestamp = timestamp,
+                    baseColor = Color(baseColor),
+                    source = source,
+                    shareAsBookmark = true,
+                ),
+            )
+        }
+    }
+}


### PR DESCRIPTION
## Description

This PR adds entry points for the Reimagine Sharing feature. Right now it redirects to dummy screen.

## Testing Instructions

1. Enable`Use new sharing designs` feature flag.
2. Share podcast from a podcast page.
3. You should see podcast dummy screen.
4. Share any bookmark.
5. You should see bookmark dummy screen.
6. Share episode.
7. You should see episode dummy screen.
8. Share episode at current position.
9. You should see episode timestamp dummy screen.
10. Disable `Use new sharing designs` feature flag.
11. All sharing should act normally without navigating to dummy screens. This also disables clip sharing.

## Screenshots or Screencast 

| Podcast | Episode | Episode timestamp | Bookmark |
| - | - | - | - |
| ![pod](https://github.com/user-attachments/assets/1ee99d18-e0dc-40c1-8254-1a2c6f14478a) | ![ep](https://github.com/user-attachments/assets/28f6766f-a94e-4134-a484-c47d2a58d730) | ![ep-time](https://github.com/user-attachments/assets/1fd23219-e15e-402a-b639-c423282efa4d) | ![book](https://github.com/user-attachments/assets/4a3a6fd7-c696-435f-96d6-9d9dac9627f3) |

## Checklist
- [x] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] ~I have considered whether it makes sense to add tests for my changes~
- [x] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [x] ~Any jetpack compose components I added or changed are covered by compose previews~
- [x] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~