### PR TITLE
AAOS: Write filters load exception to LogBuffer

### DIFF
--- a/automotive/src/main/java/au/com/shiftyjelly/pocketcasts/AutoPlaybackService.kt
+++ b/automotive/src/main/java/au/com/shiftyjelly/pocketcasts/AutoPlaybackService.kt
@@ -31,6 +31,7 @@ import au.com.shiftyjelly.pocketcasts.servers.model.DisplayStyle
 import au.com.shiftyjelly.pocketcasts.servers.model.ListType
 import au.com.shiftyjelly.pocketcasts.servers.model.transformWithRegion
 import au.com.shiftyjelly.pocketcasts.servers.server.ListRepository
+import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
 import kotlinx.coroutines.CoroutineScope
@@ -130,7 +131,9 @@ class AutoPlaybackService : PlaybackService() {
             try {
                 AutoConverter.convertPlaylistToMediaItem(this, it)
             } catch (e: Exception) {
-                Log.e(Settings.LOG_TAG_AUTO, "Filter ${it.title} load failed", e)
+                val message = "Filter ${it.title} load failed"
+                Log.e(Settings.LOG_TAG_AUTO, message, e)
+                LogBuffer.e(Settings.LOG_TAG_AUTO, message, e)
                 null
             }
         }


### PR DESCRIPTION
## Description
This writes filters load exception to Log Buffer to debug https://github.com/Automattic/pocket-casts-android/issues/2365

Internal Ref: p1721842681929319/1717944583.209849-slack-C02A333D8LQ

## Testing Instructions
Code review should be sufficient.

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [ ] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack