### PR TITLE
Clip sharing page cleanup

### DIFF
--- a/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/clip/ShareClipPage.kt
+++ b/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/clip/ShareClipPage.kt
@@ -326,6 +326,10 @@ private fun ShareClipVerticalRegularEditingPreview() = ShareClipPagePreview(
 @Composable
 private fun ShareClipVerticalSmallPreviewPreview() = ShareClipPagePreview()
 
+@Preview(name = "Foldable device", device = Devices.PortraitFoldable)
+@Composable
+private fun ShareClipVerticalFoldablePreviewPreview() = ShareClipPagePreview()
+
 @Preview(name = "Tablet device", device = Devices.PortraitTablet)
 @Composable
 private fun ShareClipVerticalTabletPreview() = ShareClipPagePreview()

--- a/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/clip/ShareClipPage.kt
+++ b/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/clip/ShareClipPage.kt
@@ -140,7 +140,7 @@ private fun VerticalClipPage(
                     .nestedScroll(rememberNestedScrollInteropConnection())
                     .verticalScroll(scrollState),
             ) {
-                TopInfo(
+                TopContent(
                     shareColors = shareColors,
                     state = state,
                 )
@@ -196,7 +196,7 @@ private fun VerticalClipPage(
 }
 
 @Composable
-private fun TopInfo(
+private fun TopContent(
     shareColors: ShareColors,
     state: ClipPageState,
 ) {

--- a/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/clip/ShareClipPage.kt
+++ b/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/clip/ShareClipPage.kt
@@ -132,7 +132,7 @@ private fun VerticalClipPage(
             .background(shareColors.background)
             .fillMaxSize(),
     ) {
-        AnimatedPodcastVisiblity(podcast = podcast, episode = episode) { podcast, episode ->
+        AnimatedVisiblity(podcast = podcast, episode = episode) { podcast, episode ->
             Column {
                 val scrollState = rememberScrollState()
                 Column(
@@ -354,7 +354,7 @@ private fun ClipControls(
 }
 
 @Composable
-private fun AnimatedPodcastVisiblity(
+private fun AnimatedVisiblity(
     podcast: Podcast?,
     episode: PodcastEpisode?,
     content: @Composable (Podcast, PodcastEpisode) -> Unit,

--- a/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/clip/ShareClipPage.kt
+++ b/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/clip/ShareClipPage.kt
@@ -160,29 +160,17 @@ private fun VerticalClipPage(
                     )
                 }
             }
-            if (podcast != null && episode != null) {
-                AnimatedContent(state.step) { step ->
-                    when (step) {
-                        SharingStep.Creating -> ClipControls(
-                            episode = episode,
-                            clipRange = clipRange,
-                            playbackProgress = playbackProgress,
-                            isPlaying = isPlaying,
-                            shareColors = shareColors,
-                            listener = listener,
-                            state = state,
-                        )
-                        SharingStep.Sharing -> Box(
-                            modifier = Modifier.padding(vertical = 24.dp),
-                        ) {
-                            PlatformBar(
-                                platforms = platforms,
-                                shareColors = shareColors,
-                                onClick = {},
-                            )
-                        }
-                    }
-                }
+            if (episode != null) {
+                BottomContent(
+                    episode = episode,
+                    clipRange = clipRange,
+                    playbackProgress = playbackProgress,
+                    isPlaying = isPlaying,
+                    platforms = platforms,
+                    shareColors = shareColors,
+                    listener = listener,
+                    state = state,
+                )
             }
         }
         CloseButton(
@@ -266,6 +254,41 @@ private fun TopContent(
                     },
                 ),
             )
+        }
+    }
+}
+
+@Composable
+private fun BottomContent(
+    episode: PodcastEpisode,
+    clipRange: Clip.Range,
+    playbackProgress: Duration,
+    isPlaying: Boolean,
+    platforms: Set<SocialPlatform>,
+    shareColors: ShareColors,
+    listener: ShareClipPageListener,
+    state: ClipPageState,
+) {
+    AnimatedContent(state.step) { step ->
+        when (step) {
+            SharingStep.Creating -> ClipControls(
+                episode = episode,
+                clipRange = clipRange,
+                playbackProgress = playbackProgress,
+                isPlaying = isPlaying,
+                shareColors = shareColors,
+                listener = listener,
+                state = state,
+            )
+            SharingStep.Sharing -> Box(
+                modifier = Modifier.padding(vertical = 24.dp),
+            ) {
+                PlatformBar(
+                    platforms = platforms,
+                    shareColors = shareColors,
+                    onClick = {},
+                )
+            }
         }
     }
 }

--- a/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/clip/ShareClipPage.kt
+++ b/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/clip/ShareClipPage.kt
@@ -148,18 +148,12 @@ private fun VerticalClipPage(
                         shareColors = shareColors,
                         state = state,
                     )
-                    val cardPadding = maxOf(
-                        LocalConfiguration.current.screenWidthDp.dp / 8,
-                        42.dp, // Close button start edge position
-                    )
-                    VerticalEpisodeCard(
+                    MiddleContent(
                         episode = episode,
                         podcast = podcast,
                         useEpisodeArtwork = useEpisodeArtwork,
                         shareColors = shareColors,
-                        captureController = assetController.captureController(CardType.Vertical),
-                        useHeightForAspectRatio = false,
-                        modifier = Modifier.padding(horizontal = cardPadding),
+                        assetController = assetController,
                     )
                 }
                 BottomContent(
@@ -257,6 +251,29 @@ private fun TopContent(
             )
         }
     }
+}
+
+@Composable
+private fun MiddleContent(
+    episode: PodcastEpisode,
+    podcast: Podcast,
+    useEpisodeArtwork: Boolean,
+    shareColors: ShareColors,
+    assetController: BackgroundAssetController,
+) {
+    val cardPadding = maxOf(
+        LocalConfiguration.current.screenWidthDp.dp / 8,
+        42.dp, // Close button start edge position
+    )
+    VerticalEpisodeCard(
+        episode = episode,
+        podcast = podcast,
+        useEpisodeArtwork = useEpisodeArtwork,
+        shareColors = shareColors,
+        captureController = assetController.captureController(CardType.Vertical),
+        useHeightForAspectRatio = false,
+        modifier = Modifier.padding(horizontal = cardPadding),
+    )
 }
 
 @Composable

--- a/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/clip/ShareClipPage.kt
+++ b/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/clip/ShareClipPage.kt
@@ -32,6 +32,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import au.com.shiftyjelly.pocketcasts.compose.Devices
 import au.com.shiftyjelly.pocketcasts.compose.buttons.RowButton
 import au.com.shiftyjelly.pocketcasts.compose.components.TextH30
 import au.com.shiftyjelly.pocketcasts.compose.components.TextH40
@@ -43,7 +44,6 @@ import au.com.shiftyjelly.pocketcasts.sharing.ui.BackgroundAssetController
 import au.com.shiftyjelly.pocketcasts.sharing.ui.CardType
 import au.com.shiftyjelly.pocketcasts.sharing.ui.ClipSelector
 import au.com.shiftyjelly.pocketcasts.sharing.ui.CloseButton
-import au.com.shiftyjelly.pocketcasts.sharing.ui.Devices
 import au.com.shiftyjelly.pocketcasts.sharing.ui.ShareColors
 import au.com.shiftyjelly.pocketcasts.sharing.ui.VerticalEpisodeCard
 import au.com.shiftyjelly.pocketcasts.sharing.ui.scrollBottomFade

--- a/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/clip/ShareClipPage.kt
+++ b/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/clip/ShareClipPage.kt
@@ -1,6 +1,9 @@
 package au.com.shiftyjelly.pocketcasts.sharing.clip
 
 import androidx.compose.animation.AnimatedContent
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
@@ -124,27 +127,27 @@ private fun VerticalClipPage(
     listener: ShareClipPageListener,
     state: ClipPageState,
 ) {
-    Box {
-        Column(
-            modifier = Modifier
-                .fillMaxSize()
-                .background(shareColors.background),
-        ) {
-            val scrollState = rememberScrollState()
-            Column(
-                verticalArrangement = Arrangement.Center,
-                modifier = Modifier
-                    .weight(1f)
-                    .fillMaxWidth()
-                    .scrollBottomFade(scrollState)
-                    .nestedScroll(rememberNestedScrollInteropConnection())
-                    .verticalScroll(scrollState),
-            ) {
-                TopContent(
-                    shareColors = shareColors,
-                    state = state,
-                )
-                if (podcast != null && episode != null) {
+    Box(
+        modifier = Modifier
+            .background(shareColors.background)
+            .fillMaxSize(),
+    ) {
+        AnimatedPodcastVisiblity(podcast = podcast, episode = episode) { podcast, episode ->
+            Column {
+                val scrollState = rememberScrollState()
+                Column(
+                    verticalArrangement = Arrangement.Center,
+                    modifier = Modifier
+                        .weight(1f)
+                        .fillMaxWidth()
+                        .scrollBottomFade(scrollState)
+                        .nestedScroll(rememberNestedScrollInteropConnection())
+                        .verticalScroll(scrollState),
+                ) {
+                    TopContent(
+                        shareColors = shareColors,
+                        state = state,
+                    )
                     val cardPadding = maxOf(
                         LocalConfiguration.current.screenWidthDp.dp / 8,
                         42.dp, // Close button start edge position
@@ -159,8 +162,6 @@ private fun VerticalClipPage(
                         modifier = Modifier.padding(horizontal = cardPadding),
                     )
                 }
-            }
-            if (episode != null) {
                 BottomContent(
                     episode = episode,
                     clipRange = clipRange,
@@ -332,6 +333,21 @@ private fun ClipControls(
         Spacer(
             modifier = Modifier.height(12.dp),
         )
+    }
+}
+
+@Composable
+private fun AnimatedPodcastVisiblity(
+    podcast: Podcast?,
+    episode: PodcastEpisode?,
+    content: @Composable (Podcast, PodcastEpisode) -> Unit,
+) = AnimatedVisibility(
+    visible = podcast != null && episode != null,
+    enter = fadeIn(),
+    exit = fadeOut(),
+) {
+    if (podcast != null && episode != null) {
+        content(podcast, episode)
     }
 }
 

--- a/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/clip/ShareClipPageColorPreview.kt
+++ b/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/clip/ShareClipPageColorPreview.kt
@@ -5,7 +5,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.tooling.preview.PreviewParameterProvider
-import au.com.shiftyjelly.pocketcasts.sharing.ui.Devices
+import au.com.shiftyjelly.pocketcasts.compose.Devices
 
 private class PodcastColorProvider : PreviewParameterProvider<Long> {
     override val values = sequenceOf(

--- a/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/episode/ShareEpisodePage.kt
+++ b/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/episode/ShareEpisodePage.kt
@@ -10,13 +10,13 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
+import au.com.shiftyjelly.pocketcasts.compose.Devices
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.sharing.SharingResponse
 import au.com.shiftyjelly.pocketcasts.sharing.social.SocialPlatform
 import au.com.shiftyjelly.pocketcasts.sharing.ui.BackgroundAssetController
 import au.com.shiftyjelly.pocketcasts.sharing.ui.CardType
-import au.com.shiftyjelly.pocketcasts.sharing.ui.Devices
 import au.com.shiftyjelly.pocketcasts.sharing.ui.HorizontalEpisodeCard
 import au.com.shiftyjelly.pocketcasts.sharing.ui.HorizontalSharePage
 import au.com.shiftyjelly.pocketcasts.sharing.ui.ShareColors

--- a/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/podcast/SharePodcastPage.kt
+++ b/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/podcast/SharePodcastPage.kt
@@ -9,12 +9,12 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
+import au.com.shiftyjelly.pocketcasts.compose.Devices
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.sharing.SharingResponse
 import au.com.shiftyjelly.pocketcasts.sharing.social.SocialPlatform
 import au.com.shiftyjelly.pocketcasts.sharing.ui.BackgroundAssetController
 import au.com.shiftyjelly.pocketcasts.sharing.ui.CardType
-import au.com.shiftyjelly.pocketcasts.sharing.ui.Devices
 import au.com.shiftyjelly.pocketcasts.sharing.ui.HorizontalPodcastCast
 import au.com.shiftyjelly.pocketcasts.sharing.ui.HorizontalSharePage
 import au.com.shiftyjelly.pocketcasts.sharing.ui.ShareColors

--- a/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/timestamp/ShareEpisodeTimestampPage.kt
+++ b/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/timestamp/ShareEpisodeTimestampPage.kt
@@ -9,13 +9,13 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
+import au.com.shiftyjelly.pocketcasts.compose.Devices
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.sharing.SharingResponse
 import au.com.shiftyjelly.pocketcasts.sharing.social.SocialPlatform
 import au.com.shiftyjelly.pocketcasts.sharing.ui.BackgroundAssetController
 import au.com.shiftyjelly.pocketcasts.sharing.ui.CardType
-import au.com.shiftyjelly.pocketcasts.sharing.ui.Devices
 import au.com.shiftyjelly.pocketcasts.sharing.ui.HorizontalEpisodeCard
 import au.com.shiftyjelly.pocketcasts.sharing.ui.HorizontalSharePage
 import au.com.shiftyjelly.pocketcasts.sharing.ui.ShareColors

--- a/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/ui/ClipSelector.kt
+++ b/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/ui/ClipSelector.kt
@@ -54,6 +54,7 @@ import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
+import au.com.shiftyjelly.pocketcasts.compose.Devices
 import au.com.shiftyjelly.pocketcasts.compose.components.TextH70
 import au.com.shiftyjelly.pocketcasts.sharing.clip.Clip
 import au.com.shiftyjelly.pocketcasts.sharing.clip.ShareClipPageListener

--- a/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/ui/HorizontalCard.kt
+++ b/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/ui/HorizontalCard.kt
@@ -19,6 +19,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
 import au.com.shiftyjelly.pocketcasts.compose.components.TextH40
 import au.com.shiftyjelly.pocketcasts.compose.components.TextH70
@@ -39,6 +40,7 @@ internal fun HorizontalPodcastCast(
     captureController: CaptureController,
     modifier: Modifier = Modifier,
     useWidthForAspectRatio: Boolean = true,
+    customSize: DpSize? = null,
 ) = HorizontalCard(
     data = PodcastCardData(
         podcast = podcast,
@@ -46,6 +48,7 @@ internal fun HorizontalPodcastCast(
     ),
     shareColors = shareColors,
     useWidthForAspectRatio = useWidthForAspectRatio,
+    customSize = customSize,
     captureController = captureController,
     modifier = modifier,
 )
@@ -59,6 +62,7 @@ internal fun HorizontalEpisodeCard(
     captureController: CaptureController,
     modifier: Modifier = Modifier,
     useWidthForAspectRatio: Boolean = true,
+    customSize: DpSize? = null,
 ) = HorizontalCard(
     data = EpisodeCardData(
         episode = episode,
@@ -67,6 +71,7 @@ internal fun HorizontalEpisodeCard(
     ),
     shareColors = shareColors,
     useWidthForAspectRatio = useWidthForAspectRatio,
+    customSize = customSize,
     captureController = captureController,
     modifier = modifier,
 )
@@ -86,6 +91,7 @@ private fun HorizontalCard(
     useWidthForAspectRatio: Boolean,
     captureController: CaptureController,
     modifier: Modifier = Modifier,
+    customSize: DpSize? = null,
 ) = BoxWithConstraints(
     contentAlignment = Alignment.Center,
     modifier = modifier,
@@ -96,10 +102,11 @@ private fun HorizontalCard(
             shareColors.cardBottom,
         ),
     )
+    val size = customSize ?: DpSize(maxWidth, maxHeight)
     val (width, height) = if (useWidthForAspectRatio) {
-        maxWidth to maxWidth * 0.52f
+        size.width to size.width * 0.52f
     } else {
-        maxHeight / 0.52f to maxHeight
+        size.height / 0.52f to size.height
     }
     Row(
         verticalAlignment = Alignment.CenterVertically,

--- a/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/ui/SquareCard.kt
+++ b/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/ui/SquareCard.kt
@@ -17,6 +17,7 @@ import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
 import au.com.shiftyjelly.pocketcasts.compose.components.TextH40
 import au.com.shiftyjelly.pocketcasts.compose.components.TextH70
@@ -36,12 +37,14 @@ internal fun SquarePodcastCast(
     shareColors: ShareColors,
     captureController: CaptureController,
     modifier: Modifier = Modifier,
+    customSize: DpSize? = null,
 ) = SquareCard(
     data = PodcastCardData(
         podcast = podcast,
         episodeCount = episodeCount,
     ),
     shareColors = shareColors,
+    customSize = customSize,
     captureController = captureController,
     modifier = modifier,
 )
@@ -54,6 +57,7 @@ internal fun SquareEpisodeCard(
     shareColors: ShareColors,
     captureController: CaptureController,
     modifier: Modifier = Modifier,
+    customSize: DpSize? = null,
 ) = SquareCard(
     data = EpisodeCardData(
         episode = episode,
@@ -61,6 +65,7 @@ internal fun SquareEpisodeCard(
         useEpisodeArtwork = useEpisodeArtwork,
     ),
     shareColors = shareColors,
+    customSize = customSize,
     captureController = captureController,
     modifier = modifier,
 )
@@ -72,30 +77,32 @@ private fun SquareCard(
     shareColors: ShareColors,
     captureController: CaptureController,
     modifier: Modifier = Modifier,
+    customSize: DpSize? = null,
 ) = BoxWithConstraints(
     contentAlignment = Alignment.Center,
     modifier = modifier,
 ) {
-    val size = minOf(maxWidth, maxHeight)
     val backgroundGradient = Brush.verticalGradient(
         listOf(
             shareColors.cardTop,
             shareColors.cardBottom,
         ),
     )
+    val size = customSize ?: DpSize(maxWidth, maxHeight)
+    val minDimension = minOf(size.width, size.height)
     Column(
         horizontalAlignment = Alignment.CenterHorizontally,
         modifier = Modifier
             .capturable(captureController)
             .background(backgroundGradient, RoundedCornerShape(12.dp))
-            .size(size),
+            .size(minDimension),
     ) {
         Spacer(
             modifier = Modifier.height(42.dp),
         )
         data.Image(
             modifier = Modifier
-                .size(size * 0.4f)
+                .size(minDimension * 0.4f)
                 .clip(RoundedCornerShape(8.dp)),
         )
         Spacer(

--- a/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/ui/VerticalCard.kt
+++ b/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/ui/VerticalCard.kt
@@ -18,6 +18,7 @@ import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
 import au.com.shiftyjelly.pocketcasts.compose.components.PocketCastsPill
 import au.com.shiftyjelly.pocketcasts.compose.components.TextH40
@@ -39,6 +40,7 @@ internal fun VerticalPodcastCast(
     captureController: CaptureController,
     modifier: Modifier = Modifier,
     useHeightForAspectRatio: Boolean = true,
+    customSize: DpSize? = null,
 ) = VerticalCard(
     data = PodcastCardData(
         podcast = podcast,
@@ -46,6 +48,7 @@ internal fun VerticalPodcastCast(
     ),
     shareColors = shareColors,
     useHeightForAspectRatio = useHeightForAspectRatio,
+    customSize = customSize,
     captureController = captureController,
     modifier = modifier,
 )
@@ -59,6 +62,7 @@ internal fun VerticalEpisodeCard(
     captureController: CaptureController,
     modifier: Modifier = Modifier,
     useHeightForAspectRatio: Boolean = true,
+    customSize: DpSize? = null,
 ) = VerticalCard(
     data = EpisodeCardData(
         episode = episode,
@@ -67,6 +71,7 @@ internal fun VerticalEpisodeCard(
     ),
     shareColors = shareColors,
     useHeightForAspectRatio = useHeightForAspectRatio,
+    customSize = customSize,
     captureController = captureController,
     modifier = modifier,
 )
@@ -79,6 +84,7 @@ private fun VerticalCard(
     useHeightForAspectRatio: Boolean,
     captureController: CaptureController,
     modifier: Modifier = Modifier,
+    customSize: DpSize? = null,
 ) = BoxWithConstraints(
     contentAlignment = Alignment.Center,
     modifier = modifier,
@@ -89,10 +95,11 @@ private fun VerticalCard(
             shareColors.cardBottom,
         ),
     )
+    val size = customSize ?: DpSize(maxWidth, maxHeight)
     val (height, width) = if (useHeightForAspectRatio) {
-        maxHeight to maxHeight / 1.5f
+        size.height to size.height / 1.5f
     } else {
-        maxWidth * 1.5f to maxWidth
+        size.width * 1.5f to size.width
     }
     Column(
         horizontalAlignment = Alignment.CenterHorizontally,

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/Devices.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/Devices.kt
@@ -4,8 +4,10 @@ object Devices {
     const val PortraitRegular = "spec:width=800px,height=1600px,dpi=320"
     const val PortraitSmall = "spec:width=720px,height=1280px,dpi=320"
     const val PortraitTablet = "spec:width=1600px,height=2560px,dpi=276"
+    const val PortraitFoldable = "spec:width=1840px,height=2208px,dpi=420"
 
     const val LandscapeRegular = "$PortraitRegular,orientation=landscape"
     const val LandscapeSmall = "$PortraitSmall,orientation=landscape"
     const val LandscapeTablet = "$PortraitTablet,orientation=landscape"
+    const val LandscapeFoldable = "$PortraitFoldable,orientation=landscape"
 }

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/Devices.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/Devices.kt
@@ -1,6 +1,6 @@
-package au.com.shiftyjelly.pocketcasts.sharing.ui
+package au.com.shiftyjelly.pocketcasts.compose
 
-internal object Devices {
+object Devices {
     const val PortraitRegular = "spec:width=800px,height=1600px,dpi=320"
     const val PortraitSmall = "spec:width=720px,height=1280px,dpi=320"
     const val PortraitTablet = "spec:width=1600px,height=2560px,dpi=276"


### PR DESCRIPTION
## Description

A simple cleanup for the clip sharing page. I want to do this in a separate PR to minimize changes when adding paging. Some changes to the code:

1. `Devices` are moved to the common `:compose` module and I added a foldable device.
2. I added ability to override size for cards. I'll need it to manage displayed cards on different devices like foldables.
3. I added a visibility animation to showing sharing page content. It most likely won't have much of an effect but it might help in cases where SQL queries get slow.

## Testing Instructions

Code review is enough.

## Checklist
- [x] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] ~I have considered whether it makes sense to add tests for my changes~
- [x] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
