### PR TITLE
Build prototype mobile app and comment on PR

### DIFF
--- a/.buildkite/commands/prototype-build.sh
+++ b/.buildkite/commands/prototype-build.sh
@@ -1,0 +1,10 @@
+#!/bin/bash -eu
+
+echo "--- :rubygems: Setting up Gems"
+install_gems
+
+echo "--- :closed_lock_with_key: Installing Secrets"
+bundle exec fastlane run configure_apply
+
+echo "--- :hammer_and_wrench: Building"
+bundle exec fastlane build_and_upload_prototype_build

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -70,6 +70,7 @@ steps:
       - "**/build/outputs/apk/**/*"
 
   - label: "Prototype Builds"
+    if: "build.pull_request.id != null"
     command: |
       ".buildkite/commands/prototype-build.sh"
     plugins: [ $CI_TOOLKIT ]

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -57,6 +57,18 @@ steps:
     artifact_paths:
       - "**/build/instrumented-tests/**/*"
 
+  - label: "Assemble release APK"
+    command: |
+      echo "--- :rubygems: Setting up Gems"
+      install_gems
+      echo "--- :closed_lock_with_key: Installing Secrets"
+      bundle exec fastlane run configure_apply
+      echo "--- ⚙️ Building release variant"
+      ./gradlew assembleRelease -PskipSentryProguardMappingUpload=true
+    plugins: [ $CI_TOOLKIT ]
+    artifact_paths:
+      - "**/build/outputs/apk/**/*"
+
   - label: "Prototype Builds"
     command: |
       ".buildkite/commands/prototype-build.sh"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -57,14 +57,11 @@ steps:
     artifact_paths:
       - "**/build/instrumented-tests/**/*"
 
-  - label: "Assemble release APK"
-    command: |
-      echo "--- :rubygems: Setting up Gems"
-      install_gems
-      echo "--- :closed_lock_with_key: Installing Secrets"
-      bundle exec fastlane run configure_apply
-      echo "--- ⚙️ Building release variant"
-      ./gradlew assembleRelease -PskipSentryProguardMappingUpload=true
-    plugins: [$CI_TOOLKIT]
-    artifact_paths:
-      - "**/build/outputs/apk/**/*"
+  - group: "🛠 Prototype Builds"
+    steps:
+      - label: "🛠 Prototype Build: Mobile App"
+        command: |
+          ".buildkite/commands/prototype-build.sh"
+        if: build.pull_request.id != null
+        plugins: [$CI_TOOLKIT]
+

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -57,11 +57,9 @@ steps:
     artifact_paths:
       - "**/build/instrumented-tests/**/*"
 
-  - group: "🛠 Prototype Builds"
-    steps:
-      - label: "🛠 Prototype Build: Mobile App"
-        command: |
-          ".buildkite/commands/prototype-build.sh"
-        if: build.pull_request.id != null
-        plugins: [$CI_TOOLKIT]
-
+  - label: "Prototype Builds"
+    command: |
+      ".buildkite/commands/prototype-build.sh"
+    plugins: [ $CI_TOOLKIT ]
+    artifact_paths:
+      - "**/build/outputs/apk/**/*"

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -431,10 +431,13 @@ platform :android do
 
   desc 'Builds a prototype build and uploads it to S3'
   lane :build_and_upload_prototype_build do
-    UI.user_error!("'BUILDKITE_ARTIFACTS_S3_BUCKET' must be defined as an environment variable.") unless ENV['BUILDKITE_ARTIFACTS_S3_BUCKET']
+#     UI.user_error!("'BUILDKITE_ARTIFACTS_S3_BUCKET' must be defined as an environment variable.") unless ENV['BUILDKITE_ARTIFACTS_S3_BUCKET']
+
+    prototype_build_type = 'debugProd'
 
     gradle(
-      task: 'assembleRelease',
+      task: 'assemble',
+      build_type: prototype_build_type,
       properties: {
         'skipSentryProguardMappingUpload' => true
       }
@@ -453,6 +456,9 @@ platform :android do
       prototype_build_details_comment(
         app_display_name: get_app_display_name(apk_path: apk_path),
         download_url: install_url,
+        metadata: {
+          'Build Type': prototype_build_type
+        },
         fold: true
       )
     end

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -430,7 +430,7 @@ platform :android do
   end
 
   desc 'Builds a prototype build and uploads it to S3'
-  lane :build_and_upload_prototype_build
+  lane :build_and_upload_prototype_build do
     UI.user_error!("'BUILDKITE_ARTIFACTS_S3_BUCKET' must be defined as an environment variable.") unless ENV['BUILDKITE_ARTIFACTS_S3_BUCKET']
 
     gradle(

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -478,7 +478,6 @@ platform :android do
 
   # This function is Buildkite-specific
   def generate_prototype_build_number
-    return ""
     if ENV['BUILDKITE']
       commit = ENV.fetch('BUILDKITE_COMMIT', nil)[0, 7]
       branch = ENV['BUILDKITE_BRANCH'].parameterize

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -474,23 +474,12 @@ platform :android do
   end
 
   def get_app_key(apk_path:)
-    if apk_path.include?('app')
-      'mobile'
-    elsif apk_path.include?('wear')
-      'wear'
-    else
-      'automotive'
-    end
+    File.basename(apk_path).split('-').first
   end
 
   def get_app_display_name(apk_path:)
-    if apk_path.include?('app')
-      '📱 Mobile'
-    elsif apk_path.include?('wear')
-      '⌚ Wear'
-    else
-      '🚗 Automotive'
-    end
+    key = get_app_key(apk_path: apk_path).to_sym
+    { app: '📱 Mobile', wear: '⌚ Wear', automotive: '🚗 Automotive' }.fetch(key, '❔ Unknown')
   end
 
   # This function is Buildkite-specific

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -463,14 +463,12 @@ platform :android do
       )
     end
 
-    unless ENV['BUILDKITE_PULL_REQUEST'].nil?
-      comment_on_pr(
-        project: 'automattic/pocket-casts-android',
-        pr_number: Integer(ENV['BUILDKITE_PULL_REQUEST']),
-        reuse_identifier: 'app-prototype-build-link',
-        body: prototype_build_comments.join
-      )
-    end
+    comment_on_pr(
+      project: 'automattic/pocket-casts-android',
+      pr_number: Integer(ENV.fetch('BUILDKITE_PULL_REQUEST', nil)),
+      reuse_identifier: 'app-prototype-build-link',
+      body: prototype_build_comments.join
+    )
   end
 
   def get_app_key(apk_path:)

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -431,7 +431,7 @@ platform :android do
 
   desc 'Builds a prototype build and uploads it to S3'
   lane :build_and_upload_prototype_build do
-#     UI.user_error!("'BUILDKITE_ARTIFACTS_S3_BUCKET' must be defined as an environment variable.") unless ENV['BUILDKITE_ARTIFACTS_S3_BUCKET']
+    UI.user_error!("'BUILDKITE_ARTIFACTS_S3_BUCKET' must be defined as an environment variable.") unless ENV['BUILDKITE_ARTIFACTS_S3_BUCKET']
 
     prototype_build_type = 'debugProd'
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -430,38 +430,50 @@ platform :android do
   end
 
   desc 'Builds a prototype build and uploads it to S3'
-  lane :build_and_upload_prototype_build do |options|
-      UI.user_error!("'BUILDKITE_ARTIFACTS_S3_BUCKET' must be defined as an environment variable.") unless ENV['BUILDKITE_ARTIFACTS_S3_BUCKET']
+  lane :build_and_upload_prototype_build
+    UI.user_error!("'BUILDKITE_ARTIFACTS_S3_BUCKET' must be defined as an environment variable.") unless ENV['BUILDKITE_ARTIFACTS_S3_BUCKET']
 
-      gradle(
-          task: ":app:assembleRelease",
-          properties: {
-          "skipSentryProguardMappingUpload" => true
-        }
-      )
+    gradle(
+        task: "assembleRelease",
+        properties: {
+        "skipSentryProguardMappingUpload" => true
+      }
+    )
 
+    prototype_build_comments = lane_context[SharedValues::GRADLE_ALL_APK_OUTPUT_PATHS].map { |apk_path|
       upload_path = upload_to_s3(
-          bucket: 'a8c-apps-public-artifacts',
-          key: "pocketcasts-mobile-prototype-build-#{generate_prototype_build_number}.apk",
-          file: lane_context[SharedValues::GRADLE_APK_OUTPUT_PATH],
-          skip_if_exists: true
+        bucket: 'a8c-apps-public-artifacts',
+        key: "pocketcasts-mobile-prototype-build-#{generate_prototype_build_number}.apk",
+        file: apk_path,
+        skip_if_exists: true
       )
 
       install_url = "#{PROTOTYPE_BUILD_DOMAIN}/#{upload_path}"
-      comment_body = prototype_build_details_comment(
-        app_display_name: "📱 Mobile",
+
+      prototype_build_details_comment(
+        app_display_name: get_app_display_name(apk_path: apk_path),
         download_url: install_url,
         fold: true
       )
+    }
 
-      unless ENV['BUILDKITE_PULL_REQUEST'].nil?
-          comment_on_pr(
-              project: 'automattic/pocket-casts-android',
-              pr_number: Integer(ENV['BUILDKITE_PULL_REQUEST']),
-              reuse_identifier: "app-prototype-build-link",
-              body: comment_body
-          )
-      end
+    unless ENV['BUILDKITE_PULL_REQUEST'].nil?
+        comment_on_pr(
+            project: 'automattic/pocket-casts-android',
+            pr_number: Integer(ENV['BUILDKITE_PULL_REQUEST']),
+            reuse_identifier: "app-prototype-build-link",
+            body: prototype_build_comments.join('\n')
+        )
+  end
+
+  def get_app_display_name(apk_path:)
+    if apk_path.include?('app')
+      "📱 Mobile"
+    elsif apk_path.include?('wear')
+      "⌚ Wear"
+    else
+      "🚗 Automotive"
+    end
   end
 
   # This function is Buildkite-specific

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -11,6 +11,7 @@ UI.user_error!('Please run fastlane via `bundle exec`') unless FastlaneCore::Hel
 ENV_FILE_NAME = '.pocketcastsandroid-env.default'
 USER_ENV_FILE_PATH = File.join(Dir.home, ENV_FILE_NAME)
 PROJECT_ROOT_FOLDER = File.dirname(File.expand_path(__dir__))
+PROTOTYPE_BUILD_DOMAIN = 'https://d2twmm2nzpx3bg.cloudfront.net'
 APP_PACKAGE_NAME = 'au.com.shiftyjelly.pocketcasts'
 GOOGLE_FIREBASE_SECRETS_PATH = File.join(PROJECT_ROOT_FOLDER, '.configure-files', 'firebase.secrets.json')
 ORIGINALS_METADATA_DIR_PATH = File.join(PROJECT_ROOT_FOLDER, 'metadata')
@@ -426,6 +427,59 @@ platform :android do
       apk_path: File.join(apk_dir, 'debug', 'app-debug.apk'),
       results_output_dir: File.join(PROJECT_ROOT_FOLDER, 'build', 'instrumented-tests')
     )
+  end
+
+  desc 'Builds a prototype build and uploads it to S3'
+  lane :build_and_upload_prototype_build do |options|
+      UI.user_error!("'BUILDKITE_ARTIFACTS_S3_BUCKET' must be defined as an environment variable.") unless ENV['BUILDKITE_ARTIFACTS_S3_BUCKET']
+
+      gradle(
+          task: ":app:assembleRelease",
+          properties: {
+          "skipSentryProguardMappingUpload" => true
+        }
+      )
+
+      upload_path = upload_to_s3(
+          bucket: 'a8c-apps-public-artifacts',
+          key: "pocketcasts-mobile-prototype-build-#{generate_prototype_build_number}.apk",
+          file: lane_context[SharedValues::GRADLE_APK_OUTPUT_PATH],
+          skip_if_exists: true
+      )
+
+      install_url = "#{PROTOTYPE_BUILD_DOMAIN}/#{upload_path}"
+      comment_body = prototype_build_details_comment(
+        app_display_name: "📱 Mobile",
+        download_url: install_url,
+        fold: true
+      )
+
+      unless ENV['BUILDKITE_PULL_REQUEST'].nil?
+          comment_on_pr(
+              project: 'automattic/pocket-casts-android',
+              pr_number: Integer(ENV['BUILDKITE_PULL_REQUEST']),
+              reuse_identifier: "app-prototype-build-link",
+              body: comment_body
+          )
+      end
+  end
+
+  # This function is Buildkite-specific
+  def generate_prototype_build_number
+    return ""
+    if ENV['BUILDKITE']
+      commit = ENV.fetch('BUILDKITE_COMMIT', nil)[0, 7]
+      branch = ENV['BUILDKITE_BRANCH'].parameterize
+      pr_num = ENV.fetch('BUILDKITE_PULL_REQUEST', nil)
+
+      pr_num == 'false' ? "#{branch}-#{commit}" : "pr#{pr_num}-#{commit}"
+    else
+      repo = Git.open(PROJECT_ROOT_FOLDER)
+      commit = repo.current_branch.parameterize
+      branch = repo.revparse('HEAD')[0, 7]
+
+      "#{branch}-#{commit}"
+    end
   end
 
   #####################################################################################

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -443,7 +443,7 @@ platform :android do
     prototype_build_comments = lane_context[SharedValues::GRADLE_ALL_APK_OUTPUT_PATHS].map do |apk_path|
       upload_path = upload_to_s3(
         bucket: 'a8c-apps-public-artifacts',
-        key: "pocketcasts-mobile-prototype-build-#{generate_prototype_build_number}.apk",
+        key: "pocketcasts-#{get_app_key(apk_path: apk_path)}-prototype-build-#{generate_prototype_build_number}.apk",
         file: apk_path,
         skip_if_exists: true
       )
@@ -464,6 +464,16 @@ platform :android do
         reuse_identifier: 'app-prototype-build-link',
         body: prototype_build_comments.join('\n')
       )
+    end
+  end
+
+  def get_app_key(apk_path:)
+    if apk_path.include?('app')
+      'mobile'
+    elsif apk_path.include?('wear')
+      'wear'
+    else
+      'automotive'
     end
   end
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -434,13 +434,13 @@ platform :android do
     UI.user_error!("'BUILDKITE_ARTIFACTS_S3_BUCKET' must be defined as an environment variable.") unless ENV['BUILDKITE_ARTIFACTS_S3_BUCKET']
 
     gradle(
-        task: "assembleRelease",
-        properties: {
-        "skipSentryProguardMappingUpload" => true
+      task: 'assembleRelease',
+      properties: {
+        'skipSentryProguardMappingUpload' => true
       }
     )
 
-    prototype_build_comments = lane_context[SharedValues::GRADLE_ALL_APK_OUTPUT_PATHS].map { |apk_path|
+    prototype_build_comments = lane_context[SharedValues::GRADLE_ALL_APK_OUTPUT_PATHS].map do |apk_path|
       upload_path = upload_to_s3(
         bucket: 'a8c-apps-public-artifacts',
         key: "pocketcasts-mobile-prototype-build-#{generate_prototype_build_number}.apk",
@@ -455,25 +455,25 @@ platform :android do
         download_url: install_url,
         fold: true
       )
-    }
+    end
 
     unless ENV['BUILDKITE_PULL_REQUEST'].nil?
-        comment_on_pr(
-            project: 'automattic/pocket-casts-android',
-            pr_number: Integer(ENV['BUILDKITE_PULL_REQUEST']),
-            reuse_identifier: "app-prototype-build-link",
-            body: prototype_build_comments.join('\n')
-        )
+      comment_on_pr(
+        project: 'automattic/pocket-casts-android',
+        pr_number: Integer(ENV['BUILDKITE_PULL_REQUEST']),
+        reuse_identifier: 'app-prototype-build-link',
+        body: prototype_build_comments.join('\n')
+      )
     end
   end
 
   def get_app_display_name(apk_path:)
     if apk_path.include?('app')
-      "📱 Mobile"
+      '📱 Mobile'
     elsif apk_path.include?('wear')
-      "⌚ Wear"
+      '⌚ Wear'
     else
-      "🚗 Automotive"
+      '🚗 Automotive'
     end
   end
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -462,7 +462,7 @@ platform :android do
         project: 'automattic/pocket-casts-android',
         pr_number: Integer(ENV['BUILDKITE_PULL_REQUEST']),
         reuse_identifier: 'app-prototype-build-link',
-        body: prototype_build_comments.join('\n')
+        body: prototype_build_comments.join
       )
     end
   end

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -464,6 +464,7 @@ platform :android do
             reuse_identifier: "app-prototype-build-link",
             body: prototype_build_comments.join('\n')
         )
+    end
   end
 
   def get_app_display_name(apk_path:)


### PR DESCRIPTION
## Description
<!-- Please include a summary of what this PR is changing and why these changes are needed. -->
Based on implementation of same feature on WooCommerce-Android.

This PR introduces a feature of commenting PRs with links to build artifacts.

#### Why not separate jobs per build artifact?
In WooCommerce Android, we have 2 CI job: one for mobile, and one for wear projects. It makes sense there, as mobile and wear projects have different codebases.

Because Pocket Casts is modularized, it benefits from reusing intermediate build artifacts i.e. wear or automotive apps can use the same outputs of compilation of modules, generated for mobile app.

For this reason, I think there's no point in preparing 3 different jobs. This strategy shouldn't also increase CI check overall time, as instrumentation tests step is either way longer.

#### Jobs names
If this PR will be approved, I'll:
- ~remove "required" restriction on `assemble-release-apk ` job~
- ~add "required" restriction on `prototype-builds` job~ - actually, I don't think this job is required. In case of any build issues, `assemble-release-apk` will catch it (even more use cases, as R8 transformation will be also executed)
