### PR TITLE
Share podcasts to different platforms

### DIFF
--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/sharing/ShareActionsTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/sharing/ShareActionsTest.kt
@@ -1,5 +1,6 @@
 package au.com.shiftyjelly.pocketcasts.sharing
 
+import android.content.ClipData
 import android.content.Context
 import android.content.Intent
 import android.content.Intent.ACTION_SEND
@@ -306,6 +307,8 @@ class ShareActionsTest {
         override fun start(context: Context, intent: Intent) {
             _intent = intent
         }
+
+        override fun copyLink(context: Context, data: ClipData) = Unit
     }
 
     private class TestTracker : Tracker {

--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/sharing/SharingClientTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/sharing/SharingClientTest.kt
@@ -1,0 +1,121 @@
+package au.com.shiftyjelly.pocketcasts.sharing
+
+import android.content.ClipData
+import android.content.Context
+import android.content.Intent
+import android.content.Intent.ACTION_SEND
+import android.content.Intent.EXTRA_INTENT
+import android.content.Intent.EXTRA_TEXT
+import android.content.Intent.EXTRA_TITLE
+import android.content.Intent.FLAG_GRANT_READ_URI_PERMISSION
+import androidx.core.content.IntentCompat
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
+import au.com.shiftyjelly.pocketcasts.sharing.social.SocialPlatform
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+import org.junit.runner.RunWith
+import au.com.shiftyjelly.pocketcasts.localization.R as LR
+
+@RunWith(AndroidJUnit4::class)
+@OptIn(ExperimentalCoroutinesApi::class)
+class SharingClientTest {
+    private val context = InstrumentationRegistry.getInstrumentation().targetContext
+
+    private val shareStarter = TestShareStarter()
+
+    private val client = createClient()
+
+    private val regularPlatforms = SocialPlatform.entries - SocialPlatform.Instagram - SocialPlatform.PocketCasts
+
+    @Test
+    fun sharePodcastToRegularPlatforms() = runTest {
+        regularPlatforms.forEach { platform ->
+            val request = SharingRequest.podcast(Podcast(uuid = "podcast-uuid", title = "Podcast Title"))
+                .setPlatform(platform)
+                .build()
+
+            client.share(request)
+            val intent = shareStarter.requireShareIntent
+
+            assertEquals(ACTION_SEND, intent.action)
+            assertEquals("text/plain", intent.type)
+            assertEquals("https://pca.st/podcast/podcast-uuid", intent.getStringExtra(EXTRA_TEXT))
+            assertEquals("Podcast Title", intent.getStringExtra(EXTRA_TITLE))
+            assertEquals(platform.packageId, intent.`package`)
+            assertEquals(FLAG_GRANT_READ_URI_PERMISSION, intent.flags and FLAG_GRANT_READ_URI_PERMISSION)
+        }
+    }
+
+    @Test
+    fun copyPodcastLink() = runTest {
+        val request = SharingRequest.podcast(Podcast(uuid = "podcast-uuid", title = "Podcast Title"))
+            .setPlatform(SocialPlatform.PocketCasts)
+            .build()
+
+        client.share(request)
+        val clipData = shareStarter.requireShareLink
+
+        assertEquals("https://pca.st/podcast/podcast-uuid", clipData.getItemAt(0).text)
+        assertEquals(context.getString(LR.string.share_link_podcast), clipData.description.label)
+        assertNull(shareStarter.shareIntent)
+    }
+
+    @Test
+    fun copyPodcastLinkWithFeedback() = runTest {
+        val client = createClient(showCustomCopyFeedback = true)
+
+        val request = SharingRequest.podcast(Podcast(uuid = "podcast-uuid", title = "Podcast Title"))
+            .setPlatform(SocialPlatform.PocketCasts)
+            .build()
+
+        val response = client.share(request)
+
+        assertEquals(context.getString(LR.string.share_link_copied_feedback), response.feedbackMessage)
+    }
+
+    @Test
+    fun copyPodcastLinkWithoutFeedback() = runTest {
+        val client = createClient(showCustomCopyFeedback = false)
+
+        val request = SharingRequest.podcast(Podcast(uuid = "podcast-uuid", title = "Podcast Title"))
+            .setPlatform(SocialPlatform.PocketCasts)
+            .build()
+
+        val response = client.share(request)
+
+        assertNull(response.feedbackMessage)
+    }
+
+    private fun createClient(
+        showCustomCopyFeedback: Boolean = false,
+    ) = SharingClient(
+        context = context,
+        displayPodcastCover = false,
+        showCustomCopyFeedback = showCustomCopyFeedback,
+        hostUrl = "https://pca.st",
+        shareStarter = shareStarter,
+    )
+
+    private class TestShareStarter : ShareStarter {
+        private var _intent: Intent? = null
+        val shareIntent get() = _intent?.let { intent -> IntentCompat.getParcelableExtra(intent, EXTRA_INTENT, Intent::class.java) }
+        val requireShareIntent get() = requireNotNull(shareIntent)
+
+        var shareLink: ClipData? = null
+            private set
+        val requireShareLink get() = requireNotNull(shareLink)
+
+        override fun start(context: Context, intent: Intent) {
+            _intent = intent
+        }
+
+        override fun copyLink(context: Context, data: ClipData) {
+            shareLink = data
+        }
+    }
+}

--- a/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/ShareActions.kt
+++ b/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/ShareActions.kt
@@ -51,7 +51,13 @@ class ShareActions(
         source = sourceView,
         displayPodcastCover = Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q,
         hostUrl = SERVER_SHORT_URL,
-        shareStarter = ShareStarter { ctx, intent -> ctx.startActivity(intent) },
+        shareStarter = object : ShareStarter {
+            override fun start(context: Context, intent: Intent) {
+                context.startActivity(intent)
+            }
+
+            override fun copyLink(context: Context, data: ClipData) = Unit
+        },
     )
 
     private val imageRequestFactory = PocketCastsImageRequestFactory(context, isDarkTheme = false).smallSize()

--- a/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/ShareStarter.kt
+++ b/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/ShareStarter.kt
@@ -1,8 +1,11 @@
 package au.com.shiftyjelly.pocketcasts.sharing
 
+import android.content.ClipData
 import android.content.Context
 import android.content.Intent
 
-fun interface ShareStarter {
+interface ShareStarter {
     fun start(context: Context, intent: Intent)
+
+    fun copyLink(context: Context, data: ClipData)
 }

--- a/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/SharingClient.kt
+++ b/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/SharingClient.kt
@@ -1,0 +1,195 @@
+package au.com.shiftyjelly.pocketcasts.sharing
+
+import android.content.ClipData
+import android.content.ClipboardManager
+import android.content.Context
+import android.content.Intent
+import android.content.Intent.EXTRA_TEXT
+import android.content.Intent.EXTRA_TITLE
+import android.content.Intent.FLAG_ACTIVITY_NEW_TASK
+import android.content.Intent.FLAG_GRANT_READ_URI_PERMISSION
+import android.graphics.Bitmap
+import android.os.Build
+import androidx.core.content.getSystemService
+import androidx.core.graphics.drawable.toBitmap
+import au.com.shiftyjelly.pocketcasts.analytics.SourceView
+import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
+import au.com.shiftyjelly.pocketcasts.repositories.images.PocketCastsImageRequestFactory
+import au.com.shiftyjelly.pocketcasts.sharing.BuildConfig.SERVER_SHORT_URL
+import au.com.shiftyjelly.pocketcasts.sharing.social.SocialPlatform
+import au.com.shiftyjelly.pocketcasts.sharing.social.SocialPlatform.Instagram
+import au.com.shiftyjelly.pocketcasts.sharing.social.SocialPlatform.More
+import au.com.shiftyjelly.pocketcasts.sharing.social.SocialPlatform.PocketCasts
+import au.com.shiftyjelly.pocketcasts.sharing.social.SocialPlatform.Telegram
+import au.com.shiftyjelly.pocketcasts.sharing.social.SocialPlatform.Tumblr
+import au.com.shiftyjelly.pocketcasts.sharing.social.SocialPlatform.WhatsApp
+import au.com.shiftyjelly.pocketcasts.sharing.social.SocialPlatform.X
+import au.com.shiftyjelly.pocketcasts.sharing.ui.CardType
+import au.com.shiftyjelly.pocketcasts.utils.FileUtil
+import coil.executeBlocking
+import coil.imageLoader
+import dagger.hilt.android.qualifiers.ApplicationContext
+import java.io.File
+import java.io.FileOutputStream
+import javax.inject.Inject
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import timber.log.Timber
+import au.com.shiftyjelly.pocketcasts.localization.R as LR
+import au.com.shiftyjelly.pocketcasts.models.entity.Podcast as PodcastModel
+
+class SharingClient(
+    private val context: Context,
+    private val displayPodcastCover: Boolean,
+    private val showCustomCopyFeedback: Boolean,
+    private val hostUrl: String,
+    private val shareStarter: ShareStarter,
+) {
+    @Inject constructor(
+        @ApplicationContext context: Context,
+    ) : this(
+        context = context,
+        displayPodcastCover = Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q,
+        showCustomCopyFeedback = Build.VERSION.SDK_INT <= Build.VERSION_CODES.S_V2,
+        hostUrl = SERVER_SHORT_URL,
+        shareStarter = object : ShareStarter {
+            override fun start(context: Context, intent: Intent) {
+                context.startActivity(intent)
+            }
+
+            override fun copyLink(context: Context, data: ClipData) {
+                requireNotNull(context.getSystemService<ClipboardManager>()).setPrimaryClip(data)
+            }
+        },
+    )
+
+    private val imageRequestFactory = PocketCastsImageRequestFactory(context, isDarkTheme = false).smallSize()
+
+    suspend fun share(request: SharingRequest) = try {
+        Timber.tag("SharingClient").i("Share: $request")
+        request.tryShare()
+    } catch (t: Throwable) {
+        Timber.tag("SharingClient").e(t, "Failed to share a request: $request")
+        SharingResponse(
+            isSuccsessful = false,
+            feedbackMessage = t.message,
+        )
+    }
+
+    private suspend fun SharingRequest.tryShare(): SharingResponse = when (data) {
+        is SharingRequest.Data.Podcast -> when (platform) {
+            Instagram -> {
+                error("Not implemented yet")
+            }
+
+            PocketCasts -> {
+                shareStarter.copyLink(context, ClipData.newPlainText(context.getString(LR.string.share_link_podcast), data.sharingUrl(hostUrl)))
+                SharingResponse(
+                    isSuccsessful = true,
+                    feedbackMessage = if (showCustomCopyFeedback) context.getString(LR.string.share_link_copied_feedback) else null,
+                )
+            }
+
+            WhatsApp, Telegram, X, Tumblr, More -> {
+                Intent()
+                    .setAction(Intent.ACTION_SEND)
+                    .setType("text/plain")
+                    .putExtra(EXTRA_TEXT, data.sharingUrl(hostUrl))
+                    .putExtra(EXTRA_TITLE, data.sharingTitle())
+                    .setPackage(platform.packageId)
+                    .addFlags(FLAG_GRANT_READ_URI_PERMISSION)
+                    .setPodcastCover(data.podcast)
+                    .share()
+                SharingResponse(
+                    isSuccsessful = true,
+                    feedbackMessage = null,
+                )
+            }
+        }
+    }
+
+    private fun Intent.share() {
+        shareStarter.start(context, toChooserIntent())
+    }
+
+    private fun Intent.toChooserIntent() = Intent
+        .createChooser(this, context.getString(LR.string.podcasts_share_via))
+        .addFlags(FLAG_ACTIVITY_NEW_TASK)
+
+    private suspend fun Intent.setPodcastCover(podcast: Podcast) = apply {
+        if (displayPodcastCover) {
+            val coverUri = withContext(Dispatchers.IO) {
+                runCatching {
+                    val request = imageRequestFactory.create(podcast)
+                    context.imageLoader.executeBlocking(request).drawable?.toBitmap()?.let { bitmap ->
+                        val imageFile = File(context.cacheDir, "share_podcast_thumbnail.jpg")
+                        FileOutputStream(imageFile).use { bitmap.compress(Bitmap.CompressFormat.JPEG, 100, it) }
+                        FileUtil.getUriForFile(context, imageFile)
+                    }
+                }.getOrNull()
+            }
+            if (coverUri != null) {
+                clipData = ClipData.newRawUri(null, coverUri)
+            }
+        }
+    }
+}
+
+data class SharingRequest internal constructor(
+    internal val data: SharingRequest.Data,
+    internal val platform: SocialPlatform,
+    internal val cardType: CardType?,
+    internal val source: SourceView,
+) {
+    companion object {
+        fun podcast(podcast: PodcastModel) = Builder(Data.Podcast(podcast))
+    }
+
+    class Builder internal constructor(
+        private var data: SharingRequest.Data,
+    ) {
+        private var platform = More
+        private var cardType: CardType? = null
+        private var source = SourceView.UNKNOWN
+
+        fun setPlatform(platform: SocialPlatform) = apply {
+            this.platform = platform
+        }
+
+        fun setCardType(cardType: CardType) = apply {
+            this.cardType = cardType
+        }
+
+        fun setSourceView(source: SourceView) = apply {
+            this.source = source
+        }
+
+        fun build() = SharingRequest(
+            data = data,
+            platform = platform,
+            cardType = cardType,
+            source = source,
+        )
+    }
+
+    internal sealed interface Data {
+        fun sharingUrl(host: String): String
+
+        fun sharingTitle(): String
+
+        data class Podcast(
+            val podcast: PodcastModel,
+        ) : Data {
+            override fun sharingUrl(host: String) = "$host/podcast/${podcast.uuid}"
+
+            override fun sharingTitle() = podcast.title
+
+            override fun toString() = "Podcast(title=${podcast.title},uuid=${podcast.uuid})"
+        }
+    }
+}
+
+data class SharingResponse(
+    val isSuccsessful: Boolean,
+    val feedbackMessage: String?,
+)

--- a/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/episode/ShareEpisodePage.kt
+++ b/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/episode/ShareEpisodePage.kt
@@ -77,7 +77,7 @@ private fun VerticalShareEpisodePage(
     shareColors = shareColors,
     socialPlatforms = socialPlatforms,
     onClose = listener::onClose,
-    onShareToPlatform = { platfrom ->
+    onShareToPlatform = { platfrom, _ ->
         if (podcast != null && episode != null) {
             listener.onShare(podcast, episode, platfrom)
         }
@@ -125,7 +125,7 @@ private fun HorizontalShareEpisodePage(
     shareColors = shareColors,
     socialPlatforms = socialPlatforms,
     onClose = listener::onClose,
-    onShareToPlatform = { platfrom ->
+    onShareToPlatform = { platfrom, _ ->
         if (podcast != null && episode != null) {
             listener.onShare(podcast, episode, platfrom)
         }

--- a/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/podcast/SharePodcastFragment.kt
+++ b/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/podcast/SharePodcastFragment.kt
@@ -21,6 +21,7 @@ import au.com.shiftyjelly.pocketcasts.utils.parceler.ColorParceler
 import au.com.shiftyjelly.pocketcasts.views.fragments.BaseDialogFragment
 import dagger.hilt.android.AndroidEntryPoint
 import dagger.hilt.android.lifecycle.withCreationCallback
+import javax.inject.Inject
 import kotlinx.parcelize.Parcelize
 import kotlinx.parcelize.TypeParceler
 
@@ -38,13 +39,15 @@ class SharePodcastFragment : BaseDialogFragment() {
         },
     )
 
+    @Inject internal lateinit var shareListenerFactory: SharePodcastListener.Factory
+
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
         savedInstanceState: Bundle?,
     ) = ComposeView(requireActivity()).apply {
         val platforms = SocialPlatform.getAvailablePlatforms(requireContext())
-        val listener = SharePodcastListener(this@SharePodcastFragment)
+        val listener = shareListenerFactory.create(this@SharePodcastFragment, args.source)
         setContent {
             val uiState by viewModel.uiState.collectAsState()
             SharePodcastPage(

--- a/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/podcast/SharePodcastListener.kt
+++ b/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/podcast/SharePodcastListener.kt
@@ -1,18 +1,46 @@
 package au.com.shiftyjelly.pocketcasts.sharing.podcast
 
 import android.widget.Toast
+import androidx.lifecycle.lifecycleScope
+import au.com.shiftyjelly.pocketcasts.analytics.SourceView
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
+import au.com.shiftyjelly.pocketcasts.sharing.SharingClient
+import au.com.shiftyjelly.pocketcasts.sharing.SharingRequest
 import au.com.shiftyjelly.pocketcasts.sharing.social.SocialPlatform
 import au.com.shiftyjelly.pocketcasts.sharing.ui.CardType
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedFactory
+import dagger.assisted.AssistedInject
+import kotlinx.coroutines.launch
 
-internal class SharePodcastListener(
-    private val fragment: SharePodcastFragment,
+internal class SharePodcastListener @AssistedInject constructor(
+    @Assisted private val fragment: SharePodcastFragment,
+    @Assisted private val sourceView: SourceView,
+    private val sharingClient: SharingClient,
 ) : SharePodcastPageListener {
     override fun onShare(podcast: Podcast, platform: SocialPlatform, cardType: CardType) {
-        Toast.makeText(fragment.requireActivity(), "Share ${podcast.title} to $platform", Toast.LENGTH_SHORT).show()
+        val request = SharingRequest.podcast(podcast)
+            .setPlatform(platform)
+            .setCardType(cardType)
+            .setSourceView(sourceView)
+            .build()
+        fragment.lifecycleScope.launch {
+            val response = sharingClient.share(request)
+            if (response.feedbackMessage != null) {
+                Toast.makeText(fragment.requireActivity(), response.feedbackMessage, Toast.LENGTH_SHORT).show()
+            }
+        }
     }
 
     override fun onClose() {
         fragment.dismiss()
+    }
+
+    @AssistedFactory
+    interface Factory {
+        fun create(
+            fragment: SharePodcastFragment,
+            sourceView: SourceView,
+        ): SharePodcastListener
     }
 }

--- a/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/podcast/SharePodcastListener.kt
+++ b/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/podcast/SharePodcastListener.kt
@@ -3,11 +3,12 @@ package au.com.shiftyjelly.pocketcasts.sharing.podcast
 import android.widget.Toast
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.sharing.social.SocialPlatform
+import au.com.shiftyjelly.pocketcasts.sharing.ui.CardType
 
 internal class SharePodcastListener(
     private val fragment: SharePodcastFragment,
 ) : SharePodcastPageListener {
-    override fun onShare(podcast: Podcast, platform: SocialPlatform) {
+    override fun onShare(podcast: Podcast, platform: SocialPlatform, cardType: CardType) {
         Toast.makeText(fragment.requireActivity(), "Share ${podcast.title} to $platform", Toast.LENGTH_SHORT).show()
     }
 

--- a/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/podcast/SharePodcastPage.kt
+++ b/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/podcast/SharePodcastPage.kt
@@ -20,12 +20,12 @@ import com.airbnb.android.showkase.annotation.ShowkaseComposable
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 internal interface SharePodcastPageListener {
-    fun onShare(podcast: Podcast, platform: SocialPlatform)
+    fun onShare(podcast: Podcast, platform: SocialPlatform, cardType: CardType)
     fun onClose()
 
     companion object {
         val Preview = object : SharePodcastPageListener {
-            override fun onShare(podcast: Podcast, platform: SocialPlatform) = Unit
+            override fun onShare(podcast: Podcast, platform: SocialPlatform, cardType: CardType) = Unit
             override fun onClose() = Unit
         }
     }
@@ -68,9 +68,9 @@ private fun VerticalSharePodcastPage(
     shareColors = shareColors,
     socialPlatforms = socialPlatforms,
     onClose = listener::onClose,
-    onShareToPlatform = { platfrom ->
+    onShareToPlatform = { platfrom, cardType ->
         if (podcast != null) {
-            listener.onShare(podcast, platfrom)
+            listener.onShare(podcast, platfrom, cardType)
         }
     },
     middleContent = { cardType, modifier ->
@@ -112,9 +112,9 @@ private fun HorizontalSharePodcastPage(
     shareColors = shareColors,
     socialPlatforms = socialPlatforms,
     onClose = listener::onClose,
-    onShareToPlatform = { platfrom ->
+    onShareToPlatform = { platfrom, cardType ->
         if (podcast != null) {
-            listener.onShare(podcast, platfrom)
+            listener.onShare(podcast, platfrom, cardType)
         }
     },
     middleContent = {

--- a/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/social/SocialPlatform.kt
+++ b/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/social/SocialPlatform.kt
@@ -7,7 +7,7 @@ import au.com.shiftyjelly.pocketcasts.utils.getPackageInfo
 import au.com.shiftyjelly.pocketcasts.images.R as IR
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
-internal enum class SocialPlatform(
+enum class SocialPlatform(
     @DrawableRes val logoId: Int,
     @StringRes val nameId: Int,
     val packageId: String?,

--- a/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/timestamp/ShareEpisodeTimestampPage.kt
+++ b/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/timestamp/ShareEpisodeTimestampPage.kt
@@ -83,7 +83,7 @@ private fun VerticalShareEpisodeTimestampPage(
     shareColors = shareColors,
     socialPlatforms = socialPlatforms,
     onClose = listener::onClose,
-    onShareToPlatform = { platfrom ->
+    onShareToPlatform = { platfrom, _ ->
         if (podcast != null && episode != null) {
             listener.onShare(podcast, episode, timestamp, platfrom)
         }
@@ -132,7 +132,7 @@ private fun HorizontalShareEpisodeTimestampPage(
     shareColors = shareColors,
     socialPlatforms = socialPlatforms,
     onClose = listener::onClose,
-    onShareToPlatform = { platfrom ->
+    onShareToPlatform = { platfrom, _ ->
         if (podcast != null && episode != null) {
             listener.onShare(podcast, episode, timestamp, platfrom)
         }

--- a/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/ui/CardType.kt
+++ b/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/ui/CardType.kt
@@ -1,6 +1,6 @@
 package au.com.shiftyjelly.pocketcasts.sharing.ui
 
-internal enum class CardType {
+enum class CardType {
     Vertical,
     Horiozntal,
     Square,

--- a/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/ui/SharePage.kt
+++ b/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/ui/SharePage.kt
@@ -36,7 +36,7 @@ internal fun VerticalSharePage(
     shareColors: ShareColors,
     socialPlatforms: Set<SocialPlatform>,
     onClose: () -> Unit,
-    onShareToPlatform: (SocialPlatform) -> Unit,
+    onShareToPlatform: (SocialPlatform, CardType) -> Unit,
     middleContent: @Composable (CardType, Modifier) -> Unit,
 ) = Column(
     modifier = Modifier
@@ -76,10 +76,10 @@ internal fun VerticalSharePage(
             )
         }
     }
+    val pagerState = rememberPagerState(pageCount = { CardType.entries.size })
     Box(
         contentAlignment = Alignment.Center,
         content = {
-            val pagerState = rememberPagerState(pageCount = { CardType.entries.size })
             Column(
                 horizontalAlignment = Alignment.CenterHorizontally,
             ) {
@@ -117,7 +117,9 @@ internal fun VerticalSharePage(
         PlatformBar(
             platforms = socialPlatforms,
             shareColors = shareColors,
-            onClick = onShareToPlatform,
+            onClick = { platform ->
+                onShareToPlatform(platform, CardType.entries[pagerState.currentPage])
+            },
         )
     }
 }
@@ -129,7 +131,7 @@ internal fun HorizontalSharePage(
     shareColors: ShareColors,
     socialPlatforms: Set<SocialPlatform>,
     onClose: () -> Unit,
-    onShareToPlatform: (SocialPlatform) -> Unit,
+    onShareToPlatform: (SocialPlatform, CardType) -> Unit,
     middleContent: @Composable BoxScope.() -> Unit,
 ) = Column(
     modifier = Modifier
@@ -196,7 +198,9 @@ internal fun HorizontalSharePage(
             PlatformBar(
                 platforms = socialPlatforms,
                 shareColors = shareColors,
-                onClick = onShareToPlatform,
+                onClick = { platform ->
+                    onShareToPlatform(platform, CardType.Horiozntal)
+                },
             )
         }
         Spacer(

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -2010,6 +2010,8 @@ up    <string name="player_sleep_in_one_chapter">Sleeping in 1 chapter</string>
     <string name="share_label_tumblr" translatable="false">Tumblr</string>
     <string name="share_label_copy_link">Copy link</string>
     <string name="share_label_more" translatable="false">@string/more</string>
+    <string name="share_link_copied_feedback">Link copied to clipboard</string>
+    <string name="share_link_podcast">Podcast link</string>
 
     <!-- Pocket Casts Champion -->
     <string name="pocket_casts_champion_dialog_title">You’re a true champion of Pocket Casts!</string>


### PR DESCRIPTION
## Description

This PR adds `SharingClient` and uses it for podcast sharing. It will eventually replace `ShareActions`, but more features like analytics and support for other media types need to be added before it can fully replace it.

Currently, the copy link feedback message is displayed in a Toast instead of a Snackbar. I will add Snackbar support in a different PR.

## Testing Instructions

1. Share a podcast to Stories. It should fail with a toast message.
2. Share a podcast to WhatsApp, Telegram, X, and Tumblr. You need to have these apps installed on your device for them to be displayed in the social sharing bar. Also they are displayed in that precedence. So if you have Instagram and WhatsApp you won't see Telegram.
3. Share a podcast using `Copy link`. On SDK >= 33, you'll see a native feedback prompt. On SDK < 33, you'll see a Toast.
4. Share a podcast using `More`. It should open a sharing sheet.

When sharing, you can verify card and source selection through logs using the `tag:SharingClient` filter.

## Checklist
- [x] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] ~Any jetpack compose components I added or changed are covered by compose previews~
- [x] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~