### PR TITLE
Fix change avatar button text alignment

### DIFF
--- a/modules/features/profile/src/main/res/layout/fragment_account_details.xml
+++ b/modules/features/profile/src/main/res/layout/fragment_account_details.xml
@@ -71,7 +71,7 @@
                 android:textColor="?attr/primary_interactive_01"
                 android:importantForAccessibility="no"
                 app:layout_constraintBottom_toBottomOf="@+id/btnChangeAvatar"
-                app:layout_constraintStart_toEndOf="@+id/imgMail"
+                app:layout_constraintStart_toEndOf="@+id/imgAvatar"
                 app:layout_constraintTop_toTopOf="@id/btnChangeAvatar" />
 
             <View


### PR DESCRIPTION
## Description

When signed in with Google, the change avatar button text is incorrectly aligned. The text is set to align with the change email icon, and the change email and password buttons are hidden when signed in with Google, so this is causing an issue.  

Fixes #2621 

## Testing Instructions
1. Sign in with a Google account
2. Tap the profile tab
3. Tap the account button

✅ Verify the change avatar button text is in the correct place

4. Sign out and sign in with an email and password
2. Tap the profile tab
3. Tap the account button

✅ Verify the change avatar button text is still in the correct place

## Screenshots 

| Before | After |
| --- | --- |
| <img width="540" alt="Screenshot_20240813_153102" src="https://github.com/user-attachments/assets/2e7dba12-eac7-4308-81aa-9739beb59a6a"> | <img width="540" alt="Screenshot_20240813_152529" src="https://github.com/user-attachments/assets/71624758-a6de-445b-82c0-f6c435d6158d"> | 

After signed in with an email and password
<img width="540" alt="Screenshot_20240813_153205" src="https://github.com/user-attachments/assets/77c010fb-d255-4953-8bcd-c3f3d021dbac">
