### PR TITLE
Add landscape layout to clip sharing

### DIFF
--- a/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/clip/ShareClipPage.kt
+++ b/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/clip/ShareClipPage.kt
@@ -197,13 +197,13 @@ private fun VerticalClipPage(
                         .nestedScroll(rememberNestedScrollInteropConnection())
                         .verticalScroll(scrollState),
                 ) {
-                    TopContent(
+                    DescriptionContent(
                         isSharing = isSharing,
                         shareColors = shareColors,
                         selectedCard = selectedCard,
                         state = state,
                     )
-                    MiddleContent(
+                    PagingContent(
                         episode = episode,
                         podcast = podcast,
                         useEpisodeArtwork = useEpisodeArtwork,
@@ -215,7 +215,7 @@ private fun VerticalClipPage(
                         pagerState = pagerState,
                     )
                 }
-                BottomContent(
+                PageControlsContent(
                     podcast = podcast,
                     episode = episode,
                     clipRange = clipRange,
@@ -246,7 +246,91 @@ private fun VerticalClipPage(
 }
 
 @Composable
-private fun TopContent(
+private fun HorizontalClipPage(
+    episode: PodcastEpisode?,
+    podcast: Podcast?,
+    clipRange: Clip.Range,
+    playbackProgress: Duration,
+    isPlaying: Boolean,
+    isSharing: Boolean,
+    useEpisodeArtwork: Boolean,
+    platforms: Set<SocialPlatform>,
+    shareColors: ShareColors,
+    assetController: BackgroundAssetController,
+    listener: ShareClipPageListener,
+    state: ClipPageState,
+    snackbarHostState: SnackbarHostState,
+) {
+    Box(
+        modifier = Modifier
+            .background(shareColors.background)
+            .fillMaxSize(),
+    ) {
+        AnimatedVisiblity(podcast, episode) { podcast, episode ->
+            Column(
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                DescriptionContent(
+                    isSharing = isSharing,
+                    shareColors = shareColors,
+                    selectedCard = CardType.Horizontal,
+                    state = state,
+                )
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    modifier = Modifier.fillMaxSize(),
+                ) {
+                    Spacer(
+                        modifier = Modifier.weight(0.1f),
+                    )
+                    HorizontalEpisodeCard(
+                        episode = episode,
+                        podcast = podcast,
+                        useEpisodeArtwork = useEpisodeArtwork,
+                        shareColors = shareColors,
+                        captureController = assetController.captureController(CardType.Horizontal),
+                        modifier = Modifier.weight(1f),
+                    )
+                    Spacer(
+                        modifier = Modifier.weight(0.05f),
+                    )
+                    PageControlsContent(
+                        podcast = podcast,
+                        episode = episode,
+                        clipRange = clipRange,
+                        playbackProgress = playbackProgress,
+                        isPlaying = isPlaying,
+                        isSharing = isSharing,
+                        platforms = platforms,
+                        shareColors = shareColors,
+                        selectedCard = CardType.Horizontal,
+                        listener = listener,
+                        state = state,
+                        modifier = Modifier.weight(1f),
+                    )
+                    Spacer(
+                        modifier = Modifier.weight(0.1f),
+                    )
+                }
+            }
+        }
+        CloseButton(
+            shareColors = shareColors,
+            onClick = listener::onClose,
+            modifier = Modifier
+                .padding(top = 12.dp, end = 12.dp)
+                .align(Alignment.TopEnd),
+        )
+        SnackbarHost(
+            hostState = snackbarHostState,
+            modifier = Modifier.align(Alignment.BottomCenter),
+            snackbar = { data -> SharingThemedSnackbar(data, shareColors) },
+        )
+    }
+}
+
+@Composable
+private fun DescriptionContent(
     isSharing: Boolean,
     shareColors: ShareColors,
     selectedCard: CardType,
@@ -342,7 +426,7 @@ private fun TopContent(
 
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
-private fun MiddleContent(
+private fun PagingContent(
     episode: PodcastEpisode,
     podcast: Podcast,
     isSharing: Boolean,
@@ -414,7 +498,7 @@ private fun MiddleContent(
 }
 
 @Composable
-private fun BottomContent(
+private fun PageControlsContent(
     podcast: Podcast,
     episode: PodcastEpisode,
     clipRange: Clip.Range,
@@ -605,90 +689,6 @@ private fun SharingControls(
                 }
             }
         }
-    }
-}
-
-@Composable
-private fun HorizontalClipPage(
-    episode: PodcastEpisode?,
-    podcast: Podcast?,
-    clipRange: Clip.Range,
-    playbackProgress: Duration,
-    isPlaying: Boolean,
-    isSharing: Boolean,
-    useEpisodeArtwork: Boolean,
-    platforms: Set<SocialPlatform>,
-    shareColors: ShareColors,
-    assetController: BackgroundAssetController,
-    listener: ShareClipPageListener,
-    state: ClipPageState,
-    snackbarHostState: SnackbarHostState,
-) {
-    Box(
-        modifier = Modifier
-            .background(shareColors.background)
-            .fillMaxSize(),
-    ) {
-        AnimatedVisiblity(podcast, episode) { podcast, episode ->
-            Column(
-                modifier = Modifier.fillMaxWidth(),
-            ) {
-                TopContent(
-                    isSharing = isSharing,
-                    shareColors = shareColors,
-                    selectedCard = CardType.Horizontal,
-                    state = state,
-                )
-                Row(
-                    verticalAlignment = Alignment.CenterVertically,
-                    modifier = Modifier.fillMaxSize(),
-                ) {
-                    Spacer(
-                        modifier = Modifier.weight(0.1f),
-                    )
-                    HorizontalEpisodeCard(
-                        episode = episode,
-                        podcast = podcast,
-                        useEpisodeArtwork = useEpisodeArtwork,
-                        shareColors = shareColors,
-                        captureController = assetController.captureController(CardType.Horizontal),
-                        modifier = Modifier.weight(1f),
-                    )
-                    Spacer(
-                        modifier = Modifier.weight(0.05f),
-                    )
-                    BottomContent(
-                        podcast = podcast,
-                        episode = episode,
-                        clipRange = clipRange,
-                        playbackProgress = playbackProgress,
-                        isPlaying = isPlaying,
-                        isSharing = isSharing,
-                        platforms = platforms,
-                        shareColors = shareColors,
-                        selectedCard = CardType.Horizontal,
-                        listener = listener,
-                        state = state,
-                        modifier = Modifier.weight(1f),
-                    )
-                    Spacer(
-                        modifier = Modifier.weight(0.1f),
-                    )
-                }
-            }
-        }
-        CloseButton(
-            shareColors = shareColors,
-            onClick = listener::onClose,
-            modifier = Modifier
-                .padding(top = 12.dp, end = 12.dp)
-                .align(Alignment.TopEnd),
-        )
-        SnackbarHost(
-            hostState = snackbarHostState,
-            modifier = Modifier.align(Alignment.BottomCenter),
-            snackbar = { data -> SharingThemedSnackbar(data, shareColors) },
-        )
     }
 }
 

--- a/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/clip/ShareClipPage.kt
+++ b/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/clip/ShareClipPage.kt
@@ -56,7 +56,6 @@ import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import au.com.shiftyjelly.pocketcasts.compose.Devices
 import au.com.shiftyjelly.pocketcasts.compose.buttons.BaseRowButton
@@ -203,10 +202,6 @@ private fun VerticalClipPage(
                         shareColors = shareColors,
                         selectedCard = selectedCard,
                         state = state,
-                        bottomSpace = when (state.step) {
-                            SharingStep.Creating -> 12.dp
-                            SharingStep.Sharing -> 48.dp
-                        },
                     )
                     MiddleContent(
                         episode = episode,
@@ -256,10 +251,10 @@ private fun TopContent(
     shareColors: ShareColors,
     selectedCard: CardType,
     state: ClipPageState,
-    bottomSpace: Dp,
 ) {
     val titleId = if (selectedCard is CardType.Audio) LR.string.share_clip_create_audio_label else LR.string.share_clip_create_label
     val descriptionId = if (selectedCard is CardType.Audio) LR.string.share_clip_create_audio_description else LR.string.single_space
+    val orientation = LocalConfiguration.current.orientation
     AnimatedContent(
         label = "TopContent",
         targetState = Triple(state.step, titleId, descriptionId),
@@ -297,13 +292,16 @@ private fun TopContent(
             )
             val alpha by animateFloatAsState(targetValue = if (isSharing) 0.3f else 1f)
             when (step) {
-                SharingStep.Creating -> TextH40(
-                    text = stringResource(descriptionId),
-                    textAlign = TextAlign.Center,
-                    maxLines = 1,
-                    color = shareColors.backgroundSecondaryText,
-                    modifier = Modifier.padding(horizontal = 24.dp),
-                )
+                SharingStep.Creating -> when (orientation) {
+                    Configuration.ORIENTATION_LANDSCAPE -> Unit
+                    else -> TextH40(
+                        text = stringResource(descriptionId),
+                        textAlign = TextAlign.Center,
+                        maxLines = 1,
+                        color = shareColors.backgroundSecondaryText,
+                        modifier = Modifier.padding(horizontal = 24.dp),
+                    )
+                }
                 SharingStep.Sharing -> TextH40(
                     text = stringResource(LR.string.share_clip_edit_label),
                     textAlign = TextAlign.Center,
@@ -327,6 +325,13 @@ private fun TopContent(
                         )
                         .padding(vertical = 4.dp, horizontal = 16.dp),
                 )
+            }
+            val bottomSpace = when (orientation) {
+                Configuration.ORIENTATION_LANDSCAPE -> 0.dp
+                else -> when (step) {
+                    SharingStep.Creating -> 12.dp
+                    SharingStep.Sharing -> 48.dp
+                }
             }
             Spacer(
                 modifier = Modifier.height(bottomSpace),
@@ -633,7 +638,6 @@ private fun HorizontalClipPage(
                     shareColors = shareColors,
                     selectedCard = CardType.Horizontal,
                     state = state,
-                    bottomSpace = 0.dp,
                 )
                 Row(
                     verticalAlignment = Alignment.CenterVertically,

--- a/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/clip/ShareClipPage.kt
+++ b/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/clip/ShareClipPage.kt
@@ -1,5 +1,6 @@
 package au.com.shiftyjelly.pocketcasts.sharing.clip
 
+import android.content.res.Configuration
 import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.core.animateFloatAsState
@@ -47,6 +48,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.rememberNestedScrollInteropConnection
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
@@ -123,21 +125,42 @@ internal fun ShareClipPage(
         firstVisibleItemIndex = (clipRange.startInSeconds - 10).coerceAtLeast(0),
     ),
     snackbarHostState: SnackbarHostState = remember { SnackbarHostState() },
-) = VerticalClipPage(
-    episode = episode,
-    podcast = podcast,
-    clipRange = clipRange,
-    playbackProgress = playbackProgress,
-    isPlaying = isPlaying,
-    isSharing = isSharing,
-    useEpisodeArtwork = useEpisodeArtwork,
-    platforms = platforms,
-    shareColors = shareColors,
-    assetController = assetController,
-    listener = listener,
-    state = state,
-    snackbarHostState = snackbarHostState,
-)
+) {
+    when (LocalConfiguration.current.orientation) {
+        Configuration.ORIENTATION_LANDSCAPE -> HorizontalClipPage(
+            episode = episode,
+            podcast = podcast,
+            clipRange = clipRange,
+            playbackProgress = playbackProgress,
+            isPlaying = isPlaying,
+            isSharing = isSharing,
+            useEpisodeArtwork = useEpisodeArtwork,
+            platforms = platforms,
+            shareColors = shareColors,
+            assetController = assetController,
+            listener = listener,
+            state = state,
+            snackbarHostState = snackbarHostState,
+        )
+        else -> VerticalClipPage(
+            episode = episode,
+            podcast = podcast,
+            clipRange = clipRange,
+            playbackProgress = playbackProgress,
+            isPlaying = isPlaying,
+            isSharing = isSharing,
+            useEpisodeArtwork = useEpisodeArtwork,
+            platforms = platforms,
+            shareColors = shareColors,
+            assetController = assetController,
+            listener = listener,
+            state = state,
+            snackbarHostState = snackbarHostState,
+        )
+    }
+
+
+}
 
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
@@ -579,6 +602,31 @@ private fun SharingControls(
 }
 
 @Composable
+private fun HorizontalClipPage(
+    episode: PodcastEpisode?,
+    podcast: Podcast?,
+    clipRange: Clip.Range,
+    playbackProgress: Duration,
+    isPlaying: Boolean,
+    isSharing: Boolean,
+    useEpisodeArtwork: Boolean,
+    platforms: Set<SocialPlatform>,
+    shareColors: ShareColors,
+    assetController: BackgroundAssetController,
+    listener: ShareClipPageListener,
+    state: ClipPageState,
+    snackbarHostState: SnackbarHostState,
+) {
+    Box(
+        modifier = Modifier
+            .background(shareColors.background)
+            .fillMaxSize()
+    ) {
+        println(listOf(episode, podcast, clipRange, playbackProgress, isPlaying, isSharing, useEpisodeArtwork, platforms, assetController, listener, state, snackbarHostState))
+    }
+}
+
+@Composable
 private fun AnimatedVisiblity(
     podcast: Podcast?,
     episode: PodcastEpisode?,
@@ -594,34 +642,55 @@ private fun AnimatedVisiblity(
     }
 }
 
-@Preview(name = "Regular device", device = Devices.PortraitRegular)
+@Preview(name = "Regular device", device = Devices.PortraitRegular, group = "vertical")
 @Composable
 private fun ShareClipVerticalRegularPreview() = ShareClipPagePreview()
 
-@Preview(name = "Regular device sharing", device = Devices.PortraitRegular)
+@Preview(name = "Regular device sharing", device = Devices.PortraitRegular, group = "vertical")
 @Composable
 private fun ShareClipVerticalRegularSharingPreview() = ShareClipPagePreview(
     step = SharingStep.Sharing,
 )
 
-@Preview(name = "Regular device clipping", device = Devices.PortraitRegular)
+@Preview(name = "Regular device clipping", device = Devices.PortraitRegular, group = "vertical")
 @Composable
 private fun ShareClipVerticalRegularClippingPreview() = ShareClipPagePreview(
     step = SharingStep.Sharing,
     isSharing = true,
 )
 
-@Preview(name = "Small device", device = Devices.PortraitSmall)
+@Preview(name = "Small device", device = Devices.PortraitSmall, group = "vertical")
 @Composable
 private fun ShareClipVerticalSmallPreviewPreview() = ShareClipPagePreview()
 
-@Preview(name = "Foldable device", device = Devices.PortraitFoldable)
+@Preview(name = "Foldable device", device = Devices.PortraitFoldable, group = "irregular")
 @Composable
 private fun ShareClipVerticalFoldablePreviewPreview() = ShareClipPagePreview()
 
-@Preview(name = "Tablet device", device = Devices.PortraitTablet)
+@Preview(name = "Tablet device", device = Devices.PortraitTablet, group = "irregular")
 @Composable
 private fun ShareClipVerticalTabletPreview() = ShareClipPagePreview()
+
+@Preview(name = "Regular device horizontal sharing", device = Devices.LandscapeRegular, group = "horizontal")
+@Composable
+private fun ShareClipHorizontalRegularPreview() = ShareClipPagePreview()
+
+@Preview(name = "Regular device horizontal clipping", device = Devices.LandscapeRegular, group = "horizontal")
+@Composable
+private fun ShareClipHorizontalRegularSharingPreview() = ShareClipPagePreview(
+    step = SharingStep.Sharing,
+)
+
+@Preview(name = "Regular device horizontal", device = Devices.LandscapeRegular, group = "horizontal")
+@Composable
+private fun ShareClipHorizontalRegularClippingPreview() = ShareClipPagePreview(
+    step = SharingStep.Sharing,
+    isSharing = true,
+)
+
+@Preview(name = "Small device horizontal", device = Devices.LandscapeSmall, group = "horizontal")
+@Composable
+private fun ShareClipHorizontalSmallPreviewPreview() = ShareClipPagePreview()
 
 @Composable
 internal fun ShareClipPagePreview(

--- a/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/ui/SharePage.kt
+++ b/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/ui/SharePage.kt
@@ -208,27 +208,19 @@ internal fun HorizontalSharePage(
     onClose: () -> Unit,
     onShareToPlatform: (SocialPlatform, VisualCardType) -> Unit,
     middleContent: @Composable BoxScope.() -> Unit,
-) = Box {
-    Column(
+) {
+    Box(
         modifier = Modifier
-            .fillMaxSize()
-            .background(shareColors.background),
+            .background(shareColors.background)
+            .fillMaxSize(),
     ) {
-        Box(
-            contentAlignment = Alignment.TopEnd,
-            modifier = Modifier
-                .weight(0.25f)
-                .fillMaxSize(),
+        Column(
+            modifier = Modifier.fillMaxSize(),
         ) {
-            CloseButton(
-                shareColors = shareColors,
-                onClick = onClose,
-                modifier = Modifier.padding(top = 12.dp, end = 12.dp),
-            )
             Column(
                 horizontalAlignment = Alignment.CenterHorizontally,
                 verticalArrangement = Arrangement.Center,
-                modifier = Modifier.fillMaxSize(),
+                modifier = Modifier.fillMaxWidth().padding(vertical = 24.dp),
             ) {
                 TextH30(
                     text = shareTitle,
@@ -246,47 +238,53 @@ internal fun HorizontalSharePage(
                     modifier = Modifier.padding(horizontal = 24.dp),
                 )
             }
-        }
-        Row(
-            modifier = Modifier
-                .weight(0.75f)
-                .fillMaxSize(),
-        ) {
-            Spacer(
-                modifier = Modifier.weight(0.1f),
-            )
-            Box(
-                contentAlignment = Alignment.Center,
-                content = middleContent,
-                modifier = Modifier
-                    .weight(1f)
-                    .fillMaxHeight(),
-            )
-            Spacer(
-                modifier = Modifier.weight(0.1f),
-            )
-            Box(
-                contentAlignment = Alignment.Center,
-                modifier = Modifier
-                    .weight(1f)
-                    .fillMaxHeight(),
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                modifier = Modifier.fillMaxSize(),
             ) {
-                PlatformBar(
-                    platforms = socialPlatforms,
-                    shareColors = shareColors,
-                    onClick = { platform ->
-                        onShareToPlatform(platform, CardType.Horizontal)
-                    },
+                Spacer(
+                    modifier = Modifier.weight(0.1f),
+                )
+                Box(
+                    contentAlignment = Alignment.Center,
+                    content = middleContent,
+                    modifier = Modifier
+                        .weight(1f)
+                        .fillMaxSize(),
+                )
+                Spacer(
+                    modifier = Modifier.weight(0.05f),
+                )
+                Box(
+                    contentAlignment = Alignment.Center,
+                    modifier = Modifier
+                        .weight(1f)
+                        .fillMaxHeight(),
+                ) {
+                    PlatformBar(
+                        platforms = socialPlatforms,
+                        shareColors = shareColors,
+                        onClick = { platform ->
+                            onShareToPlatform(platform, CardType.Horizontal)
+                        },
+                    )
+                }
+                Spacer(
+                    modifier = Modifier.weight(0.1f),
                 )
             }
-            Spacer(
-                modifier = Modifier.weight(0.1f),
-            )
         }
+        CloseButton(
+            shareColors = shareColors,
+            onClick = onClose,
+            modifier = Modifier
+                .padding(top = 12.dp, end = 12.dp)
+                .align(Alignment.TopEnd),
+        )
+        SnackbarHost(
+            hostState = snackbarHostState,
+            modifier = Modifier.align(Alignment.BottomCenter),
+            snackbar = { data -> SharingThemedSnackbar(data, shareColors) },
+        )
     }
-    SnackbarHost(
-        hostState = snackbarHostState,
-        modifier = Modifier.align(Alignment.BottomCenter),
-        snackbar = { data -> SharingThemedSnackbar(data, shareColors) },
-    )
 }


### PR DESCRIPTION
## Description

This PR adds the landscape layout for clip sharing. It supports only horizontal card.

On large devices the card is too big. I will change it in a separate PR.

## Testing Instructions

1. Start clip sharing.
2. Change your device's orientation to the horizontal one.
3. Check the sharing flow.
4. Sharing state should be persistent across configuration changes between portrait and landscape orientation.

## Screenshots or Screencast 

![Screenshot 2024-08-08 at 13 15 36](https://github.com/user-attachments/assets/986d58e1-bc48-4ee6-859f-82f5223a96a6)

## Checklist
- [x] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] ~I have considered whether it makes sense to add tests for my changes~
- [x] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
