### PR TITLE
Include ffmpeg in debug variants

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -254,6 +254,7 @@ core-ktx = "androidx.core:core-ktx:1.10.1"
 desugar-jdk = "com.android.tools:desugar_jdk_libs:2.0.4"
 device-names = "com.jaredrummler:android-device-names:2.1.0"
 encryptedlogging = "com.automattic:encryptedlogging:0.0.1"
+ffmpeg = "com.arthenica:ffmpeg-kit-full:6.0-2"
 flexbox = "com.google.android.flexbox:flexbox:3.0.0"
 fragment-ktx = "androidx.fragment:fragment-ktx:1.5.2"
 guava = "com.google.guava:guava:33.1.0-android" # Required to fix conflict between versions in exoplayer and workmanager

--- a/modules/features/sharing/build.gradle.kts
+++ b/modules/features/sharing/build.gradle.kts
@@ -18,6 +18,8 @@ android {
 }
 
 dependencies {
+    val debugProdImplementation by configurations
+
     implementation(project(":modules:services:analytics"))
     implementation(project(":modules:services:compose"))
     implementation(project(":modules:services:images"))
@@ -28,6 +30,12 @@ dependencies {
     implementation(project(":modules:services:ui"))
     implementation(project(":modules:services:utils"))
     implementation(project(":modules:services:views"))
+
+    // We do not include FFmpeg in the release variant for now
+    // to not increase the binary size.
+    // We can add it once we release clip sharing.
+    debugImplementation(libs.ffmpeg)
+    debugProdImplementation(libs.ffmpeg)
 
     testImplementation(project(":modules:services:sharedtest"))
 }


### PR DESCRIPTION
## Description

This PR adds FFmpeg in debug variants only. Release is skipped for now since the binary is quite big and we don't need it yet in production.

## Testing Instructions

Green CI is enough. But you can smoke test different app variants if they do not crash.

## Checklist
- [x] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] ~I have considered whether it makes sense to add tests for my changes~
- [x] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [x] ~Any jetpack compose components I added or changed are covered by compose previews~
- [x] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~