### PR TITLE
Improve video sharing cache

### DIFF
--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/sharing/SharingClientTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/sharing/SharingClientTest.kt
@@ -18,6 +18,8 @@ import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.sharing.clip.Clip
 import au.com.shiftyjelly.pocketcasts.sharing.social.SocialPlatform
+import au.com.shiftyjelly.pocketcasts.sharing.ui.CardType
+import au.com.shiftyjelly.pocketcasts.sharing.ui.VisualCardType
 import au.com.shiftyjelly.pocketcasts.utils.FileUtil
 import java.io.File
 import java.util.Date
@@ -580,6 +582,7 @@ class SharingClientTest {
                 podcast = Podcast(uuid = "podcast-uuid", title = "Podcast Title"),
                 episode = PodcastEpisode(uuid = "episode-uuid", title = "Episode Title", publishedDate = Date()),
                 range = Clip.Range(15.seconds, 28.seconds),
+                cardType = CardType.Square,
                 backgroundImage = File(context.cacheDir, "image.png"),
             ).setPlatform(platform)
                 .build()
@@ -606,6 +609,7 @@ class SharingClientTest {
             podcast = Podcast(uuid = "podcast-uuid", title = "Podcast Title"),
             episode = PodcastEpisode(uuid = "episode-uuid", title = "Episode Title", publishedDate = Date()),
             range = Clip.Range(15.seconds, 28.seconds),
+            cardType = CardType.Square,
             backgroundImage = File(context.cacheDir, "image.png"),
         ).setPlatform(SocialPlatform.Instagram)
             .build()
@@ -630,6 +634,7 @@ class SharingClientTest {
             podcast = Podcast(uuid = "podcast-uuid", title = "Podcast Title"),
             episode = PodcastEpisode(uuid = "episode-uuid", title = "Episode Title", publishedDate = Date()),
             range = Clip.Range(15.seconds, 28.seconds),
+            cardType = CardType.Square,
             backgroundImage = File(context.cacheDir, "image.png"),
         ).setPlatform(SocialPlatform.PocketCasts)
             .build()
@@ -654,6 +659,7 @@ class SharingClientTest {
             podcast = Podcast(uuid = "podcast-uuid", title = "Podcast Title"),
             episode = PodcastEpisode(uuid = "episode-uuid", title = "Episode Title", publishedDate = Date()),
             range = Clip.Range(15.seconds, 28.seconds),
+            cardType = CardType.Square,
             backgroundImage = File(context.cacheDir, "image.png"),
         ).build()
 
@@ -705,7 +711,7 @@ class SharingClientTest {
             requireNotNull(audioClip)
         }
 
-        override suspend fun clipVideo(podcast: Podcast, episode: PodcastEpisode, clipRange: Clip.Range, backgroundFile: File) = runCatching {
+        override suspend fun clipVideo(podcast: Podcast, episode: PodcastEpisode, clipRange: Clip.Range, cardType: VisualCardType, backgroundFile: File) = runCatching {
             requireNotNull(videoClip)
         }
     }

--- a/modules/features/sharing/src/debug/kotlin/au/com/shiftyjelly/pocketcasts/sharing/FFmpegMediaService.kt
+++ b/modules/features/sharing/src/debug/kotlin/au/com/shiftyjelly/pocketcasts/sharing/FFmpegMediaService.kt
@@ -4,6 +4,8 @@ import android.content.Context
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.sharing.clip.Clip
+import au.com.shiftyjelly.pocketcasts.sharing.ui.CardType
+import au.com.shiftyjelly.pocketcasts.sharing.ui.VisualCardType
 import au.com.shiftyjelly.pocketcasts.utils.toSecondsWithSingleMilli
 import com.arthenica.ffmpegkit.FFmpegKit
 import com.arthenica.ffmpegkit.FFmpegSession
@@ -36,8 +38,8 @@ internal class FFmpegMediaService(
             .onSuccess { sessionFiles.add(it) }
     }
 
-    override suspend fun clipVideo(podcast: Podcast, episode: PodcastEpisode, clipRange: Clip.Range, backgroundFile: File): Result<File> = withContext(Dispatchers.IO) {
-        val outputFile = File(context.cacheDir, "${sanitizedFileName(podcast, episode, clipRange)}.mp4")
+    override suspend fun clipVideo(podcast: Podcast, episode: PodcastEpisode, clipRange: Clip.Range, cardType: VisualCardType, backgroundFile: File): Result<File> = withContext(Dispatchers.IO) {
+        val outputFile = File(context.cacheDir, "${sanitizedFileName(podcast, episode, clipRange, cardType)}.mp4")
         if (outputFile in sessionFiles && outputFile.exists()) {
             return@withContext Result.success(outputFile)
         }
@@ -119,6 +121,16 @@ internal class FFmpegMediaService(
 
     private fun sanitizedFileName(podcast: Podcast, episode: PodcastEpisode, clipRange: Clip.Range): String {
         return "${podcast.title} - ${episode.title} - ${clipRange.start.toSecondsWithSingleMilli()}–${clipRange.end.toSecondsWithSingleMilli()}".replace("""\W+""".toRegex(), "_")
+    }
+
+    private fun sanitizedFileName(podcast: Podcast, episode: PodcastEpisode, clipRange: Clip.Range, cardType: VisualCardType): String {
+        return "${podcast.title} - ${episode.title} - ${clipRange.start.toSecondsWithSingleMilli()}–${clipRange.end.toSecondsWithSingleMilli()}-${cardType.id}".replace("""\W+""".toRegex(), "_")
+    }
+
+    private val VisualCardType.id get() = when (this) {
+        CardType.Horizontal -> "h"
+        CardType.Square -> "s"
+        CardType.Vertical -> "v"
     }
 
     private suspend fun executeAsyncCommand(command: String): Result<Unit> = suspendCancellableCoroutine { continuation ->

--- a/modules/features/sharing/src/debugProd/kotlin/au/com/shiftyjelly/pocketcasts/sharing/FFmpegMediaService.kt
+++ b/modules/features/sharing/src/debugProd/kotlin/au/com/shiftyjelly/pocketcasts/sharing/FFmpegMediaService.kt
@@ -4,6 +4,8 @@ import android.content.Context
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.sharing.clip.Clip
+import au.com.shiftyjelly.pocketcasts.sharing.ui.CardType
+import au.com.shiftyjelly.pocketcasts.sharing.ui.VisualCardType
 import au.com.shiftyjelly.pocketcasts.utils.toSecondsWithSingleMilli
 import com.arthenica.ffmpegkit.FFmpegKit
 import com.arthenica.ffmpegkit.FFmpegSession
@@ -36,8 +38,8 @@ internal class FFmpegMediaService(
             .onSuccess { sessionFiles.add(it) }
     }
 
-    override suspend fun clipVideo(podcast: Podcast, episode: PodcastEpisode, clipRange: Clip.Range, backgroundFile: File): Result<File> = withContext(Dispatchers.IO) {
-        val outputFile = File(context.cacheDir, "${sanitizedFileName(podcast, episode, clipRange)}.mp4")
+    override suspend fun clipVideo(podcast: Podcast, episode: PodcastEpisode, clipRange: Clip.Range, cardType: VisualCardType, backgroundFile: File): Result<File> = withContext(Dispatchers.IO) {
+        val outputFile = File(context.cacheDir, "${sanitizedFileName(podcast, episode, clipRange, cardType)}.mp4")
         if (outputFile in sessionFiles && outputFile.exists()) {
             return@withContext Result.success(outputFile)
         }
@@ -119,6 +121,16 @@ internal class FFmpegMediaService(
 
     private fun sanitizedFileName(podcast: Podcast, episode: PodcastEpisode, clipRange: Clip.Range): String {
         return "${podcast.title} - ${episode.title} - ${clipRange.start.toSecondsWithSingleMilli()}–${clipRange.end.toSecondsWithSingleMilli()}".replace("""\W+""".toRegex(), "_")
+    }
+
+    private fun sanitizedFileName(podcast: Podcast, episode: PodcastEpisode, clipRange: Clip.Range, cardType: VisualCardType): String {
+        return "${podcast.title} - ${episode.title} - ${clipRange.start.toSecondsWithSingleMilli()}–${clipRange.end.toSecondsWithSingleMilli()}-${cardType.id}".replace("""\W+""".toRegex(), "_")
+    }
+
+    private val VisualCardType.id get() = when (this) {
+        CardType.Horizontal -> "h"
+        CardType.Square -> "s"
+        CardType.Vertical -> "v"
     }
 
     private suspend fun executeAsyncCommand(command: String): Result<Unit> = suspendCancellableCoroutine { continuation ->

--- a/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/MediaService.kt
+++ b/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/MediaService.kt
@@ -3,6 +3,7 @@ package au.com.shiftyjelly.pocketcasts.sharing
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.sharing.clip.Clip
+import au.com.shiftyjelly.pocketcasts.sharing.ui.VisualCardType
 import java.io.File
 
 interface MediaService {
@@ -16,6 +17,7 @@ interface MediaService {
         podcast: Podcast,
         episode: PodcastEpisode,
         clipRange: Clip.Range,
+        cardType: VisualCardType,
         backgroundFile: File,
     ): Result<File>
 }

--- a/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/SharingClient.kt
+++ b/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/SharingClient.kt
@@ -31,6 +31,7 @@ import au.com.shiftyjelly.pocketcasts.sharing.social.SocialPlatform.WhatsApp
 import au.com.shiftyjelly.pocketcasts.sharing.social.SocialPlatform.X
 import au.com.shiftyjelly.pocketcasts.sharing.timestamp.TimestampType
 import au.com.shiftyjelly.pocketcasts.sharing.ui.CardType
+import au.com.shiftyjelly.pocketcasts.sharing.ui.VisualCardType
 import au.com.shiftyjelly.pocketcasts.utils.FileUtil
 import au.com.shiftyjelly.pocketcasts.utils.toSecondsWithSingleMilli
 import coil.executeBlocking
@@ -169,7 +170,8 @@ class SharingClient(
         is SharingRequest.Data.ClipVideo -> when (platform) {
             Instagram -> {
                 val backgroundImage = requireNotNull(backgroundImage) { "Sharing a video requires a background image" }
-                val file = mediaService.clipVideo(data.podcast, data.episode, data.range, backgroundImage).getOrThrow()
+                val cardType = requireNotNull(cardType as VisualCardType) { "Video must be shared with a visual card" }
+                val file = mediaService.clipVideo(data.podcast, data.episode, data.range, cardType, backgroundImage).getOrThrow()
                 Intent()
                     .setAction("com.instagram.share.ADD_TO_STORY")
                     .putExtra("source_application", metaAppId)
@@ -184,7 +186,8 @@ class SharingClient(
             }
             WhatsApp, Telegram, X, Tumblr, PocketCasts, More -> {
                 val backgroundImage = requireNotNull(backgroundImage) { "Sharing a video requires a background image" }
-                val file = mediaService.clipVideo(data.podcast, data.episode, data.range, backgroundImage).getOrThrow()
+                val cardType = requireNotNull(cardType as VisualCardType) { "Video must be shared with a visual card" }
+                val file = mediaService.clipVideo(data.podcast, data.episode, data.range, cardType, backgroundImage).getOrThrow()
                 Intent()
                     .setAction(Intent.ACTION_SEND)
                     .setType("video/mp4")
@@ -285,8 +288,11 @@ data class SharingRequest internal constructor(
             podcast: Podcast,
             episode: PodcastEpisode,
             range: Clip.Range,
+            cardType: VisualCardType,
             backgroundImage: File,
-        ) = Builder(Data.ClipVideo(podcast, episode, range)).setBackgroundImage(backgroundImage)
+        ) = Builder(Data.ClipVideo(podcast, episode, range))
+            .setCardType(cardType)
+            .setBackgroundImage(backgroundImage)
     }
 
     class Builder internal constructor(

--- a/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/clip/ShareClipPage.kt
+++ b/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/clip/ShareClipPage.kt
@@ -464,6 +464,8 @@ private fun PagingContent(
         ) {
             PagerDotIndicator(
                 state = pagerState,
+                activeDotColor = shareColors.onBackgroundPrimary,
+                inactiveDotColor = shareColors.onBackgroundSecondary,
             )
         }
     }

--- a/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/clip/ShareClipPage.kt
+++ b/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/clip/ShareClipPage.kt
@@ -384,7 +384,7 @@ private fun DescriptionContent(
                 ),
                 textAlign = TextAlign.Center,
                 maxLines = 1,
-                color = shareColors.backgroundPrimaryText,
+                color = shareColors.onBackgroundPrimary,
                 modifier = Modifier
                     .padding(horizontal = 24.dp)
                     .align(Alignment.CenterHorizontally),
@@ -400,7 +400,7 @@ private fun DescriptionContent(
                         text = stringResource(descriptionId),
                         textAlign = TextAlign.Center,
                         maxLines = 1,
-                        color = shareColors.backgroundSecondaryText,
+                        color = shareColors.onBackgroundSecondary,
                         modifier = Modifier.padding(horizontal = 24.dp),
                     )
                 }
@@ -408,15 +408,15 @@ private fun DescriptionContent(
                     text = stringResource(LR.string.share_clip_edit_label),
                     textAlign = TextAlign.Center,
                     maxLines = 1,
-                    color = shareColors.backgroundPrimaryText,
+                    color = shareColors.onContainerPrimary,
                     fontWeight = FontWeight.W400,
                     modifier = Modifier
                         .alpha(alpha)
-                        .background(shareColors.closeButton, CircleShape)
+                        .background(shareColors.container, CircleShape)
                         .defaultMinSize(minHeight = 24.dp)
                         .clickable(
                             interactionSource = remember(::MutableInteractionSource),
-                            indication = rememberRipple(color = shareColors.base),
+                            indication = rememberRipple(color = shareColors.accent),
                             onClickLabel = stringResource(LR.string.share_clip_edit_label),
                             role = Role.Button,
                             onClick = listener::onShowClipSelection,
@@ -504,7 +504,7 @@ private fun PagingContent(
                 Image(
                     painter = painterResource(IR.drawable.ic_audio_card),
                     contentDescription = null,
-                    colorFilter = ColorFilter.tint(shareColors.backgroundPrimaryText),
+                    colorFilter = ColorFilter.tint(shareColors.onBackgroundPrimary),
                 )
             }
         }
@@ -612,7 +612,7 @@ private fun ClipControls(
                     }
                 }
             },
-            colors = ButtonDefaults.buttonColors(backgroundColor = shareColors.clipButton),
+            colors = ButtonDefaults.buttonColors(backgroundColor = shareColors.accent),
             elevation = null,
             includePadding = false,
             modifier = Modifier.heightIn(min = 48.dp),
@@ -630,12 +630,12 @@ private fun ClipControls(
                         // Keep in the UI for to keep correct button size
                         text = if (isSharing) " " else buttonText,
                         textAlign = TextAlign.Center,
-                        color = shareColors.clipButtonText,
+                        color = shareColors.onAccent,
                         modifier = Modifier.padding(6.dp),
                     )
                     if (isSharing) {
                         CircularProgressIndicator(
-                            color = shareColors.clipButtonText,
+                            color = shareColors.onAccent,
                             strokeWidth = 2.dp,
                             modifier = Modifier.size(24.dp),
                         )
@@ -693,13 +693,13 @@ private fun SharingControls(
                 ) {
                     TextH40(
                         text = stringResource(LR.string.share_clip_sharing_clip),
-                        color = shareColors.backgroundPrimaryText,
+                        color = shareColors.onBackgroundPrimary,
                     )
                     Spacer(
                         modifier = Modifier.height(24.dp),
                     )
                     LinearProgressIndicator(
-                        color = shareColors.base,
+                        color = shareColors.accent,
                     )
                     Spacer(
                         modifier = Modifier.height(20.dp),

--- a/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/clip/ShareClipViewModel.kt
+++ b/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/clip/ShareClipViewModel.kt
@@ -265,9 +265,8 @@ class ShareClipViewModel @AssistedInject constructor(
         backgroundAsset: File,
         sourceView: SourceView,
     ): SharingRequest {
-        return SharingRequest.videoClip(podcast, episode, clipRange, backgroundAsset)
+        return SharingRequest.videoClip(podcast, episode, clipRange, cardType, backgroundAsset)
             .setPlatform(platform)
-            .setCardType(cardType)
             .setSourceView(sourceView)
             .build()
     }

--- a/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/social/PlatfromItem.kt
+++ b/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/social/PlatfromItem.kt
@@ -39,7 +39,7 @@ internal fun PlatformItem(
         horizontalAlignment = Alignment.CenterHorizontally,
         modifier = Modifier.clickable(
             interactionSource = remember(::MutableInteractionSource),
-            indication = rememberRipple(color = shareColors.base),
+            indication = rememberRipple(color = shareColors.accent),
             onClickLabel = stringResource(LR.string.share_via, stringResource(platform.nameId)),
             role = Role.Button,
             onClick = { onClick(platform) },
@@ -48,12 +48,12 @@ internal fun PlatformItem(
         Box(
             contentAlignment = Alignment.Center,
             modifier = Modifier
-                .background(shareColors.socialButton, CircleShape)
+                .background(shareColors.container, CircleShape)
                 .size(48.dp),
         ) {
             Image(
                 painter = painterResource(platform.logoId),
-                colorFilter = ColorFilter.tint(shareColors.socialButtonIcon),
+                colorFilter = ColorFilter.tint(shareColors.onContainerPrimary),
                 contentDescription = null,
                 modifier = Modifier.size(24.dp),
             )
@@ -64,7 +64,7 @@ internal fun PlatformItem(
         TextH70(
             text = stringResource(platform.nameId),
             textAlign = TextAlign.Center,
-            color = shareColors.backgroundPrimaryText.copy(alpha = 0.5f),
+            color = shareColors.onBackgroundSecondary,
             modifier = Modifier.sizeIn(maxWidth = 80.dp),
         )
     }

--- a/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/ui/ClipSelector.kt
+++ b/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/ui/ClipSelector.kt
@@ -153,18 +153,18 @@ private fun TouchClipSelector(
             modifier = Modifier
                 .fillMaxWidth()
                 .height(72.dp)
-                .background(shareColors.timeline, RoundedCornerShape(topStart = 8.dp, bottomStart = 8.dp)),
+                .background(shareColors.container, RoundedCornerShape(topStart = 8.dp, bottomStart = 8.dp)),
         ) {
             Image(
                 painter = painterResource(if (isPlaying) IR.drawable.ic_widget_pause else IR.drawable.ic_widget_play),
                 contentDescription = stringResource(if (isPlaying) LR.string.pause else LR.string.play),
-                colorFilter = ColorFilter.tint(shareColors.playPauseButton),
+                colorFilter = ColorFilter.tint(shareColors.onContainerPrimary),
                 modifier = Modifier
                     .size(72.dp)
                     .clip(RoundedCornerShape(topStart = 8.dp, bottomStart = 8.dp))
                     .clickable(
                         interactionSource = remember(::MutableInteractionSource),
-                        indication = rememberRipple(color = shareColors.base),
+                        indication = rememberRipple(color = shareColors.accent),
                         onClickLabel = stringResource(if (isPlaying) LR.string.pause else LR.string.play),
                         role = Role.Button,
                         onClick = if (isPlaying) listener::onClickPause else listener::onClickPlay,
@@ -189,14 +189,14 @@ private fun TouchClipSelector(
         Row {
             TextH70(
                 text = stringResource(LR.string.share_clip_start_position, clipRange.start.toHhMmSs()),
-                color = shareColors.backgroundSecondaryText,
+                color = shareColors.onBackgroundSecondary,
             )
             Spacer(
                 modifier = Modifier.weight(1f),
             )
             TextH70(
                 text = stringResource(LR.string.share_clip_duration, clipRange.duration.toHhMmSs()),
-                color = shareColors.backgroundSecondaryText,
+                color = shareColors.onBackgroundSecondary,
             )
         }
     }
@@ -301,7 +301,7 @@ private fun BoxWithConstraintsScope.ClipTimeline(
                 modifier = Modifier
                     .width(state.tickWidthDp)
                     .height(heightIndex)
-                    .background(shareColors.timelineTick),
+                    .background(shareColors.onBackgroundSecondary),
             )
         }
     }
@@ -361,7 +361,7 @@ private fun BoxWithConstraintsScope.ClipWindow(
                 modifier = Modifier
                     .width(2.dp)
                     .fillMaxHeight()
-                    .background(shareColors.timelineProgress),
+                    .background(shareColors.onBackgroundPrimary),
             )
         }
 
@@ -397,14 +397,14 @@ private fun BoxWithConstraintsScope.ClipWindow(
                     .width(handleWidth)
                     .fillMaxHeight()
                     .clip(RoundedCornerShape(topStart = handleWidth / 2, bottomStart = handleWidth / 2))
-                    .background(shareColors.selector),
+                    .background(shareColors.accent),
             ) {
                 Box(
                     modifier = Modifier
                         .width(2.dp)
                         .height(this@ClipWindow.maxHeight / 2)
                         .clip(RoundedCornerShape(1.dp))
-                        .background(shareColors.selectorHandle),
+                        .background(shareColors.onAccent.copy(alpha = 0.6f)),
                 )
             }
         }
@@ -440,14 +440,14 @@ private fun BoxWithConstraintsScope.ClipWindow(
                     .width(handleWidth)
                     .fillMaxHeight()
                     .clip(RoundedCornerShape(topEnd = handleWidth / 2, bottomEnd = handleWidth / 2))
-                    .background(shareColors.selector),
+                    .background(shareColors.accent),
             ) {
                 Box(
                     modifier = Modifier
                         .width(2.dp)
                         .height(this@ClipWindow.maxHeight / 2)
                         .clip(RoundedCornerShape(1.dp))
-                        .background(shareColors.selectorHandle),
+                        .background(shareColors.onAccent.copy(alpha = 0.6f)),
                 )
             }
         }
@@ -472,7 +472,7 @@ private fun BoxWithConstraintsScope.ClipWindow(
                     .offset { IntOffset(frameOffsetPx, 0) }
                     .requiredWidth(frameWidth)
                     .height(6.dp)
-                    .background(shareColors.selector),
+                    .background(shareColors.accent),
             )
             Spacer(
                 modifier = Modifier.weight(1f),
@@ -482,7 +482,7 @@ private fun BoxWithConstraintsScope.ClipWindow(
                     .offset { IntOffset(frameOffsetPx, 0) }
                     .requiredWidth(frameWidth)
                     .height(6.dp)
-                    .background(shareColors.selector),
+                    .background(shareColors.accent),
             )
         }
     }
@@ -504,20 +504,20 @@ private fun KeyboardClipSelector(
     ) {
         Box(
             modifier = Modifier
-                .background(shareColors.timeline, RoundedCornerShape(8.dp))
+                .background(shareColors.container, RoundedCornerShape(8.dp))
                 .width(72.dp)
                 .height(72.dp),
         ) {
             Image(
                 painter = painterResource(if (isPlaying) IR.drawable.ic_widget_pause else IR.drawable.ic_widget_play),
                 contentDescription = stringResource(if (isPlaying) LR.string.pause else LR.string.play),
-                colorFilter = ColorFilter.tint(shareColors.playPauseButton),
+                colorFilter = ColorFilter.tint(shareColors.onContainerPrimary),
                 modifier = Modifier
                     .fillMaxSize()
                     .clip(RoundedCornerShape(8.dp))
                     .clickable(
                         interactionSource = remember(::MutableInteractionSource),
-                        indication = rememberRipple(color = shareColors.base),
+                        indication = rememberRipple(color = shareColors.accent),
                         onClickLabel = stringResource(if (isPlaying) LR.string.pause else LR.string.play),
                         role = Role.Button,
                         onClick = if (isPlaying) listener::onClickPause else listener::onClickPlay,
@@ -528,14 +528,14 @@ private fun KeyboardClipSelector(
         Column(
             verticalArrangement = Arrangement.Center,
             modifier = Modifier
-                .background(shareColors.timeline, RoundedCornerShape(8.dp))
+                .background(shareColors.container, RoundedCornerShape(8.dp))
                 .weight(1f)
                 .heightIn(min = 72.dp)
                 .padding(12.dp),
         ) {
             TextH50(
                 text = stringResource(LR.string.share_start_position),
-                color = shareColors.backgroundSecondaryText,
+                color = shareColors.onContainerSecondary,
             )
             Spacer(
                 modifier = Modifier.height(2.dp),
@@ -553,14 +553,14 @@ private fun KeyboardClipSelector(
         Column(
             verticalArrangement = Arrangement.Center,
             modifier = Modifier
-                .background(shareColors.timeline, RoundedCornerShape(8.dp))
+                .background(shareColors.container, RoundedCornerShape(8.dp))
                 .weight(1f)
                 .heightIn(min = 72.dp)
                 .padding(12.dp),
         ) {
             TextH50(
                 text = stringResource(LR.string.share_end_position),
-                color = shareColors.backgroundSecondaryText,
+                color = shareColors.onContainerSecondary,
             )
             Spacer(
                 modifier = Modifier.height(2.dp),
@@ -674,11 +674,11 @@ private fun TimeTextField(
         },
         maxLines = 1,
         textStyle = TextStyle(
-            color = shareColors.backgroundPrimaryText,
+            color = shareColors.onContainerPrimary,
             fontSize = 18.sp,
             fontWeight = FontWeight.W500,
         ),
-        cursorBrush = SolidColor(shareColors.backgroundPrimaryText),
+        cursorBrush = SolidColor(shareColors.onContainerPrimary),
         keyboardOptions = KeyboardOptions(
             keyboardType = KeyboardType.Number,
             imeAction = ImeAction.Next,

--- a/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/ui/CloseButton.kt
+++ b/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/ui/CloseButton.kt
@@ -21,7 +21,7 @@ internal fun CloseButton(
 ) = Image(
     painter = painterResource(IR.drawable.ic_close_sheet),
     contentDescription = stringResource(LR.string.close),
-    colorFilter = ColorFilter.tint(shareColors.onContainerPrimary),
+    colorFilter = ColorFilter.tint(shareColors.onContainerSecondary),
     modifier = modifier
         .clickable(onClick = onClick)
         .clip(CircleShape)

--- a/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/ui/CloseButton.kt
+++ b/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/ui/CloseButton.kt
@@ -21,9 +21,9 @@ internal fun CloseButton(
 ) = Image(
     painter = painterResource(IR.drawable.ic_close_sheet),
     contentDescription = stringResource(LR.string.close),
-    colorFilter = ColorFilter.tint(shareColors.closeButtonIcon),
+    colorFilter = ColorFilter.tint(shareColors.onContainerPrimary),
     modifier = modifier
         .clickable(onClick = onClick)
         .clip(CircleShape)
-        .background(shareColors.closeButton),
+        .background(shareColors.container),
 )

--- a/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/ui/HorizontalCard.kt
+++ b/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/ui/HorizontalCard.kt
@@ -135,7 +135,7 @@ private fun HorizontalCard(
             TextH70(
                 text = data.topText(),
                 disableScale = true,
-                color = shareColors.cardText.copy(alpha = 0.5f),
+                color = shareColors.cardTextSecondary,
                 maxLines = 1,
             )
             Spacer(
@@ -144,7 +144,7 @@ private fun HorizontalCard(
             TextH40(
                 text = data.middleText(),
                 disableScale = true,
-                color = shareColors.cardText,
+                color = shareColors.cardTextPrimary,
                 maxLines = 3,
             )
             Spacer(
@@ -154,7 +154,7 @@ private fun HorizontalCard(
                 text = data.bottomText(),
                 disableScale = true,
                 maxLines = 2,
-                color = shareColors.cardText.copy(alpha = 0.5f),
+                color = shareColors.cardTextSecondary,
             )
         }
     }

--- a/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/ui/ShareColors.kt
+++ b/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/ui/ShareColors.kt
@@ -9,41 +9,24 @@ internal data class ShareColors(
 ) {
     val navigationBar = ColorUtils.changeHsvValue(base, factor = 0.15f)
     val background = ColorUtils.changeHsvValue(base, factor = 0.4f)
-    val backgroundPrimaryText = if (background.luminance() < 0.5f) Color.White else Color.Black
-    val backgroundSecondaryText = backgroundPrimaryText.copy(alpha = 0.5f)
+    val onBackgroundPrimary = if (background.isDark) Color.White else Color.Black
+    val onBackgroundSecondary = onBackgroundPrimary.copy(alpha = 0.5f)
 
-    val cardTop = ColorUtils.changeHsvValue(base, 1.25f)
-    val cardBottom = ColorUtils.changeHsvValue(base, 0.75f)
-    val cardText = if (base.luminance() < 0.5f) Color.White else Color.Black
+    val accent = if (background.isVeryDark) ColorUtils.changeHsvValue(base, 2f) else base
+    val onAccent = if (accent.isDark) Color.White else Color.Black
 
-    val pagerIndicatorActive = if (background.luminance() < 0.5f) Color.White else Color.Black
-    val pagerIndicatorInactive = pagerIndicatorActive.copy(alpha = 0.3f)
+    val container = (if (background.isDark) Color.White else Color.Black).copy(alpha = 0.15f)
+    val onContainerPrimary = if (background.isDark) Color.White else Color.Black
+    val onContainerSecondary = onContainerPrimary.copy(alpha = 0.5f)
 
-    val snackbar = if (background.luminance() < 0.5f) Color.White else Color.Black
-    val snackbarText = if (snackbar.luminance() < 0.5f) Color.White else Color.Black
+    val cardBottom = ColorUtils.changeHsvValue(base, 0.6f)
+    val cardTop = ColorUtils.changeHsvValue(base, 0.75f)
+    val cardTextPrimary = if (base.isDark) Color.White else Color.Black
+    val cardTextSecondary = cardTextPrimary.copy(alpha = 0.5f)
 
-    val clipButton = if (background.luminance() < 0.25) {
-        ColorUtils.changeHsvValue(base, 2f)
-    } else {
-        base
-    }
-    val clipButtonText = if (clipButton.luminance() < 0.5f) Color.White else Color.Black
-
-    val closeButton = backgroundPrimaryText.copy(alpha = 0.15f)
-    val closeButtonIcon = Color.White.copy(alpha = 0.5f)
-
-    val timeline = backgroundPrimaryText.copy(alpha = 0.15f)
-    val timelineProgress = backgroundPrimaryText
-    val timelineTick = timelineProgress.copy(alpha = 0.4f)
-    val playPauseButton = Color.White
-
-    val selector = if (background.luminance() < 0.25) {
-        ColorUtils.changeHsvValue(base, 2f)
-    } else {
-        base
-    }
-    val selectorHandle = background.copy(alpha = 0.4f)
-
-    val socialButton = backgroundPrimaryText.copy(alpha = 0.1f)
-    val socialButtonIcon = Color.White
+    val snackbar = if (background.isDark) Color.White else Color.Black
+    val snackbarText = if (snackbar.isDark) Color.White else Color.Black
 }
+
+private val Color.isDark get() = luminance() < 0.5f
+private val Color.isVeryDark get() = luminance() < 0.25f

--- a/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/ui/ShareColors.kt
+++ b/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/ui/ShareColors.kt
@@ -21,7 +21,10 @@ internal data class ShareColors(
 
     val cardBottom = ColorUtils.changeHsvValue(base, 0.6f)
     val cardTop = ColorUtils.changeHsvValue(base, 0.75f)
-    val cardTextPrimary = if (base.isDark) Color.White else Color.Black
+
+    // Text is on vertical card is about at 33% height of card
+    private val belowTextColor = ColorUtils.changeHsvValue(base, 0.65f)
+    val cardTextPrimary = if (belowTextColor.isDark) Color.White else Color.Black
     val cardTextSecondary = cardTextPrimary.copy(alpha = 0.5f)
 
     val snackbar = if (background.isDark) Color.White else Color.Black

--- a/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/ui/SharePage.kt
+++ b/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/ui/SharePage.kt
@@ -126,7 +126,7 @@ private fun TopContent(
         TextH30(
             text = shareTitle,
             textAlign = TextAlign.Center,
-            color = shareColors.backgroundPrimaryText,
+            color = shareColors.onBackgroundPrimary,
             modifier = Modifier.padding(horizontal = 24.dp),
         )
         Spacer(
@@ -135,7 +135,7 @@ private fun TopContent(
         TextH40(
             text = shareDescription,
             textAlign = TextAlign.Center,
-            color = shareColors.backgroundSecondaryText,
+            color = shareColors.onBackgroundSecondary,
             modifier = Modifier.sizeIn(maxWidth = 220.dp),
         )
     }
@@ -226,7 +226,7 @@ internal fun HorizontalSharePage(
                 TextH30(
                     text = shareTitle,
                     textAlign = TextAlign.Center,
-                    color = shareColors.backgroundPrimaryText,
+                    color = shareColors.onBackgroundPrimary,
                     modifier = Modifier.padding(horizontal = 24.dp),
                 )
                 Spacer(
@@ -235,7 +235,7 @@ internal fun HorizontalSharePage(
                 TextH40(
                     text = shareDescription,
                     textAlign = TextAlign.Center,
-                    color = shareColors.backgroundSecondaryText,
+                    color = shareColors.onBackgroundSecondary,
                     modifier = Modifier.padding(horizontal = 24.dp),
                 )
             }

--- a/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/ui/SharePage.kt
+++ b/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/ui/SharePage.kt
@@ -80,6 +80,7 @@ internal fun VerticalSharePage(
                     modifier = Modifier.onGloballyPositioned { coordinates -> topContentHeight = coordinates.size.height },
                 )
                 MiddleContent(
+                    shareColors = shareColors,
                     middleContent = middleContent,
                     pagerState = pagerState,
                     scrollState = scrollState,
@@ -144,6 +145,7 @@ private fun TopContent(
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
 private fun MiddleContent(
+    shareColors: ShareColors,
     scrollState: ScrollState,
     pagerState: PagerState,
     topContentHeight: Int,
@@ -159,6 +161,8 @@ private fun MiddleContent(
     ) {
         PagerDotIndicator(
             state = pagerState,
+            activeDotColor = shareColors.onBackgroundPrimary,
+            inactiveDotColor = shareColors.onBackgroundSecondary,
         )
     }
 

--- a/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/ui/SquareCard.kt
+++ b/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/ui/SquareCard.kt
@@ -113,7 +113,7 @@ private fun SquareCard(
             text = data.topText(),
             disableScale = true,
             maxLines = 1,
-            color = shareColors.cardText.copy(alpha = 0.5f),
+            color = shareColors.cardTextSecondary,
             modifier = Modifier.padding(horizontal = 64.dp),
         )
         Spacer(
@@ -124,7 +124,7 @@ private fun SquareCard(
             disableScale = true,
             maxLines = 2,
             textAlign = TextAlign.Center,
-            color = shareColors.cardText,
+            color = shareColors.cardTextPrimary,
             modifier = Modifier.padding(horizontal = 42.dp),
         )
         Spacer(
@@ -135,7 +135,7 @@ private fun SquareCard(
             disableScale = true,
             maxLines = 2,
             textAlign = TextAlign.Center,
-            color = shareColors.cardText.copy(alpha = 0.5f),
+            color = shareColors.cardTextSecondary,
             modifier = Modifier.padding(horizontal = 64.dp),
         )
     }

--- a/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/ui/VerticalCard.kt
+++ b/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/ui/VerticalCard.kt
@@ -125,7 +125,7 @@ private fun VerticalCard(
             text = data.topText(),
             disableScale = true,
             maxLines = 1,
-            color = shareColors.cardText.copy(alpha = 0.5f),
+            color = shareColors.cardTextSecondary,
             modifier = Modifier.padding(horizontal = width * 0.1f),
         )
         Spacer(
@@ -136,7 +136,7 @@ private fun VerticalCard(
             disableScale = true,
             maxLines = 2,
             textAlign = TextAlign.Center,
-            color = shareColors.cardText,
+            color = shareColors.cardTextPrimary,
             modifier = Modifier.padding(horizontal = width * 0.1f),
         )
         Spacer(
@@ -147,7 +147,7 @@ private fun VerticalCard(
             disableScale = true,
             maxLines = 2,
             textAlign = TextAlign.Center,
-            color = shareColors.cardText.copy(alpha = 0.5f),
+            color = shareColors.cardTextSecondary,
             modifier = Modifier.padding(horizontal = width * 0.1f),
         )
         Spacer(

--- a/modules/features/sharing/src/release/kotlin/au/com/shiftyjelly/pocketcasts/sharing/FFmpegMediaService.kt
+++ b/modules/features/sharing/src/release/kotlin/au/com/shiftyjelly/pocketcasts/sharing/FFmpegMediaService.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.sharing.clip.Clip
+import au.com.shiftyjelly.pocketcasts.sharing.ui.VisualCardType
 import java.io.File
 
 internal class FFmpegMediaService(
@@ -13,7 +14,7 @@ internal class FFmpegMediaService(
         throw AssertionError("Not supported in release")
     }
 
-    override suspend fun clipVideo(podcast: Podcast, episode: PodcastEpisode, clipRange: Clip.Range, backgroundFile: File): Result<File> {
+    override suspend fun clipVideo(podcast: Podcast, episode: PodcastEpisode, clipRange: Clip.Range, cardType: VisualCardType, backgroundFile: File): Result<File> {
         throw AssertionError("Not supported in release")
     }
 }

--- a/modules/features/sharing/src/test/kotlin/au/com/shiftyjelly/pocketcasts/sharing/SharingAnalyticsTest.kt
+++ b/modules/features/sharing/src/test/kotlin/au/com/shiftyjelly/pocketcasts/sharing/SharingAnalyticsTest.kt
@@ -185,9 +185,8 @@ class SharingAnalyticsTest {
 
     @Test
     fun `log clip video sharing`() {
-        val request = SharingRequest.videoClip(podcast, episode, clipRange, tempFolder.newFile())
+        val request = SharingRequest.videoClip(podcast, episode, clipRange, CardType.Vertical, tempFolder.newFile())
             .setPlatform(SocialPlatform.PocketCasts)
-            .setCardType(CardType.Vertical)
             .setSourceView(SourceView.PLAYER)
             .build()
 
@@ -291,7 +290,7 @@ class SharingAnalyticsTest {
 
     @Test
     fun `log clip video type property`() {
-        val request = SharingRequest.videoClip(podcast, episode, clipRange, tempFolder.newFile()).build()
+        val request = SharingRequest.videoClip(podcast, episode, clipRange, CardType.Vertical, tempFolder.newFile()).build()
 
         analytics.onShare(request)
         val event = tracker.events.single()


### PR DESCRIPTION
## Description

This is an improvement to caching for clip sharing. Previously cache didn't take into account the shared card. This could result in wrong video background being shared because we used cached one.

## Testing Instructions

1. Share a clip as a a video.
2. Without closing the sharing screen edit the clip and select a different card.
3. Share again as a video.
4. You should see a card selected in the 2nd step as a video background.

## Checklist
- [x] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] ~I have considered whether it makes sense to add tests for my changes~
- [x] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [x] ~Any jetpack compose components I added or changed are covered by compose previews~
- [x] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
