### PR TITLE
Bring back podcast_screen_share_tapped event

### DIFF
--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastFragment.kt
@@ -974,6 +974,7 @@ class PodcastFragment : BaseFragment(), Toolbar.OnMenuItemClickListener {
 
     private fun share() {
         val podcast = viewModel.podcast.value ?: return
+        analyticsTracker.track(AnalyticsEvent.PODCAST_SCREEN_SHARE_TAPPED)
         if (FeatureFlag.isEnabled(Feature.REIMAGINE_SHARING)) {
             SharePodcastFragment
                 .newInstance(podcast, SourceView.PODCAST_SCREEN)


### PR DESCRIPTION
## Description

When refactoring sharing code to use the `SharingClient` I forgot to use `podcast_screen_share_tapped` event. I'm not adding it to the `SharingClient` because it is a legacy event and it's a bit awkward to put it there when it is a very specific event for a very specific screen.

## Testing Instructions

1. Go to a podcast.
2. Tap on share icon.
3. `podcast_screen_share_tapped` should be tracked.


## Checklist
- [x] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] ~I have considered whether it makes sense to add tests for my changes~
- [x] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [x] ~Any jetpack compose components I added or changed are covered by compose previews~
- [x] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~