### PR TITLE
Fix crashes due to deep link creation on non phones

### DIFF
--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/shortcuts/PocketCastsShortcuts.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/shortcuts/PocketCastsShortcuts.kt
@@ -9,6 +9,8 @@ import android.os.Build
 import au.com.shiftyjelly.pocketcasts.deeplink.ShowFilterDeepLink
 import au.com.shiftyjelly.pocketcasts.repositories.extensions.shortcutDrawableId
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.PlaylistManager
+import au.com.shiftyjelly.pocketcasts.utils.AppPlatform
+import au.com.shiftyjelly.pocketcasts.utils.Util
 import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -30,7 +32,7 @@ object PocketCastsShortcuts {
         context: Context,
         source: Source,
     ) {
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.N_MR1) {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.N_MR1 || Util.getAppPlatform(context) != AppPlatform.Phone) {
             return
         }
         val shortcutManager = context.getSystemService(ShortcutManager::class.java) ?: return


### PR DESCRIPTION
## Description

Automotive, and perhaps Wear, doesn't support a default launcher intent and crashes the app when trying to access it. This PR adds a check before creating filter shortcuts.

## Testing Instructions

1. Sign in on an automotive device.
2. Sign in on a phone.
3. Create a filter on the phone.
4. Sync account on the phone.
5. Sync account on the automotive device.
6. App should not crash

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
