### PR TITLE
Handle all https://pocketcasts.com/get deep links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 *   Bug Fixes
     *   Links to episodes with playback position shared from the app are now correctly recognized.
         ([#2471](https://github.com/Automattic/pocket-casts-android/pull/2471))
+    *   Fix redirects to the app through https://pocketcasts.com/get links.
+        ([#2559](https://github.com/Automattic/pocket-casts-android/pull/2559))
 
 7.68
 -----

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -257,14 +257,20 @@
                 <action android:name="android.intent.action.VIEW" />
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.BROWSABLE" />
-                <data android:scheme="https" android:host="pocketcasts.com" android:path="/get" />
+                <data android:scheme="https"/>
+                <data android:host="pocketcasts.com"/>
+                <data android:path="/get"/>
+                <data android:pathPrefix="/get/"/>
             </intent-filter>
 
             <intent-filter android:autoVerify="true">
                 <action android:name="android.intent.action.VIEW" />
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.BROWSABLE" />
-                <data android:scheme="https" android:host="pocket-casts-main-development.mystagingwebsite.com" android:path="/get" />
+                <data android:scheme="https"/>
+                <data android:host="pocket-casts-main-development.mystagingwebsite.com"/>
+                <data android:path="/get"/>
+                <data android:pathPrefix="/get/"/>
             </intent-filter>
 
             <meta-data


### PR DESCRIPTION
## Description

This PR improves deep linking capabilities. Before, only exact `https://pocketcasts.com/get` opened the app. Even `https://pocketcasts.com/get/` failed. Now, any `https://pocketcasts.com/get**` should be handled.

Context: p1722525720721999-slack-C06EHRAPW12

## Testing Instructions

> [!note]
> Test this with the `release` variant signed with the production key.

1. Open this PR on your device or copy the instructions somewhere where you can access links from your device.
2. Tap on this link - https://pocketcasts.com. It should open the website.
3. Tap on this link - https://pocketcasts.com/podcast-producers. It should open the website.
4. Tap on this link - https://pocketcasts.com/gettysburg. It should open the not found website.
5. Tap on this link - https://pocketcasts.com/get. It should open the app.
6. Tap on this link - https://pocketcasts.com/get/. It should open the app.
7. Tap on this link - https://pocketcasts.com/get/something?query=value. It should open the app.

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [ ] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack