### PR TITLE
Use parent fragment manager instead of the child's one when creating Kids dialog

### DIFF
--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/ProfileFragment.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/ProfileFragment.kt
@@ -291,7 +291,7 @@ class ProfileFragment : BaseFragment() {
                     KidsProfileCard(
                         onDismiss = { viewModel.dismissKidsBanner() },
                         onRequestEarlyAccess = {
-                            KidsBottomSheetDialog().show(childFragmentManager, "KidsBottomSheetDialog")
+                            KidsBottomSheetDialog().show(parentFragmentManager, "KidsBottomSheetDialog")
                         },
                     )
                 }


### PR DESCRIPTION
## Description

Attempt to fix [the crash from Sentry](https://a8c.sentry.io/issues/5690494505/?project=6711064&query=release%3Aau.com.shiftyjelly.pocketcasts.debug%407.70-rc-2%2B9257&referrer=release-issue-stream) in beta.

From the stack trace it looks like the lambda for requesting early access is getting called. ~I'm not entirely sure how is that possible because the feature is disabled. Maybe someone is experimenting with it and enabling it on its own with memory or code manipulation.~ Ok, now I know. It is from one of our devices because the crash happened in the `.debug` version. It's still better to fix in beta.

In any case, I'm not able to reproduce the bug. But I think I found the root cause. We're using `childFragmentManager` when instantiating `KidsBottomSheetDialog`. This is wrong because then the view model of this dialog is connected to the parent fragment, which is `ProfileFragment` which might get detached. I'm fixing it by using `parentFragmentManager`.

## Testing Instructions

Not sure since I can't reproduce it. Verify the code.

## Checklist
- [x] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] ~I have considered whether it makes sense to add tests for my changes~
- [x] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [x] ~Any jetpack compose components I added or changed are covered by compose previews~
- [x] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack