### PR TITLE
Use scrolling card pattern in sharing screens

### DIFF
--- a/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/clip/ShareClipPage.kt
+++ b/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/clip/ShareClipPage.kt
@@ -323,8 +323,7 @@ private fun MiddleContent(
     }
 
     val coordiantes = estimateCardCoordinates(
-        topContentHeight = state.topContentHeight,
-        indicatorHeight = state.pagerIndicatorHeight,
+        topContentHeight = state.topContentHeight + state.pagerIndicatorHeight,
         scrollState = scrollState,
     )
     HorizontalPager(

--- a/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/clip/ShareClipPage.kt
+++ b/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/clip/ShareClipPage.kt
@@ -14,7 +14,6 @@ import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.defaultMinSize
@@ -46,8 +45,6 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.layout.onGloballyPositioned
-import androidx.compose.ui.platform.LocalConfiguration
-import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.rememberNestedScrollInteropConnection
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
@@ -55,9 +52,6 @@ import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.unit.DpSize
-import androidx.compose.ui.unit.IntOffset
-import androidx.compose.ui.unit.coerceAtMost
 import androidx.compose.ui.unit.dp
 import au.com.shiftyjelly.pocketcasts.compose.Devices
 import au.com.shiftyjelly.pocketcasts.compose.buttons.BaseRowButton
@@ -76,6 +70,7 @@ import au.com.shiftyjelly.pocketcasts.sharing.ui.CloseButton
 import au.com.shiftyjelly.pocketcasts.sharing.ui.EpisodeCard
 import au.com.shiftyjelly.pocketcasts.sharing.ui.ShareColors
 import au.com.shiftyjelly.pocketcasts.sharing.ui.VisualCardType
+import au.com.shiftyjelly.pocketcasts.sharing.ui.estimateCardCoordinates
 import au.com.shiftyjelly.pocketcasts.sharing.ui.scrollBottomFade
 import java.sql.Date
 import java.time.Instant
@@ -327,7 +322,11 @@ private fun MiddleContent(
         }
     }
 
-    val coordiantes = estimateCardCoordinates(state, scrollState)
+    val coordiantes = estimateCardCoordinates(
+        topContentHeight = state.topContentHeight,
+        indicatorHeight = state.pagerIndicatorHeight,
+        scrollState = scrollState,
+    )
     HorizontalPager(
         state = pagerState,
         userScrollEnabled = state.step == SharingStep.Creating,
@@ -366,58 +365,6 @@ private fun MiddleContent(
         }
     }
 }
-
-@Composable
-private fun estimateCardCoordinates(
-    state: ClipPageState,
-    scrollState: ScrollState,
-): CardCoordinates {
-    val screenWidth = LocalConfiguration.current.screenWidthDp.dp
-    val screenHeight = LocalConfiguration.current.screenHeightDp.dp
-
-    val maxWidth = when (screenHeight / screenWidth) {
-        in 0f..1.35f -> 300.dp
-        else -> 360.dp
-    }
-    val cardPadding = screenWidth / 10
-    val availableWidth = (screenWidth - cardPadding * 2).coerceAtMost(maxWidth)
-    val availableHeight = availableWidth * 1.5f // Vertical card has the most height so we calculate the size for it
-
-    val density = LocalDensity.current
-
-    return CardCoordinates(
-        size = DpSize(availableWidth, availableHeight),
-        padding = PaddingValues(horizontal = cardPadding),
-        // Offset is helpful for scenrarios when card doesn't fit on the screen.
-        // This way we can center horizontal and square cards in the view port
-        // and not in the pager which can have content outside of the view port.
-        offset = { type ->
-            when (type) {
-                CardType.Vertical -> IntOffset(0, 0)
-                CardType.Horizontal, CardType.Square, CardType.Audio -> {
-                    val viewPortHeight = scrollState.viewportSize
-                    val topContentHeight = state.topContentHeight
-                    val dotIndicatorHeight = state.pagerIndicatorHeight
-                    val isMeasured = viewPortHeight != 0
-
-                    if (isMeasured && (scrollState.canScrollForward || scrollState.canScrollBackward)) {
-                        val viewPortPagerPortion = density.run { (viewPortHeight - topContentHeight - dotIndicatorHeight).toDp() }
-                        val offsetValue = (viewPortPagerPortion - availableHeight) / 2
-                        IntOffset(x = 0, y = density.run { offsetValue.roundToPx() })
-                    } else {
-                        IntOffset(0, 0)
-                    }
-                }
-            }
-        },
-    )
-}
-
-private class CardCoordinates(
-    val size: DpSize,
-    val padding: PaddingValues,
-    val offset: (CardType) -> IntOffset,
-)
 
 @Composable
 private fun BottomContent(

--- a/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/clip/ShareClipPage.kt
+++ b/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/clip/ShareClipPage.kt
@@ -73,10 +73,8 @@ import au.com.shiftyjelly.pocketcasts.sharing.ui.BackgroundAssetController
 import au.com.shiftyjelly.pocketcasts.sharing.ui.CardType
 import au.com.shiftyjelly.pocketcasts.sharing.ui.ClipSelector
 import au.com.shiftyjelly.pocketcasts.sharing.ui.CloseButton
-import au.com.shiftyjelly.pocketcasts.sharing.ui.HorizontalEpisodeCard
+import au.com.shiftyjelly.pocketcasts.sharing.ui.EpisodeCard
 import au.com.shiftyjelly.pocketcasts.sharing.ui.ShareColors
-import au.com.shiftyjelly.pocketcasts.sharing.ui.SquareEpisodeCard
-import au.com.shiftyjelly.pocketcasts.sharing.ui.VerticalEpisodeCard
 import au.com.shiftyjelly.pocketcasts.sharing.ui.VisualCardType
 import au.com.shiftyjelly.pocketcasts.sharing.ui.scrollBottomFade
 import java.sql.Date
@@ -345,35 +343,16 @@ private fun MiddleContent(
             .padding(coordiantes.padding)
 
         when (cardType) {
-            is VisualCardType -> when (cardType) {
-                CardType.Vertical -> VerticalEpisodeCard(
-                    episode = episode,
-                    podcast = podcast,
-                    useEpisodeArtwork = useEpisodeArtwork,
-                    shareColors = shareColors,
-                    captureController = assetController.captureController(cardType),
-                    customSize = coordiantes.size,
-                    modifier = modifier,
-                )
-                CardType.Horizontal -> HorizontalEpisodeCard(
-                    episode = episode,
-                    podcast = podcast,
-                    useEpisodeArtwork = useEpisodeArtwork,
-                    shareColors = shareColors,
-                    captureController = assetController.captureController(cardType),
-                    customSize = coordiantes.size,
-                    modifier = modifier,
-                )
-                CardType.Square -> SquareEpisodeCard(
-                    episode = episode,
-                    podcast = podcast,
-                    useEpisodeArtwork = useEpisodeArtwork,
-                    shareColors = shareColors,
-                    captureController = assetController.captureController(cardType),
-                    customSize = coordiantes.size,
-                    modifier = modifier,
-                )
-            }
+            is VisualCardType -> EpisodeCard(
+                cardType = cardType,
+                episode = episode,
+                podcast = podcast,
+                useEpisodeArtwork = useEpisodeArtwork,
+                shareColors = shareColors,
+                captureController = assetController.captureController(cardType),
+                customSize = coordiantes.size,
+                modifier = modifier,
+            )
             is CardType.Audio -> Box(
                 contentAlignment = Alignment.Center,
                 modifier = modifier,

--- a/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/episode/ShareEpisodePage.kt
+++ b/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/episode/ShareEpisodePage.kt
@@ -17,11 +17,10 @@ import au.com.shiftyjelly.pocketcasts.sharing.SharingResponse
 import au.com.shiftyjelly.pocketcasts.sharing.social.SocialPlatform
 import au.com.shiftyjelly.pocketcasts.sharing.ui.BackgroundAssetController
 import au.com.shiftyjelly.pocketcasts.sharing.ui.CardType
+import au.com.shiftyjelly.pocketcasts.sharing.ui.EpisodeCard
 import au.com.shiftyjelly.pocketcasts.sharing.ui.HorizontalEpisodeCard
 import au.com.shiftyjelly.pocketcasts.sharing.ui.HorizontalSharePage
 import au.com.shiftyjelly.pocketcasts.sharing.ui.ShareColors
-import au.com.shiftyjelly.pocketcasts.sharing.ui.SquareEpisodeCard
-import au.com.shiftyjelly.pocketcasts.sharing.ui.VerticalEpisodeCard
 import au.com.shiftyjelly.pocketcasts.sharing.ui.VerticalSharePage
 import au.com.shiftyjelly.pocketcasts.sharing.ui.VisualCardType
 import java.sql.Date
@@ -111,32 +110,15 @@ private fun VerticalShareEpisodePage(
         middleContent = { cardType, modifier ->
             if (podcast != null && episode != null) {
                 val captureController = assetController.captureController(cardType)
-                when (cardType) {
-                    CardType.Vertical -> VerticalEpisodeCard(
-                        podcast = podcast,
-                        episode = episode,
-                        useEpisodeArtwork = useEpisodeArtwork,
-                        shareColors = shareColors,
-                        captureController = captureController,
-                        modifier = modifier,
-                    )
-                    CardType.Horizontal -> HorizontalEpisodeCard(
-                        podcast = podcast,
-                        episode = episode,
-                        useEpisodeArtwork = useEpisodeArtwork,
-                        shareColors = shareColors,
-                        captureController = captureController,
-                        modifier = modifier,
-                    )
-                    CardType.Square -> SquareEpisodeCard(
-                        podcast = podcast,
-                        episode = episode,
-                        useEpisodeArtwork = useEpisodeArtwork,
-                        shareColors = shareColors,
-                        captureController = captureController,
-                        modifier = modifier,
-                    )
-                }
+                EpisodeCard(
+                    cardType = cardType,
+                    podcast = podcast,
+                    episode = episode,
+                    useEpisodeArtwork = useEpisodeArtwork,
+                    shareColors = shareColors,
+                    captureController = captureController,
+                    modifier = modifier,
+                )
             }
         },
     )

--- a/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/podcast/SharePodcastPage.kt
+++ b/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/podcast/SharePodcastPage.kt
@@ -15,7 +15,7 @@ import au.com.shiftyjelly.pocketcasts.sharing.SharingResponse
 import au.com.shiftyjelly.pocketcasts.sharing.social.SocialPlatform
 import au.com.shiftyjelly.pocketcasts.sharing.ui.BackgroundAssetController
 import au.com.shiftyjelly.pocketcasts.sharing.ui.CardType
-import au.com.shiftyjelly.pocketcasts.sharing.ui.HorizontalPodcastCast
+import au.com.shiftyjelly.pocketcasts.sharing.ui.HorizontalPodcastCard
 import au.com.shiftyjelly.pocketcasts.sharing.ui.HorizontalSharePage
 import au.com.shiftyjelly.pocketcasts.sharing.ui.PodcastCard
 import au.com.shiftyjelly.pocketcasts.sharing.ui.ShareColors
@@ -142,7 +142,7 @@ private fun HorizontalSharePodcastPage(
         },
         middleContent = {
             if (podcast != null) {
-                HorizontalPodcastCast(
+                HorizontalPodcastCard(
                     podcast = podcast,
                     episodeCount = episodeCount,
                     shareColors = shareColors,

--- a/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/podcast/SharePodcastPage.kt
+++ b/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/podcast/SharePodcastPage.kt
@@ -17,9 +17,8 @@ import au.com.shiftyjelly.pocketcasts.sharing.ui.BackgroundAssetController
 import au.com.shiftyjelly.pocketcasts.sharing.ui.CardType
 import au.com.shiftyjelly.pocketcasts.sharing.ui.HorizontalPodcastCast
 import au.com.shiftyjelly.pocketcasts.sharing.ui.HorizontalSharePage
+import au.com.shiftyjelly.pocketcasts.sharing.ui.PodcastCard
 import au.com.shiftyjelly.pocketcasts.sharing.ui.ShareColors
-import au.com.shiftyjelly.pocketcasts.sharing.ui.SquarePodcastCast
-import au.com.shiftyjelly.pocketcasts.sharing.ui.VerticalPodcastCast
 import au.com.shiftyjelly.pocketcasts.sharing.ui.VerticalSharePage
 import au.com.shiftyjelly.pocketcasts.sharing.ui.VisualCardType
 import kotlinx.coroutines.launch
@@ -102,29 +101,14 @@ private fun VerticalSharePodcastPage(
         middleContent = { cardType, modifier ->
             if (podcast != null) {
                 val captureController = assetController.captureController(cardType)
-                when (cardType) {
-                    CardType.Vertical -> VerticalPodcastCast(
-                        podcast = podcast,
-                        episodeCount = episodeCount,
-                        shareColors = shareColors,
-                        captureController = captureController,
-                        modifier = modifier,
-                    )
-                    CardType.Horizontal -> HorizontalPodcastCast(
-                        podcast = podcast,
-                        episodeCount = episodeCount,
-                        shareColors = shareColors,
-                        captureController = captureController,
-                        modifier = modifier,
-                    )
-                    CardType.Square -> SquarePodcastCast(
-                        podcast = podcast,
-                        episodeCount = episodeCount,
-                        shareColors = shareColors,
-                        captureController = captureController,
-                        modifier = modifier,
-                    )
-                }
+                PodcastCard(
+                    cardType = cardType,
+                    podcast = podcast,
+                    episodeCount = episodeCount,
+                    shareColors = shareColors,
+                    captureController = captureController,
+                    modifier = modifier,
+                )
             }
         },
     )

--- a/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/timestamp/ShareEpisodeTimestampPage.kt
+++ b/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/timestamp/ShareEpisodeTimestampPage.kt
@@ -16,11 +16,10 @@ import au.com.shiftyjelly.pocketcasts.sharing.SharingResponse
 import au.com.shiftyjelly.pocketcasts.sharing.social.SocialPlatform
 import au.com.shiftyjelly.pocketcasts.sharing.ui.BackgroundAssetController
 import au.com.shiftyjelly.pocketcasts.sharing.ui.CardType
+import au.com.shiftyjelly.pocketcasts.sharing.ui.EpisodeCard
 import au.com.shiftyjelly.pocketcasts.sharing.ui.HorizontalEpisodeCard
 import au.com.shiftyjelly.pocketcasts.sharing.ui.HorizontalSharePage
 import au.com.shiftyjelly.pocketcasts.sharing.ui.ShareColors
-import au.com.shiftyjelly.pocketcasts.sharing.ui.SquareEpisodeCard
-import au.com.shiftyjelly.pocketcasts.sharing.ui.VerticalEpisodeCard
 import au.com.shiftyjelly.pocketcasts.sharing.ui.VerticalSharePage
 import au.com.shiftyjelly.pocketcasts.sharing.ui.VisualCardType
 import au.com.shiftyjelly.pocketcasts.utils.toHhMmSs
@@ -117,32 +116,15 @@ private fun VerticalShareEpisodeTimestampPage(
         middleContent = { cardType, modifier ->
             if (podcast != null && episode != null) {
                 val captureController = assetController.captureController(cardType)
-                when (cardType) {
-                    CardType.Vertical -> VerticalEpisodeCard(
-                        podcast = podcast,
-                        episode = episode,
-                        useEpisodeArtwork = useEpisodeArtwork,
-                        shareColors = shareColors,
-                        captureController = captureController,
-                        modifier = modifier,
-                    )
-                    CardType.Horizontal -> HorizontalEpisodeCard(
-                        podcast = podcast,
-                        episode = episode,
-                        useEpisodeArtwork = useEpisodeArtwork,
-                        shareColors = shareColors,
-                        captureController = captureController,
-                        modifier = modifier,
-                    )
-                    CardType.Square -> SquareEpisodeCard(
-                        podcast = podcast,
-                        episode = episode,
-                        useEpisodeArtwork = useEpisodeArtwork,
-                        shareColors = shareColors,
-                        captureController = captureController,
-                        modifier = modifier,
-                    )
-                }
+                EpisodeCard(
+                    cardType = cardType,
+                    podcast = podcast,
+                    episode = episode,
+                    useEpisodeArtwork = useEpisodeArtwork,
+                    shareColors = shareColors,
+                    captureController = captureController,
+                    modifier = modifier,
+                )
             }
         },
     )

--- a/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/ui/CardType.kt
+++ b/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/ui/CardType.kt
@@ -51,7 +51,7 @@ internal fun estimateCardCoordinates(
         in 0f..1.35f -> 300.dp
         else -> 360.dp
     }
-    val cardPadding = screenWidth / 10
+    val cardPadding = screenWidth / 8
     val availableWidth = (screenWidth - cardPadding * 2).coerceAtMost(maxWidth)
     val availableHeight = availableWidth * 1.5f // Vertical card has the most height so we calculate the size for it
 

--- a/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/ui/CardType.kt
+++ b/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/ui/CardType.kt
@@ -11,9 +11,15 @@ import androidx.compose.ui.unit.coerceAtMost
 import androidx.compose.ui.unit.dp
 
 sealed interface CardType {
-    data object Vertical : VisualCardType
-    data object Horizontal : VisualCardType
-    data object Square : VisualCardType
+    data object Vertical : VisualCardType {
+        override val aspectRatio = 1.5f
+    }
+    data object Horizontal : VisualCardType {
+        override val aspectRatio = 0.52f
+    }
+    data object Square : VisualCardType {
+        override val aspectRatio = 1f
+    }
     data object Audio : CardType
 
     companion object {
@@ -36,7 +42,9 @@ sealed interface CardType {
     }
 }
 
-sealed interface VisualCardType : CardType
+sealed interface VisualCardType : CardType {
+    val aspectRatio: Float
+}
 
 @Composable
 internal fun estimateCardCoordinates(
@@ -53,7 +61,7 @@ internal fun estimateCardCoordinates(
     }
     val cardPadding = screenWidth / 8
     val availableWidth = (screenWidth - cardPadding * 2).coerceAtMost(maxWidth)
-    val availableHeight = availableWidth * 1.5f // Vertical card has the most height so we calculate the size for it
+    val availableHeight = availableWidth * CardType.Vertical.aspectRatio // Vertical card has the most height so we calculate the size for it
 
     val density = LocalDensity.current
 

--- a/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/ui/CardType.kt
+++ b/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/ui/CardType.kt
@@ -49,7 +49,6 @@ sealed interface VisualCardType : CardType {
 @Composable
 internal fun estimateCardCoordinates(
     topContentHeight: Int,
-    indicatorHeight: Int,
     scrollState: ScrollState,
 ): CardCoordinates {
     val screenWidth = LocalConfiguration.current.screenWidthDp.dp
@@ -79,7 +78,7 @@ internal fun estimateCardCoordinates(
                     val isMeasured = viewPortHeight != 0
 
                     if (isMeasured && (scrollState.canScrollForward || scrollState.canScrollBackward)) {
-                        val viewPortPagerPortion = density.run { (viewPortHeight - topContentHeight - indicatorHeight).toDp() }
+                        val viewPortPagerPortion = density.run { (viewPortHeight - topContentHeight).toDp() }
                         val offsetValue = (viewPortPagerPortion - availableHeight) / 2
                         IntOffset(x = 0, y = density.run { offsetValue.roundToPx() })
                     } else {

--- a/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/ui/CardType.kt
+++ b/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/ui/CardType.kt
@@ -1,5 +1,15 @@
 package au.com.shiftyjelly.pocketcasts.sharing.ui
 
+import androidx.compose.foundation.ScrollState
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.DpSize
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.coerceAtMost
+import androidx.compose.ui.unit.dp
+
 sealed interface CardType {
     data object Vertical : VisualCardType
     data object Horizontal : VisualCardType
@@ -27,3 +37,54 @@ sealed interface CardType {
 }
 
 sealed interface VisualCardType : CardType
+
+@Composable
+internal fun estimateCardCoordinates(
+    topContentHeight: Int,
+    indicatorHeight: Int,
+    scrollState: ScrollState,
+): CardCoordinates {
+    val screenWidth = LocalConfiguration.current.screenWidthDp.dp
+    val screenHeight = LocalConfiguration.current.screenHeightDp.dp
+
+    val maxWidth = when (screenHeight / screenWidth) {
+        in 0f..1.35f -> 300.dp
+        else -> 360.dp
+    }
+    val cardPadding = screenWidth / 10
+    val availableWidth = (screenWidth - cardPadding * 2).coerceAtMost(maxWidth)
+    val availableHeight = availableWidth * 1.5f // Vertical card has the most height so we calculate the size for it
+
+    val density = LocalDensity.current
+
+    return CardCoordinates(
+        size = DpSize(availableWidth, availableHeight),
+        padding = PaddingValues(horizontal = cardPadding),
+        // Offset is helpful for scenrarios when card doesn't fit on the screen.
+        // This way we can center horizontal and square cards in the view port
+        // and not in the pager which can have content outside of the view port.
+        offset = { type ->
+            when (type) {
+                CardType.Vertical -> IntOffset(0, 0)
+                CardType.Horizontal, CardType.Square, CardType.Audio -> {
+                    val viewPortHeight = scrollState.viewportSize
+                    val isMeasured = viewPortHeight != 0
+
+                    if (isMeasured && (scrollState.canScrollForward || scrollState.canScrollBackward)) {
+                        val viewPortPagerPortion = density.run { (viewPortHeight - topContentHeight - indicatorHeight).toDp() }
+                        val offsetValue = (viewPortPagerPortion - availableHeight) / 2
+                        IntOffset(x = 0, y = density.run { offsetValue.roundToPx() })
+                    } else {
+                        IntOffset(0, 0)
+                    }
+                }
+            }
+        },
+    )
+}
+
+internal class CardCoordinates(
+    val size: DpSize,
+    val padding: PaddingValues,
+    val offset: (CardType) -> IntOffset,
+)

--- a/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/ui/EpisodeCard.kt
+++ b/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/ui/EpisodeCard.kt
@@ -1,0 +1,51 @@
+package au.com.shiftyjelly.pocketcasts.sharing.ui
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.DpSize
+import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
+import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
+import dev.shreyaspatil.capturable.controller.CaptureController
+
+@Composable
+internal fun EpisodeCard(
+    cardType: VisualCardType,
+    episode: PodcastEpisode,
+    podcast: Podcast,
+    useEpisodeArtwork: Boolean,
+    shareColors: ShareColors,
+    captureController: CaptureController,
+    modifier: Modifier = Modifier,
+    useHeightForAspectRatio: Boolean = cardType == CardType.Vertical,
+    customSize: DpSize? = null,
+) = when (cardType) {
+    CardType.Vertical -> VerticalEpisodeCard(
+        episode = episode,
+        podcast = podcast,
+        useEpisodeArtwork = useEpisodeArtwork,
+        shareColors = shareColors,
+        captureController = captureController,
+        useHeightForAspectRatio = useHeightForAspectRatio,
+        customSize = customSize,
+        modifier = modifier,
+    )
+    CardType.Horizontal -> HorizontalEpisodeCard(
+        episode = episode,
+        podcast = podcast,
+        useEpisodeArtwork = useEpisodeArtwork,
+        shareColors = shareColors,
+        captureController = captureController,
+        useHeightForAspectRatio = useHeightForAspectRatio,
+        customSize = customSize,
+        modifier = modifier,
+    )
+    CardType.Square -> SquareEpisodeCard(
+        episode = episode,
+        podcast = podcast,
+        useEpisodeArtwork = useEpisodeArtwork,
+        shareColors = shareColors,
+        captureController = captureController,
+        customSize = customSize,
+        modifier = modifier,
+    )
+}

--- a/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/ui/HorizontalCard.kt
+++ b/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/ui/HorizontalCard.kt
@@ -33,7 +33,7 @@ import java.sql.Date
 import java.time.Instant
 
 @Composable
-internal fun HorizontalPodcastCast(
+internal fun HorizontalPodcastCard(
     podcast: Podcast,
     episodeCount: Int,
     shareColors: ShareColors,

--- a/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/ui/HorizontalCard.kt
+++ b/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/ui/HorizontalCard.kt
@@ -39,7 +39,7 @@ internal fun HorizontalPodcastCast(
     shareColors: ShareColors,
     captureController: CaptureController,
     modifier: Modifier = Modifier,
-    useHeightForAspectRatio: Boolean = true,
+    useHeightForAspectRatio: Boolean = false,
     customSize: DpSize? = null,
 ) = HorizontalCard(
     data = PodcastCardData(
@@ -61,7 +61,7 @@ internal fun HorizontalEpisodeCard(
     shareColors: ShareColors,
     captureController: CaptureController,
     modifier: Modifier = Modifier,
-    useHeightForAspectRatio: Boolean = true,
+    useHeightForAspectRatio: Boolean = false,
     customSize: DpSize? = null,
 ) = HorizontalCard(
     data = EpisodeCardData(
@@ -217,6 +217,6 @@ private fun HorizontalCardPreview(
 ) = HorizontalCard(
     data = data,
     shareColors = ShareColors(baseColor),
-    useHeightForAspectRatio = true,
+    useHeightForAspectRatio = false,
     captureController = rememberCaptureController(),
 )

--- a/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/ui/HorizontalCard.kt
+++ b/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/ui/HorizontalCard.kt
@@ -39,7 +39,7 @@ internal fun HorizontalPodcastCast(
     shareColors: ShareColors,
     captureController: CaptureController,
     modifier: Modifier = Modifier,
-    useWidthForAspectRatio: Boolean = true,
+    useHeightForAspectRatio: Boolean = true,
     customSize: DpSize? = null,
 ) = HorizontalCard(
     data = PodcastCardData(
@@ -47,7 +47,7 @@ internal fun HorizontalPodcastCast(
         episodeCount = episodeCount,
     ),
     shareColors = shareColors,
-    useWidthForAspectRatio = useWidthForAspectRatio,
+    useHeightForAspectRatio = useHeightForAspectRatio,
     customSize = customSize,
     captureController = captureController,
     modifier = modifier,
@@ -61,7 +61,7 @@ internal fun HorizontalEpisodeCard(
     shareColors: ShareColors,
     captureController: CaptureController,
     modifier: Modifier = Modifier,
-    useWidthForAspectRatio: Boolean = true,
+    useHeightForAspectRatio: Boolean = true,
     customSize: DpSize? = null,
 ) = HorizontalCard(
     data = EpisodeCardData(
@@ -70,7 +70,7 @@ internal fun HorizontalEpisodeCard(
         useEpisodeArtwork = useEpisodeArtwork,
     ),
     shareColors = shareColors,
-    useWidthForAspectRatio = useWidthForAspectRatio,
+    useHeightForAspectRatio = useHeightForAspectRatio,
     customSize = customSize,
     captureController = captureController,
     modifier = modifier,
@@ -88,7 +88,7 @@ fun HorizontalPodcastCardDarkPreview() = HorizontalPodcastCardPreview(
 private fun HorizontalCard(
     data: CardData,
     shareColors: ShareColors,
-    useWidthForAspectRatio: Boolean,
+    useHeightForAspectRatio: Boolean,
     captureController: CaptureController,
     modifier: Modifier = Modifier,
     customSize: DpSize? = null,
@@ -103,10 +103,10 @@ private fun HorizontalCard(
         ),
     )
     val size = customSize ?: DpSize(maxWidth, maxHeight)
-    val (width, height) = if (useWidthForAspectRatio) {
-        size.width to size.width * 0.52f
-    } else {
+    val (width, height) = if (useHeightForAspectRatio) {
         size.height / 0.52f to size.height
+    } else {
+        size.width to size.width * 0.52f
     }
     Row(
         verticalAlignment = Alignment.CenterVertically,
@@ -217,6 +217,6 @@ private fun HorizontalCardPreview(
 ) = HorizontalCard(
     data = data,
     shareColors = ShareColors(baseColor),
-    useWidthForAspectRatio = true,
+    useHeightForAspectRatio = true,
     captureController = rememberCaptureController(),
 )

--- a/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/ui/HorizontalCard.kt
+++ b/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/ui/HorizontalCard.kt
@@ -104,9 +104,9 @@ private fun HorizontalCard(
     )
     val size = customSize ?: DpSize(maxWidth, maxHeight)
     val (width, height) = if (useHeightForAspectRatio) {
-        size.height / 0.52f to size.height
+        size.height / CardType.Horizontal.aspectRatio to size.height
     } else {
-        size.width to size.width * 0.52f
+        size.width to size.width * CardType.Horizontal.aspectRatio
     }
     Row(
         verticalAlignment = Alignment.CenterVertically,

--- a/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/ui/PodcastCard.kt
+++ b/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/ui/PodcastCard.kt
@@ -1,0 +1,46 @@
+package au.com.shiftyjelly.pocketcasts.sharing.ui
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.DpSize
+import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
+import dev.shreyaspatil.capturable.controller.CaptureController
+
+@Composable
+internal fun PodcastCard(
+    cardType: VisualCardType,
+    podcast: Podcast,
+    episodeCount: Int,
+    shareColors: ShareColors,
+    captureController: CaptureController,
+    modifier: Modifier = Modifier,
+    useHeightForAspectRatio: Boolean = cardType == CardType.Vertical,
+    customSize: DpSize? = null,
+) = when (cardType) {
+    CardType.Vertical -> VerticalPodcastCast(
+        podcast = podcast,
+        episodeCount = episodeCount,
+        shareColors = shareColors,
+        captureController = captureController,
+        useHeightForAspectRatio = useHeightForAspectRatio,
+        customSize = customSize,
+        modifier = modifier,
+    )
+    CardType.Horizontal -> HorizontalPodcastCast(
+        podcast = podcast,
+        episodeCount = episodeCount,
+        shareColors = shareColors,
+        captureController = captureController,
+        useHeightForAspectRatio = useHeightForAspectRatio,
+        customSize = customSize,
+        modifier = modifier,
+    )
+    CardType.Square -> SquarePodcastCast(
+        podcast = podcast,
+        episodeCount = episodeCount,
+        shareColors = shareColors,
+        captureController = captureController,
+        customSize = customSize,
+        modifier = modifier,
+    )
+}

--- a/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/ui/PodcastCard.kt
+++ b/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/ui/PodcastCard.kt
@@ -17,7 +17,7 @@ internal fun PodcastCard(
     useHeightForAspectRatio: Boolean = cardType == CardType.Vertical,
     customSize: DpSize? = null,
 ) = when (cardType) {
-    CardType.Vertical -> VerticalPodcastCast(
+    CardType.Vertical -> VerticalPodcastCard(
         podcast = podcast,
         episodeCount = episodeCount,
         shareColors = shareColors,
@@ -26,7 +26,7 @@ internal fun PodcastCard(
         customSize = customSize,
         modifier = modifier,
     )
-    CardType.Horizontal -> HorizontalPodcastCast(
+    CardType.Horizontal -> HorizontalPodcastCard(
         podcast = podcast,
         episodeCount = episodeCount,
         shareColors = shareColors,
@@ -35,7 +35,7 @@ internal fun PodcastCard(
         customSize = customSize,
         modifier = modifier,
     )
-    CardType.Square -> SquarePodcastCast(
+    CardType.Square -> SquarePodcastCard(
         podcast = podcast,
         episodeCount = episodeCount,
         shareColors = shareColors,

--- a/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/ui/SharePage.kt
+++ b/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/ui/SharePage.kt
@@ -168,8 +168,7 @@ private fun MiddleContent(
     }
 
     val coordiantes = estimateCardCoordinates(
-        topContentHeight = topContentHeight,
-        indicatorHeight = indicatorHeight,
+        topContentHeight = topContentHeight + indicatorHeight,
         scrollState = scrollState,
     )
     HorizontalPager(

--- a/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/ui/SharePage.kt
+++ b/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/ui/SharePage.kt
@@ -1,21 +1,26 @@
 package au.com.shiftyjelly.pocketcasts.sharing.ui
 
 import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.ScrollState
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxScope
-import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.sizeIn
 import androidx.compose.foundation.pager.HorizontalPager
+import androidx.compose.foundation.pager.PagerState
 import androidx.compose.foundation.pager.rememberPagerState
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.ButtonDefaults
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Snackbar
@@ -24,9 +29,15 @@ import androidx.compose.material.SnackbarHost
 import androidx.compose.material.SnackbarHostState
 import androidx.compose.material.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.nestedscroll.nestedScroll
+import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.platform.rememberNestedScrollInteropConnection
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import au.com.shiftyjelly.pocketcasts.compose.components.PagerDotIndicator
@@ -47,97 +58,151 @@ internal fun VerticalSharePage(
     onClose: () -> Unit,
     onShareToPlatform: (SocialPlatform, VisualCardType) -> Unit,
     middleContent: @Composable (VisualCardType, Modifier) -> Unit,
-) = Box {
-    Column(
+) {
+    Box(
         modifier = Modifier
-            .fillMaxSize()
-            .background(shareColors.background),
+            .background(shareColors.background)
+            .fillMaxSize(),
     ) {
-        Box(
-            contentAlignment = Alignment.TopEnd,
-            modifier = Modifier
-                .weight(0.2f)
-                .fillMaxSize(),
-        ) {
-            CloseButton(
-                shareColors = shareColors,
-                onClick = onClose,
-                modifier = Modifier.padding(top = 12.dp, end = 12.dp),
-            )
+        Column {
+            val pagerState = rememberPagerState(pageCount = { CardType.visualEntries.size })
+            val scrollState = rememberScrollState()
+            val selectedCard = CardType.visualEntries[pagerState.currentPage]
             Column(
-                horizontalAlignment = Alignment.CenterHorizontally,
                 verticalArrangement = Arrangement.Center,
-                modifier = Modifier.fillMaxSize(),
+                modifier = Modifier
+                    .weight(1f)
+                    .fillMaxWidth()
+                    .scrollBottomFade(scrollState)
+                    .nestedScroll(rememberNestedScrollInteropConnection())
+                    .verticalScroll(scrollState),
             ) {
-                TextH30(
-                    text = shareTitle,
-                    textAlign = TextAlign.Center,
-                    color = shareColors.backgroundPrimaryText,
-                    modifier = Modifier.padding(horizontal = 24.dp),
+                var topContentHeight by remember { mutableIntStateOf(0) }
+                TopContent(
+                    shareTitle = shareTitle,
+                    shareDescription = shareDescription,
+                    shareColors = shareColors,
+                    modifier = Modifier.onGloballyPositioned { coordinates -> topContentHeight = coordinates.size.height },
                 )
-                Spacer(
-                    modifier = Modifier.height(8.dp),
-                )
-                TextH40(
-                    text = shareDescription,
-                    textAlign = TextAlign.Center,
-                    color = shareColors.backgroundSecondaryText,
-                    modifier = Modifier.sizeIn(maxWidth = 220.dp),
+                MiddleContent(
+                    middleContent = middleContent,
+                    pagerState = pagerState,
+                    scrollState = scrollState,
+                    topContentHeight = topContentHeight,
                 )
             }
-        }
-        val pagerState = rememberPagerState(pageCount = { CardType.visualEntries.size })
-        Box(
-            contentAlignment = Alignment.Center,
-            content = {
-                Column(
-                    horizontalAlignment = Alignment.CenterHorizontally,
-                ) {
-                    BoxWithConstraints(
-                        modifier = Modifier.weight(0.92f),
-                    ) {
-                        val expectedVerticalCardPadding = remember(maxWidth, maxHeight) { (maxWidth - maxHeight / 1.5f) / 2 }
-                        HorizontalPager(
-                            state = pagerState,
-                            modifier = Modifier.fillMaxSize(),
-                        ) { pageIndex ->
-                            val cardType = CardType.visualEntries[pageIndex]
-                            val modifier = Modifier
-                                .fillMaxSize()
-                                .then(if (cardType != CardType.Vertical) Modifier.padding(horizontal = expectedVerticalCardPadding) else Modifier)
-                            middleContent(cardType, modifier)
-                        }
-                    }
-                    PagerDotIndicator(
-                        state = pagerState,
-                        activeDotColor = shareColors.pagerIndicatorActive,
-                        inactiveDotColor = shareColors.pagerIndicatorInactive,
-                        modifier = Modifier.weight(0.08f),
-                    )
-                }
-            },
-            modifier = Modifier
-                .weight(0.65f)
-                .fillMaxSize(),
-        )
-        Box(
-            contentAlignment = Alignment.Center,
-            modifier = Modifier.weight(0.15f),
-        ) {
-            PlatformBar(
-                platforms = socialPlatforms,
+            BottomContent(
                 shareColors = shareColors,
-                onClick = { platform ->
-                    onShareToPlatform(platform, CardType.visualEntries[pagerState.currentPage])
-                },
+                platforms = socialPlatforms,
+                selectedCard = selectedCard,
+                onShareToPlatform = onShareToPlatform,
             )
         }
+        CloseButton(
+            shareColors = shareColors,
+            onClick = onClose,
+            modifier = Modifier
+                .padding(top = 12.dp, end = 12.dp)
+                .align(Alignment.TopEnd),
+        )
+        SnackbarHost(
+            hostState = snackbarHostState,
+            modifier = Modifier.align(Alignment.BottomCenter),
+            snackbar = { data -> SharingThemedSnackbar(data, shareColors) },
+        )
     }
-    SnackbarHost(
-        hostState = snackbarHostState,
-        modifier = Modifier.align(Alignment.BottomCenter),
-        snackbar = { data -> SharingThemedSnackbar(data, shareColors) },
+}
+
+@Composable
+private fun TopContent(
+    shareTitle: String,
+    shareDescription: String,
+    shareColors: ShareColors,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center,
+        modifier = modifier.fillMaxWidth(),
+    ) {
+        Spacer(
+            modifier = Modifier.height(24.dp),
+        )
+        TextH30(
+            text = shareTitle,
+            textAlign = TextAlign.Center,
+            color = shareColors.backgroundPrimaryText,
+            modifier = Modifier.padding(horizontal = 24.dp),
+        )
+        Spacer(
+            modifier = Modifier.height(8.dp),
+        )
+        TextH40(
+            text = shareDescription,
+            textAlign = TextAlign.Center,
+            color = shareColors.backgroundSecondaryText,
+            modifier = Modifier.sizeIn(maxWidth = 220.dp),
+        )
+    }
+}
+
+@OptIn(ExperimentalFoundationApi::class)
+@Composable
+private fun MiddleContent(
+    scrollState: ScrollState,
+    pagerState: PagerState,
+    topContentHeight: Int,
+    middleContent: @Composable (VisualCardType, Modifier) -> Unit,
+) {
+    var indicatorHeight by remember { mutableIntStateOf(0) }
+    Row(
+        horizontalArrangement = Arrangement.Center,
+        modifier = Modifier
+            .onGloballyPositioned { coordinates -> indicatorHeight = coordinates.size.height }
+            .fillMaxWidth()
+            .padding(vertical = 24.dp),
+    ) {
+        PagerDotIndicator(
+            state = pagerState,
+        )
+    }
+
+    val coordiantes = estimateCardCoordinates(
+        topContentHeight = topContentHeight,
+        indicatorHeight = indicatorHeight,
+        scrollState = scrollState,
     )
+    HorizontalPager(
+        state = pagerState,
+        modifier = Modifier.height(coordiantes.size.height),
+    ) { pageIndex ->
+        val cardType = CardType.visualEntries[pageIndex]
+        val modifier = Modifier
+            .offset { coordiantes.offset(cardType) }
+            .fillMaxSize()
+            .padding(coordiantes.padding)
+        middleContent(cardType, modifier)
+    }
+}
+
+@Composable
+private fun BottomContent(
+    shareColors: ShareColors,
+    platforms: Set<SocialPlatform>,
+    selectedCard: VisualCardType,
+    onShareToPlatform: (SocialPlatform, VisualCardType) -> Unit,
+) {
+    Box(
+        modifier = Modifier.padding(vertical = 24.dp),
+    ) {
+        PlatformBar(
+            platforms = platforms,
+            shareColors = shareColors,
+            onClick = { platform ->
+                onShareToPlatform(platform, selectedCard)
+            },
+        )
+    }
 }
 
 @Composable

--- a/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/ui/SquareCard.kt
+++ b/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/ui/SquareCard.kt
@@ -31,7 +31,7 @@ import java.sql.Date
 import java.time.Instant
 
 @Composable
-internal fun SquarePodcastCast(
+internal fun SquarePodcastCard(
     podcast: Podcast,
     episodeCount: Int,
     shareColors: ShareColors,

--- a/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/ui/VerticalCard.kt
+++ b/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/ui/VerticalCard.kt
@@ -33,7 +33,7 @@ import java.sql.Date
 import java.time.Instant
 
 @Composable
-internal fun VerticalPodcastCast(
+internal fun VerticalPodcastCard(
     podcast: Podcast,
     episodeCount: Int,
     shareColors: ShareColors,

--- a/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/ui/VerticalCard.kt
+++ b/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/ui/VerticalCard.kt
@@ -97,9 +97,9 @@ private fun VerticalCard(
     )
     val size = customSize ?: DpSize(maxWidth, maxHeight)
     val (height, width) = if (useHeightForAspectRatio) {
-        size.height to size.height / 1.5f
+        size.height to size.height / CardType.Vertical.aspectRatio
     } else {
-        size.width * 1.5f to size.width
+        size.width * CardType.Vertical.aspectRatio to size.width
     }
     Column(
         horizontalAlignment = Alignment.CenterHorizontally,


### PR DESCRIPTION
## Description

This PR uses scrolling card pattern established in #2579 in other sharing screens.

## Testing Instructions

Test UI of podcast, episode, and episode timestamp sharing pages.

## Screenshots or Screencast 

| Pixel 6 | Small device |
| - | - |
| ![Screenshot_20240807-201319](https://github.com/user-attachments/assets/edc1b0d9-4c81-45e5-849f-56e6bf695582) | ![Screenshot_20240807_201517](https://github.com/user-attachments/assets/30785f62-6523-4980-87e5-e7447728084b) |

## Checklist
- [x] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] ~I have considered whether it makes sense to add tests for my changes~
- [x] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
