### PR TITLE
Fix create filter crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 7.72
 -----
-
+*   Bug Fixes
+    *   Fix create filter crash
+        ([#2677](https://github.com/Automattic/pocket-casts-android/pull/2677))
 
 7.71
 -----

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/CreateFilterChipFragment.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/CreateFilterChipFragment.kt
@@ -103,7 +103,7 @@ class CreateFilterChipFragment : BaseFragment(), CoroutineScope {
     }
 
     private fun observePlaylist() {
-        viewModel.playlist.observe(viewLifecycleOwner) { playlist ->
+        viewModel.playlist?.observe(viewLifecycleOwner) { playlist ->
             val color = playlist.getColor(context)
 
             val chipPodcasts = binding.chipPodcasts

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/CreateFilterContainerFragment.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/CreateFilterContainerFragment.kt
@@ -125,7 +125,7 @@ class CreateFilterContainerFragment : BaseFragment() {
     }
 
     private fun observePlaylist(adapter: CreatePagerAdapter) {
-        viewModel.playlist.observe(viewLifecycleOwner) {
+        viewModel.playlist?.observe(viewLifecycleOwner) {
             binding.btnCreate.isEnabled = !adapter.lockedToFirstPage
         }
     }

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/CreateFilterFragment.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/CreateFilterFragment.kt
@@ -278,7 +278,7 @@ class CreateFilterFragment : BaseFragment(), CoroutineScope {
     }
 
     private fun observePlaylist() {
-        viewModel.playlist.observe(viewLifecycleOwner) { filter ->
+        viewModel.playlist?.observe(viewLifecycleOwner) { filter ->
             if (binding == null) return@observe
 
             if (filter.title.isEmpty()) {

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/CreateFilterViewModel.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/CreateFilterViewModel.kt
@@ -54,7 +54,7 @@ class CreateFilterViewModel @Inject constructor(
     private val _lockedToFirstPage = MutableStateFlow(true)
     val lockedToFirstPage get() = _lockedToFirstPage.asStateFlow()
 
-    lateinit var playlist: LiveData<Playlist>
+    private var playlist: LiveData<Playlist>? = null
 
     suspend fun createFilter(name: String, iconId: Int, colorId: Int) =
         withContext(Dispatchers.IO) { playlistManager.createPlaylist(name, Playlist.calculateCombinedIconId(colorId, iconId), draft = true) }
@@ -88,7 +88,7 @@ class CreateFilterViewModel @Inject constructor(
         colorIndex: Int,
         isCreatingNewFilter: Boolean,
     ) = withContext(Dispatchers.Default) {
-        val playlist = playlist.value ?: return@withContext
+        val playlist = playlist?.value ?: return@withContext
         playlist.title = filterName.value
         playlist.iconId = Playlist.calculateCombinedIconId(colorIndex, iconIndex)
         playlist.draft = false
@@ -165,7 +165,7 @@ class CreateFilterViewModel @Inject constructor(
     fun updateDownloadLimit(limit: Int) {
         userChangedAutoDownloadEpisodeCount.recordUserChange()
         launch {
-            val playlist = playlist.value ?: return@launch
+            val playlist = playlist?.value ?: return@launch
             playlist.autodownloadLimit = limit
 
             val userPlaylistUpdate = UserPlaylistUpdate(
@@ -187,7 +187,7 @@ class CreateFilterViewModel @Inject constructor(
     fun clearNewFilter() {
         reset()
         launch(Dispatchers.Default) {
-            val playlist = playlist.value ?: return@launch
+            val playlist = playlist?.value ?: return@launch
             playlistManager.delete(playlist)
         }
     }
@@ -195,7 +195,7 @@ class CreateFilterViewModel @Inject constructor(
     fun starredChipTapped(isCreatingFilter: Boolean) {
         _lockedToFirstPage.value = false
         launch {
-            playlist.value?.let { playlist ->
+            playlist?.value?.let { playlist ->
                 playlist.starred = !playlist.starred
 
                 // Only indicate user is updating the starred property if this is not

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/CreateFilterViewModel.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/CreateFilterViewModel.kt
@@ -54,7 +54,7 @@ class CreateFilterViewModel @Inject constructor(
     private val _lockedToFirstPage = MutableStateFlow(true)
     val lockedToFirstPage get() = _lockedToFirstPage.asStateFlow()
 
-    private var playlist: LiveData<Playlist>? = null
+    var playlist: LiveData<Playlist>? = null
 
     suspend fun createFilter(name: String, iconId: Int, colorId: Int) =
         withContext(Dispatchers.IO) { playlistManager.createPlaylist(name, Playlist.calculateCombinedIconId(colorId, iconId), draft = true) }
@@ -122,7 +122,7 @@ class CreateFilterViewModel @Inject constructor(
 
     fun updateAutoDownload(autoDownload: Boolean) {
         launch {
-            playlist.value?.let { playlist ->
+            playlist?.value?.let { playlist ->
                 playlist.autoDownload = autoDownload
 
                 val userPlaylistUpdate = if (isAutoDownloadSwitchInitialized) {


### PR DESCRIPTION
## Description

While looking through the Google Play console crashes, I noticed this issue. It's not common, but I thought it was worth fixing. The issue happens on the create filter screen, as the `playlists` variable is a `lateinit`. It seems like the variable isn't being initialised quickly enough before some users call `CreateFilterContainerFragment.onDetach` which assumes the variable has been initialised.

```
Crash: Fatal crash.
kotlin.UninitializedPropertyAccessException: lateinit property playlist has not been 
	at au.com.shiftyjelly.pocketcasts.filters.CreateFilterViewModel.getPlaylist
	at au.com.shiftyjelly.pocketcasts.filters.CreateFilterViewModel$clearNewFilter$1.
	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
	at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:104)
	at kotlinx.coroutines.scheduling.CoroutineScheduler.runSafely(CoroutineScheduler.kt:584)
	at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.executeTask(CoroutineScheduler.
	at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.runWorker(CoroutineScheduler.
	at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.run(CoroutineScheduler.kt:702)
	Suppressed: kotlinx.coroutines.internal.DiagnosticCoroutineContextException: [StandaloneCoroutine{Cancelling}@a12d34b, Dispatchers.Default]
```

## Testing Instructions
1. Apply the following patch to simulate the variable not being initialised. 
[testing.patch](https://github.com/user-attachments/files/16683711/testing.patch)
2. Tap the Filters tab
3. Tap the + plus to go into the create filter screen
4. Go back 

✅  Verify the app doesn't crash

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes

