### PR TITLE
Fix show notes cache

### DIFF
--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/podcast/PodcastCacheServer.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/podcast/PodcastCacheServer.kt
@@ -13,6 +13,7 @@ import retrofit2.http.GET
 import retrofit2.http.Headers
 import retrofit2.http.POST
 import retrofit2.http.Path
+import retrofit2.http.Query
 import retrofit2.http.Url
 
 @JsonClass(generateAdapter = true)
@@ -71,11 +72,18 @@ interface PodcastCacheServer {
     fun getPodcastAndEpisodes(@Path("podcastUuid") podcastUuid: String): Single<PodcastResponse>
 
     @GET("/mobile/show_notes/full/{podcastUuid}")
-    suspend fun getShowNotes(@Path("podcastUuid") podcastUuid: String): ShowNotesResponse
+    suspend fun getShowNotesLocation(@Path("podcastUuid") podcastUuid: String, @Query("disableredirect") disableRedirect: Boolean = true): ShowNotesLocationResponse
+
+    @GET
+    suspend fun getShowNotes(@Url url: String): ShowNotesResponse
 
     @GET("/mobile/show_notes/full/{podcastUuid}")
     @Headers("Cache-Control: only-if-cached, max-stale=7776000") // Use offline cache available for 90 days
-    suspend fun getShowNotesCache(@Path("podcastUuid") podcastUuid: String): ShowNotesResponse
+    suspend fun getShowNotesLocationCache(@Path("podcastUuid") podcastUuid: String, @Query("disableredirect") disableRedirect: Boolean = true): ShowNotesLocationResponse
+
+    @GET
+    @Headers("Cache-Control: only-if-cached, max-stale=7776000") // Use offline cache available for 90 days
+    suspend fun getShowNotesCache(@Url url: String): ShowNotesResponse
 
     @GET
     suspend fun getShowNotesChapters(@Url url: String): RawChaptersResponse

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/podcast/PodcastCacheServerManagerImpl.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/podcast/PodcastCacheServerManagerImpl.kt
@@ -51,12 +51,14 @@ class PodcastCacheServerManagerImpl @Inject constructor(
     }
 
     override suspend fun getShowNotes(podcastUuid: String): ShowNotesResponse {
-        return server.getShowNotes(podcastUuid)
+        val url = server.getShowNotesLocation(podcastUuid).url
+        return server.getShowNotes(url)
     }
 
     override suspend fun getShowNotesCache(podcastUuid: String): ShowNotesResponse? {
         return try {
-            server.getShowNotesCache(podcastUuid)
+            val url = server.getShowNotesLocationCache(podcastUuid).url
+            server.getShowNotesCache(url)
         } catch (e: Exception) {
             // if the cache can't be found a HTTP 504 Unsatisfiable Request will be thrown
             if (e !is HttpException) {

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/podcast/ShowNotesResponse.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/podcast/ShowNotesResponse.kt
@@ -4,6 +4,11 @@ import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
 
 @JsonClass(generateAdapter = true)
+data class ShowNotesLocationResponse(
+    @Json(name = "url") val url: String,
+)
+
+@JsonClass(generateAdapter = true)
 data class ShowNotesResponse(
     @Json(name = "podcast") val podcast: ShowNotesPodcast?,
 ) {


### PR DESCRIPTION
## Description

Since changing how the show notes endpoint works, they weren't being cached correctly, this change fixes that. 

## Testing Instructions
1. Freshly install the app
2. Open the "App Inspection" window and the "Network Inspector" tab
3. Open a podcast page
4. Clear the network data
5. Tap an episode row

✅ Notice there are two requests, one to podcast-api.pocketcasts.net and one to shownotes.pocketcasts.net
✅ Verify the show notes load

6. Rerun the app and connect the app inspection window again
7. Open a podcast page
8. Clear the network data
9. Tap an episode row

✅ Verify there is only one request to podcast-api.pocketcasts.net and the show notes load

10. Rerun the app and connect the app inspection window again
11. Put the phone in airplane mode
12. Open a podcast page
13. Tap an episode row

✅ Verify the show notes load

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
