### PR TITLE
[Give Rating] Fix: Ratings Overlay reappears when swiped down

### DIFF
--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/components/ratings/GiveRatingFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/components/ratings/GiveRatingFragment.kt
@@ -88,6 +88,7 @@ class GiveRatingFragment : BaseDialogFragment() {
     }
 
     override fun onDismiss(dialog: DialogInterface) {
+        super.onDismiss(dialog)
         val state = viewModel.state.value
 
         if (state is GiveRatingViewModel.State.Loaded) {


### PR DESCRIPTION
## Description
- This fixes the issue reported here https://github.com/Automattic/pocket-casts-android/issues/2577

Fixes #2577

## Testing Instructions

1. Open the Rating menu of any podcast
2. Dismiss the overlay by swiping it down
3. Put the app in background
4. Reopen the app
5. ✅ Make sure you don't see the rating bottom sheet reopen again

## Screenshots or Screencast 
[Screen_recording_20240806_141712.webm](https://github.com/user-attachments/assets/49e230ba-4be5-4db6-b725-9a03a4c95494)


## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [ ] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
