### PR TITLE
Fix autoplay on Android Auto

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@
         ([#2263](https://github.com/Automattic/pocket-casts-android/pull/2263))
     *   Add the ability to rate podcasts
         ([#2506](https://github.com/Automattic/pocket-casts-android/pull/2506))
+*   Bug Fixes
+    *   Fix autoplay for Android Auto
+        ([#2528](https://github.com/Automattic/pocket-casts-android/pull/2528))
 
 7.69
 -----

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
@@ -586,10 +586,9 @@ open class PlaybackManager @Inject constructor(
             -> null
 
             SourceView.MEDIA_BUTTON_BROADCAST_SEARCH_ACTION,
-            SourceView.MEDIA_BUTTON_BROADCAST_ACTION,
             SourceView.NOTIFICATION,
             -> {
-                val source = (episode as? PodcastEpisode)?.let { AutoPlaySource.fromId(it.uuid) }
+                val source = (episode as? PodcastEpisode)?.let { AutoPlaySource.fromId(it.podcastUuid) }
                 if (source != null) {
                     settings.trackingAutoPlaySource.set(source, updateModifiedAt = false)
                 }
@@ -606,6 +605,7 @@ open class PlaybackManager @Inject constructor(
             SourceView.FILTERS,
             SourceView.PODCAST_SCREEN,
             SourceView.STARRED,
+            SourceView.MEDIA_BUTTON_BROADCAST_ACTION,
             -> settings.trackingAutoPlaySource.value
         }
 


### PR DESCRIPTION
## Description

We received user reports that the autoplay on Android Auto didn't work. The autoplay code needs to know where the episode was played from, this is now set.

Internal reference: p1721726696532059-slack-C02A333D8LQ

## Testing Instructions
1. Plug in real device
2. Start the Android Auto emulator
```
cd ??/android-sdk/extras/google/auto/
chmod +x ./desktop-head-unit
./desktop-head-unit --usb
```
3. In Android Auto, open the podcasts tab
4. Open a podcast
5. Play an episode
6. Move the playback position to the end and let the episode complete
7. ✅ Verify another episode from the podcast is started
8. Open a filter
9. Play an episode
10. Move the playback position to the end and let the episode complete
11. ✅ Verify another episode from the filter is started