### PR TITLE
Use demo UI for clip sharing

### DIFF
--- a/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/clip/ShareClipFragment.kt
+++ b/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/clip/ShareClipFragment.kt
@@ -7,10 +7,8 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.annotation.ColorInt
 import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.ui.Alignment
-import androidx.compose.ui.Modifier
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.platform.ComposeView
@@ -18,9 +16,7 @@ import androidx.core.os.BundleCompat
 import androidx.core.os.bundleOf
 import androidx.fragment.app.viewModels
 import au.com.shiftyjelly.pocketcasts.analytics.SourceView
-import au.com.shiftyjelly.pocketcasts.compose.components.TextH30
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
-import au.com.shiftyjelly.pocketcasts.sharing.ShareActions
 import au.com.shiftyjelly.pocketcasts.sharing.ui.ShareColors
 import au.com.shiftyjelly.pocketcasts.utils.parceler.ColorParceler
 import au.com.shiftyjelly.pocketcasts.utils.parceler.DurationParceler
@@ -61,11 +57,6 @@ class ShareClipFragment : BaseDialogFragment() {
 
     private lateinit var clipAnalytics: ClipAnalytics
 
-    @Inject
-    lateinit var shareActionsFactory: ShareActions.Factory
-
-    private lateinit var shareActions: ShareActions
-
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         clipAnalytics = clipAnalyticsFactory.create(
@@ -75,7 +66,6 @@ class ShareClipFragment : BaseDialogFragment() {
             sourceView = args.source,
             initialClipRange = args.clipRange,
         )
-        shareActions = shareActionsFactory.create(args.source)
         if (savedInstanceState == null) {
             viewModel.onClipScreenShown()
         }
@@ -87,18 +77,19 @@ class ShareClipFragment : BaseDialogFragment() {
         savedInstanceState: Bundle?,
     ) = ComposeView(requireActivity()).apply {
         val shareColors = shareColors
+        val listener = ShareClipListener(this@ShareClipFragment, viewModel)
         setContent {
-            Box(
-                contentAlignment = Alignment.Center,
-                modifier = Modifier
-                    .background(shareColors.background)
-                    .fillMaxSize(),
-            ) {
-                TextH30(
-                    text = "Work in progress",
-                    color = shareColors.backgroundPrimaryText,
-                )
-            }
+            val uiState by viewModel.uiState.collectAsState()
+            ShareClipPage(
+                episode = uiState.episode,
+                podcast = uiState.podcast,
+                clipRange = uiState.clipRange,
+                playbackProgress = uiState.playbackProgress,
+                isPlaying = uiState.isPlaying,
+                useEpisodeArtwork = uiState.useEpisodeArtwork,
+                shareColors = shareColors,
+                listener = listener,
+            )
         }
     }
 

--- a/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/clip/ShareClipListener.kt
+++ b/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/clip/ShareClipListener.kt
@@ -1,22 +1,24 @@
 package au.com.shiftyjelly.pocketcasts.sharing.clip
 
-import androidx.lifecycle.lifecycleScope
+import android.widget.Toast
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
-import au.com.shiftyjelly.pocketcasts.sharing.ShareActions
 import kotlin.time.Duration
-import kotlinx.coroutines.launch
 
-internal class ShareClipViewModelListener(
+internal class ShareClipListener(
     private val fragment: ShareClipFragment,
     private val viewModel: ShareClipViewModel,
-    private val shareActions: ShareActions,
 ) : ShareClipPageListener {
-    override fun onClip(podcast: Podcast, episode: PodcastEpisode, clipRange: Clip.Range) {
-        viewModel.onClipLinkShared(Clip.fromEpisode(episode, clipRange))
-        fragment.lifecycleScope.launch {
-            shareActions.shareClipLink(podcast, episode, clipRange.start, clipRange.end)
-        }
+    override suspend fun onShareClipLink(podcast: Podcast, episode: PodcastEpisode, clipRange: Clip.Range) {
+        Toast.makeText(fragment.context, "Share link", Toast.LENGTH_SHORT).show()
+    }
+
+    override suspend fun onShareClipAudio(podcast: Podcast, episode: PodcastEpisode, clipRange: Clip.Range) {
+        Toast.makeText(fragment.context, "Share audio", Toast.LENGTH_SHORT).show()
+    }
+
+    override suspend fun onShareClipVideo(podcast: Podcast, episode: PodcastEpisode, clipRange: Clip.Range) {
+        Toast.makeText(fragment.context, "Share video", Toast.LENGTH_SHORT).show()
     }
 
     override fun onClickPlay() {

--- a/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/clip/ShareClipPage.kt
+++ b/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/clip/ShareClipPage.kt
@@ -1,26 +1,20 @@
 package au.com.shiftyjelly.pocketcasts.sharing.clip
 
-import android.content.res.Configuration
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.material.ButtonDefaults
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
@@ -32,30 +26,34 @@ import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.sharing.ui.ClipSelector
 import au.com.shiftyjelly.pocketcasts.sharing.ui.ClipSelectorState
 import au.com.shiftyjelly.pocketcasts.sharing.ui.CloseButton
-import au.com.shiftyjelly.pocketcasts.sharing.ui.HorizontalEpisodeCard
+import au.com.shiftyjelly.pocketcasts.sharing.ui.Devices
 import au.com.shiftyjelly.pocketcasts.sharing.ui.ShareColors
 import au.com.shiftyjelly.pocketcasts.sharing.ui.VerticalEpisodeCard
 import au.com.shiftyjelly.pocketcasts.sharing.ui.rememberClipSelectorState
-import com.airbnb.android.showkase.annotation.ShowkaseComposable
 import java.sql.Date
 import java.time.Instant
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
+import kotlinx.coroutines.launch
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 internal interface ShareClipPageListener {
-    fun onClip(podcast: Podcast, episode: PodcastEpisode, clipRange: Clip.Range): Unit
-    fun onClickPlay(): Unit
-    fun onClickPause(): Unit
-    fun onUpdateClipStart(duration: Duration): Unit
-    fun onUpdateClipEnd(duration: Duration): Unit
-    fun onUpdateClipProgress(duration: Duration): Unit
-    fun onUpdateTimeline(scale: Float, secondsPerTick: Int): Unit
-    fun onClose(): Unit
+    suspend fun onShareClipLink(podcast: Podcast, episode: PodcastEpisode, clipRange: Clip.Range)
+    suspend fun onShareClipAudio(podcast: Podcast, episode: PodcastEpisode, clipRange: Clip.Range)
+    suspend fun onShareClipVideo(podcast: Podcast, episode: PodcastEpisode, clipRange: Clip.Range)
+    fun onClickPlay()
+    fun onClickPause()
+    fun onUpdateClipStart(duration: Duration)
+    fun onUpdateClipEnd(duration: Duration)
+    fun onUpdateClipProgress(duration: Duration)
+    fun onUpdateTimeline(scale: Float, secondsPerTick: Int)
+    fun onClose()
 
     companion object {
         val Preview = object : ShareClipPageListener {
-            override fun onClip(podcast: Podcast, episode: PodcastEpisode, clipRange: Clip.Range) = Unit
+            override suspend fun onShareClipLink(podcast: Podcast, episode: PodcastEpisode, clipRange: Clip.Range) = Unit
+            override suspend fun onShareClipAudio(podcast: Podcast, episode: PodcastEpisode, clipRange: Clip.Range) = Unit
+            override suspend fun onShareClipVideo(podcast: Podcast, episode: PodcastEpisode, clipRange: Clip.Range) = Unit
             override fun onClickPlay() = Unit
             override fun onClickPause() = Unit
             override fun onUpdateClipStart(duration: Duration) = Unit
@@ -80,30 +78,16 @@ internal fun ShareClipPage(
     state: ClipSelectorState = rememberClipSelectorState(
         firstVisibleItemIndex = (clipRange.startInSeconds - 10).coerceAtLeast(0),
     ),
-) = when (LocalConfiguration.current.orientation) {
-    Configuration.ORIENTATION_LANDSCAPE -> HorizontalClipPage(
-        episode = episode,
-        podcast = podcast,
-        clipRange = clipRange,
-        playbackProgress = playbackProgress,
-        isPlaying = isPlaying,
-        useEpisodeArtwork = useEpisodeArtwork,
-        shareColors = shareColors,
-        listener = listener,
-        state = state,
-    )
-
-    else -> VerticalClipPage(
-        episode = episode,
-        podcast = podcast,
-        clipRange = clipRange,
-        playbackProgress = playbackProgress,
-        isPlaying = isPlaying,
-        useEpisodeArtwork = useEpisodeArtwork,
-        shareColors = shareColors, listener = listener,
-        state = state,
-    )
-}
+) = VerticalClipPage(
+    episode = episode,
+    podcast = podcast,
+    clipRange = clipRange,
+    playbackProgress = playbackProgress,
+    isPlaying = isPlaying,
+    useEpisodeArtwork = useEpisodeArtwork,
+    shareColors = shareColors, listener = listener,
+    state = state,
+)
 
 @Composable
 private fun VerticalClipPage(
@@ -116,129 +100,56 @@ private fun VerticalClipPage(
     shareColors: ShareColors,
     listener: ShareClipPageListener,
     state: ClipSelectorState,
-) = Box {
-    Column(
-        horizontalAlignment = Alignment.CenterHorizontally,
-        modifier = Modifier
-            .fillMaxSize()
-            .background(shareColors.background),
-    ) {
-        Spacer(
-            modifier = Modifier.weight(0.5f),
-        )
-
-        TextH30(
-            text = stringResource(LR.string.podcast_create_clip),
-            color = shareColors.backgroundPrimaryText,
-        )
-
-        Spacer(
-            modifier = Modifier.weight(1f),
-        )
-
-        if (episode != null && podcast != null) {
-            Box(
-                contentAlignment = Alignment.Center,
-                modifier = Modifier.padding(horizontal = 50.dp),
-            ) {
-                VerticalEpisodeCard(
-                    episode = episode,
-                    podcast = podcast,
-                    useEpisodeArtwork = useEpisodeArtwork,
-                    shareColors = shareColors,
-                )
-            }
-            Spacer(
-                modifier = Modifier.weight(1f),
-            )
-            ClipSelector(
-                episodeDuration = episode.duration.seconds,
-                clipRange = clipRange,
-                playbackProgress = playbackProgress,
-                isPlaying = isPlaying,
-                shareColors = shareColors,
-                listener = listener,
-                modifier = Modifier.padding(horizontal = 16.dp),
-                state = state,
-            )
-            Spacer(
-                modifier = Modifier.height(16.dp),
-            )
-            ClipButton(
-                podcast = podcast,
-                episode = episode,
-                clipRange = clipRange,
-                shareColors = shareColors,
-                listener = listener,
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .heightIn(min = 56.dp)
-                    .padding(horizontal = 16.dp),
-            )
-        }
-    }
-    Row(
-        verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.End,
-        modifier = Modifier
-            .fillMaxWidth()
-            .wrapContentHeight(),
-    ) {
-        CloseButton(
-            shareColors = shareColors,
-            onClick = listener::onClose,
-            modifier = Modifier.padding(top = 16.dp, end = 16.dp),
-        )
-    }
-}
-
-@Composable
-private fun HorizontalClipPage(
-    episode: PodcastEpisode?,
-    podcast: Podcast?,
-    clipRange: Clip.Range,
-    playbackProgress: Duration,
-    isPlaying: Boolean,
-    useEpisodeArtwork: Boolean,
-    shareColors: ShareColors,
-    listener: ShareClipPageListener,
-    state: ClipSelectorState,
 ) {
-    Box(
-        contentAlignment = Alignment.TopEnd,
-        modifier = Modifier
-            .fillMaxSize()
-            .background(shareColors.background),
-    ) {
-        Row {
+    val scope = rememberCoroutineScope()
+    Box {
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(shareColors.background),
+        ) {
             Box(
-                contentAlignment = Alignment.Center,
+                contentAlignment = Alignment.TopEnd,
                 modifier = Modifier
-                    .weight(1f)
-                    .fillMaxHeight()
-                    .padding(start = 32.dp),
+                    .weight(0.1f)
+                    .fillMaxSize(),
             ) {
-                if (episode != null && podcast != null) {
-                    HorizontalEpisodeCard(
+                CloseButton(
+                    shareColors = shareColors,
+                    onClick = listener::onClose,
+                    modifier = Modifier.padding(top = 12.dp, end = 12.dp),
+                )
+                Column(
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    verticalArrangement = Arrangement.Center,
+                    modifier = Modifier.fillMaxSize(),
+                ) {
+                    TextH30(
+                        text = stringResource(LR.string.podcast_create_clip),
+                        textAlign = TextAlign.Center,
+                        color = shareColors.backgroundPrimaryText,
+                        modifier = Modifier.padding(horizontal = 24.dp),
+                    )
+                }
+            }
+            if (podcast != null && episode != null) {
+                Box(
+                    contentAlignment = Alignment.Center,
+                    modifier = Modifier
+                        .weight(0.65f)
+                        .fillMaxSize(),
+                ) {
+                    VerticalEpisodeCard(
                         episode = episode,
                         podcast = podcast,
                         useEpisodeArtwork = useEpisodeArtwork,
                         shareColors = shareColors,
                     )
                 }
-            }
-            Spacer(
-                modifier = Modifier.width(12.dp),
-            )
-            Column(
-                verticalArrangement = Arrangement.Center,
-                horizontalAlignment = Alignment.Start,
-                modifier = Modifier
-                    .weight(1f)
-                    .fillMaxHeight()
-                    .padding(end = 32.dp),
-            ) {
-                if (podcast != null && episode != null) {
+                Column(
+                    verticalArrangement = Arrangement.Center,
+                    modifier = Modifier.weight(0.25f),
+                ) {
                     ClipSelector(
                         episodeDuration = episode.duration.seconds,
                         clipRange = clipRange,
@@ -252,83 +163,59 @@ private fun HorizontalClipPage(
                     Spacer(
                         modifier = Modifier.height(16.dp),
                     )
-                    ClipButton(
-                        podcast = podcast,
-                        episode = episode,
-                        clipRange = clipRange,
-                        shareColors = shareColors,
-                        listener = listener,
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .heightIn(min = 56.dp)
-                            .padding(horizontal = 16.dp),
-                    )
+                    Row(
+                        horizontalArrangement = Arrangement.spacedBy(16.dp),
+                        modifier = Modifier.padding(horizontal = 16.dp),
+                    ) {
+                        RowButton(
+                            text = "Link",
+                            onClick = {
+                                scope.launch {
+                                    listener.onShareClipLink(podcast, episode, clipRange)
+                                }
+                            },
+                            colors = ButtonDefaults.buttonColors(backgroundColor = shareColors.clipButton),
+                            textColor = shareColors.clipButtonText,
+                            elevation = null,
+                            includePadding = false,
+                            modifier = Modifier.weight(1f),
+                        )
+                        RowButton(
+                            text = "Audio",
+                            onClick = {
+                                scope.launch {
+                                    listener.onShareClipAudio(podcast, episode, clipRange)
+                                }
+                            },
+                            colors = ButtonDefaults.buttonColors(backgroundColor = shareColors.clipButton),
+                            textColor = shareColors.clipButtonText,
+                            elevation = null,
+                            includePadding = false,
+                            modifier = Modifier.weight(1f),
+                        )
+                        RowButton(
+                            text = "Video",
+                            onClick = {
+                                scope.launch {
+                                    listener.onShareClipVideo(podcast, episode, clipRange)
+                                }
+                            },
+                            colors = ButtonDefaults.buttonColors(backgroundColor = shareColors.clipButton),
+                            textColor = shareColors.clipButtonText,
+                            elevation = null,
+                            includePadding = false,
+                            modifier = Modifier.weight(1f),
+                        )
+                    }
                 }
             }
         }
-        TextH30(
-            text = stringResource(LR.string.podcast_create_clip),
-            color = shareColors.backgroundPrimaryText,
-            textAlign = TextAlign.Center,
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(top = 28.dp),
-        )
-        CloseButton(
-            shareColors = shareColors,
-            onClick = listener::onClose,
-            modifier = Modifier.padding(top = 24.dp, end = 16.dp),
-        )
     }
 }
 
+@Preview(name = "ShareClipPageVertical", device = Devices.PortraitRegular)
 @Composable
-private fun ClipButton(
-    podcast: Podcast,
-    episode: PodcastEpisode,
-    clipRange: Clip.Range,
-    shareColors: ShareColors,
-    listener: ShareClipPageListener,
-    modifier: Modifier = Modifier,
-) = RowButton(
-    text = stringResource(LR.string.podcast_share_clip),
-    contentDescription = stringResource(
-        id = LR.string.podcast_share_clip_description,
-        episode.title,
-        clipRange.startInSeconds,
-        clipRange.endInSeconds,
-    ),
-    onClick = { listener.onClip(podcast, episode, clipRange) },
-    colors = ButtonDefaults.buttonColors(backgroundColor = shareColors.clipButton),
-    textColor = shareColors.clipButtonText,
-    elevation = null,
-    includePadding = false,
-    modifier = modifier,
-)
-
-internal const val PreviewDevicePortrait = "spec:width=400dp,height=800dp,dpi=320"
-internal const val PreviewDeviceLandscape = "$PreviewDevicePortrait,orientation=landscape"
-internal const val PreviewPixelsPerDuration = 11f
-
-@ShowkaseComposable(name = "ShareClipPageVertical", group = "Clip")
-@Preview(name = "ShareClipPageVertical", device = PreviewDevicePortrait)
-@Composable
-fun ShareClipPageVerticalPreview() = ShareClipPagePreview()
-
-@ShowkaseComposable(name = "ShareClipHorizontalPage", group = "Clip")
-@Preview(name = "ShareClipHorizontalPage", device = PreviewDeviceLandscape)
-@Composable
-fun ShareClipPageHorizontalPreview() = ShareClipPagePreview()
-
-@ShowkaseComposable(name = "ShareClipVerticalSmallPage", group = "Clip")
-@Preview(name = "ShareClipVerticalSmallPage", device = "spec:width=360dp,height=640dp,dpi=320,orientation=portrait")
-@Composable
-fun ShareClipPageVerticalSmallPreview() = ShareClipPagePreview()
-
-@ShowkaseComposable(name = "ShareClipHorizontalSmallPage", group = "Clip")
-@Preview(name = "ShareClipHorizontalSmallPage", device = "spec:width=360dp,height=640dp,dpi=320,orientation=landscape")
-@Composable
-fun ShareClipPageHorizontalSmallPreview() = ShareClipPagePreview()
+private fun ShareClipPageVerticalPreview() = ShareClipPagePreview()
 
 @Composable
 internal fun ShareClipPagePreview(
@@ -356,7 +243,6 @@ internal fun ShareClipPagePreview(
         listener = ShareClipPageListener.Preview,
         state = rememberClipSelectorState(
             firstVisibleItemIndex = 0,
-            endOffset = clipRange.end.inWholeSeconds * PreviewPixelsPerDuration,
         ),
     )
 }

--- a/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/clip/ShareClipPageColorPreview.kt
+++ b/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/clip/ShareClipPageColorPreview.kt
@@ -5,6 +5,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.tooling.preview.PreviewParameterProvider
+import au.com.shiftyjelly.pocketcasts.sharing.ui.Devices
 
 private class PodcastColorProvider : PreviewParameterProvider<Long> {
     override val values = sequenceOf(
@@ -29,7 +30,7 @@ private class PodcastColorProvider : PreviewParameterProvider<Long> {
     ).map { Color.parseColor("#$it").toLong() }
 }
 
-@Preview(device = PreviewDevicePortrait)
+@Preview(device = Devices.PortraitRegular)
 @Composable
 private fun VerticalCardPreview(
     @PreviewParameter(PodcastColorProvider::class) color: Long,

--- a/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/ui/ClipSelector.kt
+++ b/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/ui/ClipSelector.kt
@@ -55,7 +55,6 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import au.com.shiftyjelly.pocketcasts.sharing.clip.Clip
-import au.com.shiftyjelly.pocketcasts.sharing.clip.PreviewDevicePortrait
 import au.com.shiftyjelly.pocketcasts.sharing.clip.ShareClipPageListener
 import au.com.shiftyjelly.pocketcasts.utils.extensions.ceilDiv
 import com.airbnb.android.showkase.annotation.ShowkaseComposable
@@ -408,24 +407,23 @@ private fun BoxWithConstraintsScope.ClipBox(
     }
 }
 
-@ShowkaseComposable(name = "ClipSelectorPaused", group = "Clip")
-@Preview(name = "Paused", device = PreviewDevicePortrait)
+@ShowkaseComposable(name = "ClipSelector", group = "Sharing")
+@Preview(name = "Paused", device = Devices.PortraitRegular)
 @Composable
 fun ClipSelectorPausedPreview() = ClipSelectorPreview()
 
-@ShowkaseComposable(name = "ClipSelectorPlaying", group = "Clip")
-@Preview(name = "Playing", device = PreviewDevicePortrait)
+@Preview(name = "Playing", device = Devices.PortraitRegular)
 @Composable
-fun ClipSelectorPlayingPreview() = ClipSelectorPreview(isPlaying = true)
+private fun ClipSelectorPlayingPreview() = ClipSelectorPreview(isPlaying = true)
 
-@Preview(name = "Zoomed in", device = PreviewDevicePortrait)
+@Preview(name = "Zoomed in", device = Devices.PortraitRegular)
 @Composable
 private fun ClipSelectorZoomedPreview() = ClipSelectorPreview(
     clipEnd = 10.seconds,
     scale = 5f,
 )
 
-@Preview(name = "Scrolled", device = PreviewDevicePortrait)
+@Preview(name = "Scrolled", device = Devices.PortraitRegular)
 @Composable
 private fun ClipSelectorScrolledPreview() = ClipSelectorPreview(
     clipStart = 35.seconds,
@@ -433,26 +431,26 @@ private fun ClipSelectorScrolledPreview() = ClipSelectorPreview(
     firstVisibleItemIndex = 25,
 )
 
-@Preview(name = "No start handle", device = PreviewDevicePortrait)
+@Preview(name = "No start handle", device = Devices.PortraitRegular)
 @Composable
 private fun ClipSelectorNoStartHandlePreview() = ClipSelectorPreview(
     firstVisibleItemIndex = 5,
 )
 
-@Preview(name = "No end handle", device = PreviewDevicePortrait)
+@Preview(name = "No end handle", device = Devices.PortraitRegular)
 @Composable
 private fun ClipSelectorNoEndHandlePreview() = ClipSelectorPreview(
     clipStart = 35.seconds,
     clipEnd = 75.seconds,
 )
 
-@Preview(name = "Playback in middle", device = PreviewDevicePortrait)
+@Preview(name = "Playback in middle", device = Devices.PortraitRegular)
 @Composable
 private fun ClipSelectorInProgressPreview() = ClipSelectorPreview(
     progressPlayback = 10.seconds,
 )
 
-@Preview(name = "Playback at end", device = PreviewDevicePortrait)
+@Preview(name = "Playback at end", device = Devices.PortraitRegular)
 @Composable
 private fun ClipSelectorPlayedPreview() = ClipSelectorPreview(
     progressPlayback = 15.seconds,


### PR DESCRIPTION
## Description

Since clips UI requires a small redesign I'm currently changing it to a demo UI where we'll be able to test different features.

## Testing Instructions

1. Share a clip.
2. Verity demo UI.
3. Tapping on different buttons should display an appropriate Toast.

## Screenshots or Screencast 

![Screenshot_20240730-091938](https://github.com/user-attachments/assets/7e6b27ce-609d-4b62-9d4f-2f3fe8d7a482)

## Checklist
- [x] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] ~I have considered whether it makes sense to add tests for my changes~
- [x] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack