### PR TITLE
Display sharing feedback in a snackbar

### DIFF
--- a/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/episode/ShareEpisodeListener.kt
+++ b/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/episode/ShareEpisodeListener.kt
@@ -1,36 +1,29 @@
 package au.com.shiftyjelly.pocketcasts.sharing.episode
 
-import android.widget.Toast
-import androidx.lifecycle.lifecycleScope
 import au.com.shiftyjelly.pocketcasts.analytics.SourceView
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.sharing.SharingClient
 import au.com.shiftyjelly.pocketcasts.sharing.SharingRequest
+import au.com.shiftyjelly.pocketcasts.sharing.SharingResponse
 import au.com.shiftyjelly.pocketcasts.sharing.social.SocialPlatform
 import au.com.shiftyjelly.pocketcasts.sharing.ui.CardType
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
-import kotlinx.coroutines.launch
 
 internal class ShareEpisodeListener @AssistedInject constructor(
     @Assisted private val fragment: ShareEpisodeFragment,
     @Assisted private val sourceView: SourceView,
     private val sharingClient: SharingClient,
 ) : ShareEpisodePageListener {
-    override fun onShare(podcast: Podcast, episode: PodcastEpisode, platform: SocialPlatform, cardType: CardType) {
+    override suspend fun onShare(podcast: Podcast, episode: PodcastEpisode, platform: SocialPlatform, cardType: CardType): SharingResponse {
         val request = SharingRequest.episode(podcast, episode)
             .setPlatform(platform)
             .setCardType(cardType)
             .setSourceView(sourceView)
             .build()
-        fragment.lifecycleScope.launch {
-            val response = sharingClient.share(request)
-            if (response.feedbackMessage != null) {
-                Toast.makeText(fragment.requireActivity(), response.feedbackMessage, Toast.LENGTH_SHORT).show()
-            }
-        }
+        return sharingClient.share(request)
     }
 
     override fun onClose() {

--- a/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/podcast/SharePodcastListener.kt
+++ b/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/podcast/SharePodcastListener.kt
@@ -1,35 +1,28 @@
 package au.com.shiftyjelly.pocketcasts.sharing.podcast
 
-import android.widget.Toast
-import androidx.lifecycle.lifecycleScope
 import au.com.shiftyjelly.pocketcasts.analytics.SourceView
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.sharing.SharingClient
 import au.com.shiftyjelly.pocketcasts.sharing.SharingRequest
+import au.com.shiftyjelly.pocketcasts.sharing.SharingResponse
 import au.com.shiftyjelly.pocketcasts.sharing.social.SocialPlatform
 import au.com.shiftyjelly.pocketcasts.sharing.ui.CardType
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
-import kotlinx.coroutines.launch
 
 internal class SharePodcastListener @AssistedInject constructor(
     @Assisted private val fragment: SharePodcastFragment,
     @Assisted private val sourceView: SourceView,
     private val sharingClient: SharingClient,
 ) : SharePodcastPageListener {
-    override fun onShare(podcast: Podcast, platform: SocialPlatform, cardType: CardType) {
+    override suspend fun onShare(podcast: Podcast, platform: SocialPlatform, cardType: CardType): SharingResponse {
         val request = SharingRequest.podcast(podcast)
             .setPlatform(platform)
             .setCardType(cardType)
             .setSourceView(sourceView)
             .build()
-        fragment.lifecycleScope.launch {
-            val response = sharingClient.share(request)
-            if (response.feedbackMessage != null) {
-                Toast.makeText(fragment.requireActivity(), response.feedbackMessage, Toast.LENGTH_SHORT).show()
-            }
-        }
+        return sharingClient.share(request)
     }
 
     override fun onClose() {

--- a/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/timestamp/ShareEpisodeTimestampListener.kt
+++ b/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/timestamp/ShareEpisodeTimestampListener.kt
@@ -1,19 +1,17 @@
 package au.com.shiftyjelly.pocketcasts.sharing.timestamp
 
-import android.widget.Toast
-import androidx.lifecycle.lifecycleScope
 import au.com.shiftyjelly.pocketcasts.analytics.SourceView
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.sharing.SharingClient
 import au.com.shiftyjelly.pocketcasts.sharing.SharingRequest
+import au.com.shiftyjelly.pocketcasts.sharing.SharingResponse
 import au.com.shiftyjelly.pocketcasts.sharing.social.SocialPlatform
 import au.com.shiftyjelly.pocketcasts.sharing.ui.CardType
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
 import kotlin.time.Duration
-import kotlinx.coroutines.launch
 
 internal class ShareEpisodeTimestampListener @AssistedInject constructor(
     @Assisted private val fragment: ShareEpisodeTimestampFragment,
@@ -21,7 +19,7 @@ internal class ShareEpisodeTimestampListener @AssistedInject constructor(
     @Assisted private val sourceView: SourceView,
     private val sharingClient: SharingClient,
 ) : ShareEpisodeTimestampPageListener {
-    override fun onShare(podcast: Podcast, episode: PodcastEpisode, timestamp: Duration, platform: SocialPlatform, cardType: CardType) {
+    override suspend fun onShare(podcast: Podcast, episode: PodcastEpisode, timestamp: Duration, platform: SocialPlatform, cardType: CardType): SharingResponse {
         val builder = when (type) {
             TimestampType.Episode -> SharingRequest.episodePosition(podcast, episode, timestamp)
             TimestampType.Bookmark -> SharingRequest.bookmark(podcast, episode, timestamp)
@@ -31,12 +29,7 @@ internal class ShareEpisodeTimestampListener @AssistedInject constructor(
             .setCardType(cardType)
             .setSourceView(sourceView)
             .build()
-        fragment.lifecycleScope.launch {
-            val response = sharingClient.share(request)
-            if (response.feedbackMessage != null) {
-                Toast.makeText(fragment.requireActivity(), response.feedbackMessage, Toast.LENGTH_SHORT).show()
-            }
-        }
+        return sharingClient.share(request)
     }
 
     override fun onClose() {

--- a/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/ui/ShareColors.kt
+++ b/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/ui/ShareColors.kt
@@ -18,6 +18,9 @@ internal data class ShareColors(
     val pagerIndicatorActive = if (background.luminance() < 0.5f) Color.White else Color.Black
     val pagerIndicatorInactive = pagerIndicatorActive.copy(alpha = 0.3f)
 
+    val snackbar = if (background.luminance() < 0.5f) Color.White else Color.Black
+    val snackbarText = if (snackbar.luminance() < 0.5f) Color.White else Color.Black
+
     val clipButton = if (background.luminance() < 0.25) {
         ColorUtils.changeHsvValue(base, 2f)
     } else {

--- a/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/ui/SharePage.kt
+++ b/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/ui/SharePage.kt
@@ -16,6 +16,13 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.sizeIn
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
+import androidx.compose.material.ButtonDefaults
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Snackbar
+import androidx.compose.material.SnackbarData
+import androidx.compose.material.SnackbarHost
+import androidx.compose.material.SnackbarHostState
+import androidx.compose.material.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
@@ -25,6 +32,7 @@ import androidx.compose.ui.unit.dp
 import au.com.shiftyjelly.pocketcasts.compose.components.PagerDotIndicator
 import au.com.shiftyjelly.pocketcasts.compose.components.TextH30
 import au.com.shiftyjelly.pocketcasts.compose.components.TextH40
+import au.com.shiftyjelly.pocketcasts.compose.components.TextH50
 import au.com.shiftyjelly.pocketcasts.sharing.social.PlatformBar
 import au.com.shiftyjelly.pocketcasts.sharing.social.SocialPlatform
 
@@ -35,93 +43,101 @@ internal fun VerticalSharePage(
     shareDescription: String,
     shareColors: ShareColors,
     socialPlatforms: Set<SocialPlatform>,
+    snackbarHostState: SnackbarHostState,
     onClose: () -> Unit,
     onShareToPlatform: (SocialPlatform, CardType) -> Unit,
     middleContent: @Composable (CardType, Modifier) -> Unit,
-) = Column(
-    modifier = Modifier
-        .fillMaxSize()
-        .background(shareColors.background),
-) {
-    Box(
-        contentAlignment = Alignment.TopEnd,
+) = Box {
+    Column(
         modifier = Modifier
-            .weight(0.2f)
-            .fillMaxSize(),
+            .fillMaxSize()
+            .background(shareColors.background),
     ) {
-        CloseButton(
-            shareColors = shareColors,
-            onClick = onClose,
-            modifier = Modifier.padding(top = 12.dp, end = 12.dp),
-        )
-        Column(
-            horizontalAlignment = Alignment.CenterHorizontally,
-            verticalArrangement = Arrangement.Center,
-            modifier = Modifier.fillMaxSize(),
+        Box(
+            contentAlignment = Alignment.TopEnd,
+            modifier = Modifier
+                .weight(0.2f)
+                .fillMaxSize(),
         ) {
-            TextH30(
-                text = shareTitle,
-                textAlign = TextAlign.Center,
-                color = shareColors.backgroundPrimaryText,
-                modifier = Modifier.padding(horizontal = 24.dp),
+            CloseButton(
+                shareColors = shareColors,
+                onClick = onClose,
+                modifier = Modifier.padding(top = 12.dp, end = 12.dp),
             )
-            Spacer(
-                modifier = Modifier.height(8.dp),
-            )
-            TextH40(
-                text = shareDescription,
-                textAlign = TextAlign.Center,
-                color = shareColors.backgroundSecondaryText,
-                modifier = Modifier.sizeIn(maxWidth = 220.dp),
+            Column(
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.Center,
+                modifier = Modifier.fillMaxSize(),
+            ) {
+                TextH30(
+                    text = shareTitle,
+                    textAlign = TextAlign.Center,
+                    color = shareColors.backgroundPrimaryText,
+                    modifier = Modifier.padding(horizontal = 24.dp),
+                )
+                Spacer(
+                    modifier = Modifier.height(8.dp),
+                )
+                TextH40(
+                    text = shareDescription,
+                    textAlign = TextAlign.Center,
+                    color = shareColors.backgroundSecondaryText,
+                    modifier = Modifier.sizeIn(maxWidth = 220.dp),
+                )
+            }
+        }
+        val pagerState = rememberPagerState(pageCount = { CardType.entries.size })
+        Box(
+            contentAlignment = Alignment.Center,
+            content = {
+                Column(
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                ) {
+                    BoxWithConstraints(
+                        modifier = Modifier.weight(0.92f),
+                    ) {
+                        val expectedVerticalCardPadding = remember(maxWidth, maxHeight) { (maxWidth - maxHeight / 1.5f) / 2 }
+                        HorizontalPager(
+                            state = pagerState,
+                            modifier = Modifier.fillMaxSize(),
+                        ) { pageIndex ->
+                            val cardType = CardType.entries[pageIndex]
+                            val modifier = Modifier
+                                .fillMaxSize()
+                                .then(if (cardType != CardType.Vertical) Modifier.padding(horizontal = expectedVerticalCardPadding) else Modifier)
+                            middleContent(cardType, modifier)
+                        }
+                    }
+                    PagerDotIndicator(
+                        state = pagerState,
+                        activeDotColor = shareColors.pagerIndicatorActive,
+                        inactiveDotColor = shareColors.pagerIndicatorInactive,
+                        modifier = Modifier.weight(0.08f),
+                    )
+                }
+            },
+            modifier = Modifier
+                .weight(0.65f)
+                .fillMaxSize(),
+        )
+        Box(
+            contentAlignment = Alignment.Center,
+            modifier = Modifier.weight(0.15f),
+        ) {
+            PlatformBar(
+                platforms = socialPlatforms,
+                shareColors = shareColors,
+                onClick = { platform ->
+                    onShareToPlatform(platform, CardType.entries[pagerState.currentPage])
+                },
             )
         }
     }
-    val pagerState = rememberPagerState(pageCount = { CardType.entries.size })
-    Box(
-        contentAlignment = Alignment.Center,
-        content = {
-            Column(
-                horizontalAlignment = Alignment.CenterHorizontally,
-            ) {
-                BoxWithConstraints(
-                    modifier = Modifier.weight(0.92f),
-                ) {
-                    val expectedVerticalCardPadding = remember(maxWidth, maxHeight) { (maxWidth - maxHeight / 1.5f) / 2 }
-                    HorizontalPager(
-                        state = pagerState,
-                        modifier = Modifier.fillMaxSize(),
-                    ) { pageIndex ->
-                        val cardType = CardType.entries[pageIndex]
-                        val modifier = Modifier
-                            .fillMaxSize()
-                            .then(if (cardType != CardType.Vertical) Modifier.padding(horizontal = expectedVerticalCardPadding) else Modifier)
-                        middleContent(cardType, modifier)
-                    }
-                }
-                PagerDotIndicator(
-                    state = pagerState,
-                    activeDotColor = shareColors.pagerIndicatorActive,
-                    inactiveDotColor = shareColors.pagerIndicatorInactive,
-                    modifier = Modifier.weight(0.08f),
-                )
-            }
-        },
-        modifier = Modifier
-            .weight(0.65f)
-            .fillMaxSize(),
+    SnackbarHost(
+        hostState = snackbarHostState,
+        modifier = Modifier.align(Alignment.BottomCenter),
+        snackbar = { data -> SharingThemedSnackbar(data, shareColors) },
     )
-    Box(
-        contentAlignment = Alignment.Center,
-        modifier = Modifier.weight(0.15f),
-    ) {
-        PlatformBar(
-            platforms = socialPlatforms,
-            shareColors = shareColors,
-            onClick = { platform ->
-                onShareToPlatform(platform, CardType.entries[pagerState.currentPage])
-            },
-        )
-    }
 }
 
 @Composable
@@ -130,81 +146,119 @@ internal fun HorizontalSharePage(
     shareDescription: String,
     shareColors: ShareColors,
     socialPlatforms: Set<SocialPlatform>,
+    snackbarHostState: SnackbarHostState,
     onClose: () -> Unit,
     onShareToPlatform: (SocialPlatform, CardType) -> Unit,
     middleContent: @Composable BoxScope.() -> Unit,
-) = Column(
-    modifier = Modifier
-        .fillMaxSize()
-        .background(shareColors.background),
-) {
-    Box(
-        contentAlignment = Alignment.TopEnd,
+) = Box {
+    Column(
         modifier = Modifier
-            .weight(0.25f)
-            .fillMaxSize(),
+            .fillMaxSize()
+            .background(shareColors.background),
     ) {
-        CloseButton(
-            shareColors = shareColors,
-            onClick = onClose,
-            modifier = Modifier.padding(top = 12.dp, end = 12.dp),
-        )
-        Column(
-            horizontalAlignment = Alignment.CenterHorizontally,
-            verticalArrangement = Arrangement.Center,
-            modifier = Modifier.fillMaxSize(),
+        Box(
+            contentAlignment = Alignment.TopEnd,
+            modifier = Modifier
+                .weight(0.25f)
+                .fillMaxSize(),
         ) {
-            TextH30(
-                text = shareTitle,
-                textAlign = TextAlign.Center,
-                color = shareColors.backgroundPrimaryText,
-                modifier = Modifier.padding(horizontal = 24.dp),
+            CloseButton(
+                shareColors = shareColors,
+                onClick = onClose,
+                modifier = Modifier.padding(top = 12.dp, end = 12.dp),
+            )
+            Column(
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.Center,
+                modifier = Modifier.fillMaxSize(),
+            ) {
+                TextH30(
+                    text = shareTitle,
+                    textAlign = TextAlign.Center,
+                    color = shareColors.backgroundPrimaryText,
+                    modifier = Modifier.padding(horizontal = 24.dp),
+                )
+                Spacer(
+                    modifier = Modifier.height(8.dp),
+                )
+                TextH40(
+                    text = shareDescription,
+                    textAlign = TextAlign.Center,
+                    color = shareColors.backgroundSecondaryText,
+                    modifier = Modifier.padding(horizontal = 24.dp),
+                )
+            }
+        }
+        Row(
+            modifier = Modifier
+                .weight(0.75f)
+                .fillMaxSize(),
+        ) {
+            Spacer(
+                modifier = Modifier.weight(0.1f),
+            )
+            Box(
+                contentAlignment = Alignment.Center,
+                content = middleContent,
+                modifier = Modifier
+                    .weight(1f)
+                    .fillMaxHeight(),
             )
             Spacer(
-                modifier = Modifier.height(8.dp),
+                modifier = Modifier.weight(0.1f),
             )
-            TextH40(
-                text = shareDescription,
-                textAlign = TextAlign.Center,
-                color = shareColors.backgroundSecondaryText,
-                modifier = Modifier.padding(horizontal = 24.dp),
+            Box(
+                contentAlignment = Alignment.Center,
+                modifier = Modifier
+                    .weight(1f)
+                    .fillMaxHeight(),
+            ) {
+                PlatformBar(
+                    platforms = socialPlatforms,
+                    shareColors = shareColors,
+                    onClick = { platform ->
+                        onShareToPlatform(platform, CardType.Horiozntal)
+                    },
+                )
+            }
+            Spacer(
+                modifier = Modifier.weight(0.1f),
             )
         }
     }
-    Row(
-        modifier = Modifier
-            .weight(0.75f)
-            .fillMaxSize(),
-    ) {
-        Spacer(
-            modifier = Modifier.weight(0.1f),
-        )
-        Box(
-            contentAlignment = Alignment.Center,
-            content = middleContent,
-            modifier = Modifier
-                .weight(1f)
-                .fillMaxHeight(),
-        )
-        Spacer(
-            modifier = Modifier.weight(0.1f),
-        )
-        Box(
-            contentAlignment = Alignment.Center,
-            modifier = Modifier
-                .weight(1f)
-                .fillMaxHeight(),
-        ) {
-            PlatformBar(
-                platforms = socialPlatforms,
-                shareColors = shareColors,
-                onClick = { platform ->
-                    onShareToPlatform(platform, CardType.Horiozntal)
-                },
+    SnackbarHost(
+        hostState = snackbarHostState,
+        modifier = Modifier.align(Alignment.BottomCenter),
+        snackbar = { data -> SharingThemedSnackbar(data, shareColors) },
+    )
+}
+
+@Composable
+private fun SharingThemedSnackbar(
+    snackbarData: SnackbarData,
+    shareColors: ShareColors,
+    modifier: Modifier = Modifier,
+) {
+    val actionLabel = snackbarData.actionLabel
+    val actionComposable: (@Composable () -> Unit)? = if (actionLabel != null) {
+        @Composable {
+            TextButton(
+                colors = ButtonDefaults.textButtonColors(contentColor = shareColors.snackbarText),
+                onClick = { snackbarData.performAction() },
+                content = { TextH50(actionLabel) },
             )
         }
-        Spacer(
-            modifier = Modifier.weight(0.1f),
-        )
+    } else {
+        null
     }
+    Snackbar(
+        modifier = modifier.padding(12.dp),
+        content = { TextH50(snackbarData.message, color = shareColors.snackbarText) },
+        action = actionComposable,
+        actionOnNewLine = false,
+        shape = MaterialTheme.shapes.small,
+        backgroundColor = shareColors.snackbar,
+        contentColor = shareColors.snackbar,
+        elevation = 0.dp,
+    )
 }


### PR DESCRIPTION
## Description

This PR displays sharing feedback messages in a Snackbar instead of Toast. I didn't use the default Snackbar implementation because I have to control theming based on a podcast and the deafult implementation doesn't have an easy way to control text's color.

Designs: HR2vcQrWcS0scsolKZBitg-fi-2345_20311

## Testing Instructions

1. Share a podcast to Instagram.
2. You should see a snackbar feedback message.
3. Share an episode to Instagram.
4. You should see a snackbar feedback message.
5. Share an episode position to Instagram.
6. You should see a snackbar feedback message.

## Screenshots or Screencast 

![share_2936570251206927203](https://github.com/user-attachments/assets/373a0ff6-9d72-47c9-b3bd-6410f365f406)

## Checklist
- [x] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] ~I have considered whether it makes sense to add tests for my changes~
- [x] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [x] ~Any jetpack compose components I added or changed are covered by compose previews~
- [x] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack