### PR TITLE
Display episode sharing UI

### DIFF
--- a/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/episode/ShareEpisodeFragment.kt
+++ b/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/episode/ShareEpisodeFragment.kt
@@ -3,54 +3,69 @@ package au.com.shiftyjelly.pocketcasts.sharing.episode
 import android.os.Bundle
 import android.os.Parcelable
 import android.view.LayoutInflater
+import android.view.View
 import android.view.ViewGroup
 import androidx.annotation.ColorInt
 import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.material.Text
-import androidx.compose.ui.Alignment
-import androidx.compose.ui.Modifier
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.platform.ComposeView
-import androidx.compose.ui.unit.sp
 import androidx.core.os.BundleCompat
 import androidx.core.os.bundleOf
+import androidx.fragment.app.viewModels
 import au.com.shiftyjelly.pocketcasts.analytics.SourceView
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
+import au.com.shiftyjelly.pocketcasts.sharing.social.SocialPlatform
+import au.com.shiftyjelly.pocketcasts.sharing.ui.ShareColors
 import au.com.shiftyjelly.pocketcasts.utils.parceler.ColorParceler
 import au.com.shiftyjelly.pocketcasts.views.fragments.BaseDialogFragment
+import dagger.hilt.android.lifecycle.withCreationCallback
 import kotlinx.parcelize.Parcelize
 import kotlinx.parcelize.TypeParceler
 
 class ShareEpisodeFragment : BaseDialogFragment() {
     private val args get() = requireNotNull(arguments?.let { BundleCompat.getParcelable(it, NEW_INSTANCE_ARG, Args::class.java) })
 
+    private val shareColors get() = ShareColors(args.baseColor)
+
+    private val viewModel by viewModels<ShareEpisodeViewModel>(
+        extrasProducer = {
+            defaultViewModelCreationExtras.withCreationCallback<ShareEpisodeViewModel.Factory> { factory ->
+                factory.create(args.episodeUuid)
+            }
+        },
+    )
+
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
         savedInstanceState: Bundle?,
     ) = ComposeView(requireActivity()).apply {
+        val platforms = SocialPlatform.getAvailablePlatforms(requireContext())
+        val listener = ShareEpisodeListener(this@ShareEpisodeFragment)
         setContent {
-            Box(
-                contentAlignment = Alignment.Center,
-                modifier = Modifier
-                    .background(Color.Black)
-                    .fillMaxSize(),
-            ) {
-                Text(
-                    text = "Share episode: ${args.episodeUuid}",
-                    fontSize = 24.sp,
-                    color = Color.White,
-                )
-            }
+            val uiState by viewModel.uiState.collectAsState()
+            ShareEpisodePage(
+                podcast = uiState.podcast,
+                episode = uiState.episode,
+                useEpisodeArtwork = uiState.useEpisodeArtwork,
+                socialPlatforms = platforms,
+                shareColors = shareColors,
+                listener = listener,
+            )
         }
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        styleBackgroundColor(shareColors.background.toArgb())
     }
 
     @Parcelize
     private class Args(
         val episodeUuid: String,
-        val podcastUuid: String,
         @TypeParceler<Color, ColorParceler>() val baseColor: Color,
         val source: SourceView,
     ) : Parcelable
@@ -66,7 +81,6 @@ class ShareEpisodeFragment : BaseDialogFragment() {
             arguments = bundleOf(
                 NEW_INSTANCE_ARG to Args(
                     episodeUuid = episode.uuid,
-                    podcastUuid = episode.podcastUuid,
                     baseColor = Color(baseColor),
                     source = source,
                 ),

--- a/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/episode/ShareEpisodeListener.kt
+++ b/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/episode/ShareEpisodeListener.kt
@@ -1,0 +1,18 @@
+package au.com.shiftyjelly.pocketcasts.sharing.episode
+
+import android.widget.Toast
+import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
+import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
+import au.com.shiftyjelly.pocketcasts.sharing.social.SocialPlatform
+
+internal class ShareEpisodeListener(
+    private val fragment: ShareEpisodeFragment,
+) : ShareEpisodePageListener {
+    override fun onShare(podcast: Podcast, episode: PodcastEpisode, platform: SocialPlatform) {
+        Toast.makeText(fragment.requireActivity(), "Share ${episode.title} to $platform", Toast.LENGTH_SHORT).show()
+    }
+
+    override fun onClose() {
+        fragment.dismiss()
+    }
+}

--- a/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/episode/ShareEpisodePage.kt
+++ b/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/episode/ShareEpisodePage.kt
@@ -1,0 +1,172 @@
+package au.com.shiftyjelly.pocketcasts.sharing.episode
+
+import android.content.res.Configuration
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
+import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
+import au.com.shiftyjelly.pocketcasts.sharing.social.SocialPlatform
+import au.com.shiftyjelly.pocketcasts.sharing.ui.Devices
+import au.com.shiftyjelly.pocketcasts.sharing.ui.HorizontalEpisodeCard
+import au.com.shiftyjelly.pocketcasts.sharing.ui.HorizontalSharePage
+import au.com.shiftyjelly.pocketcasts.sharing.ui.ShareColors
+import au.com.shiftyjelly.pocketcasts.sharing.ui.VerticalEpisodeCard
+import au.com.shiftyjelly.pocketcasts.sharing.ui.VerticalSharePage
+import com.airbnb.android.showkase.annotation.ShowkaseComposable
+import java.sql.Date
+import java.time.Instant
+import au.com.shiftyjelly.pocketcasts.localization.R as LR
+
+internal interface ShareEpisodePageListener {
+    fun onShare(podcast: Podcast, episode: PodcastEpisode, platform: SocialPlatform)
+    fun onClose()
+
+    companion object {
+        val Preview = object : ShareEpisodePageListener {
+            override fun onShare(podcast: Podcast, episode: PodcastEpisode, platform: SocialPlatform) = Unit
+            override fun onClose() = Unit
+        }
+    }
+}
+
+@Composable
+internal fun ShareEpisodePage(
+    podcast: Podcast?,
+    episode: PodcastEpisode?,
+    useEpisodeArtwork: Boolean,
+    socialPlatforms: Set<SocialPlatform>,
+    shareColors: ShareColors,
+    listener: ShareEpisodePageListener,
+) = when (LocalConfiguration.current.orientation) {
+    Configuration.ORIENTATION_LANDSCAPE -> HorizontalShareEpisodePage(
+        podcast = podcast,
+        episode = episode,
+        useEpisodeArtwork = useEpisodeArtwork,
+        socialPlatforms = socialPlatforms,
+        shareColors = shareColors,
+        listener = listener,
+    )
+    else -> VerticalShareEpisodePage(
+        podcast = podcast,
+        episode = episode,
+        useEpisodeArtwork = useEpisodeArtwork,
+        socialPlatforms = socialPlatforms,
+        shareColors = shareColors,
+        listener = listener,
+    )
+}
+
+@Composable
+private fun VerticalShareEpisodePage(
+    podcast: Podcast?,
+    episode: PodcastEpisode?,
+    useEpisodeArtwork: Boolean,
+    socialPlatforms: Set<SocialPlatform>,
+    shareColors: ShareColors,
+    listener: ShareEpisodePageListener,
+) = VerticalSharePage(
+    shareTitle = stringResource(LR.string.share_episode_title),
+    shareDescription = stringResource(LR.string.share_episode_description),
+    shareColors = shareColors,
+    socialPlatforms = socialPlatforms,
+    onClose = listener::onClose,
+    onShareToPlatform = { platfrom ->
+        if (podcast != null && episode != null) {
+            listener.onShare(podcast, episode, platfrom)
+        }
+    },
+    middleContent = {
+        if (podcast != null && episode != null) {
+            VerticalEpisodeCard(
+                podcast = podcast,
+                episode = episode,
+                useEpisodeArtwork = useEpisodeArtwork,
+                shareColors = shareColors,
+            )
+        }
+    },
+)
+
+@Composable
+private fun HorizontalShareEpisodePage(
+    podcast: Podcast?,
+    episode: PodcastEpisode?,
+    useEpisodeArtwork: Boolean,
+    socialPlatforms: Set<SocialPlatform>,
+    shareColors: ShareColors,
+    listener: ShareEpisodePageListener,
+) = HorizontalSharePage(
+    shareTitle = stringResource(LR.string.share_episode_title),
+    shareDescription = stringResource(LR.string.share_episode_description),
+    shareColors = shareColors,
+    socialPlatforms = socialPlatforms,
+    onClose = listener::onClose,
+    onShareToPlatform = { platfrom ->
+        if (podcast != null && episode != null) {
+            listener.onShare(podcast, episode, platfrom)
+        }
+    },
+    middleContent = {
+        if (podcast != null && episode != null) {
+            HorizontalEpisodeCard(
+                podcast = podcast,
+                episode = episode,
+                useEpisodeArtwork = useEpisodeArtwork,
+                shareColors = shareColors,
+            )
+        }
+    },
+)
+
+@ShowkaseComposable(name = "ShareEpisodeVerticalRegularPreview", group = "Sharing")
+@Preview(name = "ShareEpisodeVerticalRegularPreview", device = Devices.PortraitRegular)
+@Composable
+fun ShareEpisodeVerticalRegularPreview() = ShareEpisodePagePreview()
+
+@ShowkaseComposable(name = "ShareEpisodeVerticalSmallPreview", group = "Sharing")
+@Preview(name = "ShareEpisodeVerticalSmallPreview", device = Devices.PortraitSmall)
+@Composable
+fun ShareEpisodeVerticalSmallPreviewPreview() = ShareEpisodePagePreview()
+
+@ShowkaseComposable(name = "ShareEpisodeVerticalTabletPreview", group = "Sharing")
+@Preview(name = "ShareEpisodeVerticalTabletPreview", device = Devices.PortraitTablet)
+@Composable
+fun ShareEpisodeVerticalTabletPreview() = ShareEpisodePagePreview()
+
+@ShowkaseComposable(name = "ShareEpisodeHorizontalRegularPreview", group = "Sharing")
+@Preview(name = "ShareEpisodeHorizontalRegularPreview", device = Devices.LandscapeRegular)
+@Composable
+fun ShareEpisodeHorizontalRegularPreview() = ShareEpisodePagePreview()
+
+@ShowkaseComposable(name = "ShareEpisodeHorizontalSmallPreview", group = "Sharing")
+@Preview(name = "ShareEpisodeHorizontalSmallPreview", device = Devices.LandscapeSmall)
+@Composable
+fun ShareEpisodeHorizontalSmallPreviewPreview() = ShareEpisodePagePreview()
+
+@ShowkaseComposable(name = "ShareEpisodeHorizontalTabletPreview", group = "Sharing")
+@Preview(name = "ShareEpisodeHorizontalTabletPreview", device = Devices.LandscapeTablet)
+@Composable
+fun ShareEpisodeHorizontalTabletPreview() = ShareEpisodePagePreview()
+
+@Composable
+private fun ShareEpisodePagePreview(
+    color: Long = 0xFFEC0404,
+) = ShareEpisodePage(
+    podcast = Podcast(
+        uuid = "podcast-id",
+        title = "Podcast title",
+    ),
+    episode = PodcastEpisode(
+        uuid = "episode-id",
+        podcastUuid = "podcast-id",
+        publishedDate = Date.from(Instant.parse("2024-12-03T10:15:30.00Z")),
+        title = "Episode title",
+    ),
+    useEpisodeArtwork = false,
+    socialPlatforms = SocialPlatform.entries.toSet(),
+    shareColors = ShareColors(Color(color)),
+    listener = ShareEpisodePageListener.Preview,
+)

--- a/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/episode/ShareEpisodeViewModel.kt
+++ b/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/episode/ShareEpisodeViewModel.kt
@@ -1,0 +1,43 @@
+package au.com.shiftyjelly.pocketcasts.sharing.episode
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
+import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
+import au.com.shiftyjelly.pocketcasts.preferences.Settings
+import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
+import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedFactory
+import dagger.assisted.AssistedInject
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
+
+@HiltViewModel(assistedFactory = ShareEpisodeViewModel.Factory::class)
+class ShareEpisodeViewModel @AssistedInject constructor(
+    @Assisted episodeUuid: String,
+    private val episodeManager: EpisodeManager,
+    private val podcastManager: PodcastManager,
+    private val settings: Settings,
+) : ViewModel() {
+    val uiState = combine(
+        podcastManager.observePodcastByEpisodeUuid(episodeUuid),
+        episodeManager.observeByUuid(episodeUuid),
+        settings.artworkConfiguration.flow.map { it.useEpisodeArtwork },
+        ::UiState,
+    ).stateIn(viewModelScope, started = SharingStarted.Lazily, initialValue = UiState())
+
+    data class UiState(
+        val podcast: Podcast? = null,
+        val episode: PodcastEpisode? = null,
+        val useEpisodeArtwork: Boolean = false,
+    )
+
+    @AssistedFactory
+    interface Factory {
+        fun create(episodeUuid: String): ShareEpisodeViewModel
+    }
+}

--- a/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/podcast/SharePodcastFragment.kt
+++ b/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/podcast/SharePodcastFragment.kt
@@ -5,7 +5,6 @@ import android.os.Parcelable
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import androidx.compose.foundation.background
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.graphics.Color

--- a/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/podcast/SharePodcastPage.kt
+++ b/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/podcast/SharePodcastPage.kt
@@ -1,36 +1,19 @@
 package au.com.shiftyjelly.pocketcasts.sharing.podcast
 
 import android.content.res.Configuration
-import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxHeight
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.sizeIn
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
-import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.unit.dp
-import au.com.shiftyjelly.pocketcasts.compose.components.TextH30
-import au.com.shiftyjelly.pocketcasts.compose.components.TextH40
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
-import au.com.shiftyjelly.pocketcasts.sharing.social.PlatformBar
 import au.com.shiftyjelly.pocketcasts.sharing.social.SocialPlatform
-import au.com.shiftyjelly.pocketcasts.sharing.ui.CloseButton
 import au.com.shiftyjelly.pocketcasts.sharing.ui.Devices
 import au.com.shiftyjelly.pocketcasts.sharing.ui.HorizontalPodcastCast
+import au.com.shiftyjelly.pocketcasts.sharing.ui.HorizontalSharePage
 import au.com.shiftyjelly.pocketcasts.sharing.ui.ShareColors
 import au.com.shiftyjelly.pocketcasts.sharing.ui.VerticalPodcastCast
+import au.com.shiftyjelly.pocketcasts.sharing.ui.VerticalSharePage
 import com.airbnb.android.showkase.annotation.ShowkaseComposable
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
@@ -77,50 +60,18 @@ private fun VerticalSharePodcastPage(
     socialPlatforms: Set<SocialPlatform>,
     shareColors: ShareColors,
     listener: SharePodcastPageListener,
-) = Column(
-    modifier = Modifier
-        .fillMaxSize()
-        .background(shareColors.background),
-) {
-    Box(
-        contentAlignment = Alignment.TopEnd,
-        modifier = Modifier
-            .weight(0.2f)
-            .fillMaxSize(),
-    ) {
-        CloseButton(
-            shareColors = shareColors,
-            onClick = listener::onClose,
-            modifier = Modifier.padding(top = 12.dp, end = 12.dp),
-        )
-        Column(
-            horizontalAlignment = Alignment.CenterHorizontally,
-            verticalArrangement = Arrangement.Center,
-            modifier = Modifier.fillMaxSize(),
-        ) {
-            TextH30(
-                text = stringResource(LR.string.share_podcast_title),
-                textAlign = TextAlign.Center,
-                color = shareColors.backgroundPrimaryText,
-                modifier = Modifier.sizeIn(maxWidth = 220.dp),
-            )
-            Spacer(
-                modifier = Modifier.height(8.dp),
-            )
-            TextH40(
-                text = stringResource(LR.string.share_podcast_description),
-                textAlign = TextAlign.Center,
-                color = shareColors.backgroundSecondaryText,
-                modifier = Modifier.sizeIn(maxWidth = 220.dp),
-            )
+) = VerticalSharePage(
+    shareTitle = stringResource(LR.string.share_podcast_title),
+    shareDescription = stringResource(LR.string.share_podcast_description),
+    shareColors = shareColors,
+    socialPlatforms = socialPlatforms,
+    onClose = listener::onClose,
+    onShareToPlatform = { platfrom ->
+        if (podcast != null) {
+            listener.onShare(podcast, platfrom)
         }
-    }
-    Box(
-        contentAlignment = Alignment.Center,
-        modifier = Modifier
-            .weight(0.6f)
-            .fillMaxSize(),
-    ) {
+    },
+    middleContent = {
         if (podcast != null) {
             VerticalPodcastCast(
                 podcast = podcast,
@@ -128,18 +79,8 @@ private fun VerticalSharePodcastPage(
                 shareColors = shareColors,
             )
         }
-    }
-    Box(
-        contentAlignment = Alignment.Center,
-        modifier = Modifier.weight(0.18f),
-    ) {
-        PlatformBar(socialPlatforms, shareColors) { platform ->
-            if (podcast != null) {
-                listener.onShare(podcast, platform)
-            }
-        }
-    }
-}
+    },
+)
 
 @Composable
 private fun HorizontalSharePodcastPage(
@@ -148,117 +89,60 @@ private fun HorizontalSharePodcastPage(
     socialPlatforms: Set<SocialPlatform>,
     shareColors: ShareColors,
     listener: SharePodcastPageListener,
-) = Column(
-    modifier = Modifier
-        .fillMaxSize()
-        .background(shareColors.background),
-) {
-    Box(
-        contentAlignment = Alignment.TopEnd,
-        modifier = Modifier
-            .weight(0.25f)
-            .fillMaxSize(),
-    ) {
-        CloseButton(
-            shareColors = shareColors,
-            onClick = listener::onClose,
-            modifier = Modifier.padding(top = 12.dp, end = 12.dp),
-        )
-        Column(
-            horizontalAlignment = Alignment.CenterHorizontally,
-            verticalArrangement = Arrangement.Center,
-            modifier = Modifier.fillMaxSize(),
-        ) {
-            TextH30(
-                text = stringResource(LR.string.share_podcast_title),
-                textAlign = TextAlign.Center,
-                color = shareColors.backgroundPrimaryText,
-            )
-            Spacer(
-                modifier = Modifier.height(8.dp),
-            )
-            TextH40(
-                text = stringResource(LR.string.share_podcast_description),
-                textAlign = TextAlign.Center,
-                color = shareColors.backgroundSecondaryText,
+) = HorizontalSharePage(
+    shareTitle = stringResource(LR.string.share_podcast_title),
+    shareDescription = stringResource(LR.string.share_podcast_description),
+    shareColors = shareColors,
+    socialPlatforms = socialPlatforms,
+    onClose = listener::onClose,
+    onShareToPlatform = { platfrom ->
+        if (podcast != null) {
+            listener.onShare(podcast, platfrom)
+        }
+    },
+    middleContent = {
+        if (podcast != null) {
+            HorizontalPodcastCast(
+                podcast = podcast,
+                episodeCount = episodeCount,
+                shareColors = shareColors,
             )
         }
-    }
-    Row(
-        modifier = Modifier
-            .weight(0.75f)
-            .fillMaxSize(),
-    ) {
-        Spacer(
-            modifier = Modifier.weight(0.1f),
-        )
-        Box(
-            contentAlignment = Alignment.Center,
-            modifier = Modifier
-                .weight(1f)
-                .fillMaxHeight(),
-        ) {
-            if (podcast != null) {
-                HorizontalPodcastCast(
-                    podcast = podcast,
-                    episodeCount = episodeCount,
-                    shareColors = shareColors,
-                )
-            }
-        }
-        Spacer(
-            modifier = Modifier.weight(0.1f),
-        )
-        Box(
-            contentAlignment = Alignment.Center,
-            modifier = Modifier
-                .weight(1f)
-                .fillMaxHeight(),
-        ) {
-            PlatformBar(socialPlatforms, shareColors) { platform ->
-                if (podcast != null) {
-                    listener.onShare(podcast, platform)
-                }
-            }
-        }
-        Spacer(
-            modifier = Modifier.weight(0.1f),
-        )
-    }
-}
+    },
+)
 
-@ShowkaseComposable(name = "SharePodcastVerticalRegularPreview", group = "Podcast")
+@ShowkaseComposable(name = "SharePodcastVerticalRegularPreview", group = "Sharing")
 @Preview(name = "SharePodcastVerticalRegularPreview", device = Devices.PortraitRegular)
 @Composable
 fun SharePodcastVerticalRegularPreview() = SharePodcastPagePreview()
 
-@ShowkaseComposable(name = "SharePodcastVerticalSmallPreview", group = "Podcast")
+@ShowkaseComposable(name = "SharePodcastVerticalSmallPreview", group = "Sharing")
 @Preview(name = "SharePodcastVerticalSmallPreview", device = Devices.PortraitSmall)
 @Composable
 fun SharePodcastVerticalSmallPreviewPreview() = SharePodcastPagePreview()
 
-@ShowkaseComposable(name = "SharePodcastVerticalTabletPreview", group = "Podcast")
+@ShowkaseComposable(name = "SharePodcastVerticalTabletPreview", group = "Sharing")
 @Preview(name = "SharePodcastVerticalTabletPreview", device = Devices.PortraitTablet)
 @Composable
 fun SharePodcastVerticalTabletPreview() = SharePodcastPagePreview()
 
-@ShowkaseComposable(name = "SharePodcastHorizontalRegularPreview", group = "Podcast")
+@ShowkaseComposable(name = "SharePodcastHorizontalRegularPreview", group = "Sharing")
 @Preview(name = "SharePodcastHorizontalRegularPreview", device = Devices.LandscapeRegular)
 @Composable
 fun SharePodcastHorizontalRegularPreview() = SharePodcastPagePreview()
 
-@ShowkaseComposable(name = "SharePodcastHorizontalSmallPreview", group = "Podcast")
+@ShowkaseComposable(name = "SharePodcastHorizontalSmallPreview", group = "Sharing")
 @Preview(name = "SharePodcastHorizontalSmallPreview", device = Devices.LandscapeSmall)
 @Composable
 fun SharePodcastHorizontalSmallPreviewPreview() = SharePodcastPagePreview()
 
-@ShowkaseComposable(name = "SharePodcastHorizontalTabletPreview", group = "Podcast")
+@ShowkaseComposable(name = "SharePodcastHorizontalTabletPreview", group = "Sharing")
 @Preview(name = "SharePodcastHorizontalTabletPreview", device = Devices.LandscapeTablet)
 @Composable
 fun SharePodcastHorizontalTabletPreview() = SharePodcastPagePreview()
 
 @Composable
-internal fun SharePodcastPagePreview(
+private fun SharePodcastPagePreview(
     color: Long = 0xFFEC0404,
 ) = SharePodcastPage(
     podcast = Podcast(

--- a/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/ui/SharePage.kt
+++ b/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/ui/SharePage.kt
@@ -1,0 +1,172 @@
+package au.com.shiftyjelly.pocketcasts.sharing.ui
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxScope
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.sizeIn
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import au.com.shiftyjelly.pocketcasts.compose.components.TextH30
+import au.com.shiftyjelly.pocketcasts.compose.components.TextH40
+import au.com.shiftyjelly.pocketcasts.sharing.social.PlatformBar
+import au.com.shiftyjelly.pocketcasts.sharing.social.SocialPlatform
+
+@Composable
+internal fun VerticalSharePage(
+    shareTitle: String,
+    shareDescription: String,
+    shareColors: ShareColors,
+    socialPlatforms: Set<SocialPlatform>,
+    onClose: () -> Unit,
+    onShareToPlatform: (SocialPlatform) -> Unit,
+    middleContent: @Composable BoxScope.() -> Unit,
+) = Column(
+    modifier = Modifier
+        .fillMaxSize()
+        .background(shareColors.background),
+) {
+    Box(
+        contentAlignment = Alignment.TopEnd,
+        modifier = Modifier
+            .weight(0.2f)
+            .fillMaxSize(),
+    ) {
+        CloseButton(
+            shareColors = shareColors,
+            onClick = onClose,
+            modifier = Modifier.padding(top = 12.dp, end = 12.dp),
+        )
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Center,
+            modifier = Modifier.fillMaxSize(),
+        ) {
+            TextH30(
+                text = shareTitle,
+                textAlign = TextAlign.Center,
+                color = shareColors.backgroundPrimaryText,
+                modifier = Modifier.padding(horizontal = 24.dp),
+            )
+            Spacer(
+                modifier = Modifier.height(8.dp),
+            )
+            TextH40(
+                text = shareDescription,
+                textAlign = TextAlign.Center,
+                color = shareColors.backgroundSecondaryText,
+                modifier = Modifier.sizeIn(maxWidth = 220.dp),
+            )
+        }
+    }
+    Box(
+        contentAlignment = Alignment.Center,
+        content = middleContent,
+        modifier = Modifier
+            .weight(0.6f)
+            .fillMaxSize(),
+    )
+    Box(
+        contentAlignment = Alignment.Center,
+        modifier = Modifier.weight(0.2f),
+    ) {
+        PlatformBar(
+            platforms = socialPlatforms,
+            shareColors = shareColors,
+            onClick = onShareToPlatform,
+        )
+    }
+}
+
+@Composable
+internal fun HorizontalSharePage(
+    shareTitle: String,
+    shareDescription: String,
+    shareColors: ShareColors,
+    socialPlatforms: Set<SocialPlatform>,
+    onClose: () -> Unit,
+    onShareToPlatform: (SocialPlatform) -> Unit,
+    middleContent: @Composable BoxScope.() -> Unit,
+) = Column(
+    modifier = Modifier
+        .fillMaxSize()
+        .background(shareColors.background),
+) {
+    Box(
+        contentAlignment = Alignment.TopEnd,
+        modifier = Modifier
+            .weight(0.25f)
+            .fillMaxSize(),
+    ) {
+        CloseButton(
+            shareColors = shareColors,
+            onClick = onClose,
+            modifier = Modifier.padding(top = 12.dp, end = 12.dp),
+        )
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Center,
+            modifier = Modifier.fillMaxSize(),
+        ) {
+            TextH30(
+                text = shareTitle,
+                textAlign = TextAlign.Center,
+                color = shareColors.backgroundPrimaryText,
+                modifier = Modifier.padding(horizontal = 24.dp),
+            )
+            Spacer(
+                modifier = Modifier.height(8.dp),
+            )
+            TextH40(
+                text = shareDescription,
+                textAlign = TextAlign.Center,
+                color = shareColors.backgroundSecondaryText,
+                modifier = Modifier.padding(horizontal = 24.dp),
+            )
+        }
+    }
+    Row(
+        modifier = Modifier
+            .weight(0.75f)
+            .fillMaxSize(),
+    ) {
+        Spacer(
+            modifier = Modifier.weight(0.1f),
+        )
+        Box(
+            contentAlignment = Alignment.Center,
+            content = middleContent,
+            modifier = Modifier
+                .weight(1f)
+                .fillMaxHeight(),
+        )
+        Spacer(
+            modifier = Modifier.weight(0.1f),
+        )
+        Box(
+            contentAlignment = Alignment.Center,
+            modifier = Modifier
+                .weight(1f)
+                .fillMaxHeight(),
+        ) {
+            PlatformBar(
+                platforms = socialPlatforms,
+                shareColors = shareColors,
+                onClick = onShareToPlatform,
+            )
+        }
+        Spacer(
+            modifier = Modifier.weight(0.1f),
+        )
+    }
+}

--- a/modules/features/sharing/src/test/kotlin/au/com/shiftyjelly/pocketcasts/sharing/episode/ShareEpisodeViewModelTest.kt
+++ b/modules/features/sharing/src/test/kotlin/au/com/shiftyjelly/pocketcasts/sharing/episode/ShareEpisodeViewModelTest.kt
@@ -1,0 +1,68 @@
+package au.com.shiftyjelly.pocketcasts.sharing.episode
+
+import app.cash.turbine.test
+import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
+import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
+import au.com.shiftyjelly.pocketcasts.preferences.Settings
+import au.com.shiftyjelly.pocketcasts.preferences.UserSetting
+import au.com.shiftyjelly.pocketcasts.preferences.model.ArtworkConfiguration
+import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
+import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
+import au.com.shiftyjelly.pocketcasts.sharedtest.MainCoroutineRule
+import au.com.shiftyjelly.pocketcasts.sharing.episode.ShareEpisodeViewModel.UiState
+import java.util.Date
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+
+@ExperimentalCoroutinesApi
+class ShareEpisodeViewModelTest {
+    @get:Rule
+    val coroutineRule = MainCoroutineRule()
+
+    private val episodeManager = mock<EpisodeManager>()
+    private val podcastManager = mock<PodcastManager>()
+    private val settings = mock<Settings>()
+
+    private val episode = PodcastEpisode(uuid = "episode-id", podcastUuid = "podcast-id", publishedDate = Date())
+    private val podcast = Podcast(uuid = "podcast-id", title = "Podcast Title")
+
+    private lateinit var viewModel: ShareEpisodeViewModel
+
+    @Before
+    fun setUp() {
+        whenever(episodeManager.observeByUuid("episode-id")).thenReturn(flowOf(episode))
+        whenever(podcastManager.observePodcastByEpisodeUuid("episode-id")).thenReturn(flowOf(podcast))
+        val artworkSetting = mock<UserSetting<ArtworkConfiguration>>()
+        whenever(artworkSetting.flow).thenReturn(MutableStateFlow(ArtworkConfiguration(useEpisodeArtwork = true)))
+        whenever(settings.artworkConfiguration).thenReturn(artworkSetting)
+
+        viewModel = ShareEpisodeViewModel(
+            episode.uuid,
+            episodeManager,
+            podcastManager,
+            settings,
+        )
+    }
+
+    @Test
+    fun `get UI state`() = runTest {
+        viewModel.uiState.test {
+            assertEquals(
+                UiState(
+                    podcast = podcast,
+                    episode = episode,
+                    useEpisodeArtwork = true,
+                ),
+                awaitItem(),
+            )
+        }
+    }
+}

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -1998,6 +1998,8 @@ up    <string name="player_sleep_in_one_chapter">Sleeping in 1 chapter</string>
     <!--  Sharing  -->
     <string name="share_podcast_title" translatable="false">@string/share_podcast</string>
     <string name="share_podcast_description">Choose a format and a platform to share to</string>
+    <string name="share_episode_title" translatable="false">@string/podcast_share_episode</string>
+    <string name="share_episode_description" translatable="false">@string/share_podcast_description</string>
     <string name="share_via">Share via %s</string>
     <string name="share_label_instagram_stories">Stories</string>
     <string name="share_label_whats_app" translatable="false">WhatsApp</string>


### PR DESCRIPTION
## Description

This PR displays episode reimagine sharing page. It is only UI and without view pager for card selection.

Designs: HR2vcQrWcS0scsolKZBitg-fi-2203_2362

## Testing Instructions

1. Share an episode.
2. Verify the UI and the page's behavior.

## Screenshots or Screencast 

| Portrait | Landscape |
| - | - |
| ![Screenshot_20240725-142250](https://github.com/user-attachments/assets/d13dd262-ce05-464f-af71-af995ebdc60c) | ![Screenshot_20240725-142258](https://github.com/user-attachments/assets/803c02e1-8cf3-4622-ba67-8dfb5fea2957) |

## Checklist
- [x] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack