### PR TITLE
Transcripts - Search logic

### DIFF
--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/PlayerHeaderFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/PlayerHeaderFragment.kt
@@ -39,6 +39,7 @@ import au.com.shiftyjelly.pocketcasts.player.databinding.AdapterPlayerHeaderBind
 import au.com.shiftyjelly.pocketcasts.player.view.ShelfFragment.Companion.AnalyticsProp
 import au.com.shiftyjelly.pocketcasts.player.view.bookmark.BookmarkActivityContract
 import au.com.shiftyjelly.pocketcasts.player.view.transcripts.TranscriptPageWrapper
+import au.com.shiftyjelly.pocketcasts.player.view.transcripts.TranscriptSearchViewModel
 import au.com.shiftyjelly.pocketcasts.player.view.transcripts.TranscriptViewModel
 import au.com.shiftyjelly.pocketcasts.player.view.video.VideoActivity
 import au.com.shiftyjelly.pocketcasts.player.viewmodel.PlayerViewModel
@@ -104,6 +105,7 @@ class PlayerHeaderFragment : BaseFragment(), PlayerClickListener {
     private lateinit var imageRequestFactory: PocketCastsImageRequestFactory
     private val viewModel: PlayerViewModel by activityViewModels()
     private val transcriptViewModel by viewModels<TranscriptViewModel>({ requireParentFragment() })
+    private val transcriptSearchViewModel by viewModels<TranscriptSearchViewModel>({ requireParentFragment() })
     private var binding: AdapterPlayerHeaderBinding? = null
     private val sourceView = SourceView.PLAYER
 
@@ -354,6 +356,7 @@ class PlayerHeaderFragment : BaseFragment(), PlayerClickListener {
             TranscriptPageWrapper(
                 playerViewModel = viewModel,
                 transcriptViewModel = transcriptViewModel,
+                searchViewModel = transcriptSearchViewModel,
                 theme = theme,
             )
         }

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/transcripts/KMPSearch.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/transcripts/KMPSearch.kt
@@ -1,0 +1,74 @@
+package au.com.shiftyjelly.pocketcasts.player.view.transcripts
+
+import javax.inject.Inject
+
+// An implementation of the Knuth-Morris-Pratt algorithm
+class KMPSearch @Inject constructor() {
+    private var pattern: CharArray = charArrayOf()
+    private var lps: IntArray = intArrayOf()
+
+    fun setPattern(pattern: String) {
+        this.pattern = pattern.lowercase().toCharArray()
+        lps = IntArray(pattern.length)
+        computeLPSArray()
+    }
+
+    private fun computeLPSArray() {
+        if (lps.isEmpty()) {
+            return
+        }
+
+        // Length of the previous longest prefix suffix
+        var length = 0
+        // lps[0] is always 0
+        lps[0] = 0
+        var i = 1
+
+        // Loop calculates the lps for i = 1 to M-1
+        while (i < pattern.size) {
+            if (pattern[i] == pattern[length]) {
+                length++
+                lps[i] = length
+                i++
+            } else {
+                if (length != 0) {
+                    length = lps[length - 1]
+                } else {
+                    lps[i] = 0
+                    i++
+                }
+            }
+        }
+    }
+
+    fun search(text: String): List<Int> {
+        if (pattern.isEmpty()) {
+            return emptyList()
+        }
+
+        val textArray = text.lowercase().toCharArray()
+        val result = mutableListOf<Int>()
+        var i = 0 // index for textArray
+        var j = 0 // index for pattern
+
+        while (i < textArray.size) {
+            if (pattern[j] == textArray[i]) {
+                i++
+                j++
+            }
+
+            if (j == pattern.size) {
+                result.add(i - j)
+                j = lps[j - 1]
+            } else if (i < textArray.size && pattern[j] != textArray[i]) {
+                if (j != 0) {
+                    j = lps[j - 1]
+                } else {
+                    i++
+                }
+            }
+        }
+
+        return result
+    }
+}

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/transcripts/KMPSearch.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/transcripts/KMPSearch.kt
@@ -1,5 +1,6 @@
 package au.com.shiftyjelly.pocketcasts.player.view.transcripts
 
+import au.com.shiftyjelly.pocketcasts.utils.extensions.removeAccents
 import javax.inject.Inject
 
 // An implementation of the Knuth-Morris-Pratt algorithm
@@ -8,7 +9,7 @@ class KMPSearch @Inject constructor() {
     private var lps: IntArray = intArrayOf()
 
     fun setPattern(pattern: String) {
-        this.pattern = pattern.lowercase().toCharArray()
+        this.pattern = pattern.removeAccents().lowercase().toCharArray()
         lps = IntArray(pattern.length)
         computeLPSArray()
     }
@@ -46,7 +47,7 @@ class KMPSearch @Inject constructor() {
             return emptyList()
         }
 
-        val textArray = text.lowercase().toCharArray()
+        val textArray = text.removeAccents().lowercase().toCharArray()
         val result = mutableListOf<Int>()
         var i = 0 // index for textArray
         var j = 0 // index for pattern

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/transcripts/TranscriptPage.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/transcripts/TranscriptPage.kt
@@ -78,6 +78,7 @@ private val ContentOffsetBottom = 80.dp
 fun TranscriptPage(
     playerViewModel: PlayerViewModel,
     transcriptViewModel: TranscriptViewModel,
+    searchViewModel: TranscriptSearchViewModel,
     theme: Theme,
     modifier: Modifier,
 ) {
@@ -127,6 +128,13 @@ fun TranscriptPage(
 
     LaunchedEffect(uiState.value.transcript?.episodeUuid + transitionState.value) {
         transcriptViewModel.parseAndLoadTranscript(transitionState.value is TransitionState.OpenTranscript)
+    }
+
+    if (uiState.value is UiState.TranscriptLoaded) {
+        val state = uiState.value as UiState.TranscriptLoaded
+        LaunchedEffect(state.displayInfo.text) {
+            searchViewModel.setSearchSourceText(state.displayInfo.text)
+        }
     }
 }
 

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/transcripts/TranscriptPage.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/transcripts/TranscriptPage.kt
@@ -403,7 +403,7 @@ private fun TranscriptWithSearchContentPreview() {
 @OptIn(UnstableApi::class)
 @Composable
 private fun TranscriptContentPreview(
-    searchState: SearchUiState
+    searchState: SearchUiState,
 ) {
     AppThemeWithBackground(Theme.ThemeType.DARK) {
         TranscriptContent(

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/transcripts/TranscriptPage.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/transcripts/TranscriptPage.kt
@@ -382,10 +382,29 @@ private data class DefaultColors(
         MaterialTheme.theme.colors.playerContrast01
 }
 
-@OptIn(UnstableApi::class)
 @Preview(name = "Dark")
 @Composable
-private fun TranscriptContentPreview() {
+private fun TranscriptWithoutSearchContentPreview() {
+    TranscriptContentPreview(searchState = SearchUiState())
+}
+
+@Preview(name = "Dark")
+@Composable
+private fun TranscriptWithSearchContentPreview() {
+    TranscriptContentPreview(
+        searchState = SearchUiState(
+            searchTerm = "se",
+            searchResultIndices = listOf(26, 61, 134),
+            currentSearchIndex = 0,
+        ),
+    )
+}
+
+@OptIn(UnstableApi::class)
+@Composable
+private fun TranscriptContentPreview(
+    searchState: SearchUiState
+) {
     AppThemeWithBackground(Theme.ThemeType.DARK) {
         TranscriptContent(
             state = UiState.TranscriptLoaded(
@@ -410,13 +429,13 @@ private fun TranscriptContentPreview() {
                 displayInfo = DisplayInfo(
                     text = "",
                     items = listOf(
-                        DisplayItem("Lorem ipsum odor amet, consectetuer adipiscing elit.", 0, 0),
-                        DisplayItem("Sodales sem fusce elementum commodo risus purus auctor neque.", 0, 0),
-                        DisplayItem("Maecenas fermentum senectus penatibus senectus integer per vulputate tellus sed.", 0, 0),
+                        DisplayItem("Lorem ipsum odor amet, consectetuer adipiscing elit.", 0, 52),
+                        DisplayItem("Sodales sem fusce elementum commodo risus purus auctor neque.", 53, 114),
+                        DisplayItem("Maecenas fermentum senectus penatibus tenectus integer per vulputate tellus ted.", 115, 195),
                     ),
                 ),
             ),
-            searchState = SearchUiState(),
+            searchState = searchState,
             colors = DefaultColors(Color.Black),
             modifier = Modifier.fillMaxSize(),
         )

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/transcripts/TranscriptPageWrapper.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/transcripts/TranscriptPageWrapper.kt
@@ -96,6 +96,7 @@ fun TranscriptPageWrapper(
             TranscriptPage(
                 playerViewModel = playerViewModel,
                 transcriptViewModel = transcriptViewModel,
+                searchViewModel = searchViewModel,
                 theme = theme,
                 modifier = Modifier
                     .height(configuration.screenHeightDp.dp),

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/transcripts/TranscriptPageWrapper.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/transcripts/TranscriptPageWrapper.kt
@@ -57,6 +57,7 @@ import au.com.shiftyjelly.pocketcasts.player.viewmodel.PlayerViewModel
 import au.com.shiftyjelly.pocketcasts.player.viewmodel.PlayerViewModel.TransitionState
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
+import au.com.shiftyjelly.pocketcasts.player.view.transcripts.TranscriptSearchViewModel.SearchUiState
 
 private val SearchBarMaxWidth = 500.dp
 private val SearchViewCornerRadius = 38.dp
@@ -117,7 +118,7 @@ fun TranscriptPageWrapper(
                 },
                 onSearchClicked = { expandSearch = true },
                 searchText = searchQueryFlow.value,
-                searchOccurencesText = searchState.value.searchOccurencesText,
+                searchState = searchState.value,
                 onSearchCleared = { searchViewModel.onSearchCleared() },
                 onSearchPreviousClicked = { searchViewModel.onSearchPrevious() },
                 onSearchNextClicked = { searchViewModel.onSearchNext() },
@@ -138,7 +139,7 @@ fun TranscriptToolbar(
     onSearchPreviousClicked: () -> Unit,
     onSearchNextClicked: () -> Unit,
     searchText: String,
-    searchOccurencesText: String,
+    searchState: SearchUiState,
     onSearchQueryChanged: (String) -> Unit,
     expandSearch: Boolean,
 ) {
@@ -194,7 +195,7 @@ fun TranscriptToolbar(
                     trailingIcon = {
                         SearchBarTrailingIcons(
                             text = searchText,
-                            searchOccurrencesText = searchOccurencesText,
+                            searchState = searchState,
                             onSearchCleared = onSearchCleared,
                             onPrevious = onSearchPreviousClicked,
                             onNext = onSearchNextClicked,
@@ -255,7 +256,7 @@ private fun SearchBarLeadingIcons(
 @Composable
 private fun SearchBarTrailingIcons(
     text: String,
-    searchOccurrencesText: String,
+    searchState: SearchUiState,
     onSearchCleared: () -> Unit,
     onPrevious: () -> Unit,
     onNext: () -> Unit,
@@ -265,7 +266,7 @@ private fun SearchBarTrailingIcons(
     ) {
         if (text.isNotEmpty()) {
             Text(
-                text = searchOccurrencesText,
+                text = searchState.searchOccurrencesText,
                 color = SearchBarIconColor,
             )
             IconButton(
@@ -279,9 +280,10 @@ private fun SearchBarTrailingIcons(
                 )
             }
         }
+
         IconButton(
             onClick = onPrevious,
-            enabled = text.isNotEmpty(),
+            enabled = searchState.prevNextArrowButtonsEnabled,
         ) {
             Icon(
                 imageVector = Icons.Default.KeyboardArrowUp,
@@ -290,7 +292,7 @@ private fun SearchBarTrailingIcons(
         }
         IconButton(
             onClick = onNext,
-            enabled = text.isNotEmpty(),
+            enabled = searchState.prevNextArrowButtonsEnabled,
         ) {
             Icon(
                 imageVector = Icons.Default.KeyboardArrowDown,
@@ -324,7 +326,7 @@ private fun TranscriptToolbarPreview(
             onSearchPreviousClicked = {},
             onSearchNextClicked = {},
             searchText = "",
-            searchOccurencesText = "",
+            searchState = SearchUiState(),
             onSearchQueryChanged = {},
             expandSearch = false,
         )
@@ -345,7 +347,7 @@ private fun TranscriptToolbarExpandedSearchPreview(
             onSearchPreviousClicked = {},
             onSearchNextClicked = {},
             searchText = "",
-            searchOccurencesText = "",
+            searchState = SearchUiState(),
             onSearchQueryChanged = {},
             expandSearch = true,
         )

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/transcripts/TranscriptSearchViewModel.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/transcripts/TranscriptSearchViewModel.kt
@@ -1,0 +1,85 @@
+package au.com.shiftyjelly.pocketcasts.player.view.transcripts
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+import kotlinx.coroutines.FlowPreview
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.debounce
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.update
+
+private const val SEARCH_DEBOUNCE = 300L
+
+@HiltViewModel
+class TranscriptSearchViewModel @Inject constructor() : ViewModel() {
+    private val _searchQueryFlow = MutableStateFlow("")
+    val searchQueryFlow = _searchQueryFlow.asStateFlow()
+
+    private val _searchState = MutableStateFlow(SearchUiState())
+    val searchState = _searchState.asStateFlow()
+
+    init {
+        @OptIn(FlowPreview::class)
+        _searchQueryFlow
+            .debounce(SEARCH_DEBOUNCE)
+            .onEach { searchQuery ->
+                performSearch(searchQuery)
+            }
+            .launchIn(viewModelScope)
+    }
+
+    fun onSearchQueryChanged(searchQuery: String) {
+        _searchQueryFlow.value = searchQuery
+    }
+
+    @Suppress("UNUSED_PARAMETER")
+    private fun performSearch(searchTerm: String) {
+    }
+
+    fun onSearchPrevious() {
+        val currentState = _searchState.value
+        val previousIndex = (currentState.currentSearchIndex - 1 + currentState.searchResultIndices.size) % currentState.searchResultIndices.size
+        _searchState.update { it.copy(currentSearchIndex = previousIndex) }
+    }
+
+    fun onSearchNext() {
+        val currentState = _searchState.value
+        val nextIndex = (currentState.currentSearchIndex + 1) % currentState.searchResultIndices.size
+        _searchState.update { it.copy(currentSearchIndex = nextIndex) }
+    }
+
+    fun onSearchDone() {
+        resetSearch()
+    }
+
+    fun onSearchCleared() {
+        resetSearch()
+    }
+
+    private fun resetSearch() {
+        onSearchQueryChanged("")
+        _searchState.update {
+            it.copy(
+                searchTerm = "",
+                currentSearchIndex = 0,
+                searchResultIndices = emptyList(),
+            )
+        }
+    }
+
+    data class SearchUiState(
+        val searchTerm: String = "",
+        val searchResultIndices: List<Int> = emptyList(),
+        val currentSearchIndex: Int = 0,
+    ) {
+        val searchOccurencesText: String
+            get() = searchResultIndices
+                .takeIf { it.isNotEmpty() }
+                ?.let { "${currentSearchIndex + 1}/${it.size}" }
+                ?: ""
+    }
+}

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/transcripts/TranscriptSearchViewModel.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/transcripts/TranscriptSearchViewModel.kt
@@ -16,6 +16,8 @@ private const val SEARCH_DEBOUNCE = 300L
 
 @HiltViewModel
 class TranscriptSearchViewModel @Inject constructor() : ViewModel() {
+    private var _searchSourceText: String = ""
+
     private val _searchQueryFlow = MutableStateFlow("")
     val searchQueryFlow = _searchQueryFlow.asStateFlow()
 
@@ -30,6 +32,10 @@ class TranscriptSearchViewModel @Inject constructor() : ViewModel() {
                 performSearch(searchQuery)
             }
             .launchIn(viewModelScope)
+    }
+
+    fun setSearchSourceText(searchSourceText: String) {
+        this._searchSourceText = searchSourceText
     }
 
     fun onSearchQueryChanged(searchQuery: String) {

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/transcripts/TranscriptSearchViewModel.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/transcripts/TranscriptSearchViewModel.kt
@@ -39,6 +39,7 @@ class TranscriptSearchViewModel @Inject constructor(
     }
 
     fun setSearchSourceText(searchSourceText: String) {
+        resetSearch()
         this._searchSourceText = searchSourceText
     }
 

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/transcripts/TranscriptSearchViewModel.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/transcripts/TranscriptSearchViewModel.kt
@@ -66,12 +66,14 @@ class TranscriptSearchViewModel @Inject constructor(
 
     fun onSearchPrevious() {
         val currentState = _searchState.value
+        if (currentState.searchResultIndices.isEmpty()) return
         val previousIndex = (currentState.currentSearchIndex - 1 + currentState.searchResultIndices.size) % currentState.searchResultIndices.size
         _searchState.update { it.copy(currentSearchIndex = previousIndex) }
     }
 
     fun onSearchNext() {
         val currentState = _searchState.value
+        if (currentState.searchResultIndices.isEmpty()) return
         val nextIndex = (currentState.currentSearchIndex + 1) % currentState.searchResultIndices.size
         _searchState.update { it.copy(currentSearchIndex = nextIndex) }
     }
@@ -100,10 +102,12 @@ class TranscriptSearchViewModel @Inject constructor(
         val searchResultIndices: List<Int> = emptyList(),
         val currentSearchIndex: Int = 0,
     ) {
-        val searchOccurencesText: String
+        val searchOccurrencesText: String
             get() = searchResultIndices
                 .takeIf { it.isNotEmpty() }
                 ?.let { "${currentSearchIndex + 1}/${searchResultIndices.size}" }
                 ?: "0"
+
+        val prevNextArrowButtonsEnabled = searchResultIndices.isNotEmpty()
     }
 }

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/transcripts/TranscriptSearchViewModel.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/transcripts/TranscriptSearchViewModel.kt
@@ -58,6 +58,7 @@ class TranscriptSearchViewModel @Inject constructor(
                 it.copy(
                     searchTerm = searchTerm,
                     searchResultIndices = searchResultIndices,
+                    currentSearchIndex = 0,
                 )
             }
         } catch (e: Exception) {

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/transcripts/TranscriptSearchViewModel.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/transcripts/TranscriptSearchViewModel.kt
@@ -59,8 +59,7 @@ class TranscriptSearchViewModel @Inject constructor(
                     )
                 }
             } catch (e: Exception) {
-                LogBuffer.e(LogBuffer.TAG_INVALID_STATE, "Error searching transcript: ${e.message}")
-                e.printStackTrace()
+                LogBuffer.e(LogBuffer.TAG_INVALID_STATE, e, "Error searching transcript")
             }
         }
     }

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/transcripts/TranscriptViewModel.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/transcripts/TranscriptViewModel.kt
@@ -144,13 +144,9 @@ class TranscriptViewModel @Inject constructor(
 
     private suspend fun buildDisplayInfo(cuesWithTimingSubtitle: List<CuesWithTiming>) = withContext(ioDispatcher) {
         val formattedText = buildString {
-            with(cuesWithTimingSubtitle) {
-                (0 until count()).forEach { index ->
-                    get(index).cues.forEach { cue ->
-                        append(cue.text)
-                    }
-                }
-            }
+            cuesWithTimingSubtitle
+                .flatMap { it.cues }
+                .forEach { cue -> append(cue.text) }
         }
         val items = formattedText.splitIgnoreEmpty("\n\n").map {
             val startIndex = formattedText.indexOf(it)

--- a/modules/features/player/src/test/java/au/com/shiftyjelly/pocketcasts/player/view/transcripts/KMPSearchTest.kt
+++ b/modules/features/player/src/test/java/au/com/shiftyjelly/pocketcasts/player/view/transcripts/KMPSearchTest.kt
@@ -47,16 +47,101 @@ class KMPSearchTest {
 
     @Test
     fun `search handles diacritics`() {
-        val text = "testing diacritics żółć zolc."
+        val text = "testing diacritics żółć zolc. frère hôtel niño über façade māter mătură čaj ząb mąż kő ångest cơm fødsel ȑat"
 
         val pattern1 = "żółć"
         kmpSearch.setPattern(pattern1)
         var result = kmpSearch.search(text)
         assertEquals(listOf(19, 24), result)
 
+        // Testing pattern without diacritics
         val pattern2 = "zolc"
         kmpSearch.setPattern(pattern2)
         result = kmpSearch.search(text)
         assertEquals(listOf(19, 24), result)
+
+        // Testing Grave Accent (`)
+        val pattern3 = "frère"
+        kmpSearch.setPattern(pattern3)
+        result = kmpSearch.search(text)
+        assertEquals(listOf(30), result)
+
+        // Testing Circumflex (^)
+        val pattern4 = "hôtel"
+        kmpSearch.setPattern(pattern4)
+        result = kmpSearch.search(text)
+        assertEquals(listOf(36), result)
+
+        // Testing Umlaut or Diaeresis (¨)
+        val pattern5 = "über"
+        kmpSearch.setPattern(pattern5)
+        result = kmpSearch.search(text)
+        assertEquals(listOf(47), result)
+
+        // Testing Cedilla (¸)
+        val pattern6 = "façade"
+        kmpSearch.setPattern(pattern6)
+        result = kmpSearch.search(text)
+        assertEquals(listOf(52), result)
+
+        // Testing Macron (¯)
+        val pattern8 = "MĀTER"
+        kmpSearch.setPattern(pattern8)
+        result = kmpSearch.search(text)
+        assertEquals(listOf(59), result)
+
+        // Testing Breve (˘)
+        val pattern9 = "mătură"
+        kmpSearch.setPattern(pattern9)
+        result = kmpSearch.search(text)
+        assertEquals(listOf(65), result)
+
+        // Testing Caron or Háček (ˇ)
+        val pattern10 = "čaj"
+        kmpSearch.setPattern(pattern10)
+        result = kmpSearch.search(text)
+        assertEquals(listOf(72), result)
+
+        // Testing Ogonek (˛)
+        val pattern11 = "ząb"
+        kmpSearch.setPattern(pattern11)
+        result = kmpSearch.search(text)
+        assertEquals(listOf(76), result)
+
+        // Testing Dot Above (˙)
+        val pattern12 = "mąż"
+        kmpSearch.setPattern(pattern12)
+        result = kmpSearch.search(text)
+        assertEquals(listOf(80), result)
+
+        // Testing Double Acute (˝)
+        val pattern13 = "kő"
+        kmpSearch.setPattern(pattern13)
+        result = kmpSearch.search(text)
+        assertEquals(listOf(84), result)
+
+        // Testing Ring Above (°)
+        val pattern14 = "ångest"
+        kmpSearch.setPattern(pattern14)
+        result = kmpSearch.search(text)
+        assertEquals(listOf(87), result)
+
+        // Testing Horn (˛)
+        val pattern15 = "cơm"
+        kmpSearch.setPattern(pattern15)
+        result = kmpSearch.search(text)
+        assertEquals(listOf(94), result)
+
+        // Testing Stroke (Ø)
+        val pattern16 = "fødsel"
+        kmpSearch.setPattern(pattern16)
+        result = kmpSearch.search(text)
+        assertEquals(listOf(98), result)
+
+        // Testing Inverted Breve (̑)
+        val pattern17 = "ȑat"
+        kmpSearch.setPattern(pattern17)
+        result = kmpSearch.search(text)
+        assertEquals(listOf(105), result)
     }
 }

--- a/modules/features/player/src/test/java/au/com/shiftyjelly/pocketcasts/player/view/transcripts/KMPSearchTest.kt
+++ b/modules/features/player/src/test/java/au/com/shiftyjelly/pocketcasts/player/view/transcripts/KMPSearchTest.kt
@@ -44,4 +44,19 @@ class KMPSearchTest {
 
         assertEquals(emptyList<Int>(), result)
     }
+
+    @Test
+    fun `search handles diacritics`() {
+        val text = "testing diacritics żółć zolc."
+
+        val pattern1 = "żółć"
+        kmpSearch.setPattern(pattern1)
+        var result = kmpSearch.search(text)
+        assertEquals(listOf(19, 24), result)
+
+        val pattern2 = "zolc"
+        kmpSearch.setPattern(pattern2)
+        result = kmpSearch.search(text)
+        assertEquals(listOf(19, 24), result)
+    }
 }

--- a/modules/features/player/src/test/java/au/com/shiftyjelly/pocketcasts/player/view/transcripts/KMPSearchTest.kt
+++ b/modules/features/player/src/test/java/au/com/shiftyjelly/pocketcasts/player/view/transcripts/KMPSearchTest.kt
@@ -1,0 +1,47 @@
+package au.com.shiftyjelly.pocketcasts.player.view.transcripts
+
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+
+class KMPSearchTest {
+    private lateinit var kmpSearch: KMPSearch
+
+    @Before
+    fun setUp() {
+        kmpSearch = KMPSearch()
+    }
+
+    @Test
+    fun `search returns correct indices when pattern is found`() {
+        val text = "this is a test. This is only a Test."
+        val pattern = "test"
+        kmpSearch.setPattern(pattern)
+
+        val result = kmpSearch.search(text)
+
+        assertEquals(listOf(10, 31), result)
+    }
+
+    @Test
+    fun `search returns empty list when pattern is not found`() {
+        val text = "this is a trial. This is only a trial."
+        val pattern = "test"
+        kmpSearch.setPattern(pattern)
+
+        val result = kmpSearch.search(text)
+
+        assertEquals(emptyList<Int>(), result)
+    }
+
+    @Test
+    fun `search returns empty list when pattern is empty`() {
+        val text = "this is a test. This is only a test."
+        val pattern = ""
+        kmpSearch.setPattern(pattern)
+
+        val result = kmpSearch.search(text)
+
+        assertEquals(emptyList<Int>(), result)
+    }
+}

--- a/modules/features/player/src/test/java/au/com/shiftyjelly/pocketcasts/player/view/transcripts/KMPSearchTest.kt
+++ b/modules/features/player/src/test/java/au/com/shiftyjelly/pocketcasts/player/view/transcripts/KMPSearchTest.kt
@@ -47,101 +47,101 @@ class KMPSearchTest {
 
     @Test
     fun `search handles diacritics`() {
-        val text = "testing diacritics żółć zolc. frère hôtel niño über façade māter mătură čaj ząb mąż kő ångest cơm fødsel ȑat"
+        val text = "testing diacritics żółŁć zolLc.frère hôtel niño über façade māter mătură čaj ząb mąż kő ångest cơm fødsel ȑat"
 
-        val pattern1 = "żółć"
+        val pattern1 = "żółŁć"
         kmpSearch.setPattern(pattern1)
         var result = kmpSearch.search(text)
-        assertEquals(listOf(19, 24), result)
+        assertEquals(listOf(19, 25), result)
 
         // Testing pattern without diacritics
-        val pattern2 = "zolc"
+        val pattern2 = "zolLc"
         kmpSearch.setPattern(pattern2)
         result = kmpSearch.search(text)
-        assertEquals(listOf(19, 24), result)
+        assertEquals(listOf(19, 25), result)
 
         // Testing Grave Accent (`)
         val pattern3 = "frère"
         kmpSearch.setPattern(pattern3)
         result = kmpSearch.search(text)
-        assertEquals(listOf(30), result)
+        assertEquals(listOf(31), result)
 
         // Testing Circumflex (^)
         val pattern4 = "hôtel"
         kmpSearch.setPattern(pattern4)
         result = kmpSearch.search(text)
-        assertEquals(listOf(36), result)
+        assertEquals(listOf(37), result)
 
         // Testing Umlaut or Diaeresis (¨)
         val pattern5 = "über"
         kmpSearch.setPattern(pattern5)
         result = kmpSearch.search(text)
-        assertEquals(listOf(47), result)
+        assertEquals(listOf(48), result)
 
         // Testing Cedilla (¸)
         val pattern6 = "façade"
         kmpSearch.setPattern(pattern6)
         result = kmpSearch.search(text)
-        assertEquals(listOf(52), result)
+        assertEquals(listOf(53), result)
 
         // Testing Macron (¯)
         val pattern8 = "MĀTER"
         kmpSearch.setPattern(pattern8)
         result = kmpSearch.search(text)
-        assertEquals(listOf(59), result)
+        assertEquals(listOf(60), result)
 
         // Testing Breve (˘)
         val pattern9 = "mătură"
         kmpSearch.setPattern(pattern9)
         result = kmpSearch.search(text)
-        assertEquals(listOf(65), result)
+        assertEquals(listOf(66), result)
 
         // Testing Caron or Háček (ˇ)
         val pattern10 = "čaj"
         kmpSearch.setPattern(pattern10)
         result = kmpSearch.search(text)
-        assertEquals(listOf(72), result)
+        assertEquals(listOf(73), result)
 
         // Testing Ogonek (˛)
         val pattern11 = "ząb"
         kmpSearch.setPattern(pattern11)
         result = kmpSearch.search(text)
-        assertEquals(listOf(76), result)
+        assertEquals(listOf(77), result)
 
         // Testing Dot Above (˙)
         val pattern12 = "mąż"
         kmpSearch.setPattern(pattern12)
         result = kmpSearch.search(text)
-        assertEquals(listOf(80), result)
+        assertEquals(listOf(81), result)
 
         // Testing Double Acute (˝)
         val pattern13 = "kő"
         kmpSearch.setPattern(pattern13)
         result = kmpSearch.search(text)
-        assertEquals(listOf(84), result)
+        assertEquals(listOf(85), result)
 
         // Testing Ring Above (°)
         val pattern14 = "ångest"
         kmpSearch.setPattern(pattern14)
         result = kmpSearch.search(text)
-        assertEquals(listOf(87), result)
+        assertEquals(listOf(88), result)
 
         // Testing Horn (˛)
         val pattern15 = "cơm"
         kmpSearch.setPattern(pattern15)
         result = kmpSearch.search(text)
-        assertEquals(listOf(94), result)
+        assertEquals(listOf(95), result)
 
         // Testing Stroke (Ø)
         val pattern16 = "fødsel"
         kmpSearch.setPattern(pattern16)
         result = kmpSearch.search(text)
-        assertEquals(listOf(98), result)
+        assertEquals(listOf(99), result)
 
         // Testing Inverted Breve (̑)
         val pattern17 = "ȑat"
         kmpSearch.setPattern(pattern17)
         result = kmpSearch.search(text)
-        assertEquals(listOf(105), result)
+        assertEquals(listOf(106), result)
     }
 }

--- a/modules/features/player/src/test/java/au/com/shiftyjelly/pocketcasts/player/view/transcripts/TranscriptSearchViewModelTest.kt
+++ b/modules/features/player/src/test/java/au/com/shiftyjelly/pocketcasts/player/view/transcripts/TranscriptSearchViewModelTest.kt
@@ -82,6 +82,21 @@ class TranscriptSearchViewModelTest {
     }
 
     @Test
+    fun `current search index is reset to zero on new search`() = runTest {
+        viewModel.onSearchQueryChanged("test1")
+        advanceUntilIdle()
+        viewModel.onSearchNext()
+        viewModel.onSearchNext() // currentSearchIndex = 2
+
+        viewModel.onSearchQueryChanged("test2")
+
+        viewModel.searchState.test {
+            assertTrue((awaitItem().currentSearchIndex == 2))
+            assertTrue((awaitItem().currentSearchIndex == 0))
+        }
+    }
+
+    @Test
     fun `search state is reset when search is done`() = runTest {
         viewModel.onSearchQueryChanged(searchTerm)
         advanceUntilIdle()

--- a/modules/features/player/src/test/java/au/com/shiftyjelly/pocketcasts/player/view/transcripts/TranscriptSearchViewModelTest.kt
+++ b/modules/features/player/src/test/java/au/com/shiftyjelly/pocketcasts/player/view/transcripts/TranscriptSearchViewModelTest.kt
@@ -34,7 +34,7 @@ class TranscriptSearchViewModelTest {
     fun setUp() {
         doNothing().whenever(kmpSearch).setPattern(anyOrNull())
         whenever(kmpSearch.search(any())).thenReturn(searchResultIndices)
-        viewModel = TranscriptSearchViewModel(kmpSearch)
+        viewModel = TranscriptSearchViewModel(kmpSearch, testDispatcher)
     }
 
     @Test

--- a/modules/features/player/src/test/java/au/com/shiftyjelly/pocketcasts/player/view/transcripts/TranscriptSearchViewModelTest.kt
+++ b/modules/features/player/src/test/java/au/com/shiftyjelly/pocketcasts/player/view/transcripts/TranscriptSearchViewModelTest.kt
@@ -1,0 +1,167 @@
+package au.com.shiftyjelly.pocketcasts.player.view.transcripts
+
+import app.cash.turbine.test
+import au.com.shiftyjelly.pocketcasts.sharedtest.MainCoroutineRule
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
+import org.mockito.kotlin.doNothing
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class TranscriptSearchViewModelTest {
+    private val testDispatcher = UnconfinedTestDispatcher()
+
+    @get:Rule
+    val coroutineRule = MainCoroutineRule(testDispatcher)
+    private lateinit var viewModel: TranscriptSearchViewModel
+    private val kmpSearch: KMPSearch = mock()
+    private val searchResultIndices = listOf(1, 2, 3)
+    private val searchTerm = "test"
+
+    @Before
+    fun setUp() {
+        doNothing().whenever(kmpSearch).setPattern(anyOrNull())
+        whenever(kmpSearch.search(any())).thenReturn(searchResultIndices)
+        viewModel = TranscriptSearchViewModel(kmpSearch)
+    }
+
+    @Test
+    fun `search is performed when search query changes`() = runTest {
+        viewModel.onSearchQueryChanged(searchTerm)
+        advanceUntilIdle()
+
+        viewModel.searchState.test {
+            verify(kmpSearch).setPattern(searchTerm)
+            verify(kmpSearch).search(any())
+            assertTrue(
+                awaitItem() == TranscriptSearchViewModel.SearchUiState(
+                    searchTerm = searchTerm,
+                    searchResultIndices = searchResultIndices,
+                    currentSearchIndex = 0,
+                ),
+            )
+        }
+    }
+
+    @Test
+    fun `search index is updated when searching previous`() = runTest {
+        viewModel.onSearchQueryChanged(searchTerm)
+        advanceUntilIdle()
+
+        viewModel.onSearchNext()
+
+        viewModel.searchState.test {
+            assertTrue((awaitItem().currentSearchIndex == 1))
+        }
+    }
+
+    @Test
+    fun `search index is updated when searching next`() = runTest {
+        viewModel.onSearchQueryChanged(searchTerm)
+        advanceUntilIdle()
+        viewModel.onSearchNext()
+        advanceUntilIdle()
+
+        viewModel.onSearchPrevious()
+
+        viewModel.searchState.test {
+            assertTrue((awaitItem().currentSearchIndex == 0))
+        }
+    }
+
+    @Test
+    fun `search state is reset when search is done`() = runTest {
+        viewModel.onSearchQueryChanged(searchTerm)
+        advanceUntilIdle()
+
+        viewModel.onSearchDone()
+
+        viewModel.searchState.test {
+            assertTrue(
+                (
+                    awaitItem() == TranscriptSearchViewModel.SearchUiState(
+                        searchTerm = "",
+                        searchResultIndices = emptyList(),
+                        currentSearchIndex = 0,
+                    )
+                    ),
+            )
+        }
+    }
+
+    @Test
+    fun `search state is reset when search is cleared`() = runTest {
+        viewModel.onSearchQueryChanged(searchTerm)
+        advanceUntilIdle()
+
+        viewModel.onSearchCleared()
+
+        viewModel.searchState.test {
+            assertTrue(
+                (
+                    awaitItem() == TranscriptSearchViewModel.SearchUiState(
+                        searchTerm = "",
+                        searchResultIndices = emptyList(),
+                        currentSearchIndex = 0,
+                    )
+                    ),
+            )
+        }
+    }
+
+    @Test
+    fun `searchOccurrencesText returns correct format when searchResultIndices is not empty`() {
+        val searchUiState = TranscriptSearchViewModel.SearchUiState(
+            searchTerm = searchTerm,
+            searchResultIndices = searchResultIndices,
+            currentSearchIndex = 1,
+        )
+
+        assertEquals("2/3", searchUiState.searchOccurrencesText)
+    }
+
+    @Test
+    fun `searchOccurrencesText returns zero when searchResultIndices is empty`() {
+        val searchUiState = TranscriptSearchViewModel.SearchUiState(
+            searchTerm = searchTerm,
+            searchResultIndices = emptyList(),
+            currentSearchIndex = 0,
+        )
+
+        assertEquals("0", searchUiState.searchOccurrencesText)
+    }
+
+    @Test
+    fun `prev next buttons enabled when search results found`() {
+        val searchUiState = TranscriptSearchViewModel.SearchUiState(
+            searchTerm = searchTerm,
+            searchResultIndices = listOf(1),
+            currentSearchIndex = 0,
+        )
+
+        assertTrue(searchUiState.prevNextArrowButtonsEnabled)
+    }
+
+    @Test
+    fun `prev next buttons disabled when search results not found`() {
+        val searchUiState = TranscriptSearchViewModel.SearchUiState(
+            searchTerm = searchTerm,
+            searchResultIndices = emptyList(),
+            currentSearchIndex = 0,
+        )
+
+        assertFalse(searchUiState.prevNextArrowButtonsEnabled)
+    }
+}

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/di/DispatcherModule.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/di/DispatcherModule.kt
@@ -14,8 +14,16 @@ object DispatcherModule {
     @IoDispatcher
     @Provides
     fun providesIoDispatcher(): CoroutineDispatcher = Dispatchers.IO
+
+    @DefaultDispatcher
+    @Provides
+    fun providesDefaultDispatcher(): CoroutineDispatcher = Dispatchers.Default
 }
 
 @Retention(AnnotationRetention.BINARY)
 @Qualifier
 annotation class IoDispatcher
+
+@Retention(AnnotationRetention.BINARY)
+@Qualifier
+annotation class DefaultDispatcher

--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/extensions/String.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/extensions/String.kt
@@ -2,6 +2,7 @@ package au.com.shiftyjelly.pocketcasts.utils.extensions
 
 import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
 import java.security.MessageDigest
+import java.text.Normalizer
 import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
@@ -64,6 +65,12 @@ fun CharSequence.splitIgnoreEmpty(delimiter: String): List<String> {
 fun String.removeNewLines(): String {
     return this.replace("[\n\r]".toRegex(), "")
 }
+
+fun String.removeAccents() =
+    Normalizer.normalize(this, Normalizer.Form.NFD)
+        .replace("\\p{Mn}+".toRegex(), "")
+        .replace("\u0141", "L") // Remove L with stroke
+        .replace("\u0142", "l") // Remove l with stroke
 
 fun String.sha1(): String? = hashString("SHA-1")
 fun String.sha256(): String? = hashString("SHA-256")


### PR DESCRIPTION
## Description

This implements transcript search logic.

Not in scope:
- Scroll to highlighted text
- Text styling Figma match

## Testing Instructions
1. Load transcript view for an episode with transcript (e.g. Cautionary Tales https://pcast.pocketcasts.net/8zpmjiru)
2. ✅ Notice that search icon is visible when transcript is shown
3. Tap on search icon
4. Search a text
5. ✅ Notice that 
    - Search occurrences text is updated in the search bar (if search results are not found, 0 is displayed)
    - Up, down arrow buttons are enabled if search results found
    - Search occurrences are highlighted in the transcript
8. Tap on up arrow in the search bar
9. ✅ Notice that next search result is highlighted (scroll to highlighted text is not added in this PR)
10. Tap on previous arrow in the search bar
11. ✅ Notice that previous search result is highlighted (scroll to highlighted text is not added in this PR) 
12. Tap on x icon in the search bar
13. ✅ Notice that the highlight style is removed
14. Stress test on a large transcript (e.g. for episode https://pca.st/1iofzvym)
15. ✅ Notice that search results are shown without any lag
16. Test search on HTML transcript (e.g. episode from If books could kill https://pca.st/tqib657g)
17. ✅ Notice that search results are shown for HTML transcript 

## Screenshots or Screencast 

https://github.com/user-attachments/assets/88cb5d32-e044-4ee4-99cb-b873c4351912


## Checklist
- [x] ~~If this is a user-facing change, I have added an entry in CHANGELOG.md~~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics. - Analytics will be added in a separate PR
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
