### PR TITLE
Support sub-second clip resolution

### DIFF
--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/sharing/SharingClientTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/sharing/SharingClientTest.kt
@@ -22,6 +22,7 @@ import au.com.shiftyjelly.pocketcasts.utils.FileUtil
 import java.io.File
 import java.util.Date
 import kotlin.random.Random
+import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
@@ -248,7 +249,7 @@ class SharingClientTest {
             val request = SharingRequest.episodePosition(
                 podcast = Podcast(uuid = "podcast-uuid", title = "Podcast Title"),
                 episode = PodcastEpisode(uuid = "episode-uuid", title = "Episode Title", publishedDate = Date()),
-                position = 10.seconds,
+                position = 10.seconds + 300.milliseconds,
             ).setPlatform(platform)
                 .build()
 
@@ -308,7 +309,7 @@ class SharingClientTest {
         val request = SharingRequest.episodePosition(
             podcast = Podcast(uuid = "podcast-uuid", title = "Podcast Title"),
             episode = PodcastEpisode(uuid = "episode-uuid", title = "Episode Title", publishedDate = Date()),
-            position = 10.seconds,
+            position = 10.seconds + 421.milliseconds,
         ).setPlatform(SocialPlatform.PocketCasts)
             .build()
 
@@ -358,7 +359,7 @@ class SharingClientTest {
             val request = SharingRequest.bookmark(
                 podcast = Podcast(uuid = "podcast-uuid", title = "Podcast Title"),
                 episode = PodcastEpisode(uuid = "episode-uuid", title = "Episode Title", publishedDate = Date()),
-                position = 10.seconds,
+                position = 10.seconds + 112.milliseconds,
             ).setPlatform(platform)
                 .build()
 
@@ -379,7 +380,7 @@ class SharingClientTest {
         val request = SharingRequest.bookmark(
             podcast = Podcast(uuid = "podcast-uuid", title = "Podcast Title"),
             episode = PodcastEpisode(uuid = "episode-uuid", title = "Episode Title", publishedDate = Date()),
-            position = 10.seconds,
+            position = 10.seconds + 677.milliseconds,
         ).setPlatform(SocialPlatform.PocketCasts)
             .build()
 
@@ -461,13 +462,13 @@ class SharingClientTest {
         val request = SharingRequest.clipLink(
             podcast = Podcast(uuid = "podcast-uuid", title = "Podcast Title"),
             episode = PodcastEpisode(uuid = "episode-uuid", title = "Episode Title", publishedDate = Date()),
-            range = Clip.Range(15.seconds, 28.seconds),
+            range = Clip.Range(15.seconds + 200.milliseconds, 28.seconds + 105.milliseconds),
         ).build()
 
         client.share(request)
         val clipData = shareStarter.requireShareLink
 
-        assertEquals("https://pca.st/episode/episode-uuid?t=15,28", clipData.getItemAt(0).text)
+        assertEquals("https://pca.st/episode/episode-uuid?t=15.2,28.1", clipData.getItemAt(0).text)
         assertEquals(context.getString(LR.string.share_link_clip), clipData.description.label)
         assertNull(shareStarter.chooserIntent)
     }

--- a/modules/features/sharing/src/debug/kotlin/au/com/shiftyjelly/pocketcasts/sharing/FFmpegMediaService.kt
+++ b/modules/features/sharing/src/debug/kotlin/au/com/shiftyjelly/pocketcasts/sharing/FFmpegMediaService.kt
@@ -86,7 +86,7 @@ internal class FFmpegMediaService(
             append("-ss ${clipRange.startInSeconds} ") // Clip start, must be in seconds or HH:MM:SS.xxx
             append("-to ${clipRange.endInSeconds} ") // Clip end, must be in seconds or HH:MM:SS.xxx
             if (isWebSource) {
-                append("-user_agent 'Pocket Casts' ")
+                append("-user_agent 'Pocket Casts' ") // Set User-Agent header so we don't get blocked by hosts
             }
             append("-i $audioSource ") // Audio stream source
             val coverFile = if (addCover) {
@@ -95,7 +95,7 @@ internal class FFmpegMediaService(
                 null
             }
             if (coverFile != null) {
-                append("-i $coverFile ")
+                append("-i $coverFile ") // Include cover in the MP3 file
             }
             append("-q:a 0 ") // Max audio quality
             append("-map 0:a:0 ") // Include only the first audio stream, videos can have multiple audio streams

--- a/modules/features/sharing/src/debug/kotlin/au/com/shiftyjelly/pocketcasts/sharing/FFmpegMediaService.kt
+++ b/modules/features/sharing/src/debug/kotlin/au/com/shiftyjelly/pocketcasts/sharing/FFmpegMediaService.kt
@@ -4,7 +4,7 @@ import android.content.Context
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.sharing.clip.Clip
-import au.com.shiftyjelly.pocketcasts.utils.toHhMmSs
+import au.com.shiftyjelly.pocketcasts.utils.toSecondsWithSingleMilli
 import com.arthenica.ffmpegkit.FFmpegKit
 import com.arthenica.ffmpegkit.FFmpegSession
 import com.arthenica.ffmpegkit.FFmpegSessionCompleteCallback
@@ -46,14 +46,15 @@ internal class FFmpegMediaService(
         createMp3Clip(episode, clipRange, addCover = false)
             .mapCatching { clipFile ->
                 val command = buildString {
-                    append("-r 1 ") // Set frame rate
-                    append("-t ${clipRange.durationInSeconds} ") // Specifcy duration
-                    append("-i $backgroundFile ") // Video stream source
+                    append("-r 10 ") // Set frame rate to 10 to allow sub-second clips
+                    append("-t ${clipRange.duration.toSecondsWithSingleMilli()} ") // Duration must be in S.xxx or HH:MM:SS.xxx format
+                    append("-i $backgroundFile ") // Image stream source
                     append("-i $clipFile ") // Audio stream source
                     append("-c:a copy ") // Copy audio codec
                     append("-c:v mpeg4 ") // Use mpeg4 video codec
+                    append("-q:v 1 ") // Use the highest video quality
                     append("-pix_fmt yuv420p ") // Use 4:2:0 pixel format
-                    val loopCount = (clipRange.durationInSeconds - 1).coerceAtLeast(1)
+                    val loopCount = (clipRange.duration.inWholeMilliseconds / 100 - 1).coerceAtLeast(1)
                     append("-vf \"loop=$loopCount:1\" ") // Loop the first frame to match clip's length
                     append("-movflags faststart ") // Move metadata to the file's start for faster playback
                     append("-y ") // Overwrite output file if it already exists
@@ -83,8 +84,8 @@ internal class FFmpegMediaService(
             }
             val isWebSource = audioSource == episode.downloadUrl
 
-            append("-ss ${clipRange.startInSeconds} ") // Clip start, must be in seconds or HH:MM:SS.xxx
-            append("-to ${clipRange.endInSeconds} ") // Clip end, must be in seconds or HH:MM:SS.xxx
+            append("-ss ${clipRange.start.toSecondsWithSingleMilli()} ") // Clip start, must be in S.xxx or HH:MM:SS.xxx format
+            append("-to ${clipRange.end.toSecondsWithSingleMilli()} ") // Clip end, must be in S.xxx or HH:MM:SS.xxx format
             if (isWebSource) {
                 append("-user_agent 'Pocket Casts' ") // Set User-Agent header so we don't get blocked by hosts
             }
@@ -117,7 +118,7 @@ internal class FFmpegMediaService(
     }
 
     private fun sanitizedFileName(podcast: Podcast, episode: PodcastEpisode, clipRange: Clip.Range): String {
-        return "${podcast.title} - ${episode.title} - ${clipRange.start.toHhMmSs()}–${clipRange.end.toHhMmSs()}".replace("""\W+""".toRegex(), "_")
+        return "${podcast.title} - ${episode.title} - ${clipRange.start.toSecondsWithSingleMilli()}–${clipRange.end.toSecondsWithSingleMilli()}".replace("""\W+""".toRegex(), "_")
     }
 
     private suspend fun executeAsyncCommand(command: String): Result<Unit> = suspendCancellableCoroutine { continuation ->

--- a/modules/features/sharing/src/debugProd/kotlin/au/com/shiftyjelly/pocketcasts/sharing/FFmpegMediaService.kt
+++ b/modules/features/sharing/src/debugProd/kotlin/au/com/shiftyjelly/pocketcasts/sharing/FFmpegMediaService.kt
@@ -86,7 +86,7 @@ internal class FFmpegMediaService(
             append("-ss ${clipRange.startInSeconds} ") // Clip start, must be in seconds or HH:MM:SS.xxx
             append("-to ${clipRange.endInSeconds} ") // Clip end, must be in seconds or HH:MM:SS.xxx
             if (isWebSource) {
-                append("-user_agent 'Pocket Casts' ")
+                append("-user_agent 'Pocket Casts' ") // Set User-Agent header so we don't get blocked by hosts
             }
             append("-i $audioSource ") // Audio stream source
             val coverFile = if (addCover) {
@@ -95,7 +95,7 @@ internal class FFmpegMediaService(
                 null
             }
             if (coverFile != null) {
-                append("-i $coverFile ")
+                append("-i $coverFile ") // Include cover in the MP3 file
             }
             append("-q:a 0 ") // Max audio quality
             append("-map 0:a:0 ") // Include only the first audio stream, videos can have multiple audio streams

--- a/modules/features/sharing/src/debugProd/kotlin/au/com/shiftyjelly/pocketcasts/sharing/FFmpegMediaService.kt
+++ b/modules/features/sharing/src/debugProd/kotlin/au/com/shiftyjelly/pocketcasts/sharing/FFmpegMediaService.kt
@@ -4,7 +4,7 @@ import android.content.Context
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.sharing.clip.Clip
-import au.com.shiftyjelly.pocketcasts.utils.toHhMmSs
+import au.com.shiftyjelly.pocketcasts.utils.toSecondsWithSingleMilli
 import com.arthenica.ffmpegkit.FFmpegKit
 import com.arthenica.ffmpegkit.FFmpegSession
 import com.arthenica.ffmpegkit.FFmpegSessionCompleteCallback
@@ -46,14 +46,15 @@ internal class FFmpegMediaService(
         createMp3Clip(episode, clipRange, addCover = false)
             .mapCatching { clipFile ->
                 val command = buildString {
-                    append("-r 1 ") // Set frame rate
-                    append("-t ${clipRange.durationInSeconds} ") // Specifcy duration
-                    append("-i $backgroundFile ") // Video stream source
+                    append("-r 10 ") // Set frame rate to 10 to allow sub-second clips
+                    append("-t ${clipRange.duration.toSecondsWithSingleMilli()} ") // Duration must be in S.xxx or HH:MM:SS.xxx format
+                    append("-i $backgroundFile ") // Image stream source
                     append("-i $clipFile ") // Audio stream source
                     append("-c:a copy ") // Copy audio codec
                     append("-c:v mpeg4 ") // Use mpeg4 video codec
+                    append("-q:v 1 ") // Use the highest video quality
                     append("-pix_fmt yuv420p ") // Use 4:2:0 pixel format
-                    val loopCount = (clipRange.durationInSeconds - 1).coerceAtLeast(1)
+                    val loopCount = (clipRange.duration.inWholeMilliseconds / 100 - 1).coerceAtLeast(1)
                     append("-vf \"loop=$loopCount:1\" ") // Loop the first frame to match clip's length
                     append("-movflags faststart ") // Move metadata to the file's start for faster playback
                     append("-y ") // Overwrite output file if it already exists
@@ -83,8 +84,8 @@ internal class FFmpegMediaService(
             }
             val isWebSource = audioSource == episode.downloadUrl
 
-            append("-ss ${clipRange.startInSeconds} ") // Clip start, must be in seconds or HH:MM:SS.xxx
-            append("-to ${clipRange.endInSeconds} ") // Clip end, must be in seconds or HH:MM:SS.xxx
+            append("-ss ${clipRange.start.toSecondsWithSingleMilli()} ") // Clip start, must be in S.xxx or HH:MM:SS.xxx format
+            append("-to ${clipRange.end.toSecondsWithSingleMilli()} ") // Clip end, must be in S.xxx or HH:MM:SS.xxx format
             if (isWebSource) {
                 append("-user_agent 'Pocket Casts' ") // Set User-Agent header so we don't get blocked by hosts
             }
@@ -117,7 +118,7 @@ internal class FFmpegMediaService(
     }
 
     private fun sanitizedFileName(podcast: Podcast, episode: PodcastEpisode, clipRange: Clip.Range): String {
-        return "${podcast.title} - ${episode.title} - ${clipRange.start.toHhMmSs()}–${clipRange.end.toHhMmSs()}".replace("""\W+""".toRegex(), "_")
+        return "${podcast.title} - ${episode.title} - ${clipRange.start.toSecondsWithSingleMilli()}–${clipRange.end.toSecondsWithSingleMilli()}".replace("""\W+""".toRegex(), "_")
     }
 
     private suspend fun executeAsyncCommand(command: String): Result<Unit> = suspendCancellableCoroutine { continuation ->

--- a/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/SharingClient.kt
+++ b/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/SharingClient.kt
@@ -32,6 +32,7 @@ import au.com.shiftyjelly.pocketcasts.sharing.social.SocialPlatform.X
 import au.com.shiftyjelly.pocketcasts.sharing.timestamp.TimestampType
 import au.com.shiftyjelly.pocketcasts.sharing.ui.CardType
 import au.com.shiftyjelly.pocketcasts.utils.FileUtil
+import au.com.shiftyjelly.pocketcasts.utils.toSecondsWithSingleMilli
 import coil.executeBlocking
 import coil.imageLoader
 import java.io.File
@@ -372,7 +373,7 @@ data class SharingRequest internal constructor(
                 TimestampType.Bookmark -> LR.string.share_link_bookmark
             }
 
-            override fun toString() = "EpisodePosition(title=${episode.title}, uuid=${episode.uuid}, position=$position, type=$type)"
+            override fun toString() = "EpisodePosition(title=${episode.title}, uuid=${episode.uuid}, position=${position.inWholeSeconds}, type=$type)"
         }
 
         class EpisodeFile internal constructor(
@@ -387,11 +388,11 @@ data class SharingRequest internal constructor(
             val episode: EpisodeModel,
             val range: Clip.Range,
         ) : Data {
-            fun sharingUrl(host: String) = "$host/episode/${episode.uuid}?t=${range.startInSeconds},${range.endInSeconds}"
+            fun sharingUrl(host: String) = "$host/episode/${episode.uuid}?t=${range.start.toSecondsWithSingleMilli()},${range.end.toSecondsWithSingleMilli()}"
 
             fun linkDescription() = LR.string.share_link_clip
 
-            override fun toString() = "ClipLink(title=${episode.title}, uuid=${episode.uuid}, start=${range.startInSeconds}, end=${range.endInSeconds})"
+            override fun toString() = "ClipLink(title=${episode.title}, uuid=${episode.uuid}, start=${range.start.toSecondsWithSingleMilli()}, end=${range.end.toSecondsWithSingleMilli()})"
         }
 
         class ClipAudio internal constructor(
@@ -399,7 +400,7 @@ data class SharingRequest internal constructor(
             val episode: EpisodeModel,
             val range: Clip.Range,
         ) : Data {
-            override fun toString() = "ClipAudio(title=${episode.title}, uuid=${episode.uuid}, start=${range.startInSeconds}, end=${range.endInSeconds})"
+            override fun toString() = "ClipAudio(title=${episode.title}, uuid=${episode.uuid}, start=${range.start.toSecondsWithSingleMilli()}, end=${range.end.toSecondsWithSingleMilli()})"
         }
 
         class ClipVideo internal constructor(
@@ -407,7 +408,7 @@ data class SharingRequest internal constructor(
             val episode: EpisodeModel,
             val range: Clip.Range,
         ) : Data {
-            override fun toString() = "ClipVideo(title=${episode.title}, uuid=${episode.uuid}, start=${range.startInSeconds}, end=${range.endInSeconds})"
+            override fun toString() = "ClipVideo(title=${episode.title}, uuid=${episode.uuid}, start=${range.start.toSecondsWithSingleMilli()}, end=${range.end.toSecondsWithSingleMilli()})"
         }
     }
 }

--- a/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/clip/ClipPlayer.kt
+++ b/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/clip/ClipPlayer.kt
@@ -216,8 +216,9 @@ private class ExoPlayerClipPlayer(
         .setUri(sourceUri)
         .setClippingConfiguration(
             ClippingConfiguration.Builder()
-                .setStartPositionMs(range.start.inWholeMilliseconds)
-                .setEndPositionMs(range.end.inWholeMilliseconds)
+                // Divide and multiple by 100 to drop insignificant for clip creation millseconds resolution
+                .setStartPositionMs((range.start.inWholeMilliseconds / 100) * 100)
+                .setEndPositionMs((range.end.inWholeMilliseconds / 100) * 100)
                 .build(),
         )
         .build()

--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/DurationUtil.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/DurationUtil.kt
@@ -10,3 +10,15 @@ fun Duration.toHhMmSs() = toComponents { hours, minutes, seconds, _ ->
         String.format(Locale.ROOT, "%02d:%02d:%02d", hours, minutes, seconds)
     }
 }
+
+fun Duration.toSecondsWithSingleMilli() = toComponents { hours, minutes, seconds, nanoseconds ->
+    val totalSeconds = hours * 3600 + minutes * 60 + seconds
+    val milliseconds = (nanoseconds + 50_000_000) / 100_000_000
+    buildString {
+        append(totalSeconds)
+        if (milliseconds != 0) {
+            append('.')
+            append(milliseconds)
+        }
+    }
+}

--- a/modules/services/utils/src/test/java/au/com/shiftyjelly/pocketcasts/utils/DurationUtilTest.kt
+++ b/modules/services/utils/src/test/java/au/com/shiftyjelly/pocketcasts/utils/DurationUtilTest.kt
@@ -2,7 +2,10 @@ package au.com.shiftyjelly.pocketcasts.utils
 
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.hours
+import kotlin.time.Duration.Companion.microseconds
+import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.minutes
+import kotlin.time.Duration.Companion.nanoseconds
 import kotlin.time.Duration.Companion.seconds
 import org.junit.Assert.assertEquals
 import org.junit.Test
@@ -58,5 +61,66 @@ class DurationUtilTest {
         val text = duration.toHhMmSs()
 
         assertEquals("3478:42:24", text)
+    }
+
+    @Test
+    fun `zero duration to seconds with single milli`() {
+        val text = Duration.ZERO.toSecondsWithSingleMilli()
+
+        assertEquals("0", text)
+    }
+
+    @Test
+    fun `duration without millis to seconds with single milli`() {
+        val duration = 10.hours + 10.minutes + 7.seconds
+
+        val text = duration.toSecondsWithSingleMilli()
+
+        assertEquals("36607", text)
+    }
+
+    @Test
+    fun `duration with millis to seconds with single milli`() {
+        val duration = 1.seconds + 200.milliseconds
+
+        val text = duration.toSecondsWithSingleMilli()
+
+        assertEquals("1.2", text)
+    }
+
+    @Test
+    fun `duration with millis to seconds with single milli rounded down`() {
+        val duration = 1.seconds + 349.milliseconds
+
+        val text = duration.toSecondsWithSingleMilli()
+
+        assertEquals("1.3", text)
+    }
+
+    @Test
+    fun `duration with millis to seconds with single milli rounded up`() {
+        val duration = 1.seconds + 50.milliseconds
+
+        val text = duration.toSecondsWithSingleMilli()
+
+        assertEquals("1.1", text)
+    }
+
+    @Test
+    fun `duration with micros to seconds with single milli`() {
+        val duration = 1.seconds + 234.microseconds
+
+        val text = duration.toSecondsWithSingleMilli()
+
+        assertEquals("1", text)
+    }
+
+    @Test
+    fun `duration with nanos to seconds with single milli`() {
+        val duration = 1.seconds + 234.nanoseconds
+
+        val text = duration.toSecondsWithSingleMilli()
+
+        assertEquals("1", text)
     }
 }


### PR DESCRIPTION
## Description

This PR introduces the ability to create sub-second clips with a resolution of 100 milliseconds. The key changes are as follows:

* Adjusted the frame rate of clips to 10 fps to support this finer resolution.
* Updated the format of generated filenames to use the `S.x` format (e.g., `12.3` for 12300 milliseconds) instead of the `hh:mm:ss` format for time marks.
* Modified the player to ensure it always starts playback from the specified clip position.
* Clip links are now generated with sub-second time marks to be in line with generated audio or video clips.
* Timestamp links continue to use a seconds-only resolution. This can be easily changed but I didn't want to change existing behavior and interop with bookmarks which support seconds only.

I also improved video quality by specifying `-q:v 1` parameter.

## Testing Instructions

Smoke test clip and timestamp sharing.

## Checklist
- [x] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [x] ~Any jetpack compose components I added or changed are covered by compose previews~
- [x] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
