### PR TITLE
Handle automatic playback from deep links

### DIFF
--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/deeplink/DeepLinkFactoryTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/deeplink/DeepLinkFactoryTest.kt
@@ -146,7 +146,7 @@ class DeepLinkFactoryTest {
 
         val deepLink = factory.create(intent)
 
-        assertEquals(ShowEpisodeDeepLink("Episode ID", "Podcast ID", "Source View"), deepLink)
+        assertEquals(ShowEpisodeDeepLink("Episode ID", "Podcast ID", "Source View", autoPlay = false), deepLink)
     }
 
     // Notifications add numbers to the action to display multiple of them
@@ -160,7 +160,7 @@ class DeepLinkFactoryTest {
 
         val deepLink = factory.create(intent)
 
-        assertEquals(ShowEpisodeDeepLink("Episode ID", "Podcast ID", "Source View"), deepLink)
+        assertEquals(ShowEpisodeDeepLink("Episode ID", "Podcast ID", "Source View", autoPlay = false), deepLink)
     }
 
     @Test
@@ -184,7 +184,7 @@ class DeepLinkFactoryTest {
 
         val deepLink = factory.create(intent)
 
-        assertEquals(ShowEpisodeDeepLink("Episode ID", podcastUuid = null, "Source View"), deepLink)
+        assertEquals(ShowEpisodeDeepLink("Episode ID", podcastUuid = null, "Source View", autoPlay = false), deepLink)
     }
 
     @Test
@@ -196,7 +196,7 @@ class DeepLinkFactoryTest {
 
         val deepLink = factory.create(intent)
 
-        assertEquals(ShowEpisodeDeepLink("Episode ID", "Podcast ID", sourceView = null), deepLink)
+        assertEquals(ShowEpisodeDeepLink("Episode ID", "Podcast ID", sourceView = null, autoPlay = false), deepLink)
     }
 
     @Test
@@ -642,18 +642,18 @@ class DeepLinkFactoryTest {
     fun sharePodcast() {
         val intent = Intent()
             .setAction(ACTION_VIEW)
-            .setData(Uri.parse("https://pca.st/podcast/podcast-id"))
+            .setData(Uri.parse("https://pca.st/podcast/podcast-id?source_view=source"))
 
         val deepLink = factory.create(intent)
 
-        assertEquals(ShowPodcastFromUrlDeepLink("https://pca.st/podcast/podcast-id"), deepLink)
+        assertEquals(ShowPodcastDeepLink("podcast-id", sourceView = "source"), deepLink)
     }
 
     @Test
     fun shareEpisode() {
         val intent = Intent()
             .setAction(ACTION_VIEW)
-            .setData(Uri.parse("https://pca.st/episode/episode-id"))
+            .setData(Uri.parse("https://pca.st/episode/episode-id?source_view=source"))
 
         val deepLink = factory.create(intent)
 
@@ -661,7 +661,8 @@ class DeepLinkFactoryTest {
             ShowEpisodeDeepLink(
                 episodeUuid = "episode-id",
                 podcastUuid = null,
-                sourceView = null,
+                sourceView = "source",
+                autoPlay = false,
             ),
             deepLink,
         )
@@ -681,6 +682,7 @@ class DeepLinkFactoryTest {
                 podcastUuid = null,
                 startTimestamp = 15.seconds,
                 sourceView = null,
+                autoPlay = false,
             ),
             deepLink,
         )
@@ -701,6 +703,45 @@ class DeepLinkFactoryTest {
                 startTimestamp = 15.seconds,
                 endTimestamp = 55.seconds,
                 sourceView = null,
+                autoPlay = false,
+            ),
+            deepLink,
+        )
+    }
+
+    @Test
+    fun shareEpisodeAutoPlayTrue() {
+        val intent = Intent()
+            .setAction(ACTION_VIEW)
+            .setData(Uri.parse("https://pca.st/episode/episode-id?auto_play=true"))
+
+        val deepLink = factory.create(intent)
+
+        assertEquals(
+            ShowEpisodeDeepLink(
+                episodeUuid = "episode-id",
+                podcastUuid = null,
+                sourceView = null,
+                autoPlay = true,
+            ),
+            deepLink,
+        )
+    }
+
+    @Test
+    fun shareEpisodeWithAutoPlayFalse() {
+        val intent = Intent()
+            .setAction(ACTION_VIEW)
+            .setData(Uri.parse("https://pca.st/episode/episode-id?auto_play-false"))
+
+        val deepLink = factory.create(intent)
+
+        assertEquals(
+            ShowEpisodeDeepLink(
+                episodeUuid = "episode-id",
+                podcastUuid = null,
+                sourceView = null,
+                autoPlay = false,
             ),
             deepLink,
         )
@@ -725,7 +766,7 @@ class DeepLinkFactoryTest {
 
         val deepLink = factory.create(intent)
 
-        assertEquals(ShowPodcastFromUrlDeepLink("http://pca.st/podcast/podcast-id"), deepLink)
+        assertEquals(ShowPodcastDeepLink("podcast-id", sourceView = null), deepLink)
     }
 
     @Test

--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/deeplink/ShowEpisodeDeepLinkTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/deeplink/ShowEpisodeDeepLinkTest.kt
@@ -1,8 +1,10 @@
 package au.com.shiftyjelly.pocketcasts.deeplink
 
 import android.content.Intent
+import android.net.Uri
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
+import kotlin.time.Duration.Companion.seconds
 import org.junit.Assert.assertEquals
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -12,13 +14,28 @@ class ShowEpisodeDeepLinkTest {
     private val context = InstrumentationRegistry.getInstrumentation().context
 
     @Test
-    fun createShowPodcastIntent() {
-        val intent = ShowEpisodeDeepLink("Episode ID", "Podcast ID", "Source View").toIntent(context)
+    fun createShowEpisodeIntent() {
+        val intent = ShowEpisodeDeepLink("Episode ID", "Podcast ID", "Source View", autoPlay = true).toIntent(context)
 
         assertEquals("INTENT_OPEN_APP_EPISODE_UUID", intent.action)
         assertEquals(Intent.FLAG_ACTIVITY_SINGLE_TOP, intent.flags and Intent.FLAG_ACTIVITY_SINGLE_TOP)
         assertEquals("Episode ID", intent.getStringExtra("episode_uuid"))
         assertEquals("Podcast ID", intent.getStringExtra("podcast_uuid"))
         assertEquals("Source View", intent.getStringExtra("source_view"))
+        assertEquals(true, intent.getBooleanExtra("auto_play", false))
+    }
+
+    @Test
+    fun createShowEpisodeUri() {
+        val uri = ShowEpisodeDeepLink("episode-id", "podcast-id", "source-view", autoPlay = true, startTimestamp = 1.seconds, endTimestamp = 20.seconds).toUri("pca.st")
+
+        assertEquals(Uri.parse("https://pca.st/episode/episode-id?t=1%2C20&auto_play=true&source_view=source-view"), uri)
+    }
+
+    @Test
+    fun createShowEpisodeUriWithoutTimestamps() {
+        val uri = ShowEpisodeDeepLink("episode-id", "podcast-id", "source-view", autoPlay = false).toUri("pca.st")
+
+        assertEquals(Uri.parse("https://pca.st/episode/episode-id?auto_play=false&source_view=source-view"), uri)
     }
 }

--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/deeplink/ShowPodcastDeepLinkTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/deeplink/ShowPodcastDeepLinkTest.kt
@@ -1,5 +1,6 @@
 package au.com.shiftyjelly.pocketcasts.deeplink
 
+import android.net.Uri
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import org.junit.Assert.assertEquals
@@ -17,5 +18,12 @@ class ShowPodcastDeepLinkTest {
         assertEquals("INTENT_OPEN_APP_PODCAST_UUID", intent.action)
         assertEquals("Podcast ID", intent.getStringExtra("podcast_uuid"))
         assertEquals("Source View", intent.getStringExtra("source_view"))
+    }
+
+    @Test
+    fun createShowPodcastUri() {
+        val uri = ShowPodcastDeepLink("podcast-id", "source-view").toUri("pca.st")
+
+        assertEquals(Uri.parse("https://pca.st/podcast/podcast-id?source_view=source-view"), uri)
     }
 }

--- a/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
+++ b/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
@@ -875,6 +875,7 @@ class MainActivity :
                                 source = EpisodeViewSource.NOTIFICATION_BOOKMARK,
                                 podcastUuid = navigationState.episode.podcastUuid,
                                 forceDark = false,
+                                autoPlay = false,
                             )
                         }
                         is NavigationState.BookmarksForUserEpisode -> {
@@ -1176,6 +1177,7 @@ class MainActivity :
             source = source,
             podcastUuid = podcastUuid,
             forceDark = false,
+            autoPlay = false,
         )
     }
 
@@ -1261,6 +1263,7 @@ class MainActivity :
                         podcastUuid = deepLink.podcastUuid,
                         source = EpisodeViewSource.fromString(deepLink.sourceView),
                         forceDark = false,
+                        autoPlay = deepLink.autoPlay,
                         startTimestamp = deepLink.startTimestamp,
                         endTimestamp = deepLink.endTimestamp,
                     )
@@ -1360,6 +1363,7 @@ class MainActivity :
         source: EpisodeViewSource,
         podcastUuid: String?,
         forceDark: Boolean,
+        autoPlay: Boolean,
         startTimestamp: Duration?,
         endTimestamp: Duration?,
     ) {
@@ -1385,6 +1389,7 @@ class MainActivity :
                         podcastUuid = localEpisode.podcastUuid,
                         forceDark = forceDark,
                         timestamp = startTimestamp,
+                        autoPlay = autoPlay,
                     )
                 }
                 null -> {
@@ -1398,6 +1403,7 @@ class MainActivity :
                             podcastUuid = it.podcastUuid,
                             forceDark = forceDark,
                             timestamp = startTimestamp,
+                            autoPlay = autoPlay,
                         )
                     }
                 }
@@ -1477,6 +1483,7 @@ class MainActivity :
                             source = EpisodeViewSource.SHARE,
                             podcastUuid = podcastUuid,
                             forceDark = false,
+                            autoPlay = false,
                             startTimestamp = deepLink.startTimestamp,
                         )
                     } else {

--- a/automotive/src/main/java/au/com/shiftyjelly/pocketcasts/AutomotiveSettingsActivity.kt
+++ b/automotive/src/main/java/au/com/shiftyjelly/pocketcasts/AutomotiveSettingsActivity.kt
@@ -128,6 +128,7 @@ class AutomotiveSettingsActivity : AppCompatActivity(), FragmentHostListener {
         source: EpisodeViewSource,
         podcastUuid: String?,
         forceDark: Boolean,
+        autoPlay: Boolean,
         startTimestamp: Duration?,
         endTimestamp: Duration?,
     ) {

--- a/modules/features/nova/src/main/kotlin/au/com/shiftyjelly/pocketcasts/nova/CatalogFactory.kt
+++ b/modules/features/nova/src/main/kotlin/au/com/shiftyjelly/pocketcasts/nova/CatalogFactory.kt
@@ -170,12 +170,14 @@ internal class CatalogFactory(
         episodeUuid = episodeId,
         podcastUuid = podcastId,
         sourceView = source.value,
+        autoPlay = false,
     ).toIntent(context)
 
     private fun openUserEpisodeIntent(episodeId: String, source: EpisodeViewSource) = ShowEpisodeDeepLink(
         episodeUuid = episodeId,
         podcastUuid = null,
         sourceView = source.value,
+        autoPlay = false,
     ).toIntent(context)
 
     private fun ApplePodcastCategory.Companion.fromCategories(categories: String) = categories.split('\n').mapNotNull(ApplePodcastCategory::valueOfSafe)

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/UpNextFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/UpNextFragment.kt
@@ -426,6 +426,7 @@ class UpNextFragment : BaseFragment(), UpNextListener, UpNextTouchCallback.ItemT
                 source = EpisodeViewSource.UP_NEXT,
                 podcastUuid = podcastUuid,
                 forceDark = true,
+                autoPlay = false,
             )
         }
     }
@@ -437,6 +438,7 @@ class UpNextFragment : BaseFragment(), UpNextListener, UpNextTouchCallback.ItemT
                 source = EpisodeViewSource.UP_NEXT,
                 podcastUuid = podcastUuid,
                 forceDark = true,
+                autoPlay = false,
             )
         } else {
             playerViewModel.playEpisode(uuid = episodeUuid, sourceView = sourceView)

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/episode/EpisodeContainerFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/episode/EpisodeContainerFragment.kt
@@ -62,6 +62,7 @@ class EpisodeContainerFragment :
             overridePodcastLink: Boolean = false,
             fromListUuid: String? = null,
             forceDark: Boolean = false,
+            autoPlay: Boolean = false,
         ) = newInstance(
             episodeUuid = episode.uuid,
             source = source,
@@ -69,6 +70,7 @@ class EpisodeContainerFragment :
             podcastUuid = episode.podcastUuid,
             fromListUuid = fromListUuid,
             forceDark = forceDark,
+            autoPlay = autoPlay,
         )
 
         fun newInstance(
@@ -79,6 +81,7 @@ class EpisodeContainerFragment :
             fromListUuid: String? = null,
             forceDark: Boolean = false,
             timestamp: Duration? = null,
+            autoPlay: Boolean = false,
         ) = EpisodeContainerFragment().apply {
             arguments = Bundle().apply {
                 putParcelable(
@@ -91,6 +94,7 @@ class EpisodeContainerFragment :
                         fromListUuid = fromListUuid,
                         forceDark = forceDark,
                         timestamp = timestamp,
+                        autoPlay = autoPlay,
                     ),
                 )
             }
@@ -131,6 +135,9 @@ class EpisodeContainerFragment :
 
     private val forceDarkTheme: Boolean
         get() = args.forceDark
+
+    private val autoPlay: Boolean
+        get() = args.autoPlay
 
     val activeTheme: Theme.ThemeType
         get() = if (forceDarkTheme && theme.isLightTheme) Theme.ThemeType.DARK else theme.activeTheme
@@ -217,6 +224,7 @@ class EpisodeContainerFragment :
             podcastUuid = podcastUuid,
             fromListUuid = fromListUuid,
             forceDarkTheme = forceDarkTheme,
+            autoPlay = autoPlay,
         )
 
         viewPager.adapter = adapter
@@ -292,6 +300,7 @@ class EpisodeContainerFragment :
         private val podcastUuid: String?,
         private val fromListUuid: String?,
         private val forceDarkTheme: Boolean,
+        private val autoPlay: Boolean,
     ) : FragmentStateAdapter(fragmentManager, lifecycle) {
         val indexOfBookmarks: Int
             get() = sections.indexOf(Section.Bookmarks)
@@ -341,15 +350,18 @@ class EpisodeContainerFragment :
         override fun createFragment(position: Int): Fragment {
             Timber.d("Creating fragment for position $position ${sections[position]}")
             return when (sections[position]) {
-                Section.Details -> EpisodeFragment.newInstance(
-                    episodeUuid = requireNotNull(episodeUUID),
-                    timestamp = timestamp,
-                    source = episodeViewSource,
-                    overridePodcastLink = overridePodcastLink,
-                    podcastUuid = podcastUuid,
-                    fromListUuid = fromListUuid,
-                    forceDark = forceDarkTheme,
-                )
+                Section.Details ->
+                    EpisodeFragment
+                        .newInstance(
+                            episodeUuid = requireNotNull(episodeUUID),
+                            timestamp = timestamp,
+                            source = episodeViewSource,
+                            overridePodcastLink = overridePodcastLink,
+                            podcastUuid = podcastUuid,
+                            fromListUuid = fromListUuid,
+                            forceDark = forceDarkTheme,
+                            autoPlay = autoPlay,
+                        )
                 Section.Bookmarks -> BookmarksFragment.newInstance(
                     sourceView = SourceView.EPISODE_DETAILS,
                     episodeUuid = requireNotNull(episodeUUID),

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/episode/EpisodeFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/episode/EpisodeFragment.kt
@@ -89,6 +89,7 @@ class EpisodeFragment : BaseFragment() {
             fromListUuid: String? = null,
             forceDark: Boolean = false,
             timestamp: Duration? = null,
+            autoPlay: Boolean = false,
         ): EpisodeFragment {
             return EpisodeFragment().apply {
                 arguments = Bundle().apply {
@@ -102,6 +103,7 @@ class EpisodeFragment : BaseFragment() {
                             fromListUuid = fromListUuid,
                             forceDark = forceDark,
                             timestamp = timestamp,
+                            autoPlay = autoPlay,
                         ),
                     )
                 }
@@ -150,6 +152,9 @@ class EpisodeFragment : BaseFragment() {
 
     val fromListUuid: String?
         get() = args.fromListUuid
+
+    private val autoPlay: Boolean
+        get() = args.autoPlay
 
     private val forceDarkTheme: Boolean
         get() = args.forceDark
@@ -219,12 +224,15 @@ class EpisodeFragment : BaseFragment() {
 
         binding?.loadingGroup?.isInvisible = true
 
-        viewModel.setup(
-            episodeUuid = episodeUUID,
-            podcastUuid = podcastUuid,
-            forceDark = forceDarkTheme,
-            timestamp = timestamp,
-        )
+        if (savedInstanceState == null) {
+            viewModel.setup(
+                episodeUuid = episodeUUID,
+                podcastUuid = podcastUuid,
+                timestamp = timestamp,
+                autoPlay = autoPlay,
+                forceDark = forceDarkTheme,
+            )
+        }
         viewModel.state.observe(
             viewLifecycleOwner,
             Observer { state ->
@@ -605,6 +613,7 @@ class EpisodeFragment : BaseFragment() {
         val podcastUuid: String? = null,
         val fromListUuid: String? = null,
         val forceDark: Boolean = false,
+        val autoPlay: Boolean = false,
         @TypeParceler<Duration?, DurationParceler>() val timestamp: Duration? = null,
     ) : Parcelable
 }

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/episode/EpisodeFragmentViewModel.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/episode/EpisodeFragmentViewModel.kt
@@ -22,7 +22,6 @@ import au.com.shiftyjelly.pocketcasts.repositories.playback.UpNextQueue
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
 import au.com.shiftyjelly.pocketcasts.repositories.shownotes.ShowNotesManager
-import au.com.shiftyjelly.pocketcasts.servers.ServerManager
 import au.com.shiftyjelly.pocketcasts.servers.shownotes.ShowNotesState
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import au.com.shiftyjelly.pocketcasts.utils.Network
@@ -52,7 +51,6 @@ class EpisodeFragmentViewModel @Inject constructor(
     val podcastManager: PodcastManager,
     val theme: Theme,
     val downloadManager: DownloadManager,
-    val serverManager: ServerManager,
     val playbackManager: PlaybackManager,
     val settings: Settings,
     private val showNotesManager: ShowNotesManager,

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/episode/EpisodeFragmentViewModel.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/episode/EpisodeFragmentViewModel.kt
@@ -74,14 +74,17 @@ class EpisodeFragmentViewModel @Inject constructor(
     var isFragmentChangingConfigurations: Boolean = false
 
     private var startPlaybackTimestamp: Duration? = null
+    private var autoDispatchPlay = false
 
     fun setup(
         episodeUuid: String,
         podcastUuid: String?,
-        forceDark: Boolean,
         timestamp: Duration?,
+        autoPlay: Boolean,
+        forceDark: Boolean,
     ) {
         startPlaybackTimestamp = timestamp
+        autoDispatchPlay = autoPlay
         val isDarkTheme = forceDark || theme.isDarkTheme
         val progressUpdatesObservable = downloadManager.progressUpdateRelay
             .filter { it.episodeUuid == episodeUuid }
@@ -129,7 +132,17 @@ class EpisodeFragmentViewModel @Inject constructor(
                     zipper,
                 )
             }
-            .doOnNext { if (it is EpisodeFragmentState.Loaded) { episode = it.episode } }
+            .doOnNext {
+                if (it is EpisodeFragmentState.Loaded) {
+                    if (autoDispatchPlay) {
+                        val playTimestamp = startPlaybackTimestamp
+                        autoDispatchPlay = false
+                        startPlaybackTimestamp = null
+                        play(it.episode, playTimestamp)
+                    }
+                    episode = it.episode
+                }
+            }
             .onErrorReturn { EpisodeFragmentState.Error(it) }
             .observeOn(AndroidSchedulers.mainThread())
             .subscribeOn(Schedulers.io())
@@ -277,9 +290,12 @@ class EpisodeFragmentViewModel @Inject constructor(
                 }
                 timestamp != null -> {
                     startPlaybackTimestamp = null
-                    playAtTimestamp(episode, timestamp)
+                    autoDispatchPlay = false
+                    play(episode, timestamp)
                     return true
                 } else -> {
+                    startPlaybackTimestamp = null
+                    autoDispatchPlay = false
                     fromListUuid?.let {
                         analyticsTracker.track(AnalyticsEvent.DISCOVER_LIST_EPISODE_PLAY, mapOf(LIST_ID_KEY to it, PODCAST_ID_KEY to episode.podcastUuid))
                     }
@@ -298,13 +314,15 @@ class EpisodeFragmentViewModel @Inject constructor(
         return false
     }
 
-    private fun playAtTimestamp(
+    private fun play(
         episode: BaseEpisode,
-        timestamp: Duration,
+        timestamp: Duration?,
     ) {
         viewModelScope.launch(Dispatchers.IO + NonCancellable) {
             playbackManager.playNowSync(episode, sourceView = source)
-            playbackManager.seekToTimeMsSuspend(timestamp.toInt(DurationUnit.MILLISECONDS))
+            if (timestamp != null) {
+                playbackManager.seekToTimeMsSuspend(timestamp.toInt(DurationUnit.MILLISECONDS))
+            }
         }
     }
 

--- a/modules/services/deeplink/src/main/kotlin/au/com/shiftyjelly/pocketcasts/deeplink/DeepLink.kt
+++ b/modules/services/deeplink/src/main/kotlin/au/com/shiftyjelly/pocketcasts/deeplink/DeepLink.kt
@@ -11,6 +11,7 @@ import au.com.shiftyjelly.pocketcasts.deeplink.DeepLink.Companion.ACTION_OPEN_DE
 import au.com.shiftyjelly.pocketcasts.deeplink.DeepLink.Companion.ACTION_OPEN_DOWNLOADS
 import au.com.shiftyjelly.pocketcasts.deeplink.DeepLink.Companion.ACTION_OPEN_EPISODE
 import au.com.shiftyjelly.pocketcasts.deeplink.DeepLink.Companion.ACTION_OPEN_PODCAST
+import au.com.shiftyjelly.pocketcasts.deeplink.DeepLink.Companion.EXTRA_AUTO_PLAY
 import au.com.shiftyjelly.pocketcasts.deeplink.DeepLink.Companion.EXTRA_BOOKMARK_UUID
 import au.com.shiftyjelly.pocketcasts.deeplink.DeepLink.Companion.EXTRA_EPISODE_UUID
 import au.com.shiftyjelly.pocketcasts.deeplink.DeepLink.Companion.EXTRA_FILTER_ID
@@ -33,6 +34,7 @@ sealed interface DeepLink {
         const val EXTRA_BOOKMARK_UUID = "bookmark_uuid"
         const val EXTRA_PODCAST_UUID = "podcast_uuid"
         const val EXTRA_EPISODE_UUID = "episode_uuid"
+        const val EXTRA_AUTO_PLAY = "auto_play"
         const val EXTRA_SOURCE_VIEW = "source_view"
         const val EXTRA_NOTIFICATION_TAG = "NOTIFICATION_TAG"
         const val EXTRA_PAGE = "launch-page"
@@ -42,6 +44,10 @@ sealed interface DeepLink {
 
 sealed interface IntentableDeepLink : DeepLink {
     fun toIntent(context: Context): Intent
+}
+
+sealed interface UriDeepLink : DeepLink {
+    fun toUri(shareHost: String): Uri
 }
 
 data object DownloadsDeepLink : IntentableDeepLink {
@@ -85,26 +91,57 @@ data class DeleteBookmarkDeepLink(
 data class ShowPodcastDeepLink(
     val podcastUuid: String,
     val sourceView: String?,
-) : IntentableDeepLink {
+) : IntentableDeepLink, UriDeepLink {
     override fun toIntent(context: Context) = context.launcherIntent
         .setAction(ACTION_OPEN_PODCAST)
         .putExtra(EXTRA_PODCAST_UUID, podcastUuid)
         .putExtra(EXTRA_SOURCE_VIEW, sourceView)
+
+    override fun toUri(shareHost: String): Uri {
+        return Uri.Builder()
+            .scheme("https")
+            .authority(shareHost)
+            .appendPath("podcast")
+            .appendPath(podcastUuid)
+            .let { if (sourceView != null) it.appendQueryParameter(EXTRA_SOURCE_VIEW, sourceView) else it }
+            .build()
+    }
 }
 
 data class ShowEpisodeDeepLink(
     val episodeUuid: String,
     val podcastUuid: String?,
     val sourceView: String?,
+    val autoPlay: Boolean,
     val startTimestamp: Duration? = null,
     val endTimestamp: Duration? = null,
-) : IntentableDeepLink {
+) : IntentableDeepLink, UriDeepLink {
     override fun toIntent(context: Context) = context.launcherIntent
         .setAction(ACTION_OPEN_EPISODE)
         .addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP)
         .putExtra(EXTRA_EPISODE_UUID, episodeUuid)
         .putExtra(EXTRA_PODCAST_UUID, podcastUuid)
+        .putExtra(EXTRA_AUTO_PLAY, autoPlay)
         .putExtra(EXTRA_SOURCE_VIEW, sourceView)
+
+    override fun toUri(shareHost: String): Uri {
+        return Uri.Builder()
+            .scheme("https")
+            .authority(shareHost)
+            .appendPath("episode")
+            .appendPath(episodeUuid)
+            .let { builder ->
+                val timestamps = listOfNotNull(startTimestamp?.inWholeSeconds, endTimestamp?.inWholeSeconds)
+                if (timestamps.isNotEmpty()) {
+                    builder.appendQueryParameter("t", timestamps.joinToString(separator = ","))
+                } else {
+                    builder
+                }
+            }
+            .appendQueryParameter(EXTRA_AUTO_PLAY, autoPlay.toString())
+            .let { if (sourceView != null) it.appendQueryParameter(EXTRA_SOURCE_VIEW, sourceView) else it }
+            .build()
+    }
 }
 
 sealed interface ShowPageDeepLink : IntentableDeepLink {

--- a/modules/services/deeplink/src/main/kotlin/au/com/shiftyjelly/pocketcasts/deeplink/DeepLinkFactory.kt
+++ b/modules/services/deeplink/src/main/kotlin/au/com/shiftyjelly/pocketcasts/deeplink/DeepLinkFactory.kt
@@ -18,6 +18,7 @@ import au.com.shiftyjelly.pocketcasts.deeplink.DeepLink.Companion.ACTION_OPEN_DE
 import au.com.shiftyjelly.pocketcasts.deeplink.DeepLink.Companion.ACTION_OPEN_DOWNLOADS
 import au.com.shiftyjelly.pocketcasts.deeplink.DeepLink.Companion.ACTION_OPEN_EPISODE
 import au.com.shiftyjelly.pocketcasts.deeplink.DeepLink.Companion.ACTION_OPEN_PODCAST
+import au.com.shiftyjelly.pocketcasts.deeplink.DeepLink.Companion.EXTRA_AUTO_PLAY
 import au.com.shiftyjelly.pocketcasts.deeplink.DeepLink.Companion.EXTRA_BOOKMARK_UUID
 import au.com.shiftyjelly.pocketcasts.deeplink.DeepLink.Companion.EXTRA_EPISODE_UUID
 import au.com.shiftyjelly.pocketcasts.deeplink.DeepLink.Companion.EXTRA_FILTER_ID
@@ -146,6 +147,7 @@ private class ShowEpisodeAdapter : DeepLinkAdapter {
             ShowEpisodeDeepLink(
                 episodeUuid = episodeUuid,
                 podcastUuid = intent.getStringExtra(EXTRA_PODCAST_UUID),
+                autoPlay = intent.getBooleanExtra(EXTRA_AUTO_PLAY, false),
                 sourceView = intent.getStringExtra(EXTRA_SOURCE_VIEW),
             )
         }
@@ -375,14 +377,19 @@ private class ShareLinkAdapter(
                     startTimestamp = timestamps?.first,
                     endTimestamp = timestamps?.second,
                 )
+                uriData.pathSegments[0] == "podcast" -> ShowPodcastDeepLink(
+                    podcastUuid = uriData.pathSegments[1],
+                    sourceView = uriData.getQueryParameter(EXTRA_SOURCE_VIEW),
+                )
                 uriData.pathSegments[0] == "episode" -> ShowEpisodeDeepLink(
                     episodeUuid = uriData.pathSegments[1],
                     podcastUuid = null,
                     startTimestamp = timestamps?.first,
                     endTimestamp = timestamps?.second,
-                    sourceView = null,
+                    autoPlay = uriData.getQueryParameter(EXTRA_AUTO_PLAY).toBoolean(),
+                    sourceView = uriData.getQueryParameter(EXTRA_SOURCE_VIEW),
                 )
-                // handle the different podcast share links such as /podcast/uuid, /itunes/itunes_id, /feed/feed_url
+                // handle the different podcast share links such as /itunes/itunes_id, /feed/feed_url
                 else -> ShowPodcastFromUrlDeepLink(uriData.toString())
             }
         } else {

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/refresh/RefreshPodcastsThread.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/refresh/RefreshPodcastsThread.kt
@@ -477,6 +477,7 @@ class RefreshPodcastsThread(
                 episodeUuid = episode.uuid,
                 podcastUuid = podcast.uuid,
                 sourceView = EpisodeViewSource.NOTIFICATION.value,
+                autoPlay = false,
             ).toIntent(context).apply {
                 action = action + System.currentTimeMillis() + intentId
             }

--- a/modules/services/ui/src/main/java/au/com/shiftyjelly/pocketcasts/ui/helper/FragmentHostListener.kt
+++ b/modules/services/ui/src/main/java/au/com/shiftyjelly/pocketcasts/ui/helper/FragmentHostListener.kt
@@ -31,6 +31,7 @@ interface FragmentHostListener {
         source: EpisodeViewSource,
         podcastUuid: String?,
         forceDark: Boolean,
+        autoPlay: Boolean,
         startTimestamp: Duration? = null,
         endTimestamp: Duration? = null,
     )


### PR DESCRIPTION
## Description

Engage SDK has these required attributes on the `PodcastEpisodeEntity`.

![Screenshot 2024-08-21 at 17 25 13](https://github.com/user-attachments/assets/32161501-8508-4961-962d-d58a4e8a4933)

Currently we don't have automatic playback capability from a deep link. This PR adds support for it. I also added support for a source view. Even though Enage SDK adds their own `source_tag` query parameter I prefer to have our custom one so it has a wider support.

## Testing Instructions

### Regressions

Do regressions tests on opening episode details. Open it from different contexts and make sure that they don't auto play.

### Deep linking

Use this for deep linking into episodes:

```
adb shell am start -n au.com.shiftyjelly.pocketcasts.debug/au.com.shiftyjelly.pocketcasts.ui.MainActivity -a android.intent.action.VIEW -d "https://pca.st/episode/<EPISODE_ID>?auto_play=<VALUE>"
```

Episode should start auto playing only when `auto_play` is present and is set to `true`.


## Checklist
- [x] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [x] ~Any jetpack compose components I added or changed are covered by compose previews~
- [x] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
