### PR TITLE
Ignore `*.bak` files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,6 @@ firebase.secrets.json
 
 # Sentry
 sentry.properties
+
+# Backup Files
+*.bak


### PR DESCRIPTION
They're generated if `configure_update` detects a conflict between existing files and these from recent mobile secrets

Internal reference: p1722587393513229-slack-CC7L49W13