### PR TITLE
Use aac codec for mp4 audio

### DIFF
--- a/modules/features/sharing/src/debug/kotlin/au/com/shiftyjelly/pocketcasts/sharing/FFmpegMediaService.kt
+++ b/modules/features/sharing/src/debug/kotlin/au/com/shiftyjelly/pocketcasts/sharing/FFmpegMediaService.kt
@@ -50,7 +50,7 @@ internal class FFmpegMediaService(
                     append("-t ${clipRange.duration.toSecondsWithSingleMilli()} ") // Duration must be in S.xxx or HH:MM:SS.xxx format
                     append("-i $backgroundFile ") // Image stream source
                     append("-i $clipFile ") // Audio stream source
-                    append("-c:a aac ") // Use aac audio codec, it helps with Qucik Time which doesn't handle libmp3lame
+                    append("-c:a aac ") // Use aac audio codec, it helps with Quick Time which doesn't handle libmp3lame
                     append("-c:v mpeg4 ") // Use mpeg4 video codec
                     append("-q:v 1 ") // Use the highest video quality
                     append("-pix_fmt yuv420p ") // Use 4:2:0 pixel format

--- a/modules/features/sharing/src/debug/kotlin/au/com/shiftyjelly/pocketcasts/sharing/FFmpegMediaService.kt
+++ b/modules/features/sharing/src/debug/kotlin/au/com/shiftyjelly/pocketcasts/sharing/FFmpegMediaService.kt
@@ -50,7 +50,7 @@ internal class FFmpegMediaService(
                     append("-t ${clipRange.duration.toSecondsWithSingleMilli()} ") // Duration must be in S.xxx or HH:MM:SS.xxx format
                     append("-i $backgroundFile ") // Image stream source
                     append("-i $clipFile ") // Audio stream source
-                    append("-c:a copy ") // Copy audio codec
+                    append("-c:a aac ") // Use aac audio codec, it helps with Qucik Time which doesn't handle libmp3lame
                     append("-c:v mpeg4 ") // Use mpeg4 video codec
                     append("-q:v 1 ") // Use the highest video quality
                     append("-pix_fmt yuv420p ") // Use 4:2:0 pixel format

--- a/modules/features/sharing/src/debugProd/kotlin/au/com/shiftyjelly/pocketcasts/sharing/FFmpegMediaService.kt
+++ b/modules/features/sharing/src/debugProd/kotlin/au/com/shiftyjelly/pocketcasts/sharing/FFmpegMediaService.kt
@@ -50,7 +50,7 @@ internal class FFmpegMediaService(
                     append("-t ${clipRange.duration.toSecondsWithSingleMilli()} ") // Duration must be in S.xxx or HH:MM:SS.xxx format
                     append("-i $backgroundFile ") // Image stream source
                     append("-i $clipFile ") // Audio stream source
-                    append("-c:a aac ") // Use aac audio codec, it helps with Qucik Time which doesn't handle libmp3lame
+                    append("-c:a aac ") // Use aac audio codec, it helps with Quick Time which doesn't handle libmp3lame
                     append("-c:v mpeg4 ") // Use mpeg4 video codec
                     append("-q:v 1 ") // Use the highest video quality
                     append("-pix_fmt yuv420p ") // Use 4:2:0 pixel format

--- a/modules/features/sharing/src/debugProd/kotlin/au/com/shiftyjelly/pocketcasts/sharing/FFmpegMediaService.kt
+++ b/modules/features/sharing/src/debugProd/kotlin/au/com/shiftyjelly/pocketcasts/sharing/FFmpegMediaService.kt
@@ -50,7 +50,7 @@ internal class FFmpegMediaService(
                     append("-t ${clipRange.duration.toSecondsWithSingleMilli()} ") // Duration must be in S.xxx or HH:MM:SS.xxx format
                     append("-i $backgroundFile ") // Image stream source
                     append("-i $clipFile ") // Audio stream source
-                    append("-c:a copy ") // Copy audio codec
+                    append("-c:a aac ") // Use aac audio codec, it helps with Qucik Time which doesn't handle libmp3lame
                     append("-c:v mpeg4 ") // Use mpeg4 video codec
                     append("-q:v 1 ") // Use the highest video quality
                     append("-pix_fmt yuv420p ") // Use 4:2:0 pixel format


### PR DESCRIPTION
## Description

QuickTime being QuickTime has issues with the standard `libmp3lame` codec. Switching to `aac` to help it.

See: p1723683477741549-slack-C02LGFKP0AE 

## Testing Instructions

1. Share a video clip so you can download it on your desktop.
2. Play the clip in QuickTime.
3. It should work.

## Checklist
- [x] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] ~I have considered whether it makes sense to add tests for my changes~
- [x] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [x] ~Any jetpack compose components I added or changed are covered by compose previews~
- [x] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack