### PR TITLE
Transcripts - Add select text capability

### DIFF
--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/transcripts/TranscriptPage.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/transcripts/TranscriptPage.kt
@@ -17,11 +17,14 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.platform.LocalTextToolbar
+import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.ParagraphStyle
 import androidx.compose.ui.text.SpanStyle
@@ -39,6 +42,7 @@ import au.com.shiftyjelly.pocketcasts.compose.extensions.gradientBackground
 import au.com.shiftyjelly.pocketcasts.compose.loading.LoadingView
 import au.com.shiftyjelly.pocketcasts.compose.text.HtmlText
 import au.com.shiftyjelly.pocketcasts.compose.theme
+import au.com.shiftyjelly.pocketcasts.compose.toolbars.textselection.CustomTextToolbar
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.player.view.transcripts.TranscriptViewModel.TranscriptError
 import au.com.shiftyjelly.pocketcasts.player.view.transcripts.TranscriptViewModel.UiState
@@ -153,14 +157,20 @@ private fun TranscriptContent(
                     .verticalScroll(rememberScrollState()),
             )
         } else {
-            SelectionContainer {
-                Text(
-                    displayString,
-                    modifier = Modifier
-                        .padding(horizontal = 16.dp)
-                        .padding(bottom = bottomPadding)
-                        .verticalScroll(rememberScrollState()),
+            CompositionLocalProvider(
+                LocalTextToolbar provides CustomTextToolbar(
+                    LocalView.current,
                 )
+            ) {
+                SelectionContainer {
+                    Text(
+                        displayString,
+                        modifier = Modifier
+                            .padding(horizontal = 16.dp)
+                            .padding(bottom = bottomPadding)
+                            .verticalScroll(rememberScrollState()),
+                    )
+                }
             }
         }
 

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/transcripts/TranscriptPage.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/transcripts/TranscriptPage.kt
@@ -1,6 +1,7 @@
 package au.com.shiftyjelly.pocketcasts.player.view.transcripts
 
 import android.content.res.Configuration
+import android.os.Build
 import androidx.annotation.OptIn
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
@@ -22,6 +23,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalClipboardManager
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalTextToolbar
 import androidx.compose.ui.platform.LocalView
@@ -42,6 +44,7 @@ import au.com.shiftyjelly.pocketcasts.compose.extensions.gradientBackground
 import au.com.shiftyjelly.pocketcasts.compose.loading.LoadingView
 import au.com.shiftyjelly.pocketcasts.compose.text.HtmlText
 import au.com.shiftyjelly.pocketcasts.compose.theme
+import au.com.shiftyjelly.pocketcasts.compose.toolbars.textselection.CustomMenuItemOption
 import au.com.shiftyjelly.pocketcasts.compose.toolbars.textselection.CustomTextToolbar
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.player.view.transcripts.TranscriptViewModel.TranscriptError
@@ -157,10 +160,19 @@ private fun TranscriptContent(
                     .verticalScroll(rememberScrollState()),
             )
         } else {
+            val customMenu = buildList {
+                if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) {
+                    add(CustomMenuItemOption.Share)
+                }
+                add(CustomMenuItemOption.SelectAll)
+            }
             CompositionLocalProvider(
                 LocalTextToolbar provides CustomTextToolbar(
                     LocalView.current,
-                )
+                    customMenu,
+                    LocalClipboardManager.current,
+                    displayString,
+                ),
             ) {
                 SelectionContainer {
                     Text(

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/transcripts/TranscriptPage.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/transcripts/TranscriptPage.kt
@@ -12,6 +12,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.selection.SelectionContainer
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
@@ -145,19 +146,22 @@ private fun TranscriptContent(
                 html = displayString.toString(),
                 color = colors.textColor(),
                 textStyleResId = UR.style.H40,
+                selectable = true,
                 modifier = modifier
                     .padding(horizontal = 16.dp)
                     .padding(bottom = bottomPadding)
                     .verticalScroll(rememberScrollState()),
             )
         } else {
-            Text(
-                displayString,
-                modifier = Modifier
-                    .padding(horizontal = 16.dp)
-                    .padding(bottom = bottomPadding)
-                    .verticalScroll(rememberScrollState()),
-            )
+            SelectionContainer {
+                Text(
+                    displayString,
+                    modifier = Modifier
+                        .padding(horizontal = 16.dp)
+                        .padding(bottom = bottomPadding)
+                        .verticalScroll(rememberScrollState()),
+                )
+            }
         }
 
         GradientView(

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/transcripts/TranscriptPage.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/transcripts/TranscriptPage.kt
@@ -164,14 +164,12 @@ private fun TranscriptContent(
                 if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) {
                     add(CustomMenuItemOption.Share)
                 }
-                add(CustomMenuItemOption.SelectAll)
             }
             CompositionLocalProvider(
                 LocalTextToolbar provides CustomTextToolbar(
                     LocalView.current,
                     customMenu,
                     LocalClipboardManager.current,
-                    displayString,
                 ),
             ) {
                 SelectionContainer {

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/toolbars/textselection/CustomMenuItemOption.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/toolbars/textselection/CustomMenuItemOption.kt
@@ -1,0 +1,16 @@
+package au.com.shiftyjelly.pocketcasts.compose.toolbars.textselection
+
+import au.com.shiftyjelly.pocketcasts.localization.R as LR
+
+enum class CustomMenuItemOption(val id: Int) {
+    Share(1),
+    SelectAll(2),
+    ;
+
+    val titleResource: Int
+        get() = when (this) {
+            Share -> LR.string.share
+            SelectAll -> LR.string.select_all
+        }
+    val order = id
+}

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/toolbars/textselection/CustomMenuItemOption.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/toolbars/textselection/CustomMenuItemOption.kt
@@ -4,13 +4,11 @@ import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 enum class CustomMenuItemOption(val id: Int) {
     Share(1),
-    SelectAll(2),
     ;
 
     val titleResource: Int
         get() = when (this) {
             Share -> LR.string.share
-            SelectAll -> LR.string.select_all
         }
     val order = id
 }

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/toolbars/textselection/CustomTextToolbar.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/toolbars/textselection/CustomTextToolbar.kt
@@ -1,0 +1,79 @@
+package au.com.shiftyjelly.pocketcasts.compose.toolbars.textselection
+
+import android.view.ActionMode
+import android.view.View
+import androidx.annotation.DoNotInline
+import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.platform.TextToolbar
+import androidx.compose.ui.platform.TextToolbarStatus
+
+/**
+ * Custom implementation for [TextToolbar].
+ * Refers Compose class androidx.compose.ui.platform.AndroidTextToolbar.
+ */
+class CustomTextToolbar(
+    private val view: View,
+) : TextToolbar {
+    private var actionMode: ActionMode? = null
+    private val textActionModeCallback = TextActionModeCallback(
+        onActionModeDestroy = {
+            actionMode = null
+        }
+    )
+    override var status: TextToolbarStatus = TextToolbarStatus.Hidden
+        private set
+
+    override fun showMenu(
+        rect: Rect,
+        onCopyRequested: (() -> Unit)?,
+        onPasteRequested: (() -> Unit)?,
+        onCutRequested: (() -> Unit)?,
+        onSelectAllRequested: (() -> Unit)?
+    ) {
+        textActionModeCallback.rect = rect
+        textActionModeCallback.onCopyRequested = onCopyRequested
+        textActionModeCallback.onCutRequested = onCutRequested
+        textActionModeCallback.onPasteRequested = onPasteRequested
+        textActionModeCallback.onSelectAllRequested = onSelectAllRequested
+        if (actionMode == null) {
+            status = TextToolbarStatus.Shown
+            actionMode =
+                TextToolbarHelperMethods.startActionMode(
+                    view,
+                    FloatingTextActionModeCallback(textActionModeCallback),
+                    ActionMode.TYPE_FLOATING
+                )
+
+        } else {
+            actionMode?.invalidate()
+        }
+    }
+
+    override fun hide() {
+        status = TextToolbarStatus.Hidden
+        actionMode?.finish()
+        actionMode = null
+    }
+}
+
+/**
+ * This class is here to ensure that the classes that use this API will get verified and can be
+ * AOT compiled. It is expected that this class will soft-fail verification, but the classes
+ * which use this method will pass.
+ */
+internal object TextToolbarHelperMethods {
+    @DoNotInline
+    fun startActionMode(
+        view: View,
+        actionModeCallback: ActionMode.Callback,
+        type: Int
+    ): ActionMode? {
+        return view.startActionMode(
+            actionModeCallback,
+            type
+        )
+    }
+}
+
+
+

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/toolbars/textselection/CustomTextToolbar.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/toolbars/textselection/CustomTextToolbar.kt
@@ -9,7 +9,6 @@ import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.platform.ClipboardManager
 import androidx.compose.ui.platform.TextToolbar
 import androidx.compose.ui.platform.TextToolbarStatus
-import androidx.compose.ui.text.AnnotatedString
 import au.com.shiftyjelly.pocketcasts.localization.R
 
 /**
@@ -20,7 +19,6 @@ class CustomTextToolbar(
     private val view: View,
     private val customMenuItems: List<CustomMenuItemOption>,
     private val clipboardManager: ClipboardManager,
-    private val displayString: AnnotatedString,
 ) : TextToolbar {
     private var actionMode: ActionMode? = null
     private val textActionModeCallback = TextActionModeCallback(
@@ -76,10 +74,6 @@ class CustomTextToolbar(
                         type = "text/plain"
                     }
                     context.startActivity(createChooser(shareIntent, context.getString(R.string.share)))
-                }
-
-                CustomMenuItemOption.SelectAll -> {
-                    clipboardManager.setText(displayString)
                 }
             }
         } catch (e: Exception) {

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/toolbars/textselection/FloatingTextActionModeCallback.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/toolbars/textselection/FloatingTextActionModeCallback.kt
@@ -7,7 +7,7 @@ import android.view.MenuItem
 import android.view.View
 
 internal class FloatingTextActionModeCallback(
-    private val callback: TextActionModeCallback
+    private val callback: TextActionModeCallback,
 ) : ActionMode.Callback2() {
     override fun onActionItemClicked(mode: ActionMode?, item: MenuItem?): Boolean {
         return callback.onActionItemClicked(mode, item)
@@ -28,14 +28,14 @@ internal class FloatingTextActionModeCallback(
     override fun onGetContentRect(
         mode: ActionMode?,
         view: View?,
-        outRect: Rect?
+        outRect: Rect?,
     ) {
         val rect = callback.rect
         outRect?.set(
             rect.left.toInt(),
             rect.top.toInt(),
             rect.right.toInt(),
-            rect.bottom.toInt()
+            rect.bottom.toInt(),
         )
     }
 }

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/toolbars/textselection/FloatingTextActionModeCallback.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/toolbars/textselection/FloatingTextActionModeCallback.kt
@@ -1,0 +1,41 @@
+package au.com.shiftyjelly.pocketcasts.compose.toolbars.textselection
+
+import android.graphics.Rect
+import android.view.ActionMode
+import android.view.Menu
+import android.view.MenuItem
+import android.view.View
+
+internal class FloatingTextActionModeCallback(
+    private val callback: TextActionModeCallback
+) : ActionMode.Callback2() {
+    override fun onActionItemClicked(mode: ActionMode?, item: MenuItem?): Boolean {
+        return callback.onActionItemClicked(mode, item)
+    }
+
+    override fun onCreateActionMode(mode: ActionMode?, menu: Menu?): Boolean {
+        return callback.onCreateActionMode(mode, menu)
+    }
+
+    override fun onPrepareActionMode(mode: ActionMode?, menu: Menu?): Boolean {
+        return callback.onPrepareActionMode(mode, menu)
+    }
+
+    override fun onDestroyActionMode(mode: ActionMode?) {
+        callback.onDestroyActionMode()
+    }
+
+    override fun onGetContentRect(
+        mode: ActionMode?,
+        view: View?,
+        outRect: Rect?
+    ) {
+        val rect = callback.rect
+        outRect?.set(
+            rect.left.toInt(),
+            rect.top.toInt(),
+            rect.right.toInt(),
+            rect.bottom.toInt()
+        )
+    }
+}

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/toolbars/textselection/TextActionModeCallback.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/toolbars/textselection/TextActionModeCallback.kt
@@ -1,0 +1,103 @@
+package au.com.shiftyjelly.pocketcasts.compose.toolbars.textselection
+
+import android.view.ActionMode
+import android.view.Menu
+import android.view.MenuItem
+import androidx.annotation.VisibleForTesting
+import androidx.compose.ui.geometry.Rect
+
+internal class TextActionModeCallback(
+    val onActionModeDestroy: (() -> Unit)? = null,
+    var rect: Rect = Rect.Zero,
+    var onCopyRequested: (() -> Unit)? = null,
+    var onPasteRequested: (() -> Unit)? = null,
+    var onCutRequested: (() -> Unit)? = null,
+    var onSelectAllRequested: (() -> Unit)? = null
+) {
+    fun onCreateActionMode(mode: ActionMode?, menu: Menu?): Boolean {
+        requireNotNull(menu) { "onCreateActionMode requires a non-null menu" }
+        requireNotNull(mode) { "onCreateActionMode requires a non-null mode" }
+
+        onCopyRequested?.let {
+            addMenuItem(menu, MenuItemOption.Copy)
+        }
+        onPasteRequested?.let {
+            addMenuItem(menu, MenuItemOption.Paste)
+        }
+        onCutRequested?.let {
+            addMenuItem(menu, MenuItemOption.Cut)
+        }
+        onSelectAllRequested?.let {
+            addMenuItem(menu, MenuItemOption.SelectAll)
+        }
+        return true
+    }
+
+    // this method is called to populate new menu items when the actionMode was invalidated
+    fun onPrepareActionMode(mode: ActionMode?, menu: Menu?): Boolean {
+        if (mode == null || menu == null) return false
+        updateMenuItems(menu)
+        // should return true so that new menu items are populated
+        return true
+    }
+
+    fun onActionItemClicked(mode: ActionMode?, item: MenuItem?): Boolean {
+        when (item!!.itemId) {
+            MenuItemOption.Copy.id -> onCopyRequested?.invoke()
+            MenuItemOption.Paste.id -> onPasteRequested?.invoke()
+            MenuItemOption.Cut.id -> onCutRequested?.invoke()
+            MenuItemOption.SelectAll.id -> onSelectAllRequested?.invoke()
+            else -> return false
+        }
+        mode?.finish()
+        return true
+    }
+
+    fun onDestroyActionMode() {
+        onActionModeDestroy?.invoke()
+    }
+
+    @VisibleForTesting
+    internal fun updateMenuItems(menu: Menu) {
+        addOrRemoveMenuItem(menu, MenuItemOption.Copy, onCopyRequested)
+        addOrRemoveMenuItem(menu, MenuItemOption.Paste, onPasteRequested)
+        addOrRemoveMenuItem(menu, MenuItemOption.Cut, onCutRequested)
+        addOrRemoveMenuItem(menu, MenuItemOption.SelectAll, onSelectAllRequested)
+    }
+
+    internal fun addMenuItem(menu: Menu, item: MenuItemOption) {
+        menu.add(0, item.id, item.order, item.titleResource)
+            .setShowAsAction(MenuItem.SHOW_AS_ACTION_IF_ROOM)
+    }
+
+    private fun addOrRemoveMenuItem(
+        menu: Menu,
+        item: MenuItemOption,
+        callback: (() -> Unit)?
+    ) {
+        when {
+            callback != null && menu.findItem(item.id) == null -> addMenuItem(menu, item)
+            callback == null && menu.findItem(item.id) != null -> menu.removeItem(item.id)
+        }
+    }
+}
+
+internal enum class MenuItemOption(val id: Int) {
+    Copy(0),
+    Paste(1),
+    Cut(2),
+    SelectAll(3);
+
+    val titleResource: Int
+        get() = when (this) {
+            Copy -> android.R.string.copy
+            Paste -> android.R.string.paste
+            Cut -> android.R.string.cut
+            SelectAll -> android.R.string.selectAll
+        }
+
+    /**
+     * This item will be shown before all items that have order greater than this value.
+     */
+    val order = id
+}


### PR DESCRIPTION
## Description

This adds select text capability.

Default text selection  in Compose Text view only allows `Copy` option: https://issuetracker.google.com/issues/235259768

I added a custom menu `Select All` to select all text and `Share` for older devices (API level < 33). In newer devices,  `Copy` option allows you to share copied text.

EDIT: `Select All` is added to [Compose 1.7.0-alpha08](https://developer.android.com/jetpack/androidx/releases/compose-foundation#1.7.0-beta06:~:text=Added%20%22Select%20all%22%20to%20all%20text%20contextual%20menus%20in%20SelectionContainer.). We will not need this custom action once 1.7.0 gets stable and we switch to it.


## Testing Instructions
1. Play an episode with transcript
2. Open full-screen player
3. Tap on the transcript bottom shelf icon
4. Long-press on the transcript text
5. ✅ Notice that text is selected with a text toolbar to copy, and select all for newer devices (API level >=33 and copy, share, and select all for older devices where copy does not allow you to share copied text.
 
## Screenshots or Screencast 

API 33

https://github.com/user-attachments/assets/4fde2850-b12b-4800-b418-e85405d6519a

API 32

https://github.com/user-attachments/assets/ea84a74d-09f7-4057-bf3c-a572a48721a4


## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
