### PR TITLE
[Kids Profile] Send feedback 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 7.71
 -----
-
+*   New Features
+    *   Adds the kids banner in profile
+        ([#2591](https://github.com/Automattic/pocket-casts-android/pull/2591))
 
 7.70
 -----

--- a/modules/features/kids/src/main/java/au/com/shiftyjelly/pocketcasts/kids/KidsBottomSheetDialog.kt
+++ b/modules/features/kids/src/main/java/au/com/shiftyjelly/pocketcasts/kids/KidsBottomSheetDialog.kt
@@ -5,6 +5,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.FrameLayout
+import android.widget.Toast
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.core.EaseInOut
 import androidx.compose.animation.core.tween
@@ -20,18 +21,18 @@ import androidx.fragment.app.viewModels
 import au.com.shiftyjelly.pocketcasts.compose.AppTheme
 import au.com.shiftyjelly.pocketcasts.kids.viewmodel.KidsSendFeedbackViewModel
 import au.com.shiftyjelly.pocketcasts.kids.viewmodel.SendFeedbackState
+import au.com.shiftyjelly.pocketcasts.ui.helper.FragmentHostListener
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.google.android.material.bottomsheet.BottomSheetDialog
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
+import com.google.android.material.snackbar.Snackbar
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
+import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 @AndroidEntryPoint
-class KidsBottomSheetDialog(
-    private val onFeedbackSentSuccess: () -> Unit,
-    private val onFeedbackSentError: () -> Unit,
-) : BottomSheetDialogFragment() {
+class KidsBottomSheetDialog : BottomSheetDialogFragment() {
 
     @Inject
     lateinit var theme: Theme
@@ -43,6 +44,8 @@ class KidsBottomSheetDialog(
         easing = EaseInOut,
     )
 
+    private var snackBarCoordinatorLayout: View? = null
+
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
         return ComposeView(requireContext()).apply {
             setContent {
@@ -51,10 +54,10 @@ class KidsBottomSheetDialog(
 
                 LaunchedEffect(sendFeedbackState) {
                     if (sendFeedbackState is SendFeedbackState.Success) {
-                        onFeedbackSentSuccess.invoke()
+                        displayMessage(getString(LR.string.thank_you_for_your_feedback))
                         dismiss()
                     } else if (sendFeedbackState is SendFeedbackState.Error) {
-                        onFeedbackSentError.invoke()
+                        displayMessage(getString(LR.string.something_went_wrong_when_sending_feedback))
                         dismiss()
                     }
                 }
@@ -109,6 +112,17 @@ class KidsBottomSheetDialog(
                     peekHeight = 0
                     skipCollapsed = true
                 }
+            }
+        }
+        snackBarCoordinatorLayout = (activity as? FragmentHostListener)?.snackBarView()
+    }
+
+    private fun displayMessage(message: String) {
+        snackBarCoordinatorLayout?.let {
+            Snackbar.make(it, message, Snackbar.LENGTH_LONG).show()
+        } ?: run {
+            context?.let { context ->
+                Toast.makeText(context, message, Toast.LENGTH_LONG).show()
             }
         }
     }

--- a/modules/features/kids/src/main/java/au/com/shiftyjelly/pocketcasts/kids/KidsBottomSheetDialog.kt
+++ b/modules/features/kids/src/main/java/au/com/shiftyjelly/pocketcasts/kids/KidsBottomSheetDialog.kt
@@ -28,7 +28,10 @@ import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
 
 @AndroidEntryPoint
-class KidsBottomSheetDialog : BottomSheetDialogFragment() {
+class KidsBottomSheetDialog(
+    private val onFeedbackSentSuccess: () -> Unit,
+    private val onFeedbackSentError: () -> Unit,
+) : BottomSheetDialogFragment() {
 
     @Inject
     lateinit var theme: Theme
@@ -48,8 +51,10 @@ class KidsBottomSheetDialog : BottomSheetDialogFragment() {
 
                 LaunchedEffect(sendFeedbackState) {
                     if (sendFeedbackState is SendFeedbackState.Success) {
+                        onFeedbackSentSuccess.invoke()
                         dismiss()
                     } else if (sendFeedbackState is SendFeedbackState.Error) {
+                        onFeedbackSentError.invoke()
                         dismiss()
                     }
                 }

--- a/modules/features/kids/src/main/java/au/com/shiftyjelly/pocketcasts/kids/KidsSendFeedbackDialog.kt
+++ b/modules/features/kids/src/main/java/au/com/shiftyjelly/pocketcasts/kids/KidsSendFeedbackDialog.kt
@@ -30,12 +30,14 @@ import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import au.com.shiftyjelly.pocketcasts.compose.AppThemeWithBackground
 import au.com.shiftyjelly.pocketcasts.compose.CallOnce
 import au.com.shiftyjelly.pocketcasts.compose.buttons.RowButton
@@ -125,6 +127,9 @@ fun KidsSendFeedbackDialog(
                             color = MaterialTheme.theme.colors.primaryText02,
                         )
                     },
+                    textStyle = TextStyle(
+                        fontSize = 13.sp,
+                    ),
                     modifier = Modifier
                         .fillMaxWidth()
                         .padding(bottom = 16.dp)

--- a/modules/features/kids/src/main/java/au/com/shiftyjelly/pocketcasts/kids/feedback/FeedbackManager.kt
+++ b/modules/features/kids/src/main/java/au/com/shiftyjelly/pocketcasts/kids/feedback/FeedbackManager.kt
@@ -2,7 +2,6 @@ package au.com.shiftyjelly.pocketcasts.kids.feedback
 
 import au.com.shiftyjelly.pocketcasts.repositories.sync.SyncManager
 import javax.inject.Inject
-import retrofit2.Response
 
 class FeedbackManager @Inject constructor(
     private val syncManager: SyncManager,
@@ -12,8 +11,12 @@ class FeedbackManager @Inject constructor(
         const val INBOX = "research"
     }
 
-    suspend fun sendAnonymousFeedback(message: String): FeedbackResult = try {
-        val response: Response<Void> = syncManager.sendAnonymousFeedback(SUBJECT, INBOX, message)
+    suspend fun sendFeedback(message: String): FeedbackResult {
+        return processFeedback(message, isAnonymous = !syncManager.isLoggedIn())
+    }
+
+    private suspend fun processFeedback(message: String, isAnonymous: Boolean): FeedbackResult = try {
+        val response = if (isAnonymous) syncManager.sendAnonymousFeedback(SUBJECT, INBOX, message) else syncManager.sendFeedback(SUBJECT, INBOX, message)
         if (response.isSuccessful) {
             FeedbackResult.Success
         } else {

--- a/modules/features/kids/src/main/java/au/com/shiftyjelly/pocketcasts/kids/viewmodel/KidsSendFeedbackViewModel.kt
+++ b/modules/features/kids/src/main/java/au/com/shiftyjelly/pocketcasts/kids/viewmodel/KidsSendFeedbackViewModel.kt
@@ -49,7 +49,7 @@ class KidsSendFeedbackViewModel @Inject constructor(
         analyticsTracker.track(AnalyticsEvent.KIDS_PROFILE_FEEDBACK_SENT)
 
         viewModelScope.launch {
-            val result: FeedbackResult = feedbackManager.sendAnonymousFeedback(feedback)
+            val result: FeedbackResult = feedbackManager.sendFeedback(feedback)
             if (result is FeedbackResult.Success) {
                 _sendFeedbackState.value = SendFeedbackState.Success
             } else {

--- a/modules/features/kids/src/test/java/au/com/shiftyjelly/pocketcasts/KidsSendFeedbackViewModelTest.kt
+++ b/modules/features/kids/src/test/java/au/com/shiftyjelly/pocketcasts/KidsSendFeedbackViewModelTest.kt
@@ -60,7 +60,7 @@ class KidsSendFeedbackViewModelTest {
         val feedback = "Great app!"
         val feedbackResult = FeedbackResult.Success
 
-        whenever(feedbackManager.sendAnonymousFeedback(feedback)).thenReturn(feedbackResult)
+        whenever(feedbackManager.sendFeedback(feedback)).thenReturn(feedbackResult)
 
         viewModel.submitFeedback(feedback)
 
@@ -73,7 +73,7 @@ class KidsSendFeedbackViewModelTest {
         val feedback = "Great app!"
         val feedbackResult = FeedbackResult.Error
 
-        whenever(feedbackManager.sendAnonymousFeedback(feedback)).thenReturn(feedbackResult)
+        whenever(feedbackManager.sendFeedback(feedback)).thenReturn(feedbackResult)
 
         viewModel.submitFeedback(feedback)
 

--- a/modules/features/kids/src/test/java/au/com/shiftyjelly/pocketcasts/kids/feedback/FeedbackManagerTest.kt
+++ b/modules/features/kids/src/test/java/au/com/shiftyjelly/pocketcasts/kids/feedback/FeedbackManagerTest.kt
@@ -25,48 +25,101 @@ class FeedbackManagerTest {
     }
 
     @Test
-    fun `should return success when response is successful`() = runTest {
+    fun `should return success when send anonymous feedback`() = runTest {
         val subject = FeedbackManager.SUBJECT
         val inbox = FeedbackManager.INBOX
         val message = "Message"
 
         val response: Response<Void> = Response.success(null)
+        `when`(syncManager.isLoggedIn()).thenReturn(false)
         `when`(syncManager.sendAnonymousFeedback(subject, inbox, message)).thenReturn(response)
 
         val feedbackManager = FeedbackManager(syncManager)
 
-        val result = feedbackManager.sendAnonymousFeedback(message)
+        val result = feedbackManager.sendFeedback(message)
 
         assertEquals(FeedbackResult.Success, result)
     }
 
     @Test
-    fun `should return error when throws an exception`() = runTest {
+    fun `should return error when throws an exception while sending anonymous feedback`() = runTest {
         val subject = FeedbackManager.SUBJECT
         val inbox = FeedbackManager.INBOX
         val message = "Message"
 
         `when`(syncManager.sendAnonymousFeedback(subject, inbox, message)).thenThrow(RuntimeException("Test Exception"))
+        `when`(syncManager.isLoggedIn()).thenReturn(false)
 
         val feedbackManager = FeedbackManager(syncManager)
 
-        val result = feedbackManager.sendAnonymousFeedback(message)
+        val result = feedbackManager.sendFeedback(message)
 
         assertEquals(FeedbackResult.Error, result)
     }
 
     @Test
-    fun `should return error when response is not successful`() = runTest {
+    fun `should return error when response is not successful while sending anonymous feedback`() = runTest {
         val subject = FeedbackManager.SUBJECT
         val inbox = FeedbackManager.INBOX
         val message = "Message"
 
         val response: Response<Void> = Response.error(400, "".toResponseBody(null))
         `when`(syncManager.sendAnonymousFeedback(subject, inbox, message)).thenReturn(response)
+        `when`(syncManager.isLoggedIn()).thenReturn(false)
 
         val feedbackManager = FeedbackManager(syncManager)
 
-        val result = feedbackManager.sendAnonymousFeedback(message)
+        val result = feedbackManager.sendFeedback(message)
+
+        assertEquals(FeedbackResult.Error, result)
+    }
+
+    @Test
+    fun `should return success when send feedback`() = runTest {
+        val subject = FeedbackManager.SUBJECT
+        val inbox = FeedbackManager.INBOX
+        val message = "Message"
+
+        val response: Response<Void> = Response.success(null)
+        `when`(syncManager.sendFeedback(subject, inbox, message)).thenReturn(response)
+        `when`(syncManager.isLoggedIn()).thenReturn(true)
+
+        val feedbackManager = FeedbackManager(syncManager)
+
+        val result = feedbackManager.sendFeedback(message)
+
+        assertEquals(FeedbackResult.Success, result)
+    }
+
+    @Test
+    fun `should return error when throws an exception while sending feedback`() = runTest {
+        val subject = FeedbackManager.SUBJECT
+        val inbox = FeedbackManager.INBOX
+        val message = "Message"
+
+        `when`(syncManager.sendFeedback(subject, inbox, message)).thenThrow(RuntimeException("Test Exception"))
+        `when`(syncManager.isLoggedIn()).thenReturn(true)
+
+        val feedbackManager = FeedbackManager(syncManager)
+
+        val result = feedbackManager.sendFeedback(message)
+
+        assertEquals(FeedbackResult.Error, result)
+    }
+
+    @Test
+    fun `should return error when response is not successful while sending feedback`() = runTest {
+        val subject = FeedbackManager.SUBJECT
+        val inbox = FeedbackManager.INBOX
+        val message = "Message"
+
+        val response: Response<Void> = Response.error(400, "".toResponseBody(null))
+        `when`(syncManager.sendFeedback(subject, inbox, message)).thenReturn(response)
+        `when`(syncManager.isLoggedIn()).thenReturn(true)
+
+        val feedbackManager = FeedbackManager(syncManager)
+
+        val result = feedbackManager.sendFeedback(message)
 
         assertEquals(FeedbackResult.Error, result)
     }

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/ProfileFragment.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/ProfileFragment.kt
@@ -7,7 +7,6 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.TextView
-import android.widget.Toast
 import androidx.annotation.StringRes
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -56,7 +55,6 @@ import au.com.shiftyjelly.pocketcasts.utils.extensions.dpToPx
 import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
 import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
 import au.com.shiftyjelly.pocketcasts.views.fragments.BaseFragment
-import com.google.android.material.snackbar.Snackbar
 import dagger.hilt.android.AndroidEntryPoint
 import java.util.Date
 import javax.inject.Inject
@@ -78,8 +76,6 @@ class ProfileFragment : BaseFragment() {
     @Inject lateinit var analyticsTracker: AnalyticsTracker
 
     private val viewModel: ProfileViewModel by viewModels()
-
-    private var snackBarCoordinatorLayout: View? = null
 
     private var binding: FragmentProfileBinding? = null
     private val sections = arrayListOf(
@@ -115,8 +111,6 @@ class ProfileFragment : BaseFragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-
-        snackBarCoordinatorLayout = (activity as FragmentHostListener).snackBarView()
 
         val binding = binding ?: return
 
@@ -302,14 +296,7 @@ class ProfileFragment : BaseFragment() {
                         },
                         onRequestEarlyAccess = {
                             analyticsTracker.track(AnalyticsEvent.KIDS_PROFILE_EARLY_ACCESS_REQUESTED)
-                            KidsBottomSheetDialog(
-                                onFeedbackSentSuccess = {
-                                    showSnackBar(getString(LR.string.thank_you_for_your_feedback))
-                                },
-                                onFeedbackSentError = {
-                                    showSnackBar(getString(LR.string.something_went_wrong_when_sending_feedback))
-                                },
-                            ).show(childFragmentManager, "KidsBottomSheetDialog")
+                            KidsBottomSheetDialog().show(childFragmentManager, "KidsBottomSheetDialog")
                         },
                     )
                 }
@@ -376,16 +363,6 @@ class ProfileFragment : BaseFragment() {
     override fun onBackPressed(): Boolean {
         viewModel.updateState()
         return super.onBackPressed()
-    }
-
-    private fun showSnackBar(message: String) {
-        snackBarCoordinatorLayout?.let {
-            Snackbar.make(it, message, Snackbar.LENGTH_LONG).show()
-        } ?: run {
-            context?.let { context ->
-                Toast.makeText(context, message, Toast.LENGTH_LONG).show()
-            }
-        }
     }
 
     private fun convertSecsToTimeAndUnit(seconds: Long): TimeAndUnit {

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -2046,4 +2046,6 @@ up    <string name="player_sleep_in_one_chapter">Sleeping in 1 chapter</string>
     <string name="send_feedback_title">What would you like to see in a Kids profile for Pocket Casts?</string>
     <string name="feedback_form_placeholder">I would like to filter episodes by</string>
     <string name="swipe_affordance_icon">Swipe Affordance Icon</string>
+    <string name="thank_you_for_your_feedback">Thank you for your feedback!</string>
+    <string name="something_went_wrong_when_sending_feedback">Something went wrong. Please try submitting your feedback again.</string>
 </resources>

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/SyncManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/SyncManager.kt
@@ -100,4 +100,5 @@ interface SyncManager : NamedSettingsCaller {
     fun upNextSync(request: UpNextSyncRequest): Single<UpNextSyncResponse>
     suspend fun getBookmarks(): List<Bookmark>
     suspend fun sendAnonymousFeedback(subject: String, inbox: String, message: String): Response<Void>
+    suspend fun sendFeedback(subject: String, inbox: String, message: String): Response<Void>
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/SyncManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/SyncManagerImpl.kt
@@ -413,6 +413,11 @@ class SyncManagerImpl @Inject constructor(
         return syncServerManager.sendAnonymousFeedback(subject, inbox, message)
     }
 
+    override suspend fun sendFeedback(subject: String, inbox: String, message: String): Response<Void> =
+        getCacheTokenOrLogin { token ->
+            syncServerManager.sendFeedback(subject, inbox, message, token)
+        }
+
     override suspend fun loadStats(): StatsBundle =
         getCacheTokenOrLogin { token ->
             syncServerManager.loadStats(token)

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/SyncServer.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/SyncServer.kt
@@ -181,4 +181,8 @@ interface SyncServer {
     @Headers("Content-Type: application/octet-stream")
     @POST("/anonymous/feedback")
     suspend fun sendAnonymousFeedback(@Body request: SupportFeedbackRequest): Response<Void>
+
+    @Headers("Content-Type: application/octet-stream")
+    @POST("/support/feedback")
+    suspend fun sendFeedback(@Header("Authorization") authorization: String, @Body request: SupportFeedbackRequest): Response<Void>
 }

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/SyncServerManager.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/SyncServerManager.kt
@@ -297,6 +297,15 @@ open class SyncServerManager @Inject constructor(
         return server.sendAnonymousFeedback(request)
     }
 
+    suspend fun sendFeedback(subject: String, inbox: String, message: String, token: AccessToken): Response<Void> {
+        val request = SupportFeedbackRequest.newBuilder()
+            .setSubject(subject)
+            .setInbox(inbox)
+            .setMessage(message)
+            .build()
+        return server.sendFeedback(addBearer(token), request)
+    }
+
     fun signOut() {
         cache.evictAll()
     }


### PR DESCRIPTION
## Description
- After implementing the anonymous feedback here https://github.com/Automattic/pocket-casts-android/pull/2581 this PR includes the non anonymous feedback, which is for the case the user is logged in.
- This uses the other endpoint `/support/feedback`
- Also, displays an snack bar after sending the feedback form

Fixes #2511

## Testing Instructions
- Have the Kids Feature flag enabled
- Follow these steps: p1722955409841369/1722954751.866389-slack-C07CGGZR59U to verify if your feedback was sent

### Logged user
1. Make sure you are logged in
2. Go to Profile -> Request Early access -> Send Feedback
3. Type something to enable the Send Feedback button
4. Send feedback
5. ✅ Ensure your feedback was sent. (check the testing instructions section)
6. ✅ Ensure you see the snack bar with a message

### Anonymous
1. Make sure you are not logged in
2. Go to Profile -> Request Early access -> Send Feedback
3. Type something to enable the Send Feedback button
4. Send feedback
5. ✅ Ensure your feedback was sent. (check the testing instructions section)
6. ✅ Ensure you see the snack bar with a message

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.

## Demo

[Screen_recording_20240807_144507.webm](https://github.com/user-attachments/assets/9d289b84-6891-4cad-a552-cc4b70e186eb)

 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack