### PR TITLE
[Paywall redesign] Add the new paywall 

### DIFF
--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeFeaturesPage.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeFeaturesPage.kt
@@ -123,7 +123,7 @@ internal fun OnboardingUpgradeFeaturesPage(
         is OnboardingUpgradeFeaturesState.Loaded -> {
             val loadedState = state as OnboardingUpgradeFeaturesState.Loaded
             if (FeatureFlag.isEnabled(Feature.PAYWALL_EXPERIMENT)) {
-                UpgradePlusLayoutExperiment(
+                UpgradeLayoutFeatures(
                     state = loadedState,
                     source = source,
                     onNotNowPressed = onNotNowPressed,

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeFeaturesPage.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeFeaturesPage.kt
@@ -126,11 +126,10 @@ internal fun OnboardingUpgradeFeaturesPage(
                 UpgradePlusLayoutExperiment(
                     state = loadedState,
                     source = source,
-                    scrollState = scrollState,
                     onNotNowPressed = onNotNowPressed,
-                    onSubscriptionFrequencyChanged = { viewModel.onSubscriptionFrequencyChanged(it) },
                     onFeatureCardChanged = { viewModel.onFeatureCardChanged(loadedState.featureCardsState.featureCards[it]) },
                     onClickSubscribe = onClickSubscribe,
+                    scrollState = scrollState,
                     canUpgrade = canUpgrade,
                 )
             } else {

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeFeaturesPage.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeFeaturesPage.kt
@@ -127,7 +127,6 @@ internal fun OnboardingUpgradeFeaturesPage(
                     state = loadedState,
                     source = source,
                     scrollState = scrollState,
-                    onBackPressed = onBackPressed,
                     onNotNowPressed = onNotNowPressed,
                     onSubscriptionFrequencyChanged = { viewModel.onSubscriptionFrequencyChanged(it) },
                     onFeatureCardChanged = { viewModel.onFeatureCardChanged(loadedState.featureCardsState.featureCards[it]) },

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeFeaturesPage.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeFeaturesPage.kt
@@ -133,7 +133,7 @@ internal fun OnboardingUpgradeFeaturesPage(
                     canUpgrade = canUpgrade,
                 )
             } else {
-                UpgradeLayout(
+                UpgradeLayoutOriginal(
                     state = loadedState,
                     source = source,
                     scrollState = scrollState,
@@ -157,7 +157,7 @@ internal fun OnboardingUpgradeFeaturesPage(
 }
 
 @Composable
-private fun UpgradeLayout(
+private fun UpgradeLayoutOriginal(
     state: OnboardingUpgradeFeaturesState.Loaded,
     source: OnboardingUpgradeSource,
     scrollState: ScrollState,

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeFeaturesPage.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeFeaturesPage.kt
@@ -79,6 +79,8 @@ import au.com.shiftyjelly.pocketcasts.models.type.SubscriptionFrequency
 import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingFlow
 import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingUpgradeSource
 import au.com.shiftyjelly.pocketcasts.utils.extensions.pxToDp
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 private const val MAX_OFFER_BADGE_TEXT_LENGTH = 23
@@ -120,17 +122,31 @@ internal fun OnboardingUpgradeFeaturesPage(
         is OnboardingUpgradeFeaturesState.Loading -> Unit // Do Nothing
         is OnboardingUpgradeFeaturesState.Loaded -> {
             val loadedState = state as OnboardingUpgradeFeaturesState.Loaded
-            UpgradeLayout(
-                state = loadedState,
-                source = source,
-                scrollState = scrollState,
-                onBackPressed = onBackPressed,
-                onNotNowPressed = onNotNowPressed,
-                onSubscriptionFrequencyChanged = { viewModel.onSubscriptionFrequencyChanged(it) },
-                onFeatureCardChanged = { viewModel.onFeatureCardChanged(loadedState.featureCardsState.featureCards[it]) },
-                onClickSubscribe = onClickSubscribe,
-                canUpgrade = canUpgrade,
-            )
+            if (FeatureFlag.isEnabled(Feature.PAYWALL_EXPERIMENT)) {
+                UpgradePlusLayoutExperiment(
+                    state = loadedState,
+                    source = source,
+                    scrollState = scrollState,
+                    onBackPressed = onBackPressed,
+                    onNotNowPressed = onNotNowPressed,
+                    onSubscriptionFrequencyChanged = { viewModel.onSubscriptionFrequencyChanged(it) },
+                    onFeatureCardChanged = { viewModel.onFeatureCardChanged(loadedState.featureCardsState.featureCards[it]) },
+                    onClickSubscribe = onClickSubscribe,
+                    canUpgrade = canUpgrade,
+                )
+            } else {
+                UpgradeLayout(
+                    state = loadedState,
+                    source = source,
+                    scrollState = scrollState,
+                    onBackPressed = onBackPressed,
+                    onNotNowPressed = onNotNowPressed,
+                    onSubscriptionFrequencyChanged = { viewModel.onSubscriptionFrequencyChanged(it) },
+                    onFeatureCardChanged = { viewModel.onFeatureCardChanged(loadedState.featureCardsState.featureCards[it]) },
+                    onClickSubscribe = onClickSubscribe,
+                    canUpgrade = canUpgrade,
+                )
+            }
         }
         is OnboardingUpgradeFeaturesState.NoSubscriptions -> {
             NoSubscriptionsLayout(
@@ -395,7 +411,7 @@ private fun FeatureCard(
 }
 
 @Composable
-private fun UpgradeButton(
+internal fun UpgradeButton(
     button: UpgradeButton,
     onClickSubscribe: () -> Unit,
 ) {
@@ -454,7 +470,7 @@ private fun SetStatusBarBackground(
 }
 
 @Composable
-private fun BoxWithConstraintsScope.calculateMinimumHeightWithInsets(): Dp {
+internal fun BoxWithConstraintsScope.calculateMinimumHeightWithInsets(): Dp {
     val statusBarPadding = WindowInsets.statusBars
         .asPaddingValues()
         .calculateTopPadding()

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/UpgradeLayoutFeatures.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/UpgradeLayoutFeatures.kt
@@ -47,7 +47,7 @@ import au.com.shiftyjelly.pocketcasts.localization.R as LR
 import au.com.shiftyjelly.pocketcasts.ui.R as UR
 
 @Composable
-internal fun UpgradePlusLayoutExperiment(
+internal fun UpgradeLayoutFeatures(
     state: OnboardingUpgradeFeaturesState.Loaded,
     source: OnboardingUpgradeSource,
     scrollState: ScrollState,

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/UpgradeLayoutFeatures.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/UpgradeLayoutFeatures.kt
@@ -7,16 +7,13 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.statusBars
-import androidx.compose.foundation.layout.windowInsetsBottomHeight
 import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.ButtonDefaults
@@ -110,7 +107,7 @@ internal fun UpgradeLayoutFeatures(
                             }
 
                             Box(
-                                modifier = Modifier.padding(bottom = 20.dp),
+                                modifier = Modifier.padding(bottom = 40.dp),
                                 contentAlignment = Alignment.Center,
                             ) {
                                 AutoResizeText(
@@ -127,8 +124,6 @@ internal fun UpgradeLayoutFeatures(
                                 )
                             }
 
-                            Spacer(Modifier.height(20.dp))
-
                             FeatureCards(
                                 // TODO: it will be replaced for the new one
                                 state = state,
@@ -136,8 +131,6 @@ internal fun UpgradeLayoutFeatures(
                                 onFeatureCardChanged = onFeatureCardChanged,
                             )
                         }
-
-                        Spacer(Modifier.weight(1f))
                     }
                 }
             }
@@ -156,23 +149,17 @@ private fun SubscribeButton(
     Box(
         contentAlignment = Alignment.BottomCenter,
     ) {
-        Column {
-            RowButton(
-                text = stringResource(LR.string.get_pocket_casts_plus),
-                onClick = onClickSubscribe,
-                fontWeight = FontWeight.W600,
-                fontSize = 18.sp,
-                textColor = Color.Black,
-                colors = ButtonDefaults.buttonColors(
-                    backgroundColor = colorResource(UR.color.plus_gold),
-                ),
-            )
-
-            Spacer(
-                modifier = Modifier
-                    .windowInsetsBottomHeight(WindowInsets.navigationBars),
-            )
-        }
+        RowButton(
+            modifier = Modifier.padding(bottom = 80.dp),
+            text = stringResource(LR.string.get_pocket_casts_plus),
+            onClick = onClickSubscribe,
+            fontWeight = FontWeight.W600,
+            fontSize = 18.sp,
+            textColor = Color.Black,
+            colors = ButtonDefaults.buttonColors(
+                backgroundColor = colorResource(UR.color.plus_gold),
+            ),
+        )
     }
 }
 

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/UpgradePlusLayoutExperiment.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/UpgradePlusLayoutExperiment.kt
@@ -18,9 +18,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.statusBars
 import androidx.compose.foundation.layout.windowInsetsBottomHeight
 import androidx.compose.foundation.layout.windowInsetsPadding
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material.Button
 import androidx.compose.material.ButtonDefaults
 import androidx.compose.material.MaterialTheme
 import androidx.compose.runtime.Composable
@@ -35,6 +33,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import au.com.shiftyjelly.pocketcasts.account.viewmodel.OnboardingUpgradeFeaturesState
 import au.com.shiftyjelly.pocketcasts.compose.AppTheme
+import au.com.shiftyjelly.pocketcasts.compose.buttons.RowButton
 import au.com.shiftyjelly.pocketcasts.compose.buttons.RowTextButton
 import au.com.shiftyjelly.pocketcasts.compose.components.AutoResizeText
 import au.com.shiftyjelly.pocketcasts.compose.images.SubscriptionBadgeDisplayMode
@@ -157,34 +156,17 @@ private fun SubscribeButton(
         contentAlignment = Alignment.BottomCenter,
     ) {
         Column {
-            Button(
+            RowButton(
+                text = stringResource(LR.string.get_pocket_casts_plus),
                 onClick = onClickSubscribe,
-                shape = RoundedCornerShape(12.dp),
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(horizontal = 16.dp, vertical = 24.dp)
-                    .heightIn(min = 56.dp),
+                fontWeight = FontWeight.W600,
+                fontSize = 18.sp,
+                textColor = Color.Black,
                 colors = ButtonDefaults.buttonColors(
                     backgroundColor = colorResource(UR.color.plus_gold),
                 ),
-            ) {
-                Column(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(horizontal = 34.dp),
-                    horizontalAlignment = Alignment.CenterHorizontally,
-                ) {
-                    AutoResizeText(
-                        text = stringResource(LR.string.get_pocket_casts_plus),
-                        color = Color.Black,
-                        maxFontSize = 18.sp,
-                        lineHeight = 22.sp,
-                        fontWeight = FontWeight.W600,
-                        maxLines = 1,
-                        textAlign = TextAlign.Center,
-                    )
-                }
-            }
+            )
+
             Spacer(
                 modifier = Modifier
                     .windowInsetsBottomHeight(WindowInsets.navigationBars),

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/UpgradePlusLayoutExperiment.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/UpgradePlusLayoutExperiment.kt
@@ -1,0 +1,161 @@
+package au.com.shiftyjelly.pocketcasts.account.onboarding.upgrade
+
+import androidx.compose.foundation.ScrollState
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.navigationBars
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.statusBars
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.windowInsetsPadding
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import au.com.shiftyjelly.pocketcasts.account.viewmodel.OnboardingUpgradeFeaturesState
+import au.com.shiftyjelly.pocketcasts.compose.bars.NavigationIconButton
+import au.com.shiftyjelly.pocketcasts.compose.components.AutoResizeText
+import au.com.shiftyjelly.pocketcasts.compose.components.StyledToggle
+import au.com.shiftyjelly.pocketcasts.compose.components.TextH30
+import au.com.shiftyjelly.pocketcasts.localization.R
+import au.com.shiftyjelly.pocketcasts.models.type.SubscriptionFrequency
+import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingUpgradeSource
+
+@Composable
+internal fun UpgradePlusLayoutExperiment(
+    state: OnboardingUpgradeFeaturesState.Loaded,
+    source: OnboardingUpgradeSource,
+    scrollState: ScrollState,
+    onBackPressed: () -> Unit,
+    onNotNowPressed: () -> Unit,
+    onSubscriptionFrequencyChanged: (SubscriptionFrequency) -> Unit,
+    onFeatureCardChanged: (Int) -> Unit,
+    onClickSubscribe: () -> Unit,
+    canUpgrade: Boolean,
+    modifier: Modifier = Modifier,
+) {
+    Box(
+        modifier = modifier.fillMaxHeight(),
+        contentAlignment = Alignment.BottomCenter,
+    ) {
+        // Need this BoxWithConstraints so we can force the inner column to fill the screen with vertical scroll enabled
+        BoxWithConstraints(
+            Modifier
+                .fillMaxHeight()
+                .background(OnboardingUpgradeHelper.backgroundColor),
+        ) {
+            OnboardingUpgradeHelper.UpgradeBackground(
+                modifier = Modifier.verticalScroll(scrollState),
+                tier = state.currentFeatureCard.subscriptionTier,
+                backgroundGlowsRes = state.currentFeatureCard.backgroundGlowsRes,
+            ) {
+                Column(
+                    Modifier
+                        .windowInsetsPadding(WindowInsets.statusBars)
+                        .windowInsetsPadding(WindowInsets.navigationBars)
+                        .heightIn(min = this.calculateMinimumHeightWithInsets())
+                        .padding(bottom = 100.dp), // Added to allow scrolling feature cards beyond upgrade button in large font sizes
+                ) {
+                    Spacer(Modifier.height(8.dp))
+
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.SpaceBetween,
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        NavigationIconButton(
+                            onNavigationClick = onBackPressed,
+                            iconColor = Color.White,
+                            modifier = Modifier
+                                .height(48.dp)
+                                .width(48.dp),
+                        )
+                        if (state.showNotNow) {
+                            TextH30(
+                                text = stringResource(R.string.not_now),
+                                color = Color.White,
+                                modifier = Modifier
+                                    .padding(horizontal = 24.dp)
+                                    .clickable { onNotNowPressed() },
+                            )
+                        }
+                    }
+
+                    Spacer(Modifier.weight(1f))
+
+                    Column {
+                        Box(
+                            modifier = Modifier.heightIn(min = 70.dp),
+                            contentAlignment = Alignment.Center,
+                        ) {
+                            AutoResizeText(
+                                text = stringResource(state.currentFeatureCard.titleRes(source)),
+                                color = Color.White,
+                                maxFontSize = 22.sp,
+                                lineHeight = 30.sp,
+                                fontWeight = FontWeight.W700,
+                                maxLines = 2,
+                                textAlign = TextAlign.Center,
+                                modifier = Modifier
+                                    .padding(horizontal = 24.dp)
+                                    .fillMaxWidth(),
+                            )
+                        }
+
+                        Spacer(Modifier.height(24.dp))
+
+                        Box(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(bottom = 24.dp),
+                            contentAlignment = Alignment.Center,
+                        ) {
+                            StyledToggle(
+                                items = state.subscriptionFrequencies
+                                    .map { stringResource(id = it.localisedLabelRes) },
+                                defaultSelectedItemIndex = state.subscriptionFrequencies.indexOf(
+                                    state.currentSubscriptionFrequency,
+                                ),
+                            ) {
+                                val selectedFrequency = state.subscriptionFrequencies[it]
+                                onSubscriptionFrequencyChanged(selectedFrequency)
+                            }
+                        }
+
+                        FeatureCards(
+                            state = state,
+                            upgradeButton = state.currentUpgradeButton,
+                            onFeatureCardChanged = onFeatureCardChanged,
+                        )
+                    }
+
+                    Spacer(Modifier.weight(1f))
+                }
+            }
+        }
+
+        if (canUpgrade) {
+            UpgradeButton(
+                button = state.currentUpgradeButton,
+                onClickSubscribe = onClickSubscribe,
+            )
+        }
+    }
+}

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/UpgradePlusLayoutExperiment.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/UpgradePlusLayoutExperiment.kt
@@ -2,7 +2,6 @@ package au.com.shiftyjelly.pocketcasts.account.onboarding.upgrade
 
 import androidx.compose.foundation.ScrollState
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
@@ -36,12 +35,11 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import au.com.shiftyjelly.pocketcasts.account.viewmodel.OnboardingUpgradeFeaturesState
 import au.com.shiftyjelly.pocketcasts.compose.AppTheme
+import au.com.shiftyjelly.pocketcasts.compose.buttons.RowTextButton
 import au.com.shiftyjelly.pocketcasts.compose.components.AutoResizeText
-import au.com.shiftyjelly.pocketcasts.compose.components.TextP30
 import au.com.shiftyjelly.pocketcasts.compose.images.SubscriptionBadgeDisplayMode
 import au.com.shiftyjelly.pocketcasts.compose.images.SubscriptionBadgeForTier
 import au.com.shiftyjelly.pocketcasts.compose.theme
-import au.com.shiftyjelly.pocketcasts.localization.R
 import au.com.shiftyjelly.pocketcasts.models.type.Subscription.SubscriptionTier
 import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingUpgradeSource
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
@@ -83,12 +81,16 @@ internal fun UpgradePlusLayoutExperiment(
                                 .padding(top = 8.dp),
                             horizontalArrangement = Arrangement.End,
                         ) {
-                            TextP30(
-                                text = stringResource(R.string.not_now),
-                                color = Color.White,
-                                modifier = Modifier
-                                    .padding(start = 24.dp, end = 24.dp, top = 8.dp)
-                                    .clickable { onNotNowPressed() },
+                            RowTextButton(
+                                text = stringResource(LR.string.not_now),
+                                colors = ButtonDefaults.outlinedButtonColors(
+                                    backgroundColor = Color.Transparent,
+                                    contentColor = Color.White,
+                                ),
+                                fontSize = 18.sp,
+                                onClick = onNotNowPressed,
+                                fullWidth = false,
+                                includePadding = false,
                             )
                         }
 

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/UpgradePlusLayoutExperiment.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/UpgradePlusLayoutExperiment.kt
@@ -17,7 +17,6 @@ import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.statusBars
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
@@ -30,10 +29,9 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import au.com.shiftyjelly.pocketcasts.account.viewmodel.OnboardingUpgradeFeaturesState
-import au.com.shiftyjelly.pocketcasts.compose.bars.NavigationIconButton
 import au.com.shiftyjelly.pocketcasts.compose.components.AutoResizeText
 import au.com.shiftyjelly.pocketcasts.compose.components.StyledToggle
-import au.com.shiftyjelly.pocketcasts.compose.components.TextH30
+import au.com.shiftyjelly.pocketcasts.compose.components.TextP30
 import au.com.shiftyjelly.pocketcasts.localization.R
 import au.com.shiftyjelly.pocketcasts.models.type.SubscriptionFrequency
 import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingUpgradeSource
@@ -43,7 +41,6 @@ internal fun UpgradePlusLayoutExperiment(
     state: OnboardingUpgradeFeaturesState.Loaded,
     source: OnboardingUpgradeSource,
     scrollState: ScrollState,
-    onBackPressed: () -> Unit,
     onNotNowPressed: () -> Unit,
     onSubscriptionFrequencyChanged: (SubscriptionFrequency) -> Unit,
     onFeatureCardChanged: (Int) -> Unit,
@@ -77,25 +74,15 @@ internal fun UpgradePlusLayoutExperiment(
 
                     Row(
                         modifier = Modifier.fillMaxWidth(),
-                        horizontalArrangement = Arrangement.SpaceBetween,
-                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.End,
                     ) {
-                        NavigationIconButton(
-                            onNavigationClick = onBackPressed,
-                            iconColor = Color.White,
+                        TextP30(
+                            text = stringResource(R.string.not_now),
+                            color = Color.White,
                             modifier = Modifier
-                                .height(48.dp)
-                                .width(48.dp),
+                                .padding(start = 24.dp, end = 24.dp, top = 8.dp)
+                                .clickable { onNotNowPressed() },
                         )
-                        if (state.showNotNow) {
-                            TextH30(
-                                text = stringResource(R.string.not_now),
-                                color = Color.White,
-                                modifier = Modifier
-                                    .padding(horizontal = 24.dp)
-                                    .clickable { onNotNowPressed() },
-                            )
-                        }
                     }
 
                     Spacer(Modifier.weight(1f))

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/UpgradePlusLayoutExperiment.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/UpgradePlusLayoutExperiment.kt
@@ -29,6 +29,7 @@ import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import au.com.shiftyjelly.pocketcasts.account.viewmodel.OnboardingUpgradeFeaturesState
@@ -173,4 +174,10 @@ private fun SubscribeButton(
             )
         }
     }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun SubscribeButtonPreview() {
+    SubscribeButton(onClickSubscribe = { })
 }

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/UpgradePlusLayoutExperiment.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/UpgradePlusLayoutExperiment.kt
@@ -23,6 +23,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.Button
 import androidx.compose.material.ButtonDefaults
+import androidx.compose.material.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -34,13 +35,16 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import au.com.shiftyjelly.pocketcasts.account.viewmodel.OnboardingUpgradeFeaturesState
+import au.com.shiftyjelly.pocketcasts.compose.AppTheme
 import au.com.shiftyjelly.pocketcasts.compose.components.AutoResizeText
 import au.com.shiftyjelly.pocketcasts.compose.components.TextP30
 import au.com.shiftyjelly.pocketcasts.compose.images.SubscriptionBadgeDisplayMode
 import au.com.shiftyjelly.pocketcasts.compose.images.SubscriptionBadgeForTier
+import au.com.shiftyjelly.pocketcasts.compose.theme
 import au.com.shiftyjelly.pocketcasts.localization.R
 import au.com.shiftyjelly.pocketcasts.models.type.Subscription.SubscriptionTier
 import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingUpgradeSource
+import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 import au.com.shiftyjelly.pocketcasts.ui.R as UR
 
@@ -55,87 +59,90 @@ internal fun UpgradePlusLayoutExperiment(
     canUpgrade: Boolean,
     modifier: Modifier = Modifier,
 ) {
-    Box(
-        modifier = modifier.fillMaxHeight(),
-        contentAlignment = Alignment.BottomCenter,
-    ) {
-        BoxWithConstraints(
-            Modifier
-                .fillMaxHeight()
-                .background(Color.Black),
+    AppTheme(Theme.ThemeType.DARK) { // We need to set Dark since this screen will have dark colors for all themes
+        Box(
+            modifier = modifier.fillMaxHeight(),
+            contentAlignment = Alignment.BottomCenter,
         ) {
-            Box(modifier = Modifier.verticalScroll(scrollState)) {
-                Column(
-                    Modifier
-                        .windowInsetsPadding(WindowInsets.statusBars)
-                        .windowInsetsPadding(WindowInsets.navigationBars)
-                        .heightIn(min = this@BoxWithConstraints.calculateMinimumHeightWithInsets())
-                        .padding(bottom = 100.dp),
-                ) {
-                    Row(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(top = 8.dp),
-                        horizontalArrangement = Arrangement.End,
+            BoxWithConstraints(
+                Modifier
+                    .fillMaxHeight()
+                    .background(color = MaterialTheme.theme.colors.primaryUi02),
+            ) {
+                Box(modifier = Modifier.verticalScroll(scrollState)) {
+                    Column(
+                        Modifier
+                            .windowInsetsPadding(WindowInsets.statusBars)
+                            .windowInsetsPadding(WindowInsets.navigationBars)
+                            .heightIn(min = this@BoxWithConstraints.calculateMinimumHeightWithInsets())
+                            .padding(bottom = 100.dp),
                     ) {
-                        TextP30(
-                            text = stringResource(R.string.not_now),
-                            color = Color.White,
-                            modifier = Modifier
-                                .padding(start = 24.dp, end = 24.dp, top = 8.dp)
-                                .clickable { onNotNowPressed() },
-                        )
-                    }
-
-                    Column {
-                        Box(
+                        Row(
                             modifier = Modifier
                                 .fillMaxWidth()
-                                .padding(bottom = 12.dp, top = 24.dp),
-                            contentAlignment = Alignment.Center,
+                                .padding(top = 8.dp),
+                            horizontalArrangement = Arrangement.End,
                         ) {
-                            SubscriptionBadgeForTier(
-                                tier = SubscriptionTier.PLUS,
-                                displayMode = SubscriptionBadgeDisplayMode.ColoredWithBlackForeground,
-                                fontSize = 16.sp,
-                                padding = 8.dp,
-                            )
-                        }
-
-                        Box(
-                            modifier = Modifier.padding(bottom = 20.dp),
-                            contentAlignment = Alignment.Center,
-                        ) {
-                            AutoResizeText(
-                                text = stringResource(state.currentFeatureCard.titleRes(source)),
+                            TextP30(
+                                text = stringResource(R.string.not_now),
                                 color = Color.White,
-                                maxFontSize = 22.sp,
-                                lineHeight = 30.sp,
-                                fontWeight = FontWeight.W700,
-                                maxLines = 2,
-                                textAlign = TextAlign.Center,
                                 modifier = Modifier
-                                    .padding(horizontal = 24.dp)
-                                    .fillMaxWidth(),
+                                    .padding(start = 24.dp, end = 24.dp, top = 8.dp)
+                                    .clickable { onNotNowPressed() },
                             )
                         }
 
-                        Spacer(Modifier.height(20.dp))
+                        Column {
+                            Box(
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .padding(bottom = 12.dp, top = 24.dp),
+                                contentAlignment = Alignment.Center,
+                            ) {
+                                SubscriptionBadgeForTier(
+                                    tier = SubscriptionTier.PLUS,
+                                    displayMode = SubscriptionBadgeDisplayMode.ColoredWithBlackForeground,
+                                    fontSize = 16.sp,
+                                    padding = 8.dp,
+                                )
+                            }
 
-                        FeatureCards( // TODO: it will be replaced for the new one
-                            state = state,
-                            upgradeButton = state.currentUpgradeButton,
-                            onFeatureCardChanged = onFeatureCardChanged,
-                        )
+                            Box(
+                                modifier = Modifier.padding(bottom = 20.dp),
+                                contentAlignment = Alignment.Center,
+                            ) {
+                                AutoResizeText(
+                                    text = stringResource(state.currentFeatureCard.titleRes(source)),
+                                    color = Color.White,
+                                    maxFontSize = 22.sp,
+                                    lineHeight = 30.sp,
+                                    fontWeight = FontWeight.W700,
+                                    maxLines = 2,
+                                    textAlign = TextAlign.Center,
+                                    modifier = Modifier
+                                        .padding(horizontal = 24.dp)
+                                        .fillMaxWidth(),
+                                )
+                            }
+
+                            Spacer(Modifier.height(20.dp))
+
+                            FeatureCards(
+                                // TODO: it will be replaced for the new one
+                                state = state,
+                                upgradeButton = state.currentUpgradeButton,
+                                onFeatureCardChanged = onFeatureCardChanged,
+                            )
+                        }
+
+                        Spacer(Modifier.weight(1f))
                     }
-
-                    Spacer(Modifier.weight(1f))
                 }
             }
-        }
 
-        if (canUpgrade) {
-            SubscribeButton(onClickSubscribe)
+            if (canUpgrade) {
+                SubscribeButton(onClickSubscribe)
+            }
         }
     }
 }

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/buttons/BaseRowButton.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/buttons/BaseRowButton.kt
@@ -26,7 +26,9 @@ import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.TextUnit
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import au.com.shiftyjelly.pocketcasts.compose.components.TextP40
 import au.com.shiftyjelly.pocketcasts.compose.theme
 
@@ -39,6 +41,7 @@ fun BaseRowButton(
     border: BorderStroke? = null,
     colors: ButtonColors = ButtonDefaults.buttonColors(),
     textColor: Color = MaterialTheme.theme.colors.primaryInteractive02,
+    fontSize: TextUnit = 16.sp,
     elevation: ButtonElevation? = ButtonDefaults.elevation(),
     fontFamily: FontFamily? = null,
     fontWeight: FontWeight? = null,
@@ -86,6 +89,7 @@ fun BaseRowButton(
                 TextP40(
                     text = text,
                     fontFamily = fontFamily,
+                    fontSize = fontSize,
                     fontWeight = fontWeight,
                     modifier = Modifier
                         .padding(vertical = textVerticalPadding, horizontal = 6.dp),

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/buttons/RowButton.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/buttons/RowButton.kt
@@ -16,7 +16,9 @@ import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.TextUnit
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import au.com.shiftyjelly.pocketcasts.compose.AppThemeWithBackground
 import au.com.shiftyjelly.pocketcasts.compose.theme
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
@@ -32,6 +34,7 @@ fun RowButton(
     border: BorderStroke? = null,
     colors: ButtonColors = ButtonDefaults.buttonColors(),
     textColor: Color = MaterialTheme.theme.colors.primaryInteractive02,
+    fontSize: TextUnit = 16.sp,
     elevation: ButtonElevation? = ButtonDefaults.elevation(),
     fontFamily: FontFamily? = null,
     fontWeight: FontWeight? = null,
@@ -50,6 +53,7 @@ fun RowButton(
         border = border,
         colors = colors,
         textColor = textColor,
+        fontSize = fontSize,
         elevation = elevation,
         fontFamily = fontFamily,
         fontWeight = fontWeight,

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/images/SubscriptionBadge.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/images/SubscriptionBadge.kt
@@ -81,9 +81,13 @@ fun SubscriptionBadge(
 fun SubscriptionBadgeForTier(
     tier: SubscriptionTier,
     displayMode: SubscriptionBadgeDisplayMode,
+    fontSize: TextUnit = 14.sp,
+    padding: Dp = 4.dp,
 ) {
     when (tier) {
         SubscriptionTier.PLUS -> SubscriptionBadge(
+            fontSize = fontSize,
+            padding = padding,
             iconRes = IR.drawable.ic_plus,
             shortNameRes = LR.string.pocket_casts_plus_short,
             iconColor = when (displayMode) {
@@ -104,6 +108,8 @@ fun SubscriptionBadgeForTier(
             },
         )
         SubscriptionTier.PATRON -> SubscriptionBadge(
+            fontSize = fontSize,
+            padding = padding,
             iconRes = IR.drawable.ic_patron,
             shortNameRes = LR.string.pocket_casts_patron_short,
             iconColor = when (displayMode) {

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -115,6 +115,7 @@
     <string name="subscribe_to">Subscribe to %s</string>
     <string name="upgrade_to">Upgrade to %s</string>
     <string name="unarchive_all">Unarchive all</string>
+    <string name="get_pocket_casts_plus">Get Pocket Casts Plus</string>
     <string name="unplayed">Unplayed</string>
     <string name="unsubscribe">Unsubscribe</string>
     <string name="up_next">Up Next</string>

--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/Feature.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/Feature.kt
@@ -155,6 +155,14 @@ enum class Feature(
         hasFirebaseRemoteFlag = false,
         hasDevToggle = true,
     ),
+    PAYWALL_EXPERIMENT(
+        key = "paywall_experiment",
+        title = "Paywall Experiment",
+        defaultValue = BuildConfig.DEBUG,
+        tier = FeatureTier.Free,
+        hasFirebaseRemoteFlag = false,
+        hasDevToggle = true,
+    ),
     ;
 
     companion object {


### PR DESCRIPTION
## Description
- This adds the first changes for the paywall redesign. I will address the feature cards in a later PR and also the text below of the button
- See: SEQe6JBDCeegcpa9Bfg5Ww-fi-3_756
- The background will be the same for all themes: p1723556268631729-slack-C07G1MH890E 
- This redesign is currently behind a temporary local feature flag. We are going to change in a later PR for the testing experiment

Fixes #2630

## Testing Instructions
1. Apply this [paywall.patch](https://github.com/user-attachments/files/16612993/paywall.patch)
2. Run in `debug`
3. Make sure PAYWALL_EXPERIMENT feature flag is enabled
4. Make sure you have the same account logged in Play Store
5. Go to Profile -> Settings -> Pocket Casts Plus
6. Verify the Paywall redesign
7. ✅ Make sure the background is black
8. ✅ Make sure you `Not now` button instead of arrow
9. ✅ Make sure you don't see the Monthly and Yearly pills

## Screenshots or Screencast 

<img src="https://github.com/user-attachments/assets/c80f6df7-55b6-4e46-a76a-08b5f6390cf6" width="300">



## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack