### PR TITLE
[Kids Profile] Send Anonymous feedback

### DIFF
--- a/modules/features/kids/build.gradle.kts
+++ b/modules/features/kids/build.gradle.kts
@@ -20,6 +20,8 @@ dependencies {
     implementation(project(":modules:services:localization"))
     implementation(project(":modules:services:images"))
     implementation(project(":modules:services:ui"))
+    implementation(project(":modules:services:repositories"))
+    implementation(project(":modules:services:servers"))
     implementation(project(":modules:services:analytics"))
 
     testImplementation(project(":modules:services:sharedtest"))

--- a/modules/features/kids/src/main/java/au/com/shiftyjelly/pocketcasts/kids/KidsBottomSheetDialog.kt
+++ b/modules/features/kids/src/main/java/au/com/shiftyjelly/pocketcasts/kids/KidsBottomSheetDialog.kt
@@ -65,7 +65,7 @@ class KidsBottomSheetDialog : BottomSheetDialogFragment() {
                         KidsSendFeedbackDialog(
                             onSeen = viewModel::onFeedbackFormSeen,
                             onSubmitFeedback = { feedback ->
-                                viewModel.sendFeedback(feedback)
+                                viewModel.submitFeedback(feedback)
                             },
                         )
                     }

--- a/modules/features/kids/src/main/java/au/com/shiftyjelly/pocketcasts/kids/KidsBottomSheetDialog.kt
+++ b/modules/features/kids/src/main/java/au/com/shiftyjelly/pocketcasts/kids/KidsBottomSheetDialog.kt
@@ -9,6 +9,7 @@ import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.core.EaseInOut
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.expandVertically
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
@@ -18,6 +19,7 @@ import androidx.core.view.doOnLayout
 import androidx.fragment.app.viewModels
 import au.com.shiftyjelly.pocketcasts.compose.AppTheme
 import au.com.shiftyjelly.pocketcasts.kids.viewmodel.KidsSendFeedbackViewModel
+import au.com.shiftyjelly.pocketcasts.kids.viewmodel.SendFeedbackState
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.google.android.material.bottomsheet.BottomSheetDialog
@@ -42,6 +44,15 @@ class KidsBottomSheetDialog : BottomSheetDialogFragment() {
         return ComposeView(requireContext()).apply {
             setContent {
                 val showFeedbackDialog by viewModel.showFeedbackDialog.collectAsState()
+                val sendFeedbackState by viewModel.sendFeedbackState.collectAsState()
+
+                LaunchedEffect(sendFeedbackState) {
+                    if (sendFeedbackState is SendFeedbackState.Success) {
+                        dismiss()
+                    } else if (sendFeedbackState is SendFeedbackState.Error) {
+                        dismiss()
+                    }
+                }
 
                 AppTheme(theme.activeTheme) {
                     AnimatedVisibility(
@@ -53,9 +64,8 @@ class KidsBottomSheetDialog : BottomSheetDialogFragment() {
                     ) {
                         KidsSendFeedbackDialog(
                             onSeen = viewModel::onFeedbackFormSeen,
-                            onSubmitFeedback = {
-                                viewModel.onSubmitFeedback()
-                                dismiss()
+                            onSubmitFeedback = { feedback ->
+                                viewModel.sendFeedback(feedback)
                             },
                         )
                     }

--- a/modules/features/kids/src/main/java/au/com/shiftyjelly/pocketcasts/kids/KidsSendFeedbackDialog.kt
+++ b/modules/features/kids/src/main/java/au/com/shiftyjelly/pocketcasts/kids/KidsSendFeedbackDialog.kt
@@ -111,6 +111,7 @@ fun KidsSendFeedbackDialog(
                         feedbackText = it
                     },
                     colors = TextFieldDefaults.outlinedTextFieldColors(
+                        textColor = MaterialTheme.theme.colors.primaryText01,
                         placeholderColor = MaterialTheme.theme.colors.primaryText02,
                         backgroundColor = MaterialTheme.theme.colors.primaryUi01,
                         focusedBorderColor = MaterialTheme.theme.colors.primaryUi05,

--- a/modules/features/kids/src/main/java/au/com/shiftyjelly/pocketcasts/kids/KidsSendFeedbackDialog.kt
+++ b/modules/features/kids/src/main/java/au/com/shiftyjelly/pocketcasts/kids/KidsSendFeedbackDialog.kt
@@ -51,7 +51,7 @@ import au.com.shiftyjelly.pocketcasts.localization.R as LR
 fun KidsSendFeedbackDialog(
     modifier: Modifier = Modifier,
     onSeen: () -> Unit,
-    onSubmitFeedback: () -> Unit,
+    onSubmitFeedback: (String) -> Unit,
 ) {
     val keyboardController = LocalSoftwareKeyboardController.current
     val focusManager = LocalFocusManager.current
@@ -61,7 +61,7 @@ fun KidsSendFeedbackDialog(
     val onFeedbackTapped = {
         keyboardController?.hide()
         focusManager.clearFocus()
-        onSubmitFeedback()
+        onSubmitFeedback(feedbackText.text)
     }
 
     CallOnce {

--- a/modules/features/kids/src/main/java/au/com/shiftyjelly/pocketcasts/kids/KidsSendFeedbackDialog.kt
+++ b/modules/features/kids/src/main/java/au/com/shiftyjelly/pocketcasts/kids/KidsSendFeedbackDialog.kt
@@ -136,6 +136,7 @@ fun KidsSendFeedbackDialog(
                     contentDescription = stringResource(LR.string.send_feedback),
                     onClick = { onFeedbackTapped() },
                     includePadding = false,
+                    enabled = feedbackText.text.isNotEmpty(),
                     textColor = MaterialTheme.theme.colors.primaryInteractive02,
                     modifier = Modifier.padding(bottom = 12.dp),
                     colors = ButtonDefaults.buttonColors(

--- a/modules/features/kids/src/main/java/au/com/shiftyjelly/pocketcasts/kids/feedback/FeedbackManager.kt
+++ b/modules/features/kids/src/main/java/au/com/shiftyjelly/pocketcasts/kids/feedback/FeedbackManager.kt
@@ -7,8 +7,13 @@ import kotlinx.coroutines.rx2.await
 class FeedbackManager @Inject constructor(
     private val syncManager: SyncManager,
 ) {
-    suspend fun sendFeedback(subject: String, inbox: String, message: String): FeedbackResult = try {
-        val response = syncManager.sendSupportFeedback(subject, inbox, message).await()
+    companion object {
+        const val SUBJECT = "Pocket Casts - Kids Profile Ideas"
+        const val INBOX = "research"
+    }
+
+    suspend fun sendAnonymousFeedback(message: String): FeedbackResult = try {
+        val response = syncManager.sendAnonymousFeedback(SUBJECT, INBOX, message).await()
         if (response.isSuccessful) {
             FeedbackResult.Success
         } else {

--- a/modules/features/kids/src/main/java/au/com/shiftyjelly/pocketcasts/kids/feedback/FeedbackManager.kt
+++ b/modules/features/kids/src/main/java/au/com/shiftyjelly/pocketcasts/kids/feedback/FeedbackManager.kt
@@ -1,0 +1,25 @@
+package au.com.shiftyjelly.pocketcasts.kids.feedback
+
+import au.com.shiftyjelly.pocketcasts.repositories.sync.SyncManager
+import javax.inject.Inject
+import kotlinx.coroutines.rx2.await
+
+class FeedbackManager @Inject constructor(
+    private val syncManager: SyncManager,
+) {
+    suspend fun sendFeedback(subject: String, inbox: String, message: String): FeedbackResult = try {
+        val response = syncManager.sendSupportFeedback(subject, inbox, message).await()
+        if (response.isSuccessful) {
+            FeedbackResult.Success
+        } else {
+            FeedbackResult.Error
+        }
+    } catch (e: Exception) {
+        FeedbackResult.Error
+    }
+}
+
+sealed class FeedbackResult {
+    data object Success : FeedbackResult()
+    data object Error : FeedbackResult()
+}

--- a/modules/features/kids/src/main/java/au/com/shiftyjelly/pocketcasts/kids/feedback/FeedbackManager.kt
+++ b/modules/features/kids/src/main/java/au/com/shiftyjelly/pocketcasts/kids/feedback/FeedbackManager.kt
@@ -2,7 +2,7 @@ package au.com.shiftyjelly.pocketcasts.kids.feedback
 
 import au.com.shiftyjelly.pocketcasts.repositories.sync.SyncManager
 import javax.inject.Inject
-import kotlinx.coroutines.rx2.await
+import retrofit2.Response
 
 class FeedbackManager @Inject constructor(
     private val syncManager: SyncManager,
@@ -13,7 +13,7 @@ class FeedbackManager @Inject constructor(
     }
 
     suspend fun sendAnonymousFeedback(message: String): FeedbackResult = try {
-        val response = syncManager.sendAnonymousFeedback(SUBJECT, INBOX, message).await()
+        val response: Response<Void> = syncManager.sendAnonymousFeedback(SUBJECT, INBOX, message)
         if (response.isSuccessful) {
             FeedbackResult.Success
         } else {

--- a/modules/features/kids/src/main/java/au/com/shiftyjelly/pocketcasts/kids/viewmodel/KidsSendFeedbackViewModel.kt
+++ b/modules/features/kids/src/main/java/au/com/shiftyjelly/pocketcasts/kids/viewmodel/KidsSendFeedbackViewModel.kt
@@ -2,6 +2,8 @@ package au.com.shiftyjelly.pocketcasts.kids.viewmodel
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import au.com.shiftyjelly.pocketcasts.kids.feedback.FeedbackManager
+import au.com.shiftyjelly.pocketcasts.kids.feedback.FeedbackResult
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTracker
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -12,11 +14,14 @@ import kotlinx.coroutines.launch
 
 @HiltViewModel
 class KidsSendFeedbackViewModel @Inject constructor(
+    private val feedbackManager: FeedbackManager,
     private val analyticsTracker: AnalyticsTracker,
 ) : ViewModel() {
-
     private val _showFeedbackDialog = MutableStateFlow(false)
     val showFeedbackDialog: StateFlow<Boolean> = _showFeedbackDialog
+
+    private val _feedbackSent = MutableStateFlow(false)
+    val feedbackSent: StateFlow<Boolean> = _feedbackSent
 
     fun onThankYouForYourInterestSeen() {
         analyticsTracker.track(AnalyticsEvent.KIDS_PROFILE_THANK_YOU_FOR_YOUR_INTEREST_SEEN)
@@ -40,7 +45,12 @@ class KidsSendFeedbackViewModel @Inject constructor(
         }
     }
 
-    fun onSubmitFeedback() {
+    fun sendFeedback(feedback: String) {
         analyticsTracker.track(AnalyticsEvent.KIDS_PROFILE_FEEDBACK_SENT)
+
+        viewModelScope.launch {
+            val result: FeedbackResult = feedbackManager.sendAnonymousFeedback(feedback)
+            _feedbackSent.value = result is FeedbackResult.Success
+        }
     }
 }

--- a/modules/features/kids/src/main/java/au/com/shiftyjelly/pocketcasts/kids/viewmodel/KidsSendFeedbackViewModel.kt
+++ b/modules/features/kids/src/main/java/au/com/shiftyjelly/pocketcasts/kids/viewmodel/KidsSendFeedbackViewModel.kt
@@ -2,10 +2,10 @@ package au.com.shiftyjelly.pocketcasts.kids.viewmodel
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import au.com.shiftyjelly.pocketcasts.kids.feedback.FeedbackManager
-import au.com.shiftyjelly.pocketcasts.kids.feedback.FeedbackResult
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTracker
+import au.com.shiftyjelly.pocketcasts.kids.feedback.FeedbackManager
+import au.com.shiftyjelly.pocketcasts.kids.feedback.FeedbackResult
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -45,7 +45,7 @@ class KidsSendFeedbackViewModel @Inject constructor(
         }
     }
 
-    fun sendFeedback(feedback: String) {
+    fun submitFeedback(feedback: String) {
         analyticsTracker.track(AnalyticsEvent.KIDS_PROFILE_FEEDBACK_SENT)
 
         viewModelScope.launch {

--- a/modules/features/kids/src/main/java/au/com/shiftyjelly/pocketcasts/kids/viewmodel/KidsSendFeedbackViewModel.kt
+++ b/modules/features/kids/src/main/java/au/com/shiftyjelly/pocketcasts/kids/viewmodel/KidsSendFeedbackViewModel.kt
@@ -20,8 +20,8 @@ class KidsSendFeedbackViewModel @Inject constructor(
     private val _showFeedbackDialog = MutableStateFlow(false)
     val showFeedbackDialog: StateFlow<Boolean> = _showFeedbackDialog
 
-    private val _feedbackSent = MutableStateFlow(false)
-    val feedbackSent: StateFlow<Boolean> = _feedbackSent
+    private val _sendFeedbackState = MutableStateFlow<SendFeedbackState>(SendFeedbackState.None)
+    val sendFeedbackState: StateFlow<SendFeedbackState> = _sendFeedbackState
 
     fun onThankYouForYourInterestSeen() {
         analyticsTracker.track(AnalyticsEvent.KIDS_PROFILE_THANK_YOU_FOR_YOUR_INTEREST_SEEN)
@@ -50,7 +50,17 @@ class KidsSendFeedbackViewModel @Inject constructor(
 
         viewModelScope.launch {
             val result: FeedbackResult = feedbackManager.sendAnonymousFeedback(feedback)
-            _feedbackSent.value = result is FeedbackResult.Success
+            if (result is FeedbackResult.Success) {
+                _sendFeedbackState.value = SendFeedbackState.Success
+            } else {
+                _sendFeedbackState.value = SendFeedbackState.Error
+            }
         }
     }
+}
+
+sealed class SendFeedbackState {
+    data object None : SendFeedbackState()
+    data object Success : SendFeedbackState()
+    data object Error : SendFeedbackState()
 }

--- a/modules/features/kids/src/test/java/au/com/shiftyjelly/pocketcasts/KidsSendFeedbackViewModelTest.kt
+++ b/modules/features/kids/src/test/java/au/com/shiftyjelly/pocketcasts/KidsSendFeedbackViewModelTest.kt
@@ -15,8 +15,8 @@ import org.junit.Rule
 import org.junit.Test
 import org.mockito.Mock
 import org.mockito.MockitoAnnotations
-import org.mockito.kotlin.whenever
 import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
 
 @ExperimentalCoroutinesApi
 class KidsSendFeedbackViewModelTest {
@@ -28,7 +28,6 @@ class KidsSendFeedbackViewModelTest {
 
     @Mock
     private lateinit var feedbackManager: FeedbackManager
-
 
     @Mock
     private lateinit var tracker: AnalyticsTracker
@@ -63,9 +62,10 @@ class KidsSendFeedbackViewModelTest {
 
         whenever(feedbackManager.sendAnonymousFeedback(feedback)).thenReturn(feedbackResult)
 
-        viewModel.sendFeedback(feedback)
+        viewModel.submitFeedback(feedback)
 
         assertEquals(SendFeedbackState.Success, viewModel.sendFeedbackState.value)
+        verify(tracker).track(AnalyticsEvent.KIDS_PROFILE_FEEDBACK_SENT)
     }
 
     @Test
@@ -75,14 +75,9 @@ class KidsSendFeedbackViewModelTest {
 
         whenever(feedbackManager.sendAnonymousFeedback(feedback)).thenReturn(feedbackResult)
 
-        viewModel.sendFeedback(feedback)
+        viewModel.submitFeedback(feedback)
 
         assertEquals(SendFeedbackState.Error, viewModel.sendFeedbackState.value)
-    }
-
-    @Test
-    fun `should track event for when feedback was submitted`() {
-        viewModel.onSubmitFeedback()
         verify(tracker).track(AnalyticsEvent.KIDS_PROFILE_FEEDBACK_SENT)
     }
 

--- a/modules/features/kids/src/test/java/au/com/shiftyjelly/pocketcasts/KidsSendFeedbackViewModelTest.kt
+++ b/modules/features/kids/src/test/java/au/com/shiftyjelly/pocketcasts/KidsSendFeedbackViewModelTest.kt
@@ -5,6 +5,7 @@ import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTracker
 import au.com.shiftyjelly.pocketcasts.kids.feedback.FeedbackManager
 import au.com.shiftyjelly.pocketcasts.kids.feedback.FeedbackResult
 import au.com.shiftyjelly.pocketcasts.kids.viewmodel.KidsSendFeedbackViewModel
+import au.com.shiftyjelly.pocketcasts.kids.viewmodel.SendFeedbackState
 import au.com.shiftyjelly.pocketcasts.sharedtest.MainCoroutineRule
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
@@ -64,7 +65,7 @@ class KidsSendFeedbackViewModelTest {
 
         viewModel.sendFeedback(feedback)
 
-        assertEquals(true, viewModel.feedbackSent.value)
+        assertEquals(SendFeedbackState.Success, viewModel.sendFeedbackState.value)
     }
 
     @Test
@@ -76,7 +77,7 @@ class KidsSendFeedbackViewModelTest {
 
         viewModel.sendFeedback(feedback)
 
-        assertEquals(false, viewModel.feedbackSent.value)
+        assertEquals(SendFeedbackState.Error, viewModel.sendFeedbackState.value)
     }
 
     @Test

--- a/modules/features/kids/src/test/java/au/com/shiftyjelly/pocketcasts/kids/feedback/FeedbackManagerTest.kt
+++ b/modules/features/kids/src/test/java/au/com/shiftyjelly/pocketcasts/kids/feedback/FeedbackManagerTest.kt
@@ -1,0 +1,75 @@
+package au.com.shiftyjelly.pocketcasts.kids.feedback
+
+import au.com.shiftyjelly.pocketcasts.repositories.sync.SyncManager
+import io.reactivex.Single
+import kotlinx.coroutines.test.runTest
+import okhttp3.ResponseBody.Companion.toResponseBody
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.mockito.Mockito.`when`
+import org.mockito.MockitoAnnotations
+import org.mockito.junit.MockitoJUnitRunner
+import retrofit2.Response
+
+@RunWith(MockitoJUnitRunner::class)
+class FeedbackManagerTest {
+
+    @Mock
+    private lateinit var syncManager: SyncManager
+
+    @Before
+    fun setUp() {
+        MockitoAnnotations.openMocks(this)
+    }
+
+    @Test
+    fun `should return success when send support feedback`() = runTest {
+        val subject = "Subject"
+        val inbox = "inbox@example.com"
+        val message = "Message"
+
+        val response: Response<Void> = Response.success(null)
+
+        `when`(syncManager.sendSupportFeedback(subject, inbox, message)).thenReturn(Single.just(response))
+
+        val feedbackManager = FeedbackManager(syncManager)
+
+        val result = feedbackManager.sendFeedback(subject, inbox, message)
+
+        assertEquals(FeedbackResult.Success, result)
+    }
+
+    @Test
+    fun `should return error when throws an exception`() = runTest {
+        val subject = "Subject"
+        val inbox = "inbox@example.com"
+        val message = "Message"
+
+        `when`(syncManager.sendSupportFeedback(subject, inbox, message)).thenReturn(Single.error(Exception()))
+
+        val feedbackManager = FeedbackManager(syncManager)
+
+        val result = feedbackManager.sendFeedback(subject, inbox, message)
+
+        assertEquals(FeedbackResult.Error, result)
+    }
+
+    @Test
+    fun `should return error when response is not successful`() = runTest {
+        val subject = "Subject"
+        val inbox = "inbox@example.com"
+        val message = "Message"
+        val responseError: Response<Void> = Response.error(400, "".toResponseBody(null))
+
+        `when`(syncManager.sendSupportFeedback(subject, inbox, message)).thenReturn(Single.just(responseError))
+
+        val feedbackManager = FeedbackManager(syncManager)
+
+        val result = feedbackManager.sendFeedback(subject, inbox, message)
+
+        assertEquals(FeedbackResult.Error, result)
+    }
+}

--- a/modules/features/kids/src/test/java/au/com/shiftyjelly/pocketcasts/kids/feedback/FeedbackManagerTest.kt
+++ b/modules/features/kids/src/test/java/au/com/shiftyjelly/pocketcasts/kids/feedback/FeedbackManagerTest.kt
@@ -1,7 +1,6 @@
 package au.com.shiftyjelly.pocketcasts.kids.feedback
 
 import au.com.shiftyjelly.pocketcasts.repositories.sync.SyncManager
-import io.reactivex.Single
 import kotlinx.coroutines.test.runTest
 import okhttp3.ResponseBody.Companion.toResponseBody
 import org.junit.Assert.assertEquals
@@ -26,14 +25,13 @@ class FeedbackManagerTest {
     }
 
     @Test
-    fun `should return success when send support feedback`() = runTest {
+    fun `should return success when response is successful`() = runTest {
         val subject = FeedbackManager.SUBJECT
         val inbox = FeedbackManager.INBOX
         val message = "Message"
 
         val response: Response<Void> = Response.success(null)
-
-        `when`(syncManager.sendAnonymousFeedback(subject, inbox, message)).thenReturn(Single.just(response))
+        `when`(syncManager.sendAnonymousFeedback(subject, inbox, message)).thenReturn(response)
 
         val feedbackManager = FeedbackManager(syncManager)
 
@@ -48,7 +46,7 @@ class FeedbackManagerTest {
         val inbox = FeedbackManager.INBOX
         val message = "Message"
 
-        `when`(syncManager.sendAnonymousFeedback(subject, inbox, message)).thenReturn(Single.error(Exception()))
+        `when`(syncManager.sendAnonymousFeedback(subject, inbox, message)).thenThrow(RuntimeException("Test Exception"))
 
         val feedbackManager = FeedbackManager(syncManager)
 
@@ -62,9 +60,9 @@ class FeedbackManagerTest {
         val subject = FeedbackManager.SUBJECT
         val inbox = FeedbackManager.INBOX
         val message = "Message"
-        val responseError: Response<Void> = Response.error(400, "".toResponseBody(null))
 
-        `when`(syncManager.sendAnonymousFeedback(subject, inbox, message)).thenReturn(Single.just(responseError))
+        val response: Response<Void> = Response.error(400, "".toResponseBody(null))
+        `when`(syncManager.sendAnonymousFeedback(subject, inbox, message)).thenReturn(response)
 
         val feedbackManager = FeedbackManager(syncManager)
 

--- a/modules/features/kids/src/test/java/au/com/shiftyjelly/pocketcasts/kids/feedback/FeedbackManagerTest.kt
+++ b/modules/features/kids/src/test/java/au/com/shiftyjelly/pocketcasts/kids/feedback/FeedbackManagerTest.kt
@@ -27,48 +27,48 @@ class FeedbackManagerTest {
 
     @Test
     fun `should return success when send support feedback`() = runTest {
-        val subject = "Subject"
-        val inbox = "inbox@example.com"
+        val subject = FeedbackManager.SUBJECT
+        val inbox = FeedbackManager.INBOX
         val message = "Message"
 
         val response: Response<Void> = Response.success(null)
 
-        `when`(syncManager.sendSupportFeedback(subject, inbox, message)).thenReturn(Single.just(response))
+        `when`(syncManager.sendAnonymousFeedback(subject, inbox, message)).thenReturn(Single.just(response))
 
         val feedbackManager = FeedbackManager(syncManager)
 
-        val result = feedbackManager.sendFeedback(subject, inbox, message)
+        val result = feedbackManager.sendAnonymousFeedback(message)
 
         assertEquals(FeedbackResult.Success, result)
     }
 
     @Test
     fun `should return error when throws an exception`() = runTest {
-        val subject = "Subject"
-        val inbox = "inbox@example.com"
+        val subject = FeedbackManager.SUBJECT
+        val inbox = FeedbackManager.INBOX
         val message = "Message"
 
-        `when`(syncManager.sendSupportFeedback(subject, inbox, message)).thenReturn(Single.error(Exception()))
+        `when`(syncManager.sendAnonymousFeedback(subject, inbox, message)).thenReturn(Single.error(Exception()))
 
         val feedbackManager = FeedbackManager(syncManager)
 
-        val result = feedbackManager.sendFeedback(subject, inbox, message)
+        val result = feedbackManager.sendAnonymousFeedback(message)
 
         assertEquals(FeedbackResult.Error, result)
     }
 
     @Test
     fun `should return error when response is not successful`() = runTest {
-        val subject = "Subject"
-        val inbox = "inbox@example.com"
+        val subject = FeedbackManager.SUBJECT
+        val inbox = FeedbackManager.INBOX
         val message = "Message"
         val responseError: Response<Void> = Response.error(400, "".toResponseBody(null))
 
-        `when`(syncManager.sendSupportFeedback(subject, inbox, message)).thenReturn(Single.just(responseError))
+        `when`(syncManager.sendAnonymousFeedback(subject, inbox, message)).thenReturn(Single.just(responseError))
 
         val feedbackManager = FeedbackManager(syncManager)
 
-        val result = feedbackManager.sendFeedback(subject, inbox, message)
+        val result = feedbackManager.sendAnonymousFeedback(message)
 
         assertEquals(FeedbackResult.Error, result)
     }

--- a/modules/services/protobuf/src/main/proto/sync_api.proto
+++ b/modules/services/protobuf/src/main/proto/sync_api.proto
@@ -225,7 +225,9 @@ message PodcastRatingShowRequest {
 }
 
 message SupportFeedbackRequest {
-     string subject = 1;
-      string inbox = 2;
-      string message = 3;
+    string message = 1;
+    string email = 2;
+    string subject = 3;
+    string debug = 4;
+    string inbox = 5;
 }

--- a/modules/services/protobuf/src/main/proto/sync_api.proto
+++ b/modules/services/protobuf/src/main/proto/sync_api.proto
@@ -223,3 +223,10 @@ message PodcastRatingAddRequest {
 message PodcastRatingShowRequest {
     string podcast_uuid = 1;
 }
+
+message SupportFeedbackRequest {
+     string subject = 1;
+      string inbox = 2;
+      string message = 3;
+      string debug = 4;
+}

--- a/modules/services/protobuf/src/main/proto/sync_api.proto
+++ b/modules/services/protobuf/src/main/proto/sync_api.proto
@@ -228,5 +228,4 @@ message SupportFeedbackRequest {
      string subject = 1;
       string inbox = 2;
       string message = 3;
-      string debug = 4;
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/SyncManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/SyncManager.kt
@@ -99,5 +99,5 @@ interface SyncManager : NamedSettingsCaller {
     suspend fun loadStats(): StatsBundle
     fun upNextSync(request: UpNextSyncRequest): Single<UpNextSyncResponse>
     suspend fun getBookmarks(): List<Bookmark>
-    suspend fun sendAnonymousFeedback(subject: String, inbox: String, message: String): Single<Response<Void>>
+    suspend fun sendAnonymousFeedback(subject: String, inbox: String, message: String): Response<Void>
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/SyncManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/SyncManager.kt
@@ -99,5 +99,5 @@ interface SyncManager : NamedSettingsCaller {
     suspend fun loadStats(): StatsBundle
     fun upNextSync(request: UpNextSyncRequest): Single<UpNextSyncResponse>
     suspend fun getBookmarks(): List<Bookmark>
-    suspend fun sendSupportFeedback(subject: String, inbox: String, message: String): Single<Response<Void>>
+    suspend fun sendAnonymousFeedback(subject: String, inbox: String, message: String): Single<Response<Void>>
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/SyncManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/SyncManager.kt
@@ -99,4 +99,5 @@ interface SyncManager : NamedSettingsCaller {
     suspend fun loadStats(): StatsBundle
     fun upNextSync(request: UpNextSyncRequest): Single<UpNextSyncResponse>
     suspend fun getBookmarks(): List<Bookmark>
+    suspend fun sendSupportFeedback(subject: String, inbox: String, message: String): Single<Response<Void>>
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/SyncManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/SyncManagerImpl.kt
@@ -409,7 +409,7 @@ class SyncManagerImpl @Inject constructor(
         }
     }
 
-    override suspend fun sendAnonymousFeedback(subject: String, inbox: String, message: String): Single<Response<Void>> {
+    override suspend fun sendAnonymousFeedback(subject: String, inbox: String, message: String): Response<Void> {
         return syncServerManager.sendAnonymousFeedback(subject, inbox, message)
     }
 

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/SyncManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/SyncManagerImpl.kt
@@ -409,10 +409,8 @@ class SyncManagerImpl @Inject constructor(
         }
     }
 
-    override suspend fun sendSupportFeedback(subject: String, inbox: String, message: String): Single<Response<Void>> {
-        return getCacheTokenOrLogin { token ->
-            syncServerManager.sendSupportFeedback(subject, inbox, message, token)
-        }
+    override suspend fun sendAnonymousFeedback(subject: String, inbox: String, message: String): Single<Response<Void>> {
+        return syncServerManager.sendAnonymousFeedback(subject, inbox, message)
     }
 
     override suspend fun loadStats(): StatsBundle =

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/SyncManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/SyncManagerImpl.kt
@@ -409,6 +409,12 @@ class SyncManagerImpl @Inject constructor(
         }
     }
 
+    override suspend fun sendSupportFeedback(subject: String, inbox: String, message: String): Single<Response<Void>> {
+        return getCacheTokenOrLogin { token ->
+            syncServerManager.sendSupportFeedback(subject, inbox, message, token)
+        }
+    }
+
     override suspend fun loadStats(): StatsBundle =
         getCacheTokenOrLogin { token ->
             syncServerManager.loadStats(token)

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/SyncServer.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/SyncServer.kt
@@ -17,6 +17,7 @@ import com.pocketcasts.service.api.BookmarksResponse
 import com.pocketcasts.service.api.PodcastRatingAddRequest
 import com.pocketcasts.service.api.PodcastRatingResponse
 import com.pocketcasts.service.api.PodcastRatingShowRequest
+import com.pocketcasts.service.api.SupportFeedbackRequest
 import com.pocketcasts.service.api.SyncUpdateRequest
 import com.pocketcasts.service.api.SyncUpdateResponse
 import com.pocketcasts.service.api.UserPodcastListRequest
@@ -176,4 +177,8 @@ interface SyncServer {
     @Headers("Content-Type: application/octet-stream")
     @POST("/user/podcast_rating/show")
     suspend fun getPodcastRating(@Header("Authorization") authorization: String, @Body request: PodcastRatingShowRequest): PodcastRatingResponse
+
+    @Headers("Content-Type: application/octet-stream")
+    @POST("/support/feedback")
+    suspend fun sendSupportFeedback(@Header("Authorization") authorization: String, @Body request: SupportFeedbackRequest): Single<Response<Void>>
 }

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/SyncServer.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/SyncServer.kt
@@ -179,6 +179,6 @@ interface SyncServer {
     suspend fun getPodcastRating(@Header("Authorization") authorization: String, @Body request: PodcastRatingShowRequest): PodcastRatingResponse
 
     @Headers("Content-Type: application/octet-stream")
-    @POST("/support/feedback")
-    suspend fun sendSupportFeedback(@Header("Authorization") authorization: String, @Body request: SupportFeedbackRequest): Single<Response<Void>>
+    @POST("/anonymous/feedback")
+    fun sendAnonymousFeedback(@Body request: SupportFeedbackRequest): Single<Response<Void>>
 }

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/SyncServer.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/SyncServer.kt
@@ -180,5 +180,5 @@ interface SyncServer {
 
     @Headers("Content-Type: application/octet-stream")
     @POST("/anonymous/feedback")
-    fun sendAnonymousFeedback(@Body request: SupportFeedbackRequest): Single<Response<Void>>
+    suspend fun sendAnonymousFeedback(@Body request: SupportFeedbackRequest): Response<Void>
 }

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/SyncServerManager.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/SyncServerManager.kt
@@ -288,14 +288,13 @@ open class SyncServerManager @Inject constructor(
         return server.getPodcastRating(addBearer(token), request)
     }
 
-    suspend fun sendSupportFeedback(subject: String, inbox: String, message: String, token: AccessToken): Single<Response<Void>> {
+    fun sendAnonymousFeedback(subject: String, inbox: String, message: String): Single<Response<Void>> {
         val request = SupportFeedbackRequest.newBuilder()
             .setSubject(subject)
             .setInbox(inbox)
             .setMessage(message)
-            .setDebug("string")
             .build()
-        return server.sendSupportFeedback(addBearer(token), request)
+        return server.sendAnonymousFeedback(request)
     }
 
     fun signOut() {

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/SyncServerManager.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/SyncServerManager.kt
@@ -27,6 +27,7 @@ import au.com.shiftyjelly.pocketcasts.utils.extensions.parseIsoDate
 import com.pocketcasts.service.api.PodcastRatingAddRequest
 import com.pocketcasts.service.api.PodcastRatingResponse
 import com.pocketcasts.service.api.PodcastRatingShowRequest
+import com.pocketcasts.service.api.SupportFeedbackRequest
 import com.pocketcasts.service.api.SyncUpdateRequest
 import com.pocketcasts.service.api.SyncUpdateResponse
 import com.pocketcasts.service.api.UserPodcastListResponse
@@ -285,6 +286,16 @@ open class SyncServerManager @Inject constructor(
             .setPodcastUuid(podcastUuid)
             .build()
         return server.getPodcastRating(addBearer(token), request)
+    }
+
+    suspend fun sendSupportFeedback(subject: String, inbox: String, message: String, token: AccessToken): Single<Response<Void>> {
+        val request = SupportFeedbackRequest.newBuilder()
+            .setSubject(subject)
+            .setInbox(inbox)
+            .setMessage(message)
+            .setDebug("string")
+            .build()
+        return server.sendSupportFeedback(addBearer(token), request)
     }
 
     fun signOut() {

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/SyncServerManager.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/SyncServerManager.kt
@@ -288,7 +288,7 @@ open class SyncServerManager @Inject constructor(
         return server.getPodcastRating(addBearer(token), request)
     }
 
-    fun sendAnonymousFeedback(subject: String, inbox: String, message: String): Single<Response<Void>> {
+    suspend fun sendAnonymousFeedback(subject: String, inbox: String, message: String): Response<Void> {
         val request = SupportFeedbackRequest.newBuilder()
             .setSubject(subject)
             .setInbox(inbox)


### PR DESCRIPTION
## Description
- This sends the anonymous feedback using the `/anonymous/feedback` endpoint. I will add another PR to handle an non anonymous feedback, witch is for the case the user is logged in.
- This PR does not handle UI feedback after sending the request. I will work on the snack bar feedback in a later PR
- See: p1722564959720889/1722564947.563029-slack-C07CGGZR59U

## Testing Instructions
1. Have the Kids Feature flag enabled
2. Go to Profile -> Request Early access -> Send Feedback
3. Type something to enable the Send Feedback button
4. Send feedback
5. ✅ Ensure the `/anonymous/feedback` is called (check on logcat) 
6. If you want to see the feedback sent to the email you can follow these steps: p1722955409841369/1722954751.866389-slack-C07CGGZR59U

## Screenshots or Screencast 
[Screen_recording_20240806_123157.webm](https://github.com/user-attachments/assets/fd32d6c1-6e58-4044-8a41-99bec891970e)


## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack