### PR TITLE
Transcripts - Disable highlight and scroll

### DIFF
--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/transcripts/TranscriptPage.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/transcripts/TranscriptPage.kt
@@ -16,31 +16,20 @@ import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.ParagraphStyle
 import androidx.compose.ui.text.SpanStyle
-import androidx.compose.ui.text.TextLayoutResult
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.withStyle
-import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.media3.common.util.UnstableApi
-import androidx.media3.extractor.text.CuesWithTimingSubtitle
 import au.com.shiftyjelly.pocketcasts.compose.components.TextH30
 import au.com.shiftyjelly.pocketcasts.compose.components.TextP40
 import au.com.shiftyjelly.pocketcasts.compose.extensions.FadeDirection
@@ -51,8 +40,6 @@ import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.player.view.transcripts.TranscriptViewModel.TranscriptError
 import au.com.shiftyjelly.pocketcasts.player.view.transcripts.TranscriptViewModel.UiState
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
-import kotlin.time.Duration
-import kotlinx.coroutines.launch
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 @Composable
@@ -107,13 +94,8 @@ private fun TranscriptContent(
     modifier: Modifier,
 ) {
     val defaultTextStyle = SpanStyle(fontSize = 16.sp, color = colors.textColor())
-    val highlightedTextStyle = SpanStyle(fontSize = 18.sp, color = Color.White)
     val configuration = LocalConfiguration.current
     val bottomPadding = if (configuration.orientation == Configuration.ORIENTATION_LANDSCAPE) 0.dp else 125.dp
-    var highlightedText: CharSequence? by remember { mutableStateOf(null) }
-    var contentSize by remember { mutableStateOf(IntSize.Zero) }
-    var textLayoutResult by remember { mutableStateOf<TextLayoutResult?>(null) }
-    val coroutineScope = rememberCoroutineScope()
 
     val annotatedString = buildAnnotatedString {
         withStyle(style = ParagraphStyle(lineHeight = 30.sp)) {
@@ -123,12 +105,7 @@ private fun TranscriptContent(
                 append("\n")
                 (0 until eventTimeCount).forEach { index ->
                     getCues(getEventTime(index)).forEach { cue ->
-                        if (shouldHighlightCueAtIndex(index, state.playbackPosition)) {
-                            highlightedText = cue.text
-                            withStyle(style = highlightedTextStyle) { append(cue.text) }
-                        } else {
-                            withStyle(style = defaultTextStyle) { append(cue.text) }
-                        }
+                        withStyle(style = defaultTextStyle) { append(cue.text) }
                         append(" ")
                     }
                 }
@@ -141,8 +118,7 @@ private fun TranscriptContent(
     Box(
         modifier = modifier
             .fillMaxWidth()
-            .background(colors.backgroundColor())
-            .onGloballyPositioned { contentSize = it.size },
+            .background(colors.backgroundColor()),
     ) {
         Text(
             annotatedString,
@@ -150,7 +126,6 @@ private fun TranscriptContent(
                 .padding(horizontal = 16.dp)
                 .padding(bottom = bottomPadding)
                 .verticalScroll(scrollState),
-            onTextLayout = { textLayoutResult = it },
         )
 
         GradientView(
@@ -167,15 +142,6 @@ private fun TranscriptContent(
                 .padding(bottom = bottomPadding),
             fadeDirection = FadeDirection.BottomToTop,
         )
-    }
-
-    LaunchedEffect(state.playbackPosition) {
-        coroutineScope.launch {
-            textLayoutResult?.findHighlightedTextLineOffset(annotatedString, highlightedText)
-                ?.let { lineOffset ->
-                    scrollToVisibleRange(contentSize, lineOffset, scrollState)
-                }
-        }
     }
 }
 
@@ -200,38 +166,6 @@ private fun GradientView(
             ),
     )
 }
-
-private suspend fun scrollToVisibleRange(
-    contentSize: IntSize,
-    lineOffset: Float,
-    scrollState: ScrollState,
-) {
-    val visibleRect = Rect(0f, 0f, contentSize.width.toFloat(), (contentSize.height * .9).toFloat())
-    val lineRect = Rect(0f, (lineOffset - scrollState.value), contentSize.width.toFloat(), (lineOffset - scrollState.value) + 10)
-
-    if (visibleRect.intersect(lineRect).isEmpty) {
-        // Calculate an offset to adjust the scrolling position,
-        // ensuring that the highlighted text line is brought into a visible portion of the screen.
-        // If the line is above the current view, it scrolls down slightly (10% of content height).
-        // If the line is below, it scrolls up slightly (80% of content height).
-        val contentOffset = (if (lineOffset < scrollState.value) .1 else .8) * contentSize.height
-        scrollState.animateScrollTo((lineOffset - contentOffset).toInt())
-    }
-}
-
-@OptIn(UnstableApi::class)
-private fun CuesWithTimingSubtitle.shouldHighlightCueAtIndex(
-    index: Int,
-    playbackPosition: Duration,
-) = playbackPosition.inWholeMicroseconds in
-    getEventTime(index)..<getEventTime((index + 1).coerceAtMost(eventTimeCount - 1))
-
-private fun TextLayoutResult.findHighlightedTextLineOffset(
-    annotatedString: AnnotatedString,
-    highlightedText: CharSequence?,
-) = multiParagraph.getLineTop(
-    multiParagraph.getLineForOffset(annotatedString.indexOf(highlightedText.toString())),
-)
 
 @Composable
 private fun TranscriptError(

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/transcripts/TranscriptPageWrapper.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/transcripts/TranscriptPageWrapper.kt
@@ -3,7 +3,6 @@ package au.com.shiftyjelly.pocketcasts.player.view.transcripts
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.rememberScrollState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
@@ -24,7 +23,6 @@ fun TranscriptPageWrapper(
     theme: Theme,
 ) {
     AppTheme(theme.activeTheme) {
-        val scrollState = rememberScrollState()
         val configuration = LocalConfiguration.current
         val connection = remember { object : NestedScrollConnection {} }
 
@@ -34,9 +32,9 @@ fun TranscriptPageWrapper(
                 .nestedScroll(connection),
         ) {
             TranscriptPage(
-                viewModel = transcriptViewModel,
+                playerViewModel = viewModel,
+                transcriptViewModel = transcriptViewModel,
                 theme = theme,
-                scrollState = scrollState,
                 modifier = Modifier
                     .height(configuration.screenHeightDp.dp),
             )

--- a/modules/features/player/src/test/java/au/com/shiftyjelly/pocketcasts/player/view/transcripts/TranscriptViewModelTest.kt
+++ b/modules/features/player/src/test/java/au/com/shiftyjelly/pocketcasts/player/view/transcripts/TranscriptViewModelTest.kt
@@ -23,7 +23,11 @@ import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
 import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoInteractions
 import org.mockito.kotlin.whenever
 
 class TranscriptViewModelTest {
@@ -62,12 +66,44 @@ class TranscriptViewModelTest {
     }
 
     @Test
+    fun `given transcript view is not open, when transcript load invoked, then transcript is not parsed and loaded`() = runTest {
+        whenever(transcriptsManager.observerTranscriptForEpisode(any())).thenReturn(flowOf(transcript))
+        whenever(subtitleParserFactory.supportsFormat(any())).thenReturn(true)
+        initViewModel()
+
+        viewModel.parseAndLoadTranscript(isTranscriptViewOpen = false)
+
+        viewModel.uiState.test {
+            verifyNoInteractions(subtitleParserFactory)
+            assertEquals(transcript, (awaitItem() as UiState.TranscriptFound).transcript)
+        }
+    }
+
+    @Test
+    fun `given transcript view is open, when transcript load invoked, then transcript is parsed`() = runTest {
+        whenever(transcriptsManager.observerTranscriptForEpisode(any())).thenReturn(flowOf(transcript))
+        whenever(subtitleParserFactory.supportsFormat(any())).thenReturn(true)
+        whenever(urlUtil.contentBytes(anyOrNull())).thenReturn(byteArrayOf())
+        val parser = mock<SubtitleParser>()
+        whenever(subtitleParserFactory.create(anyOrNull())).thenReturn(parser)
+
+        initViewModel()
+
+        viewModel.parseAndLoadTranscript(isTranscriptViewOpen = true)
+
+        viewModel.uiState.test {
+            verify(parser).parse(any(), any(), any())
+            cancelAndConsumeRemainingEvents()
+        }
+    }
+
+    @Test
     fun `given transcript is supported, when transcript load invoked, then loaded state is returned`() = runTest {
         whenever(transcriptsManager.observerTranscriptForEpisode(any())).thenReturn(flowOf(transcript))
         whenever(subtitleParserFactory.supportsFormat(any())).thenReturn(true)
         initViewModel()
 
-        viewModel.parseAndLoadTranscript()
+        viewModel.parseAndLoadTranscript(isTranscriptViewOpen = true)
 
         viewModel.uiState.test {
             assertEquals(transcript, (awaitItem() as UiState.TranscriptLoaded).transcript)
@@ -80,7 +116,7 @@ class TranscriptViewModelTest {
         whenever(subtitleParserFactory.supportsFormat(any())).thenReturn(false)
         initViewModel()
 
-        viewModel.parseAndLoadTranscript()
+        viewModel.parseAndLoadTranscript(isTranscriptViewOpen = true)
 
         viewModel.uiState.test {
             assertTrue((awaitItem() as UiState.Error).error is TranscriptError.NotSupported)
@@ -94,7 +130,7 @@ class TranscriptViewModelTest {
         whenever(urlUtil.contentBytes(any())).thenThrow(RuntimeException())
         initViewModel()
 
-        viewModel.parseAndLoadTranscript()
+        viewModel.parseAndLoadTranscript(isTranscriptViewOpen = true)
 
         viewModel.uiState.test {
             assertTrue((awaitItem() as UiState.Error).error is TranscriptError.FailedToLoad)


### PR DESCRIPTION
## Description

This removes highlighting and scrolling capabilities for transcripts as the audio <-> text sync is currently inaccurate. 
This matches iOS behavior ([Ref](https://href.li/?https://github.com/Automattic/pocket-casts-ios/pull/1867#pullrequestreview-2172307195)).

## Testing Instructions
1. Launch the app
2. Play an episode having a transcript
3. Open full-screen player
4. Tap on the transcript bottom shelf icon
5. ✅ Notice that the transcript is shown but cues are not highlighted or scrolled based on playback position

** I also do not parse the transcript until the transcript view is open in eaa17369026170eb8514c249fcf6575b22e05472. Verify that newly added tests are green.


## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
