### PR TITLE
Tweaks to the features page

### DIFF
--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/BetaFeaturesFragment.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/BetaFeaturesFragment.kt
@@ -16,18 +16,24 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.fragment.app.viewModels
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import au.com.shiftyjelly.pocketcasts.compose.AppTheme
 import au.com.shiftyjelly.pocketcasts.compose.AppThemeWithBackground
 import au.com.shiftyjelly.pocketcasts.compose.bars.ThemedTopAppBar
 import au.com.shiftyjelly.pocketcasts.compose.components.SettingRow
 import au.com.shiftyjelly.pocketcasts.compose.components.SettingRowToggle
+import au.com.shiftyjelly.pocketcasts.compose.preview.ThemePreviewParameterProvider
 import au.com.shiftyjelly.pocketcasts.localization.R
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.settings.viewmodel.BetaFeaturesViewModel
-import au.com.shiftyjelly.pocketcasts.utils.extensions.dpToPx
+import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
+import au.com.shiftyjelly.pocketcasts.utils.extensions.pxToDp
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
 import au.com.shiftyjelly.pocketcasts.views.fragments.BaseFragment
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
@@ -38,6 +44,8 @@ class BetaFeaturesFragment : BaseFragment() {
     @Inject
     lateinit var settings: Settings
 
+    private val viewModel: BetaFeaturesViewModel by viewModels()
+
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
@@ -47,52 +55,69 @@ class BetaFeaturesFragment : BaseFragment() {
             setContent {
                 AppThemeWithBackground(theme.activeTheme) {
                     setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
+                    val state by viewModel.state.collectAsState()
                     val bottomInset = settings.bottomInset.collectAsStateWithLifecycle(0)
                     BetaFeaturesPage(
-                        onBackPressed = {
+                        state = state,
+                        onFeatureEnabled = viewModel::setFeatureEnabled,
+                        onBackClick = {
                             @Suppress("DEPRECATION")
                             activity?.onBackPressed()
                         },
-                        bottomInset = bottomInset.value.dpToPx(LocalContext.current).dp,
+                        bottomInset = bottomInset.value.pxToDp(LocalContext.current).dp,
                     )
                 }
             }
         }
     }
+}
 
-    @Composable
-    fun BetaFeaturesPage(
-        onBackPressed: () -> Unit,
-        bottomInset: Dp,
+@Composable
+private fun BetaFeaturesPage(
+    state: BetaFeaturesViewModel.State,
+    onFeatureEnabled: (Feature, Boolean) -> Unit,
+    onBackClick: () -> Unit,
+    bottomInset: Dp,
+) {
+    LazyColumn(
+        contentPadding = PaddingValues(top = 16.dp, bottom = bottomInset + 16.dp),
     ) {
-        val viewModel = hiltViewModel<BetaFeaturesViewModel>()
-        val state by viewModel.state.collectAsState()
-        LazyColumn(
-            contentPadding = PaddingValues(bottom = bottomInset),
-        ) {
+        item {
+            ThemedTopAppBar(
+                title = stringResource(R.string.settings_beta_features),
+                onNavigationClick = { onBackClick() },
+            )
+        }
+
+        for (feature in state.featureFlags) {
             item {
-                ThemedTopAppBar(
-                    title = stringResource(R.string.settings_beta_features),
-                    bottomShadow = true,
-                    onNavigationClick = { onBackPressed() },
+                SettingRow(
+                    primaryText = feature.featureFlag.title,
+                    toggle = SettingRowToggle.Switch(checked = feature.isEnabled),
+                    modifier = Modifier.toggleable(
+                        value = feature.isEnabled,
+                        role = Role.Switch,
+                    ) {
+                        onFeatureEnabled(feature.featureFlag, it)
+                    },
+                    indent = false,
                 )
             }
-
-            for (feature in state.featureFlags) {
-                item {
-                    SettingRow(
-                        primaryText = feature.featureFlag.title,
-                        toggle = SettingRowToggle.Switch(checked = feature.isEnabled),
-                        modifier = Modifier.toggleable(
-                            value = feature.isEnabled,
-                            role = Role.Switch,
-                        ) {
-                            viewModel.setFeatureEnabled(feature.featureFlag, it)
-                        },
-                        indent = false,
-                    )
-                }
-            }
         }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun BetaFeaturesPagePreview(
+    @PreviewParameter(ThemePreviewParameterProvider::class) themeType: Theme.ThemeType,
+) {
+    AppTheme(themeType) {
+        BetaFeaturesPage(
+            state = BetaFeaturesViewModel.State(featureFlags = Feature.entries.map { BetaFeaturesViewModel.FeatureFlagWrapper(featureFlag = it, isEnabled = true) }),
+            onFeatureEnabled = { _, _ -> },
+            onBackClick = {},
+            bottomInset = 0.dp,
+        )
     }
 }

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/viewmodel/BetaFeaturesViewModel.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/viewmodel/BetaFeaturesViewModel.kt
@@ -21,8 +21,9 @@ class BetaFeaturesViewModel @Inject constructor() : ViewModel() {
     val state: StateFlow<State> = _state
 
     private val featureFlags: List<FeatureFlagWrapper>
-        get() = Feature.values()
+        get() = Feature.entries
             .filter { it.hasDevToggle }
+            .sortedBy { it.title }
             .map {
                 FeatureFlagWrapper(
                     featureFlag = it,


### PR DESCRIPTION
## Description

Minor tweaks to the features page

## Testing Instructions
1. Play an episode so it's in the mini player
2. Open the features page

✅  Verify there is no padding at the bottom of the page and the items are sorted by title

## Screenshots 
| Before | After |
| --- | --- |
| ![Screenshot_20240814_234837](https://github.com/user-attachments/assets/8b8d9b51-a209-496f-b36b-fbd2a6709331) | ![Screenshot_20240815_000609](https://github.com/user-attachments/assets/699a375a-6ab6-4f1b-a30d-28c006ec5a83) | 
