### PR TITLE
Add clip link sharing

### DIFF
--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/sharing/SharingClientTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/sharing/SharingClientTest.kt
@@ -16,6 +16,7 @@ import androidx.test.platform.app.InstrumentationRegistry
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTracker
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
+import au.com.shiftyjelly.pocketcasts.sharing.clip.Clip
 import au.com.shiftyjelly.pocketcasts.sharing.social.SocialPlatform
 import au.com.shiftyjelly.pocketcasts.utils.FileUtil
 import java.io.File
@@ -342,6 +343,52 @@ class SharingClientTest {
         assertEquals(context.getString(LR.string.error), response.feedbackMessage)
 
         assertNull(shareStarter.shareIntent)
+    }
+
+    @Test
+    fun copyClipLink() = runTest {
+        val request = SharingRequest.clipLink(
+            podcast = Podcast(uuid = "podcast-uuid", title = "Podcast Title"),
+            episode = PodcastEpisode(uuid = "episode-uuid", title = "Episode Title", publishedDate = Date()),
+            range = Clip.Range(15.seconds, 28.seconds),
+        ).build()
+
+        client.share(request)
+        val clipData = shareStarter.requireShareLink
+
+        assertEquals("https://pca.st/episode/episode-uuid?t=15,28", clipData.getItemAt(0).text)
+        assertEquals(context.getString(LR.string.share_link_clip), clipData.description.label)
+        assertNull(shareStarter.shareIntent)
+    }
+
+    @Test
+    fun copyClipLinkWithFeedback() = runTest {
+        val client = createClient(showCustomCopyFeedback = true)
+
+        val request = SharingRequest.clipLink(
+            podcast = Podcast(uuid = "podcast-uuid", title = "Podcast Title"),
+            episode = PodcastEpisode(uuid = "episode-uuid", title = "Episode Title", publishedDate = Date()),
+            range = Clip.Range(15.seconds, 28.seconds),
+        ).build()
+
+        val response = client.share(request)
+
+        assertEquals(context.getString(LR.string.share_link_copied_feedback), response.feedbackMessage)
+    }
+
+    @Test
+    fun copyClipLinkWithoutFeedback() = runTest {
+        val client = createClient(showCustomCopyFeedback = false)
+
+        val request = SharingRequest.clipLink(
+            podcast = Podcast(uuid = "podcast-uuid", title = "Podcast Title"),
+            episode = PodcastEpisode(uuid = "episode-uuid", title = "Episode Title", publishedDate = Date()),
+            range = Clip.Range(15.seconds, 28.seconds),
+        ).build()
+
+        val response = client.share(request)
+
+        assertNull(response.feedbackMessage)
     }
 
     private fun createClient(

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -254,6 +254,7 @@ core-ktx = "androidx.core:core-ktx:1.10.1"
 desugar-jdk = "com.android.tools:desugar_jdk_libs:2.0.4"
 device-names = "com.jaredrummler:android-device-names:2.1.0"
 encryptedlogging = "com.automattic:encryptedlogging:0.0.1"
+ffmpeg = "com.arthenica:ffmpeg-kit-full:6.0-2"
 flexbox = "com.google.android.flexbox:flexbox:3.0.0"
 fragment-ktx = "androidx.fragment:fragment-ktx:1.5.2"
 guava = "com.google.guava:guava:33.1.0-android" # Required to fix conflict between versions in exoplayer and workmanager

--- a/modules/features/sharing/build.gradle.kts
+++ b/modules/features/sharing/build.gradle.kts
@@ -18,6 +18,8 @@ android {
 }
 
 dependencies {
+    val debugProdImplementation by configurations
+
     implementation(project(":modules:services:analytics"))
     implementation(project(":modules:services:compose"))
     implementation(project(":modules:services:images"))
@@ -28,6 +30,12 @@ dependencies {
     implementation(project(":modules:services:ui"))
     implementation(project(":modules:services:utils"))
     implementation(project(":modules:services:views"))
+
+    // We do not include FFmpeg in the release variant for now
+    // to not increase the binary size.
+    // We can add it once we release clip sharing.
+    debugImplementation(libs.ffmpeg)
+    debugProdImplementation(libs.ffmpeg)
 
     testImplementation(project(":modules:services:sharedtest"))
 }

--- a/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/SharingAnalytics.kt
+++ b/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/SharingAnalytics.kt
@@ -31,6 +31,7 @@ internal class SharingAnalytics(
             TimestampType.Bookmark -> "bookmark_time"
         }
         is SharingRequest.Data.EpisodeFile -> "episode_file"
+        is SharingRequest.Data.ClipLink -> "clip_link"
     }
 
     private val SocialPlatform.analyticsValue get() = when (this) {

--- a/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/clip/ShareClipFragment.kt
+++ b/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/clip/ShareClipFragment.kt
@@ -17,6 +17,7 @@ import androidx.core.os.bundleOf
 import androidx.fragment.app.viewModels
 import au.com.shiftyjelly.pocketcasts.analytics.SourceView
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
+import au.com.shiftyjelly.pocketcasts.sharing.SharingClient
 import au.com.shiftyjelly.pocketcasts.sharing.ui.ShareColors
 import au.com.shiftyjelly.pocketcasts.utils.parceler.ColorParceler
 import au.com.shiftyjelly.pocketcasts.utils.parceler.DurationParceler
@@ -53,6 +54,9 @@ class ShareClipFragment : BaseDialogFragment() {
     lateinit var clipPlayerFactory: ClipPlayer.Factory
 
     @Inject
+    lateinit var sharingClient: SharingClient
+
+    @Inject
     lateinit var clipAnalyticsFactory: ClipAnalytics.Factory
 
     private lateinit var clipAnalytics: ClipAnalytics
@@ -77,7 +81,7 @@ class ShareClipFragment : BaseDialogFragment() {
         savedInstanceState: Bundle?,
     ) = ComposeView(requireActivity()).apply {
         val shareColors = shareColors
-        val listener = ShareClipListener(this@ShareClipFragment, viewModel)
+        val listener = ShareClipListener(this@ShareClipFragment, viewModel, sharingClient)
         setContent {
             val uiState by viewModel.uiState.collectAsState()
             ShareClipPage(

--- a/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/clip/ShareClipListener.kt
+++ b/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/clip/ShareClipListener.kt
@@ -3,14 +3,21 @@ package au.com.shiftyjelly.pocketcasts.sharing.clip
 import android.widget.Toast
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
+import au.com.shiftyjelly.pocketcasts.sharing.SharingClient
+import au.com.shiftyjelly.pocketcasts.sharing.SharingRequest
 import kotlin.time.Duration
 
 internal class ShareClipListener(
     private val fragment: ShareClipFragment,
     private val viewModel: ShareClipViewModel,
+    private val sharingClient: SharingClient,
 ) : ShareClipPageListener {
     override suspend fun onShareClipLink(podcast: Podcast, episode: PodcastEpisode, clipRange: Clip.Range) {
-        Toast.makeText(fragment.context, "Share link", Toast.LENGTH_SHORT).show()
+        val request = SharingRequest.clipLink(podcast, episode, clipRange).build()
+        val response = sharingClient.share(request)
+        if (response.feedbackMessage != null) {
+            Toast.makeText(fragment.requireContext(), response.feedbackMessage, Toast.LENGTH_SHORT).show()
+        }
     }
 
     override suspend fun onShareClipAudio(podcast: Podcast, episode: PodcastEpisode, clipRange: Clip.Range) {

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -2014,6 +2014,7 @@ up    <string name="player_sleep_in_one_chapter">Sleeping in 1 chapter</string>
     <string name="share_link_episode">Episode link</string>
     <string name="share_link_episode_position">Episode position link</string>
     <string name="share_link_bookmark">Bookmark link</string>
+    <string name="share_link_clip">Clip link</string>
 
     <!-- Pocket Casts Champion -->
     <string name="pocket_casts_champion_dialog_title">You’re a true champion of Pocket Casts!</string>


### PR DESCRIPTION
## Description

This PR adds clip link sharing. Link is always copied to the clipboard.

## Testing Instructions

1. Go to the clip creation.
2. Share a clip as link.
3. It should be copied to your clipboard. Currently, on older devices feedback message is displayed in a Toast instead of a Snackbar.

## Checklist
- [x] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] ~Any jetpack compose components I added or changed are covered by compose previews~
- [x] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~