### PR TITLE
Share episode positions to different platforms

### DIFF
--- a/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/episode/ShareEpisodePage.kt
+++ b/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/episode/ShareEpisodePage.kt
@@ -77,9 +77,9 @@ private fun VerticalShareEpisodePage(
     shareColors = shareColors,
     socialPlatforms = socialPlatforms,
     onClose = listener::onClose,
-    onShareToPlatform = { platfrom, cardType ->
+    onShareToPlatform = { platform, cardType ->
         if (podcast != null && episode != null) {
-            listener.onShare(podcast, episode, platfrom, cardType)
+            listener.onShare(podcast, episode, platform, cardType)
         }
     },
     middleContent = { cardType, modifier ->
@@ -125,9 +125,9 @@ private fun HorizontalShareEpisodePage(
     shareColors = shareColors,
     socialPlatforms = socialPlatforms,
     onClose = listener::onClose,
-    onShareToPlatform = { platfrom, cardType ->
+    onShareToPlatform = { platform, cardType ->
         if (podcast != null && episode != null) {
-            listener.onShare(podcast, episode, platfrom, cardType)
+            listener.onShare(podcast, episode, platform, cardType)
         }
     },
     middleContent = {

--- a/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/podcast/SharePodcastPage.kt
+++ b/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/podcast/SharePodcastPage.kt
@@ -68,9 +68,9 @@ private fun VerticalSharePodcastPage(
     shareColors = shareColors,
     socialPlatforms = socialPlatforms,
     onClose = listener::onClose,
-    onShareToPlatform = { platfrom, cardType ->
+    onShareToPlatform = { platform, cardType ->
         if (podcast != null) {
-            listener.onShare(podcast, platfrom, cardType)
+            listener.onShare(podcast, platform, cardType)
         }
     },
     middleContent = { cardType, modifier ->
@@ -112,9 +112,9 @@ private fun HorizontalSharePodcastPage(
     shareColors = shareColors,
     socialPlatforms = socialPlatforms,
     onClose = listener::onClose,
-    onShareToPlatform = { platfrom, cardType ->
+    onShareToPlatform = { platform, cardType ->
         if (podcast != null) {
-            listener.onShare(podcast, platfrom, cardType)
+            listener.onShare(podcast, platform, cardType)
         }
     },
     middleContent = {

--- a/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/timestamp/ShareEpisodeTimestampFragment.kt
+++ b/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/timestamp/ShareEpisodeTimestampFragment.kt
@@ -22,12 +22,15 @@ import au.com.shiftyjelly.pocketcasts.sharing.ui.ShareColors
 import au.com.shiftyjelly.pocketcasts.utils.parceler.ColorParceler
 import au.com.shiftyjelly.pocketcasts.utils.parceler.DurationParceler
 import au.com.shiftyjelly.pocketcasts.views.fragments.BaseDialogFragment
+import dagger.hilt.android.AndroidEntryPoint
 import dagger.hilt.android.lifecycle.withCreationCallback
+import javax.inject.Inject
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
 import kotlinx.parcelize.Parcelize
 import kotlinx.parcelize.TypeParceler
 
+@AndroidEntryPoint
 class ShareEpisodeTimestampFragment : BaseDialogFragment() {
     private val args get() = requireNotNull(arguments?.let { BundleCompat.getParcelable(it, NEW_INSTANCE_ARG, Args::class.java) })
 
@@ -41,13 +44,15 @@ class ShareEpisodeTimestampFragment : BaseDialogFragment() {
         },
     )
 
+    @Inject internal lateinit var shareListenerFactory: ShareEpisodeTimestampListener.Factory
+
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
         savedInstanceState: Bundle?,
     ) = ComposeView(requireActivity()).apply {
         val platforms = SocialPlatform.getAvailablePlatforms(requireContext())
-        val listener = ShareEpisodeTimestampListener(args.timestampType, this@ShareEpisodeTimestampFragment)
+        val listener = shareListenerFactory.create(this@ShareEpisodeTimestampFragment, args.timestampType, args.source)
         setContent {
             val uiState by viewModel.uiState.collectAsState()
             ShareEpisodeTimestampPage(

--- a/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/timestamp/ShareEpisodeTimestampListener.kt
+++ b/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/timestamp/ShareEpisodeTimestampListener.kt
@@ -1,20 +1,54 @@
 package au.com.shiftyjelly.pocketcasts.sharing.timestamp
 
 import android.widget.Toast
+import androidx.lifecycle.lifecycleScope
+import au.com.shiftyjelly.pocketcasts.analytics.SourceView
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
+import au.com.shiftyjelly.pocketcasts.sharing.SharingClient
+import au.com.shiftyjelly.pocketcasts.sharing.SharingRequest
 import au.com.shiftyjelly.pocketcasts.sharing.social.SocialPlatform
+import au.com.shiftyjelly.pocketcasts.sharing.ui.CardType
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedFactory
+import dagger.assisted.AssistedInject
 import kotlin.time.Duration
+import kotlinx.coroutines.launch
 
-internal class ShareEpisodeTimestampListener(
-    private val type: TimestampType,
-    private val fragment: ShareEpisodeTimestampFragment,
+internal class ShareEpisodeTimestampListener @AssistedInject constructor(
+    @Assisted private val fragment: ShareEpisodeTimestampFragment,
+    @Assisted private val type: TimestampType,
+    @Assisted private val sourceView: SourceView,
+    private val sharingClient: SharingClient,
 ) : ShareEpisodeTimestampPageListener {
-    override fun onShare(podcast: Podcast, episode: PodcastEpisode, timestamp: Duration, platform: SocialPlatform) {
-        Toast.makeText(fragment.requireActivity(), "Share $timestamp as $type to $platform", Toast.LENGTH_SHORT).show()
+    override fun onShare(podcast: Podcast, episode: PodcastEpisode, timestamp: Duration, platform: SocialPlatform, cardType: CardType) {
+        val builder = when (type) {
+            TimestampType.Episode -> SharingRequest.episodePosition(podcast, episode, timestamp)
+            TimestampType.Bookmark -> SharingRequest.bookmark(podcast, episode, timestamp)
+        }
+        val request = builder
+            .setPlatform(platform)
+            .setCardType(cardType)
+            .setSourceView(sourceView)
+            .build()
+        fragment.lifecycleScope.launch {
+            val response = sharingClient.share(request)
+            if (response.feedbackMessage != null) {
+                Toast.makeText(fragment.requireActivity(), response.feedbackMessage, Toast.LENGTH_SHORT).show()
+            }
+        }
     }
 
     override fun onClose() {
         fragment.dismiss()
+    }
+
+    @AssistedFactory
+    interface Factory {
+        fun create(
+            fragment: ShareEpisodeTimestampFragment,
+            type: TimestampType,
+            sourceView: SourceView,
+        ): ShareEpisodeTimestampListener
     }
 }

--- a/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/timestamp/ShareEpisodeTimestampPage.kt
+++ b/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/timestamp/ShareEpisodeTimestampPage.kt
@@ -27,12 +27,12 @@ import kotlin.time.Duration.Companion.seconds
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 internal interface ShareEpisodeTimestampPageListener {
-    fun onShare(podcast: Podcast, episode: PodcastEpisode, timestamp: Duration, platform: SocialPlatform)
+    fun onShare(podcast: Podcast, episode: PodcastEpisode, timestamp: Duration, platform: SocialPlatform, cardType: CardType)
     fun onClose()
 
     companion object {
         val Preview = object : ShareEpisodeTimestampPageListener {
-            override fun onShare(podcast: Podcast, episode: PodcastEpisode, timestamp: Duration, platform: SocialPlatform) = Unit
+            override fun onShare(podcast: Podcast, episode: PodcastEpisode, timestamp: Duration, platform: SocialPlatform, cardType: CardType) = Unit
             override fun onClose() = Unit
         }
     }
@@ -83,9 +83,9 @@ private fun VerticalShareEpisodeTimestampPage(
     shareColors = shareColors,
     socialPlatforms = socialPlatforms,
     onClose = listener::onClose,
-    onShareToPlatform = { platfrom, _ ->
+    onShareToPlatform = { platform, cardType ->
         if (podcast != null && episode != null) {
-            listener.onShare(podcast, episode, timestamp, platfrom)
+            listener.onShare(podcast, episode, timestamp, platform, cardType)
         }
     },
     middleContent = { cardType, modifier ->
@@ -132,9 +132,9 @@ private fun HorizontalShareEpisodeTimestampPage(
     shareColors = shareColors,
     socialPlatforms = socialPlatforms,
     onClose = listener::onClose,
-    onShareToPlatform = { platfrom, _ ->
+    onShareToPlatform = { platform, cardType ->
         if (podcast != null && episode != null) {
-            listener.onShare(podcast, episode, timestamp, platfrom)
+            listener.onShare(podcast, episode, timestamp, platform, cardType)
         }
     },
     middleContent = {

--- a/modules/features/sharing/src/test/kotlin/au/com/shiftyjelly/pocketcasts/sharing/social/SocialPlatformTest.kt
+++ b/modules/features/sharing/src/test/kotlin/au/com/shiftyjelly/pocketcasts/sharing/social/SocialPlatformTest.kt
@@ -5,8 +5,8 @@ import org.junit.Test
 
 class SocialPlatformTest {
     @Test
-    fun `social platfrom are correctly prioritzed`() {
-        val sortedPlatfroms = SocialPlatform.entries
+    fun `social platform are correctly prioritzed`() {
+        val sortedplatforms = SocialPlatform.entries
 
         assertEquals(
             listOf(
@@ -18,7 +18,7 @@ class SocialPlatformTest {
                 SocialPlatform.PocketCasts,
                 SocialPlatform.More,
             ),
-            sortedPlatfroms,
+            sortedplatforms,
         )
     }
 }

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -2012,6 +2012,8 @@ up    <string name="player_sleep_in_one_chapter">Sleeping in 1 chapter</string>
     <string name="share_link_copied_feedback">Link copied to clipboard</string>
     <string name="share_link_podcast">Podcast link</string>
     <string name="share_link_episode">Episode link</string>
+    <string name="share_link_episode_position">Episode position link</string>
+    <string name="share_link_bookmark">Bookmark link</string>
 
     <!-- Pocket Casts Champion -->
     <string name="pocket_casts_champion_dialog_title">You’re a true champion of Pocket Casts!</string>


### PR DESCRIPTION
## Description

This PR uses `SharingClient` for episode position sharing.

Currently, the copy link feedback message is displayed in a Toast instead of a Snackbar. I will add Snackbar support in a different PR.

## Testing Instructions

1. Share an episode at current position to Stories. It should fail with a toast message.
2. Share an episode at current position to WhatsApp, Telegram, X, and Tumblr. You need to have these apps installed on your device for them to be displayed in the social sharing bar. Also they are displayed in that precedence. So if you have Instagram and WhatsApp you won't see Telegram.
3. Share an episode at current position using `Copy link`. On SDK >= 33, you'll see a native feedback prompt. On SDK < 33, you'll see a Toast.
4. Share an episode at current position using `More`. It should open a sharing sheet.
5. Share a bookmark to Stories. It should fail with a toast message.
6. Share a bookmark position to WhatsApp, Telegram, X, and Tumblr. You need to have these apps installed on your device for them to be displayed in the social sharing bar. Also they are displayed in that precedence. So if you have Instagram and WhatsApp you won't see Telegram.
7. Share a bookmark using `Copy link`. On SDK >= 33, you'll see a native feedback prompt. On SDK < 33, you'll see a Toast.
8. Share a bookmark using `More`. It should open a sharing sheet.

When sharing, you can verify card, source, and timestamp type through logs using the `tag:SharingClient` filter.

## Checklist
- [x] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] ~Any jetpack compose components I added or changed are covered by compose previews~
- [x] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~