### PR TITLE
Add square sharing card

### DIFF
--- a/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/ui/CardType.kt
+++ b/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/ui/CardType.kt
@@ -1,0 +1,77 @@
+package au.com.shiftyjelly.pocketcasts.sharing.ui
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalInspectionMode
+import androidx.compose.ui.res.pluralStringResource
+import androidx.compose.ui.res.stringResource
+import au.com.shiftyjelly.pocketcasts.compose.components.EpisodeImage
+import au.com.shiftyjelly.pocketcasts.compose.components.PodcastImage
+import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
+import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
+import au.com.shiftyjelly.pocketcasts.repositories.images.PocketCastsImageRequestFactory.PlaceholderType
+import au.com.shiftyjelly.pocketcasts.utils.extensions.toLocalizedFormatMediumStyle
+import au.com.shiftyjelly.pocketcasts.localization.R as LR
+
+internal sealed interface CardType {
+    @Composable
+    fun topText(): String
+
+    @Composable
+    fun middleText(): String
+
+    @Composable
+    fun bottomText(): String
+
+    @Composable
+    fun Image(modifier: Modifier)
+}
+
+internal data class PodcastCardType(
+    val podcast: Podcast,
+    val episodeCount: Int,
+) : CardType {
+    @Composable
+    override fun topText() = podcast.title
+
+    @Composable
+    override fun middleText() = podcast.title
+
+    @Composable
+    override fun bottomText() = listOfNotNull(
+        pluralStringResource(LR.plurals.episode_count, count = episodeCount, episodeCount),
+        podcast.displayableFrequency(LocalContext.current.resources),
+    ).joinToString(" · ")
+
+    @Composable
+    override fun Image(modifier: Modifier) = PodcastImage(
+        uuid = podcast.uuid,
+        title = stringResource(LR.string.podcast_cover_description, podcast.title),
+        placeholderType = if (LocalInspectionMode.current) PlaceholderType.Large else PlaceholderType.None,
+        modifier = modifier,
+    )
+}
+
+internal data class EpisodeCardType(
+    val episode: PodcastEpisode,
+    val podcast: Podcast,
+    val useEpisodeArtwork: Boolean,
+) : CardType {
+    @Composable
+    override fun topText() = episode.publishedDate.toLocalizedFormatMediumStyle()
+
+    @Composable
+    override fun middleText() = episode.title
+
+    @Composable
+    override fun bottomText() = podcast.title
+
+    @Composable
+    override fun Image(modifier: Modifier) = EpisodeImage(
+        episode = episode,
+        useEpisodeArtwork = useEpisodeArtwork,
+        placeholderType = if (LocalInspectionMode.current) PlaceholderType.Large else PlaceholderType.None,
+        modifier = modifier,
+    )
+}

--- a/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/ui/SquareCard.kt
+++ b/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/ui/SquareCard.kt
@@ -119,33 +119,33 @@ private fun SquareCard(
 @ShowkaseComposable(name = "SquarePodcastCard", group = "Sharing", styleName = "Light")
 @Preview(name = "SquarePodcastCardLight")
 @Composable
-fun SquarePodcastCardLightPreview() = SqurePodcastCardPreview(
+fun SquarePodcastCardLightPreview() = SquarePodcastCardPreview(
     baseColor = Color(0xFFFBCB04),
 )
 
 @ShowkaseComposable(name = "SquarePodcastCard", group = "Sharing", styleName = "Dark")
 @Preview(name = "SquarePodcastCardDark")
 @Composable
-fun SquarePodcastCardDarkPreview() = SqurePodcastCardPreview(
+fun SquarePodcastCardDarkPreview() = SquarePodcastCardPreview(
     baseColor = Color(0xFFEC0404),
 )
 
 @ShowkaseComposable(name = "SquareEpisodeCard", group = "Sharing", styleName = "Light")
 @Preview(name = "SquareEpisodeCardLight")
 @Composable
-fun SquareEpisodeCardLightPreview() = SqureEpisodeCardPreview(
+fun SquareEpisodeCardLightPreview() = SquareEpisodeCardPreview(
     baseColor = Color(0xFFFBCB04),
 )
 
 @ShowkaseComposable(name = "SquareEpisodeCard", group = "Sharing", styleName = "Dark")
 @Preview(name = "SquareEpisodeCardDark")
 @Composable
-fun SquareEpisodeCardDarkPreview() = SqureEpisodeCardPreview(
+fun SquareEpisodeCardDarkPreview() = SquareEpisodeCardPreview(
     baseColor = Color(0xFFEC0404),
 )
 
 @Composable
-private fun SqurePodcastCardPreview(
+private fun SquarePodcastCardPreview(
     baseColor: Color,
 ) = SquareCardPreview(
     type = PodcastCardType(
@@ -160,7 +160,7 @@ private fun SqurePodcastCardPreview(
 )
 
 @Composable
-private fun SqureEpisodeCardPreview(
+private fun SquareEpisodeCardPreview(
     baseColor: Color,
 ) = SquareCardPreview(
     type = EpisodeCardType(

--- a/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/ui/SquareCard.kt
+++ b/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/ui/SquareCard.kt
@@ -1,0 +1,261 @@
+package au.com.shiftyjelly.pocketcasts.sharing.ui
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalInspectionMode
+import androidx.compose.ui.res.pluralStringResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.coerceAtMost
+import androidx.compose.ui.unit.dp
+import au.com.shiftyjelly.pocketcasts.compose.components.EpisodeImage
+import au.com.shiftyjelly.pocketcasts.compose.components.PodcastImage
+import au.com.shiftyjelly.pocketcasts.compose.components.TextH40
+import au.com.shiftyjelly.pocketcasts.compose.components.TextH70
+import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
+import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
+import au.com.shiftyjelly.pocketcasts.repositories.images.PocketCastsImageRequestFactory.PlaceholderType
+import au.com.shiftyjelly.pocketcasts.utils.extensions.toLocalizedFormatMediumStyle
+import com.airbnb.android.showkase.annotation.ShowkaseComposable
+import java.sql.Date
+import java.time.Instant
+import au.com.shiftyjelly.pocketcasts.localization.R as LR
+
+@Composable
+internal fun SquarePodcastCast(
+    podcast: Podcast,
+    episodeCount: Int,
+    shareColors: ShareColors,
+    modifier: Modifier = Modifier,
+) = SquareCard(
+    type = PodcastCardType(
+        podcast = podcast,
+        episodeCount = episodeCount,
+    ),
+    shareColors = shareColors,
+    modifier = modifier,
+)
+
+@Composable
+internal fun SquareEpisodeCard(
+    episode: PodcastEpisode,
+    podcast: Podcast,
+    useEpisodeArtwork: Boolean,
+    shareColors: ShareColors,
+    modifier: Modifier = Modifier,
+) = SquareCard(
+    type = EpisodeCardType(
+        episode = episode,
+        podcast = podcast,
+        useEpisodeArtwork = useEpisodeArtwork,
+    ),
+    shareColors = shareColors,
+    modifier = modifier,
+)
+
+@Composable
+private fun SquareCard(
+    type: CardType,
+    shareColors: ShareColors,
+    modifier: Modifier = Modifier,
+) = BoxWithConstraints {
+    val size = minOf(maxWidth, maxHeight)
+    val backgroundGradient = Brush.verticalGradient(
+        listOf(
+            shareColors.cardTop,
+            shareColors.cardBottom,
+        ),
+    )
+    Column(
+        horizontalAlignment = Alignment.CenterHorizontally,
+        modifier = modifier
+            .background(backgroundGradient, RoundedCornerShape(12.dp))
+            .size(size),
+    ) {
+        Spacer(
+            modifier = Modifier.height(42.dp),
+        )
+        type.Image(
+            modifier = Modifier
+                .size(size * 0.4f)
+                .clip(RoundedCornerShape(8.dp)),
+        )
+        Spacer(
+            modifier = Modifier.height(24.dp),
+        )
+        TextH70(
+            text = type.topText(),
+            maxLines = 1,
+            color = shareColors.cardText.copy(alpha = 0.5f),
+            modifier = Modifier.padding(horizontal = 64.dp),
+        )
+        Spacer(
+            modifier = Modifier.height(6.dp),
+        )
+        TextH40(
+            text = type.middleText(),
+            maxLines = 2,
+            textAlign = TextAlign.Center,
+            color = shareColors.cardText,
+            modifier = Modifier.padding(horizontal = 42.dp),
+        )
+        Spacer(
+            modifier = Modifier.height(6.dp),
+        )
+        TextH70(
+            text = type.bottomText(),
+            maxLines = 2,
+            textAlign = TextAlign.Center,
+            color = shareColors.cardText.copy(alpha = 0.5f),
+            modifier = Modifier.padding(horizontal = 64.dp),
+        )
+    }
+}
+
+private sealed interface CardType {
+    @Composable
+    fun topText(): String
+
+    @Composable
+    fun middleText(): String
+
+    @Composable
+    fun bottomText(): String
+
+    @Composable
+    fun Image(modifier: Modifier)
+}
+
+private data class PodcastCardType(
+    val podcast: Podcast,
+    val episodeCount: Int,
+) : CardType {
+    @Composable
+    override fun topText() = podcast.title
+
+    @Composable
+    override fun middleText() = podcast.title
+
+    @Composable
+    override fun bottomText() = listOfNotNull(
+        pluralStringResource(LR.plurals.episode_count, count = episodeCount, episodeCount),
+        podcast.displayableFrequency(LocalContext.current.resources),
+    ).joinToString(" · ")
+
+    @Composable
+    override fun Image(modifier: Modifier) = PodcastImage(
+        uuid = podcast.uuid,
+        title = stringResource(LR.string.podcast_cover_description, podcast.title),
+        placeholderType = if (LocalInspectionMode.current) PlaceholderType.Large else PlaceholderType.None,
+        modifier = modifier,
+    )
+}
+
+private data class EpisodeCardType(
+    val episode: PodcastEpisode,
+    val podcast: Podcast,
+    val useEpisodeArtwork: Boolean,
+) : CardType {
+    @Composable
+    override fun topText() = episode.publishedDate.toLocalizedFormatMediumStyle()
+
+    @Composable
+    override fun middleText() = episode.title
+
+    @Composable
+    override fun bottomText() = podcast.title
+
+    @Composable
+    override fun Image(modifier: Modifier) = EpisodeImage(
+        episode = episode,
+        useEpisodeArtwork = useEpisodeArtwork,
+        placeholderType = if (LocalInspectionMode.current) PlaceholderType.Large else PlaceholderType.None,
+        modifier = modifier,
+    )
+}
+
+@ShowkaseComposable(name = "SquarePodcastCard", group = "Sharing", styleName = "Light")
+@Preview(name = "SquarePodcastCardLight")
+@Composable
+fun SquarePodcastCardLightPreview() = SqurePodcastCardPreview(
+    baseColor = Color(0xFFFBCB04),
+)
+
+@ShowkaseComposable(name = "SquarePodcastCard", group = "Sharing", styleName = "Dark")
+@Preview(name = "SquarePodcastCardDark")
+@Composable
+fun SquarePodcastCardDarkPreview() = SqurePodcastCardPreview(
+    baseColor = Color(0xFFEC0404),
+)
+
+@ShowkaseComposable(name = "SquareEpisodeCard", group = "Sharing", styleName = "Light")
+@Preview(name = "SquareEpisodeCardLight")
+@Composable
+fun SquareEpisodeCardLightPreview() = SqureEpisodeCardPreview(
+    baseColor = Color(0xFFFBCB04),
+)
+
+@ShowkaseComposable(name = "SquareEpisodeCard", group = "Sharing", styleName = "Dark")
+@Preview(name = "SquareEpisodeCardDark")
+@Composable
+fun SquareEpisodeCardDarkPreview() = SqureEpisodeCardPreview(
+    baseColor = Color(0xFFEC0404),
+)
+
+@Composable
+private fun SqurePodcastCardPreview(
+    baseColor: Color,
+) = SquareCardPreview(
+    type = PodcastCardType(
+        podcast = Podcast(
+            uuid = "podcast-id",
+            title = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.",
+            episodeFrequency = "monthly",
+        ),
+        episodeCount = 120,
+    ),
+    baseColor = baseColor,
+)
+
+@Composable
+private fun SqureEpisodeCardPreview(
+    baseColor: Color,
+) = SquareCardPreview(
+    type = EpisodeCardType(
+        episode = PodcastEpisode(
+            uuid = "episode-id",
+            podcastUuid = "podcast-id",
+            publishedDate = Date.from(Instant.parse("2024-12-03T10:15:30.00Z")),
+            title = "Nobis sapiente fugit vitae. Iusto magnam nam nam et odio. Debitis cupiditate officiis et. Sit quia in voluptate sit voluptatem magni.",
+        ),
+        podcast = Podcast(
+            uuid = "podcast-id",
+            title = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.",
+        ),
+        useEpisodeArtwork = true,
+    ),
+    baseColor = baseColor,
+)
+
+@Composable
+private fun SquareCardPreview(
+    type: CardType,
+    baseColor: Color,
+) = SquareCard(
+    type = type,
+    shareColors = ShareColors(baseColor),
+)

--- a/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/ui/SquareCard.kt
+++ b/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/ui/SquareCard.kt
@@ -14,26 +14,16 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.platform.LocalInspectionMode
-import androidx.compose.ui.res.pluralStringResource
-import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.unit.coerceAtMost
 import androidx.compose.ui.unit.dp
-import au.com.shiftyjelly.pocketcasts.compose.components.EpisodeImage
-import au.com.shiftyjelly.pocketcasts.compose.components.PodcastImage
 import au.com.shiftyjelly.pocketcasts.compose.components.TextH40
 import au.com.shiftyjelly.pocketcasts.compose.components.TextH70
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
-import au.com.shiftyjelly.pocketcasts.repositories.images.PocketCastsImageRequestFactory.PlaceholderType
-import au.com.shiftyjelly.pocketcasts.utils.extensions.toLocalizedFormatMediumStyle
 import com.airbnb.android.showkase.annotation.ShowkaseComposable
 import java.sql.Date
 import java.time.Instant
-import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 @Composable
 internal fun SquarePodcastCast(
@@ -124,68 +114,6 @@ private fun SquareCard(
             modifier = Modifier.padding(horizontal = 64.dp),
         )
     }
-}
-
-private sealed interface CardType {
-    @Composable
-    fun topText(): String
-
-    @Composable
-    fun middleText(): String
-
-    @Composable
-    fun bottomText(): String
-
-    @Composable
-    fun Image(modifier: Modifier)
-}
-
-private data class PodcastCardType(
-    val podcast: Podcast,
-    val episodeCount: Int,
-) : CardType {
-    @Composable
-    override fun topText() = podcast.title
-
-    @Composable
-    override fun middleText() = podcast.title
-
-    @Composable
-    override fun bottomText() = listOfNotNull(
-        pluralStringResource(LR.plurals.episode_count, count = episodeCount, episodeCount),
-        podcast.displayableFrequency(LocalContext.current.resources),
-    ).joinToString(" · ")
-
-    @Composable
-    override fun Image(modifier: Modifier) = PodcastImage(
-        uuid = podcast.uuid,
-        title = stringResource(LR.string.podcast_cover_description, podcast.title),
-        placeholderType = if (LocalInspectionMode.current) PlaceholderType.Large else PlaceholderType.None,
-        modifier = modifier,
-    )
-}
-
-private data class EpisodeCardType(
-    val episode: PodcastEpisode,
-    val podcast: Podcast,
-    val useEpisodeArtwork: Boolean,
-) : CardType {
-    @Composable
-    override fun topText() = episode.publishedDate.toLocalizedFormatMediumStyle()
-
-    @Composable
-    override fun middleText() = episode.title
-
-    @Composable
-    override fun bottomText() = podcast.title
-
-    @Composable
-    override fun Image(modifier: Modifier) = EpisodeImage(
-        episode = episode,
-        useEpisodeArtwork = useEpisodeArtwork,
-        placeholderType = if (LocalInspectionMode.current) PlaceholderType.Large else PlaceholderType.None,
-        modifier = modifier,
-    )
 }
 
 @ShowkaseComposable(name = "SquarePodcastCard", group = "Sharing", styleName = "Light")

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/PodcastImage.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/PodcastImage.kt
@@ -13,6 +13,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import au.com.shiftyjelly.pocketcasts.repositories.images.PocketCastsImageRequestFactory
+import au.com.shiftyjelly.pocketcasts.repositories.images.PocketCastsImageRequestFactory.PlaceholderType
 import au.com.shiftyjelly.pocketcasts.ui.extensions.themed
 
 fun podcastImageCornerSize(width: Dp): Dp {
@@ -33,11 +34,12 @@ fun PodcastImage(
     dropShadow: Boolean = true,
     cornerSize: Dp? = null,
     elevation: Dp? = null,
+    placeholderType: PlaceholderType = PlaceholderType.Large,
 ) {
     val context = LocalContext.current
 
     val imageRequest = remember(uuid) {
-        PocketCastsImageRequestFactory(context).themed().createForPodcast(uuid)
+        PocketCastsImageRequestFactory(context, placeholderType = placeholderType).themed().createForPodcast(uuid)
     }
 
     BoxWithConstraints(modifier = modifier) {

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -615,6 +615,7 @@ up    <string name="player_sleep_in_one_chapter">Sleeping in 1 chapter</string>
     <string name="podcast_season_x">Season %d</string>
     <string name="podcast_refresh_artwork">Refresh artwork</string>
     <string name="podcast_rate">Rate %s</string>
+    <string name="podcast_cover_description">Cover of %s podcast</string>
 
     <!-- Give Rating -->
 


### PR DESCRIPTION
## Description

Adds a square card variant for sharing. Card image isn't `120 dp` like in the designs but instead 40% of the card size. This is done to accommodate for different screen sizes.

Podcast card design: HR2vcQrWcS0scsolKZBitg-fi-2120_7557
Episode card design: HR2vcQrWcS0scsolKZBitg-fi-2118_6892

## Testing Instructions

Since code isn't used anywhere yet you can compare code and previews with the designs.

## Screenshots or Screencast 

![Screenshot 2024-07-24 at 11 20 31](https://github.com/user-attachments/assets/fb8e4256-f0ce-4109-9848-4a501a31701b)

## Checklist
- [x] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] ~I have considered whether it makes sense to add tests for my changes~
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack