### PR TITLE
Make texts in cards non-scaling

### DIFF
--- a/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/ui/HorizontalCard.kt
+++ b/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/ui/HorizontalCard.kt
@@ -133,6 +133,7 @@ private fun HorizontalCard(
         ) {
             TextH70(
                 text = data.topText(),
+                disableScale = true,
                 color = shareColors.cardText.copy(alpha = 0.5f),
                 maxLines = 1,
             )
@@ -141,6 +142,7 @@ private fun HorizontalCard(
             )
             TextH40(
                 text = data.middleText(),
+                disableScale = true,
                 color = shareColors.cardText,
                 maxLines = 3,
             )
@@ -149,6 +151,7 @@ private fun HorizontalCard(
             )
             TextH70(
                 text = data.bottomText(),
+                disableScale = true,
                 maxLines = 2,
                 color = shareColors.cardText.copy(alpha = 0.5f),
             )

--- a/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/ui/SquareCard.kt
+++ b/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/ui/SquareCard.kt
@@ -110,6 +110,7 @@ private fun SquareCard(
         )
         TextH70(
             text = data.topText(),
+            disableScale = true,
             maxLines = 1,
             color = shareColors.cardText.copy(alpha = 0.5f),
             modifier = Modifier.padding(horizontal = 64.dp),
@@ -119,6 +120,7 @@ private fun SquareCard(
         )
         TextH40(
             text = data.middleText(),
+            disableScale = true,
             maxLines = 2,
             textAlign = TextAlign.Center,
             color = shareColors.cardText,
@@ -129,6 +131,7 @@ private fun SquareCard(
         )
         TextH70(
             text = data.bottomText(),
+            disableScale = true,
             maxLines = 2,
             textAlign = TextAlign.Center,
             color = shareColors.cardText.copy(alpha = 0.5f),

--- a/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/ui/VerticalCard.kt
+++ b/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/ui/VerticalCard.kt
@@ -122,6 +122,7 @@ private fun VerticalCard(
         )
         TextH70(
             text = data.topText(),
+            disableScale = true,
             maxLines = 1,
             color = shareColors.cardText.copy(alpha = 0.5f),
             modifier = Modifier.padding(horizontal = width * 0.1f),
@@ -131,6 +132,7 @@ private fun VerticalCard(
         )
         TextH40(
             text = data.middleText(),
+            disableScale = true,
             maxLines = 2,
             textAlign = TextAlign.Center,
             color = shareColors.cardText,
@@ -141,6 +143,7 @@ private fun VerticalCard(
         )
         TextH70(
             text = data.bottomText(),
+            disableScale = true,
             maxLines = 2,
             textAlign = TextAlign.Center,
             color = shareColors.cardText.copy(alpha = 0.5f),
@@ -149,7 +152,9 @@ private fun VerticalCard(
         Spacer(
             modifier = Modifier.weight(1f),
         )
-        PocketCastsPill()
+        PocketCastsPill(
+            disableScale = true,
+        )
         Spacer(
             modifier = Modifier.weight(1f),
         )

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/PocketCastsPill.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/PocketCastsPill.kt
@@ -24,6 +24,7 @@ import au.com.shiftyjelly.pocketcasts.localization.R as LR
 @Composable
 fun PocketCastsPill(
     modifier: Modifier = Modifier,
+    disableScale: Boolean = false,
 ) = Row(
     verticalAlignment = Alignment.CenterVertically,
     modifier = modifier
@@ -42,6 +43,7 @@ fun PocketCastsPill(
     TextH70(
         text = stringResource(id = LR.string.pocket_casts),
         color = Color.White,
+        disableScale = disableScale,
     )
 }
 


### PR DESCRIPTION
## Description

Follow-up to https://github.com/Automattic/pocket-casts-android/pull/2592#issuecomment-2275087479. Scaling font sizes in card assets doesn't make a lot of sense since they are supposed to be shared to other platforms and not look like 💩.

## Testing Instructions

Inspect UI of sharing cards with different font sizes. The text content in cards shouldn't scale.

## Checklist
- [x] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] ~I have considered whether it makes sense to add tests for my changes~
- [x] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [ ] with a landscape orientation
- [x] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
