### PR TITLE
Add card paging to sharing

### DIFF
--- a/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/episode/ShareEpisodePage.kt
+++ b/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/episode/ShareEpisodePage.kt
@@ -1,7 +1,15 @@
 package au.com.shiftyjelly.pocketcasts.sharing.episode
 
 import android.content.res.Configuration
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.pager.HorizontalPager
+import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.res.stringResource
@@ -13,6 +21,7 @@ import au.com.shiftyjelly.pocketcasts.sharing.ui.Devices
 import au.com.shiftyjelly.pocketcasts.sharing.ui.HorizontalEpisodeCard
 import au.com.shiftyjelly.pocketcasts.sharing.ui.HorizontalSharePage
 import au.com.shiftyjelly.pocketcasts.sharing.ui.ShareColors
+import au.com.shiftyjelly.pocketcasts.sharing.ui.SquareEpisodeCard
 import au.com.shiftyjelly.pocketcasts.sharing.ui.VerticalEpisodeCard
 import au.com.shiftyjelly.pocketcasts.sharing.ui.VerticalSharePage
 import com.airbnb.android.showkase.annotation.ShowkaseComposable
@@ -59,6 +68,7 @@ internal fun ShareEpisodePage(
     )
 }
 
+@OptIn(ExperimentalFoundationApi::class)
 @Composable
 private fun VerticalShareEpisodePage(
     podcast: Podcast?,
@@ -79,13 +89,44 @@ private fun VerticalShareEpisodePage(
         }
     },
     middleContent = {
+        val pagerState = rememberPagerState(pageCount = { 3 })
         if (podcast != null && episode != null) {
-            VerticalEpisodeCard(
-                podcast = podcast,
-                episode = episode,
-                useEpisodeArtwork = useEpisodeArtwork,
-                shareColors = shareColors,
-            )
+            BoxWithConstraints {
+                val expectedVerticalCardPadding = remember(maxWidth, maxHeight) { (maxWidth - maxHeight / 1.5f) / 2 }
+                HorizontalPager(
+                    state = pagerState,
+                    modifier = Modifier.fillMaxSize(),
+                ) { pageIndex ->
+                    when (pageIndex) {
+                        0 -> VerticalEpisodeCard(
+                            podcast = podcast,
+                            episode = episode,
+                            useEpisodeArtwork = useEpisodeArtwork,
+                            shareColors = shareColors,
+                            modifier = Modifier.fillMaxSize(),
+                        )
+                        1 -> HorizontalEpisodeCard(
+                            podcast = podcast,
+                            episode = episode,
+                            useEpisodeArtwork = useEpisodeArtwork,
+                            shareColors = shareColors,
+                            modifier = Modifier
+                                .fillMaxSize()
+                                .padding(horizontal = expectedVerticalCardPadding),
+                        )
+                        2 -> SquareEpisodeCard(
+                            podcast = podcast,
+                            episode = episode,
+                            useEpisodeArtwork = useEpisodeArtwork,
+                            shareColors = shareColors,
+                            modifier = Modifier
+                                .fillMaxSize()
+                                .padding(horizontal = expectedVerticalCardPadding),
+                        )
+                        else -> error("Unexpected card page index: $pageIndex")
+                    }
+                }
+            }
         }
     },
 )

--- a/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/episode/ShareEpisodePage.kt
+++ b/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/episode/ShareEpisodePage.kt
@@ -3,17 +3,20 @@ package au.com.shiftyjelly.pocketcasts.sharing.episode
 import android.content.res.Configuration
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
+import au.com.shiftyjelly.pocketcasts.compose.PagerDotIndicator
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.sharing.social.SocialPlatform
@@ -91,41 +94,51 @@ private fun VerticalShareEpisodePage(
     middleContent = {
         val pagerState = rememberPagerState(pageCount = { 3 })
         if (podcast != null && episode != null) {
-            BoxWithConstraints {
-                val expectedVerticalCardPadding = remember(maxWidth, maxHeight) { (maxWidth - maxHeight / 1.5f) / 2 }
-                HorizontalPager(
-                    state = pagerState,
-                    modifier = Modifier.fillMaxSize(),
-                ) { pageIndex ->
-                    when (pageIndex) {
-                        0 -> VerticalEpisodeCard(
-                            podcast = podcast,
-                            episode = episode,
-                            useEpisodeArtwork = useEpisodeArtwork,
-                            shareColors = shareColors,
-                            modifier = Modifier.fillMaxSize(),
-                        )
-                        1 -> HorizontalEpisodeCard(
-                            podcast = podcast,
-                            episode = episode,
-                            useEpisodeArtwork = useEpisodeArtwork,
-                            shareColors = shareColors,
-                            modifier = Modifier
-                                .fillMaxSize()
-                                .padding(horizontal = expectedVerticalCardPadding),
-                        )
-                        2 -> SquareEpisodeCard(
-                            podcast = podcast,
-                            episode = episode,
-                            useEpisodeArtwork = useEpisodeArtwork,
-                            shareColors = shareColors,
-                            modifier = Modifier
-                                .fillMaxSize()
-                                .padding(horizontal = expectedVerticalCardPadding),
-                        )
-                        else -> error("Unexpected card page index: $pageIndex")
+            Column(
+                horizontalAlignment = Alignment.CenterHorizontally,
+            ) {
+                BoxWithConstraints(
+                    modifier = Modifier.weight(0.92f),
+                ) {
+                    val expectedVerticalCardPadding = remember(maxWidth, maxHeight) { (maxWidth - maxHeight / 1.5f) / 2 }
+                    HorizontalPager(
+                        state = pagerState,
+                        modifier = Modifier.fillMaxSize(),
+                    ) { pageIndex ->
+                        when (pageIndex) {
+                            0 -> VerticalEpisodeCard(
+                                podcast = podcast,
+                                episode = episode,
+                                useEpisodeArtwork = useEpisodeArtwork,
+                                shareColors = shareColors,
+                                modifier = Modifier.fillMaxSize(),
+                            )
+                            1 -> HorizontalEpisodeCard(
+                                podcast = podcast,
+                                episode = episode,
+                                useEpisodeArtwork = useEpisodeArtwork,
+                                shareColors = shareColors,
+                                modifier = Modifier
+                                    .fillMaxSize()
+                                    .padding(horizontal = expectedVerticalCardPadding),
+                            )
+                            2 -> SquareEpisodeCard(
+                                podcast = podcast,
+                                episode = episode,
+                                useEpisodeArtwork = useEpisodeArtwork,
+                                shareColors = shareColors,
+                                modifier = Modifier
+                                    .fillMaxSize()
+                                    .padding(horizontal = expectedVerticalCardPadding),
+                            )
+                            else -> error("Unexpected card page index: $pageIndex")
+                        }
                     }
                 }
+                PagerDotIndicator(
+                    state = pagerState,
+                    modifier = Modifier.weight(0.08f),
+                )
             }
         }
     },

--- a/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/episode/ShareEpisodePage.kt
+++ b/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/episode/ShareEpisodePage.kt
@@ -2,24 +2,15 @@ package au.com.shiftyjelly.pocketcasts.sharing.episode
 
 import android.content.res.Configuration
 import androidx.compose.foundation.ExperimentalFoundationApi
-import androidx.compose.foundation.layout.BoxWithConstraints
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.pager.HorizontalPager
-import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.remember
-import androidx.compose.ui.Alignment
-import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
-import au.com.shiftyjelly.pocketcasts.compose.PagerDotIndicator
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.sharing.social.SocialPlatform
+import au.com.shiftyjelly.pocketcasts.sharing.ui.CardType
 import au.com.shiftyjelly.pocketcasts.sharing.ui.Devices
 import au.com.shiftyjelly.pocketcasts.sharing.ui.HorizontalEpisodeCard
 import au.com.shiftyjelly.pocketcasts.sharing.ui.HorizontalSharePage
@@ -91,53 +82,29 @@ private fun VerticalShareEpisodePage(
             listener.onShare(podcast, episode, platfrom)
         }
     },
-    middleContent = {
-        val pagerState = rememberPagerState(pageCount = { 3 })
+    middleContent = { cardType, modifier ->
         if (podcast != null && episode != null) {
-            Column(
-                horizontalAlignment = Alignment.CenterHorizontally,
-            ) {
-                BoxWithConstraints(
-                    modifier = Modifier.weight(0.92f),
-                ) {
-                    val expectedVerticalCardPadding = remember(maxWidth, maxHeight) { (maxWidth - maxHeight / 1.5f) / 2 }
-                    HorizontalPager(
-                        state = pagerState,
-                        modifier = Modifier.fillMaxSize(),
-                    ) { pageIndex ->
-                        when (pageIndex) {
-                            0 -> VerticalEpisodeCard(
-                                podcast = podcast,
-                                episode = episode,
-                                useEpisodeArtwork = useEpisodeArtwork,
-                                shareColors = shareColors,
-                                modifier = Modifier.fillMaxSize(),
-                            )
-                            1 -> HorizontalEpisodeCard(
-                                podcast = podcast,
-                                episode = episode,
-                                useEpisodeArtwork = useEpisodeArtwork,
-                                shareColors = shareColors,
-                                modifier = Modifier
-                                    .fillMaxSize()
-                                    .padding(horizontal = expectedVerticalCardPadding),
-                            )
-                            2 -> SquareEpisodeCard(
-                                podcast = podcast,
-                                episode = episode,
-                                useEpisodeArtwork = useEpisodeArtwork,
-                                shareColors = shareColors,
-                                modifier = Modifier
-                                    .fillMaxSize()
-                                    .padding(horizontal = expectedVerticalCardPadding),
-                            )
-                            else -> error("Unexpected card page index: $pageIndex")
-                        }
-                    }
-                }
-                PagerDotIndicator(
-                    state = pagerState,
-                    modifier = Modifier.weight(0.08f),
+            when (cardType) {
+                CardType.Vertical -> VerticalEpisodeCard(
+                    podcast = podcast,
+                    episode = episode,
+                    useEpisodeArtwork = useEpisodeArtwork,
+                    shareColors = shareColors,
+                    modifier = modifier,
+                )
+                CardType.Horiozntal -> HorizontalEpisodeCard(
+                    podcast = podcast,
+                    episode = episode,
+                    useEpisodeArtwork = useEpisodeArtwork,
+                    shareColors = shareColors,
+                    modifier = modifier,
+                )
+                CardType.Square -> SquareEpisodeCard(
+                    podcast = podcast,
+                    episode = episode,
+                    useEpisodeArtwork = useEpisodeArtwork,
+                    shareColors = shareColors,
+                    modifier = modifier,
                 )
             }
         }

--- a/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/podcast/SharePodcastPage.kt
+++ b/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/podcast/SharePodcastPage.kt
@@ -8,10 +8,12 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.sharing.social.SocialPlatform
+import au.com.shiftyjelly.pocketcasts.sharing.ui.CardType
 import au.com.shiftyjelly.pocketcasts.sharing.ui.Devices
 import au.com.shiftyjelly.pocketcasts.sharing.ui.HorizontalPodcastCast
 import au.com.shiftyjelly.pocketcasts.sharing.ui.HorizontalSharePage
 import au.com.shiftyjelly.pocketcasts.sharing.ui.ShareColors
+import au.com.shiftyjelly.pocketcasts.sharing.ui.SquarePodcastCast
 import au.com.shiftyjelly.pocketcasts.sharing.ui.VerticalPodcastCast
 import au.com.shiftyjelly.pocketcasts.sharing.ui.VerticalSharePage
 import com.airbnb.android.showkase.annotation.ShowkaseComposable
@@ -71,13 +73,28 @@ private fun VerticalSharePodcastPage(
             listener.onShare(podcast, platfrom)
         }
     },
-    middleContent = {
+    middleContent = { cardType, modifier ->
         if (podcast != null) {
-            VerticalPodcastCast(
-                podcast = podcast,
-                episodeCount = episodeCount,
-                shareColors = shareColors,
-            )
+            when (cardType) {
+                CardType.Vertical -> VerticalPodcastCast(
+                    podcast = podcast,
+                    episodeCount = episodeCount,
+                    shareColors = shareColors,
+                    modifier = modifier,
+                )
+                CardType.Horiozntal -> HorizontalPodcastCast(
+                    podcast = podcast,
+                    episodeCount = episodeCount,
+                    shareColors = shareColors,
+                    modifier = modifier,
+                )
+                CardType.Square -> SquarePodcastCast(
+                    podcast = podcast,
+                    episodeCount = episodeCount,
+                    shareColors = shareColors,
+                    modifier = modifier,
+                )
+            }
         }
     },
 )

--- a/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/timestamp/ShareEpisodeTimestampPage.kt
+++ b/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/timestamp/ShareEpisodeTimestampPage.kt
@@ -9,10 +9,12 @@ import androidx.compose.ui.tooling.preview.Preview
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.sharing.social.SocialPlatform
+import au.com.shiftyjelly.pocketcasts.sharing.ui.CardType
 import au.com.shiftyjelly.pocketcasts.sharing.ui.Devices
 import au.com.shiftyjelly.pocketcasts.sharing.ui.HorizontalEpisodeCard
 import au.com.shiftyjelly.pocketcasts.sharing.ui.HorizontalSharePage
 import au.com.shiftyjelly.pocketcasts.sharing.ui.ShareColors
+import au.com.shiftyjelly.pocketcasts.sharing.ui.SquareEpisodeCard
 import au.com.shiftyjelly.pocketcasts.sharing.ui.VerticalEpisodeCard
 import au.com.shiftyjelly.pocketcasts.sharing.ui.VerticalSharePage
 import com.airbnb.android.showkase.annotation.ShowkaseComposable
@@ -86,14 +88,31 @@ private fun VerticalShareEpisodeTimestampPage(
             listener.onShare(podcast, episode, timestamp, platfrom)
         }
     },
-    middleContent = {
+    middleContent = { cardType, modifier ->
         if (podcast != null && episode != null) {
-            VerticalEpisodeCard(
-                podcast = podcast,
-                episode = episode,
-                useEpisodeArtwork = useEpisodeArtwork,
-                shareColors = shareColors,
-            )
+            when (cardType) {
+                CardType.Vertical -> VerticalEpisodeCard(
+                    podcast = podcast,
+                    episode = episode,
+                    useEpisodeArtwork = useEpisodeArtwork,
+                    shareColors = shareColors,
+                    modifier = modifier,
+                )
+                CardType.Horiozntal -> HorizontalEpisodeCard(
+                    podcast = podcast,
+                    episode = episode,
+                    useEpisodeArtwork = useEpisodeArtwork,
+                    shareColors = shareColors,
+                    modifier = modifier,
+                )
+                CardType.Square -> SquareEpisodeCard(
+                    podcast = podcast,
+                    episode = episode,
+                    useEpisodeArtwork = useEpisodeArtwork,
+                    shareColors = shareColors,
+                    modifier = modifier,
+                )
+            }
         }
     },
 )

--- a/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/ui/CardData.kt
+++ b/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/ui/CardData.kt
@@ -14,7 +14,7 @@ import au.com.shiftyjelly.pocketcasts.repositories.images.PocketCastsImageReques
 import au.com.shiftyjelly.pocketcasts.utils.extensions.toLocalizedFormatMediumStyle
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
-internal sealed interface CardType {
+internal sealed interface CardData {
     @Composable
     fun topText(): String
 
@@ -28,10 +28,10 @@ internal sealed interface CardType {
     fun Image(modifier: Modifier)
 }
 
-internal data class PodcastCardType(
+internal data class PodcastCardData(
     val podcast: Podcast,
     val episodeCount: Int,
-) : CardType {
+) : CardData {
     @Composable
     override fun topText() = podcast.title
 
@@ -53,11 +53,11 @@ internal data class PodcastCardType(
     )
 }
 
-internal data class EpisodeCardType(
+internal data class EpisodeCardData(
     val episode: PodcastEpisode,
     val podcast: Podcast,
     val useEpisodeArtwork: Boolean,
-) : CardType {
+) : CardData {
     @Composable
     override fun topText() = episode.publishedDate.toLocalizedFormatMediumStyle()
 

--- a/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/ui/CardType.kt
+++ b/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/ui/CardType.kt
@@ -1,0 +1,7 @@
+package au.com.shiftyjelly.pocketcasts.sharing.ui
+
+internal enum class CardType {
+    Vertical,
+    Horiozntal,
+    Square,
+}

--- a/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/ui/HorizontalCard.kt
+++ b/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/ui/HorizontalCard.kt
@@ -34,7 +34,7 @@ internal fun HorizontalPodcastCast(
     shareColors: ShareColors,
     modifier: Modifier = Modifier,
 ) = HorizontalCard(
-    type = PodcastCardType(
+    data = PodcastCardData(
         podcast = podcast,
         episodeCount = episodeCount,
     ),
@@ -50,7 +50,7 @@ internal fun HorizontalEpisodeCard(
     shareColors: ShareColors,
     modifier: Modifier = Modifier,
 ) = HorizontalCard(
-    type = EpisodeCardType(
+    data = EpisodeCardData(
         episode = episode,
         podcast = podcast,
         useEpisodeArtwork = useEpisodeArtwork,
@@ -61,7 +61,7 @@ internal fun HorizontalEpisodeCard(
 
 @Composable
 private fun HorizontalCard(
-    type: CardType,
+    data: CardData,
     shareColors: ShareColors,
     modifier: Modifier = Modifier,
 ) = BoxWithConstraints {
@@ -82,7 +82,7 @@ private fun HorizontalCard(
         Spacer(
             modifier = Modifier.width(cardHeight * 0.15f),
         )
-        type.Image(
+        data.Image(
             modifier = Modifier
                 .size(cardHeight * 0.7f)
                 .clip(RoundedCornerShape(8.dp)),
@@ -95,7 +95,7 @@ private fun HorizontalCard(
             modifier = Modifier.padding(end = cardHeight * 0.15f),
         ) {
             TextH70(
-                text = type.topText(),
+                text = data.topText(),
                 color = shareColors.cardText.copy(alpha = 0.5f),
                 maxLines = 1,
             )
@@ -103,7 +103,7 @@ private fun HorizontalCard(
                 modifier = Modifier.height(6.dp),
             )
             TextH40(
-                text = type.middleText(),
+                text = data.middleText(),
                 color = shareColors.cardText,
                 maxLines = 3,
             )
@@ -111,7 +111,7 @@ private fun HorizontalCard(
                 modifier = Modifier.height(6.dp),
             )
             TextH70(
-                text = type.bottomText(),
+                text = data.bottomText(),
                 maxLines = 2,
                 color = shareColors.cardText.copy(alpha = 0.5f),
             )
@@ -151,7 +151,7 @@ fun HorizontalEpisodeCardDarkPreview() = HorizontalEpisodeCardPreview(
 private fun HorizontalPodcastCardPreview(
     baseColor: Color,
 ) = HorizontalCardPreview(
-    type = PodcastCardType(
+    data = PodcastCardData(
         podcast = Podcast(
             uuid = "podcast-id",
             title = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.",
@@ -166,7 +166,7 @@ private fun HorizontalPodcastCardPreview(
 private fun HorizontalEpisodeCardPreview(
     baseColor: Color,
 ) = HorizontalCardPreview(
-    type = EpisodeCardType(
+    data = EpisodeCardData(
         episode = PodcastEpisode(
             uuid = "episode-id",
             podcastUuid = "podcast-id",
@@ -184,9 +184,9 @@ private fun HorizontalEpisodeCardPreview(
 
 @Composable
 private fun HorizontalCardPreview(
-    type: CardType,
+    data: CardData,
     baseColor: Color,
 ) = HorizontalCard(
-    type = type,
+    data = data,
     shareColors = ShareColors(baseColor),
 )

--- a/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/ui/HorizontalCard.kt
+++ b/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/ui/HorizontalCard.kt
@@ -33,12 +33,14 @@ internal fun HorizontalPodcastCast(
     episodeCount: Int,
     shareColors: ShareColors,
     modifier: Modifier = Modifier,
+    useWidthForAspectRatio: Boolean = true,
 ) = HorizontalCard(
     data = PodcastCardData(
         podcast = podcast,
         episodeCount = episodeCount,
     ),
     shareColors = shareColors,
+    useWidthForAspectRatio = useWidthForAspectRatio,
     modifier = modifier,
 )
 
@@ -49,6 +51,7 @@ internal fun HorizontalEpisodeCard(
     useEpisodeArtwork: Boolean,
     shareColors: ShareColors,
     modifier: Modifier = Modifier,
+    useWidthForAspectRatio: Boolean = true,
 ) = HorizontalCard(
     data = EpisodeCardData(
         episode = episode,
@@ -56,6 +59,7 @@ internal fun HorizontalEpisodeCard(
         useEpisodeArtwork = useEpisodeArtwork,
     ),
     shareColors = shareColors,
+    useWidthForAspectRatio = useWidthForAspectRatio,
     modifier = modifier,
 )
 
@@ -63,6 +67,7 @@ internal fun HorizontalEpisodeCard(
 private fun HorizontalCard(
     data: CardData,
     shareColors: ShareColors,
+    useWidthForAspectRatio: Boolean,
     modifier: Modifier = Modifier,
 ) = BoxWithConstraints {
     val backgroundGradient = Brush.verticalGradient(
@@ -71,28 +76,32 @@ private fun HorizontalCard(
             shareColors.cardBottom,
         ),
     )
-    val cardHeight = maxWidth * 0.52f
+    val (width, height) = if (useWidthForAspectRatio) {
+        maxWidth to maxWidth * 0.52f
+    } else {
+        maxHeight / 0.52f to maxHeight
+    }
     Row(
         verticalAlignment = Alignment.CenterVertically,
         modifier = modifier
             .background(backgroundGradient, RoundedCornerShape(12.dp))
-            .width(maxWidth)
-            .height(cardHeight),
+            .width(width)
+            .height(height),
     ) {
         Spacer(
-            modifier = Modifier.width(cardHeight * 0.15f),
+            modifier = Modifier.width(height * 0.15f),
         )
         data.Image(
             modifier = Modifier
-                .size(cardHeight * 0.7f)
+                .size(height * 0.7f)
                 .clip(RoundedCornerShape(8.dp)),
         )
         Spacer(
-            modifier = Modifier.width(cardHeight * 0.15f),
+            modifier = Modifier.width(height * 0.15f),
         )
         Column(
             verticalArrangement = Arrangement.Center,
-            modifier = Modifier.padding(end = cardHeight * 0.15f),
+            modifier = Modifier.padding(end = height * 0.15f),
         ) {
             TextH70(
                 text = data.topText(),
@@ -189,4 +198,5 @@ private fun HorizontalCardPreview(
 ) = HorizontalCard(
     data = data,
     shareColors = ShareColors(baseColor),
+    useWidthForAspectRatio = true,
 )

--- a/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/ui/HorizontalCard.kt
+++ b/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/ui/HorizontalCard.kt
@@ -69,7 +69,10 @@ private fun HorizontalCard(
     shareColors: ShareColors,
     useWidthForAspectRatio: Boolean,
     modifier: Modifier = Modifier,
-) = BoxWithConstraints {
+) = BoxWithConstraints(
+    contentAlignment = Alignment.Center,
+    modifier = modifier,
+) {
     val backgroundGradient = Brush.verticalGradient(
         listOf(
             shareColors.cardTop,
@@ -83,7 +86,7 @@ private fun HorizontalCard(
     }
     Row(
         verticalAlignment = Alignment.CenterVertically,
-        modifier = modifier
+        modifier = Modifier
             .background(backgroundGradient, RoundedCornerShape(12.dp))
             .width(width)
             .height(height),

--- a/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/ui/ShareColors.kt
+++ b/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/ui/ShareColors.kt
@@ -15,6 +15,9 @@ internal data class ShareColors(
     val cardBottom = ColorUtils.changeHsvValue(base, 0.75f)
     val cardText = if (base.luminance() < 0.5f) Color.White else Color.Black
 
+    val pagerIndicatorActive = if (background.luminance() < 0.5f) Color.White else Color.Black
+    val pagerIndicatorInactive = pagerIndicatorActive.copy(alpha = 0.3f)
+
     val clipButton = if (background.luminance() < 0.25) {
         ColorUtils.changeHsvValue(base, 2f)
     } else {

--- a/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/ui/SharePage.kt
+++ b/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/ui/SharePage.kt
@@ -100,6 +100,8 @@ internal fun VerticalSharePage(
                 }
                 PagerDotIndicator(
                     state = pagerState,
+                    activeDotColor = shareColors.pagerIndicatorActive,
+                    inactiveDotColor = shareColors.pagerIndicatorInactive,
                     modifier = Modifier.weight(0.08f),
                 )
             }

--- a/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/ui/SharePage.kt
+++ b/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/ui/SharePage.kt
@@ -73,12 +73,12 @@ internal fun VerticalSharePage(
         contentAlignment = Alignment.Center,
         content = middleContent,
         modifier = Modifier
-            .weight(0.6f)
+            .weight(0.65f)
             .fillMaxSize(),
     )
     Box(
         contentAlignment = Alignment.Center,
-        modifier = Modifier.weight(0.2f),
+        modifier = Modifier.weight(0.15f),
     ) {
         PlatformBar(
             platforms = socialPlatforms,

--- a/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/ui/SharePage.kt
+++ b/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/ui/SharePage.kt
@@ -22,7 +22,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
-import au.com.shiftyjelly.pocketcasts.compose.PagerDotIndicator
+import au.com.shiftyjelly.pocketcasts.compose.components.PagerDotIndicator
 import au.com.shiftyjelly.pocketcasts.compose.components.TextH30
 import au.com.shiftyjelly.pocketcasts.compose.components.TextH40
 import au.com.shiftyjelly.pocketcasts.sharing.social.PlatformBar

--- a/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/ui/SharePage.kt
+++ b/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/ui/SharePage.kt
@@ -1,9 +1,11 @@
 package au.com.shiftyjelly.pocketcasts.sharing.ui
 
+import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxScope
+import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -12,16 +14,21 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.sizeIn
+import androidx.compose.foundation.pager.HorizontalPager
+import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import au.com.shiftyjelly.pocketcasts.compose.PagerDotIndicator
 import au.com.shiftyjelly.pocketcasts.compose.components.TextH30
 import au.com.shiftyjelly.pocketcasts.compose.components.TextH40
 import au.com.shiftyjelly.pocketcasts.sharing.social.PlatformBar
 import au.com.shiftyjelly.pocketcasts.sharing.social.SocialPlatform
 
+@OptIn(ExperimentalFoundationApi::class)
 @Composable
 internal fun VerticalSharePage(
     shareTitle: String,
@@ -30,7 +37,7 @@ internal fun VerticalSharePage(
     socialPlatforms: Set<SocialPlatform>,
     onClose: () -> Unit,
     onShareToPlatform: (SocialPlatform) -> Unit,
-    middleContent: @Composable BoxScope.() -> Unit,
+    middleContent: @Composable (CardType, Modifier) -> Unit,
 ) = Column(
     modifier = Modifier
         .fillMaxSize()
@@ -71,7 +78,32 @@ internal fun VerticalSharePage(
     }
     Box(
         contentAlignment = Alignment.Center,
-        content = middleContent,
+        content = {
+            val pagerState = rememberPagerState(pageCount = { CardType.entries.size })
+            Column(
+                horizontalAlignment = Alignment.CenterHorizontally,
+            ) {
+                BoxWithConstraints(
+                    modifier = Modifier.weight(0.92f),
+                ) {
+                    val expectedVerticalCardPadding = remember(maxWidth, maxHeight) { (maxWidth - maxHeight / 1.5f) / 2 }
+                    HorizontalPager(
+                        state = pagerState,
+                        modifier = Modifier.fillMaxSize(),
+                    ) { pageIndex ->
+                        val cardType = CardType.entries[pageIndex]
+                        val modifier = Modifier
+                            .fillMaxSize()
+                            .then(if (cardType != CardType.Vertical) Modifier.padding(horizontal = expectedVerticalCardPadding) else Modifier)
+                        middleContent(cardType, modifier)
+                    }
+                }
+                PagerDotIndicator(
+                    state = pagerState,
+                    modifier = Modifier.weight(0.08f),
+                )
+            }
+        },
         modifier = Modifier
             .weight(0.65f)
             .fillMaxSize(),

--- a/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/ui/SquareCard.kt
+++ b/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/ui/SquareCard.kt
@@ -62,7 +62,10 @@ private fun SquareCard(
     data: CardData,
     shareColors: ShareColors,
     modifier: Modifier = Modifier,
-) = BoxWithConstraints {
+) = BoxWithConstraints(
+    contentAlignment = Alignment.Center,
+    modifier = modifier,
+) {
     val size = minOf(maxWidth, maxHeight)
     val backgroundGradient = Brush.verticalGradient(
         listOf(
@@ -72,7 +75,7 @@ private fun SquareCard(
     )
     Column(
         horizontalAlignment = Alignment.CenterHorizontally,
-        modifier = modifier
+        modifier = Modifier
             .background(backgroundGradient, RoundedCornerShape(12.dp))
             .size(size),
     ) {

--- a/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/ui/SquareCard.kt
+++ b/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/ui/SquareCard.kt
@@ -32,7 +32,7 @@ internal fun SquarePodcastCast(
     shareColors: ShareColors,
     modifier: Modifier = Modifier,
 ) = SquareCard(
-    type = PodcastCardType(
+    data = PodcastCardData(
         podcast = podcast,
         episodeCount = episodeCount,
     ),
@@ -48,7 +48,7 @@ internal fun SquareEpisodeCard(
     shareColors: ShareColors,
     modifier: Modifier = Modifier,
 ) = SquareCard(
-    type = EpisodeCardType(
+    data = EpisodeCardData(
         episode = episode,
         podcast = podcast,
         useEpisodeArtwork = useEpisodeArtwork,
@@ -59,7 +59,7 @@ internal fun SquareEpisodeCard(
 
 @Composable
 private fun SquareCard(
-    type: CardType,
+    data: CardData,
     shareColors: ShareColors,
     modifier: Modifier = Modifier,
 ) = BoxWithConstraints {
@@ -79,7 +79,7 @@ private fun SquareCard(
         Spacer(
             modifier = Modifier.height(42.dp),
         )
-        type.Image(
+        data.Image(
             modifier = Modifier
                 .size(size * 0.4f)
                 .clip(RoundedCornerShape(8.dp)),
@@ -88,7 +88,7 @@ private fun SquareCard(
             modifier = Modifier.height(24.dp),
         )
         TextH70(
-            text = type.topText(),
+            text = data.topText(),
             maxLines = 1,
             color = shareColors.cardText.copy(alpha = 0.5f),
             modifier = Modifier.padding(horizontal = 64.dp),
@@ -97,7 +97,7 @@ private fun SquareCard(
             modifier = Modifier.height(6.dp),
         )
         TextH40(
-            text = type.middleText(),
+            text = data.middleText(),
             maxLines = 2,
             textAlign = TextAlign.Center,
             color = shareColors.cardText,
@@ -107,7 +107,7 @@ private fun SquareCard(
             modifier = Modifier.height(6.dp),
         )
         TextH70(
-            text = type.bottomText(),
+            text = data.bottomText(),
             maxLines = 2,
             textAlign = TextAlign.Center,
             color = shareColors.cardText.copy(alpha = 0.5f),
@@ -148,7 +148,7 @@ fun SquareEpisodeCardDarkPreview() = SquareEpisodeCardPreview(
 private fun SquarePodcastCardPreview(
     baseColor: Color,
 ) = SquareCardPreview(
-    type = PodcastCardType(
+    data = PodcastCardData(
         podcast = Podcast(
             uuid = "podcast-id",
             title = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.",
@@ -163,7 +163,7 @@ private fun SquarePodcastCardPreview(
 private fun SquareEpisodeCardPreview(
     baseColor: Color,
 ) = SquareCardPreview(
-    type = EpisodeCardType(
+    data = EpisodeCardData(
         episode = PodcastEpisode(
             uuid = "episode-id",
             podcastUuid = "podcast-id",
@@ -181,9 +181,9 @@ private fun SquareEpisodeCardPreview(
 
 @Composable
 private fun SquareCardPreview(
-    type: CardType,
+    data: CardData,
     baseColor: Color,
 ) = SquareCard(
-    type = type,
+    data = data,
     shareColors = ShareColors(baseColor),
 )

--- a/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/ui/VerticalCard.kt
+++ b/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/ui/VerticalCard.kt
@@ -69,7 +69,10 @@ private fun VerticalCard(
     shareColors: ShareColors,
     useHeightForAspectRatio: Boolean,
     modifier: Modifier = Modifier,
-) = BoxWithConstraints {
+) = BoxWithConstraints(
+    contentAlignment = Alignment.Center,
+    modifier = modifier,
+) {
     val backgroundGradient = Brush.verticalGradient(
         listOf(
             shareColors.cardTop,
@@ -83,7 +86,7 @@ private fun VerticalCard(
     }
     Column(
         horizontalAlignment = Alignment.CenterHorizontally,
-        modifier = modifier
+        modifier = Modifier
             .background(backgroundGradient, RoundedCornerShape(12.dp))
             .width(width)
             .height(height),

--- a/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/ui/VerticalCard.kt
+++ b/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/ui/VerticalCard.kt
@@ -35,7 +35,7 @@ internal fun VerticalPodcastCast(
     modifier: Modifier = Modifier,
     useHeightForAspectRatio: Boolean = true,
 ) = VerticalCard(
-    type = PodcastCardType(
+    data = PodcastCardData(
         podcast = podcast,
         episodeCount = episodeCount,
     ),
@@ -53,7 +53,7 @@ internal fun VerticalEpisodeCard(
     modifier: Modifier = Modifier,
     useHeightForAspectRatio: Boolean = true,
 ) = VerticalCard(
-    type = EpisodeCardType(
+    data = EpisodeCardData(
         episode = episode,
         podcast = podcast,
         useEpisodeArtwork = useEpisodeArtwork,
@@ -65,7 +65,7 @@ internal fun VerticalEpisodeCard(
 
 @Composable
 private fun VerticalCard(
-    type: CardType,
+    data: CardData,
     shareColors: ShareColors,
     useHeightForAspectRatio: Boolean,
     modifier: Modifier = Modifier,
@@ -91,7 +91,7 @@ private fun VerticalCard(
         Spacer(
             modifier = Modifier.height(width * 0.15f),
         )
-        type.Image(
+        data.Image(
             modifier = Modifier
                 .size(width * 0.7f)
                 .clip(RoundedCornerShape(8.dp)),
@@ -100,7 +100,7 @@ private fun VerticalCard(
             modifier = Modifier.height(height * 0.05f),
         )
         TextH70(
-            text = type.topText(),
+            text = data.topText(),
             maxLines = 1,
             color = shareColors.cardText.copy(alpha = 0.5f),
             modifier = Modifier.padding(horizontal = width * 0.1f),
@@ -109,7 +109,7 @@ private fun VerticalCard(
             modifier = Modifier.height(6.dp),
         )
         TextH40(
-            text = type.middleText(),
+            text = data.middleText(),
             maxLines = 2,
             textAlign = TextAlign.Center,
             color = shareColors.cardText,
@@ -119,7 +119,7 @@ private fun VerticalCard(
             modifier = Modifier.height(6.dp),
         )
         TextH70(
-            text = type.bottomText(),
+            text = data.bottomText(),
             maxLines = 2,
             textAlign = TextAlign.Center,
             color = shareColors.cardText.copy(alpha = 0.5f),
@@ -167,7 +167,7 @@ fun VerticalEpisodeCardDarkPreview() = VerticalEpisodeCardPreview(
 private fun VerticalPodcastCardPreview(
     baseColor: Color,
 ) = VerticalCardPreview(
-    type = PodcastCardType(
+    data = PodcastCardData(
         podcast = Podcast(
             uuid = "podcast-id",
             title = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.",
@@ -182,7 +182,7 @@ private fun VerticalPodcastCardPreview(
 private fun VerticalEpisodeCardPreview(
     baseColor: Color,
 ) = VerticalCardPreview(
-    type = EpisodeCardType(
+    data = EpisodeCardData(
         episode = PodcastEpisode(
             uuid = "episode-id",
             podcastUuid = "podcast-id",
@@ -200,10 +200,10 @@ private fun VerticalEpisodeCardPreview(
 
 @Composable
 private fun VerticalCardPreview(
-    type: CardType,
+    data: CardData,
     baseColor: Color,
 ) = VerticalCard(
-    type = type,
+    data = data,
     shareColors = ShareColors(baseColor),
     useHeightForAspectRatio = false,
 )

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/PagerDotIndicator.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/PagerDotIndicator.kt
@@ -1,0 +1,91 @@
+package au.com.shiftyjelly.pocketcasts.compose
+
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.pager.PagerState
+import androidx.compose.foundation.pager.rememberPagerState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.dp
+import kotlin.math.absoluteValue
+import kotlin.math.roundToInt
+import kotlin.math.sign
+
+private val dotWidth = 8.dp
+
+@OptIn(ExperimentalFoundationApi::class)
+@Composable
+fun PagerDotIndicator(
+    state: PagerState,
+    modifier: Modifier = Modifier,
+    activeDotColor: Color = Color.White,
+    inactiveDotColor: Color = activeDotColor.copy(alpha = 0.3f),
+) {
+    if (state.pageCount <= 0) {
+        return
+    }
+    val dotWidthPx = LocalDensity.current.run { dotWidth.roundToPx() }
+    Box(
+        contentAlignment = Alignment.CenterStart,
+        modifier = modifier,
+    ) {
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(dotWidth),
+        ) {
+            repeat(state.pageCount) {
+                Box(
+                    modifier = Modifier
+                        .size(dotWidth)
+                        .background(inactiveDotColor, CircleShape),
+                )
+            }
+        }
+        Box(
+            modifier = Modifier
+                .offset {
+                    val currentPageIndex = state.currentPage
+                    val currentPageOffset = state.currentPageOffsetFraction
+                    val nextPageIndex = currentPageIndex + currentPageOffset.sign.toInt()
+                    val scrollPosition = (nextPageIndex - currentPageIndex) * currentPageOffset.absoluteValue + currentPageIndex
+                    val normalizedScrollPosition = scrollPosition.coerceIn(0f, (state.pageCount - 1).toFloat())
+                    IntOffset(
+                        x = (2 * dotWidthPx * normalizedScrollPosition).roundToInt(),
+                        y = 0,
+                    )
+                }
+                .size(dotWidth)
+                .background(activeDotColor, CircleShape),
+        )
+    }
+}
+
+@OptIn(ExperimentalFoundationApi::class)
+@Preview
+@Composable
+private fun PagerDotIndicatorPreview() = Column(
+    verticalArrangement = Arrangement.spacedBy(16.dp),
+    horizontalAlignment = Alignment.CenterHorizontally,
+    modifier = Modifier.background(Color.Black).padding(16.dp),
+) {
+    PagerDotIndicator(rememberPagerState(pageCount = { 3 }))
+    PagerDotIndicator(rememberPagerState(initialPage = 1, initialPageOffsetFraction = -0.5f, pageCount = { 3 }))
+    PagerDotIndicator(rememberPagerState(initialPage = 1, initialPageOffsetFraction = -0.25f, pageCount = { 3 }))
+    PagerDotIndicator(rememberPagerState(initialPage = 1, pageCount = { 3 }))
+    PagerDotIndicator(rememberPagerState(initialPage = 1, initialPageOffsetFraction = 0.25f, pageCount = { 3 }))
+    PagerDotIndicator(rememberPagerState(initialPage = 1, initialPageOffsetFraction = 0.5f, pageCount = { 3 }))
+    PagerDotIndicator(rememberPagerState(pageCount = { 0 }))
+}

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/HorizontalPagerWrapper.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/HorizontalPagerWrapper.kt
@@ -1,22 +1,15 @@
 package au.com.shiftyjelly.pocketcasts.compose.components
 
 import androidx.compose.foundation.ExperimentalFoundationApi
-import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.PageSize
-import androidx.compose.foundation.pager.PagerState
 import androidx.compose.foundation.pager.rememberPagerState
-import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -25,7 +18,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.layout
 import androidx.compose.ui.layout.onGloballyPositioned
@@ -86,42 +78,12 @@ fun HorizontalPagerWrapper(
         }
 
         if (showPageIndicator) {
-            PageIndicator(
-                pageCount = pageCount,
-                pagerState = pagerState,
-                color = pageIndicatorColor,
+            PagerDotIndicator(
+                state = pagerState,
+                activeDotColor = pageIndicatorColor,
             )
         } else {
             Spacer(modifier = Modifier.height(16.dp))
-        }
-    }
-}
-
-@OptIn(ExperimentalFoundationApi::class)
-@Composable
-private fun PageIndicator(
-    pageCount: Int,
-    pagerState: PagerState,
-    modifier: Modifier = Modifier,
-    color: Color = Color.White,
-) {
-    Row(
-        Modifier
-            .height(40.dp)
-            .fillMaxWidth()
-            .padding(top = 16.dp),
-        horizontalArrangement = Arrangement.Center,
-    ) {
-        repeat(pageCount) { iteration ->
-            val circleColor =
-                if (pagerState.currentPage == iteration) color else color.copy(alpha = 0.5f)
-            Box(
-                modifier = modifier
-                    .padding(4.dp)
-                    .clip(CircleShape)
-                    .background(circleColor)
-                    .size(8.dp),
-            )
         }
     }
 }

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/PagerDotIndicator.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/PagerDotIndicator.kt
@@ -1,4 +1,4 @@
-package au.com.shiftyjelly.pocketcasts.compose
+package au.com.shiftyjelly.pocketcasts.compose.components
 
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background


### PR DESCRIPTION
## Description

This PR adds paging to sharing. Paging is available only in the portrait mode. Landscape always displays horizontal card. This is because the vertical card would look really bad on non-tablet devices.

## Testing Instructions

1. Start podcast sharing flow. You should be able to page between different cards.
2. Start episode sharing flow. You should be able to page between different cards.
3. Start episode position sharing flow. You should be able to page between different cards.
4. Start bookmark sharing flow. You should be able to page between different cards.

## Screenshots or Screencast 

![sample](https://github.com/user-attachments/assets/ad4ce0a3-4d7b-408e-b0eb-8ebff41d9aae)

## Checklist
- [x] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] ~I have considered whether it makes sense to add tests for my changes~
- [x] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
