### PR TITLE
Share episodes to different platforms

### DIFF
--- a/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/SharingClient.kt
+++ b/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/SharingClient.kt
@@ -10,10 +10,12 @@ import android.content.Intent.FLAG_ACTIVITY_NEW_TASK
 import android.content.Intent.FLAG_GRANT_READ_URI_PERMISSION
 import android.graphics.Bitmap
 import android.os.Build
+import androidx.annotation.StringRes
 import androidx.core.content.getSystemService
 import androidx.core.graphics.drawable.toBitmap
 import au.com.shiftyjelly.pocketcasts.analytics.SourceView
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
+import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.repositories.images.PocketCastsImageRequestFactory
 import au.com.shiftyjelly.pocketcasts.sharing.BuildConfig.SERVER_SHORT_URL
 import au.com.shiftyjelly.pocketcasts.sharing.social.SocialPlatform
@@ -37,6 +39,7 @@ import kotlinx.coroutines.withContext
 import timber.log.Timber
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast as PodcastModel
+import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode as EpisodeModel
 
 class SharingClient(
     private val context: Context,
@@ -76,35 +79,33 @@ class SharingClient(
         )
     }
 
-    private suspend fun SharingRequest.tryShare(): SharingResponse = when (data) {
-        is SharingRequest.Data.Podcast -> when (platform) {
-            Instagram -> {
-                error("Not implemented yet")
-            }
+    private suspend fun SharingRequest.tryShare(): SharingResponse = when (platform) {
+        Instagram -> {
+            error("Not implemented yet")
+        }
 
-            PocketCasts -> {
-                shareStarter.copyLink(context, ClipData.newPlainText(context.getString(LR.string.share_link_podcast), data.sharingUrl(hostUrl)))
-                SharingResponse(
-                    isSuccsessful = true,
-                    feedbackMessage = if (showCustomCopyFeedback) context.getString(LR.string.share_link_copied_feedback) else null,
-                )
-            }
+        PocketCasts -> {
+            shareStarter.copyLink(context, ClipData.newPlainText(context.getString(data.linkDescription()), data.sharingUrl(hostUrl)))
+            SharingResponse(
+                isSuccsessful = true,
+                feedbackMessage = if (showCustomCopyFeedback) context.getString(LR.string.share_link_copied_feedback) else null,
+            )
+        }
 
-            WhatsApp, Telegram, X, Tumblr, More -> {
-                Intent()
-                    .setAction(Intent.ACTION_SEND)
-                    .setType("text/plain")
-                    .putExtra(EXTRA_TEXT, data.sharingUrl(hostUrl))
-                    .putExtra(EXTRA_TITLE, data.sharingTitle())
-                    .setPackage(platform.packageId)
-                    .addFlags(FLAG_GRANT_READ_URI_PERMISSION)
-                    .setPodcastCover(data.podcast)
-                    .share()
-                SharingResponse(
-                    isSuccsessful = true,
-                    feedbackMessage = null,
-                )
-            }
+        WhatsApp, Telegram, X, Tumblr, More -> {
+            Intent()
+                .setAction(Intent.ACTION_SEND)
+                .setType("text/plain")
+                .putExtra(EXTRA_TEXT, data.sharingUrl(hostUrl))
+                .putExtra(EXTRA_TITLE, data.sharingTitle())
+                .setPackage(platform.packageId)
+                .addFlags(FLAG_GRANT_READ_URI_PERMISSION)
+                .setPodcastCover(data.podcast)
+                .share()
+            SharingResponse(
+                isSuccsessful = true,
+                feedbackMessage = null,
+            )
         }
     }
 
@@ -143,6 +144,8 @@ data class SharingRequest internal constructor(
 ) {
     companion object {
         fun podcast(podcast: PodcastModel) = Builder(Data.Podcast(podcast))
+
+        fun episode(podcast: PodcastModel, episode: PodcastEpisode) = Builder(Data.Episode(podcast, episode))
     }
 
     class Builder internal constructor(
@@ -173,18 +176,37 @@ data class SharingRequest internal constructor(
     }
 
     internal sealed interface Data {
+        val podcast: PodcastModel
+
         fun sharingUrl(host: String): String
 
         fun sharingTitle(): String
 
+        @StringRes fun linkDescription(): Int
+
         data class Podcast(
-            val podcast: PodcastModel,
+            override val podcast: PodcastModel,
         ) : Data {
             override fun sharingUrl(host: String) = "$host/podcast/${podcast.uuid}"
 
             override fun sharingTitle() = podcast.title
 
+            override fun linkDescription() = LR.string.share_link_podcast
+
             override fun toString() = "Podcast(title=${podcast.title},uuid=${podcast.uuid})"
+        }
+
+        data class Episode(
+            override val podcast: PodcastModel,
+            val episode: EpisodeModel,
+        ) : Data {
+            override fun sharingUrl(host: String) = "$host/episode/${episode.uuid}"
+
+            override fun sharingTitle() = episode.title
+
+            override fun linkDescription() = LR.string.share_link_episode
+
+            override fun toString() = "Podcast(title=${episode.title},uuid=${episode.uuid})"
         }
     }
 }

--- a/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/SharingClient.kt
+++ b/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/SharingClient.kt
@@ -206,7 +206,7 @@ data class SharingRequest internal constructor(
 
             override fun linkDescription() = LR.string.share_link_episode
 
-            override fun toString() = "Podcast(title=${episode.title},uuid=${episode.uuid})"
+            override fun toString() = "Episode(title=${episode.title},uuid=${episode.uuid})"
         }
     }
 }

--- a/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/episode/ShareEpisodeFragment.kt
+++ b/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/episode/ShareEpisodeFragment.kt
@@ -21,10 +21,13 @@ import au.com.shiftyjelly.pocketcasts.sharing.social.SocialPlatform
 import au.com.shiftyjelly.pocketcasts.sharing.ui.ShareColors
 import au.com.shiftyjelly.pocketcasts.utils.parceler.ColorParceler
 import au.com.shiftyjelly.pocketcasts.views.fragments.BaseDialogFragment
+import dagger.hilt.android.AndroidEntryPoint
 import dagger.hilt.android.lifecycle.withCreationCallback
+import javax.inject.Inject
 import kotlinx.parcelize.Parcelize
 import kotlinx.parcelize.TypeParceler
 
+@AndroidEntryPoint
 class ShareEpisodeFragment : BaseDialogFragment() {
     private val args get() = requireNotNull(arguments?.let { BundleCompat.getParcelable(it, NEW_INSTANCE_ARG, Args::class.java) })
 
@@ -38,13 +41,15 @@ class ShareEpisodeFragment : BaseDialogFragment() {
         },
     )
 
+    @Inject internal lateinit var shareListenerFactory: ShareEpisodeListener.Factory
+
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
         savedInstanceState: Bundle?,
     ) = ComposeView(requireActivity()).apply {
         val platforms = SocialPlatform.getAvailablePlatforms(requireContext())
-        val listener = ShareEpisodeListener(this@ShareEpisodeFragment)
+        val listener = shareListenerFactory.create(this@ShareEpisodeFragment, args.source)
         setContent {
             val uiState by viewModel.uiState.collectAsState()
             ShareEpisodePage(

--- a/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/episode/ShareEpisodeListener.kt
+++ b/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/episode/ShareEpisodeListener.kt
@@ -1,18 +1,47 @@
 package au.com.shiftyjelly.pocketcasts.sharing.episode
 
 import android.widget.Toast
+import androidx.lifecycle.lifecycleScope
+import au.com.shiftyjelly.pocketcasts.analytics.SourceView
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
+import au.com.shiftyjelly.pocketcasts.sharing.SharingClient
+import au.com.shiftyjelly.pocketcasts.sharing.SharingRequest
 import au.com.shiftyjelly.pocketcasts.sharing.social.SocialPlatform
+import au.com.shiftyjelly.pocketcasts.sharing.ui.CardType
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedFactory
+import dagger.assisted.AssistedInject
+import kotlinx.coroutines.launch
 
-internal class ShareEpisodeListener(
-    private val fragment: ShareEpisodeFragment,
+internal class ShareEpisodeListener @AssistedInject constructor(
+    @Assisted private val fragment: ShareEpisodeFragment,
+    @Assisted private val sourceView: SourceView,
+    private val sharingClient: SharingClient,
 ) : ShareEpisodePageListener {
-    override fun onShare(podcast: Podcast, episode: PodcastEpisode, platform: SocialPlatform) {
-        Toast.makeText(fragment.requireActivity(), "Share ${episode.title} to $platform", Toast.LENGTH_SHORT).show()
+    override fun onShare(podcast: Podcast, episode: PodcastEpisode, platform: SocialPlatform, cardType: CardType) {
+        val request = SharingRequest.episode(podcast, episode)
+            .setPlatform(platform)
+            .setCardType(cardType)
+            .setSourceView(sourceView)
+            .build()
+        fragment.lifecycleScope.launch {
+            val response = sharingClient.share(request)
+            if (response.feedbackMessage != null) {
+                Toast.makeText(fragment.requireActivity(), response.feedbackMessage, Toast.LENGTH_SHORT).show()
+            }
+        }
     }
 
     override fun onClose() {
         fragment.dismiss()
+    }
+
+    @AssistedFactory
+    interface Factory {
+        fun create(
+            fragment: ShareEpisodeFragment,
+            sourceView: SourceView,
+        ): ShareEpisodeListener
     }
 }

--- a/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/episode/ShareEpisodePage.kt
+++ b/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/episode/ShareEpisodePage.kt
@@ -24,12 +24,12 @@ import java.time.Instant
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 internal interface ShareEpisodePageListener {
-    fun onShare(podcast: Podcast, episode: PodcastEpisode, platform: SocialPlatform)
+    fun onShare(podcast: Podcast, episode: PodcastEpisode, platform: SocialPlatform, cardType: CardType)
     fun onClose()
 
     companion object {
         val Preview = object : ShareEpisodePageListener {
-            override fun onShare(podcast: Podcast, episode: PodcastEpisode, platform: SocialPlatform) = Unit
+            override fun onShare(podcast: Podcast, episode: PodcastEpisode, platform: SocialPlatform, cardType: CardType) = Unit
             override fun onClose() = Unit
         }
     }
@@ -77,9 +77,9 @@ private fun VerticalShareEpisodePage(
     shareColors = shareColors,
     socialPlatforms = socialPlatforms,
     onClose = listener::onClose,
-    onShareToPlatform = { platfrom, _ ->
+    onShareToPlatform = { platfrom, cardType ->
         if (podcast != null && episode != null) {
-            listener.onShare(podcast, episode, platfrom)
+            listener.onShare(podcast, episode, platfrom, cardType)
         }
     },
     middleContent = { cardType, modifier ->
@@ -125,9 +125,9 @@ private fun HorizontalShareEpisodePage(
     shareColors = shareColors,
     socialPlatforms = socialPlatforms,
     onClose = listener::onClose,
-    onShareToPlatform = { platfrom, _ ->
+    onShareToPlatform = { platfrom, cardType ->
         if (podcast != null && episode != null) {
-            listener.onShare(podcast, episode, platfrom)
+            listener.onShare(podcast, episode, platfrom, cardType)
         }
     },
     middleContent = {

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -2011,6 +2011,7 @@ up    <string name="player_sleep_in_one_chapter">Sleeping in 1 chapter</string>
     <string name="share_label_more" translatable="false">@string/more</string>
     <string name="share_link_copied_feedback">Link copied to clipboard</string>
     <string name="share_link_podcast">Podcast link</string>
+    <string name="share_link_episode">Episode link</string>
 
     <!-- Pocket Casts Champion -->
     <string name="pocket_casts_champion_dialog_title">You’re a true champion of Pocket Casts!</string>


### PR DESCRIPTION
## Description

This PR uses `SharingClient` for episode sharing.

Currently, the copy link feedback message is displayed in a Toast instead of a Snackbar. I will add Snackbar support in a different PR.

## Testing Instructions

1. Share an episode to Stories. It should fail with a toast message.
2. Share an episode to WhatsApp, Telegram, X, and Tumblr. You need to have these apps installed on your device for them to be displayed in the social sharing bar. Also they are displayed in that precedence. So if you have Instagram and WhatsApp you won't see Telegram.
3. Share an episode using `Copy link`. On SDK >= 33, you'll see a native feedback prompt. On SDK < 33, you'll see a Toast.
4. Share an episode using `More`. It should open a sharing sheet.

When sharing, you can verify card and source selection through logs using the `tag:SharingClient` filter.

## Checklist
- [x] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] ~Any jetpack compose components I added or changed are covered by compose previews~
- [x] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~