### PR TITLE
Sharing code cleanup

### DIFF
--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/sharing/SharingClientTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/sharing/SharingClientTest.kt
@@ -13,7 +13,6 @@ import android.net.Uri
 import androidx.core.content.IntentCompat
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
-import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTracker
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.sharing.clip.Clip
@@ -535,7 +534,7 @@ class SharingClientTest {
     ) = SharingClient(
         context = context,
         mediaService = testMediaService,
-        tracker = AnalyticsTracker.test(),
+        listeners = emptySet(),
         displayPodcastCover = false,
         showCustomCopyFeedback = showCustomCopyFeedback,
         hostUrl = "https://pca.st",

--- a/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/SharingAnalytics.kt
+++ b/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/SharingAnalytics.kt
@@ -8,8 +8,8 @@ import au.com.shiftyjelly.pocketcasts.sharing.ui.CardType
 
 internal class SharingAnalytics(
     private val tracker: AnalyticsTracker,
-) {
-    fun logPodcastSharedEvent(request: SharingRequest) {
+) : SharingClient.Listener {
+    override fun onShare(request: SharingRequest) {
         tracker.track(
             AnalyticsEvent.PODCAST_SHARED,
             buildMap {

--- a/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/SharingLogger.kt
+++ b/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/SharingLogger.kt
@@ -1,0 +1,30 @@
+package au.com.shiftyjelly.pocketcasts.sharing
+
+import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
+import timber.log.Timber
+
+internal class SharingLogger : SharingClient.Listener {
+    override fun onShare(request: SharingRequest) {
+        val message = "Sharing: $request"
+        Timber.tag(TAG).i(message)
+        LogBuffer.i(TAG, message)
+    }
+
+    override fun onShared(request: SharingRequest, response: SharingResponse) {
+        if (response.isSuccsessful) {
+            Timber.tag(TAG).i("Shared $request")
+        } else {
+            val message = "Failed to share $request. Error message: ${response.feedbackMessage}"
+            Timber.tag(TAG).e(response.error, message)
+            if (response.error != null) {
+                LogBuffer.e(TAG, response.error, message)
+            } else {
+                LogBuffer.e(TAG, message)
+            }
+        }
+    }
+
+    private companion object {
+        const val TAG = "Sharing"
+    }
+}

--- a/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/di/SharingModule.kt
+++ b/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/di/SharingModule.kt
@@ -12,13 +12,16 @@ import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.sharing.FFmpegMediaService
 import au.com.shiftyjelly.pocketcasts.sharing.ShareDialogFragment
+import au.com.shiftyjelly.pocketcasts.sharing.SharingAnalytics
 import au.com.shiftyjelly.pocketcasts.sharing.SharingClient
+import au.com.shiftyjelly.pocketcasts.sharing.SharingLogger
 import au.com.shiftyjelly.pocketcasts.views.dialog.ShareDialogFactory
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
+import dagger.multibindings.IntoSet
 import java.io.File
 import javax.inject.Singleton
 
@@ -49,10 +52,20 @@ object SharingModule {
     @Provides
     fun provideSharingClient(
         @ApplicationContext context: Context,
-        analyticsTracker: AnalyticsTracker,
+        listeners: Set<@JvmSuppressWildcards SharingClient.Listener>,
     ): SharingClient = SharingClient(
         context,
         FFmpegMediaService(context),
-        analyticsTracker,
+        listeners,
     )
+
+    @Provides
+    @IntoSet
+    fun provideAnalyticsListener(
+        analyticsTracker: AnalyticsTracker,
+    ): SharingClient.Listener = SharingAnalytics(analyticsTracker)
+
+    @Provides
+    @IntoSet
+    fun provideLoggingListener(): SharingClient.Listener = SharingLogger()
 }

--- a/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/episode/ShareEpisodePage.kt
+++ b/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/episode/ShareEpisodePage.kt
@@ -22,7 +22,6 @@ import au.com.shiftyjelly.pocketcasts.sharing.ui.ShareColors
 import au.com.shiftyjelly.pocketcasts.sharing.ui.SquareEpisodeCard
 import au.com.shiftyjelly.pocketcasts.sharing.ui.VerticalEpisodeCard
 import au.com.shiftyjelly.pocketcasts.sharing.ui.VerticalSharePage
-import com.airbnb.android.showkase.annotation.ShowkaseComposable
 import dev.shreyaspatil.capturable.controller.CaptureController
 import dev.shreyaspatil.capturable.controller.rememberCaptureController
 import java.sql.Date
@@ -177,35 +176,29 @@ private fun HorizontalShareEpisodePage(
     )
 }
 
-@ShowkaseComposable(name = "ShareEpisodeVerticalRegularPreview", group = "Sharing")
 @Preview(name = "ShareEpisodeVerticalRegularPreview", device = Devices.PortraitRegular)
 @Composable
-fun ShareEpisodeVerticalRegularPreview() = ShareEpisodePagePreview()
+private fun ShareEpisodeVerticalRegularPreview() = ShareEpisodePagePreview()
 
-@ShowkaseComposable(name = "ShareEpisodeVerticalSmallPreview", group = "Sharing")
 @Preview(name = "ShareEpisodeVerticalSmallPreview", device = Devices.PortraitSmall)
 @Composable
-fun ShareEpisodeVerticalSmallPreviewPreview() = ShareEpisodePagePreview()
+private fun ShareEpisodeVerticalSmallPreviewPreview() = ShareEpisodePagePreview()
 
-@ShowkaseComposable(name = "ShareEpisodeVerticalTabletPreview", group = "Sharing")
 @Preview(name = "ShareEpisodeVerticalTabletPreview", device = Devices.PortraitTablet)
 @Composable
-fun ShareEpisodeVerticalTabletPreview() = ShareEpisodePagePreview()
+private fun ShareEpisodeVerticalTabletPreview() = ShareEpisodePagePreview()
 
-@ShowkaseComposable(name = "ShareEpisodeHorizontalRegularPreview", group = "Sharing")
 @Preview(name = "ShareEpisodeHorizontalRegularPreview", device = Devices.LandscapeRegular)
 @Composable
-fun ShareEpisodeHorizontalRegularPreview() = ShareEpisodePagePreview()
+private fun ShareEpisodeHorizontalRegularPreview() = ShareEpisodePagePreview()
 
-@ShowkaseComposable(name = "ShareEpisodeHorizontalSmallPreview", group = "Sharing")
 @Preview(name = "ShareEpisodeHorizontalSmallPreview", device = Devices.LandscapeSmall)
 @Composable
-fun ShareEpisodeHorizontalSmallPreviewPreview() = ShareEpisodePagePreview()
+private fun ShareEpisodeHorizontalSmallPreviewPreview() = ShareEpisodePagePreview()
 
-@ShowkaseComposable(name = "ShareEpisodeHorizontalTabletPreview", group = "Sharing")
 @Preview(name = "ShareEpisodeHorizontalTabletPreview", device = Devices.LandscapeTablet)
 @Composable
-fun ShareEpisodeHorizontalTabletPreview() = ShareEpisodePagePreview()
+private fun ShareEpisodeHorizontalTabletPreview() = ShareEpisodePagePreview()
 
 @Composable
 private fun ShareEpisodePagePreview(

--- a/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/episode/ShareEpisodePage.kt
+++ b/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/episode/ShareEpisodePage.kt
@@ -38,6 +38,7 @@ internal interface ShareEpisodePageListener {
             override suspend fun onShare(podcast: Podcast, episode: PodcastEpisode, platform: SocialPlatform, cardType: CardType) = SharingResponse(
                 isSuccsessful = true,
                 feedbackMessage = null,
+                error = null,
             )
             override fun onClose() = Unit
         }

--- a/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/podcast/SharePodcastPage.kt
+++ b/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/podcast/SharePodcastPage.kt
@@ -34,6 +34,7 @@ internal interface SharePodcastPageListener {
             override suspend fun onShare(podcast: Podcast, platform: SocialPlatform, cardType: CardType) = SharingResponse(
                 isSuccsessful = true,
                 feedbackMessage = null,
+                error = null,
             )
             override fun onClose() = Unit
         }

--- a/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/podcast/SharePodcastPage.kt
+++ b/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/podcast/SharePodcastPage.kt
@@ -20,7 +20,6 @@ import au.com.shiftyjelly.pocketcasts.sharing.ui.ShareColors
 import au.com.shiftyjelly.pocketcasts.sharing.ui.SquarePodcastCast
 import au.com.shiftyjelly.pocketcasts.sharing.ui.VerticalPodcastCast
 import au.com.shiftyjelly.pocketcasts.sharing.ui.VerticalSharePage
-import com.airbnb.android.showkase.annotation.ShowkaseComposable
 import dev.shreyaspatil.capturable.controller.CaptureController
 import dev.shreyaspatil.capturable.controller.rememberCaptureController
 import kotlinx.coroutines.launch
@@ -163,35 +162,29 @@ private fun HorizontalSharePodcastPage(
     )
 }
 
-@ShowkaseComposable(name = "SharePodcastVerticalRegularPreview", group = "Sharing")
 @Preview(name = "SharePodcastVerticalRegularPreview", device = Devices.PortraitRegular)
 @Composable
-fun SharePodcastVerticalRegularPreview() = SharePodcastPagePreview()
+private fun SharePodcastVerticalRegularPreview() = SharePodcastPagePreview()
 
-@ShowkaseComposable(name = "SharePodcastVerticalSmallPreview", group = "Sharing")
 @Preview(name = "SharePodcastVerticalSmallPreview", device = Devices.PortraitSmall)
 @Composable
-fun SharePodcastVerticalSmallPreviewPreview() = SharePodcastPagePreview()
+private fun SharePodcastVerticalSmallPreviewPreview() = SharePodcastPagePreview()
 
-@ShowkaseComposable(name = "SharePodcastVerticalTabletPreview", group = "Sharing")
 @Preview(name = "SharePodcastVerticalTabletPreview", device = Devices.PortraitTablet)
 @Composable
-fun SharePodcastVerticalTabletPreview() = SharePodcastPagePreview()
+private fun SharePodcastVerticalTabletPreview() = SharePodcastPagePreview()
 
-@ShowkaseComposable(name = "SharePodcastHorizontalRegularPreview", group = "Sharing")
 @Preview(name = "SharePodcastHorizontalRegularPreview", device = Devices.LandscapeRegular)
 @Composable
-fun SharePodcastHorizontalRegularPreview() = SharePodcastPagePreview()
+private fun SharePodcastHorizontalRegularPreview() = SharePodcastPagePreview()
 
-@ShowkaseComposable(name = "SharePodcastHorizontalSmallPreview", group = "Sharing")
 @Preview(name = "SharePodcastHorizontalSmallPreview", device = Devices.LandscapeSmall)
 @Composable
-fun SharePodcastHorizontalSmallPreviewPreview() = SharePodcastPagePreview()
+private fun SharePodcastHorizontalSmallPreviewPreview() = SharePodcastPagePreview()
 
-@ShowkaseComposable(name = "SharePodcastHorizontalTabletPreview", group = "Sharing")
 @Preview(name = "SharePodcastHorizontalTabletPreview", device = Devices.LandscapeTablet)
 @Composable
-fun SharePodcastHorizontalTabletPreview() = SharePodcastPagePreview()
+private fun SharePodcastHorizontalTabletPreview() = SharePodcastPagePreview()
 
 @Composable
 private fun SharePodcastPagePreview(

--- a/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/timestamp/ShareEpisodeTimestampPage.kt
+++ b/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/timestamp/ShareEpisodeTimestampPage.kt
@@ -41,6 +41,7 @@ internal interface ShareEpisodeTimestampPageListener {
             override suspend fun onShare(podcast: Podcast, episode: PodcastEpisode, timestamp: Duration, platform: SocialPlatform, cardType: CardType) = SharingResponse(
                 isSuccsessful = true,
                 feedbackMessage = null,
+                error = null,
             )
             override fun onClose() = Unit
         }

--- a/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/timestamp/ShareEpisodeTimestampPage.kt
+++ b/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/timestamp/ShareEpisodeTimestampPage.kt
@@ -22,7 +22,6 @@ import au.com.shiftyjelly.pocketcasts.sharing.ui.SquareEpisodeCard
 import au.com.shiftyjelly.pocketcasts.sharing.ui.VerticalEpisodeCard
 import au.com.shiftyjelly.pocketcasts.sharing.ui.VerticalSharePage
 import au.com.shiftyjelly.pocketcasts.utils.toHhMmSs
-import com.airbnb.android.showkase.annotation.ShowkaseComposable
 import dev.shreyaspatil.capturable.controller.CaptureController
 import dev.shreyaspatil.capturable.controller.rememberCaptureController
 import java.sql.Date
@@ -184,35 +183,29 @@ private fun HorizontalShareEpisodeTimestampPage(
     )
 }
 
-@ShowkaseComposable(name = "ShareEpisodeTimestampVerticalRegularPreview", group = "Sharing")
 @Preview(name = "ShareEpisodeTimestampVerticalRegularPreview", device = Devices.PortraitRegular)
 @Composable
-fun ShareEpisodeTimestampVerticalRegularPreview() = ShareEpisodeTimestampPagePreview()
+private fun ShareEpisodeTimestampVerticalRegularPreview() = ShareEpisodeTimestampPagePreview()
 
-@ShowkaseComposable(name = "ShareEpisodeTimestampVerticalSmallPreview", group = "Sharing")
 @Preview(name = "ShareEpisodeTimestampVerticalSmallPreview", device = Devices.PortraitSmall)
 @Composable
-fun ShareEpisodeTimestampVerticalSmallPreviewPreview() = ShareEpisodeTimestampPagePreview()
+private fun ShareEpisodeTimestampVerticalSmallPreviewPreview() = ShareEpisodeTimestampPagePreview()
 
-@ShowkaseComposable(name = "ShareEpisodeTimestampVerticalTabletPreview", group = "Sharing")
 @Preview(name = "ShareEpisodeTimestampVerticalTabletPreview", device = Devices.PortraitTablet)
 @Composable
-fun ShareEpisodeTimestampVerticalTabletPreview() = ShareEpisodeTimestampPagePreview()
+private fun ShareEpisodeTimestampVerticalTabletPreview() = ShareEpisodeTimestampPagePreview()
 
-@ShowkaseComposable(name = "ShareEpisodeTimestampHorizontalRegularPreview", group = "Sharing")
 @Preview(name = "ShareEpisodeTimestampHorizontalRegularPreview", device = Devices.LandscapeRegular)
 @Composable
-fun ShareEpisodeTimestampHorizontalRegularPreview() = ShareEpisodeTimestampPagePreview()
+private fun ShareEpisodeTimestampHorizontalRegularPreview() = ShareEpisodeTimestampPagePreview()
 
-@ShowkaseComposable(name = "ShareEpisodeTimestampHorizontalSmallPreview", group = "Sharing")
 @Preview(name = "ShareEpisodeTimestampHorizontalSmallPreview", device = Devices.LandscapeSmall)
 @Composable
-fun ShareEpisodeTimestampHorizontalSmallPreviewPreview() = ShareEpisodeTimestampPagePreview()
+private fun ShareEpisodeTimestampHorizontalSmallPreviewPreview() = ShareEpisodeTimestampPagePreview()
 
-@ShowkaseComposable(name = "ShareEpisodeTimestampHorizontalTabletPreview", group = "Sharing")
 @Preview(name = "ShareEpisodeTimestampHorizontalTabletPreview", device = Devices.LandscapeTablet)
 @Composable
-fun ShareEpisodeTimestampHorizontalTabletPreview() = ShareEpisodeTimestampPagePreview()
+private fun ShareEpisodeTimestampHorizontalTabletPreview() = ShareEpisodeTimestampPagePreview()
 
 @Composable
 private fun ShareEpisodeTimestampPagePreview(

--- a/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/ui/ClipSelector.kt
+++ b/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/ui/ClipSelector.kt
@@ -407,7 +407,7 @@ private fun BoxWithConstraintsScope.ClipBox(
     }
 }
 
-@ShowkaseComposable(name = "ClipSelector", group = "Sharing")
+@ShowkaseComposable(name = "Clip selector", group = "Sharing")
 @Preview(name = "Paused", device = Devices.PortraitRegular)
 @Composable
 fun ClipSelectorPausedPreview() = ClipSelectorPreview()
@@ -467,7 +467,10 @@ private fun ClipSelectorPreview(
 ) {
     val shareColors = ShareColors(Color(0xFFEC0404))
     Box(
-        modifier = Modifier.background(shareColors.background),
+        modifier = Modifier.background(
+            color = shareColors.background,
+            shape = RoundedCornerShape(topStart = 8.dp, bottomStart = 8.dp),
+        ),
     ) {
         ClipSelector(
             episodeDuration = 5.minutes,

--- a/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/ui/HorizontalCard.kt
+++ b/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/ui/HorizontalCard.kt
@@ -131,32 +131,30 @@ private fun HorizontalCard(
     }
 }
 
-@ShowkaseComposable(name = "HorizontalPodcastCard", group = "Sharing", styleName = "Light")
-@Preview(name = "HorizontalPodcastCardLight")
-@Composable
-fun HorizontalPodcastCardLightPreview() = HorizontalPodcastCardPreview(
-    baseColor = Color(0xFFFBCB04),
-)
-
-@ShowkaseComposable(name = "HorizontalPodcastCard", group = "Sharing", styleName = "Dark")
+@ShowkaseComposable(name = "Horizontal podcast card", group = "Sharing")
 @Preview(name = "HorizontalPodcastCardDark")
 @Composable
 fun HorizontalPodcastCardDarkPreview() = HorizontalPodcastCardPreview(
     baseColor = Color(0xFFEC0404),
 )
 
-@ShowkaseComposable(name = "HorizontalEpisodeCard", group = "Sharing", styleName = "Light")
-@Preview(name = "HorizontalEpisodeCardLight")
+@Preview(name = "HorizontalPodcastCardLight")
 @Composable
-fun HorizontalEpisodeCardLightPreview() = HorizontalEpisodeCardPreview(
+private fun HorizontalPodcastCardLightPreview() = HorizontalPodcastCardPreview(
     baseColor = Color(0xFFFBCB04),
 )
 
-@ShowkaseComposable(name = "HorizontalEpisodeCard", group = "Sharing", styleName = "Dark")
+@ShowkaseComposable(name = "Horizontal episode card", group = "Sharing")
 @Preview(name = "HorizontalEpisodeCardDark")
 @Composable
 fun HorizontalEpisodeCardDarkPreview() = HorizontalEpisodeCardPreview(
     baseColor = Color(0xFFEC0404),
+)
+
+@Preview(name = "HorizontalEpisodeCardLight")
+@Composable
+private fun HorizontalEpisodeCardLightPreview() = HorizontalEpisodeCardPreview(
+    baseColor = Color(0xFFFBCB04),
 )
 
 @Composable

--- a/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/ui/SquareCard.kt
+++ b/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/ui/SquareCard.kt
@@ -119,32 +119,30 @@ private fun SquareCard(
     }
 }
 
-@ShowkaseComposable(name = "SquarePodcastCard", group = "Sharing", styleName = "Light")
-@Preview(name = "SquarePodcastCardLight")
-@Composable
-fun SquarePodcastCardLightPreview() = SquarePodcastCardPreview(
-    baseColor = Color(0xFFFBCB04),
-)
-
-@ShowkaseComposable(name = "SquarePodcastCard", group = "Sharing", styleName = "Dark")
+@ShowkaseComposable(name = "Square podcast card", group = "Sharing")
 @Preview(name = "SquarePodcastCardDark")
 @Composable
 fun SquarePodcastCardDarkPreview() = SquarePodcastCardPreview(
     baseColor = Color(0xFFEC0404),
 )
 
-@ShowkaseComposable(name = "SquareEpisodeCard", group = "Sharing", styleName = "Light")
-@Preview(name = "SquareEpisodeCardLight")
+@Preview(name = "SquarePodcastCardLight")
 @Composable
-fun SquareEpisodeCardLightPreview() = SquareEpisodeCardPreview(
+private fun SquarePodcastCardLightPreview() = SquarePodcastCardPreview(
     baseColor = Color(0xFFFBCB04),
 )
 
-@ShowkaseComposable(name = "SquareEpisodeCard", group = "Sharing", styleName = "Dark")
+@ShowkaseComposable(name = "Square episode card", group = "Sharing")
 @Preview(name = "SquareEpisodeCardDark")
 @Composable
 fun SquareEpisodeCardDarkPreview() = SquareEpisodeCardPreview(
     baseColor = Color(0xFFEC0404),
+)
+
+@Preview(name = "SquareEpisodeCardLight")
+@Composable
+private fun SquareEpisodeCardLightPreview() = SquareEpisodeCardPreview(
+    baseColor = Color(0xFFFBCB04),
 )
 
 @Composable

--- a/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/ui/VerticalCard.kt
+++ b/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/ui/VerticalCard.kt
@@ -156,32 +156,30 @@ private fun VerticalCard(
     }
 }
 
-@ShowkaseComposable(name = "VerticalPodcastCard", group = "Sharing", styleName = "Light")
-@Preview(name = "VerticalPodcastCardLight")
-@Composable
-fun VerticalPodcastCardLightPreview() = VerticalPodcastCardPreview(
-    baseColor = Color(0xFFFBCB04),
-)
-
-@ShowkaseComposable(name = "VerticalPodcastCard", group = "Sharing", styleName = "Dark")
+@ShowkaseComposable(name = "Vertical podcast card", group = "Sharing")
 @Preview(name = "VerticalPodcastCardDark")
 @Composable
 fun VerticalPodcastCardDarkPreview() = VerticalPodcastCardPreview(
     baseColor = Color(0xFFEC0404),
 )
 
-@ShowkaseComposable(name = "VerticalEpisodeCard", group = "Sharing", styleName = "Light")
-@Preview(name = "VerticalEpisodeCardLight")
+@Preview(name = "VerticalPodcastCardLight")
 @Composable
-fun VerticalEpisodeCardLightPreview() = VerticalEpisodeCardPreview(
+private fun VerticalPodcastCardLightPreview() = VerticalPodcastCardPreview(
     baseColor = Color(0xFFFBCB04),
 )
 
-@ShowkaseComposable(name = "VerticalEpisodeCard", group = "Sharing", styleName = "Dark")
+@ShowkaseComposable(name = "Vertical episode card", group = "Sharing")
 @Preview(name = "VerticalEpisodeCardDark")
 @Composable
 fun VerticalEpisodeCardDarkPreview() = VerticalEpisodeCardPreview(
     baseColor = Color(0xFFEC0404),
+)
+
+@Preview(name = "VerticalEpisodeCardLight")
+@Composable
+private fun VerticalEpisodeCardLightPreview() = VerticalEpisodeCardPreview(
+    baseColor = Color(0xFFFBCB04),
 )
 
 @Composable

--- a/modules/features/sharing/src/test/kotlin/au/com/shiftyjelly/pocketcasts/sharing/SharingAnalyticsTest.kt
+++ b/modules/features/sharing/src/test/kotlin/au/com/shiftyjelly/pocketcasts/sharing/SharingAnalyticsTest.kt
@@ -37,7 +37,7 @@ class SharingAnalyticsTest {
             .setSourceView(SourceView.PLAYER)
             .build()
 
-        analytics.logPodcastSharedEvent(request)
+        analytics.onShare(request)
         val event = tracker.events.single()
 
         event.assertType(AnalyticsEvent.PODCAST_SHARED)
@@ -59,7 +59,7 @@ class SharingAnalyticsTest {
             .setSourceView(SourceView.PLAYER)
             .build()
 
-        analytics.logPodcastSharedEvent(request)
+        analytics.onShare(request)
         val event = tracker.events.single()
 
         event.assertType(AnalyticsEvent.PODCAST_SHARED)
@@ -81,7 +81,7 @@ class SharingAnalyticsTest {
             .setSourceView(SourceView.PLAYER)
             .build()
 
-        analytics.logPodcastSharedEvent(request)
+        analytics.onShare(request)
         val event = tracker.events.single()
 
         event.assertType(AnalyticsEvent.PODCAST_SHARED)
@@ -103,7 +103,7 @@ class SharingAnalyticsTest {
             .setSourceView(SourceView.PLAYER)
             .build()
 
-        analytics.logPodcastSharedEvent(request)
+        analytics.onShare(request)
         val event = tracker.events.single()
 
         event.assertType(AnalyticsEvent.PODCAST_SHARED)
@@ -125,7 +125,7 @@ class SharingAnalyticsTest {
             .setSourceView(SourceView.PLAYER)
             .build()
 
-        analytics.logPodcastSharedEvent(request)
+        analytics.onShare(request)
         val event = tracker.events.single()
 
         event.assertType(AnalyticsEvent.PODCAST_SHARED)
@@ -147,7 +147,7 @@ class SharingAnalyticsTest {
             .setSourceView(SourceView.PLAYER)
             .build()
 
-        analytics.logPodcastSharedEvent(request)
+        analytics.onShare(request)
         val event = tracker.events.single()
 
         event.assertType(AnalyticsEvent.PODCAST_SHARED)
@@ -169,7 +169,7 @@ class SharingAnalyticsTest {
             .setSourceView(SourceView.PLAYER)
             .build()
 
-        analytics.logPodcastSharedEvent(request)
+        analytics.onShare(request)
         val event = tracker.events.single()
 
         event.assertType(AnalyticsEvent.PODCAST_SHARED)
@@ -191,7 +191,7 @@ class SharingAnalyticsTest {
             .setSourceView(SourceView.PLAYER)
             .build()
 
-        analytics.logPodcastSharedEvent(request)
+        analytics.onShare(request)
         val event = tracker.events.single()
 
         event.assertType(AnalyticsEvent.PODCAST_SHARED)
@@ -212,7 +212,7 @@ class SharingAnalyticsTest {
                 .setSourceView(source)
                 .build()
 
-            analytics.logPodcastSharedEvent(request)
+            analytics.onShare(request)
             val event = tracker.events.last()
 
             event.assertProperty("source", source.analyticsValue)
@@ -223,7 +223,7 @@ class SharingAnalyticsTest {
     fun `log podcast type property`() {
         val request = SharingRequest.podcast(podcast).build()
 
-        analytics.logPodcastSharedEvent(request)
+        analytics.onShare(request)
         val event = tracker.events.single()
 
         event.assertProperty("type", "podcast")
@@ -233,7 +233,7 @@ class SharingAnalyticsTest {
     fun `log epiosde type property`() {
         val request = SharingRequest.episode(podcast, episode).build()
 
-        analytics.logPodcastSharedEvent(request)
+        analytics.onShare(request)
         val event = tracker.events.single()
 
         event.assertProperty("type", "episode")
@@ -243,7 +243,7 @@ class SharingAnalyticsTest {
     fun `log epiosde position type property`() {
         val request = SharingRequest.episodePosition(podcast, episode, position).build()
 
-        analytics.logPodcastSharedEvent(request)
+        analytics.onShare(request)
         val event = tracker.events.single()
 
         event.assertProperty("type", "current_time")
@@ -253,7 +253,7 @@ class SharingAnalyticsTest {
     fun `log bookmark type property`() {
         val request = SharingRequest.bookmark(podcast, episode, position).build()
 
-        analytics.logPodcastSharedEvent(request)
+        analytics.onShare(request)
         val event = tracker.events.single()
 
         event.assertProperty("type", "bookmark_time")
@@ -263,7 +263,7 @@ class SharingAnalyticsTest {
     fun `log episode file type property`() {
         val request = SharingRequest.episodeFile(podcast, episode).build()
 
-        analytics.logPodcastSharedEvent(request)
+        analytics.onShare(request)
         val event = tracker.events.single()
 
         event.assertProperty("type", "episode_file")
@@ -273,7 +273,7 @@ class SharingAnalyticsTest {
     fun `log clip link type property`() {
         val request = SharingRequest.clipLink(podcast, episode, clipRange).build()
 
-        analytics.logPodcastSharedEvent(request)
+        analytics.onShare(request)
         val event = tracker.events.single()
 
         event.assertProperty("type", "clip_link")
@@ -283,7 +283,7 @@ class SharingAnalyticsTest {
     fun `log clip audio type property`() {
         val request = SharingRequest.audioClip(podcast, episode, clipRange).build()
 
-        analytics.logPodcastSharedEvent(request)
+        analytics.onShare(request)
         val event = tracker.events.single()
 
         event.assertProperty("type", "clip_audio")
@@ -293,7 +293,7 @@ class SharingAnalyticsTest {
     fun `log clip video type property`() {
         val request = SharingRequest.videoClip(podcast, episode, clipRange, tempFolder.newFile()).build()
 
-        analytics.logPodcastSharedEvent(request)
+        analytics.onShare(request)
         val event = tracker.events.single()
 
         event.assertProperty("type", "clip_video")
@@ -305,7 +305,7 @@ class SharingAnalyticsTest {
             .setPlatform(SocialPlatform.Instagram)
             .build()
 
-        analytics.logPodcastSharedEvent(request)
+        analytics.onShare(request)
         val event = tracker.events.single()
 
         event.assertProperty("action", "ig_story")
@@ -317,7 +317,7 @@ class SharingAnalyticsTest {
             .setPlatform(SocialPlatform.WhatsApp)
             .build()
 
-        analytics.logPodcastSharedEvent(request)
+        analytics.onShare(request)
         val event = tracker.events.single()
 
         event.assertProperty("action", "whats_app")
@@ -329,7 +329,7 @@ class SharingAnalyticsTest {
             .setPlatform(SocialPlatform.Telegram)
             .build()
 
-        analytics.logPodcastSharedEvent(request)
+        analytics.onShare(request)
         val event = tracker.events.single()
 
         event.assertProperty("action", "telegram")
@@ -341,7 +341,7 @@ class SharingAnalyticsTest {
             .setPlatform(SocialPlatform.X)
             .build()
 
-        analytics.logPodcastSharedEvent(request)
+        analytics.onShare(request)
         val event = tracker.events.single()
 
         event.assertProperty("action", "twitter")
@@ -353,7 +353,7 @@ class SharingAnalyticsTest {
             .setPlatform(SocialPlatform.Tumblr)
             .build()
 
-        analytics.logPodcastSharedEvent(request)
+        analytics.onShare(request)
         val event = tracker.events.single()
 
         event.assertProperty("action", "tumblr")
@@ -365,7 +365,7 @@ class SharingAnalyticsTest {
             .setPlatform(SocialPlatform.PocketCasts)
             .build()
 
-        analytics.logPodcastSharedEvent(request)
+        analytics.onShare(request)
         val event = tracker.events.single()
 
         event.assertProperty("action", "url")
@@ -377,7 +377,7 @@ class SharingAnalyticsTest {
             .setPlatform(SocialPlatform.More)
             .build()
 
-        analytics.logPodcastSharedEvent(request)
+        analytics.onShare(request)
         val event = tracker.events.single()
 
         event.assertProperty("action", "system_sheet")
@@ -389,7 +389,7 @@ class SharingAnalyticsTest {
             .setCardType(CardType.Vertical)
             .build()
 
-        analytics.logPodcastSharedEvent(request)
+        analytics.onShare(request)
         val event = tracker.events.single()
 
         event.assertProperty("card_type", "vertical")
@@ -401,7 +401,7 @@ class SharingAnalyticsTest {
             .setCardType(CardType.Horiozntal)
             .build()
 
-        analytics.logPodcastSharedEvent(request)
+        analytics.onShare(request)
         val event = tracker.events.single()
 
         event.assertProperty("card_type", "horizontal")
@@ -413,7 +413,7 @@ class SharingAnalyticsTest {
             .setCardType(CardType.Square)
             .build()
 
-        analytics.logPodcastSharedEvent(request)
+        analytics.onShare(request)
         val event = tracker.events.single()
 
         event.assertProperty("card_type", "square")
@@ -423,7 +423,7 @@ class SharingAnalyticsTest {
     fun `log no card type property`() {
         val request = SharingRequest.podcast(podcast).build()
 
-        analytics.logPodcastSharedEvent(request)
+        analytics.onShare(request)
         val event = tracker.events.single()
 
         event.assertProperty("card_type", null)


### PR DESCRIPTION
## Description

Some small cleanup of the sharing code.

* Removed unnecessary Showkase annotations.
* Decoupled `SharingClient` from analytics and logging via listeners.

## Testing Instructions

Smoke test sharing and check if analytics and logging still work.

## Checklist
- [x] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] ~I have considered whether it makes sense to add tests for my changes~
- [x] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [x] ~Any jetpack compose components I added or changed are covered by compose previews~
- [x] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~