### PR TITLE
Add sharing analytics

### DIFF
--- a/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/clip/ClipAnalytics.kt
+++ b/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/clip/ClipAnalytics.kt
@@ -3,6 +3,7 @@ package au.com.shiftyjelly.pocketcasts.sharing.clip
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTracker
 import au.com.shiftyjelly.pocketcasts.analytics.SourceView
+import au.com.shiftyjelly.pocketcasts.sharing.ui.CardType
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
@@ -16,27 +17,37 @@ class ClipAnalytics @AssistedInject constructor(
     private val analyticsTracker: AnalyticsTracker,
 ) {
     fun screenShown() {
-        trackEvent(createBaseEvent(AnalyticsEvent.CLIP_SCREEN_SHOWN))
+        val event = createBaseEvent(
+            AnalyticsEvent.SHARE_SCREEN_SHOWN,
+            mapOf("type" to "clip"),
+        )
+        trackEvent(event)
     }
 
     fun playTapped() {
-        trackEvent(createBaseEvent(AnalyticsEvent.CLIP_SCREEN_PLAY_TAPPED))
+        trackEvent(createBaseEvent(AnalyticsEvent.SHARE_SCREEN_PLAY_TAPPED))
     }
 
     fun pauseTapped() {
-        trackEvent(createBaseEvent(AnalyticsEvent.CLIP_SCREEN_PAUSE_TAPPED))
+        trackEvent(createBaseEvent(AnalyticsEvent.SHARE_SCREEN_PAUSE_TAPPED))
     }
 
-    fun linkShared(clip: Clip) {
-        val isStartModified = initialClipRange.startInSeconds != clip.range.startInSeconds
-        val isEndMofidied = initialClipRange.endInSeconds != clip.range.endInSeconds
+    fun clipShared(
+        clipRange: Clip.Range,
+        shareType: ClipShareType,
+        cardType: CardType,
+    ) {
+        val isStartModified = initialClipRange.startInSeconds != clipRange.startInSeconds
+        val isEndMofidied = initialClipRange.endInSeconds != clipRange.endInSeconds
         val event = createBaseEvent(
-            AnalyticsEvent.CLIP_SCREEN_LINK_SHARED,
+            AnalyticsEvent.SHARE_SCREEN_CLIP_SHARED,
             mapOf(
-                "start" to clip.range.startInSeconds,
-                "end" to clip.range.endInSeconds,
+                "start" to clipRange.startInSeconds,
+                "end" to clipRange.endInSeconds,
                 "start_modified" to isStartModified,
                 "end_modified" to isEndMofidied,
+                "type" to shareType.analyticsValue,
+                "card_type" to cardType.analyticsValue,
             ),
         )
         trackEvent(event)
@@ -55,6 +66,19 @@ class ClipAnalytics @AssistedInject constructor(
             "source" to source.analyticsValue,
         ) + properties,
     )
+
+    private val ClipShareType.analyticsValue get() = when (this) {
+        ClipShareType.Audio -> "audio"
+        ClipShareType.Video -> "video"
+        ClipShareType.Link -> "link"
+    }
+
+    private val CardType.analyticsValue get() = when (this) {
+        CardType.Audio -> "audio"
+        CardType.Horizontal -> "horizontal"
+        CardType.Square -> "square"
+        CardType.Vertical -> "vertical"
+    }
 
     private class Event(
         val type: AnalyticsEvent,

--- a/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/clip/ClipShareType.kt
+++ b/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/clip/ClipShareType.kt
@@ -1,0 +1,7 @@
+package au.com.shiftyjelly.pocketcasts.sharing.clip
+
+enum class ClipShareType {
+    Audio,
+    Video,
+    Link,
+}

--- a/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/clip/ShareClipFragment.kt
+++ b/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/clip/ShareClipFragment.kt
@@ -78,7 +78,7 @@ class ShareClipFragment : BaseDialogFragment() {
             initialClipRange = args.clipRange,
         )
         if (savedInstanceState == null) {
-            viewModel.onClipScreenShown()
+            viewModel.onScreenShown()
         }
     }
 

--- a/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/clip/ShareClipViewModel.kt
+++ b/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/clip/ShareClipViewModel.kt
@@ -103,14 +103,9 @@ class ShareClipViewModel @AssistedInject constructor(
         clipPlayer.stop()
     }
 
-    fun onClipScreenShown() {
+    fun onScreenShown() {
         Timber.tag(TAG).d("Clip screen shown")
         clipAnalytics.screenShown()
-    }
-
-    fun onClipLinkShared(clip: Clip) {
-        Timber.tag(TAG).d("Clip shared: $clip")
-        clipAnalytics.linkShared(clip)
     }
 
     fun updateClipProgress(progress: Duration) {
@@ -170,18 +165,21 @@ class ShareClipViewModel @AssistedInject constructor(
         return when (cardType) {
             is VisualCardType -> when (platform) {
                 SocialPlatform.PocketCasts -> {
+                    clipAnalytics.clipShared(clipRange, ClipShareType.Link, cardType)
                     Result.success(clipLinkRequest(podcast, episode, clipRange, cardType, sourceView))
                 }
 
                 SocialPlatform.Instagram, SocialPlatform.WhatsApp, SocialPlatform.Telegram,
                 SocialPlatform.X, SocialPlatform.Tumblr, SocialPlatform.More,
                 -> {
+                    clipAnalytics.clipShared(clipRange, ClipShareType.Video, cardType)
                     createBackgroundAsset(cardType).map { asset ->
                         videoClipReequest(podcast, episode, clipRange, platform, cardType, asset, sourceView)
                     }
                 }
             }
             is CardType.Audio -> {
+                clipAnalytics.clipShared(clipRange, ClipShareType.Audio, cardType)
                 Result.success(audioClipRequest(podcast, episode, clipRange, sourceView))
             }
         }

--- a/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/episode/ShareEpisodeFragment.kt
+++ b/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/episode/ShareEpisodeFragment.kt
@@ -36,12 +36,23 @@ class ShareEpisodeFragment : BaseDialogFragment() {
     private val viewModel by viewModels<ShareEpisodeViewModel>(
         extrasProducer = {
             defaultViewModelCreationExtras.withCreationCallback<ShareEpisodeViewModel.Factory> { factory ->
-                factory.create(args.episodeUuid)
+                factory.create(
+                    podcastUuid = args.podcastUuid,
+                    episodeUuid = args.episodeUuid,
+                    sourceView = args.source,
+                )
             }
         },
     )
 
     @Inject internal lateinit var shareListenerFactory: ShareEpisodeListener.Factory
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        if (savedInstanceState == null) {
+            viewModel.onScreenShown()
+        }
+    }
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -75,6 +86,7 @@ class ShareEpisodeFragment : BaseDialogFragment() {
 
     @Parcelize
     private class Args(
+        val podcastUuid: String,
         val episodeUuid: String,
         @TypeParceler<Color, ColorParceler>() val baseColor: Color,
         val source: SourceView,
@@ -90,6 +102,7 @@ class ShareEpisodeFragment : BaseDialogFragment() {
         ) = ShareEpisodeFragment().apply {
             arguments = bundleOf(
                 NEW_INSTANCE_ARG to Args(
+                    podcastUuid = episode.podcastUuid,
                     episodeUuid = episode.uuid,
                     baseColor = Color(baseColor),
                     source = source,

--- a/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/episode/ShareEpisodeViewModel.kt
+++ b/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/episode/ShareEpisodeViewModel.kt
@@ -2,6 +2,9 @@ package au.com.shiftyjelly.pocketcasts.sharing.episode
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
+import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTracker
+import au.com.shiftyjelly.pocketcasts.analytics.SourceView
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
@@ -18,10 +21,13 @@ import kotlinx.coroutines.flow.stateIn
 
 @HiltViewModel(assistedFactory = ShareEpisodeViewModel.Factory::class)
 class ShareEpisodeViewModel @AssistedInject constructor(
-    @Assisted episodeUuid: String,
+    @Assisted("podcastId") private val podcastUuid: String,
+    @Assisted("episodeId") private val episodeUuid: String,
+    @Assisted private val sourceView: SourceView,
     private val episodeManager: EpisodeManager,
     private val podcastManager: PodcastManager,
     private val settings: Settings,
+    private val tracker: AnalyticsTracker,
 ) : ViewModel() {
     val uiState = combine(
         podcastManager.observePodcastByEpisodeUuid(episodeUuid),
@@ -36,8 +42,24 @@ class ShareEpisodeViewModel @AssistedInject constructor(
         val useEpisodeArtwork: Boolean = false,
     )
 
+    fun onScreenShown() {
+        tracker.track(
+            AnalyticsEvent.SHARE_SCREEN_SHOWN,
+            mapOf(
+                "type" to "episode",
+                "podcast_uuid" to podcastUuid,
+                "episode_uuid" to episodeUuid,
+                "source" to sourceView.analyticsValue,
+            ),
+        )
+    }
+
     @AssistedFactory
     interface Factory {
-        fun create(episodeUuid: String): ShareEpisodeViewModel
+        fun create(
+            @Assisted("podcastId") podcastUuid: String,
+            @Assisted("episodeId") episodeUuid: String,
+            sourceView: SourceView,
+        ): ShareEpisodeViewModel
     }
 }

--- a/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/podcast/SharePodcastFragment.kt
+++ b/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/podcast/SharePodcastFragment.kt
@@ -35,12 +35,22 @@ class SharePodcastFragment : BaseDialogFragment() {
     private val viewModel by viewModels<SharePodcastViewModel>(
         extrasProducer = {
             defaultViewModelCreationExtras.withCreationCallback<SharePodcastViewModel.Factory> { factory ->
-                factory.create(args.podcastUuid)
+                factory.create(
+                    podcastUuid = args.podcastUuid,
+                    sourceView = args.source,
+                )
             }
         },
     )
 
     @Inject internal lateinit var shareListenerFactory: SharePodcastListener.Factory
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        if (savedInstanceState == null) {
+            viewModel.onScreenShown()
+        }
+    }
 
     override fun onCreateView(
         inflater: LayoutInflater,

--- a/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/timestamp/ShareEpisodeTimestampFragment.kt
+++ b/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/timestamp/ShareEpisodeTimestampFragment.kt
@@ -39,12 +39,23 @@ class ShareEpisodeTimestampFragment : BaseDialogFragment() {
     private val viewModel by viewModels<ShareEpisodeTimestampViewModel>(
         extrasProducer = {
             defaultViewModelCreationExtras.withCreationCallback<ShareEpisodeTimestampViewModel.Factory> { factory ->
-                factory.create(args.episodeUuid)
+                factory.create(
+                    podcastUuid = args.podcastUuid,
+                    episodeUuid = args.episodeUuid,
+                    sourceView = args.source,
+                )
             }
         },
     )
 
     @Inject internal lateinit var shareListenerFactory: ShareEpisodeTimestampListener.Factory
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        if (savedInstanceState == null) {
+            viewModel.onScreenShown()
+        }
+    }
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -79,6 +90,7 @@ class ShareEpisodeTimestampFragment : BaseDialogFragment() {
 
     @Parcelize
     private class Args(
+        val podcastUuid: String,
         val episodeUuid: String,
         @TypeParceler<Duration, DurationParceler>() val timestamp: Duration,
         @TypeParceler<Color, ColorParceler>() val baseColor: Color,
@@ -96,6 +108,7 @@ class ShareEpisodeTimestampFragment : BaseDialogFragment() {
         ) = ShareEpisodeTimestampFragment().apply {
             arguments = bundleOf(
                 NEW_INSTANCE_ARG to Args(
+                    podcastUuid = episode.podcastUuid,
                     episodeUuid = episode.uuid,
                     timestamp = episode.playedUpTo.seconds,
                     baseColor = Color(baseColor),
@@ -113,6 +126,7 @@ class ShareEpisodeTimestampFragment : BaseDialogFragment() {
         ) = ShareEpisodeTimestampFragment().apply {
             arguments = bundleOf(
                 NEW_INSTANCE_ARG to Args(
+                    podcastUuid = episode.podcastUuid,
                     episodeUuid = episode.uuid,
                     timestamp = timestamp,
                     baseColor = Color(baseColor),

--- a/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/timestamp/ShareEpisodeTimestampViewModel.kt
+++ b/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/timestamp/ShareEpisodeTimestampViewModel.kt
@@ -2,6 +2,9 @@ package au.com.shiftyjelly.pocketcasts.sharing.timestamp
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
+import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTracker
+import au.com.shiftyjelly.pocketcasts.analytics.SourceView
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
@@ -18,10 +21,13 @@ import kotlinx.coroutines.flow.stateIn
 
 @HiltViewModel(assistedFactory = ShareEpisodeTimestampViewModel.Factory::class)
 class ShareEpisodeTimestampViewModel @AssistedInject constructor(
-    @Assisted episodeUuid: String,
+    @Assisted("podcastId") private val podcastUuid: String,
+    @Assisted("episodeId") private val episodeUuid: String,
+    @Assisted private val sourceView: SourceView,
     private val episodeManager: EpisodeManager,
     private val podcastManager: PodcastManager,
     private val settings: Settings,
+    private val tracker: AnalyticsTracker,
 ) : ViewModel() {
     val uiState = combine(
         podcastManager.observePodcastByEpisodeUuid(episodeUuid),
@@ -36,8 +42,24 @@ class ShareEpisodeTimestampViewModel @AssistedInject constructor(
         val useEpisodeArtwork: Boolean = false,
     )
 
+    fun onScreenShown() {
+        tracker.track(
+            AnalyticsEvent.SHARE_SCREEN_SHOWN,
+            mapOf(
+                "type" to "episode_timestamp",
+                "podcast_uuid" to podcastUuid,
+                "episode_uuid" to episodeUuid,
+                "source" to sourceView.analyticsValue,
+            ),
+        )
+    }
+
     @AssistedFactory
     interface Factory {
-        fun create(episodeUuid: String): ShareEpisodeTimestampViewModel
+        fun create(
+            @Assisted("podcastId") podcastUuid: String,
+            @Assisted("episodeId") episodeUuid: String,
+            sourceView: SourceView,
+        ): ShareEpisodeTimestampViewModel
     }
 }

--- a/modules/features/sharing/src/test/kotlin/au/com/shiftyjelly/pocketcasts/sharing/FakeTracker.kt
+++ b/modules/features/sharing/src/test/kotlin/au/com/shiftyjelly/pocketcasts/sharing/FakeTracker.kt
@@ -1,4 +1,4 @@
-package au.com.shiftyjelly.pocketcasts.sharing.clip
+package au.com.shiftyjelly.pocketcasts.sharing
 
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
 import au.com.shiftyjelly.pocketcasts.analytics.Tracker

--- a/modules/features/sharing/src/test/kotlin/au/com/shiftyjelly/pocketcasts/sharing/timestamp/ShareEpisodeTimestampViewModelTest.kt
+++ b/modules/features/sharing/src/test/kotlin/au/com/shiftyjelly/pocketcasts/sharing/timestamp/ShareEpisodeTimestampViewModelTest.kt
@@ -1,6 +1,9 @@
 package au.com.shiftyjelly.pocketcasts.sharing.timestamp
 
 import app.cash.turbine.test
+import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
+import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTracker
+import au.com.shiftyjelly.pocketcasts.analytics.SourceView
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
@@ -9,6 +12,8 @@ import au.com.shiftyjelly.pocketcasts.preferences.model.ArtworkConfiguration
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
 import au.com.shiftyjelly.pocketcasts.sharedtest.MainCoroutineRule
+import au.com.shiftyjelly.pocketcasts.sharing.FakeTracker
+import au.com.shiftyjelly.pocketcasts.sharing.TrackEvent
 import au.com.shiftyjelly.pocketcasts.sharing.timestamp.ShareEpisodeTimestampViewModel.UiState
 import java.util.Date
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -27,6 +32,7 @@ class ShareEpisodeTimestampViewModelTest {
     @get:Rule
     val coroutineRule = MainCoroutineRule()
 
+    private val tracker = FakeTracker()
     private val episodeManager = mock<EpisodeManager>()
     private val podcastManager = mock<PodcastManager>()
     private val settings = mock<Settings>()
@@ -45,10 +51,13 @@ class ShareEpisodeTimestampViewModelTest {
         whenever(settings.artworkConfiguration).thenReturn(artworkSetting)
 
         viewModel = ShareEpisodeTimestampViewModel(
+            podcast.uuid,
             episode.uuid,
+            SourceView.PLAYER,
             episodeManager,
             podcastManager,
             settings,
+            AnalyticsTracker.test(tracker, isEnabled = true),
         )
     }
 
@@ -64,5 +73,25 @@ class ShareEpisodeTimestampViewModelTest {
                 awaitItem(),
             )
         }
+    }
+
+    @Test
+    fun `track screen show event`() = runTest {
+        viewModel.onScreenShown()
+
+        val event = tracker.events.last()
+
+        assertEquals(
+            TrackEvent(
+                AnalyticsEvent.SHARE_SCREEN_SHOWN,
+                mapOf(
+                    "type" to "episode_timestamp",
+                    "episode_uuid" to "episode-id",
+                    "podcast_uuid" to "podcast-id",
+                    "source" to "player",
+                ),
+            ),
+            event,
+        )
     }
 }

--- a/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
+++ b/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
@@ -625,11 +625,11 @@ enum class AnalyticsEvent(val key: String) {
     WIDGET_INSTALLED("widget_installed"),
     WIDGET_UNINSTALLED("widget_uninstalled"),
 
-    /* Clips */
-    CLIP_SCREEN_SHOWN("clip_screen_shown"),
-    CLIP_SCREEN_PLAY_TAPPED("clip_screen_play_tapped"),
-    CLIP_SCREEN_PAUSE_TAPPED("clip_screen_pause_tapped"),
-    CLIP_SCREEN_LINK_SHARED("clip_screen_link_shared"),
+    /* Sharing */
+    SHARE_SCREEN_SHOWN("share_screen_shown"),
+    SHARE_SCREEN_PLAY_TAPPED("share_screen_play_tapped"),
+    SHARE_SCREEN_PAUSE_TAPPED("share_screen_pause_tapped"),
+    SHARE_SCREEN_CLIP_SHARED("share_screen_clip_shared"),
 
     /* Pocket Casts Champion */
     POCKET_CASTS_CHAMPION_DIALOG_SHOWN("pocket_casts_champion_dialog_shown"),


### PR DESCRIPTION
## Description

Implementation of analytics for sharing. 

## Testing Instructions

Verify these events:
* [Old sharing event](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?gid=0#gid=0&range=312:312)
* [New sharing events](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?gid=0#gid=0&range=482:485)

## Checklist
- [x] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [x] ~Any jetpack compose components I added or changed are covered by compose previews~
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.