### PR TITLE
Refresh the podcast rating after rating

### DIFF
--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/GiveRatingViewModel.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/GiveRatingViewModel.kt
@@ -155,6 +155,7 @@ class GiveRatingViewModel @Inject constructor(
 
         if (result is PodcastRatingResult.Success) {
             LogBuffer.i(TAG, "Submitted a rating of ${result.rating} for $podcastUuid")
+            ratingManager.refreshPodcastRatings(podcastUuid = podcastUuid, useCache = false)
             onSuccess()
         } else {
             LogBuffer.e(TAG, "Error when submitting rating for: $podcastUuid")

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/PodcastRatingsViewModel.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/PodcastRatingsViewModel.kt
@@ -62,7 +62,7 @@ class PodcastRatingsViewModel
     fun refreshPodcastRatings(uuid: String) {
         launch(Dispatchers.IO) {
             try {
-                ratingsManager.refreshPodcastRatings(uuid)
+                ratingsManager.refreshPodcastRatings(podcastUuid = uuid, useCache = true)
             } catch (e: Exception) {
                 val message = "Failed to refresh podcast ratings"
                 // don't report missing rating or network errors to Sentry

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/ratings/RatingsManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/ratings/RatingsManager.kt
@@ -5,7 +5,7 @@ import kotlinx.coroutines.flow.Flow
 
 interface RatingsManager {
     fun podcastRatings(podcastUuid: String): Flow<PodcastRatings>
-    suspend fun refreshPodcastRatings(podcastUuid: String)
+    suspend fun refreshPodcastRatings(podcastUuid: String, useCache: Boolean)
     suspend fun getPodcastRating(podcastUuid: String): PodcastRatingResult
     suspend fun submitPodcastRating(podcastUuid: String, rate: Int): PodcastRatingResult
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/ratings/RatingsManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/ratings/RatingsManagerImpl.kt
@@ -25,8 +25,9 @@ class RatingsManagerImpl @Inject constructor(
         podcastRatingsDao.podcastRatings(podcastUuid)
             .map { it.firstOrNull() ?: noRatings(podcastUuid) }
 
-    override suspend fun refreshPodcastRatings(podcastUuid: String) {
-        val ratings = cacheServerManager.getPodcastRatings(podcastUuid)
+    override suspend fun refreshPodcastRatings(podcastUuid: String, useCache: Boolean) {
+        // The server asks for the ratings to be cached for a period of time. After a user rates ignore the cache to get the new rating.
+        val ratings = cacheServerManager.getPodcastRatings(podcastUuid, useCache)
         podcastRatingsDao.insert(
             PodcastRatings(
                 podcastUuid = podcastUuid,

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/podcast/PodcastCacheServer.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/podcast/PodcastCacheServer.kt
@@ -97,4 +97,8 @@ interface PodcastCacheServer {
 
     @GET("/podcast/rating/{podcastUuid}")
     suspend fun getPodcastRatings(@Path("podcastUuid") podcastUuid: String): PodcastRatingsResponse
+
+    @GET("/podcast/rating/{podcastUuid}")
+    @Headers("Cache-Control: no-cache")
+    suspend fun getPodcastRatingsNoCache(@Path("podcastUuid") podcastUuid: String): PodcastRatingsResponse
 }

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/podcast/PodcastCacheServerManager.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/podcast/PodcastCacheServerManager.kt
@@ -14,7 +14,7 @@ interface PodcastCacheServerManager {
     fun searchEpisodes(podcastUuid: String, searchTerm: String): Single<List<String>>
     fun searchEpisodes(searchTerm: String): Single<EpisodeSearch>
     fun getPodcastResponse(podcastUuid: String): Single<Response<PodcastResponse>>
-    suspend fun getPodcastRatings(podcastUuid: String): PodcastRatings
+    suspend fun getPodcastRatings(podcastUuid: String, useCache: Boolean): PodcastRatings
     suspend fun getShowNotes(podcastUuid: String): ShowNotesResponse
     suspend fun getShowNotesCache(podcastUuid: String): ShowNotesResponse?
     suspend fun getEpisodeUrl(episode: PodcastEpisode): String?

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/podcast/PodcastCacheServerManagerImpl.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/podcast/PodcastCacheServerManagerImpl.kt
@@ -2,6 +2,7 @@ package au.com.shiftyjelly.pocketcasts.servers.podcast
 
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
+import au.com.shiftyjelly.pocketcasts.models.entity.PodcastRatings
 import au.com.shiftyjelly.pocketcasts.servers.discover.EpisodeSearch
 import io.reactivex.Single
 import javax.inject.Inject
@@ -41,8 +42,13 @@ class PodcastCacheServerManagerImpl @Inject constructor(
         }
     }
 
-    override suspend fun getPodcastRatings(podcastUuid: String) =
-        server.getPodcastRatings(podcastUuid).toPodcastRatings(podcastUuid)
+    override suspend fun getPodcastRatings(podcastUuid: String, useCache: Boolean): PodcastRatings {
+        return if (useCache) {
+            server.getPodcastRatings(podcastUuid).toPodcastRatings(podcastUuid)
+        } else {
+            server.getPodcastRatingsNoCache(podcastUuid).toPodcastRatings(podcastUuid)
+        }
+    }
 
     override suspend fun getShowNotes(podcastUuid: String): ShowNotesResponse {
         return server.getShowNotes(podcastUuid)


### PR DESCRIPTION
## Description

We would like to show the user's rating on the podcast page as soon as they rate. This is done by refreshing after the rating has been sent and ignoring the cache on refresh. 

## Testing Instructions
1. Search for a podcast that has no ratings
2. Open the podcast page
3. Wait for over 10 seconds (a server fix will remove this later)
4. Rate the podcast

✅  Verify the rating changes

https://github.com/user-attachments/assets/4d23ecfe-f607-482e-83bb-b1b743550296

