### PR TITLE
Transcripts - Support json format

### DIFF
--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/transcripts/TranscriptJsonParser.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/transcripts/TranscriptJsonParser.kt
@@ -1,0 +1,33 @@
+package au.com.shiftyjelly.pocketcasts.player.view.transcripts
+
+import com.squareup.moshi.Json
+import com.squareup.moshi.JsonAdapter
+import com.squareup.moshi.JsonClass
+import com.squareup.moshi.Moshi
+
+@JsonClass(generateAdapter = true)
+data class TranscriptSegments(
+    @field:Json(name = "segments") var segments: List<TranscriptCue>,
+)
+
+@JsonClass(generateAdapter = true)
+data class TranscriptCue(
+    @field:Json(name = "body") var body: String?,
+    @field:Json(name = "startTime") var startTime: Double?,
+    @field:Json(name = "endTime") var endTime: Double?,
+    @field:Json(name = "speaker") var speaker: String?,
+)
+
+object TranscriptJsonParser {
+    private val moshi = Moshi.Builder()
+        .build()
+
+    fun parse(jsonString: String): List<TranscriptCue> {
+        val jsonAdapter: JsonAdapter<TranscriptSegments> =
+            moshi.adapter(TranscriptSegments::class.java)
+        val transcriptJson =
+            jsonAdapter.fromJson(jsonString) ?: throw IllegalArgumentException("Invalid JSON")
+
+        return transcriptJson.segments
+    }
+}

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/transcripts/TranscriptJsonParser.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/transcripts/TranscriptJsonParser.kt
@@ -4,6 +4,7 @@ import com.squareup.moshi.Json
 import com.squareup.moshi.JsonAdapter
 import com.squareup.moshi.JsonClass
 import com.squareup.moshi.Moshi
+import javax.inject.Inject
 
 @JsonClass(generateAdapter = true)
 data class TranscriptSegments(
@@ -18,10 +19,9 @@ data class TranscriptCue(
     @field:Json(name = "speaker") var speaker: String?,
 )
 
-object TranscriptJsonParser {
-    private val moshi = Moshi.Builder()
-        .build()
-
+class TranscriptJsonParser @Inject constructor(
+    private val moshi: Moshi,
+) {
     fun parse(jsonString: String): List<TranscriptCue> {
         val jsonAdapter: JsonAdapter<TranscriptSegments> =
             moshi.adapter(TranscriptSegments::class.java)

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/transcripts/TranscriptPage.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/transcripts/TranscriptPage.kt
@@ -395,7 +395,7 @@ private fun TranscriptContentPreview(
                             ),
                             0,
                             0,
-                        )
+                        ),
                     ),
                 ),
                 displayInfo = DisplayInfo(

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/transcripts/TranscriptPage.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/transcripts/TranscriptPage.kt
@@ -385,16 +385,17 @@ private fun TranscriptContentPreview(
                     type = TranscriptFormat.HTML.mimeType,
                     url = "url",
                 ),
-                cuesWithTimingSubtitle =
-                ImmutableList.of(
-                    CuesWithTiming(
-                        ImmutableList.of(
-                            Cue.Builder().setText(
-                                "Lorem ipsum odor amet, consectetuer adipiscing elit. Sodales sem fusce elementum commodo risus purus auctor neque. Maecenas fermentum senectus penatibus senectus integer per vulputate tellus sed.",
-                            ).build(),
-                        ),
-                        0,
-                        0,
+                cuesInfo = ImmutableList.of(
+                    TranscriptViewModel.TranscriptCuesInfo(
+                        CuesWithTiming(
+                            ImmutableList.of(
+                                Cue.Builder().setText(
+                                    "Speaker 1",
+                                ).build(),
+                            ),
+                            0,
+                            0,
+                        )
                     ),
                 ),
                 displayInfo = DisplayInfo(
@@ -427,7 +428,7 @@ private fun TranscriptEmptyContentPreview() {
                     type = TranscriptFormat.HTML.mimeType,
                     url = "url",
                 ),
-                cuesWithTimingSubtitle = emptyList(),
+                cuesInfo = emptyList(),
                 displayInfo = DisplayInfo(
                     text = "",
                     items = emptyList(),

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/transcripts/TranscriptViewModel.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/transcripts/TranscriptViewModel.kt
@@ -45,6 +45,7 @@ class TranscriptViewModel @Inject constructor(
     private val subtitleParserFactory: SubtitleParser.Factory,
     private val analyticsTracker: AnalyticsTracker,
     @IoDispatcher private val ioDispatcher: CoroutineDispatcher,
+    private val transcriptJsonParser: TranscriptJsonParser,
 ) : ViewModel() {
     private var _uiState: MutableStateFlow<UiState> = MutableStateFlow(UiState.Empty())
     val uiState: StateFlow<UiState> = _uiState
@@ -151,7 +152,7 @@ class TranscriptViewModel @Inject constructor(
                     emptyList()
                 } else {
                     // Parse json following PodcastIndex.org transcript json spec: https://github.com/Podcastindex-org/podcast-namespace/blob/main/transcripts/transcripts.md#json
-                    val transcriptCues = TranscriptJsonParser.parse(jsonString)
+                    val transcriptCues = transcriptJsonParser.parse(jsonString)
                     transcriptCues.map { cue ->
                         val startTimeUs = cue.startTime?.toMicroSeconds ?: 0
                         val endTimeUs = cue.endTime?.toMicroSeconds ?: 0

--- a/modules/features/player/src/test/java/au/com/shiftyjelly/pocketcasts/player/view/transcripts/TranscriptViewModelTest.kt
+++ b/modules/features/player/src/test/java/au/com/shiftyjelly/pocketcasts/player/view/transcripts/TranscriptViewModelTest.kt
@@ -197,7 +197,8 @@ class TranscriptViewModelTest {
         initViewModel(jsonString)
 
         viewModel.parseAndLoadTranscript(
-            isTranscriptViewOpen = true, pulledToRefresh = false
+            isTranscriptViewOpen = true,
+            pulledToRefresh = false,
         )
 
         viewModel.uiState.test {
@@ -207,7 +208,7 @@ class TranscriptViewModelTest {
                     TranscriptViewModel.DisplayItem("Speaker 1", true, 2, 11),
                     TranscriptViewModel.DisplayItem("Hello.", false, 13, 19),
                     TranscriptViewModel.DisplayItem("World!", false, 21, 27),
-                )
+                ),
             )
         }
     }

--- a/modules/features/player/src/test/java/au/com/shiftyjelly/pocketcasts/player/view/transcripts/TranscriptViewModelTest.kt
+++ b/modules/features/player/src/test/java/au/com/shiftyjelly/pocketcasts/player/view/transcripts/TranscriptViewModelTest.kt
@@ -39,6 +39,7 @@ class TranscriptViewModelTest {
     private val transcriptsManager: TranscriptsManager = mock()
     private val playbackManager: PlaybackManager = mock()
     private val subtitleParserFactory: SubtitleParser.Factory = mock()
+    private val transcriptJsonParser: TranscriptJsonParser = mock()
     private val transcript: Transcript = Transcript("episode_id", "url", "type")
     private val playbackStateFlow = MutableStateFlow(PlaybackState(podcast = Podcast("podcast_id"), episodeUuid = "episode_id"))
     private lateinit var viewModel: TranscriptViewModel
@@ -194,6 +195,12 @@ class TranscriptViewModelTest {
             {"version":"1.0.0","segments":[{"speaker":"Speaker 1","startTime":0,"endTime":10,"body":"Hello."},{"speaker":null,"startTime":11,"endTime":20,"body":"World!"}]}
         """.trimIndent()
         whenever(transcriptsManager.observerTranscriptForEpisode(any())).thenReturn(flowOf(transcript.copy(type = "application/json")))
+        whenever(transcriptJsonParser.parse(jsonString)).thenReturn(
+            listOf(
+                TranscriptCue(speaker = "Speaker 1", startTime = 0.0, endTime = 10.0, body = "Hello."),
+                TranscriptCue(speaker = null, startTime = 11.0, endTime = 20.0, body = "World!"),
+            ),
+        )
         initViewModel(jsonString)
 
         viewModel.parseAndLoadTranscript(
@@ -237,6 +244,7 @@ class TranscriptViewModelTest {
             subtitleParserFactory = subtitleParserFactory,
             ioDispatcher = UnconfinedTestDispatcher(),
             analyticsTracker = mock(),
+            transcriptJsonParser = transcriptJsonParser,
         )
     }
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/TranscriptsManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/TranscriptsManagerImpl.kt
@@ -19,7 +19,7 @@ class TranscriptsManagerImpl @Inject constructor(
     private val service: TranscriptCacheServer,
     private val networkWrapper: NetworkWrapper,
 ) : TranscriptsManager {
-    private val supportedFormats = listOf(TranscriptFormat.SRT, TranscriptFormat.VTT, TranscriptFormat.HTML)
+    private val supportedFormats = listOf(TranscriptFormat.SRT, TranscriptFormat.VTT, TranscriptFormat.JSON_PODCAST_INDEX, TranscriptFormat.HTML)
 
     override suspend fun updateTranscripts(
         episodeUuid: String,
@@ -88,6 +88,7 @@ class TranscriptsManagerImpl @Inject constructor(
 enum class TranscriptFormat(val mimeType: String) {
     SRT("application/srt"),
     VTT("text/vtt"),
+    JSON_PODCAST_INDEX("application/json"),
     HTML("text/html"),
     ;
 


### PR DESCRIPTION
## Description
This supports JSON transcript format.

## Testing Instructions
1. Prioritise `TranscriptFormat.JSON_PODCAST_INDEX` in `TranscriptsManagerImpl.supportedFormats` at line 22
2. Install the app 
3. Play [this episode](https://pca.st/episode/cadc4a0f-97c3-47c6-9e7d-16452a2cf18a) from `Chaosradio`
4. Open transcript view
5. Notice that JSON format transcript is loaded

## Screenshots or Screencast 

Loaded from [transcript content](https://chaosradio.de/cr291-vorratsdatenspeicherung?podlove_transcript=json_podcastindex) 

<img width=320 src="https://github.com/user-attachments/assets/017a667b-5d4f-4011-a2ec-347a495332b1"/>

## Checklist
- [x] ~~If this is a user-facing change, I have added an entry in CHANGELOG.md~~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] ~~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~~
- [x] ~~Any jetpack compose components I added or changed are covered by compose previews~~
- [x] ~~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~~
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] ~~with different themes~~
- [x] ~~with a landscape orientation~~
- [x] ~~with the device set to have a large display and font size~~
- [x] ~~for accessibility with TalkBack~~
