### PR TITLE
Fix crash when clicking on chapter title within player

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 *   Bug Fixes
     *   Update the episode star value in the Media Session to fix places where it's shown outside the app
         ([#2613](https://github.com/Automattic/pocket-casts-android/pull/2613))
+    *   Fix crash when clicking on chapter title within player
+        ([#2657](https://github.com/Automattic/pocket-casts-android/pull/2657))
 
 7.70
 -----

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/chapters/ChaptersFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/chapters/ChaptersFragment.kt
@@ -82,7 +82,7 @@ class ChaptersFragment : BaseFragment() {
                     LaunchedEffect(Unit) {
                         viewModel.scrollToChapter.collect {
                             delay(250)
-                            lazyListState.animateScrollToItem(it.index - 1)
+                            lazyListState.animateScrollToItem(it.index)
                         }
                     }
 


### PR DESCRIPTION
## Description

The application crashes, when clicking the chapter title. The code assumes the capters index starts from 1 but instead it now starts at 0.

Fixes https://github.com/Automattic/pocket-casts-android/issues/2647

<details><summary>Exception</summary>
<p>

```
Process: au.com.shiftyjelly.pocketcasts.debug, PID: 9543
java.lang.IllegalArgumentException: Index should be non-negative (-1)
	at androidx.compose.foundation.lazy.layout.LazyAnimateScrollKt$animateScrollToItem$2.invokeSuspend(LazyAnimateScroll.kt:120)
	at androidx.compose.foundation.lazy.layout.LazyAnimateScrollKt$animateScrollToItem$2.invoke(Unknown Source:8)
	at androidx.compose.foundation.lazy.layout.LazyAnimateScrollKt$animateScrollToItem$2.invoke(Unknown Source:4)
	at androidx.compose.foundation.gestures.DefaultScrollableState$scroll$2$1.invokeSuspend(ScrollableState.kt:181)
	at androidx.compose.foundation.gestures.DefaultScrollableState$scroll$2$1.invoke(Unknown Source:8)
	at androidx.compose.foundation.gestures.DefaultScrollableState$scroll$2$1.invoke(Unknown Source:4)
	at androidx.compose.foundation.MutatorMutex$mutateWith$2.invokeSuspend(MutatorMutex.kt:173)
	at androidx.compose.foundation.MutatorMutex$mutateWith$2.invoke(Unknown Source:8)
	at androidx.compose.foundation.MutatorMutex$mutateWith$2.invoke(Unknown Source:4)
	at kotlinx.coroutines.intrinsics.UndispatchedKt.startUndispatchedOrReturn(Undispatched.kt:61)
	at kotlinx.coroutines.CoroutineScopeKt.coroutineScope(CoroutineScope.kt:261)
	at androidx.compose.foundation.MutatorMutex.mutateWith(MutatorMutex.kt:166)
	at androidx.compose.foundation.gestures.DefaultScrollableState$scroll$2.invokeSuspend(ScrollableState.kt:178)
	at androidx.compose.foundation.gestures.DefaultScrollableState$scroll$2.invoke(Unknown Source:8)
	at androidx.compose.foundation.gestures.DefaultScrollableState$scroll$2.invoke(Unknown Source:4)
	at kotlinx.coroutines.intrinsics.UndispatchedKt.startUndispatchedOrReturn(Undispatched.kt:61)
	at kotlinx.coroutines.CoroutineScopeKt.coroutineScope(CoroutineScope.kt:261)
	at androidx.compose.foundation.gestures.DefaultScrollableState.scroll(ScrollableState.kt:177)
	at androidx.compose.foundation.lazy.LazyListState.scroll(LazyListState.kt:295)
	at androidx.compose.foundation.gestures.ScrollableState.scroll$default(ScrollableState.kt:53)
	at androidx.compose.foundation.lazy.LazyListAnimateScrollScope.scroll(LazyListAnimateScrollScope.kt:60)
	at androidx.compose.foundation.lazy.layout.LazyAnimateScrollKt.animateScrollToItem(LazyAnimateScroll.kt:119)
	at androidx.compose.foundation.lazy.LazyListState.animateScrollToItem(LazyListState.kt:433)
	at androidx.compose.foundation.lazy.LazyListState.animateScrollToItem$default(LazyListState.kt:428)
	at au.com.shiftyjelly.pocketcasts.player.view.chapters.ChaptersFragment$onCreateView$1$1$1$1$5$1.emit(ChaptersFragment.kt:86)
	at au.com.shiftyjelly.pocketcasts.player.view.chapters.ChaptersFragment$onCreateView$1$1$1$1$5$1$emit$1.invokeSuspend(Unknown Source:15)
```

</p>
</details> 

## Testing Instructions

1. Play an episode for a podcast that has chapters, such as https://pca.st/einschlafen
2. Open the full screen player
3. When in the first chapter click the chapter title
4. Return to the player view
5. Click the chapter title again

✅ Verify the app doesn't crash

## Screenshots 

https://github.com/user-attachments/assets/5b41934c-247b-4a2d-9aa0-3d77d31d4daa
