### PR TITLE
Tweak kids banner style

### DIFF
--- a/modules/features/kids/src/main/java/au/com/shiftyjelly/pocketcasts/kids/KidsBanner.kt
+++ b/modules/features/kids/src/main/java/au/com/shiftyjelly/pocketcasts/kids/KidsBanner.kt
@@ -11,19 +11,18 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.foundation.text.ClickableText
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
-import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
@@ -37,6 +36,7 @@ import au.com.shiftyjelly.pocketcasts.compose.components.TextH70
 import au.com.shiftyjelly.pocketcasts.compose.preview.ThemePreviewParameterProvider
 import au.com.shiftyjelly.pocketcasts.compose.theme
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
+import coil.compose.AsyncImagePainter.State.Empty.painter
 import au.com.shiftyjelly.pocketcasts.images.R as IR
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
@@ -59,10 +59,10 @@ fun KidsProfileCard(
             painter = painterResource(IR.drawable.ic_close),
             contentDescription = stringResource(LR.string.close),
             modifier = Modifier
-                .padding(11.dp)
+                .clickable { onDismiss() }
+                .padding(8.dp)
                 .size(22.dp)
-                .align(Alignment.TopEnd)
-                .clickable { onDismiss() },
+                .align(Alignment.TopEnd),
         )
 
         Row(
@@ -84,13 +84,17 @@ fun KidsProfileCard(
                         contentAlignment = Alignment.Center,
                         modifier = Modifier
                             .background(MaterialTheme.theme.colors.primaryInteractive01, shape = RoundedCornerShape(4.dp))
-                            .padding(horizontal = 6.dp, vertical = 2.dp),
+                            .padding(horizontal = 6.dp),
                     ) {
                         Text(
                             text = stringResource(LR.string.soon_label),
                             color = MaterialTheme.theme.colors.primaryInteractive02,
                             fontSize = 11.sp,
+                            lineHeight = 11.sp,
                             fontWeight = FontWeight.W600,
+                            modifier = Modifier
+                                .alpha(0.8f)
+                                .padding(vertical = 2.dp),
                         )
                     }
                 }
@@ -98,17 +102,20 @@ fun KidsProfileCard(
                     text = stringResource(LR.string.kids_profile_banner_description),
                     color = MaterialTheme.theme.colors.primaryText02,
                     modifier = Modifier
-                        .padding(start = 24.dp, end = 116.dp, bottom = 8.dp),
+                        .padding(start = 24.dp, end = 116.dp, bottom = 2.dp)
+                        .alpha(0.8f),
                     fontWeight = FontWeight.W600,
                 )
-
-                ClickableText(
-                    text = AnnotatedString(text = stringResource(LR.string.request_early_access)),
-                    onClick = { onRequestEarlyAccess() },
-                    modifier = Modifier.padding(start = 24.dp, bottom = 14.dp),
+                Text(
+                    text = stringResource(LR.string.request_early_access),
+                    modifier = Modifier
+                        .padding(start = 12.dp, end = 12.dp, bottom = 7.dp)
+                        .clip(RoundedCornerShape(4.dp))
+                        .clickable { onRequestEarlyAccess() }
+                        .padding(horizontal = 12.dp, vertical = 7.dp),
                     style = TextStyle(
                         color = MaterialTheme.theme.colors.primaryInteractive01,
-                        fontSize = 11.sp,
+                        fontSize = 13.sp,
                         fontWeight = FontWeight.W600,
                         textAlign = TextAlign.Start,
                     ),


### PR DESCRIPTION
## Description

The "Request Early Access" button text was looking a bit small. I have increased it after talking to the designer. While I was here I made some other tweaks so it was closer to the design.

## Testing Instructions
1. Tap the Profile tab

✅  Verify the design.

## Screenshots 

Design

<img width="393" alt="Kids profile 1" src="https://github.com/user-attachments/assets/a40857e3-acfa-4b23-9bed-514ff8291af1">


| Before | After |
| --- | --- |
| ![Screenshot_20240815_132143](https://github.com/user-attachments/assets/b4083bee-3d02-4497-8530-21df772a36cc) | ![Screenshot_20240815_145008](https://github.com/user-attachments/assets/e930bb82-e4f5-4ce6-bf24-578c995f916c) | 






## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [ ] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
