### PR TITLE
Fix pre SDK 3.23 SQL boolean constants

### DIFF
--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/UpNextDao.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/UpNextDao.kt
@@ -208,7 +208,7 @@ abstract class UpNextDao {
           LEFT JOIN (
             SELECT
               -- common properties
-              TRUE AS is_podcast_episode, 
+              1 AS is_podcast_episode, 
               episode.uuid AS id, 
               episode.title AS title, 
               episode.duration AS duration, 
@@ -227,7 +227,7 @@ abstract class UpNextDao {
             UNION ALL 
             SELECT
               -- common properties
-              FALSE AS is_podcast_episode, 
+              0 AS is_podcast_episode, 
               episode.uuid AS id, 
               episode.title AS title, 
               episode.duration AS duration, 


### PR DESCRIPTION
## Description

Boolean constants were added to SQLite in [`3.23`](https://www.sqlite.org/releaselog/3_23_0.html) which is SDK 30. The query crashed on older devices.

## Testing Instructions

Code review is enough.

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [ ] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.