### PR TITLE
Handle more podcast share links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
         ([#2649](https://github.com/Automattic/pocket-casts-android/pull/2649))
     *   Fix crash when clicking on chapter title within player
         ([#2657](https://github.com/Automattic/pocket-casts-android/pull/2657))
+    *   Handle more podcast share links
+        ([#2666](https://github.com/Automattic/pocket-casts-android/pull/2666))
 
 7.70
 -----

--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/deeplink/DeepLinkFactoryTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/deeplink/DeepLinkFactoryTest.kt
@@ -707,14 +707,14 @@ class DeepLinkFactoryTest {
     }
 
     @Test
-    fun shareUnknownItem() {
+    fun shareItunesId() {
         val intent = Intent()
             .setAction(ACTION_VIEW)
-            .setData(Uri.parse("https://pca.st/unidentified-sharing-object/object-id"))
+            .setData(Uri.parse("https://pca.st/itunes/1671087656"))
 
         val deepLink = factory.create(intent)
 
-        assertNull(deepLink)
+        assertEquals(ShowPodcastFromUrlDeepLink("https://pca.st/itunes/1671087656"), deepLink)
     }
 
     @Test

--- a/modules/services/deeplink/src/main/kotlin/au/com/shiftyjelly/pocketcasts/deeplink/DeepLinkFactory.kt
+++ b/modules/services/deeplink/src/main/kotlin/au/com/shiftyjelly/pocketcasts/deeplink/DeepLinkFactory.kt
@@ -375,7 +375,6 @@ private class ShareLinkAdapter(
                     startTimestamp = timestamps?.first,
                     endTimestamp = timestamps?.second,
                 )
-                uriData.pathSegments[0] == "podcast" -> ShowPodcastFromUrlDeepLink(uriData.toString())
                 uriData.pathSegments[0] == "episode" -> ShowEpisodeDeepLink(
                     episodeUuid = uriData.pathSegments[1],
                     podcastUuid = null,
@@ -383,7 +382,8 @@ private class ShareLinkAdapter(
                     endTimestamp = timestamps?.second,
                     sourceView = null,
                 )
-                else -> null
+                // handle the different podcast share links such as /podcast/uuid, /itunes/itunes_id, /feed/feed_url
+                else -> ShowPodcastFromUrlDeepLink(uriData.toString())
             }
         } else {
             null


### PR DESCRIPTION
## Description

This change fixes the issue that when a podcast share link using an iTunes ID it fails to open the podcast. An example of a share link is [https://pca.st/itunes/1671087656](https://pca.st/itunes/1671087656). Tapping the URL should open the Pocket Casts app instead of the share web page. The issue is that we don't handle /itunes or other paths such as /feed. It seems safer to pass the URL on to search instead of handling each case in the code. 

## Testing Instructions
1. Install the debugProd variant
2. Tap on this link [https://pca.st/itunes/1671087656](https://pca.st/itunes/1671087656)

✅ Verify the app is opened and the podcast page for 'This Day in AI Podcast' is shown.

3. Close the podcast page
4. Tap on this link [https://pca.st/feed/feeds.transistor.fm/this-day-in-ai](https://pca.st/feed/feeds.transistor.fm/this-day-in-ai)

✅ Verify the podcast page for 'This Day in AI Podcast' is shown again.

## Video

https://github.com/user-attachments/assets/4afc9739-5a0e-44f7-bd89-418888790ba4

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes