### PR TITLE
Transcripts - Search UI

### DIFF
--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/PlayerHeaderFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/PlayerHeaderFragment.kt
@@ -352,7 +352,7 @@ class PlayerHeaderFragment : BaseFragment(), PlayerClickListener {
     private fun setupTranscriptPage() {
         binding?.transcriptPage?.setContent {
             TranscriptPageWrapper(
-                viewModel = viewModel,
+                playerViewModel = viewModel,
                 transcriptViewModel = transcriptViewModel,
                 theme = theme,
             )

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/transcripts/TranscriptPageWrapper.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/transcripts/TranscriptPageWrapper.kt
@@ -39,8 +39,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
-import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.res.painterResource
@@ -76,15 +74,8 @@ fun TranscriptPageWrapper(
         val transitionState = playerViewModel.transitionState.collectAsStateWithLifecycle(null)
 
         val configuration = LocalConfiguration.current
-        val connection = remember { object : NestedScrollConnection {} }
 
         var expandSearch by remember { mutableStateOf(false) }
-        val onSearchClicked = {
-            expandSearch = true
-        }
-        val onSearchDoneClicked = {
-            expandSearch = false
-        }
         when (transitionState.value) {
             is TransitionState.CloseTranscript -> {
                 if (expandSearch) expandSearch = false
@@ -95,8 +86,7 @@ fun TranscriptPageWrapper(
 
         Box(
             modifier = Modifier
-                .fillMaxSize()
-                .nestedScroll(connection),
+                .fillMaxSize(),
         ) {
             TranscriptPage(
                 playerViewModel = playerViewModel,
@@ -114,8 +104,8 @@ fun TranscriptPageWrapper(
                         playerViewModel.closeTranscript(withTransition = true)
                     }
                 },
-                onSearchDoneClicked = onSearchDoneClicked,
-                onSearchClicked = onSearchClicked,
+                onSearchDoneClicked = { expandSearch = false },
+                onSearchClicked = { expandSearch = true },
                 expandSearch = expandSearch,
             )
         }

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/transcripts/TranscriptPageWrapper.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/transcripts/TranscriptPageWrapper.kt
@@ -266,7 +266,7 @@ private fun SearchBarTrailingIcons(text: String, onTextChanged: (String) -> Unit
         ) {
             Icon(
                 imageVector = Icons.Default.KeyboardArrowUp,
-                contentDescription = stringResource(LR.string.go_to_top),
+                contentDescription = stringResource(LR.string.go_to_previous),
             )
         }
         IconButton(
@@ -275,7 +275,7 @@ private fun SearchBarTrailingIcons(text: String, onTextChanged: (String) -> Unit
         ) {
             Icon(
                 imageVector = Icons.Default.KeyboardArrowDown,
-                contentDescription = stringResource(LR.string.go_to_bottom),
+                contentDescription = stringResource(LR.string.go_to_next),
             )
         }
     }

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/transcripts/TranscriptPageWrapper.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/transcripts/TranscriptPageWrapper.kt
@@ -8,11 +8,8 @@ import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.animation.shrinkHorizontally
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
-import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -25,7 +22,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
 import androidx.compose.material.icons.filled.KeyboardArrowDown
 import androidx.compose.material.icons.filled.KeyboardArrowUp
-import androidx.compose.material.ripple.rememberRipple
+import androidx.compose.material.icons.filled.Search
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -50,7 +47,6 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import au.com.shiftyjelly.pocketcasts.compose.AppTheme
 import au.com.shiftyjelly.pocketcasts.compose.buttons.CloseButton
 import au.com.shiftyjelly.pocketcasts.compose.components.SearchBar
-import au.com.shiftyjelly.pocketcasts.compose.components.TextH50
 import au.com.shiftyjelly.pocketcasts.images.R
 import au.com.shiftyjelly.pocketcasts.player.viewmodel.PlayerViewModel
 import au.com.shiftyjelly.pocketcasts.player.viewmodel.PlayerViewModel.TransitionState
@@ -142,10 +138,18 @@ fun TranscriptToolbar(
             enter = fadeIn(),
             exit = fadeOut(),
         ) {
-            SearchButton(
+            IconButton(
                 onClick = onSearchClicked,
-                modifier = Modifier.align(Alignment.TopEnd),
-            )
+                modifier = Modifier
+                    .padding(end = 16.dp)
+                    .background(Color.White.copy(alpha = 0.2f), shape = RoundedCornerShape(SearchViewCornerRadius))
+            ) {
+                Icon(
+                    imageVector = Icons.Default.Search,
+                    contentDescription = stringResource(LR.string.search),
+                    tint = Color.White,
+                )
+            }
         }
         transition.AnimatedVisibility(
             visible = { it },
@@ -178,34 +182,6 @@ fun TranscriptToolbar(
         } else {
             focusManager.clearFocus()
         }
-    }
-}
-
-@Composable
-private fun SearchButton(
-    onClick: () -> Unit,
-    modifier: Modifier,
-) {
-    Box(
-        contentAlignment = Alignment.Center,
-        modifier = modifier
-            .padding(end = 16.dp)
-            .defaultMinSize(
-                minHeight = 48.dp,
-            )
-            .background(Color.White.copy(alpha = 0.2f), RoundedCornerShape(SearchViewCornerRadius))
-            .clickable(
-                interactionSource = remember { MutableInteractionSource() },
-                indication = rememberRipple(color = Color.White, radius = SearchViewCornerRadius),
-                onClick = onClick,
-            ),
-    ) {
-        TextH50(
-            text = stringResource(LR.string.search),
-            color = Color.White,
-            modifier = Modifier
-                .padding(horizontal = 16.dp, vertical = 4.dp),
-        )
     }
 }
 

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/transcripts/TranscriptPageWrapper.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/transcripts/TranscriptPageWrapper.kt
@@ -1,38 +1,106 @@
 package au.com.shiftyjelly.pocketcasts.player.view.transcripts
 
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.ExperimentalAnimationApi
+import androidx.compose.animation.core.updateTransition
+import androidx.compose.animation.expandHorizontally
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.shrinkHorizontally
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.Icon
+import androidx.compose.material.IconButton
+import androidx.compose.material.Text
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
+import androidx.compose.material.icons.filled.KeyboardArrowDown
+import androidx.compose.material.icons.filled.KeyboardArrowUp
+import androidx.compose.material.ripple.rememberRipple
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import au.com.shiftyjelly.pocketcasts.compose.AppTheme
 import au.com.shiftyjelly.pocketcasts.compose.buttons.CloseButton
+import au.com.shiftyjelly.pocketcasts.compose.components.SearchBar
+import au.com.shiftyjelly.pocketcasts.compose.components.TextH50
+import au.com.shiftyjelly.pocketcasts.images.R
 import au.com.shiftyjelly.pocketcasts.player.viewmodel.PlayerViewModel
+import au.com.shiftyjelly.pocketcasts.player.viewmodel.PlayerViewModel.TransitionState
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
+import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
+private val SearchBarMaxWidth = 500.dp
+private val SearchViewCornerRadius = 38.dp
+
+@OptIn(ExperimentalAnimationApi::class)
 @Composable
 fun TranscriptPageWrapper(
-    viewModel: PlayerViewModel,
+    playerViewModel: PlayerViewModel,
     transcriptViewModel: TranscriptViewModel,
     theme: Theme,
 ) {
-    AppTheme(theme.activeTheme) {
+    AppTheme(Theme.ThemeType.LIGHT) {
+        val transitionState = playerViewModel.transitionState.collectAsStateWithLifecycle(null)
+
         val configuration = LocalConfiguration.current
         val connection = remember { object : NestedScrollConnection {} }
 
+        val focusRequester = remember { FocusRequester() }
+        val focusManager = LocalFocusManager.current
+        var expandSearch by remember { mutableStateOf(false) }
+
+        var searchFieldValue by remember { mutableStateOf(TextFieldValue()) }
+
+        val onTextChanged = { text: String ->
+            searchFieldValue = TextFieldValue(text)
+        }
+        val onSearchDoneClicked = {
+            expandSearch = false
+        }
+
+        when (transitionState.value) {
+            is TransitionState.CloseTranscript -> {
+                if (expandSearch) expandSearch = false
+            }
+
+            else -> Unit
+        }
+
         Box(
+            contentAlignment = Alignment.TopEnd,
             modifier = Modifier
                 .fillMaxSize()
                 .nestedScroll(connection),
         ) {
             TranscriptPage(
-                playerViewModel = viewModel,
+                playerViewModel = playerViewModel,
                 transcriptViewModel = transcriptViewModel,
                 theme = theme,
                 modifier = Modifier
@@ -41,7 +109,144 @@ fun TranscriptPageWrapper(
 
             CloseButton(
                 modifier = Modifier.align(Alignment.TopStart),
-                onClick = { viewModel.closeTranscript(withTransition = true) },
+                onClick = { playerViewModel.closeTranscript(withTransition = true) },
+            )
+            val transition = updateTransition(expandSearch, label = "search transition")
+            transition.AnimatedVisibility(
+                visible = { !it },
+                enter = fadeIn(),
+                exit = fadeOut(),
+            ) {
+                SearchButton(
+                    onClick = { expandSearch = true },
+                    modifier = Modifier.align(Alignment.TopEnd),
+                )
+            }
+            transition.AnimatedVisibility(
+                visible = { it },
+                enter = expandHorizontally(),
+                exit = shrinkHorizontally(targetWidth = { 50 }) + fadeOut(),
+            ) {
+                SearchBar(
+                    text = searchFieldValue.text,
+                    leadingIcon = {
+                        SearchBarLeadingIcons(onTextChanged, onSearchDoneClicked)
+                    },
+                    trailingIcon = {
+                        SearchBarTrailingIcons(searchFieldValue.text, onTextChanged)
+                    },
+                    placeholder = stringResource(LR.string.search),
+                    onTextChanged = onTextChanged,
+                    onSearch = {},
+                    cornerRadius = SearchViewCornerRadius,
+                    modifier = Modifier
+                        .width(SearchBarMaxWidth)
+                        .focusRequester(focusRequester)
+                        .padding(start = 56.dp, end = 16.dp),
+                )
+            }
+        }
+
+        LaunchedEffect(expandSearch) {
+            if (expandSearch) {
+                focusRequester.requestFocus()
+            } else {
+                focusManager.clearFocus()
+            }
+        }
+    }
+}
+
+@Composable
+private fun SearchButton(
+    onClick: () -> Unit,
+    modifier: Modifier,
+) {
+    Box(
+        contentAlignment = Alignment.Center,
+        modifier = modifier
+            .padding(end = 16.dp)
+            .defaultMinSize(
+                minHeight = 48.dp,
+            )
+            .background(Color.White.copy(alpha = 0.2f), RoundedCornerShape(SearchViewCornerRadius))
+            .clickable(
+                interactionSource = remember { MutableInteractionSource() },
+                indication = rememberRipple(color = Color.White, radius = SearchViewCornerRadius),
+                onClick = onClick,
+            ),
+    ) {
+        TextH50(
+            text = stringResource(LR.string.search),
+            color = Color.White,
+            modifier = Modifier
+                .padding(horizontal = 16.dp, vertical = 4.dp),
+        )
+    }
+}
+
+@Composable
+private fun SearchBarLeadingIcons(
+    onTextChanged: (String) -> Unit,
+    onDoneClicked: () -> Unit,
+) {
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        IconButton(
+            onClick = {
+                onTextChanged("")
+                onDoneClicked()
+            },
+        ) {
+            Icon(
+                imageVector = Icons.AutoMirrored.Filled.KeyboardArrowRight,
+                contentDescription = stringResource(LR.string.done),
+            )
+        }
+        Icon(
+            painter = painterResource(R.drawable.ic_search),
+            contentDescription = null,
+        )
+    }
+}
+
+@Composable
+private fun SearchBarTrailingIcons(text: String, onTextChanged: (String) -> Unit) {
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Text(
+            text = "0/0",
+        )
+        if (text.isNotEmpty()) {
+            IconButton(
+                onClick = {
+                    onTextChanged("")
+                },
+            ) {
+                Icon(
+                    painter = painterResource(R.drawable.ic_cancel),
+                    contentDescription = stringResource(LR.string.cancel),
+                )
+            }
+        }
+        IconButton(
+            onClick = {},
+            enabled = text.isNotEmpty(),
+        ) {
+            Icon(
+                imageVector = Icons.Default.KeyboardArrowUp,
+                contentDescription = stringResource(LR.string.go_to_top),
+            )
+        }
+        IconButton(
+            onClick = {},
+            enabled = text.isNotEmpty(),
+        ) {
+            Icon(
+                imageVector = Icons.Default.KeyboardArrowDown,
+                contentDescription = stringResource(LR.string.go_to_bottom),
             )
         }
     }

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/transcripts/TranscriptPageWrapper.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/transcripts/TranscriptPageWrapper.kt
@@ -97,7 +97,13 @@ fun TranscriptPageWrapper(
             )
 
             TranscriptToolbar(
-                onCloseClick = { playerViewModel.closeTranscript(withTransition = true) },
+                onCloseClick = {
+                    if (expandSearch) {
+                        expandSearch = false
+                    } else {
+                        playerViewModel.closeTranscript(withTransition = true)
+                    }
+                },
                 onSearchDoneClicked = onSearchDoneClicked,
                 onSearchClicked = onSearchClicked,
                 expandSearch = expandSearch,

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/SearchBar.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/SearchBar.kt
@@ -40,6 +40,7 @@ import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import au.com.shiftyjelly.pocketcasts.compose.AppTheme
 import au.com.shiftyjelly.pocketcasts.compose.theme
@@ -53,11 +54,14 @@ import au.com.shiftyjelly.pocketcasts.localization.R as LR
 fun SearchBar(
     text: String,
     onTextChanged: (String) -> Unit,
+    modifier: Modifier = Modifier,
+    leadingIcon: @Composable (() -> Unit)? = null,
+    trailingIcon: @Composable (() -> Unit)? = null,
     placeholder: String = stringResource(LR.string.search_podcasts_or_add_url),
     onSearch: () -> Unit = {},
-    modifier: Modifier = Modifier,
     enabled: Boolean = true,
     textStyle: TextStyle = LocalTextStyle.current,
+    cornerRadius: Dp = 10.dp,
 ) {
     val focusManager = LocalFocusManager.current
     val colors = TextFieldDefaults.outlinedTextFieldColors(
@@ -80,7 +84,7 @@ fun SearchBar(
     }
     val mergedTextStyle = textStyle.merge(TextStyle(color = textColor))
 
-    val shape = RoundedCornerShape(10.dp)
+    val shape = RoundedCornerShape(cornerRadius)
     BasicTextField(
         value = text,
         onValueChange = {
@@ -123,13 +127,13 @@ fun SearchBar(
                         overflow = TextOverflow.Ellipsis,
                     )
                 },
-                leadingIcon = {
+                leadingIcon = leadingIcon ?: {
                     Icon(
                         painter = painterResource(IR.drawable.ic_search),
                         contentDescription = null,
                     )
                 },
-                trailingIcon = {
+                trailingIcon = trailingIcon ?: {
                     if (text.isNotEmpty()) {
                         IconButton(
                             onClick = {

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/SearchBar.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/SearchBar.kt
@@ -19,6 +19,7 @@ import androidx.compose.material.IconButton
 import androidx.compose.material.LocalTextStyle
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
+import androidx.compose.material.TextFieldColors
 import androidx.compose.material.TextFieldDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
@@ -49,6 +50,40 @@ import au.com.shiftyjelly.pocketcasts.utils.extensions.removeNewLines
 import au.com.shiftyjelly.pocketcasts.images.R as IR
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
+object SearchBarDefaults {
+    @Composable
+    fun colors(
+        cursorColor: Color = MaterialTheme.theme.colors.primaryText02,
+        textColor: Color = MaterialTheme.theme.colors.primaryText01,
+        disabledTextColor: Color = MaterialTheme.theme.colors.primaryText01,
+        placeholderColor: Color = MaterialTheme.theme.colors.primaryText02,
+        disabledPlaceholderColor: Color = MaterialTheme.theme.colors.primaryText02,
+        leadingIconColor: Color = MaterialTheme.theme.colors.primaryIcon02,
+        disabledLeadingIconColor: Color = MaterialTheme.theme.colors.primaryIcon02,
+        trailingIconColor: Color = MaterialTheme.theme.colors.primaryIcon02,
+        disabledTrailingIconColor: Color = MaterialTheme.theme.colors.primaryIcon02,
+        backgroundColor: Color = MaterialTheme.theme.colors.primaryField01,
+        focusedBorderColor: Color = Color.Transparent,
+        unfocusedBorderColor: Color = Color.Transparent,
+        disabledBorderColorColor: Color = Color.Transparent,
+
+    ) = TextFieldDefaults.outlinedTextFieldColors(
+        cursorColor = cursorColor,
+        textColor = textColor,
+        disabledTextColor = disabledTextColor,
+        placeholderColor = placeholderColor,
+        disabledPlaceholderColor = disabledPlaceholderColor,
+        leadingIconColor = leadingIconColor,
+        disabledLeadingIconColor = disabledLeadingIconColor,
+        trailingIconColor = trailingIconColor,
+        disabledTrailingIconColor = disabledTrailingIconColor,
+        backgroundColor = backgroundColor,
+        focusedBorderColor = focusedBorderColor,
+        unfocusedBorderColor = unfocusedBorderColor,
+        disabledBorderColor = disabledBorderColorColor,
+    )
+}
+
 @OptIn(ExperimentalMaterialApi::class)
 @Composable
 fun SearchBar(
@@ -62,23 +97,9 @@ fun SearchBar(
     enabled: Boolean = true,
     textStyle: TextStyle = LocalTextStyle.current,
     cornerRadius: Dp = 10.dp,
+    colors: TextFieldColors = SearchBarDefaults.colors(),
 ) {
     val focusManager = LocalFocusManager.current
-    val colors = TextFieldDefaults.outlinedTextFieldColors(
-        cursorColor = MaterialTheme.theme.colors.primaryText02,
-        textColor = MaterialTheme.theme.colors.primaryText01,
-        disabledTextColor = MaterialTheme.theme.colors.primaryText01,
-        placeholderColor = MaterialTheme.theme.colors.primaryText02,
-        disabledPlaceholderColor = MaterialTheme.theme.colors.primaryText02,
-        leadingIconColor = MaterialTheme.theme.colors.primaryIcon02,
-        disabledLeadingIconColor = MaterialTheme.theme.colors.primaryIcon02,
-        trailingIconColor = MaterialTheme.theme.colors.primaryIcon02,
-        disabledTrailingIconColor = MaterialTheme.theme.colors.primaryIcon02,
-        backgroundColor = MaterialTheme.theme.colors.primaryField01,
-        focusedBorderColor = Color.Transparent,
-        unfocusedBorderColor = Color.Transparent,
-        disabledBorderColor = Color.Transparent,
-    )
     val textColor = textStyle.color.takeOrElse {
         colors.textColor(enabled).value
     }

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -160,6 +160,8 @@
     <string name="support">Support</string>
     <string name="go_to_top">Go to top</string>
     <string name="go_to_bottom">Go to bottom</string>
+    <string name="go_to_previous">Go to previous</string>
+    <string name="go_to_next">Go to next</string>
     <string name="submit">Submit</string>
     <string name="report">Report</string>
     <string name="report_subtitle">Report inappropriate content</string>


### PR DESCRIPTION
## Description

This adds a search UI for Transcripts.
Internal discussion: p1723120902384739/1723091130.165579-slack-C078746V6UX

## Testing Instructions
1. Open transcript view for episode supporting transcripts e.g. ()
2. ✅ Notice search icon at the end of toolbar
3. Tap on search icon
4. ✅ Notice that a search bar is shown with an animation
5. Tap ">" arrow leading icon of the search bar
6. ✅ Notice that search bar closes with animation and search icon is visible
7. Tap on the search icon again
8. Tap close (x) icon while search bar is displaying
9. ✅ Notice that instead of screen closing, search bar is closed (this is done to prevent accidentally closing the screen while thinking that the close (x) button is to close the search bar)
10. Tap close (x) icon again while search bar is collapsed
11. ✅ Notice that the screen closes

## Screenshots or Screencast 

Portrait 

https://github.com/user-attachments/assets/870463c5-b75b-4d2c-9512-d55296011097

Landscape

https://github.com/user-attachments/assets/dbd54f11-0187-440a-aeac-a5cb6b5ca3f8

## Checklist
- [x] ~~If this is a user-facing change, I have added an entry in CHANGELOG.md~~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics. - **Analytics will be added as part of a separate task**
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack