### PR TITLE
Fix crash when clicking on chapter name within Player

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
     *   Adds the kids banner in profile
         ([#2591](https://github.com/Automattic/pocket-casts-android/pull/2591))
 *   Bug Fixes
+    *   Fix crash when clicking on chapter name within Player
+        ([#2650](https://github.com/Automattic/pocket-casts-android/pull/2650)) 
     *   Update the episode star value in the Media Session to fix places where it's shown outside the app
         ([#2613](https://github.com/Automattic/pocket-casts-android/pull/2613))
 

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/chapters/ChaptersFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/chapters/ChaptersFragment.kt
@@ -82,7 +82,7 @@ class ChaptersFragment : BaseFragment() {
                     LaunchedEffect(Unit) {
                         viewModel.scrollToChapter.collect {
                             delay(250)
-                            lazyListState.animateScrollToItem(it.index - 1)
+                            lazyListState.animateScrollToItem(it.index)
                         }
                     }
 


### PR DESCRIPTION
## Description
<!-- Please include a summary of what this PR is changing and why these changes are needed. -->

Fixes # <!-- issue number, if applicable -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Tap on the Filters tab -->
<!-- 2. Tap on a filter -->
<!-- 3. etc. -->

## Screenshots or Screencast 
<!-- if applicable -->

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [ ] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
