### PR TITLE
Fix pager indicator position

### DIFF
--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/HorizontalPagerWrapper.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/HorizontalPagerWrapper.kt
@@ -17,6 +17,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.layout
@@ -47,7 +48,10 @@ fun HorizontalPagerWrapper(
     }
 
     var pagerHeight by remember { mutableStateOf(0) }
-    Column(modifier = modifier) {
+    Column(
+        horizontalAlignment = Alignment.CenterHorizontally,
+        modifier = modifier,
+    ) {
         HorizontalPager(
             state = pagerState,
             pageSize = pageSize,
@@ -81,6 +85,7 @@ fun HorizontalPagerWrapper(
             PagerDotIndicator(
                 state = pagerState,
                 activeDotColor = pageIndicatorColor,
+                modifier = Modifier.height(40.dp),
             )
         } else {
             Spacer(modifier = Modifier.height(16.dp))


### PR DESCRIPTION
## Description

In #2530 I introduced a paging bug UI to upsell screens. The pager indicator was no longer centered below the cards.

## Testing Instructions

1. Install `release` variant of the app.
2. Sign in with a brand new account.
3. You should see the onboarding upsell screen with a correctly positioned pager indicator.
4. Go to your profile.
5. You should see the embedded upsell cards with a correctly positioned pager indicator.

## Screenshots or Screencast 

| Onboarding before | Onboarding after | Profile before | Profile after |
| - | - | - | - |
| ![upsell-2-pre](https://github.com/user-attachments/assets/1926041e-fa0d-4a2c-b63a-72ab852deffd) | ![upsell-2-post](https://github.com/user-attachments/assets/97e58dfc-2ec4-460d-831b-fdf7ff21ff28) | ![upsell-1-pre](https://github.com/user-attachments/assets/db16a79a-436a-409a-a2b3-8b2cf089fb63) | ![upsell-1-post](https://github.com/user-attachments/assets/c42f2c79-1002-4769-b4a9-8210befbcd68) |

## Checklist
- [x] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] ~I have considered whether it makes sense to add tests for my changes~
- [x] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [x] ~Any jetpack compose components I added or changed are covered by compose previews~
- [x] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
