### PR TITLE
Display podcast sharing UI

### DIFF
--- a/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/clip/ShareClipFragment.kt
+++ b/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/clip/ShareClipFragment.kt
@@ -6,8 +6,11 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.annotation.ColorInt
-import androidx.compose.runtime.collectAsState
-import androidx.compose.runtime.getValue
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.platform.ComposeView
@@ -15,6 +18,7 @@ import androidx.core.os.BundleCompat
 import androidx.core.os.bundleOf
 import androidx.fragment.app.viewModels
 import au.com.shiftyjelly.pocketcasts.analytics.SourceView
+import au.com.shiftyjelly.pocketcasts.compose.components.TextH30
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.sharing.ShareActions
 import au.com.shiftyjelly.pocketcasts.sharing.ui.ShareColors
@@ -82,21 +86,19 @@ class ShareClipFragment : BaseDialogFragment() {
         container: ViewGroup?,
         savedInstanceState: Bundle?,
     ) = ComposeView(requireActivity()).apply {
-        val listener = ShareClipViewModelListener(this@ShareClipFragment, viewModel, shareActions)
         val shareColors = shareColors
         setContent {
-            val state by viewModel.uiState.collectAsState()
-
-            ShareClipPage(
-                episode = state.episode,
-                podcast = state.podcast,
-                clipRange = state.clipRange,
-                playbackProgress = state.playbackProgress,
-                isPlaying = state.isPlaying,
-                useEpisodeArtwork = state.useEpisodeArtwork,
-                shareColors = shareColors,
-                listener = listener,
-            )
+            Box(
+                contentAlignment = Alignment.Center,
+                modifier = Modifier
+                    .background(shareColors.background)
+                    .fillMaxSize(),
+            ) {
+                TextH30(
+                    text = "Work in progress",
+                    color = shareColors.backgroundPrimaryText,
+                )
+            }
         }
     }
 

--- a/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/clip/ShareClipFragment.kt
+++ b/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/clip/ShareClipFragment.kt
@@ -1,6 +1,5 @@
 package au.com.shiftyjelly.pocketcasts.sharing.clip
 
-import android.content.res.ColorStateList
 import android.os.Bundle
 import android.os.Parcelable
 import android.view.LayoutInflater
@@ -10,12 +9,10 @@ import androidx.annotation.ColorInt
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.luminance
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.platform.ComposeView
 import androidx.core.os.BundleCompat
 import androidx.core.os.bundleOf
-import androidx.core.view.WindowInsetsControllerCompat
 import androidx.fragment.app.viewModels
 import au.com.shiftyjelly.pocketcasts.analytics.SourceView
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
@@ -105,18 +102,7 @@ class ShareClipFragment : BaseDialogFragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        val shareColors = shareColors
-        val argbColor = shareColors.background.toArgb()
-
-        requireActivity().window?.let { activityWindow ->
-            activityWindow.statusBarColor = argbColor
-            WindowInsetsControllerCompat(activityWindow, activityWindow.decorView).isAppearanceLightStatusBars = shareColors.background.luminance() > 0.5f
-        }
-        requireDialog().window?.let { dialogWindow ->
-            dialogWindow.navigationBarColor = argbColor
-            WindowInsetsControllerCompat(dialogWindow, dialogWindow.decorView).isAppearanceLightNavigationBars = shareColors.background.luminance() > 0.5f
-        }
-        bottomSheetView()?.backgroundTintList = ColorStateList.valueOf(argbColor)
+        styleBackgroundColor(shareColors.background.toArgb())
     }
 
     @Parcelize

--- a/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/clip/ShareClipPage.kt
+++ b/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/clip/ShareClipPage.kt
@@ -1,9 +1,7 @@
 package au.com.shiftyjelly.pocketcasts.sharing.clip
 
 import android.content.res.Configuration
-import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -17,16 +15,12 @@ import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.wrapContentHeight
-import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.ButtonDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.platform.LocalConfiguration
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
@@ -37,6 +31,7 @@ import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.sharing.ui.ClipSelector
 import au.com.shiftyjelly.pocketcasts.sharing.ui.ClipSelectorState
+import au.com.shiftyjelly.pocketcasts.sharing.ui.CloseButton
 import au.com.shiftyjelly.pocketcasts.sharing.ui.HorizontalEpisodeCard
 import au.com.shiftyjelly.pocketcasts.sharing.ui.ShareColors
 import au.com.shiftyjelly.pocketcasts.sharing.ui.VerticalEpisodeCard
@@ -46,7 +41,6 @@ import java.sql.Date
 import java.time.Instant
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
-import au.com.shiftyjelly.pocketcasts.images.R as IR
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 internal interface ShareClipPageListener {
@@ -192,7 +186,7 @@ private fun VerticalClipPage(
     ) {
         CloseButton(
             shareColors = shareColors,
-            onClose = listener::onClose,
+            onClick = listener::onClose,
             modifier = Modifier.padding(top = 16.dp, end = 16.dp),
         )
     }
@@ -282,7 +276,7 @@ private fun HorizontalClipPage(
         )
         CloseButton(
             shareColors = shareColors,
-            onClose = listener::onClose,
+            onClick = listener::onClose,
             modifier = Modifier.padding(top = 24.dp, end = 16.dp),
         )
     }
@@ -310,21 +304,6 @@ private fun ClipButton(
     elevation = null,
     includePadding = false,
     modifier = modifier,
-)
-
-@Composable
-private fun CloseButton(
-    shareColors: ShareColors,
-    onClose: () -> Unit,
-    modifier: Modifier = Modifier,
-) = Image(
-    painter = painterResource(IR.drawable.ic_close_sheet),
-    contentDescription = stringResource(LR.string.close),
-    colorFilter = ColorFilter.tint(shareColors.closeButtonIcon),
-    modifier = modifier
-        .clickable(onClick = onClose)
-        .clip(CircleShape)
-        .background(shareColors.closeButton),
 )
 
 internal const val PreviewDevicePortrait = "spec:width=400dp,height=800dp,dpi=320"

--- a/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/clip/ShareClipPage.kt
+++ b/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/clip/ShareClipPage.kt
@@ -135,7 +135,7 @@ private fun VerticalClipPage(
 
         TextH30(
             text = stringResource(LR.string.podcast_create_clip),
-            color = shareColors.backgroundText,
+            color = shareColors.backgroundPrimaryText,
         )
 
         Spacer(
@@ -274,7 +274,7 @@ private fun HorizontalClipPage(
         }
         TextH30(
             text = stringResource(LR.string.podcast_create_clip),
-            color = shareColors.backgroundText,
+            color = shareColors.backgroundPrimaryText,
             textAlign = TextAlign.Center,
             modifier = Modifier
                 .fillMaxWidth()

--- a/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/podcast/SharePodcastFragment.kt
+++ b/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/podcast/SharePodcastFragment.kt
@@ -3,6 +3,7 @@ package au.com.shiftyjelly.pocketcasts.sharing.podcast
 import android.os.Bundle
 import android.os.Parcelable
 import android.view.LayoutInflater
+import android.view.View
 import android.view.ViewGroup
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
@@ -11,12 +12,14 @@ import androidx.compose.material.Text
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.unit.sp
 import androidx.core.os.BundleCompat
 import androidx.core.os.bundleOf
 import au.com.shiftyjelly.pocketcasts.analytics.SourceView
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
+import au.com.shiftyjelly.pocketcasts.sharing.ui.ShareColors
 import au.com.shiftyjelly.pocketcasts.utils.parceler.ColorParceler
 import au.com.shiftyjelly.pocketcasts.views.fragments.BaseDialogFragment
 import kotlinx.parcelize.Parcelize
@@ -24,6 +27,8 @@ import kotlinx.parcelize.TypeParceler
 
 class SharePodcastFragment : BaseDialogFragment() {
     private val args get() = requireNotNull(arguments?.let { BundleCompat.getParcelable(it, NEW_INSTANCE_ARG, Args::class.java) })
+
+    private val shareColors get() = ShareColors(args.baseColor)
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -44,6 +49,11 @@ class SharePodcastFragment : BaseDialogFragment() {
                 )
             }
         }
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        styleBackgroundColor(shareColors.background.toArgb())
     }
 
     @Parcelize

--- a/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/podcast/SharePodcastFragment.kt
+++ b/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/podcast/SharePodcastFragment.kt
@@ -6,48 +6,55 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.material.Text
-import androidx.compose.ui.Alignment
-import androidx.compose.ui.Modifier
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.platform.ComposeView
-import androidx.compose.ui.unit.sp
 import androidx.core.os.BundleCompat
 import androidx.core.os.bundleOf
+import androidx.fragment.app.viewModels
 import au.com.shiftyjelly.pocketcasts.analytics.SourceView
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
+import au.com.shiftyjelly.pocketcasts.sharing.social.SocialPlatform
 import au.com.shiftyjelly.pocketcasts.sharing.ui.ShareColors
 import au.com.shiftyjelly.pocketcasts.utils.parceler.ColorParceler
 import au.com.shiftyjelly.pocketcasts.views.fragments.BaseDialogFragment
+import dagger.hilt.android.AndroidEntryPoint
+import dagger.hilt.android.lifecycle.withCreationCallback
 import kotlinx.parcelize.Parcelize
 import kotlinx.parcelize.TypeParceler
 
+@AndroidEntryPoint
 class SharePodcastFragment : BaseDialogFragment() {
     private val args get() = requireNotNull(arguments?.let { BundleCompat.getParcelable(it, NEW_INSTANCE_ARG, Args::class.java) })
 
     private val shareColors get() = ShareColors(args.baseColor)
+
+    private val viewModel by viewModels<SharePodcastViewModel>(
+        extrasProducer = {
+            defaultViewModelCreationExtras.withCreationCallback<SharePodcastViewModel.Factory> { factory ->
+                factory.create(args.podcastUuid)
+            }
+        },
+    )
 
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
         savedInstanceState: Bundle?,
     ) = ComposeView(requireActivity()).apply {
+        val platforms = SocialPlatform.getAvailablePlatforms(requireContext())
+        val listener = SharePodcastListener(this@SharePodcastFragment)
         setContent {
-            Box(
-                contentAlignment = Alignment.Center,
-                modifier = Modifier
-                    .background(Color.Black)
-                    .fillMaxSize(),
-            ) {
-                Text(
-                    text = "Share podcast: ${args.podcastUuid}",
-                    fontSize = 24.sp,
-                    color = Color.White,
-                )
-            }
+            val uiState by viewModel.uiState.collectAsState()
+            SharePodcastPage(
+                podcast = uiState.podcast,
+                episodeCount = uiState.episodeCount,
+                socialPlatforms = platforms,
+                shareColors = shareColors,
+                listener = listener,
+            )
         }
     }
 

--- a/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/podcast/SharePodcastListener.kt
+++ b/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/podcast/SharePodcastListener.kt
@@ -1,0 +1,17 @@
+package au.com.shiftyjelly.pocketcasts.sharing.podcast
+
+import android.widget.Toast
+import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
+import au.com.shiftyjelly.pocketcasts.sharing.social.SocialPlatform
+
+internal class SharePodcastListener(
+    private val fragment: SharePodcastFragment,
+) : SharePodcastPageListener {
+    override fun onShare(podcast: Podcast, platform: SocialPlatform) {
+        Toast.makeText(fragment.requireActivity(), "Share ${podcast.title} to $platform", Toast.LENGTH_SHORT).show()
+    }
+
+    override fun onClose() {
+        fragment.dismiss()
+    }
+}

--- a/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/podcast/SharePodcastPage.kt
+++ b/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/podcast/SharePodcastPage.kt
@@ -5,7 +5,9 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -25,6 +27,7 @@ import au.com.shiftyjelly.pocketcasts.sharing.social.PlatformBar
 import au.com.shiftyjelly.pocketcasts.sharing.social.SocialPlatform
 import au.com.shiftyjelly.pocketcasts.sharing.ui.CloseButton
 import au.com.shiftyjelly.pocketcasts.sharing.ui.Devices
+import au.com.shiftyjelly.pocketcasts.sharing.ui.HorizontalPodcastCast
 import au.com.shiftyjelly.pocketcasts.sharing.ui.ShareColors
 import au.com.shiftyjelly.pocketcasts.sharing.ui.VerticalPodcastCast
 import com.airbnb.android.showkase.annotation.ShowkaseComposable
@@ -49,7 +52,13 @@ internal fun SharePodcastPage(
     shareColors: ShareColors,
     listener: SharePodcastPageListener,
 ) = when (LocalConfiguration.current.orientation) {
-    Configuration.ORIENTATION_LANDSCAPE -> Box { }
+    Configuration.ORIENTATION_LANDSCAPE -> HorizontalSharePodcastPage(
+        podcast = podcast,
+        episodeCount = episodeCount,
+        socialPlatforms = socialPlatforms,
+        shareColors = shareColors,
+        listener = listener,
+    )
     else -> VerticalSharePodcastPage(
         podcast = podcast,
         episodeCount = episodeCount,
@@ -127,6 +136,92 @@ private fun VerticalSharePodcastPage(
                 listener.onShare(podcast, platform)
             }
         }
+    }
+}
+
+@Composable
+private fun HorizontalSharePodcastPage(
+    podcast: Podcast?,
+    episodeCount: Int,
+    socialPlatforms: Set<SocialPlatform>,
+    shareColors: ShareColors,
+    listener: SharePodcastPageListener,
+) = Column(
+    modifier = Modifier
+        .fillMaxSize()
+        .background(shareColors.background),
+) {
+    Box(
+        contentAlignment = Alignment.TopEnd,
+        modifier = Modifier
+            .weight(0.25f)
+            .fillMaxSize(),
+    ) {
+        CloseButton(
+            shareColors = shareColors,
+            onClick = listener::onClose,
+            modifier = Modifier.padding(top = 12.dp, end = 12.dp),
+        )
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Center,
+            modifier = Modifier.fillMaxSize(),
+        ) {
+            TextH30(
+                text = "Share podcast",
+                textAlign = TextAlign.Center,
+                color = shareColors.backgroundPrimaryText,
+            )
+            Spacer(
+                modifier = Modifier.height(8.dp),
+            )
+            TextH40(
+                text = "Chose a format and a platform to share to",
+                textAlign = TextAlign.Center,
+                color = shareColors.backgroundSecondaryText,
+            )
+        }
+    }
+    Row(
+        modifier = Modifier
+            .weight(0.75f)
+            .fillMaxSize(),
+    ) {
+        Spacer(
+            modifier = Modifier.weight(0.1f),
+        )
+        Box(
+            contentAlignment = Alignment.Center,
+            modifier = Modifier
+                .weight(1f)
+                .fillMaxHeight(),
+        ) {
+            if (podcast != null) {
+                HorizontalPodcastCast(
+                    podcast = podcast,
+                    episodeCount = episodeCount,
+                    shareColors = shareColors,
+                )
+            }
+        }
+        Spacer(
+            modifier = Modifier.weight(0.1f),
+        )
+        Box(
+            contentAlignment = Alignment.Center,
+            modifier = Modifier
+                .weight(1f)
+                .fillMaxHeight(),
+        ) {
+            PlatformBar(socialPlatforms, shareColors) { platform ->
+                if (podcast != null) {
+                    listener.onShare(podcast, platform)
+                }
+            }
+        }
+        Spacer(
+            modifier = Modifier.weight(0.1f),
+        )
     }
 }
 

--- a/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/podcast/SharePodcastPage.kt
+++ b/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/podcast/SharePodcastPage.kt
@@ -17,6 +17,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -31,6 +32,7 @@ import au.com.shiftyjelly.pocketcasts.sharing.ui.HorizontalPodcastCast
 import au.com.shiftyjelly.pocketcasts.sharing.ui.ShareColors
 import au.com.shiftyjelly.pocketcasts.sharing.ui.VerticalPodcastCast
 import com.airbnb.android.showkase.annotation.ShowkaseComposable
+import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 internal interface SharePodcastPageListener {
     fun onShare(podcast: Podcast, platform: SocialPlatform)
@@ -97,7 +99,7 @@ private fun VerticalSharePodcastPage(
             modifier = Modifier.fillMaxSize(),
         ) {
             TextH30(
-                text = "Share podcast",
+                text = stringResource(LR.string.share_podcast_title),
                 textAlign = TextAlign.Center,
                 color = shareColors.backgroundPrimaryText,
                 modifier = Modifier.sizeIn(maxWidth = 220.dp),
@@ -106,7 +108,7 @@ private fun VerticalSharePodcastPage(
                 modifier = Modifier.height(8.dp),
             )
             TextH40(
-                text = "Chose a format and a platform to share to",
+                text = stringResource(LR.string.share_podcast_description),
                 textAlign = TextAlign.Center,
                 color = shareColors.backgroundSecondaryText,
                 modifier = Modifier.sizeIn(maxWidth = 220.dp),

--- a/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/podcast/SharePodcastPage.kt
+++ b/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/podcast/SharePodcastPage.kt
@@ -1,0 +1,176 @@
+package au.com.shiftyjelly.pocketcasts.sharing.podcast
+
+import android.content.res.Configuration
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.sizeIn
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import au.com.shiftyjelly.pocketcasts.compose.components.TextH30
+import au.com.shiftyjelly.pocketcasts.compose.components.TextH40
+import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
+import au.com.shiftyjelly.pocketcasts.sharing.social.PlatformBar
+import au.com.shiftyjelly.pocketcasts.sharing.social.SocialPlatform
+import au.com.shiftyjelly.pocketcasts.sharing.ui.CloseButton
+import au.com.shiftyjelly.pocketcasts.sharing.ui.Devices
+import au.com.shiftyjelly.pocketcasts.sharing.ui.ShareColors
+import au.com.shiftyjelly.pocketcasts.sharing.ui.VerticalPodcastCast
+import com.airbnb.android.showkase.annotation.ShowkaseComposable
+
+internal interface SharePodcastPageListener {
+    fun onShare(podcast: Podcast, platform: SocialPlatform)
+    fun onClose()
+
+    companion object {
+        val Preview = object : SharePodcastPageListener {
+            override fun onShare(podcast: Podcast, platform: SocialPlatform) = Unit
+            override fun onClose() = Unit
+        }
+    }
+}
+
+@Composable
+internal fun SharePodcastPage(
+    podcast: Podcast?,
+    episodeCount: Int,
+    socialPlatforms: Set<SocialPlatform>,
+    shareColors: ShareColors,
+    listener: SharePodcastPageListener,
+) = when (LocalConfiguration.current.orientation) {
+    Configuration.ORIENTATION_LANDSCAPE -> Box { }
+    else -> VerticalSharePodcastPage(
+        podcast = podcast,
+        episodeCount = episodeCount,
+        socialPlatforms = socialPlatforms,
+        shareColors = shareColors,
+        listener = listener,
+    )
+}
+
+@Composable
+private fun VerticalSharePodcastPage(
+    podcast: Podcast?,
+    episodeCount: Int,
+    socialPlatforms: Set<SocialPlatform>,
+    shareColors: ShareColors,
+    listener: SharePodcastPageListener,
+) = Column(
+    modifier = Modifier
+        .fillMaxSize()
+        .background(shareColors.background),
+) {
+    Box(
+        contentAlignment = Alignment.TopEnd,
+        modifier = Modifier
+            .weight(0.2f)
+            .fillMaxSize(),
+    ) {
+        CloseButton(
+            shareColors = shareColors,
+            onClick = listener::onClose,
+            modifier = Modifier.padding(top = 12.dp, end = 12.dp),
+        )
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Center,
+            modifier = Modifier.fillMaxSize(),
+        ) {
+            TextH30(
+                text = "Share podcast",
+                textAlign = TextAlign.Center,
+                color = shareColors.backgroundPrimaryText,
+                modifier = Modifier.sizeIn(maxWidth = 220.dp),
+            )
+            Spacer(
+                modifier = Modifier.height(8.dp),
+            )
+            TextH40(
+                text = "Chose a format and a platform to share to",
+                textAlign = TextAlign.Center,
+                color = shareColors.backgroundSecondaryText,
+                modifier = Modifier.sizeIn(maxWidth = 220.dp),
+            )
+        }
+    }
+    Box(
+        contentAlignment = Alignment.Center,
+        modifier = Modifier
+            .weight(0.6f)
+            .fillMaxSize(),
+    ) {
+        if (podcast != null) {
+            VerticalPodcastCast(
+                podcast = podcast,
+                episodeCount = episodeCount,
+                shareColors = shareColors,
+            )
+        }
+    }
+    Box(
+        contentAlignment = Alignment.Center,
+        modifier = Modifier.weight(0.18f),
+    ) {
+        PlatformBar(socialPlatforms, shareColors) { platform ->
+            if (podcast != null) {
+                listener.onShare(podcast, platform)
+            }
+        }
+    }
+}
+
+@ShowkaseComposable(name = "SharePodcastVerticalRegularPreview", group = "Podcast")
+@Preview(name = "SharePodcastVerticalRegularPreview", device = Devices.PortraitRegular)
+@Composable
+fun SharePodcastVerticalRegularPreview() = SharePodcastPagePreview()
+
+@ShowkaseComposable(name = "SharePodcastVerticalSmallPreview", group = "Podcast")
+@Preview(name = "SharePodcastVerticalSmallPreview", device = Devices.PortraitSmall)
+@Composable
+fun SharePodcastVerticalSmallPreviewPreview() = SharePodcastPagePreview()
+
+@ShowkaseComposable(name = "SharePodcastVerticalTabletPreview", group = "Podcast")
+@Preview(name = "SharePodcastVerticalTabletPreview", device = Devices.PortraitTablet)
+@Composable
+fun SharePodcastVerticalTabletPreview() = SharePodcastPagePreview()
+
+@ShowkaseComposable(name = "SharePodcastHorizontalRegularPreview", group = "Podcast")
+@Preview(name = "SharePodcastHorizontalRegularPreview", device = Devices.LandscapeRegular)
+@Composable
+fun SharePodcastHorizontalRegularPreview() = SharePodcastPagePreview()
+
+@ShowkaseComposable(name = "SharePodcastHorizontalSmallPreview", group = "Podcast")
+@Preview(name = "SharePodcastHorizontalSmallPreview", device = Devices.LandscapeSmall)
+@Composable
+fun SharePodcastHorizontalSmallPreviewPreview() = SharePodcastPagePreview()
+
+@ShowkaseComposable(name = "SharePodcastHorizontalTabletPreview", group = "Podcast")
+@Preview(name = "SharePodcastHorizontalTabletPreview", device = Devices.LandscapeTablet)
+@Composable
+fun SharePodcastHorizontalTabletPreview() = SharePodcastPagePreview()
+
+@Composable
+internal fun SharePodcastPagePreview(
+    color: Long = 0xFFEC0404,
+) = SharePodcastPage(
+    podcast = Podcast(
+        uuid = "podcast-id",
+        title = "Podcast title",
+        episodeFrequency = "monthly",
+    ),
+    episodeCount = 120,
+    socialPlatforms = SocialPlatform.entries.toSet(),
+    shareColors = ShareColors(Color(color)),
+    listener = SharePodcastPageListener.Preview,
+)

--- a/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/podcast/SharePodcastPage.kt
+++ b/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/podcast/SharePodcastPage.kt
@@ -170,7 +170,7 @@ private fun HorizontalSharePodcastPage(
             modifier = Modifier.fillMaxSize(),
         ) {
             TextH30(
-                text = "Share podcast",
+                text = stringResource(LR.string.share_podcast_title),
                 textAlign = TextAlign.Center,
                 color = shareColors.backgroundPrimaryText,
             )
@@ -178,7 +178,7 @@ private fun HorizontalSharePodcastPage(
                 modifier = Modifier.height(8.dp),
             )
             TextH40(
-                text = "Chose a format and a platform to share to",
+                text = stringResource(LR.string.share_podcast_description),
                 textAlign = TextAlign.Center,
                 color = shareColors.backgroundSecondaryText,
             )

--- a/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/podcast/SharePodcastViewModel.kt
+++ b/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/podcast/SharePodcastViewModel.kt
@@ -1,0 +1,35 @@
+package au.com.shiftyjelly.pocketcasts.sharing.podcast
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
+import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedFactory
+import dagger.assisted.AssistedInject
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.stateIn
+
+@HiltViewModel(assistedFactory = SharePodcastViewModel.Factory::class)
+class SharePodcastViewModel @AssistedInject constructor(
+    @Assisted podcastUuid: String,
+    private val podcastManager: PodcastManager,
+) : ViewModel() {
+    val uiState = combine(
+        podcastManager.observePodcastByUuidFlow(podcastUuid),
+        podcastManager.observeEpisodeCountByPodcatUuid(podcastUuid),
+        ::UiState,
+    ).stateIn(viewModelScope, started = SharingStarted.Lazily, initialValue = UiState())
+
+    data class UiState(
+        val podcast: Podcast? = null,
+        val episodeCount: Int = 0,
+    )
+
+    @AssistedFactory
+    interface Factory {
+        fun create(podcastUuid: String): SharePodcastViewModel
+    }
+}

--- a/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/social/PlatfromItem.kt
+++ b/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/social/PlatfromItem.kt
@@ -60,7 +60,7 @@ internal fun PlatformItem(
         )
         TextH70(
             text = stringResource(platform.nameId),
-            color = shareColors.backgroundText.copy(alpha = 0.5f),
+            color = shareColors.backgroundPrimaryText.copy(alpha = 0.5f),
         )
     }
 }

--- a/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/social/PlatfromItem.kt
+++ b/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/social/PlatfromItem.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.sizeIn
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.ripple.rememberRipple
 import androidx.compose.runtime.Composable
@@ -20,13 +21,14 @@ import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.tooling.preview.PreviewParameterProvider
 import androidx.compose.ui.unit.dp
 import au.com.shiftyjelly.pocketcasts.compose.components.TextH70
 import au.com.shiftyjelly.pocketcasts.sharing.ui.ShareColors
-
+import au.com.shiftyjelly.pocketcasts.localization.R as LR
 @Composable
 internal fun PlatformItem(
     platform: SocialPlatform,
@@ -38,7 +40,7 @@ internal fun PlatformItem(
         modifier = Modifier.clickable(
             interactionSource = remember(::MutableInteractionSource),
             indication = rememberRipple(color = shareColors.base),
-            onClickLabel = stringResource(platform.nameId),
+            onClickLabel = stringResource(LR.string.share_via, stringResource(platform.nameId)),
             role = Role.Button,
             onClick = { onClick(platform) },
         ),
@@ -52,7 +54,8 @@ internal fun PlatformItem(
             Image(
                 painter = painterResource(platform.logoId),
                 colorFilter = ColorFilter.tint(shareColors.socialButtonIcon),
-                contentDescription = stringResource(platform.nameId),
+                contentDescription = null,
+                modifier = Modifier.size(24.dp),
             )
         }
         Spacer(
@@ -60,7 +63,9 @@ internal fun PlatformItem(
         )
         TextH70(
             text = stringResource(platform.nameId),
+            textAlign = TextAlign.Center,
             color = shareColors.backgroundPrimaryText.copy(alpha = 0.5f),
+            modifier = Modifier.sizeIn(maxWidth = 64.dp),
         )
     }
 }

--- a/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/social/PlatfromItem.kt
+++ b/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/social/PlatfromItem.kt
@@ -65,7 +65,7 @@ internal fun PlatformItem(
             text = stringResource(platform.nameId),
             textAlign = TextAlign.Center,
             color = shareColors.backgroundPrimaryText.copy(alpha = 0.5f),
-            modifier = Modifier.sizeIn(maxWidth = 64.dp),
+            modifier = Modifier.sizeIn(maxWidth = 80.dp),
         )
     }
 }

--- a/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/ui/CloseButton.kt
+++ b/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/ui/CloseButton.kt
@@ -1,0 +1,29 @@
+package au.com.shiftyjelly.pocketcasts.sharing.ui
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import au.com.shiftyjelly.pocketcasts.images.R as IR
+import au.com.shiftyjelly.pocketcasts.localization.R as LR
+
+@Composable
+internal fun CloseButton(
+    shareColors: ShareColors,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) = Image(
+    painter = painterResource(IR.drawable.ic_close_sheet),
+    contentDescription = stringResource(LR.string.close),
+    colorFilter = ColorFilter.tint(shareColors.closeButtonIcon),
+    modifier = modifier
+        .clickable(onClick = onClick)
+        .clip(CircleShape)
+        .background(shareColors.closeButton),
+)

--- a/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/ui/Devices.kt
+++ b/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/ui/Devices.kt
@@ -1,0 +1,11 @@
+package au.com.shiftyjelly.pocketcasts.sharing.ui
+
+internal object Devices {
+    const val PortraitRegular = "spec:width=800px,height=1600px,dpi=320"
+    const val PortraitSmall = "spec:width=720px,height=1280px,dpi=320"
+    const val PortraitTablet = "spec:width=1600px,height=2560px,dpi=276"
+
+    const val LandscapeRegular = "$PortraitRegular,orientation=landscape"
+    const val LandscapeSmall = "$PortraitSmall,orientation=landscape"
+    const val LandscapeTablet = "$PortraitTablet,orientation=landscape"
+}

--- a/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/ui/ShareColors.kt
+++ b/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/ui/ShareColors.kt
@@ -8,7 +8,8 @@ internal data class ShareColors(
     val base: Color,
 ) {
     val background = ColorUtils.changeHsvValue(base, factor = 0.4f)
-    val backgroundText = if (background.luminance() < 0.5f) Color.White else Color.Black
+    val backgroundPrimaryText = if (background.luminance() < 0.5f) Color.White else Color.Black
+    val backgroundSecondaryText = backgroundPrimaryText.copy(alpha = 0.5f)
 
     val cardTop = ColorUtils.changeHsvValue(base, 1.25f)
     val cardBottom = ColorUtils.changeHsvValue(base, 0.75f)
@@ -21,11 +22,11 @@ internal data class ShareColors(
     }
     val clipButtonText = if (clipButton.luminance() < 0.5f) Color.White else Color.Black
 
-    val closeButton = backgroundText.copy(alpha = 0.15f)
+    val closeButton = backgroundPrimaryText.copy(alpha = 0.15f)
     val closeButtonIcon = Color.White.copy(alpha = 0.5f)
 
-    val timeline = backgroundText.copy(alpha = 0.15f)
-    val timelineProgress = backgroundText
+    val timeline = backgroundPrimaryText.copy(alpha = 0.15f)
+    val timelineProgress = backgroundPrimaryText
     val timelineTick = timelineProgress.copy(alpha = 0.4f)
     val playPauseButton = Color.White
 
@@ -36,6 +37,6 @@ internal data class ShareColors(
     }
     val selectorHandle = background.copy(alpha = 0.4f)
 
-    val socialButton = backgroundText.copy(alpha = 0.1f)
+    val socialButton = backgroundPrimaryText.copy(alpha = 0.1f)
     val socialButtonIcon = Color.White
 }

--- a/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/ui/VerticalCard.kt
+++ b/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/ui/VerticalCard.kt
@@ -33,12 +33,14 @@ internal fun VerticalPodcastCast(
     episodeCount: Int,
     shareColors: ShareColors,
     modifier: Modifier = Modifier,
+    useHeightForAspectRatio: Boolean = true,
 ) = VerticalCard(
     type = PodcastCardType(
         podcast = podcast,
         episodeCount = episodeCount,
     ),
     shareColors = shareColors,
+    useHeightForAspectRatio = useHeightForAspectRatio,
     modifier = modifier,
 )
 
@@ -49,6 +51,7 @@ internal fun VerticalEpisodeCard(
     useEpisodeArtwork: Boolean,
     shareColors: ShareColors,
     modifier: Modifier = Modifier,
+    useHeightForAspectRatio: Boolean = true,
 ) = VerticalCard(
     type = EpisodeCardType(
         episode = episode,
@@ -56,6 +59,7 @@ internal fun VerticalEpisodeCard(
         useEpisodeArtwork = useEpisodeArtwork,
     ),
     shareColors = shareColors,
+    useHeightForAspectRatio = useHeightForAspectRatio,
     modifier = modifier,
 )
 
@@ -63,6 +67,7 @@ internal fun VerticalEpisodeCard(
 private fun VerticalCard(
     type: CardType,
     shareColors: ShareColors,
+    useHeightForAspectRatio: Boolean,
     modifier: Modifier = Modifier,
 ) = BoxWithConstraints {
     val backgroundGradient = Brush.verticalGradient(
@@ -71,8 +76,11 @@ private fun VerticalCard(
             shareColors.cardBottom,
         ),
     )
-    val height = maxHeight
-    val width = height / 1.5f
+    val (height, width) = if (useHeightForAspectRatio) {
+        maxHeight to maxHeight / 1.5f
+    } else {
+        maxWidth * 1.5f to maxWidth
+    }
     Column(
         horizontalAlignment = Alignment.CenterHorizontally,
         modifier = modifier
@@ -95,7 +103,7 @@ private fun VerticalCard(
             text = type.topText(),
             maxLines = 1,
             color = shareColors.cardText.copy(alpha = 0.5f),
-            modifier = Modifier.padding(horizontal = width * 0.22f),
+            modifier = Modifier.padding(horizontal = width * 0.1f),
         )
         Spacer(
             modifier = Modifier.height(6.dp),
@@ -105,7 +113,7 @@ private fun VerticalCard(
             maxLines = 2,
             textAlign = TextAlign.Center,
             color = shareColors.cardText,
-            modifier = Modifier.padding(horizontal = width * 0.15f),
+            modifier = Modifier.padding(horizontal = width * 0.1f),
         )
         Spacer(
             modifier = Modifier.height(6.dp),
@@ -115,7 +123,7 @@ private fun VerticalCard(
             maxLines = 2,
             textAlign = TextAlign.Center,
             color = shareColors.cardText.copy(alpha = 0.5f),
-            modifier = Modifier.padding(horizontal = width * 0.22f),
+            modifier = Modifier.padding(horizontal = width * 0.1f),
         )
         Spacer(
             modifier = Modifier.weight(1f),
@@ -197,4 +205,5 @@ private fun VerticalCardPreview(
 ) = VerticalCard(
     type = type,
     shareColors = ShareColors(baseColor),
+    useHeightForAspectRatio = false,
 )

--- a/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/ui/VerticalCard.kt
+++ b/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/ui/VerticalCard.kt
@@ -71,29 +71,31 @@ private fun VerticalCard(
             shareColors.cardBottom,
         ),
     )
+    val height = maxHeight
+    val width = height / 1.5f
     Column(
         horizontalAlignment = Alignment.CenterHorizontally,
         modifier = modifier
             .background(backgroundGradient, RoundedCornerShape(12.dp))
-            .width(maxWidth)
-            .height(maxWidth * 1.5f),
+            .width(width)
+            .height(height),
     ) {
         Spacer(
-            modifier = Modifier.height(this@BoxWithConstraints.maxWidth * 0.15f),
+            modifier = Modifier.height(width * 0.15f),
         )
         type.Image(
             modifier = Modifier
-                .size(this@BoxWithConstraints.maxWidth * 0.7f)
+                .size(width * 0.7f)
                 .clip(RoundedCornerShape(8.dp)),
         )
         Spacer(
-            modifier = Modifier.height(24.dp),
+            modifier = Modifier.height(height * 0.05f),
         )
         TextH70(
             text = type.topText(),
             maxLines = 1,
             color = shareColors.cardText.copy(alpha = 0.5f),
-            modifier = Modifier.padding(horizontal = 64.dp),
+            modifier = Modifier.padding(horizontal = width * 0.22f),
         )
         Spacer(
             modifier = Modifier.height(6.dp),
@@ -103,7 +105,7 @@ private fun VerticalCard(
             maxLines = 2,
             textAlign = TextAlign.Center,
             color = shareColors.cardText,
-            modifier = Modifier.padding(horizontal = 42.dp),
+            modifier = Modifier.padding(horizontal = width * 0.15f),
         )
         Spacer(
             modifier = Modifier.height(6.dp),
@@ -113,7 +115,7 @@ private fun VerticalCard(
             maxLines = 2,
             textAlign = TextAlign.Center,
             color = shareColors.cardText.copy(alpha = 0.5f),
-            modifier = Modifier.padding(horizontal = 64.dp),
+            modifier = Modifier.padding(horizontal = width * 0.22f),
         )
         Spacer(
             modifier = Modifier.weight(1f),

--- a/modules/features/sharing/src/test/kotlin/au/com/shiftyjelly/pocketcasts/sharing/podcast/SharePodcastViewModelTest.kt
+++ b/modules/features/sharing/src/test/kotlin/au/com/shiftyjelly/pocketcasts/sharing/podcast/SharePodcastViewModelTest.kt
@@ -1,0 +1,49 @@
+package au.com.shiftyjelly.pocketcasts.sharing.podcast
+
+import app.cash.turbine.test
+import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
+import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
+import au.com.shiftyjelly.pocketcasts.sharedtest.MainCoroutineRule
+import au.com.shiftyjelly.pocketcasts.sharing.podcast.SharePodcastViewModel.UiState
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+
+@ExperimentalCoroutinesApi
+class SharePodcastViewModelTest {
+    @get:Rule
+    val coroutineRule = MainCoroutineRule()
+
+    private val podcastManager = mock<PodcastManager>()
+
+    private val podcast = Podcast(uuid = "podcast-id", title = "Podcast Title")
+
+    private lateinit var viewModel: SharePodcastViewModel
+
+    @Before
+    fun setUp() {
+        whenever(podcastManager.observePodcastByUuidFlow("podcast-id")).thenReturn(flowOf(podcast))
+        whenever(podcastManager.observeEpisodeCountByPodcatUuid("podcast-id")).thenReturn(flowOf(50))
+
+        viewModel = SharePodcastViewModel(podcast.uuid, podcastManager)
+    }
+
+    @Test
+    fun `get UI state`() = runTest {
+        viewModel.uiState.test {
+            assertEquals(
+                UiState(
+                    podcast = podcast,
+                    episodeCount = 50,
+                ),
+                awaitItem(),
+            )
+        }
+    }
+}

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -1997,7 +1997,7 @@ up    <string name="player_sleep_in_one_chapter">Sleeping in 1 chapter</string>
 
     <!--  Sharing  -->
     <string name="share_podcast_title" translatable="false">@string/share_podcast</string>
-    <string name="share_podcast_description">Chose a format and a platform to share to</string>
+    <string name="share_podcast_description">Choose a format and a platform to share to</string>
     <string name="share_via">Share via %s</string>
     <string name="share_label_instagram_stories">Stories</string>
     <string name="share_label_whats_app" translatable="false">WhatsApp</string>

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -1996,6 +1996,8 @@ up    <string name="player_sleep_in_one_chapter">Sleeping in 1 chapter</string>
     <string name="nova_launcher_up_next" translatable="false">@string/up_next</string>
 
     <!--  Sharing  -->
+    <string name="share_podcast_title" translatable="false">@string/share_podcast</string>
+    <string name="share_podcast_description">Chose a format and a platform to share to</string>
     <string name="share_label_instagram_stories">Stories</string>
     <string name="share_label_whats_app" translatable="false">WhatsApp</string>
     <string name="share_label_telegram" translatable="false">Telegram</string>

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -1998,11 +1998,12 @@ up    <string name="player_sleep_in_one_chapter">Sleeping in 1 chapter</string>
     <!--  Sharing  -->
     <string name="share_podcast_title" translatable="false">@string/share_podcast</string>
     <string name="share_podcast_description">Chose a format and a platform to share to</string>
+    <string name="share_via">Share via %s</string>
     <string name="share_label_instagram_stories">Stories</string>
     <string name="share_label_whats_app" translatable="false">WhatsApp</string>
     <string name="share_label_telegram" translatable="false">Telegram</string>
     <string name="share_label_x" translatable="false">X</string>
     <string name="share_label_tumblr" translatable="false">Tumblr</string>
     <string name="share_label_copy_link">Copy link</string>
-    <string name="share_label_more">More</string>
+    <string name="share_label_more" translatable="false">@string/more</string>
 </resources>

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PodcastManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PodcastManager.kt
@@ -56,6 +56,7 @@ interface PodcastManager {
 
     fun exists(podcastUuid: String): Boolean
     fun observeEpisodeCountByEpisodeUuid(uuid: String): Flow<Int>
+    fun observeEpisodeCountByPodcatUuid(uuid: String): Flow<Int>
 
     /** Add methods  */
     fun subscribeToPodcast(podcastUuid: String, sync: Boolean)

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PodcastManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PodcastManagerImpl.kt
@@ -200,6 +200,10 @@ class PodcastManagerImpl @Inject constructor(
         }
     }
 
+    override fun observeEpisodeCountByPodcatUuid(uuid: String): Flow<Int> {
+        return podcastDao.episodeCount(uuid)
+    }
+
     override fun refreshPodcastsIfRequired(fromLog: String) {
         // if it's been more than 5 minutes since the last refresh, do another one
         val lastUpdateTime = settings.getLastRefreshTime()

--- a/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/fragments/BaseDialogFragment.kt
+++ b/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/fragments/BaseDialogFragment.kt
@@ -2,9 +2,14 @@ package au.com.shiftyjelly.pocketcasts.views.fragments
 
 import android.app.Dialog
 import android.content.DialogInterface
+import android.content.res.ColorStateList
 import android.os.Bundle
 import android.view.View
 import android.widget.FrameLayout
+import androidx.annotation.ColorInt
+import androidx.compose.ui.graphics.luminance
+import androidx.core.graphics.ColorUtils
+import androidx.core.view.WindowInsetsControllerCompat
 import androidx.core.view.doOnLayout
 import androidx.navigation.NavHostController
 import au.com.shiftyjelly.pocketcasts.ui.extensions.getThemeColor
@@ -110,5 +115,18 @@ open class BaseDialogFragment : BottomSheetDialogFragment(), CoroutineScope {
                 }
             }
         }
+    }
+
+    protected fun styleBackgroundColor(@ColorInt color: Int) {
+        val luminance = ColorUtils.calculateLuminance(color)
+        requireActivity().window?.let { activityWindow ->
+            activityWindow.statusBarColor = color
+            WindowInsetsControllerCompat(activityWindow, activityWindow.decorView).isAppearanceLightStatusBars = luminance > 0.5f
+        }
+        requireDialog().window?.let { dialogWindow ->
+            dialogWindow.navigationBarColor = color
+            WindowInsetsControllerCompat(dialogWindow, dialogWindow.decorView).isAppearanceLightNavigationBars = luminance > 0.5f
+        }
+        bottomSheetView()?.backgroundTintList = ColorStateList.valueOf(color)
     }
 }


### PR DESCRIPTION
## Description

This PR displays podcast reimagine sharing page. It is only UI and without view pager for card selection. Also, the issue with tablets described [here](https://github.com/Automattic/pocket-casts-android/pull/2518#pullrequestreview-2198387211) should be fixed now.

Designs: HR2vcQrWcS0scsolKZBitg-fi-2203_2359

## Testing Instructions

1. Share a podcast.
2. Verify the UI and the page's behavior.

Because it is the first integration of social platforms bar you can also test it. Check if the app detects correctly if the apps installed on your device. Note that the page doesn't update itself live for installed apps. You need to reopen the page to verify installations.

## Screenshots or Screencast 

| Portrait | Landscape |
| - | - |
| ![Screenshot_20240725-121040](https://github.com/user-attachments/assets/2e3545cf-f8a1-4950-a383-ee92adad59f8) | ![Screenshot_20240725-121825](https://github.com/user-attachments/assets/b668d2df-5220-41cc-9a35-0c5fe7de51cd) |

## Checklist
- [x] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack