### PR TITLE
[Paywall Experiment] Updates the Paywall experiment screen

### DIFF
--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeFeaturesPage.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeFeaturesPage.kt
@@ -89,7 +89,7 @@ internal fun OnboardingUpgradeFeaturesPage(
     flow: OnboardingFlow,
     source: OnboardingUpgradeSource,
     onBackPressed: () -> Unit,
-    onClickSubscribe: () -> Unit,
+    onClickSubscribe: (showUpgradeBottomSheet: Boolean) -> Unit,
     onNotNowPressed: () -> Unit,
     canUpgrade: Boolean,
     onUpdateSystemBars: (SystemBarsStyles) -> Unit,
@@ -127,7 +127,7 @@ internal fun OnboardingUpgradeFeaturesPage(
                         source = source,
                         onNotNowPressed = onNotNowPressed,
                         onFeatureCardChanged = { viewModel.onFeatureCardChanged(loadedState.featureCardsState.featureCards[it]) },
-                        onClickSubscribe = onClickSubscribe,
+                        onClickSubscribe = { onClickSubscribe(true) },
                         scrollState = scrollState,
                         canUpgrade = canUpgrade,
                     )
@@ -141,7 +141,7 @@ internal fun OnboardingUpgradeFeaturesPage(
                         onNotNowPressed = onNotNowPressed,
                         onSubscriptionFrequencyChanged = { viewModel.onSubscriptionFrequencyChanged(it) },
                         onFeatureCardChanged = { viewModel.onFeatureCardChanged(loadedState.featureCardsState.featureCards[it]) },
-                        onClickSubscribe = onClickSubscribe,
+                        onClickSubscribe = { onClickSubscribe(false) },
                         canUpgrade = canUpgrade,
                     )
                 }

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeFlow.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeFlow.kt
@@ -120,15 +120,21 @@ fun OnboardingUpgradeFlow(
                     flow = flow,
                     source = source,
                     onBackPressed = onBackPressed,
-                    onClickSubscribe = {
+                    onClickSubscribe = { showUpgradeBottomSheet ->
                         if (activity != null) {
                             if (isLoggedIn) {
-                                mainSheetViewModel.onClickSubscribe(
-                                    activity = activity,
-                                    flow = flow,
-                                    source = source,
-                                    onComplete = onProceed,
-                                )
+                                if (showUpgradeBottomSheet) {
+                                    coroutineScope.launch {
+                                        sheetState.show()
+                                    }
+                                } else {
+                                    mainSheetViewModel.onClickSubscribe(
+                                        activity = activity,
+                                        flow = flow,
+                                        source = source,
+                                        onComplete = onProceed,
+                                    )
+                                }
                             } else {
                                 onNeedLogin()
                             }

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/UpgradeLayoutFeatures.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/UpgradeLayoutFeatures.kt
@@ -158,7 +158,7 @@ internal fun UpgradeLayoutFeatures(
                     verticalArrangement = Arrangement.Center,
                     horizontalAlignment = Alignment.CenterHorizontally,
                 ) {
-                    val bottomPadding = if (shouldShowOffer) 0.dp else 50.dp
+                    val bottomPadding = if (shouldShowOffer) 0.dp else 34.dp
 
                     SubscribeButton(onClickSubscribe, Modifier.padding(bottom = bottomPadding))
 

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/UpgradeLayoutFeatures.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/UpgradeLayoutFeatures.kt
@@ -8,9 +8,11 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.padding
@@ -166,8 +168,8 @@ internal fun UpgradeLayoutFeatures(
                             TextP50(
                                 text = it,
                                 fontWeight = FontWeight.W400,
-                                modifier = Modifier.padding(bottom = 50.dp),
                             )
+                            Spacer(Modifier.height(50.dp))
                         }
                     }
                 }

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/UpgradeLayoutFeatures.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/UpgradeLayoutFeatures.kt
@@ -31,7 +31,6 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import au.com.shiftyjelly.pocketcasts.account.viewmodel.OnboardingUpgradeFeaturesState
@@ -161,7 +160,7 @@ internal fun UpgradeLayoutFeatures(
                 ) {
                     val bottomPadding = if (shouldShowOffer) 0.dp else 50.dp
 
-                    SubscribeButton(onClickSubscribe, bottomPadding)
+                    SubscribeButton(onClickSubscribe, Modifier.padding(bottom = bottomPadding))
 
                     if (shouldShowOffer) {
                         offerText?.let {
@@ -181,13 +180,14 @@ internal fun UpgradeLayoutFeatures(
 @Composable
 private fun SubscribeButton(
     onClickSubscribe: () -> Unit,
-    bottomPadding: Dp,
+    modifier: Modifier = Modifier,
 ) {
     Box(
         contentAlignment = Alignment.BottomCenter,
+        modifier = modifier,
     ) {
         RowButton(
-            modifier = Modifier.padding(bottom = bottomPadding).padding(horizontal = 16.dp),
+            modifier = Modifier.padding(horizontal = 16.dp),
             text = stringResource(LR.string.get_pocket_casts_plus),
             onClick = onClickSubscribe,
             fontWeight = FontWeight.W600,
@@ -203,5 +203,5 @@ private fun SubscribeButton(
 @Preview(showBackground = true)
 @Composable
 fun SubscribeButtonPreview() {
-    SubscribeButton(onClickSubscribe = { }, bottomPadding = 50.dp)
+    SubscribeButton(onClickSubscribe = { }, Modifier)
 }

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/UpgradeLayoutFeatures.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/UpgradeLayoutFeatures.kt
@@ -1,5 +1,6 @@
 package au.com.shiftyjelly.pocketcasts.account.onboarding.upgrade
 
+import android.content.res.Configuration
 import androidx.compose.foundation.ScrollState
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
@@ -22,11 +23,13 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import au.com.shiftyjelly.pocketcasts.account.viewmodel.OnboardingUpgradeFeaturesState
@@ -34,9 +37,11 @@ import au.com.shiftyjelly.pocketcasts.compose.AppTheme
 import au.com.shiftyjelly.pocketcasts.compose.buttons.RowButton
 import au.com.shiftyjelly.pocketcasts.compose.buttons.RowTextButton
 import au.com.shiftyjelly.pocketcasts.compose.components.AutoResizeText
+import au.com.shiftyjelly.pocketcasts.compose.components.TextP50
 import au.com.shiftyjelly.pocketcasts.compose.images.SubscriptionBadgeDisplayMode
 import au.com.shiftyjelly.pocketcasts.compose.images.SubscriptionBadgeForTier
 import au.com.shiftyjelly.pocketcasts.compose.theme
+import au.com.shiftyjelly.pocketcasts.models.type.Subscription
 import au.com.shiftyjelly.pocketcasts.models.type.Subscription.SubscriptionTier
 import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingUpgradeSource
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
@@ -54,6 +59,17 @@ internal fun UpgradeLayoutFeatures(
     canUpgrade: Boolean,
     modifier: Modifier = Modifier,
 ) {
+    val configuration = LocalConfiguration.current
+    val isLandscape = configuration.orientation == Configuration.ORIENTATION_LANDSCAPE
+
+    val offerText = when (state.currentSubscription) {
+        is Subscription.Trial -> stringResource(LR.string.paywall_free_1_month_trial)
+        is Subscription.Intro -> stringResource(LR.string.paywall_save_50_off)
+        else -> null
+    }
+
+    val shouldShowOffer = offerText != null && !isLandscape
+
     AppTheme(Theme.ThemeType.DARK) { // We need to set Dark since this screen will have dark colors for all themes
         Box(
             modifier = modifier.fillMaxHeight(),
@@ -136,7 +152,25 @@ internal fun UpgradeLayoutFeatures(
             }
 
             if (canUpgrade) {
-                SubscribeButton(onClickSubscribe)
+                Column(
+                    modifier = Modifier,
+                    verticalArrangement = Arrangement.Center,
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                ) {
+                    val bottomPadding = if (shouldShowOffer) 0.dp else 50.dp
+
+                    SubscribeButton(onClickSubscribe, bottomPadding)
+
+                    if (shouldShowOffer) {
+                        offerText?.let {
+                            TextP50(
+                                text = it,
+                                fontWeight = FontWeight.W400,
+                                modifier = Modifier.padding(bottom = 50.dp),
+                            )
+                        }
+                    }
+                }
             }
         }
     }
@@ -145,12 +179,13 @@ internal fun UpgradeLayoutFeatures(
 @Composable
 private fun SubscribeButton(
     onClickSubscribe: () -> Unit,
+    bottomPadding: Dp,
 ) {
     Box(
         contentAlignment = Alignment.BottomCenter,
     ) {
         RowButton(
-            modifier = Modifier.padding(bottom = 80.dp),
+            modifier = Modifier.padding(bottom = bottomPadding).padding(horizontal = 16.dp),
             text = stringResource(LR.string.get_pocket_casts_plus),
             onClick = onClickSubscribe,
             fontWeight = FontWeight.W600,
@@ -166,5 +201,5 @@ private fun SubscribeButton(
 @Preview(showBackground = true)
 @Composable
 fun SubscribeButtonPreview() {
-    SubscribeButton(onClickSubscribe = { })
+    SubscribeButton(onClickSubscribe = { }, bottomPadding = 50.dp)
 }

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -2061,4 +2061,9 @@ up    <string name="player_sleep_in_one_chapter">Sleeping in 1 chapter</string>
     <string name="swipe_affordance_icon">Swipe Affordance Icon</string>
     <string name="thank_you_for_your_feedback">Thank you for your feedback!</string>
     <string name="something_went_wrong_when_sending_feedback">Something went wrong. Please try submitting your feedback again.</string>
+
+    <!-- Paywall -->
+    <string name="paywall_save_50_off">Save 50% off your first year.</string>
+    <string name="paywall_free_1_month_trial">Free 1-month trial.</string>
+
 </resources>


### PR DESCRIPTION
## Description
- Add the label for trial or 50% offer below of subscribe button
- Opens the existing upgrade bottom sheet dialog
- See: SEQe6JBDCeegcpa9Bfg5Ww-fi-3_756
- I will update the bottom sheet in a later PR

> [!NOTE]  
> 50% offer is not available for India, South Africa and Brazil. Trial offer is available for them instead 

Fixes #2628

## Testing Instructions
Apply this [paywall.patch](https://github.com/user-attachments/files/16612993/paywall.patch) and run in `debug`

### With PAYWALL_AB_EXPERIMENT feature flag ON
1. Log with a free user account
2. Access the paywall
3. ✅ Ensure you see the secondary text below of `Get Pocket Casts Plus Button`
4. Tap on this button
5. ✅ Ensure the bottom sheet upgrade opens
6. Tap on subscribe button
7. ✅ Ensure the Google play bottom sheet opens

[new.webm](https://github.com/user-attachments/assets/25ced3d3-0fcd-4a2f-9a12-c49cbab4e457)



### With PAYWALL_AB_EXPERIMENT feature flag OFF
1. Log with a free user account
2. Access the paywall
3. ✅ Ensure you don't see the secondary text below of `Get Pocket Casts Plus Button`
4. Tap on this button
5. ✅ Ensure the Google play bottom sheet opens

[Screen_recording_20240820_125213.webm](https://github.com/user-attachments/assets/a612cd7e-cdb5-44db-9b4e-0bc41373880b)


## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [ ] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack