### PR TITLE
Tweak podcast page ratings UI

### DIFF
--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/components/ratings/StarRatingView.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/components/ratings/StarRatingView.kt
@@ -67,10 +67,13 @@ private fun Content(
     state: RatingState.Loaded,
     onClick: () -> Unit,
 ) {
-    val verticalPadding = if (FeatureFlag.isEnabled(Feature.GIVE_RATINGS)) 8.dp else 18.dp
-
     Row(
-        modifier = Modifier.padding(horizontal = 16.dp, vertical = verticalPadding),
+        modifier = Modifier.padding(
+            start = 16.dp,
+            end = 4.dp,
+            top = if (FeatureFlag.isEnabled(Feature.GIVE_RATINGS)) 8.dp else 18.dp,
+            bottom = if (FeatureFlag.isEnabled(Feature.GIVE_RATINGS)) 0.dp else 18.dp,
+        ),
         verticalAlignment = Alignment.CenterVertically,
     ) {
         Stars(

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/PodcastRatingsViewModel.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/PodcastRatingsViewModel.kt
@@ -1,15 +1,16 @@
 package au.com.shiftyjelly.pocketcasts.podcasts.viewmodel
 
-import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.StarHalf
-import androidx.compose.material.icons.filled.Star
-import androidx.compose.material.icons.filled.StarBorder
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.fragment.app.FragmentManager
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTracker
+import au.com.shiftyjelly.pocketcasts.images.PocketCastsIcons
+import au.com.shiftyjelly.pocketcasts.images.icons.StarEmpty
+import au.com.shiftyjelly.pocketcasts.images.icons.StarFull
+import au.com.shiftyjelly.pocketcasts.images.icons.StarHalf
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastRatings
 import au.com.shiftyjelly.pocketcasts.podcasts.view.components.ratings.GiveRatingFragment
 import au.com.shiftyjelly.pocketcasts.repositories.ratings.RatingsManager
@@ -134,9 +135,9 @@ class PodcastRatingsViewModel
     }
 
     enum class Star(val icon: ImageVector) {
-        FilledStar(Icons.Filled.Star),
-        HalfStar(Icons.AutoMirrored.Filled.StarHalf),
-        BorderedStar(Icons.Filled.StarBorder),
+        FilledStar(PocketCastsIcons.StarFull),
+        HalfStar(PocketCastsIcons.StarHalf),
+        BorderedStar(PocketCastsIcons.StarEmpty),
     }
 
     companion object {

--- a/modules/services/images/src/main/java/au/com/shiftyjelly/pocketcasts/images/PocketCastsIcons.kt
+++ b/modules/services/images/src/main/java/au/com/shiftyjelly/pocketcasts/images/PocketCastsIcons.kt
@@ -1,0 +1,21 @@
+package au.com.shiftyjelly.pocketcasts.images
+
+import androidx.compose.ui.graphics.vector.ImageVector
+import au.com.shiftyjelly.pocketcasts.images.icons.StarEmpty
+import au.com.shiftyjelly.pocketcasts.images.icons.StarFull
+import au.com.shiftyjelly.pocketcasts.images.icons.StarHalf
+
+private var icons: List<ImageVector>? = null
+
+object PocketCastsIcons {
+    val AllIcons: List<ImageVector>
+        get() {
+            var iconsLoaded = icons
+            if (iconsLoaded != null) {
+                return iconsLoaded
+            }
+            iconsLoaded = listOf(StarFull, StarEmpty, StarHalf)
+            icons = iconsLoaded
+            return iconsLoaded
+        }
+}

--- a/modules/services/images/src/main/java/au/com/shiftyjelly/pocketcasts/images/icons/StarEmpty.kt
+++ b/modules/services/images/src/main/java/au/com/shiftyjelly/pocketcasts/images/icons/StarEmpty.kt
@@ -1,0 +1,60 @@
+package au.com.shiftyjelly.pocketcasts.images.icons
+
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.PathFillType.Companion.NonZero
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.StrokeCap.Companion.Round
+import androidx.compose.ui.graphics.StrokeJoin
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.graphics.vector.ImageVector.Builder
+import androidx.compose.ui.graphics.vector.path
+import androidx.compose.ui.unit.dp
+import au.com.shiftyjelly.pocketcasts.images.PocketCastsIcons
+
+val PocketCastsIcons.StarEmpty: ImageVector
+    get() {
+        if (_starEmpty != null) {
+            return _starEmpty!!
+        }
+        _starEmpty = Builder(
+            name = "StarEmpty", defaultWidth = 16.0.dp, defaultHeight = 16.0.dp,
+            viewportWidth = 16.0f, viewportHeight = 16.0f,
+        ).apply {
+            path(
+                fill = SolidColor(Color(0x00000000)), stroke = SolidColor(Color(0xFF808080)),
+                strokeLineWidth = 1.0f, strokeLineCap = Round,
+                strokeLineJoin =
+                StrokeJoin.Companion.Round,
+                strokeLineMiter = 4.0f, pathFillType = NonZero,
+            ) {
+                moveTo(8.402f, 2.2885f)
+                lineTo(10.1827f, 5.8149f)
+                lineTo(13.6098f, 6.1501f)
+                curveTo(13.8439f, 6.166f, 14.0195f, 6.373f, 13.9983f, 6.607f)
+                curveTo(13.9876f, 6.7081f, 13.945f, 6.8039f, 13.8705f, 6.873f)
+                lineTo(11.0501f, 9.6674f)
+                lineTo(12.0931f, 13.4603f)
+                curveTo(12.1517f, 13.6891f, 12.0133f, 13.9232f, 11.7845f, 13.987f)
+                curveTo(11.678f, 14.0136f, 11.5716f, 13.9976f, 11.4758f, 13.9551f)
+                lineTo(8.0013f, 12.2315f)
+                lineTo(4.5316f, 13.9444f)
+                curveTo(4.3134f, 14.0508f, 4.058f, 13.9657f, 3.9462f, 13.7476f)
+                curveTo(3.8984f, 13.6519f, 3.8824f, 13.5401f, 3.9143f, 13.4391f)
+                lineTo(4.9574f, 9.6408f)
+                lineTo(2.1284f, 6.8422f)
+                verticalLineTo(6.8416f)
+                curveTo(1.9581f, 6.6719f, 1.9581f, 6.4006f, 2.1231f, 6.2357f)
+                curveTo(2.1923f, 6.1612f, 2.288f, 6.1187f, 2.3891f, 6.108f)
+                lineTo(5.8163f, 5.7676f)
+                lineTo(7.5937f, 2.2406f)
+                curveTo(7.7001f, 2.0225f, 7.9609f, 1.9374f, 8.1791f, 2.0491f)
+                curveTo(8.2589f, 2.0864f, 8.3228f, 2.1555f, 8.3653f, 2.2353f)
+                lineTo(8.402f, 2.2885f)
+                close()
+            }
+        }
+            .build()
+        return _starEmpty!!
+    }
+
+private var _starEmpty: ImageVector? = null

--- a/modules/services/images/src/main/java/au/com/shiftyjelly/pocketcasts/images/icons/StarFull.kt
+++ b/modules/services/images/src/main/java/au/com/shiftyjelly/pocketcasts/images/icons/StarFull.kt
@@ -1,0 +1,82 @@
+package au.com.shiftyjelly.pocketcasts.images.icons
+
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.PathFillType.Companion.NonZero
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.StrokeCap.Companion.Butt
+import androidx.compose.ui.graphics.StrokeCap.Companion.Round
+import androidx.compose.ui.graphics.StrokeJoin
+import androidx.compose.ui.graphics.StrokeJoin.Companion.Miter
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.graphics.vector.ImageVector.Builder
+import androidx.compose.ui.graphics.vector.path
+import androidx.compose.ui.unit.dp
+import au.com.shiftyjelly.pocketcasts.images.PocketCastsIcons
+
+val PocketCastsIcons.StarFull: ImageVector
+    get() {
+        if (_starFull != null) {
+            return _starFull!!
+        }
+        _starFull = Builder(
+            name = "StarFull", defaultWidth = 16.0.dp, defaultHeight = 16.0.dp,
+            viewportWidth = 16.0f, viewportHeight = 16.0f,
+        ).apply {
+            path(
+                fill = SolidColor(Color(0xFF808080)), stroke = SolidColor(Color(0xFF808080)),
+                strokeLineWidth = 1.0f, strokeLineCap = Round,
+                strokeLineJoin =
+                StrokeJoin.Companion.Round,
+                strokeLineMiter = 4.0f, pathFillType = NonZero,
+            ) {
+                moveTo(8.402f, 2.2885f)
+                lineTo(10.1827f, 5.8149f)
+                lineTo(13.6098f, 6.1501f)
+                curveTo(13.8439f, 6.166f, 14.0195f, 6.373f, 13.9983f, 6.607f)
+                curveTo(13.9876f, 6.7081f, 13.945f, 6.8039f, 13.8705f, 6.873f)
+                lineTo(11.0501f, 9.6674f)
+                lineTo(12.0931f, 13.4603f)
+                curveTo(12.1517f, 13.6891f, 12.0133f, 13.9232f, 11.7845f, 13.987f)
+                curveTo(11.678f, 14.0136f, 11.5716f, 13.9976f, 11.4758f, 13.9551f)
+                lineTo(8.0013f, 12.2315f)
+                lineTo(4.5316f, 13.9444f)
+                curveTo(4.3134f, 14.0508f, 4.058f, 13.9657f, 3.9462f, 13.7476f)
+                curveTo(3.8984f, 13.6519f, 3.8824f, 13.5401f, 3.9143f, 13.4391f)
+                lineTo(4.9574f, 9.6408f)
+                lineTo(2.1284f, 6.8422f)
+                verticalLineTo(6.8416f)
+                curveTo(1.9581f, 6.6719f, 1.9581f, 6.4006f, 2.1231f, 6.2357f)
+                curveTo(2.1923f, 6.1612f, 2.288f, 6.1187f, 2.3891f, 6.108f)
+                lineTo(5.8163f, 5.7676f)
+                lineTo(7.5937f, 2.2406f)
+                curveTo(7.7001f, 2.0225f, 7.9609f, 1.9374f, 8.1791f, 2.0491f)
+                curveTo(8.2589f, 2.0864f, 8.3228f, 2.1555f, 8.3653f, 2.2353f)
+                lineTo(8.402f, 2.2885f)
+                close()
+            }
+            path(
+                fill = SolidColor(Color(0xFF808080)), stroke = null, strokeLineWidth = 0.0f,
+                strokeLineCap = Butt, strokeLineJoin = Miter, strokeLineMiter = 4.0f,
+                pathFillType = NonZero,
+            ) {
+                moveTo(8.0f, 2.0002f)
+                curveTo(7.8349f, 1.9949f, 7.6858f, 2.0911f, 7.6113f, 2.2408f)
+                lineTo(5.8275f, 5.7796f)
+                lineTo(2.3984f, 6.1164f)
+                lineTo(2.3958f, 6.1111f)
+                curveTo(2.1562f, 6.1271f, 1.9805f, 6.3356f, 2.0017f, 6.5708f)
+                curveTo(2.0071f, 6.6724f, 2.0497f, 6.7686f, 2.1242f, 6.8381f)
+                lineTo(4.9463f, 9.6462f)
+                lineTo(3.9027f, 13.4577f)
+                curveTo(3.8388f, 13.6876f, 3.9772f, 13.9228f, 4.2062f, 13.9869f)
+                curveTo(4.3073f, 14.0137f, 4.4138f, 13.9976f, 4.5097f, 13.9549f)
+                lineTo(7.9814f, 12.2282f)
+                lineTo(8.0f, 2.0002f)
+                close()
+            }
+        }
+            .build()
+        return _starFull!!
+    }
+
+private var _starFull: ImageVector? = null

--- a/modules/services/images/src/main/java/au/com/shiftyjelly/pocketcasts/images/icons/StarHalf.kt
+++ b/modules/services/images/src/main/java/au/com/shiftyjelly/pocketcasts/images/icons/StarHalf.kt
@@ -1,0 +1,82 @@
+package au.com.shiftyjelly.pocketcasts.images.icons
+
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.PathFillType.Companion.NonZero
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.StrokeCap.Companion.Butt
+import androidx.compose.ui.graphics.StrokeCap.Companion.Round
+import androidx.compose.ui.graphics.StrokeJoin
+import androidx.compose.ui.graphics.StrokeJoin.Companion.Miter
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.graphics.vector.ImageVector.Builder
+import androidx.compose.ui.graphics.vector.path
+import androidx.compose.ui.unit.dp
+import au.com.shiftyjelly.pocketcasts.images.PocketCastsIcons
+
+val PocketCastsIcons.StarHalf: ImageVector
+    get() {
+        if (_starHalf != null) {
+            return _starHalf!!
+        }
+        _starHalf = Builder(
+            name = "StarHalf", defaultWidth = 16.0.dp, defaultHeight = 16.0.dp,
+            viewportWidth = 16.0f, viewportHeight = 16.0f,
+        ).apply {
+            path(
+                fill = SolidColor(Color(0x00000000)), stroke = SolidColor(Color(0xFF808080)),
+                strokeLineWidth = 1.0f, strokeLineCap = Round,
+                strokeLineJoin =
+                StrokeJoin.Companion.Round,
+                strokeLineMiter = 4.0f, pathFillType = NonZero,
+            ) {
+                moveTo(8.402f, 2.2885f)
+                lineTo(10.1827f, 5.8149f)
+                lineTo(13.6098f, 6.1501f)
+                curveTo(13.8439f, 6.166f, 14.0195f, 6.373f, 13.9983f, 6.607f)
+                curveTo(13.9876f, 6.7081f, 13.945f, 6.8039f, 13.8705f, 6.873f)
+                lineTo(11.0501f, 9.6674f)
+                lineTo(12.0931f, 13.4603f)
+                curveTo(12.1517f, 13.6891f, 12.0133f, 13.9232f, 11.7845f, 13.987f)
+                curveTo(11.678f, 14.0136f, 11.5716f, 13.9976f, 11.4758f, 13.9551f)
+                lineTo(8.0013f, 12.2315f)
+                lineTo(4.5316f, 13.9444f)
+                curveTo(4.3134f, 14.0508f, 4.058f, 13.9657f, 3.9462f, 13.7476f)
+                curveTo(3.8984f, 13.6519f, 3.8824f, 13.5401f, 3.9143f, 13.4391f)
+                lineTo(4.9574f, 9.6408f)
+                lineTo(2.1284f, 6.8422f)
+                verticalLineTo(6.8416f)
+                curveTo(1.9581f, 6.6719f, 1.9581f, 6.4006f, 2.1231f, 6.2357f)
+                curveTo(2.1923f, 6.1612f, 2.288f, 6.1187f, 2.3891f, 6.108f)
+                lineTo(5.8163f, 5.7676f)
+                lineTo(7.5937f, 2.2406f)
+                curveTo(7.7001f, 2.0225f, 7.9609f, 1.9374f, 8.1791f, 2.0491f)
+                curveTo(8.2589f, 2.0864f, 8.3228f, 2.1555f, 8.3653f, 2.2353f)
+                lineTo(8.402f, 2.2885f)
+                close()
+            }
+            path(
+                fill = SolidColor(Color(0xFF808080)), stroke = null, strokeLineWidth = 0.0f,
+                strokeLineCap = Butt, strokeLineJoin = Miter, strokeLineMiter = 4.0f,
+                pathFillType = NonZero,
+            ) {
+                moveTo(8.0f, 2.0002f)
+                curveTo(7.8349f, 1.9949f, 7.6858f, 2.0911f, 7.6113f, 2.2408f)
+                lineTo(5.8275f, 5.7796f)
+                lineTo(2.3984f, 6.1164f)
+                lineTo(2.3958f, 6.1111f)
+                curveTo(2.1562f, 6.1271f, 1.9805f, 6.3356f, 2.0017f, 6.5708f)
+                curveTo(2.0071f, 6.6724f, 2.0497f, 6.7686f, 2.1242f, 6.8381f)
+                lineTo(4.9463f, 9.6462f)
+                lineTo(3.9027f, 13.4577f)
+                curveTo(3.8388f, 13.6876f, 3.9772f, 13.9228f, 4.2062f, 13.9869f)
+                curveTo(4.3073f, 14.0137f, 4.4138f, 13.9976f, 4.5097f, 13.9549f)
+                lineTo(7.9814f, 12.2282f)
+                lineTo(8.0f, 2.0002f)
+                close()
+            }
+        }
+            .build()
+        return _starHalf!!
+    }
+
+private var _starHalf: ImageVector? = null


### PR DESCRIPTION
## Description

This change tweaks the new ratings UI to match the designs. It moves the "Rate" closer to the right, reduces the space below ratings section, and switches the star icons from Material to our designs.

## Testing Instructions

1. Open the podcast page
2. ✅ Verify the rating section looks correct.

## Screenshots 

| Before | After |
| --- | --- |
| ![Screenshot_20240802_222151](https://github.com/user-attachments/assets/4f10e0cd-86d3-4bb5-9e07-f07d2739a11e) | ![Screenshot_20240802_222047](https://github.com/user-attachments/assets/996913f7-5531-4154-a248-0c31443729d0) |

**Design**

<img width="375" alt="iPhone 13 mini - 9" src="https://github.com/user-attachments/assets/78ace101-1e28-46b1-a557-e755448c0551">
