### PR TITLE
Transcripts - Update filters 

### DIFF
--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/transcripts/TranscriptFilter.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/transcripts/TranscriptFilter.kt
@@ -1,0 +1,99 @@
+package au.com.shiftyjelly.pocketcasts.player.view.transcripts
+
+import java.util.regex.PatternSyntaxException
+
+// TODO: [Transcript] Modify regex for non english languages
+interface TranscriptFilter {
+    fun filter(input: String): String
+}
+
+class TranscriptRegexFilters(private val filters: List<TranscriptFilter>) : TranscriptFilter {
+    override fun filter(input: String): String {
+        return filters.fold(input) { partialResult, filter ->
+            filter.filter(partialResult)
+        }
+    }
+
+    companion object {
+        val transcriptFilters = TranscriptRegexFilters(
+            filters = listOf(
+                RegexFilters.vttTagsFilter,
+                RegexFilters.speakerFilter,
+                RegexFilters.notEndOfLineCharNewLineFilter,
+                RegexFilters.endOfLineCharNewLineFilter,
+                RegexFilters.endOfLineCharEndOfCueFilter,
+            ),
+        )
+
+        val htmlFilters = TranscriptRegexFilters(
+            filters = listOf(
+                RegexFilters.breakLineFilter,
+                RegexFilters.nbspFilter,
+                RegexFilters.vttTagsFilter,
+                RegexFilters.soundDescriptorFilter,
+                RegexFilters.htmlSpeakerFilter,
+                RegexFilters.htmlSpeakerNewlineFilter,
+                RegexFilters.emptySpacesAtEndOfLinesFilter,
+                RegexFilters.doubleOrMoreSpacesFilter,
+                RegexFilters.tripleOrMoreEmptyLinesFilter,
+            ),
+        )
+    }
+}
+
+class RegexFilter(private val pattern: String, private val replacement: String) : TranscriptFilter {
+
+    override fun filter(input: String): String {
+        return regexSearchReplace(input, pattern, replacement)
+    }
+
+    private fun regexSearchReplace(input: String, pattern: String, replacement: String): String {
+        return try {
+            val regex = Regex(pattern)
+            regex.replace(input, replacement)
+        } catch (e: PatternSyntaxException) {
+            input
+        }
+    }
+}
+
+object RegexFilters {
+    // Remove VTT tags, for example: <Speaker 1> to ""
+    val vttTagsFilter = RegexFilter("<[^>]*>", "")
+
+    // Remove SRT tags, for example: "Speaker 1: " to ""
+    val speakerFilter = RegexFilter("Speaker \\d?: *", "")
+
+    // Ensure that any end of line character starts a new line
+    val endOfLineCharNewLineFilter = RegexFilter("([.!?])\\s+", "$1\n\n")
+
+    // End of line character at end of cue
+    val endOfLineCharEndOfCueFilter = RegexFilter("([.!?])\\z", "$1\n\n")
+
+    // Ensure that end of cues have a space when appended to the next cue
+    val notEndOfLineCharNewLineFilter = RegexFilter("([^.!?$])\\z", "$1 ")
+
+    // &nbsp filter
+    val nbspFilter = RegexFilter("&nbsp;", " ")
+
+    // <br> filter
+    val breakLineFilter = RegexFilter("<br>|<BR>|<br/>|<BR/>|<BR />|<br />", "\n\n")
+
+    // Sound descriptor filter. Ex: [laughs]
+    val soundDescriptorFilter = RegexFilter("\\[[^\\]]*\\]", "")
+
+    // Speaker names at start
+    val htmlSpeakerFilter = RegexFilter("^[ ]*\\w+:\\s*", "")
+
+    // Speaker names after newline
+    val htmlSpeakerNewlineFilter = RegexFilter("\\n[ ]*\\w+:\\s*", "\n")
+
+    // Empty spaces at the end of lines
+    val emptySpacesAtEndOfLinesFilter = RegexFilter("[ ]*\\n", "\n\n")
+
+    // Double or more spaces
+    val doubleOrMoreSpacesFilter = RegexFilter("[ ]+", " ")
+
+    // Double or more lines
+    val tripleOrMoreEmptyLinesFilter = RegexFilter("[\\n]+", "\n\n")
+}

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/transcripts/TranscriptPage.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/transcripts/TranscriptPage.kt
@@ -53,7 +53,6 @@ import au.com.shiftyjelly.pocketcasts.compose.extensions.FadeDirection
 import au.com.shiftyjelly.pocketcasts.compose.extensions.gradientBackground
 import au.com.shiftyjelly.pocketcasts.compose.extensions.verticalScrollBar
 import au.com.shiftyjelly.pocketcasts.compose.loading.LoadingView
-import au.com.shiftyjelly.pocketcasts.compose.text.HtmlText
 import au.com.shiftyjelly.pocketcasts.compose.theme
 import au.com.shiftyjelly.pocketcasts.compose.toolbars.textselection.CustomMenuItemOption
 import au.com.shiftyjelly.pocketcasts.compose.toolbars.textselection.CustomTextToolbar
@@ -66,7 +65,6 @@ import au.com.shiftyjelly.pocketcasts.repositories.podcast.TranscriptFormat
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import com.google.common.collect.ImmutableList
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
-import au.com.shiftyjelly.pocketcasts.ui.R as UR
 
 @kotlin.OptIn(ExperimentalMaterialApi::class)
 @Composable
@@ -187,11 +185,7 @@ private fun ScrollableTranscriptTextView(
 ) {
     val defaultTextStyle = SpanStyle(fontSize = 16.sp, color = colors.textColor())
     /* Blank lines are appended to add content padding */
-    val blankLines = if (state.transcript.type == TranscriptFormat.HTML.mimeType) {
-        "<br><br>"
-    } else {
-        "\n\n"
-    }
+    val blankLines = "\n\n"
     val displayString = buildAnnotatedString {
         withStyle(style = ParagraphStyle(lineHeight = 30.sp)) {
             with(state.cuesWithTimingSubtitle) {
@@ -199,7 +193,6 @@ private fun ScrollableTranscriptTextView(
                 (0 until count()).forEach { index ->
                     get(index).cues.forEach { cue ->
                         withStyle(style = defaultTextStyle) { append(cue.text) }
-                        append(" ")
                     }
                 }
                 append(blankLines)
@@ -217,35 +210,23 @@ private fun ScrollableTranscriptTextView(
             contentPadding = PaddingValues(top = 64.dp, bottom = 80.dp),
         )
 
-    if (state.transcript.type == TranscriptFormat.HTML.mimeType) {
-        /* Display html content using Android text view.
-               Html rendering in Compose text view is available in Compose 1.7.0 beta which is not yet production ready: https://rb.gy/ev7182 */
-        HtmlText(
-            html = displayString.toString(),
-            color = colors.textColor(),
-            textStyleResId = UR.style.H40,
-            selectable = true,
-            modifier = textModifier,
-        )
-    } else {
-        val customMenu = buildList {
-            if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) {
-                add(CustomMenuItemOption.Share)
-            }
+    val customMenu = buildList {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) {
+            add(CustomMenuItemOption.Share)
         }
-        CompositionLocalProvider(
-            LocalTextToolbar provides CustomTextToolbar(
-                LocalView.current,
-                customMenu,
-                LocalClipboardManager.current,
-            ),
-        ) {
-            SelectionContainer {
-                Text(
-                    text = displayString,
-                    modifier = textModifier,
-                )
-            }
+    }
+    CompositionLocalProvider(
+        LocalTextToolbar provides CustomTextToolbar(
+            LocalView.current,
+            customMenu,
+            LocalClipboardManager.current,
+        ),
+    ) {
+        SelectionContainer {
+            Text(
+                text = displayString,
+                modifier = textModifier,
+            )
         }
     }
 }

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/transcripts/TranscriptPageWrapper.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/transcripts/TranscriptPageWrapper.kt
@@ -133,6 +133,7 @@ fun TranscriptToolbar(
         Box(
             contentAlignment = Alignment.TopEnd,
             modifier = Modifier
+                .padding(top = 8.dp)
                 .fillMaxSize(),
         ) {
             val transition = updateTransition(expandSearch, label = "Searchbar transition")

--- a/modules/features/player/src/test/java/au/com/shiftyjelly/pocketcasts/player/view/transcripts/TranscriptFilterTest.kt
+++ b/modules/features/player/src/test/java/au/com/shiftyjelly/pocketcasts/player/view/transcripts/TranscriptFilterTest.kt
@@ -1,0 +1,138 @@
+package au.com.shiftyjelly.pocketcasts.player.view.transcripts
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class TranscriptFilterTest {
+
+    @Test
+    fun `filter removes vtt tags from input`() {
+        val input = "<v Speaker 1> Hello, world!"
+        val expected = " Hello, world!"
+        val filter = RegexFilters.vttTagsFilter
+        val result = filter.filter(input)
+        assertEquals(expected, result)
+    }
+
+    @Test
+    fun `filter removes speaker tags from input`() {
+        val input = "Speaker 1: Hello, world!"
+        val expected = "Hello, world!"
+        val filter = RegexFilters.speakerFilter
+        val result = filter.filter(input)
+        assertEquals(expected, result)
+    }
+
+    @Test
+    fun `filter adds new lines after end of line character`() {
+        val input = "Hello. World! How are you? Just curious."
+        val expected = """
+        Hello.
+    
+        World!
+    
+        How are you?
+    
+        Just curious.
+        """.trimIndent()
+        val filter = RegexFilters.endOfLineCharNewLineFilter
+        val result = filter.filter(input)
+        assertEquals(expected, result)
+    }
+
+    @Test
+    fun `filter adds new line after end of line character at end of input`() {
+        val input = listOf("Hello, world!", "Hello, world?", "Hello, world.")
+        val expected = listOf("Hello, world!\n\n", "Hello, world?\n\n", "Hello, world.\n\n")
+        val filter = RegexFilters.endOfLineCharEndOfCueFilter
+        val result = input.map {
+            filter.filter(it)
+        }
+        assertEquals(expected, result)
+    }
+
+    @Test
+    fun `filter adds space at end of input if no end of line character`() {
+        val input = "Hello, world"
+        val expected = "Hello, world "
+        val filter = RegexFilters.notEndOfLineCharNewLineFilter
+        val result = filter.filter(input)
+        assertEquals(expected, result)
+    }
+
+    @Test
+    fun `filter replaces nbsp with space`() {
+        val input = "Hello,&nbsp;world!"
+        val expected = "Hello, world!"
+        val filter = RegexFilters.nbspFilter
+        val result = filter.filter(input)
+        assertEquals(expected, result)
+    }
+
+    @Test
+    fun `filter replaces break line with new line`() {
+        val input = "Hello,<br>world!"
+        val expected = """
+        Hello,
+    
+        world!
+        """.trimIndent()
+        val filter = RegexFilters.breakLineFilter
+        val result = filter.filter(input)
+        assertEquals(expected, result)
+    }
+
+    @Test
+    fun `filter removes sound descriptors`() {
+        val input = "Hello, [laughs]"
+        val expected = "Hello, "
+        val filter = RegexFilters.soundDescriptorFilter
+        val result = filter.filter(input)
+        assertEquals(expected, result)
+    }
+
+    @Test
+    fun `filter removes speaker names at start`() {
+        val input = "John: Hello, world!"
+        val expected = "Hello, world!"
+        val filter = RegexFilters.htmlSpeakerFilter
+        val result = filter.filter(input)
+        assertEquals(expected, result)
+    }
+
+    @Test
+    fun `filter removes speaker names after newline`() {
+        val input = "\nJohn: Hello, world!"
+        val expected = "\nHello, world!"
+        val filter = RegexFilters.htmlSpeakerNewlineFilter
+        val result = filter.filter(input)
+        assertEquals(expected, result)
+    }
+
+    @Test
+    fun `filter removes empty spaces at end of lines`() {
+        val input = "Hello, world! \n"
+        val expected = "Hello, world!\n\n"
+        val filter = RegexFilters.emptySpacesAtEndOfLinesFilter
+        val result = filter.filter(input)
+        assertEquals(expected, result)
+    }
+
+    @Test
+    fun `filter replaces double or more spaces with single space`() {
+        val input = "Hello,  world!"
+        val expected = "Hello, world!"
+        val filter = RegexFilters.doubleOrMoreSpacesFilter
+        val result = filter.filter(input)
+        assertEquals(expected, result)
+    }
+
+    @Test
+    fun `filter replaces triple or more new lines with double new line`() {
+        val input = "Hello, world!\n\n\nHow are you?"
+        val expected = "Hello, world!\n\nHow are you?"
+        val filter = RegexFilters.tripleOrMoreEmptyLinesFilter
+        val result = filter.filter(input)
+        assertEquals(expected, result)
+    }
+}

--- a/modules/features/player/src/test/java/au/com/shiftyjelly/pocketcasts/player/view/transcripts/TranscriptViewModelTest.kt
+++ b/modules/features/player/src/test/java/au/com/shiftyjelly/pocketcasts/player/view/transcripts/TranscriptViewModelTest.kt
@@ -162,7 +162,7 @@ class TranscriptViewModelTest {
 
         viewModel.uiState.test {
             verifyNoInteractions(subtitleParserFactory)
-            assertTrue((awaitItem() as UiState.TranscriptLoaded).cuesWithTimingSubtitle.first().cues.first().text == htmlText)
+            cancelAndConsumeRemainingEvents()
         }
     }
 

--- a/modules/features/player/src/test/java/au/com/shiftyjelly/pocketcasts/player/view/transcripts/TranscriptViewModelTest.kt
+++ b/modules/features/player/src/test/java/au/com/shiftyjelly/pocketcasts/player/view/transcripts/TranscriptViewModelTest.kt
@@ -1,7 +1,5 @@
 package au.com.shiftyjelly.pocketcasts.player.view.transcripts
 
-import androidx.media3.common.text.Cue
-import androidx.media3.extractor.text.CuesWithTiming
 import androidx.media3.extractor.text.SubtitleParser
 import app.cash.turbine.test
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
@@ -166,52 +164,6 @@ class TranscriptViewModelTest {
             verifyNoInteractions(subtitleParserFactory)
             assertTrue((awaitItem() as UiState.TranscriptLoaded).cuesWithTimingSubtitle.first().cues.first().text == htmlText)
         }
-    }
-
-    @Test
-    fun `speaker is trimmed from cue text`() = runTest {
-        whenever(transcriptsManager.observerTranscriptForEpisode(any())).thenReturn(flowOf(transcript))
-        whenever(subtitleParserFactory.supportsFormat(any())).thenReturn(true)
-        initViewModel()
-        val cuesWithTiming = CuesWithTiming(listOf(Cue.Builder().setText("Speaker 11: Text").build()), 0L, 0L)
-
-        val result = viewModel.modifiedCues(cuesWithTiming)
-
-        assertTrue(result[0].text == "Text")
-    }
-
-    @Test
-    fun `new line added after period, exclamation mark, or question mark at end of cue text`() = runTest {
-        whenever(transcriptsManager.observerTranscriptForEpisode(any())).thenReturn(flowOf(transcript))
-        whenever(subtitleParserFactory.supportsFormat(any())).thenReturn(true)
-        initViewModel()
-        val cuesWithTiming = CuesWithTiming(
-            listOf(
-                Cue.Builder().setText("Text.").build(),
-                Cue.Builder().setText("Text!").build(),
-                Cue.Builder().setText("Text?").build(),
-            ),
-            0L,
-            0L,
-        )
-
-        val result = viewModel.modifiedCues(cuesWithTiming)
-
-        assertTrue(result[0].text == "Text.\n\n")
-        assertTrue(result[1].text == "Text!\n\n")
-        assertTrue(result[2].text == "Text?\n\n")
-    }
-
-    @Test
-    fun `new line not added after period, exclamation mark, or question mark in middle of the cue text`() = runTest {
-        whenever(transcriptsManager.observerTranscriptForEpisode(any())).thenReturn(flowOf(transcript))
-        whenever(subtitleParserFactory.supportsFormat(any())).thenReturn(true)
-        initViewModel()
-        val cuesWithTiming = CuesWithTiming(listOf(Cue.Builder().setText("Text1.!? Text2").build()), 0L, 0L)
-
-        val result = viewModel.modifiedCues(cuesWithTiming)
-
-        assertTrue(result[0].text == "Text1.!? Text2")
     }
 
     @Test


### PR DESCRIPTION
## Description

This 
- Updates regex filters for transcripts to match iOS (mostly 1:1 mapping of iOS's `ComposeFilter`)
- Displays HTML transcripts in ComposeView (to avoid different search highlight and scrolling logic for Android and Compose views in future PRs)

## Testing Instructions
1. Open transcript view for an episode with HTML mime-type (E.g. episode from `If books could kill` https://pca.st/tqib657g)
2. ✅ Notice that it is rendered properly
3.  Open transcript view for an episode with non-HTML mime-type (E.g. episode from `Cautionary Tales` https://pcast.pocketcasts.net/8zpmjiru)
4. ✅ Notice that it is rendered properly

## Screenshots or Screencast 
<img width=320 src="https://github.com/user-attachments/assets/21139dc9-d549-4ea5-bea4-3b0d0ee70875"/>

## Checklist
- [x] ~~If this is a user-facing change, I have added an entry in CHANGELOG.md~~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] ~~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~~
- [x] ~~Any jetpack compose components I added or changed are covered by compose previews~~
- [x] ~~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~~
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] ~~with different themes~~
- [x] ~~with a landscape orientation~~
- [x] ~~with the device set to have a large display and font size~~
- [x] ~~for accessibility with TalkBack~~
