### PR TITLE
Animate transition between clip sharing steps

### DIFF
--- a/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/clip/ClipPageState.kt
+++ b/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/clip/ClipPageState.kt
@@ -1,0 +1,62 @@
+package au.com.shiftyjelly.pocketcasts.sharing.clip
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.Saver
+import androidx.compose.runtime.saveable.listSaver
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import au.com.shiftyjelly.pocketcasts.sharing.ui.ClipSelectorState
+
+@Composable
+internal fun rememberClipPageState(
+    firstVisibleItemIndex: Int,
+) = rememberSaveable(
+    saver = ClipPageState.Saver,
+    init = {
+        ClipPageState(
+            step = SharingStep.Creating,
+            selectorState = ClipSelectorState(
+                firstVisibleItemIndex = firstVisibleItemIndex,
+                firstVisibleItemScrollOffset = 0,
+                scale = 1f,
+                secondsPerTick = 1,
+                itemWidth = 0f,
+                startOffset = 0f,
+                endOffset = 0f,
+            ),
+        )
+    },
+)
+
+internal class ClipPageState(
+    step: SharingStep,
+    val selectorState: ClipSelectorState,
+) {
+    var step by mutableStateOf(step)
+
+    companion object {
+        val Saver: Saver<ClipPageState, Any> = listSaver(
+            save = {
+                listOf(
+                    it.step,
+                    with(ClipSelectorState.Saver) { save(it.selectorState) },
+                )
+            },
+            restore = {
+                ClipPageState(
+                    step = it[0] as SharingStep,
+                    selectorState = requireNotNull(ClipSelectorState.Saver.restore(it.drop(1))) {
+                        "ClipSelectorState.Saver should never return null"
+                    },
+                )
+            },
+        )
+    }
+}
+
+internal enum class SharingStep {
+    Creating,
+    Sharing,
+}

--- a/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/clip/ClipPageState.kt
+++ b/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/clip/ClipPageState.kt
@@ -47,7 +47,7 @@ internal class ClipPageState(
             restore = {
                 ClipPageState(
                     step = it[0] as SharingStep,
-                    selectorState = requireNotNull(ClipSelectorState.Saver.restore(it.drop(1))) {
+                    selectorState = requireNotNull(ClipSelectorState.Saver.restore(it[1] as Any)) {
                         "ClipSelectorState.Saver should never return null"
                     },
                 )

--- a/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/clip/ClipPageState.kt
+++ b/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/clip/ClipPageState.kt
@@ -12,11 +12,12 @@ import au.com.shiftyjelly.pocketcasts.sharing.ui.ClipSelectorState
 @Composable
 internal fun rememberClipPageState(
     firstVisibleItemIndex: Int,
+    step: SharingStep = SharingStep.Creating,
 ) = rememberSaveable(
     saver = ClipPageState.Saver,
     init = {
         ClipPageState(
-            step = SharingStep.Creating,
+            step = step,
             selectorState = ClipSelectorState(
                 firstVisibleItemIndex = firstVisibleItemIndex,
                 firstVisibleItemScrollOffset = 0,

--- a/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/clip/ShareClipFragment.kt
+++ b/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/clip/ShareClipFragment.kt
@@ -17,6 +17,7 @@ import androidx.fragment.app.viewModels
 import au.com.shiftyjelly.pocketcasts.analytics.SourceView
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.sharing.SharingClient
+import au.com.shiftyjelly.pocketcasts.sharing.social.SocialPlatform
 import au.com.shiftyjelly.pocketcasts.sharing.ui.BackgroundAssetController
 import au.com.shiftyjelly.pocketcasts.sharing.ui.ShareColors
 import au.com.shiftyjelly.pocketcasts.utils.parceler.ColorParceler
@@ -80,7 +81,7 @@ class ShareClipFragment : BaseDialogFragment() {
         container: ViewGroup?,
         savedInstanceState: Bundle?,
     ) = ComposeView(requireActivity()).apply {
-        val shareColors = shareColors
+        val platforms = SocialPlatform.getAvailablePlatforms(requireContext())
         val assetController = BackgroundAssetController.create(requireContext(), shareColors)
         val listener = ShareClipListener(this@ShareClipFragment, viewModel, sharingClient, assetController)
         setContent {
@@ -92,6 +93,7 @@ class ShareClipFragment : BaseDialogFragment() {
                 playbackProgress = uiState.playbackProgress,
                 isPlaying = uiState.isPlaying,
                 useEpisodeArtwork = uiState.useEpisodeArtwork,
+                platforms = platforms,
                 shareColors = shareColors,
                 assetController = assetController,
                 listener = listener,

--- a/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/clip/ShareClipPage.kt
+++ b/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/clip/ShareClipPage.kt
@@ -312,21 +312,28 @@ private fun ClipControls(
     }
 }
 
-@Preview(name = "ShareClipVerticalRegularPreview", device = Devices.PortraitRegular)
+@Preview(name = "Regular device", device = Devices.PortraitRegular)
 @Composable
 private fun ShareClipVerticalRegularPreview() = ShareClipPagePreview()
 
-@Preview(name = "ShareClipVerticalSmallPreview", device = Devices.PortraitSmall)
+@Preview(name = "Regular device sharing", device = Devices.PortraitRegular)
+@Composable
+private fun ShareClipVerticalRegularEditingPreview() = ShareClipPagePreview(
+    step = SharingStep.Sharing,
+)
+
+@Preview(name = "Small device", device = Devices.PortraitSmall)
 @Composable
 private fun ShareClipVerticalSmallPreviewPreview() = ShareClipPagePreview()
 
-@Preview(name = "ShareClipVerticalTabletPreview", device = Devices.PortraitTablet)
+@Preview(name = "Tablet device", device = Devices.PortraitTablet)
 @Composable
 private fun ShareClipVerticalTabletPreview() = ShareClipPagePreview()
 
 @Composable
 internal fun ShareClipPagePreview(
     color: Long = 0xFFEC0404,
+    step: SharingStep = SharingStep.Creating,
 ) {
     val clipRange = Clip.Range(0.seconds, 15.seconds)
     ShareClipPage(
@@ -352,6 +359,7 @@ internal fun ShareClipPagePreview(
         listener = ShareClipPageListener.Preview,
         state = rememberClipPageState(
             firstVisibleItemIndex = 0,
+            step = step,
         ),
     )
 }

--- a/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/clip/ShareClipPage.kt
+++ b/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/clip/ShareClipPage.kt
@@ -36,7 +36,6 @@ import au.com.shiftyjelly.pocketcasts.sharing.ui.CloseButton
 import au.com.shiftyjelly.pocketcasts.sharing.ui.Devices
 import au.com.shiftyjelly.pocketcasts.sharing.ui.ShareColors
 import au.com.shiftyjelly.pocketcasts.sharing.ui.VerticalEpisodeCard
-import au.com.shiftyjelly.pocketcasts.sharing.ui.rememberClipSelectorState
 import au.com.shiftyjelly.pocketcasts.sharing.ui.scrollBottomFade
 import java.sql.Date
 import java.time.Instant
@@ -83,7 +82,7 @@ internal fun ShareClipPage(
     shareColors: ShareColors,
     assetController: BackgroundAssetController,
     listener: ShareClipPageListener,
-    state: ClipSelectorState = rememberClipSelectorState(
+    state: ClipPageState = rememberClipPageState(
         firstVisibleItemIndex = (clipRange.startInSeconds - 10).coerceAtLeast(0),
     ),
 ) = VerticalClipPage(
@@ -109,7 +108,7 @@ private fun VerticalClipPage(
     shareColors: ShareColors,
     assetController: BackgroundAssetController,
     listener: ShareClipPageListener,
-    state: ClipSelectorState,
+    state: ClipPageState,
 ) {
     Box {
         Column(
@@ -154,7 +153,7 @@ private fun VerticalClipPage(
                     isPlaying = isPlaying,
                     shareColors = shareColors,
                     listener = listener,
-                    state = state,
+                    state = state.selectorState,
                 )
             }
         }
@@ -285,7 +284,7 @@ internal fun ShareClipPagePreview(
         shareColors = ShareColors(Color(color)),
         assetController = BackgroundAssetController.preview(),
         listener = ShareClipPageListener.Preview,
-        state = rememberClipSelectorState(
+        state = rememberClipPageState(
             firstVisibleItemIndex = 0,
         ),
     )

--- a/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/clip/ShareClipPage.kt
+++ b/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/clip/ShareClipPage.kt
@@ -2,18 +2,24 @@ package au.com.shiftyjelly.pocketcasts.sharing.clip
 
 import androidx.compose.animation.AnimatedContent
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.ButtonDefaults
+import androidx.compose.material.ripple.rememberRipple
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -21,6 +27,8 @@ import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.rememberNestedScrollInteropConnection
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -134,6 +142,7 @@ private fun VerticalClipPage(
             ) {
                 TopInfo(
                     shareColors = shareColors,
+                    state = state,
                 )
                 if (podcast != null && episode != null) {
                     val cardPadding = maxOf(
@@ -189,38 +198,75 @@ private fun VerticalClipPage(
 @Composable
 private fun TopInfo(
     shareColors: ShareColors,
+    state: ClipPageState,
 ) {
-    Column(
-        horizontalAlignment = Alignment.CenterHorizontally,
-        verticalArrangement = Arrangement.Center,
-        modifier = Modifier.fillMaxWidth(),
-    ) {
-        Spacer(
-            modifier = Modifier.height(40.dp),
-        )
-        TextH30(
-            text = stringResource(LR.string.podcast_create_clip),
-            textAlign = TextAlign.Center,
-            maxLines = 1,
-            color = shareColors.backgroundPrimaryText,
-            modifier = Modifier
-                .padding(horizontal = 24.dp)
-                .align(Alignment.CenterHorizontally),
-        )
-        Spacer(
-            modifier = Modifier.height(8.dp),
-        )
-        // Placeholder until audio clips are added
-        TextH40(
-            text = " ",
-            textAlign = TextAlign.Center,
-            maxLines = 1,
-            color = shareColors.backgroundSecondaryText,
-            modifier = Modifier.padding(horizontal = 24.dp),
-        )
-        Spacer(
-            modifier = Modifier.height(12.dp),
-        )
+    AnimatedContent(state.step) { step ->
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Center,
+            modifier = Modifier.fillMaxWidth(),
+        ) {
+            Spacer(
+                modifier = Modifier.height(
+                    when (step) {
+                        SharingStep.Creating -> 40.dp
+                        SharingStep.Sharing -> 24.dp
+                    },
+                ),
+            )
+            TextH30(
+                text = stringResource(
+                    when (step) {
+                        SharingStep.Creating -> LR.string.share_clip_create_label
+                        SharingStep.Sharing -> LR.string.share_clip_share_label
+                    },
+                ),
+                textAlign = TextAlign.Center,
+                maxLines = 1,
+                color = shareColors.backgroundPrimaryText,
+                modifier = Modifier
+                    .padding(horizontal = 24.dp)
+                    .align(Alignment.CenterHorizontally),
+            )
+            Spacer(
+                modifier = Modifier.height(8.dp),
+            )
+            when (step) {
+                SharingStep.Creating -> TextH40(
+                    text = " ", // Placeholder until audio clips are added
+                    textAlign = TextAlign.Center,
+                    maxLines = 1,
+                    color = shareColors.backgroundSecondaryText,
+                    modifier = Modifier.padding(horizontal = 24.dp),
+                )
+                SharingStep.Sharing -> TextH40(
+                    text = stringResource(LR.string.share_clip_edit_label),
+                    textAlign = TextAlign.Center,
+                    maxLines = 1,
+                    color = shareColors.backgroundPrimaryText,
+                    fontWeight = FontWeight.W400,
+                    modifier = Modifier
+                        .background(shareColors.closeButton, CircleShape)
+                        .defaultMinSize(minHeight = 24.dp)
+                        .clickable(
+                            interactionSource = remember(::MutableInteractionSource),
+                            indication = rememberRipple(color = shareColors.base),
+                            onClickLabel = stringResource(LR.string.share_clip_edit_label),
+                            role = Role.Button,
+                            onClick = { state.step = SharingStep.Creating },
+                        )
+                        .padding(vertical = 4.dp, horizontal = 16.dp),
+                )
+            }
+            Spacer(
+                modifier = Modifier.height(
+                    when (step) {
+                        SharingStep.Creating -> 12.dp
+                        SharingStep.Sharing -> 48.dp
+                    },
+                ),
+            )
+        }
     }
 }
 

--- a/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/ui/ClipSelectorState.kt
+++ b/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/ui/ClipSelectorState.kt
@@ -24,8 +24,6 @@ internal fun rememberClipSelectorState(
     firstVisibleItemIndex: Int,
     firstVisibleItemScrollOffset: Int = 0,
     scale: Float = 1f,
-    startOffset: Float = 0f,
-    endOffset: Float = 0f,
 ) = rememberSaveable(
     saver = ClipSelectorState.Saver,
     init = {
@@ -35,8 +33,8 @@ internal fun rememberClipSelectorState(
             scale = scale,
             secondsPerTick = 1,
             itemWidth = 0f,
-            startOffset = startOffset,
-            endOffset = endOffset,
+            startOffset = 0f,
+            endOffset = 0f,
         )
     },
 )
@@ -168,7 +166,7 @@ internal class ClipSelectorState(
 
         fun itemWidth(scale: Float) = TickWidth + SpaceWidth * scale
 
-        val Saver: Saver<ClipSelectorState, *> = listSaver(
+        val Saver: Saver<ClipSelectorState, Any> = listSaver(
             save = {
                 listOf(
                     it.listState.firstVisibleItemIndex,

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -2022,6 +2022,9 @@ up    <string name="player_sleep_in_one_chapter">Sleeping in 1 chapter</string>
     <string name="share_clip_start_position">%s Start</string>
     <!--  The duration of a shared clip. It is in HH:MM:SS format.  -->
     <string name="share_clip_duration">%s Duration</string>
+    <string name="share_clip_create_label" translatable="false">@string/podcast_create_clip</string>
+    <string name="share_clip_share_label">Share clip</string>
+    <string name="share_clip_edit_label">Edit clip</string>
 
     <!-- Pocket Casts Champion -->
     <string name="pocket_casts_champion_dialog_title">You’re a true champion of Pocket Casts!</string>


### PR DESCRIPTION
## Description

This PR adds animation for clip sharing between creating and sharing states.

Figma: HR2vcQrWcS0scsolKZBitg-fi-2345_20387

## Testing Instructions

1. Start clip sharing.
2. Tap on the `Next` button.
3. Screen should animate to the sharing state.
4. Tap on the `Edit clip` button.
5. Screen should animate to the editing state.

## Screenshots or Screencast 

![demo](https://github.com/user-attachments/assets/54efdf3a-3e06-480f-8b90-f23242007288)


## Checklist
- [x] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] ~I have considered whether it makes sense to add tests for my changes~
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [ ] with a landscape orientation
- [x] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack