### PR TITLE
Transcripts - Scroll to highlighted search text

### DIFF
--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/transcripts/TranscriptPage.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/transcripts/TranscriptPage.kt
@@ -33,6 +33,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalClipboardManager
 import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalTextToolbar
 import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.res.stringResource
@@ -73,6 +74,7 @@ import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 private val ContentOffsetTop = 64.dp
 private val ContentOffsetBottom = 80.dp
+private val ScrollToHighlightedTextOffset = 100.dp
 private val SearchOccurrenceDefaultSpanStyle = SpanStyle(fontSize = 16.sp, background = Color.DarkGray, color = Color.White)
 private val SearchOccurrenceSelectedSpanStyle = SpanStyle(fontSize = 16.sp, background = Color.White, color = Color.Black)
 
@@ -241,6 +243,23 @@ private fun ScrollableTranscriptView(
                         searchState = searchState,
                     )
                 }
+            }
+        }
+    }
+
+    // Scroll to highlighted text
+    if (searchState.searchResultIndices.isNotEmpty()) {
+        val density = LocalDensity.current
+        LaunchedEffect(searchState.searchTerm, searchState.currentSearchIndex) {
+            val displayItems = state.displayInfo.items
+            val targetSearchResultIndexIndex = searchState.searchResultIndices[searchState.currentSearchIndex]
+            displayItems.find { item ->
+                targetSearchResultIndexIndex in item.startIndex until item.endIndex
+            }?.let { displayItemWithCurrentSearchText ->
+                scrollState.animateScrollToItem(
+                    displayItems.indexOf(displayItemWithCurrentSearchText),
+                    scrollOffset = -(density.run { ScrollToHighlightedTextOffset.roundToPx() }),
+                )
             }
         }
     }


### PR DESCRIPTION
## Description
This supports scrolling to highlighted search text **

** Currently, the view scrolls to the sentence with search text. It works well with reasonable font sizes and sentence lengths. I will get back to adding more precision after completing other important tasks for the project.


## Testing Instructions
1. Load transcript view for an episode
2. Search for a text with several occurrences
3. Tap on up, next arrows
4. ✅ Notice that the view scrolls to the sentence with the search item

## Screenshots or Screencast 

https://github.com/user-attachments/assets/d9e1d597-c4dd-4748-9abe-2f8af957d3d1



## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
