### PR TITLE
[Tooling] Apply required CI checks too when setting branch protection settings on release branch

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -125,7 +125,7 @@ platform :android do
       release_notes_file_path: RELEASE_NOTES_SOURCE_PATH
     )
     push_to_git_remote(tags: false)
-    set_branch_protection(repository: GH_REPOSITORY, branch: "release/#{new_version}")
+    copy_branch_protection(repository: GH_REPOSITORY, from_branch: DEFAULT_BRANCH, to_branch: "release/#{new_version}")
     set_milestone_frozen_marker(repository: GH_REPOSITORY, milestone: new_version)
   end
 


### PR DESCRIPTION
Context: p1723805743869889-slack-CC7L49W13

## Description

During code freeze, after creating the `release/N` branch, we set GitHub Branch Protection settings on it to require Pull Requests with at least one reviewer etc.

But until now, we were using our `set_branch_protection` action (from our `release-toolkit` fastlane plugin), which is nowadays legacy because this action were only setting a minimal set of branch protection settings on the branch. In particular, it didn't set any "required checks" from CI to pass before allowing a PR to be merged.

This PR changes this to use the more recent `copy_branch_protection` action from our `release-toolkit`, which copies the same branch protection settings from `trunk` on the `release/N` branch instead, thus also copying the "required CI checks" from the trunk branch protection settings too.


## Testing Instructions

This could be tested after doing the next code freeze, checking that after the code freeze has happened and has created the next `release/N` branch, its branch protection settings on GitHub include the expected list of requested CI checks too before a PR to `release/N` can be merged.
