### PR TITLE
Constraint max sharing card size on all screens

### DIFF
--- a/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/clip/ShareClipPage.kt
+++ b/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/clip/ShareClipPage.kt
@@ -480,7 +480,7 @@ private fun PagingContent(
                 useEpisodeArtwork = useEpisodeArtwork,
                 shareColors = shareColors,
                 captureController = assetController.captureController(cardType),
-                customSize = coordiantes.size,
+                constrainedSize = { _, _ -> coordiantes.size },
                 modifier = modifier,
             )
             is CardType.Audio -> Box(

--- a/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/clip/ShareClipPage.kt
+++ b/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/clip/ShareClipPage.kt
@@ -56,6 +56,8 @@ import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.DpSize
+import androidx.compose.ui.unit.coerceAtMost
 import androidx.compose.ui.unit.dp
 import au.com.shiftyjelly.pocketcasts.compose.Devices
 import au.com.shiftyjelly.pocketcasts.compose.buttons.BaseRowButton
@@ -289,6 +291,7 @@ private fun HorizontalClipPage(
                         useEpisodeArtwork = useEpisodeArtwork,
                         shareColors = shareColors,
                         captureController = assetController.captureController(CardType.Horizontal),
+                        constrainedSize = { maxWidth, maxHeight -> DpSize(maxWidth.coerceAtMost(400.dp), maxHeight) },
                         modifier = Modifier.weight(1f),
                     )
                     Spacer(
@@ -708,55 +711,63 @@ private fun AnimatedVisiblity(
     }
 }
 
-@Preview(name = "Regular device", device = Devices.PortraitRegular, group = "vertical")
+@Preview(name = "Regular", device = Devices.PortraitRegular, group = "vertical")
 @Composable
 private fun ShareClipVerticalRegularPreview() = ShareClipPagePreview()
 
-@Preview(name = "Regular device sharing", device = Devices.PortraitRegular, group = "vertical")
+@Preview(name = "Regular sharing", device = Devices.PortraitRegular, group = "vertical")
 @Composable
 private fun ShareClipVerticalRegularSharingPreview() = ShareClipPagePreview(
     step = SharingStep.Sharing,
 )
 
-@Preview(name = "Regular device clipping", device = Devices.PortraitRegular, group = "vertical")
+@Preview(name = "Regular clipping", device = Devices.PortraitRegular, group = "vertical")
 @Composable
 private fun ShareClipVerticalRegularClippingPreview() = ShareClipPagePreview(
     step = SharingStep.Sharing,
     isSharing = true,
 )
 
-@Preview(name = "Small device", device = Devices.PortraitSmall, group = "vertical")
+@Preview(name = "Small", device = Devices.PortraitSmall, group = "vertical")
 @Composable
 private fun ShareClipVerticalSmallPreviewPreview() = ShareClipPagePreview()
 
-@Preview(name = "Foldable device", device = Devices.PortraitFoldable, group = "irregular")
-@Composable
-private fun ShareClipVerticalFoldablePreviewPreview() = ShareClipPagePreview()
-
-@Preview(name = "Tablet device", device = Devices.PortraitTablet, group = "irregular")
-@Composable
-private fun ShareClipVerticalTabletPreview() = ShareClipPagePreview()
-
-@Preview(name = "Regular device horizontal sharing", device = Devices.LandscapeRegular, group = "horizontal")
+@Preview(name = "Regular", device = Devices.LandscapeRegular, group = "horizontal")
 @Composable
 private fun ShareClipHorizontalRegularPreview() = ShareClipPagePreview()
 
-@Preview(name = "Regular device horizontal clipping", device = Devices.LandscapeRegular, group = "horizontal")
+@Preview(name = "Regular sharing", device = Devices.LandscapeRegular, group = "horizontal")
 @Composable
 private fun ShareClipHorizontalRegularSharingPreview() = ShareClipPagePreview(
     step = SharingStep.Sharing,
 )
 
-@Preview(name = "Regular device horizontal", device = Devices.LandscapeRegular, group = "horizontal")
+@Preview(name = "Regular clipping", device = Devices.LandscapeRegular, group = "horizontal")
 @Composable
 private fun ShareClipHorizontalRegularClippingPreview() = ShareClipPagePreview(
     step = SharingStep.Sharing,
     isSharing = true,
 )
 
-@Preview(name = "Small device horizontal", device = Devices.LandscapeSmall, group = "horizontal")
+@Preview(name = "Small", device = Devices.LandscapeSmall, group = "horizontal")
 @Composable
 private fun ShareClipHorizontalSmallPreviewPreview() = ShareClipPagePreview()
+
+@Preview(name = "Foldable", device = Devices.PortraitFoldable, group = "irregular")
+@Composable
+private fun ShareClipVerticalFoldablePreviewPreview() = ShareClipPagePreview()
+
+@Preview(name = "Foldable", device = Devices.LandscapeFoldable, group = "irregular")
+@Composable
+private fun ShareClipHorizontalFoldablePreviewPreview() = ShareClipPagePreview()
+
+@Preview(name = "Tablet", device = Devices.PortraitTablet, group = "irregular")
+@Composable
+private fun ShareClipVerticalTabletPreview() = ShareClipPagePreview()
+
+@Preview(name = "Tablet", device = Devices.LandscapeTablet, group = "irregular")
+@Composable
+private fun ShareClipHorizontalTabletPreview() = ShareClipPagePreview()
 
 @Composable
 internal fun ShareClipPagePreview(

--- a/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/episode/ShareEpisodePage.kt
+++ b/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/episode/ShareEpisodePage.kt
@@ -10,6 +10,9 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.DpSize
+import androidx.compose.ui.unit.coerceAtMost
+import androidx.compose.ui.unit.dp
 import au.com.shiftyjelly.pocketcasts.compose.Devices
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
@@ -159,6 +162,7 @@ private fun HorizontalShareEpisodePage(
                     episode = episode,
                     useEpisodeArtwork = useEpisodeArtwork,
                     shareColors = shareColors,
+                    constrainedSize = { maxWidth, maxHeight -> DpSize(maxWidth.coerceAtMost(400.dp), maxHeight) },
                     captureController = assetController.captureController(CardType.Horizontal),
                 )
             }

--- a/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/episode/ShareEpisodePage.kt
+++ b/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/episode/ShareEpisodePage.kt
@@ -107,7 +107,7 @@ private fun VerticalShareEpisodePage(
                 }
             }
         },
-        middleContent = { cardType, modifier ->
+        middleContent = { cardType, cardSize, modifier ->
             if (podcast != null && episode != null) {
                 val captureController = assetController.captureController(cardType)
                 EpisodeCard(
@@ -117,6 +117,7 @@ private fun VerticalShareEpisodePage(
                     useEpisodeArtwork = useEpisodeArtwork,
                     shareColors = shareColors,
                     captureController = captureController,
+                    constrainedSize = { _, _ -> cardSize },
                     modifier = modifier,
                 )
             }

--- a/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/podcast/SharePodcastPage.kt
+++ b/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/podcast/SharePodcastPage.kt
@@ -9,6 +9,9 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.DpSize
+import androidx.compose.ui.unit.coerceAtMost
+import androidx.compose.ui.unit.dp
 import au.com.shiftyjelly.pocketcasts.compose.Devices
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.sharing.SharingResponse
@@ -147,6 +150,7 @@ private fun HorizontalSharePodcastPage(
                     podcast = podcast,
                     episodeCount = episodeCount,
                     shareColors = shareColors,
+                    constrainedSize = { maxWidth, maxHeight -> DpSize(maxWidth.coerceAtMost(400.dp), maxHeight) },
                     captureController = assetController.captureController(CardType.Horizontal),
                 )
             }

--- a/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/podcast/SharePodcastPage.kt
+++ b/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/podcast/SharePodcastPage.kt
@@ -98,7 +98,7 @@ private fun VerticalSharePodcastPage(
                 }
             }
         },
-        middleContent = { cardType, modifier ->
+        middleContent = { cardType, cardSize, modifier ->
             if (podcast != null) {
                 val captureController = assetController.captureController(cardType)
                 PodcastCard(
@@ -107,6 +107,7 @@ private fun VerticalSharePodcastPage(
                     episodeCount = episodeCount,
                     shareColors = shareColors,
                     captureController = captureController,
+                    constrainedSize = { _, _ -> cardSize },
                     modifier = modifier,
                 )
             }

--- a/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/timestamp/ShareEpisodeTimestampPage.kt
+++ b/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/timestamp/ShareEpisodeTimestampPage.kt
@@ -113,7 +113,7 @@ private fun VerticalShareEpisodeTimestampPage(
                 }
             }
         },
-        middleContent = { cardType, modifier ->
+        middleContent = { cardType, cardSize, modifier ->
             if (podcast != null && episode != null) {
                 val captureController = assetController.captureController(cardType)
                 EpisodeCard(
@@ -123,6 +123,7 @@ private fun VerticalShareEpisodeTimestampPage(
                     useEpisodeArtwork = useEpisodeArtwork,
                     shareColors = shareColors,
                     captureController = captureController,
+                    constrainedSize = { _, _ -> cardSize },
                     modifier = modifier,
                 )
             }

--- a/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/timestamp/ShareEpisodeTimestampPage.kt
+++ b/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/timestamp/ShareEpisodeTimestampPage.kt
@@ -9,6 +9,9 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.DpSize
+import androidx.compose.ui.unit.coerceAtMost
+import androidx.compose.ui.unit.dp
 import au.com.shiftyjelly.pocketcasts.compose.Devices
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
@@ -166,6 +169,7 @@ private fun HorizontalShareEpisodeTimestampPage(
                     episode = episode,
                     useEpisodeArtwork = useEpisodeArtwork,
                     shareColors = shareColors,
+                    constrainedSize = { maxWidth, maxHeight -> DpSize(maxWidth.coerceAtMost(400.dp), maxHeight) },
                     captureController = assetController.captureController(CardType.Horizontal),
                 )
             }

--- a/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/ui/EpisodeCard.kt
+++ b/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/ui/EpisodeCard.kt
@@ -2,6 +2,7 @@ package au.com.shiftyjelly.pocketcasts.sharing.ui
 
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.DpSize
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
@@ -17,7 +18,7 @@ internal fun EpisodeCard(
     captureController: CaptureController,
     modifier: Modifier = Modifier,
     useHeightForAspectRatio: Boolean = cardType == CardType.Vertical,
-    customSize: DpSize? = null,
+    constrainedSize: (maxWidth: Dp, maxHeight: Dp) -> DpSize = { width, height -> DpSize(width, height) },
 ) = when (cardType) {
     CardType.Vertical -> VerticalEpisodeCard(
         episode = episode,
@@ -26,7 +27,7 @@ internal fun EpisodeCard(
         shareColors = shareColors,
         captureController = captureController,
         useHeightForAspectRatio = useHeightForAspectRatio,
-        customSize = customSize,
+        constrainedSize = constrainedSize,
         modifier = modifier,
     )
     CardType.Horizontal -> HorizontalEpisodeCard(
@@ -36,7 +37,7 @@ internal fun EpisodeCard(
         shareColors = shareColors,
         captureController = captureController,
         useHeightForAspectRatio = useHeightForAspectRatio,
-        customSize = customSize,
+        constrainedSize = constrainedSize,
         modifier = modifier,
     )
     CardType.Square -> SquareEpisodeCard(
@@ -45,7 +46,7 @@ internal fun EpisodeCard(
         useEpisodeArtwork = useEpisodeArtwork,
         shareColors = shareColors,
         captureController = captureController,
-        customSize = customSize,
+        constrainedSize = constrainedSize,
         modifier = modifier,
     )
 }

--- a/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/ui/HorizontalCard.kt
+++ b/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/ui/HorizontalCard.kt
@@ -19,6 +19,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
 import au.com.shiftyjelly.pocketcasts.compose.components.TextH40
@@ -40,7 +41,7 @@ internal fun HorizontalPodcastCard(
     captureController: CaptureController,
     modifier: Modifier = Modifier,
     useHeightForAspectRatio: Boolean = false,
-    customSize: DpSize? = null,
+    constrainedSize: (maxWidth: Dp, maxHeight: Dp) -> DpSize = { width, height -> DpSize(width, height) },
 ) = HorizontalCard(
     data = PodcastCardData(
         podcast = podcast,
@@ -48,7 +49,7 @@ internal fun HorizontalPodcastCard(
     ),
     shareColors = shareColors,
     useHeightForAspectRatio = useHeightForAspectRatio,
-    customSize = customSize,
+    constrainedSize = constrainedSize,
     captureController = captureController,
     modifier = modifier,
 )
@@ -62,7 +63,7 @@ internal fun HorizontalEpisodeCard(
     captureController: CaptureController,
     modifier: Modifier = Modifier,
     useHeightForAspectRatio: Boolean = false,
-    customSize: DpSize? = null,
+    constrainedSize: (maxWidth: Dp, maxHeight: Dp) -> DpSize = { width, height -> DpSize(width, height) },
 ) = HorizontalCard(
     data = EpisodeCardData(
         episode = episode,
@@ -71,7 +72,7 @@ internal fun HorizontalEpisodeCard(
     ),
     shareColors = shareColors,
     useHeightForAspectRatio = useHeightForAspectRatio,
-    customSize = customSize,
+    constrainedSize = constrainedSize,
     captureController = captureController,
     modifier = modifier,
 )
@@ -91,7 +92,7 @@ private fun HorizontalCard(
     useHeightForAspectRatio: Boolean,
     captureController: CaptureController,
     modifier: Modifier = Modifier,
-    customSize: DpSize? = null,
+    constrainedSize: (maxWidth: Dp, maxHeight: Dp) -> DpSize = { width, height -> DpSize(width, height) },
 ) = BoxWithConstraints(
     contentAlignment = Alignment.Center,
     modifier = modifier,
@@ -102,7 +103,7 @@ private fun HorizontalCard(
             shareColors.cardBottom,
         ),
     )
-    val size = customSize ?: DpSize(maxWidth, maxHeight)
+    val size = constrainedSize(maxWidth, maxHeight)
     val (width, height) = if (useHeightForAspectRatio) {
         size.height / CardType.Horizontal.aspectRatio to size.height
     } else {

--- a/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/ui/PodcastCard.kt
+++ b/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/ui/PodcastCard.kt
@@ -2,6 +2,7 @@ package au.com.shiftyjelly.pocketcasts.sharing.ui
 
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.DpSize
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import dev.shreyaspatil.capturable.controller.CaptureController
@@ -15,7 +16,7 @@ internal fun PodcastCard(
     captureController: CaptureController,
     modifier: Modifier = Modifier,
     useHeightForAspectRatio: Boolean = cardType == CardType.Vertical,
-    customSize: DpSize? = null,
+    constrainedSize: (maxWidth: Dp, maxHeight: Dp) -> DpSize = { width, height -> DpSize(width, height) },
 ) = when (cardType) {
     CardType.Vertical -> VerticalPodcastCard(
         podcast = podcast,
@@ -23,7 +24,7 @@ internal fun PodcastCard(
         shareColors = shareColors,
         captureController = captureController,
         useHeightForAspectRatio = useHeightForAspectRatio,
-        customSize = customSize,
+        constrainedSize = constrainedSize,
         modifier = modifier,
     )
     CardType.Horizontal -> HorizontalPodcastCard(
@@ -32,7 +33,7 @@ internal fun PodcastCard(
         shareColors = shareColors,
         captureController = captureController,
         useHeightForAspectRatio = useHeightForAspectRatio,
-        customSize = customSize,
+        constrainedSize = constrainedSize,
         modifier = modifier,
     )
     CardType.Square -> SquarePodcastCard(
@@ -40,7 +41,7 @@ internal fun PodcastCard(
         episodeCount = episodeCount,
         shareColors = shareColors,
         captureController = captureController,
-        customSize = customSize,
+        constrainedSize = constrainedSize,
         modifier = modifier,
     )
 }

--- a/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/ui/SharePage.kt
+++ b/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/ui/SharePage.kt
@@ -34,6 +34,7 @@ import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.platform.rememberNestedScrollInteropConnection
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
 import au.com.shiftyjelly.pocketcasts.compose.components.PagerDotIndicator
 import au.com.shiftyjelly.pocketcasts.compose.components.TextH30
@@ -51,7 +52,7 @@ internal fun VerticalSharePage(
     snackbarHostState: SnackbarHostState,
     onClose: () -> Unit,
     onShareToPlatform: (SocialPlatform, VisualCardType) -> Unit,
-    middleContent: @Composable (VisualCardType, Modifier) -> Unit,
+    middleContent: @Composable (VisualCardType, DpSize, Modifier) -> Unit,
 ) {
     Box(
         modifier = Modifier
@@ -146,7 +147,7 @@ private fun MiddleContent(
     scrollState: ScrollState,
     pagerState: PagerState,
     topContentHeight: Int,
-    middleContent: @Composable (VisualCardType, Modifier) -> Unit,
+    middleContent: @Composable (VisualCardType, DpSize, Modifier) -> Unit,
 ) {
     var indicatorHeight by remember { mutableIntStateOf(0) }
     Row(
@@ -174,7 +175,7 @@ private fun MiddleContent(
             .offset { coordiantes.offset(cardType) }
             .fillMaxSize()
             .padding(coordiantes.padding)
-        middleContent(cardType, modifier)
+        middleContent(cardType, coordiantes.size, modifier)
     }
 }
 

--- a/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/ui/SquareCard.kt
+++ b/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/ui/SquareCard.kt
@@ -17,6 +17,7 @@ import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
 import au.com.shiftyjelly.pocketcasts.compose.components.TextH40
@@ -37,14 +38,14 @@ internal fun SquarePodcastCard(
     shareColors: ShareColors,
     captureController: CaptureController,
     modifier: Modifier = Modifier,
-    customSize: DpSize? = null,
+    constrainedSize: (maxWidth: Dp, maxHeight: Dp) -> DpSize = { width, height -> DpSize(width, height) },
 ) = SquareCard(
     data = PodcastCardData(
         podcast = podcast,
         episodeCount = episodeCount,
     ),
     shareColors = shareColors,
-    customSize = customSize,
+    constrainedSize = constrainedSize,
     captureController = captureController,
     modifier = modifier,
 )
@@ -57,7 +58,7 @@ internal fun SquareEpisodeCard(
     shareColors: ShareColors,
     captureController: CaptureController,
     modifier: Modifier = Modifier,
-    customSize: DpSize? = null,
+    constrainedSize: (maxWidth: Dp, maxHeight: Dp) -> DpSize = { width, height -> DpSize(width, height) },
 ) = SquareCard(
     data = EpisodeCardData(
         episode = episode,
@@ -65,7 +66,7 @@ internal fun SquareEpisodeCard(
         useEpisodeArtwork = useEpisodeArtwork,
     ),
     shareColors = shareColors,
-    customSize = customSize,
+    constrainedSize = constrainedSize,
     captureController = captureController,
     modifier = modifier,
 )
@@ -77,7 +78,7 @@ private fun SquareCard(
     shareColors: ShareColors,
     captureController: CaptureController,
     modifier: Modifier = Modifier,
-    customSize: DpSize? = null,
+    constrainedSize: (maxWidth: Dp, maxHeight: Dp) -> DpSize = { width, height -> DpSize(width, height) },
 ) = BoxWithConstraints(
     contentAlignment = Alignment.Center,
     modifier = modifier,
@@ -88,7 +89,7 @@ private fun SquareCard(
             shareColors.cardBottom,
         ),
     )
-    val size = customSize ?: DpSize(maxWidth, maxHeight)
+    val size = constrainedSize(maxWidth, maxHeight)
     val minDimension = minOf(size.width, size.height)
     Column(
         horizontalAlignment = Alignment.CenterHorizontally,

--- a/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/ui/VerticalCard.kt
+++ b/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/ui/VerticalCard.kt
@@ -18,6 +18,7 @@ import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
 import au.com.shiftyjelly.pocketcasts.compose.components.PocketCastsPill
@@ -40,7 +41,7 @@ internal fun VerticalPodcastCard(
     captureController: CaptureController,
     modifier: Modifier = Modifier,
     useHeightForAspectRatio: Boolean = true,
-    customSize: DpSize? = null,
+    constrainedSize: (maxWidth: Dp, maxHeight: Dp) -> DpSize = { width, height -> DpSize(width, height) },
 ) = VerticalCard(
     data = PodcastCardData(
         podcast = podcast,
@@ -48,7 +49,7 @@ internal fun VerticalPodcastCard(
     ),
     shareColors = shareColors,
     useHeightForAspectRatio = useHeightForAspectRatio,
-    customSize = customSize,
+    constrainedSize = constrainedSize,
     captureController = captureController,
     modifier = modifier,
 )
@@ -62,7 +63,7 @@ internal fun VerticalEpisodeCard(
     captureController: CaptureController,
     modifier: Modifier = Modifier,
     useHeightForAspectRatio: Boolean = true,
-    customSize: DpSize? = null,
+    constrainedSize: (maxWidth: Dp, maxHeight: Dp) -> DpSize = { width, height -> DpSize(width, height) },
 ) = VerticalCard(
     data = EpisodeCardData(
         episode = episode,
@@ -71,7 +72,7 @@ internal fun VerticalEpisodeCard(
     ),
     shareColors = shareColors,
     useHeightForAspectRatio = useHeightForAspectRatio,
-    customSize = customSize,
+    constrainedSize = constrainedSize,
     captureController = captureController,
     modifier = modifier,
 )
@@ -84,7 +85,7 @@ private fun VerticalCard(
     useHeightForAspectRatio: Boolean,
     captureController: CaptureController,
     modifier: Modifier = Modifier,
-    customSize: DpSize? = null,
+    constrainedSize: (maxWidth: Dp, maxHeight: Dp) -> DpSize = { width, height -> DpSize(width, height) },
 ) = BoxWithConstraints(
     contentAlignment = Alignment.Center,
     modifier = modifier,
@@ -95,7 +96,7 @@ private fun VerticalCard(
             shareColors.cardBottom,
         ),
     )
-    val size = customSize ?: DpSize(maxWidth, maxHeight)
+    val size = constrainedSize(maxWidth, maxHeight)
     val (height, width) = if (useHeightForAspectRatio) {
         size.height to size.height / CardType.Vertical.aspectRatio
     } else {


### PR DESCRIPTION
## Description

Allowing cards to occupy the whole available space is wrong because when it is shared as an image or a video we scale it down to `1080x1920` bitmap. This would make fonts extremely small. This PR address this issue by constraining card sizes.

## Testing Instructions

1. Preview UI in landscape layout for clip and podcast sharing on a tablet or a foldable device.
2. Preview UI in portrait mode for podcast, episode, and episode timestamp sharing on a tablet or a foldable device.

## Screenshots or Screencast 

Example of a constrained square card

| Before | After |
| - | - |
|  ![Screenshot 2024-08-12 at 09 17 29](https://github.com/user-attachments/assets/d80c8d42-8fb3-49ba-a377-ba294794e24f) | ![Screenshot 2024-08-12 at 09 17 11](https://github.com/user-attachments/assets/f5357faf-ef9b-49f7-b073-5532054b95ee) |

## Checklist
- [x] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] ~I have considered whether it makes sense to add tests for my changes~
- [x] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
