### PR TITLE
[Give ratings] Catch all exceptions when refreshing ratings

### DIFF
--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/PodcastRatingsViewModel.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/PodcastRatingsViewModel.kt
@@ -27,7 +27,6 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
-import retrofit2.HttpException
 import timber.log.Timber
 
 private const val MAX_STARS = 5
@@ -61,17 +60,7 @@ class PodcastRatingsViewModel
 
     fun refreshPodcastRatings(uuid: String) {
         launch(Dispatchers.IO) {
-            try {
-                ratingsManager.refreshPodcastRatings(podcastUuid = uuid, useCache = true)
-            } catch (e: Exception) {
-                val message = "Failed to refresh podcast ratings"
-                // don't report missing rating or network errors to Sentry
-                if (e is HttpException || e is IOException) {
-                    Timber.i(e, message)
-                } else {
-                    Timber.e(e, message)
-                }
-            }
+            ratingsManager.refreshPodcastRatings(podcastUuid = uuid, useCache = true)
         }
     }
 

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/ratings/RatingsManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/ratings/RatingsManagerImpl.kt
@@ -4,6 +4,7 @@ import au.com.shiftyjelly.pocketcasts.models.db.AppDatabase
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastRatings
 import au.com.shiftyjelly.pocketcasts.repositories.sync.SyncManager
 import au.com.shiftyjelly.pocketcasts.servers.podcast.PodcastCacheServerManager
+import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
 import java.io.IOException
 import javax.inject.Inject
 import kotlin.coroutines.CoroutineContext
@@ -44,7 +45,7 @@ class RatingsManagerImpl @Inject constructor(
             if (e is HttpException || e is IOException) {
                 Timber.i(e, message)
             } else {
-                Timber.e(e, message)
+                LogBuffer.e(LogBuffer.TAG_CRASH, e, message)
             }
         }
     }


### PR DESCRIPTION
## Description
- This is an attempt to fix this issue here p1724091189386829/1724091158.301499-slack-C028JAG44VD
- I believe the root cause was that we were not catching Http Exceptions when refreshing ratings after submit a new rate, so I am catching all exceptions for `RatingsManager.refreshPodcastRatings` to avoid this issue

## Testing Instructions
- Smoke test give ratings feature
- Try to rate an podcast
- Update your rate


## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack