### PR TITLE
 Display episode timestamp sharing UI

### DIFF
--- a/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/timestamp/ShareEpisodeTimestampFragment.kt
+++ b/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/timestamp/ShareEpisodeTimestampFragment.kt
@@ -3,24 +3,26 @@ package au.com.shiftyjelly.pocketcasts.sharing.timestamp
 import android.os.Bundle
 import android.os.Parcelable
 import android.view.LayoutInflater
+import android.view.View
 import android.view.ViewGroup
 import androidx.annotation.ColorInt
 import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.material.Text
-import androidx.compose.ui.Alignment
-import androidx.compose.ui.Modifier
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.platform.ComposeView
-import androidx.compose.ui.unit.sp
 import androidx.core.os.BundleCompat
 import androidx.core.os.bundleOf
+import androidx.fragment.app.viewModels
 import au.com.shiftyjelly.pocketcasts.analytics.SourceView
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
+import au.com.shiftyjelly.pocketcasts.sharing.social.SocialPlatform
+import au.com.shiftyjelly.pocketcasts.sharing.ui.ShareColors
 import au.com.shiftyjelly.pocketcasts.utils.parceler.ColorParceler
 import au.com.shiftyjelly.pocketcasts.utils.parceler.DurationParceler
 import au.com.shiftyjelly.pocketcasts.views.fragments.BaseDialogFragment
+import dagger.hilt.android.lifecycle.withCreationCallback
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
 import kotlinx.parcelize.Parcelize
@@ -29,35 +31,49 @@ import kotlinx.parcelize.TypeParceler
 class ShareEpisodeTimestampFragment : BaseDialogFragment() {
     private val args get() = requireNotNull(arguments?.let { BundleCompat.getParcelable(it, NEW_INSTANCE_ARG, Args::class.java) })
 
+    private val shareColors get() = ShareColors(args.baseColor)
+
+    private val viewModel by viewModels<ShareEpisodeTimestampViewModel>(
+        extrasProducer = {
+            defaultViewModelCreationExtras.withCreationCallback<ShareEpisodeTimestampViewModel.Factory> { factory ->
+                factory.create(args.episodeUuid)
+            }
+        },
+    )
+
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
         savedInstanceState: Bundle?,
     ) = ComposeView(requireActivity()).apply {
+        val platforms = SocialPlatform.getAvailablePlatforms(requireContext())
+        val listener = ShareEpisodeTimestampListener(args.timestampType, this@ShareEpisodeTimestampFragment)
         setContent {
-            Box(
-                contentAlignment = Alignment.Center,
-                modifier = Modifier
-                    .background(Color.Black)
-                    .fillMaxSize(),
-            ) {
-                Text(
-                    text = "Share ${if (args.shareAsBookmark) "bookmark" else "episode timestamp"}: ${args.episodeUuid}",
-                    fontSize = 24.sp,
-                    color = Color.White,
-                )
-            }
+            val uiState by viewModel.uiState.collectAsState()
+            ShareEpisodeTimestampPage(
+                podcast = uiState.podcast,
+                episode = uiState.episode,
+                timestamp = args.timestamp,
+                useEpisodeArtwork = uiState.useEpisodeArtwork,
+                socialPlatforms = platforms,
+                shareColors = shareColors,
+                listener = listener,
+            )
         }
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        styleBackgroundColor(shareColors.background.toArgb())
     }
 
     @Parcelize
     private class Args(
         val episodeUuid: String,
-        val podcastUuid: String,
         @TypeParceler<Duration, DurationParceler>() val timestamp: Duration,
         @TypeParceler<Color, ColorParceler>() val baseColor: Color,
         val source: SourceView,
-        val shareAsBookmark: Boolean,
+        val timestampType: TimestampType,
     ) : Parcelable
 
     companion object {
@@ -71,11 +87,10 @@ class ShareEpisodeTimestampFragment : BaseDialogFragment() {
             arguments = bundleOf(
                 NEW_INSTANCE_ARG to Args(
                     episodeUuid = episode.uuid,
-                    podcastUuid = episode.podcastUuid,
                     timestamp = episode.playedUpTo.seconds,
                     baseColor = Color(baseColor),
                     source = source,
-                    shareAsBookmark = false,
+                    timestampType = TimestampType.Episode,
                 ),
             )
         }
@@ -89,11 +104,10 @@ class ShareEpisodeTimestampFragment : BaseDialogFragment() {
             arguments = bundleOf(
                 NEW_INSTANCE_ARG to Args(
                     episodeUuid = episode.uuid,
-                    podcastUuid = episode.podcastUuid,
                     timestamp = timestamp,
                     baseColor = Color(baseColor),
                     source = source,
-                    shareAsBookmark = true,
+                    timestampType = TimestampType.Bookmark,
                 ),
             )
         }

--- a/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/timestamp/ShareEpisodeTimestampListener.kt
+++ b/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/timestamp/ShareEpisodeTimestampListener.kt
@@ -1,0 +1,20 @@
+package au.com.shiftyjelly.pocketcasts.sharing.timestamp
+
+import android.widget.Toast
+import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
+import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
+import au.com.shiftyjelly.pocketcasts.sharing.social.SocialPlatform
+import kotlin.time.Duration
+
+internal class ShareEpisodeTimestampListener(
+    private val type: TimestampType,
+    private val fragment: ShareEpisodeTimestampFragment,
+) : ShareEpisodeTimestampPageListener {
+    override fun onShare(podcast: Podcast, episode: PodcastEpisode, timestamp: Duration, platform: SocialPlatform) {
+        Toast.makeText(fragment.requireActivity(), "Share $timestamp as $type to $platform", Toast.LENGTH_SHORT).show()
+    }
+
+    override fun onClose() {
+        fragment.dismiss()
+    }
+}

--- a/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/timestamp/ShareEpisodeTimestampPage.kt
+++ b/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/timestamp/ShareEpisodeTimestampPage.kt
@@ -1,0 +1,190 @@
+package au.com.shiftyjelly.pocketcasts.sharing.timestamp
+
+import android.content.res.Configuration
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
+import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
+import au.com.shiftyjelly.pocketcasts.sharing.social.SocialPlatform
+import au.com.shiftyjelly.pocketcasts.sharing.ui.Devices
+import au.com.shiftyjelly.pocketcasts.sharing.ui.HorizontalEpisodeCard
+import au.com.shiftyjelly.pocketcasts.sharing.ui.HorizontalSharePage
+import au.com.shiftyjelly.pocketcasts.sharing.ui.ShareColors
+import au.com.shiftyjelly.pocketcasts.sharing.ui.VerticalEpisodeCard
+import au.com.shiftyjelly.pocketcasts.sharing.ui.VerticalSharePage
+import com.airbnb.android.showkase.annotation.ShowkaseComposable
+import java.sql.Date
+import java.time.Instant
+import java.util.Locale
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.minutes
+import kotlin.time.Duration.Companion.seconds
+import au.com.shiftyjelly.pocketcasts.localization.R as LR
+
+internal interface ShareEpisodeTimestampPageListener {
+    fun onShare(podcast: Podcast, episode: PodcastEpisode, timestamp: Duration, platform: SocialPlatform)
+    fun onClose()
+
+    companion object {
+        val Preview = object : ShareEpisodeTimestampPageListener {
+            override fun onShare(podcast: Podcast, episode: PodcastEpisode, timestamp: Duration, platform: SocialPlatform) = Unit
+            override fun onClose() = Unit
+        }
+    }
+}
+
+@Composable
+internal fun ShareEpisodeTimestampPage(
+    podcast: Podcast?,
+    episode: PodcastEpisode?,
+    timestamp: Duration,
+    useEpisodeArtwork: Boolean,
+    socialPlatforms: Set<SocialPlatform>,
+    shareColors: ShareColors,
+    listener: ShareEpisodeTimestampPageListener,
+) = when (LocalConfiguration.current.orientation) {
+    Configuration.ORIENTATION_LANDSCAPE -> HorizontalShareEpisodeTimestampPage(
+        podcast = podcast,
+        episode = episode,
+        timestamp = timestamp,
+        useEpisodeArtwork = useEpisodeArtwork,
+        socialPlatforms = socialPlatforms,
+        shareColors = shareColors,
+        listener = listener,
+    )
+    else -> VerticalShareEpisodeTimestampPage(
+        podcast = podcast,
+        episode = episode,
+        timestamp = timestamp,
+        useEpisodeArtwork = useEpisodeArtwork,
+        socialPlatforms = socialPlatforms,
+        shareColors = shareColors,
+        listener = listener,
+    )
+}
+
+@Composable
+private fun VerticalShareEpisodeTimestampPage(
+    podcast: Podcast?,
+    episode: PodcastEpisode?,
+    useEpisodeArtwork: Boolean,
+    timestamp: Duration,
+    socialPlatforms: Set<SocialPlatform>,
+    shareColors: ShareColors,
+    listener: ShareEpisodeTimestampPageListener,
+) = VerticalSharePage(
+    shareTitle = stringResource(LR.string.share_episode_timestamp_title, timestamp.toHhMmSs()),
+    shareDescription = stringResource(LR.string.share_episode_timestamp_description),
+    shareColors = shareColors,
+    socialPlatforms = socialPlatforms,
+    onClose = listener::onClose,
+    onShareToPlatform = { platfrom ->
+        if (podcast != null && episode != null) {
+            listener.onShare(podcast, episode, timestamp, platfrom)
+        }
+    },
+    middleContent = {
+        if (podcast != null && episode != null) {
+            VerticalEpisodeCard(
+                podcast = podcast,
+                episode = episode,
+                useEpisodeArtwork = useEpisodeArtwork,
+                shareColors = shareColors,
+            )
+        }
+    },
+)
+
+@Composable
+private fun HorizontalShareEpisodeTimestampPage(
+    podcast: Podcast?,
+    episode: PodcastEpisode?,
+    timestamp: Duration,
+    useEpisodeArtwork: Boolean,
+    socialPlatforms: Set<SocialPlatform>,
+    shareColors: ShareColors,
+    listener: ShareEpisodeTimestampPageListener,
+) = HorizontalSharePage(
+    shareTitle = stringResource(LR.string.share_episode_timestamp_title, timestamp.toHhMmSs()),
+    shareDescription = stringResource(LR.string.share_episode_timestamp_description),
+    shareColors = shareColors,
+    socialPlatforms = socialPlatforms,
+    onClose = listener::onClose,
+    onShareToPlatform = { platfrom ->
+        if (podcast != null && episode != null) {
+            listener.onShare(podcast, episode, timestamp, platfrom)
+        }
+    },
+    middleContent = {
+        if (podcast != null && episode != null) {
+            HorizontalEpisodeCard(
+                podcast = podcast,
+                episode = episode,
+                useEpisodeArtwork = useEpisodeArtwork,
+                shareColors = shareColors,
+            )
+        }
+    },
+)
+
+private fun Duration.toHhMmSs() = toComponents { hours, minutes, seconds, _ ->
+    if (hours == 0L) {
+        String.format(Locale.ROOT, "%02d:%02d", minutes, seconds)
+    } else {
+        String.format(Locale.ROOT, "%02d:%02d:%02d", hours, minutes, seconds)
+    }
+}
+
+@ShowkaseComposable(name = "ShareEpisodeTimestampVerticalRegularPreview", group = "Sharing")
+@Preview(name = "ShareEpisodeTimestampVerticalRegularPreview", device = Devices.PortraitRegular)
+@Composable
+fun ShareEpisodeTimestampVerticalRegularPreview() = ShareEpisodeTimestampPagePreview()
+
+@ShowkaseComposable(name = "ShareEpisodeTimestampVerticalSmallPreview", group = "Sharing")
+@Preview(name = "ShareEpisodeTimestampVerticalSmallPreview", device = Devices.PortraitSmall)
+@Composable
+fun ShareEpisodeTimestampVerticalSmallPreviewPreview() = ShareEpisodeTimestampPagePreview()
+
+@ShowkaseComposable(name = "ShareEpisodeTimestampVerticalTabletPreview", group = "Sharing")
+@Preview(name = "ShareEpisodeTimestampVerticalTabletPreview", device = Devices.PortraitTablet)
+@Composable
+fun ShareEpisodeTimestampVerticalTabletPreview() = ShareEpisodeTimestampPagePreview()
+
+@ShowkaseComposable(name = "ShareEpisodeTimestampHorizontalRegularPreview", group = "Sharing")
+@Preview(name = "ShareEpisodeTimestampHorizontalRegularPreview", device = Devices.LandscapeRegular)
+@Composable
+fun ShareEpisodeTimestampHorizontalRegularPreview() = ShareEpisodeTimestampPagePreview()
+
+@ShowkaseComposable(name = "ShareEpisodeTimestampHorizontalSmallPreview", group = "Sharing")
+@Preview(name = "ShareEpisodeTimestampHorizontalSmallPreview", device = Devices.LandscapeSmall)
+@Composable
+fun ShareEpisodeTimestampHorizontalSmallPreviewPreview() = ShareEpisodeTimestampPagePreview()
+
+@ShowkaseComposable(name = "ShareEpisodeTimestampHorizontalTabletPreview", group = "Sharing")
+@Preview(name = "ShareEpisodeTimestampHorizontalTabletPreview", device = Devices.LandscapeTablet)
+@Composable
+fun ShareEpisodeTimestampHorizontalTabletPreview() = ShareEpisodeTimestampPagePreview()
+
+@Composable
+private fun ShareEpisodeTimestampPagePreview(
+    color: Long = 0xFFEC0404,
+) = ShareEpisodeTimestampPage(
+    podcast = Podcast(
+        uuid = "podcast-id",
+        title = "Podcast title",
+    ),
+    episode = PodcastEpisode(
+        uuid = "episode-id",
+        podcastUuid = "podcast-id",
+        publishedDate = Date.from(Instant.parse("2024-12-03T10:15:30.00Z")),
+        title = "Episode title",
+    ),
+    timestamp = 23.minutes + 11.seconds,
+    useEpisodeArtwork = false,
+    socialPlatforms = SocialPlatform.entries.toSet(),
+    shareColors = ShareColors(Color(color)),
+    listener = ShareEpisodeTimestampPageListener.Preview,
+)

--- a/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/timestamp/ShareEpisodeTimestampViewModel.kt
+++ b/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/timestamp/ShareEpisodeTimestampViewModel.kt
@@ -1,0 +1,43 @@
+package au.com.shiftyjelly.pocketcasts.sharing.timestamp
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
+import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
+import au.com.shiftyjelly.pocketcasts.preferences.Settings
+import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
+import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedFactory
+import dagger.assisted.AssistedInject
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
+
+@HiltViewModel(assistedFactory = ShareEpisodeTimestampViewModel.Factory::class)
+class ShareEpisodeTimestampViewModel @AssistedInject constructor(
+    @Assisted episodeUuid: String,
+    private val episodeManager: EpisodeManager,
+    private val podcastManager: PodcastManager,
+    private val settings: Settings,
+) : ViewModel() {
+    val uiState = combine(
+        podcastManager.observePodcastByEpisodeUuid(episodeUuid),
+        episodeManager.observeByUuid(episodeUuid),
+        settings.artworkConfiguration.flow.map { it.useEpisodeArtwork },
+        ::UiState,
+    ).stateIn(viewModelScope, started = SharingStarted.Lazily, initialValue = UiState())
+
+    data class UiState(
+        val podcast: Podcast? = null,
+        val episode: PodcastEpisode? = null,
+        val useEpisodeArtwork: Boolean = false,
+    )
+
+    @AssistedFactory
+    interface Factory {
+        fun create(episodeUuid: String): ShareEpisodeTimestampViewModel
+    }
+}

--- a/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/timestamp/TimestampType.kt
+++ b/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/timestamp/TimestampType.kt
@@ -1,0 +1,6 @@
+package au.com.shiftyjelly.pocketcasts.sharing.timestamp
+
+enum class TimestampType {
+    Episode,
+    Bookmark,
+}

--- a/modules/features/sharing/src/test/kotlin/au/com/shiftyjelly/pocketcasts/sharing/timestamp/ShareEpisodeTimestampViewModelTest.kt
+++ b/modules/features/sharing/src/test/kotlin/au/com/shiftyjelly/pocketcasts/sharing/timestamp/ShareEpisodeTimestampViewModelTest.kt
@@ -1,0 +1,68 @@
+package au.com.shiftyjelly.pocketcasts.sharing.timestamp
+
+import app.cash.turbine.test
+import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
+import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
+import au.com.shiftyjelly.pocketcasts.preferences.Settings
+import au.com.shiftyjelly.pocketcasts.preferences.UserSetting
+import au.com.shiftyjelly.pocketcasts.preferences.model.ArtworkConfiguration
+import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
+import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
+import au.com.shiftyjelly.pocketcasts.sharedtest.MainCoroutineRule
+import au.com.shiftyjelly.pocketcasts.sharing.timestamp.ShareEpisodeTimestampViewModel.UiState
+import java.util.Date
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+
+@ExperimentalCoroutinesApi
+class ShareEpisodeTimestampViewModelTest {
+    @get:Rule
+    val coroutineRule = MainCoroutineRule()
+
+    private val episodeManager = mock<EpisodeManager>()
+    private val podcastManager = mock<PodcastManager>()
+    private val settings = mock<Settings>()
+
+    private val episode = PodcastEpisode(uuid = "episode-id", podcastUuid = "podcast-id", publishedDate = Date())
+    private val podcast = Podcast(uuid = "podcast-id", title = "Podcast Title")
+
+    private lateinit var viewModel: ShareEpisodeTimestampViewModel
+
+    @Before
+    fun setUp() {
+        whenever(episodeManager.observeByUuid("episode-id")).thenReturn(flowOf(episode))
+        whenever(podcastManager.observePodcastByEpisodeUuid("episode-id")).thenReturn(flowOf(podcast))
+        val artworkSetting = mock<UserSetting<ArtworkConfiguration>>()
+        whenever(artworkSetting.flow).thenReturn(MutableStateFlow(ArtworkConfiguration(useEpisodeArtwork = true)))
+        whenever(settings.artworkConfiguration).thenReturn(artworkSetting)
+
+        viewModel = ShareEpisodeTimestampViewModel(
+            episode.uuid,
+            episodeManager,
+            podcastManager,
+            settings,
+        )
+    }
+
+    @Test
+    fun `get UI state`() = runTest {
+        viewModel.uiState.test {
+            assertEquals(
+                UiState(
+                    podcast = podcast,
+                    episode = episode,
+                    useEpisodeArtwork = true,
+                ),
+                awaitItem(),
+            )
+        }
+    }
+}

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -2000,6 +2000,8 @@ up    <string name="player_sleep_in_one_chapter">Sleeping in 1 chapter</string>
     <string name="share_podcast_description">Choose a format and a platform to share to</string>
     <string name="share_episode_title" translatable="false">@string/podcast_share_episode</string>
     <string name="share_episode_description" translatable="false">@string/share_podcast_description</string>
+    <string name="share_episode_timestamp_title">Share episode at %s</string>
+    <string name="share_episode_timestamp_description" translatable="false">@string/share_podcast_description</string>
     <string name="share_via">Share via %s</string>
     <string name="share_label_instagram_stories">Stories</string>
     <string name="share_label_whats_app" translatable="false">WhatsApp</string>


### PR DESCRIPTION
## Description

This PR displays episode timestamp reimagine sharing page. It is only UI and without view pager for card selection.

Designs: HR2vcQrWcS0scsolKZBitg-fi-2203_2447

## Testing Instructions

1. Share an episode at current position.
2. Verify the UI and the page's behavior.
3. Tapping on social icons should mock-share it as an episode.
4. Share a bookmark.
5. Tapping on social icons should mock-share it as a bookmark.

## Screenshots or Screencast 

| Portrait | Landscape |
| - | - |
| ![Screenshot_20240725-144517](https://github.com/user-attachments/assets/cf79cf4a-3599-4e7c-afc1-08bb20bc4b79) | ![Screenshot_20240725-144525](https://github.com/user-attachments/assets/a6a40d2b-e52a-4414-8b8e-059aeb92fe02) |

## Checklist
- [x] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack