### PR TITLE
[Give Rating] Add action tapping to stars

### DIFF
--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/components/ratings/StarRatingView.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/components/ratings/StarRatingView.kt
@@ -15,6 +15,8 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
@@ -36,6 +38,7 @@ import au.com.shiftyjelly.pocketcasts.utils.extensions.abbreviated
 import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
 import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
 import java.util.UUID
+import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 @Composable
 fun StarRatingView(
@@ -57,6 +60,7 @@ fun StarRatingView(
                 },
             )
         }
+
         is RatingState.Loading,
         is RatingState.Error,
         -> Unit // Do Nothing
@@ -68,6 +72,8 @@ private fun Content(
     state: RatingState.Loaded,
     onClick: () -> Unit,
 ) {
+    val starsContentDescription = stringResource(LR.string.podcast_star_rating_content_description)
+
     Row(
         modifier = Modifier.padding(
             start = 16.dp,
@@ -77,28 +83,31 @@ private fun Content(
         ),
         verticalAlignment = Alignment.CenterVertically,
     ) {
-        Stars(
-            stars = state.stars,
-            color = MaterialTheme.theme.colors.primaryUi05Selected,
-            onClick = onClick,
-        )
+        Row(
+            modifier = Modifier
+                .clickable { onClick() }
+                .semantics {
+                    this.contentDescription = starsContentDescription
+                },
+        ) {
+            Stars(
+                stars = state.stars,
+                color = MaterialTheme.theme.colors.primaryUi05Selected,
+            )
 
-        if (!state.noRatings) {
+            if (!state.noRatings) {
+                TextP40(
+                    text = state.roundedAverage,
+                    modifier = Modifier.padding(start = 4.dp),
+                    fontWeight = FontWeight.W700,
+                )
+            }
+
             TextP40(
-                text = state.roundedAverage,
-                modifier = Modifier
-                    .padding(start = 4.dp)
-                    .clickable { onClick() },
-                fontWeight = FontWeight.W700,
+                text = if (state.noRatings) stringResource(R.string.no_ratings) else "(${state.total?.abbreviated})",
+                modifier = Modifier.padding(start = 4.dp),
             )
         }
-
-        TextP40(
-            text = if (state.noRatings) stringResource(R.string.no_ratings) else "(${state.total?.abbreviated})",
-            modifier = Modifier
-                .padding(start = 4.dp)
-                .clickable { onClick() },
-        )
 
         Spacer(modifier = Modifier.weight(1f))
 
@@ -126,11 +135,9 @@ private fun Content(
 private fun Stars(
     stars: List<Star>,
     color: Color,
-    onClick: () -> Unit,
 ) {
     Row(
         horizontalArrangement = Arrangement.Start,
-        modifier = Modifier.clickable { onClick() },
     ) {
         stars.forEach { star ->
             Icon(

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/components/ratings/StarRatingView.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/components/ratings/StarRatingView.kt
@@ -76,7 +76,7 @@ private fun Content(
 
     Row(
         modifier = Modifier.padding(
-            start = 16.dp,
+            start = 8.dp,
             end = 4.dp,
             top = if (FeatureFlag.isEnabled(Feature.GIVE_RATINGS)) 8.dp else 18.dp,
             bottom = if (FeatureFlag.isEnabled(Feature.GIVE_RATINGS)) 0.dp else 18.dp,
@@ -84,8 +84,10 @@ private fun Content(
         verticalAlignment = Alignment.CenterVertically,
     ) {
         Row(
+            verticalAlignment = Alignment.CenterVertically,
             modifier = Modifier
                 .clickable { onClick() }
+                .padding(8.dp)
                 .semantics {
                     this.contentDescription = starsContentDescription
                 },

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/components/ratings/StarRatingView.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/components/ratings/StarRatingView.kt
@@ -1,5 +1,6 @@
 package au.com.shiftyjelly.pocketcasts.podcasts.view.components.ratings
 
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -79,13 +80,15 @@ private fun Content(
         Stars(
             stars = state.stars,
             color = MaterialTheme.theme.colors.primaryUi05Selected,
+            onClick = onClick,
         )
 
         if (!state.noRatings) {
             TextP40(
                 text = state.roundedAverage,
                 modifier = Modifier
-                    .padding(start = 4.dp),
+                    .padding(start = 4.dp)
+                    .clickable { onClick() },
                 fontWeight = FontWeight.W700,
             )
         }
@@ -93,7 +96,8 @@ private fun Content(
         TextP40(
             text = if (state.noRatings) stringResource(R.string.no_ratings) else "(${state.total?.abbreviated})",
             modifier = Modifier
-                .padding(start = 4.dp),
+                .padding(start = 4.dp)
+                .clickable { onClick() },
         )
 
         Spacer(modifier = Modifier.weight(1f))
@@ -122,9 +126,11 @@ private fun Content(
 private fun Stars(
     stars: List<Star>,
     color: Color,
+    onClick: () -> Unit,
 ) {
     Row(
         horizontalArrangement = Arrangement.Start,
+        modifier = Modifier.clickable { onClick() },
     ) {
         stars.forEach { star ->
             Icon(

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -629,6 +629,7 @@ up    <string name="player_sleep_in_one_chapter">Sleeping in 1 chapter</string>
     <string name="whats_new_new_rating_title">Now Available: Podcast Ratings &#127881;</string>
     <string name="whats_new_new_rating_message">Rate your top podcasts and let creators know how much you appreciate their work. Plus, your ratings help others find new favorite shows!</string>
     <string name="star_rating_animation">Star Rating Animation</string>
+    <string name="podcast_star_rating_content_description">Podcast Star Rating</string>
 
     <!-- Episodes -->
 


### PR DESCRIPTION
## Description
- Adds the action tapping to stars to open the rate screen
- We are going to keep the Rate button
- See: p1723652426719639/1723638851.314939-slack-C05RR9P9RAT

Fixes #2638

## Testing Instructions
1. Open an podcast to rate
2. Tap on stars
3. ✅ Make sure the rate screen is open
4. Back to the previous screen
5. ✅ Tap on rating average
6. ✅ Make sure the rate screen is open

## Screenshots or Screencast 
[Screen_recording_20240814_134952.webm](https://github.com/user-attachments/assets/3fa0991c-112f-4ade-a8ad-b464d14aad9f)


## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [ ] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack