### PR TITLE
[Giver Rating] Remove half star from podcast view

### DIFF
--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/components/ratings/StarRatingView.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/components/ratings/StarRatingView.kt
@@ -80,7 +80,7 @@ private fun Content(
 
         if (!state.noRatings) {
             TextP40(
-                text = state.roundedAverage,
+                text = state.roundedAverage.toString(),
                 modifier = Modifier
                     .padding(start = 4.dp),
                 fontWeight = FontWeight.W700,

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/PodcastRatingsViewModel.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/PodcastRatingsViewModel.kt
@@ -1,7 +1,6 @@
 package au.com.shiftyjelly.pocketcasts.podcasts.viewmodel
 
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.StarHalf
 import androidx.compose.material.icons.filled.Star
 import androidx.compose.material.icons.filled.StarBorder
 import androidx.compose.ui.graphics.vector.ImageVector
@@ -104,28 +103,21 @@ class PodcastRatingsViewModel
 
             val stars: List<Star> = starsList()
 
-            val roundedAverage: String
+            val roundedAverage: Double
                 get() {
                     val rating = average ?: 0.0
-                    return (Math.round(rating * 10) / 10.0).toString()
+                    return Math.round(rating).toDouble()
                 }
 
             private fun starsList(): List<Star> {
-                val rating = average ?: 0.0
-                // truncate the floating points off without rounding
-                val ratingInt = rating.toInt()
-                // Get the float value
-                val half = rating % 1
-
                 val stars = (0 until MAX_STARS).map { index ->
-                    starFor(index, ratingInt, half)
+                    starFor(index, roundedAverage)
                 }
                 return stars
             }
 
-            private fun starFor(index: Int, rating: Int, half: Double) = when {
+            private fun starFor(index: Int, rating: Double) = when {
                 index < rating -> Star.FilledStar
-                (index == rating) && (half >= 0.5) -> Star.HalfStar
                 else -> Star.BorderedStar
             }
         }
@@ -135,7 +127,6 @@ class PodcastRatingsViewModel
 
     enum class Star(val icon: ImageVector) {
         FilledStar(Icons.Filled.Star),
-        HalfStar(Icons.AutoMirrored.Filled.StarHalf),
         BorderedStar(Icons.Filled.StarBorder),
     }
 


### PR DESCRIPTION
## Description
- Removes half star from podcast view
- Round the average value to the nearest whole number
- See: p1722403643119169-slack-C077XU4GF9D

Fixes #2547

## Testing Instructions
1. Run the app in `debugProd`
2. Open the same podcast from the screenshot that as 4.95
3. Make sure you see only full stars

## Screenshots or Screencast 

| Before | After |
|--------|--------|
| <img width="500" alt="image" src="https://github.com/user-attachments/assets/b60618c5-3b46-49d2-9c00-014d72b5c84f"> | <img width="500" alt="image" src="https://github.com/user-attachments/assets/9761e8a8-47fd-4734-a9f5-5436e1762c45"> | 





## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [ ] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack