### PR TITLE
Fix Up Next user files opening episode dialog

### DIFF
--- a/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
+++ b/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
@@ -1387,7 +1387,7 @@ class MainActivity :
         }
 
         launch(Dispatchers.Main.immediate) {
-            when (val localEpisode = withContext(Dispatchers.Default) { episodeManager.findEpisodeByUuid(episodeUuid) }) {
+            val fragment = when (val localEpisode = withContext(Dispatchers.Default) { episodeManager.findEpisodeByUuid(episodeUuid) }) {
                 is UserEpisode -> {
                     CloudFileBottomSheetFragment.newInstance(localEpisode.uuid, forceDark = true, source)
                 }
@@ -1398,24 +1398,24 @@ class MainActivity :
                         podcastUuid = localEpisode.podcastUuid,
                         forceDark = forceDark,
                         timestamp = startTimestamp,
-                    ).showAllowingStateLoss(supportFragmentManager, "episode_card")
+                    )
                 }
                 null -> {
                     val dialog = android.app.ProgressDialog.show(this@MainActivity, getString(LR.string.loading), getString(LR.string.please_wait), true)
                     val searchResult = serverManager.getSharedItemDetailsSuspend("/social/share/show/$episodeUuid")
                     dialog.hide()
-                    val episode = searchResult?.episode
-                    if (episode != null) {
+                    searchResult?.episode?.let {
                         EpisodeContainerFragment.newInstance(
-                            episodeUuid = episode.uuid,
+                            episodeUuid = it.uuid,
                             source = source,
-                            podcastUuid = episode.podcastUuid,
+                            podcastUuid = it.podcastUuid,
                             forceDark = forceDark,
                             timestamp = startTimestamp,
-                        ).showAllowingStateLoss(supportFragmentManager, "episode_card")
+                        )
                     }
                 }
             }
+            fragment?.showAllowingStateLoss(supportFragmentManager, "episode_card")
         }
     }
 


### PR DESCRIPTION
## Description

A user reported in the beta that tapping a user file in the Up Next no longer opened the episode dialog. This fixes that issue. I believe this was introduced in 7.69 so I haven't added a change log entry and have targeted the release branch. 

## Testing Instructions
1. Add a user file episode
2. Add the episode to the Up Next, in the Up Next and not the playing episode
3. Tap the "Up Next" tab
4. Tap the user episode
5. ✅ Verify the user file dialog is opened
6. Close the dialog
7. Tap the Up Next icon in the mini player
8. Tap the user episode
9. ✅ Verify the user file dialog is opened

## Screenshots or Screencast 

https://github.com/user-attachments/assets/1a5146f5-e54b-4ac4-8c3b-e70ce273add5
