### PR TITLE
Transcript - Transition from player screen

### DIFF
--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/PlayerContainerFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/PlayerContainerFragment.kt
@@ -265,6 +265,13 @@ class PlayerContainerFragment : BaseFragment(), HasBackstack {
         upNextBottomSheetBehavior.state = BottomSheetBehavior.STATE_EXPANDED
     }
 
+    fun updateTabsVisibility(show: Boolean) {
+        if (FeatureFlag.isEnabled(Feature.TRANSCRIPTS)) {
+            binding?.tabHolder?.isVisible = show
+            binding?.viewPager?.isUserInputEnabled = show
+        }
+    }
+
     fun onPlayerOpen() {
         try {
             if (isAdded) {
@@ -277,6 +284,10 @@ class PlayerContainerFragment : BaseFragment(), HasBackstack {
     }
 
     fun onPlayerClose() {
+        if (FeatureFlag.isEnabled(Feature.TRANSCRIPTS)) {
+            viewModel.closeTranscript()
+        }
+
         try {
             if (isAdded) {
                 ((childFragmentManager.fragments.firstOrNull { it is BookmarksFragment }) as? BookmarksFragment)

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/PlayerControlsHelper.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/PlayerControlsHelper.kt
@@ -2,7 +2,6 @@ package au.com.shiftyjelly.pocketcasts.player.view
 
 import au.com.shiftyjelly.pocketcasts.player.databinding.PlayerControlsBinding
 import au.com.shiftyjelly.pocketcasts.player.viewmodel.PlayerViewModel
-import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
 import au.com.shiftyjelly.pocketcasts.views.helper.toCircle
 import com.airbnb.lottie.LottieAnimationView
 import com.airbnb.lottie.LottieProperty
@@ -49,4 +48,11 @@ fun PlayerControlsBinding.updatePlayerControls(
     jumpForwardText.text = headerViewModel.skipForwardInSecs.toString()
     skipBack.toCircle(true)
     skipBackText.text = headerViewModel.skipBackwardInSecs.toString()
+}
+
+fun PlayerControlsBinding.scale(
+    scaleBy: Float,
+) {
+    root.scaleX = scaleBy
+    root.scaleY = scaleBy
 }

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/PlayerControlsHelper.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/PlayerControlsHelper.kt
@@ -1,0 +1,52 @@
+package au.com.shiftyjelly.pocketcasts.player.view
+
+import au.com.shiftyjelly.pocketcasts.player.databinding.PlayerControlsBinding
+import au.com.shiftyjelly.pocketcasts.player.viewmodel.PlayerViewModel
+import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
+import au.com.shiftyjelly.pocketcasts.views.helper.toCircle
+import com.airbnb.lottie.LottieAnimationView
+import com.airbnb.lottie.LottieProperty
+import com.airbnb.lottie.SimpleColorFilter
+import com.airbnb.lottie.model.KeyPath
+
+fun PlayerControlsBinding.initPlayerControls(
+    onSkipBack: () -> Unit,
+    onSkipForward: () -> Unit,
+    onSkipForwardLongPress: () -> Unit,
+    onPlayClicked: () -> Unit,
+) {
+    skipBack.setOnClickListener {
+        onSkipBack()
+        (it as LottieAnimationView).playAnimation()
+    }
+    skipForward.setOnClickListener {
+        onSkipForward()
+        (it as LottieAnimationView).playAnimation()
+    }
+    skipForward.setOnLongClickListener {
+        onSkipForwardLongPress()
+        (it as LottieAnimationView).playAnimation()
+        true
+    }
+    largePlayButton.setOnPlayClicked {
+        onPlayClicked()
+    }
+}
+
+fun PlayerControlsBinding.updatePlayerControls(
+    headerViewModel: PlayerViewModel.PlayerHeader,
+    color: Int,
+) {
+    largePlayButton.setPlaying(isPlaying = headerViewModel.isPlaying, animate = true)
+    largePlayButton.setCircleTintColor(color)
+    skipBackText.setTextColor(color)
+    jumpForwardText.setTextColor(color)
+    skipBack.post { // this only works the second time it's called unless it's in a post
+        skipBack.addValueCallback(KeyPath("**"), LottieProperty.COLOR_FILTER) { SimpleColorFilter(color) }
+        skipForward.addValueCallback(KeyPath("**"), LottieProperty.COLOR_FILTER) { SimpleColorFilter(color) }
+    }
+    skipForward.toCircle(true)
+    jumpForwardText.text = headerViewModel.skipForwardInSecs.toString()
+    skipBack.toCircle(true)
+    skipBackText.text = headerViewModel.skipBackwardInSecs.toString()
+}

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/PlayerHeaderFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/PlayerHeaderFragment.kt
@@ -395,7 +395,9 @@ class PlayerHeaderFragment : BaseFragment(), PlayerClickListener {
         seekBar.isVisible = resources.configuration.orientation != Configuration.ORIENTATION_LANDSCAPE
         playerControls.root.isVisible = resources.configuration.orientation != Configuration.ORIENTATION_LANDSCAPE
         playerControls.scale(0.6f)
-        (seekBar.layoutParams as ViewGroup.MarginLayoutParams).bottomMargin = resources.getDimensionPixelSize(R.dimen.seekbar_margin_bottom_transcript)
+        if (resources.configuration.orientation == Configuration.ORIENTATION_PORTRAIT) {
+            (seekBar.layoutParams as ViewGroup.MarginLayoutParams).bottomMargin = resources.getDimensionPixelSize(R.dimen.seekbar_margin_bottom_transcript)
+        }
         val containerFragment = parentFragment as? PlayerContainerFragment
         containerFragment?.updateTabsVisibility(false)
     }
@@ -409,7 +411,9 @@ class PlayerHeaderFragment : BaseFragment(), PlayerClickListener {
         seekBar.isVisible = true
         playerControls.root.isVisible = true
         playerControls.scale(1f)
-        (seekBar.layoutParams as ViewGroup.MarginLayoutParams).bottomMargin = resources.getDimensionPixelSize(R.dimen.seekbar_margin_bottom)
+        if (resources.configuration.orientation == Configuration.ORIENTATION_PORTRAIT) {
+            (seekBar.layoutParams as ViewGroup.MarginLayoutParams).bottomMargin = resources.getDimensionPixelSize(R.dimen.seekbar_margin_bottom)
+        }
         val containerFragment = parentFragment as? PlayerContainerFragment
         containerFragment?.updateTabsVisibility(true)
     }

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/PlayerHeaderFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/PlayerHeaderFragment.kt
@@ -238,6 +238,14 @@ class PlayerHeaderFragment : BaseFragment(), PlayerClickListener {
             val headerViewModel = it.podcastHeader
             val playerContrast1 = ThemeColor.playerContrast01(headerViewModel.theme)
 
+            binding.seekBar.setSeekBarState(
+                durationMs = headerViewModel.durationMs,
+                positionMs = headerViewModel.positionMs,
+                tintColor = headerViewModel.iconTintColor,
+                bufferedUpTo = headerViewModel.bufferedUpToMs,
+                isBuffering = headerViewModel.isBuffering,
+                theme = headerViewModel.theme,
+            )
             binding.playerControls.updatePlayerControls(headerViewModel, playerContrast1)
 
             binding.episodeTitle.setTextColor(playerContrast1)
@@ -384,7 +392,10 @@ class PlayerHeaderFragment : BaseFragment(), PlayerClickListener {
         playerGroup.layoutTransition = LayoutTransition()
         transcriptPage.isVisible = true
         shelf.isVisible = false
+        seekBar.isVisible = resources.configuration.orientation != Configuration.ORIENTATION_LANDSCAPE
         playerControls.root.isVisible = resources.configuration.orientation != Configuration.ORIENTATION_LANDSCAPE
+        playerControls.scale(0.6f)
+        (seekBar.layoutParams as ViewGroup.MarginLayoutParams).bottomMargin = resources.getDimensionPixelSize(R.dimen.seekbar_margin_bottom_transcript)
         val containerFragment = parentFragment as? PlayerContainerFragment
         containerFragment?.updateTabsVisibility(false)
     }
@@ -395,7 +406,10 @@ class PlayerHeaderFragment : BaseFragment(), PlayerClickListener {
         playerGroup.layoutTransition = if (withTransition) LayoutTransition() else null
         shelf.isVisible = true
         transcriptPage.isVisible = false
+        seekBar.isVisible = true
         playerControls.root.isVisible = true
+        playerControls.scale(1f)
+        (seekBar.layoutParams as ViewGroup.MarginLayoutParams).bottomMargin = resources.getDimensionPixelSize(R.dimen.seekbar_margin_bottom)
         val containerFragment = parentFragment as? PlayerContainerFragment
         containerFragment?.updateTabsVisibility(true)
     }

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/PlayerHeaderFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/PlayerHeaderFragment.kt
@@ -405,6 +405,7 @@ class PlayerHeaderFragment : BaseFragment(), PlayerClickListener {
             requireContext(),
             object : GestureDetector.SimpleOnGestureListener() {
                 override fun onFling(e1: MotionEvent?, e2: MotionEvent, velocityX: Float, velocityY: Float): Boolean {
+                    if (binding.transcriptPage.isVisible) return false
                     val containerFragment = parentFragment as? PlayerContainerFragment ?: return false
                     val upNextBottomSheetBehavior = containerFragment.upNextBottomSheetBehavior
 

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/ShelfBottomSheet.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/ShelfBottomSheet.kt
@@ -153,6 +153,7 @@ class ShelfBottomSheet : BaseDialogFragment() {
             }
 
             ShelfItem.Transcript -> {
+                playerViewModel.openTranscript()
             }
 
             ShelfItem.Share -> {

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/PlayerViewModel.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/PlayerViewModel.kt
@@ -62,6 +62,8 @@ import kotlin.time.DurationUnit
 import kotlin.time.toDuration
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.rx2.asFlowable
@@ -157,6 +159,9 @@ class PlayerViewModel @Inject constructor(
     var chaptersExpanded = settings.getBooleanForKey(Settings.PREFERENCE_CHAPTERS_EXPANDED, true)
 
     private val disposables = CompositeDisposable()
+
+    private val _transitionState = MutableSharedFlow<TransitionState>()
+    val transitionState = _transitionState.asSharedFlow()
 
     private val playbackStateObservable: Observable<PlaybackState> = playbackManager.playbackStateRelay
         .observeOn(Schedulers.io())
@@ -670,5 +675,22 @@ class PlayerViewModel @Inject constructor(
 
     fun previousChapter() {
         playbackManager.skipToPreviousSelectedOrLastChapter()
+    }
+
+    fun openTranscript() {
+        viewModelScope.launch {
+            _transitionState.emit(TransitionState.OpenTranscript)
+        }
+    }
+
+    fun closeTranscript(withTransition: Boolean = false) {
+        viewModelScope.launch {
+            _transitionState.emit(TransitionState.CloseTranscript(withTransition))
+        }
+    }
+
+    sealed class TransitionState {
+        data object OpenTranscript : TransitionState()
+        data class CloseTranscript(val withTransition: Boolean) : TransitionState()
     }
 }

--- a/modules/features/player/src/main/res/layout-land/adapter_player_header.xml
+++ b/modules/features/player/src/main/res/layout-land/adapter_player_header.xml
@@ -223,79 +223,14 @@
             app:layout_constraintStart_toStartOf="@+id/previousChapter"
             app:layout_constraintTop_toBottomOf="@id/secondaryTextBottomBarrier" />
 
-        <au.com.shiftyjelly.pocketcasts.views.buttons.AnimatedPlayButton
-            android:id="@+id/largePlayButton"
-            android:layout_width="80dp"
-            android:layout_height="80dp"
-            app:icon_tint="?attr/player_contrast_06"
-            app:layout_constraintEnd_toStartOf="@+id/skipForward"
-            app:layout_constraintStart_toEndOf="@+id/skipBack"
-            app:layout_constraintTop_toBottomOf="@id/seekBar"
-            tools:src="@tools:sample/avatars" />
-
-        <com.airbnb.lottie.LottieAnimationView
-            android:id="@+id/skipForward"
+        <include layout="@layout/player_controls"
+            android:id="@+id/player_controls"
             android:layout_width="0dp"
-            android:layout_height="0dp"
-            android:layout_marginEnd="8dp"
-            android:background="?android:attr/selectableItemBackgroundBorderless"
-            android:contentDescription="@string/skip_forward"
-            android:scaleType="centerInside"
-            android:scaleX="-1"
-            app:layout_constraintBottom_toBottomOf="@+id/largePlayButton"
-            app:layout_constraintEnd_toEndOf="@+id/seekBar"
-            app:layout_constraintStart_toEndOf="@+id/largePlayButton"
-            app:layout_constraintTop_toTopOf="@+id/largePlayButton"
-            app:lottie_rawRes="@raw/skip_button"
-            tools:src="@tools:sample/avatars" />
-
-        <TextView
-            android:id="@+id/jumpForwardText"
-            android:layout_width="45dp"
-            android:layout_height="53dp"
-            android:fontFamily="sans-serif-medium"
-            android:gravity="center"
-            android:importantForAccessibility="no"
-            android:includeFontPadding="false"
-            android:paddingTop="8dp"
-            android:textColor="#FFFFFF"
-            android:textSize="15sp"
-            app:layout_constraintBottom_toBottomOf="@+id/skipForward"
-            app:layout_constraintEnd_toEndOf="@+id/skipForward"
-            app:layout_constraintStart_toStartOf="@+id/skipForward"
-            app:layout_constraintTop_toTopOf="@+id/skipForward"
-            tools:text="30" />
-
-        <com.airbnb.lottie.LottieAnimationView
-            android:id="@+id/skipBack"
-            android:layout_width="0dp"
-            android:layout_height="0dp"
-            android:background="?android:attr/selectableItemBackgroundBorderless"
-            android:contentDescription="@string/skip_back"
-            android:scaleType="centerInside"
-            app:layout_constraintBottom_toBottomOf="@+id/largePlayButton"
-            app:layout_constraintEnd_toStartOf="@+id/largePlayButton"
-            app:layout_constraintStart_toStartOf="@+id/seekBar"
-            app:layout_constraintTop_toTopOf="@+id/largePlayButton"
-            app:lottie_rawRes="@raw/skip_button"
-            tools:src="@tools:sample/avatars" />
-
-        <TextView
-            android:id="@+id/skipBackText"
-            android:layout_width="45dp"
-            android:layout_height="53dp"
-            android:fontFamily="sans-serif-medium"
-            android:gravity="center"
-            android:importantForAccessibility="no"
-            android:includeFontPadding="false"
-            android:paddingTop="8dp"
-            android:textColor="#FFFFFF"
-            android:textSize="15sp"
-            app:layout_constraintBottom_toBottomOf="@+id/skipBack"
-            app:layout_constraintEnd_toEndOf="@+id/skipBack"
-            app:layout_constraintStart_toStartOf="@+id/skipBack"
-            app:layout_constraintTop_toTopOf="@+id/skipBack"
-            tools:text="15" />
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            app:layout_constraintEnd_toEndOf="@+id/nextChapter"
+            app:layout_constraintStart_toStartOf="@+id/previousChapter"
+            app:layout_constraintTop_toBottomOf="@id/seekBar"/>
 
         <LinearLayout
             android:id="@+id/shelf"
@@ -307,7 +242,7 @@
             android:orientation="horizontal"
             android:paddingHorizontal="8dp"
             android:weightSum="5"
-            app:layout_constraintTop_toBottomOf="@+id/largePlayButton"
+            app:layout_constraintTop_toBottomOf="@+id/player_controls"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent">

--- a/modules/features/player/src/main/res/layout-land/adapter_player_header.xml
+++ b/modules/features/player/src/main/res/layout-land/adapter_player_header.xml
@@ -234,7 +234,7 @@
             app:layout_constraintTop_toBottomOf="@id/secondaryTextBottomBarrier" />
 
         <include layout="@layout/player_controls"
-            android:id="@+id/player_controls"
+            android:id="@+id/playerControls"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginTop="8dp"
@@ -252,7 +252,7 @@
             android:orientation="horizontal"
             android:paddingHorizontal="8dp"
             android:weightSum="5"
-            app:layout_constraintTop_toBottomOf="@+id/player_controls"
+            app:layout_constraintTop_toBottomOf="@+id/playerControls"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent">

--- a/modules/features/player/src/main/res/layout-land/adapter_player_header.xml
+++ b/modules/features/player/src/main/res/layout-land/adapter_player_header.xml
@@ -214,6 +214,16 @@
             app:barrierDirection="bottom"
             app:constraint_referenced_ids="podcastTitle,chapterSummary" />
 
+        <androidx.compose.ui.platform.ComposeView
+            android:id="@+id/transcriptPage"
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:visibility="gone"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent" />
+
         <au.com.shiftyjelly.pocketcasts.player.view.PlayerSeekBar
             android:id="@+id/seekBar"
             android:layout_width="0dp"

--- a/modules/features/player/src/main/res/layout-land/adapter_player_header.xml
+++ b/modules/features/player/src/main/res/layout-land/adapter_player_header.xml
@@ -237,7 +237,6 @@
             android:id="@+id/playerControls"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
-            android:layout_marginTop="8dp"
             app:layout_constraintEnd_toEndOf="@+id/nextChapter"
             app:layout_constraintStart_toStartOf="@+id/previousChapter"
             app:layout_constraintTop_toBottomOf="@id/seekBar"/>

--- a/modules/features/player/src/main/res/layout/adapter_player_header.xml
+++ b/modules/features/player/src/main/res/layout/adapter_player_header.xml
@@ -212,6 +212,16 @@
             app:layout_constraintTop_toBottomOf="@+id/nextChapter"
             tools:text="9m" />
 
+        <androidx.compose.ui.platform.ComposeView
+            android:id="@+id/transcriptPage"
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:visibility="gone"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent" />
+
         <au.com.shiftyjelly.pocketcasts.player.view.PlayerSeekBar
             android:id="@+id/seekBar"
             android:layout_width="0dp"

--- a/modules/features/player/src/main/res/layout/adapter_player_header.xml
+++ b/modules/features/player/src/main/res/layout/adapter_player_header.xml
@@ -217,92 +217,18 @@
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginBottom="10dp"
-            app:layout_constraintBottom_toTopOf="@+id/largePlayButton"
+            app:layout_constraintBottom_toTopOf="@+id/player_controls"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintWidth_percent="@dimen/seekbar_width_percentage" />
 
-        <au.com.shiftyjelly.pocketcasts.views.buttons.AnimatedPlayButton
-            android:id="@+id/largePlayButton"
-            android:layout_width="80dp"
-            android:layout_height="80dp"
-            android:layout_marginBottom="24dp"
-            app:icon_height="40dp"
-            app:icon_tint="?attr/player_contrast_06"
-            app:icon_width="40dp"
-            app:layout_constraintBottom_toTopOf="@+id/shelf"
+        <include layout="@layout/player_controls"
+            android:id="@+id/player_controls"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            tools:src="@tools:sample/avatars" />
-
-        <com.airbnb.lottie.LottieAnimationView
-            android:id="@+id/skipForward"
-            android:layout_width="103dp"
-            android:layout_height="103dp"
-            android:layout_marginTop="8dp"
-            android:layout_marginEnd="8dp"
-            android:layout_marginBottom="8dp"
-            android:background="?android:attr/selectableItemBackgroundBorderless"
-            android:contentDescription="@string/skip_forward"
-            android:scaleType="centerInside"
-            android:scaleX="-1"
-            app:layout_constraintBottom_toBottomOf="@+id/largePlayButton"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toEndOf="@+id/largePlayButton"
-            app:layout_constraintTop_toTopOf="@+id/largePlayButton"
-            app:lottie_rawRes="@raw/skip_button"
-            tools:src="@tools:sample/avatars" />
-
-        <TextView
-            android:id="@+id/jumpForwardText"
-            android:layout_width="45dp"
-            android:layout_height="53dp"
-            android:fontFamily="sans-serif-medium"
-            android:gravity="center"
-            android:importantForAccessibility="no"
-            android:includeFontPadding="false"
-            android:paddingTop="8dp"
-            android:textColor="#FFFFFF"
-            android:textSize="15sp"
-            app:layout_constraintBottom_toBottomOf="@+id/skipForward"
-            app:layout_constraintEnd_toEndOf="@+id/skipForward"
-            app:layout_constraintStart_toStartOf="@+id/skipForward"
-            app:layout_constraintTop_toTopOf="@+id/skipForward"
-            tools:text="30" />
-
-        <com.airbnb.lottie.LottieAnimationView
-            android:id="@+id/skipBack"
-            android:layout_width="103dp"
-            android:layout_height="103dp"
-            android:layout_marginStart="8dp"
-            android:layout_marginTop="8dp"
-            android:layout_marginBottom="8dp"
-            android:background="?android:attr/selectableItemBackgroundBorderless"
-            android:contentDescription="@string/skip_back"
-            android:scaleType="centerInside"
-            app:layout_constraintBottom_toBottomOf="@+id/largePlayButton"
-            app:layout_constraintEnd_toStartOf="@+id/largePlayButton"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="@+id/largePlayButton"
-            app:lottie_rawRes="@raw/skip_button"
-            tools:src="@tools:sample/avatars" />
-
-        <TextView
-            android:id="@+id/skipBackText"
-            android:layout_width="45dp"
-            android:layout_height="53dp"
-            android:fontFamily="sans-serif-medium"
-            android:gravity="center"
-            android:importantForAccessibility="no"
-            android:includeFontPadding="false"
-            android:paddingTop="8dp"
-            android:textColor="#FFFFFF"
-            android:textSize="15sp"
-            app:layout_constraintBottom_toBottomOf="@+id/skipBack"
-            app:layout_constraintEnd_toEndOf="@+id/skipBack"
-            app:layout_constraintStart_toStartOf="@+id/skipBack"
-            app:layout_constraintTop_toTopOf="@+id/skipBack"
-            tools:text="15" />
+            app:layout_constraintBottom_toTopOf="@+id/shelf"/>
 
         <LinearLayout
             android:id="@+id/shelf"

--- a/modules/features/player/src/main/res/layout/adapter_player_header.xml
+++ b/modules/features/player/src/main/res/layout/adapter_player_header.xml
@@ -227,13 +227,13 @@
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginBottom="10dp"
-            app:layout_constraintBottom_toTopOf="@+id/player_controls"
+            app:layout_constraintBottom_toTopOf="@+id/playerControls"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintWidth_percent="@dimen/seekbar_width_percentage" />
 
         <include layout="@layout/player_controls"
-            android:id="@+id/player_controls"
+            android:id="@+id/playerControls"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             app:layout_constraintEnd_toEndOf="parent"

--- a/modules/features/player/src/main/res/layout/player_controls.xml
+++ b/modules/features/player/src/main/res/layout/player_controls.xml
@@ -9,7 +9,7 @@
         android:id="@+id/largePlayButton"
         android:layout_width="80dp"
         android:layout_height="80dp"
-        android:layout_marginBottom="24dp"
+        android:layout_marginBottom="@dimen/large_play_button_margin_bottom"
         app:icon_height="40dp"
         app:icon_tint="?attr/player_contrast_06"
         app:icon_width="40dp"

--- a/modules/features/player/src/main/res/layout/player_controls.xml
+++ b/modules/features/player/src/main/res/layout/player_controls.xml
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content">
+
+    <au.com.shiftyjelly.pocketcasts.views.buttons.AnimatedPlayButton
+        android:id="@+id/largePlayButton"
+        android:layout_width="80dp"
+        android:layout_height="80dp"
+        android:layout_marginBottom="24dp"
+        app:icon_height="40dp"
+        app:icon_tint="?attr/player_contrast_06"
+        app:icon_width="40dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        tools:src="@tools:sample/avatars" />
+
+    <com.airbnb.lottie.LottieAnimationView
+        android:id="@+id/skipForward"
+        android:layout_width="103dp"
+        android:layout_height="103dp"
+        android:layout_marginTop="8dp"
+        android:layout_marginEnd="8dp"
+        android:layout_marginBottom="8dp"
+        android:background="?android:attr/selectableItemBackgroundBorderless"
+        android:contentDescription="@string/skip_forward"
+        android:scaleType="centerInside"
+        android:scaleX="-1"
+        app:layout_constraintBottom_toBottomOf="@+id/largePlayButton"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toEndOf="@+id/largePlayButton"
+        app:layout_constraintTop_toTopOf="@+id/largePlayButton"
+        app:lottie_rawRes="@raw/skip_button"
+        tools:src="@tools:sample/avatars" />
+
+    <TextView
+        android:id="@+id/jumpForwardText"
+        android:layout_width="45dp"
+        android:layout_height="53dp"
+        android:fontFamily="sans-serif-medium"
+        android:gravity="center"
+        android:importantForAccessibility="no"
+        android:includeFontPadding="false"
+        android:paddingTop="8dp"
+        android:textColor="#FFFFFF"
+        android:textSize="15sp"
+        app:layout_constraintBottom_toBottomOf="@+id/skipForward"
+        app:layout_constraintEnd_toEndOf="@+id/skipForward"
+        app:layout_constraintStart_toStartOf="@+id/skipForward"
+        app:layout_constraintTop_toTopOf="@+id/skipForward"
+        tools:text="30" />
+
+    <com.airbnb.lottie.LottieAnimationView
+        android:id="@+id/skipBack"
+        android:layout_width="103dp"
+        android:layout_height="103dp"
+        android:layout_marginStart="8dp"
+        android:layout_marginTop="8dp"
+        android:layout_marginBottom="8dp"
+        android:background="?android:attr/selectableItemBackgroundBorderless"
+        android:contentDescription="@string/skip_back"
+        android:scaleType="centerInside"
+        app:layout_constraintBottom_toBottomOf="@+id/largePlayButton"
+        app:layout_constraintEnd_toStartOf="@+id/largePlayButton"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="@+id/largePlayButton"
+        app:lottie_rawRes="@raw/skip_button"
+        tools:src="@tools:sample/avatars" />
+
+    <TextView
+        android:id="@+id/skipBackText"
+        android:layout_width="45dp"
+        android:layout_height="53dp"
+        android:fontFamily="sans-serif-medium"
+        android:gravity="center"
+        android:importantForAccessibility="no"
+        android:includeFontPadding="false"
+        android:paddingTop="8dp"
+        android:textColor="#FFFFFF"
+        android:textSize="15sp"
+        app:layout_constraintBottom_toBottomOf="@+id/skipBack"
+        app:layout_constraintEnd_toEndOf="@+id/skipBack"
+        app:layout_constraintStart_toStartOf="@+id/skipBack"
+        app:layout_constraintTop_toTopOf="@+id/skipBack"
+        tools:text="15" />
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/modules/features/player/src/main/res/values-land/dimens.xml
+++ b/modules/features/player/src/main/res/values-land/dimens.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <dimen name="large_play_button_margin_bottom">00dp</dimen>
+</resources>

--- a/modules/features/player/src/main/res/values/dimens.xml
+++ b/modules/features/player/src/main/res/values/dimens.xml
@@ -3,6 +3,7 @@
     <item name="seekbar_width_percentage" format="float" type="dimen">1.0</item>
     <dimen name="seekbar_margin_bottom">10dp</dimen>
     <dimen name="seekbar_margin_bottom_transcript">-25dp</dimen>
+    <dimen name="large_play_button_margin_bottom">24dp</dimen>
     <dimen name="player_fragment_start_y">69dp</dimen>
     <dimen name="player_tab_text_size">14sp</dimen>
     <dimen name="player_tab_padding">6dp</dimen>

--- a/modules/features/player/src/main/res/values/dimens.xml
+++ b/modules/features/player/src/main/res/values/dimens.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <item name="seekbar_width_percentage" format="float" type="dimen">1.0</item>
+    <dimen name="seekbar_margin_bottom">10dp</dimen>
+    <dimen name="seekbar_margin_bottom_transcript">-25dp</dimen>
     <dimen name="player_fragment_start_y">69dp</dimen>
     <dimen name="player_tab_text_size">14sp</dimen>
     <dimen name="player_tab_padding">6dp</dimen>

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/buttons/RowCloseButton.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/buttons/RowCloseButton.kt
@@ -20,11 +20,12 @@ fun RowCloseButton(
     onClose: () -> Unit,
     modifier: Modifier = Modifier,
     tintColor: Color = Color.White,
+    horizontalArrangement: Arrangement.Horizontal = Arrangement.End,
 ) {
     Row(
         modifier = modifier
             .fillMaxWidth(),
-        horizontalArrangement = Arrangement.End,
+        horizontalArrangement = horizontalArrangement,
     ) {
         IconButton(
             onClick = onClose,


### PR DESCRIPTION
## Description
When the transcript shelf item is clicked, a blank transcript screen opens with an animation.

** I've tried to match [animation on iOS](https://github.com/Automattic/pocket-casts-ios/pull/1899).

## Testing Instructions
1. Play an episode from "Cautionary Tales" (https://pcast.pocketcasts.net/8zpmjiru)
2. Open full screen player
3. Tap on the Transcript shelf icon
4. ✅ Notice that a blank Transcript screen is shown with a transition, player controls are shown at the bottom
5. Drag up on the Transcript screen
6. ✅ Notice that the up next screen is not shown
7. Tap on the close button on Transcript screen
8. ✅ Notice that Transcript screen is closed
9. Drag up on the Player screen
10. ✅ Notice that the up next screen is shown

## Screenshots or Screencast 

Portrait - Phone

https://github.com/user-attachments/assets/62ee69ea-3406-4441-8470-5919b6a3999b

Landscape - Phone

https://github.com/user-attachments/assets/e410fa50-6f0b-4117-a19a-c449be8d1d36

** I need to check the transition for the Tablet landscape. On iOS, the iPad landscape layout is the same as the portrait. We might want to copy that behavior.

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
