### PR TITLE
Update the episode star value in the Media Session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 *   New Features
     *   Adds the kids banner in profile
         ([#2591](https://github.com/Automattic/pocket-casts-android/pull/2591))
+*   Bug Fixes
+    *   Update the episode star value in the Media Session to fix places where it's shown outside the app
+        ([#2613](https://github.com/Automattic/pocket-casts-android/pull/2613))
 
 7.70
 -----

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/entity/BaseEpisode.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/entity/BaseEpisode.kt
@@ -43,6 +43,7 @@ sealed interface BaseEpisode {
     var downloadErrorDetails: String?
     var deselectedChapters: ChapterIndices
     var deselectedChaptersModified: Date?
+    var isStarred: Boolean
 
     // temporary variables
     var playing: Boolean

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/entity/PodcastEpisode.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/entity/PodcastEpisode.kt
@@ -39,7 +39,7 @@ data class PodcastEpisode(
     @ColumnInfo(name = "podcast_id") var podcastUuid: String = "",
     @ColumnInfo(name = "added_date") override var addedDate: Date = Date(),
     @ColumnInfo(name = "auto_download_status") override var autoDownloadStatus: Int = 0,
-    @ColumnInfo(name = "starred") var isStarred: Boolean = false,
+    @ColumnInfo(name = "starred") override var isStarred: Boolean = false,
     @ColumnInfo(name = "thumbnail_status") var thumbnailStatus: Int = THUMBNAIL_STATUS_UNKNOWN,
     @ColumnInfo(name = "last_download_attempt_date") override var lastDownloadAttemptDate: Date? = null,
     @ColumnInfo(name = "playing_status_modified") override var playingStatusModified: Long? = null,

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/entity/UserEpisode.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/entity/UserEpisode.kt
@@ -54,6 +54,9 @@ data class UserEpisode(
     override var playing: Boolean = false
 
     @Ignore
+    override var isStarred: Boolean = false
+
+    @Ignore
     var hasBookmark: Boolean = false
 
     override fun displaySubtitle(podcast: Podcast?): String {

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/MediaSessionManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/MediaSessionManager.kt
@@ -22,7 +22,6 @@ import au.com.shiftyjelly.pocketcasts.analytics.SourceView
 import au.com.shiftyjelly.pocketcasts.models.entity.BaseEpisode
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
-import au.com.shiftyjelly.pocketcasts.models.entity.UserEpisode
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.preferences.Settings.MediaNotificationControls
 import au.com.shiftyjelly.pocketcasts.preferences.model.HeadphoneAction
@@ -170,8 +169,8 @@ class MediaSessionManager(
             .distinctUntilChanged { stateOne, stateTwo ->
                 UpNextQueue.State.isEqualWithEpisodeCompare(stateOne, stateTwo) { episodeOne, episodeTwo ->
                     episodeOne.uuid == episodeTwo.uuid &&
-                    episodeOne.duration == episodeTwo.duration &&
-                    episodeOne.isStarred == episodeTwo.isStarred
+                        episodeOne.duration == episodeTwo.duration &&
+                        episodeOne.isStarred == episodeTwo.isStarred
                 }
             }
 

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/MediaSessionManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/MediaSessionManager.kt
@@ -22,6 +22,7 @@ import au.com.shiftyjelly.pocketcasts.analytics.SourceView
 import au.com.shiftyjelly.pocketcasts.models.entity.BaseEpisode
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
+import au.com.shiftyjelly.pocketcasts.models.entity.UserEpisode
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.preferences.Settings.MediaNotificationControls
 import au.com.shiftyjelly.pocketcasts.preferences.model.HeadphoneAction
@@ -168,7 +169,9 @@ class MediaSessionManager(
         val upNextQueueChanges = playbackManager.upNextQueue.getChangesFlowWithLiveCurrentEpisode(episodeManager, podcastManager)
             .distinctUntilChanged { stateOne, stateTwo ->
                 UpNextQueue.State.isEqualWithEpisodeCompare(stateOne, stateTwo) { episodeOne, episodeTwo ->
-                    episodeOne.uuid == episodeTwo.uuid && episodeOne.duration == episodeTwo.duration
+                    episodeOne.uuid == episodeTwo.uuid &&
+                    episodeOne.duration == episodeTwo.duration &&
+                    episodeOne.isStarred == episodeTwo.isStarred
                 }
             }
 
@@ -394,6 +397,10 @@ class MediaSessionManager(
             .putLong(MediaMetadataCompat.METADATA_KEY_DURATION, episode.durationMs.toLong())
             .putString(MediaMetadataCompat.METADATA_KEY_GENRE, "Podcast")
             .putString(MediaMetadataCompat.METADATA_KEY_TITLE, episode.title)
+
+        if (episode is PodcastEpisode) {
+            nowPlayingBuilder.putRating(MediaMetadataCompat.METADATA_KEY_RATING, RatingCompat.newHeartRating(episode.isStarred))
+        }
 
         if (podcast != null && podcast.author.isNotEmpty()) {
             nowPlayingBuilder.putString(MediaMetadataCompat.METADATA_KEY_ALBUM, podcast.author)


### PR DESCRIPTION
## Description

Car manufacturers using Pocket Casts have reported that when they change the episode star it doesn't update. I believe this is because we aren't setting the rating in the media session. We don't say it's an action we support and instead use custom actions but as they are adding the action and we do support setting the value it seems like a good change to make. 

## Testing Instructions

1. As this isn't possible to test in the Automotive emulator as a Timber below the `putRating` call.
2. Deploy to the Automotive emulator
3. Play an episode
4. Open the full screen player
5. Tap the overflow dots
6. Star the episode
7. ✅ Verify the media session is updated
8. Unstar the episode
9. ✅ Verify the media session is updated 

