### PR TITLE
[Paywall Experiment] Add new featured cards instead of the old ones

### DIFF
--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeFeaturesPage.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeFeaturesPage.kt
@@ -126,10 +126,9 @@ internal fun OnboardingUpgradeFeaturesPage(
                     UpgradeLayoutFeatures(
                         state = loadedState,
                         source = source,
-                        onNotNowPressed = onNotNowPressed,
-                        onFeatureCardChanged = { viewModel.onFeatureCardChanged(loadedState.featureCardsState.featureCards[it]) },
-                        onClickSubscribe = { onClickSubscribe(true) },
                         scrollState = scrollState,
+                        onNotNowPressed = onNotNowPressed,
+                        onClickSubscribe = { onClickSubscribe(true) },
                         canUpgrade = canUpgrade,
                     )
                 }

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/paywallfeatures/FeaturesPaywallCards.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/paywallfeatures/FeaturesPaywallCards.kt
@@ -1,7 +1,10 @@
 package au.com.shiftyjelly.pocketcasts.account.onboarding.upgrade.paywallfeatures
 
+import androidx.annotation.DrawableRes
+import androidx.annotation.StringRes
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
@@ -9,6 +12,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Card
 import androidx.compose.runtime.Composable
@@ -32,17 +36,34 @@ import au.com.shiftyjelly.pocketcasts.images.R as IR
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 import au.com.shiftyjelly.pocketcasts.ui.R as UR
 
-data class CardData(
-    val imageResId: Int,
-    val contentDescription: String,
-    val title: String,
-    val description: String,
-    val imageHeight: Dp,
-    val imageTopPadding: Dp,
-)
+@Composable
+fun FeaturedPaywallCards(modifier: Modifier = Modifier) {
+    val featuredCards: List<CardData> = listOf(
+        bookmarks,
+        folders,
+        desktop,
+        watch,
+        slumber,
+        storage,
+        themes,
+    )
+
+    LazyRow(
+        horizontalArrangement = Arrangement.spacedBy(16.dp),
+        modifier = modifier,
+    ) {
+        items(
+            count = featuredCards.size,
+            key = { index -> index },
+
+        ) { index ->
+            FeaturedPaywallCard(cardData = featuredCards[index])
+        }
+    }
+}
 
 @Composable
-fun FeaturePaywallCard(cardData: CardData) {
+fun FeaturedPaywallCard(cardData: CardData) {
     Card(
         shape = RoundedCornerShape(8.dp),
         modifier = Modifier
@@ -57,7 +78,7 @@ fun FeaturePaywallCard(cardData: CardData) {
         ) {
             Image(
                 painter = painterResource(cardData.imageResId),
-                contentDescription = cardData.contentDescription,
+                contentDescription = stringResource(cardData.contentDescriptionResourceId),
                 modifier = Modifier
                     .align(Alignment.TopCenter)
                     .padding(top = cardData.imageTopPadding)
@@ -73,7 +94,7 @@ fun FeaturePaywallCard(cardData: CardData) {
                     .fillMaxWidth(),
             ) {
                 TextH30(
-                    text = cardData.title,
+                    text = stringResource(cardData.titleResourceId),
                     textAlign = TextAlign.Start,
                     fontWeight = FontWeight.W600,
                     color = Color.White,
@@ -83,7 +104,7 @@ fun FeaturePaywallCard(cardData: CardData) {
                 )
 
                 TextP50(
-                    text = cardData.description,
+                    text = stringResource(cardData.descriptionResourceId),
                     textAlign = TextAlign.Start,
                     fontWeight = FontWeight.W400,
                     color = colorResource(UR.color.coolgrey_50),
@@ -94,102 +115,83 @@ fun FeaturePaywallCard(cardData: CardData) {
     }
 }
 
-@Composable
-fun BookmarksCard() {
-    val bookmarksCardData = CardData(
-        imageResId = IR.drawable.bookmarks,
-        contentDescription = stringResource(LR.string.paywall_bookmarks_content_description),
-        title = stringResource(LR.string.paywall_bookmarks_title),
-        description = stringResource(LR.string.paywall_bookmarks_description),
-        imageHeight = 224.dp,
-        imageTopPadding = 37.dp,
-    )
-    FeaturePaywallCard(cardData = bookmarksCardData)
-}
+data class CardData(
+    @DrawableRes val imageResId: Int,
+    @StringRes val contentDescriptionResourceId: Int,
+    @StringRes val titleResourceId: Int,
+    @StringRes val descriptionResourceId: Int,
+    val imageHeight: Dp,
+    val imageTopPadding: Dp,
+)
 
-@Composable
-fun FoldersCard() {
-    val foldersCardData = CardData(
-        imageResId = IR.drawable.folders,
-        contentDescription = stringResource(LR.string.paywall_folders_content_description),
-        title = stringResource(LR.string.paywall_folders_title),
-        description = stringResource(LR.string.paywall_folders_description),
-        imageHeight = 227.dp,
-        imageTopPadding = 34.dp,
-    )
-    FeaturePaywallCard(cardData = foldersCardData)
-}
+private val bookmarks = CardData(
+    imageResId = IR.drawable.bookmarks,
+    contentDescriptionResourceId = LR.string.paywall_bookmarks_content_description,
+    titleResourceId = LR.string.paywall_bookmarks_title,
+    descriptionResourceId = LR.string.paywall_bookmarks_description,
+    imageHeight = 224.dp,
+    imageTopPadding = 37.dp,
+)
 
-@Composable
-fun DesktopWebAppCard() {
-    val desktopCardData = CardData(
-        imageResId = IR.drawable.desktop,
-        contentDescription = stringResource(LR.string.paywall_desktop_and_web_content_description),
-        title = stringResource(LR.string.paywall_desktop_and_web_title),
-        description = stringResource(LR.string.paywall_desktop_and_web_description),
-        imageHeight = 186.dp,
-        imageTopPadding = 57.dp,
-    )
-    FeaturePaywallCard(cardData = desktopCardData)
-}
+private val folders = CardData(
+    imageResId = IR.drawable.folders,
+    contentDescriptionResourceId = LR.string.paywall_folders_content_description,
+    titleResourceId = LR.string.paywall_folders_title,
+    descriptionResourceId = LR.string.paywall_folders_description,
+    imageHeight = 227.dp,
+    imageTopPadding = 34.dp,
+)
 
-@Composable
-fun WatchCard() {
-    val watchCardData = CardData(
-        imageResId = IR.drawable.watch,
-        contentDescription = stringResource(LR.string.paywall_watch_content_description),
-        title = stringResource(LR.string.paywall_watch_title),
-        description = stringResource(LR.string.paywall_watch_description),
-        imageHeight = 231.dp,
-        imageTopPadding = 26.dp,
-    )
-    FeaturePaywallCard(cardData = watchCardData)
-}
+private val desktop = CardData(
+    imageResId = IR.drawable.desktop,
+    contentDescriptionResourceId = LR.string.paywall_desktop_and_web_content_description,
+    titleResourceId = LR.string.paywall_desktop_and_web_title,
+    descriptionResourceId = LR.string.paywall_desktop_and_web_description,
+    imageHeight = 186.dp,
+    imageTopPadding = 57.dp,
+)
 
-@Composable
-fun SlumberStudiosCard() {
-    val slumberCardData = CardData(
-        imageResId = IR.drawable.slumber,
-        contentDescription = stringResource(LR.string.paywall_slumber_studios_content_description),
-        title = stringResource(LR.string.paywall_slumber_studios_title),
-        description = stringResource(LR.string.paywall_slumber_studios_description),
-        imageHeight = 195.dp,
-        imageTopPadding = 49.dp,
-    )
-    FeaturePaywallCard(cardData = slumberCardData)
-}
+private val watch = CardData(
+    imageResId = IR.drawable.watch,
+    contentDescriptionResourceId = LR.string.paywall_watch_content_description,
+    titleResourceId = LR.string.paywall_watch_title,
+    descriptionResourceId = LR.string.paywall_watch_description,
+    imageHeight = 231.dp,
+    imageTopPadding = 26.dp,
+)
 
-@Composable
-fun StorageCard() {
-    val slumberCardData = CardData(
-        imageResId = IR.drawable.storage,
-        contentDescription = stringResource(LR.string.paywall_storage_content_description),
-        title = stringResource(LR.string.paywall_storage_title),
-        description = stringResource(LR.string.paywall_storage_description),
-        imageHeight = 163.dp,
-        imageTopPadding = 64.dp,
-    )
-    FeaturePaywallCard(cardData = slumberCardData)
-}
+private val slumber = CardData(
+    imageResId = IR.drawable.slumber,
+    contentDescriptionResourceId = LR.string.paywall_slumber_studios_content_description,
+    titleResourceId = LR.string.paywall_slumber_studios_title,
+    descriptionResourceId = LR.string.paywall_slumber_studios_description,
+    imageHeight = 195.dp,
+    imageTopPadding = 49.dp,
+)
 
-@Composable
-fun ThemesCard() {
-    val slumberCardData = CardData(
-        imageResId = IR.drawable.themes,
-        contentDescription = stringResource(LR.string.paywall_themes_content_description),
-        title = stringResource(LR.string.paywall_themes_title),
-        description = stringResource(LR.string.paywall_themes_description),
-        imageHeight = 84.dp,
-        imageTopPadding = 105.dp,
-    )
-    FeaturePaywallCard(cardData = slumberCardData)
-}
+private val storage = CardData(
+    imageResId = IR.drawable.storage,
+    contentDescriptionResourceId = LR.string.paywall_storage_content_description,
+    titleResourceId = LR.string.paywall_storage_title,
+    descriptionResourceId = LR.string.paywall_storage_description,
+    imageHeight = 163.dp,
+    imageTopPadding = 64.dp,
+)
+
+private val themes = CardData(
+    imageResId = IR.drawable.themes,
+    contentDescriptionResourceId = LR.string.paywall_themes_content_description,
+    titleResourceId = LR.string.paywall_themes_title,
+    descriptionResourceId = LR.string.paywall_themes_description,
+    imageHeight = 84.dp,
+    imageTopPadding = 105.dp,
+)
 
 @Preview
 @Composable
 private fun WatchCardPreview() {
     AppTheme(Theme.ThemeType.LIGHT) {
-        WatchCard()
+        FeaturedPaywallCard(watch)
     }
 }
 
@@ -197,7 +199,7 @@ private fun WatchCardPreview() {
 @Composable
 private fun BookmarksCardPreview() {
     AppTheme(Theme.ThemeType.LIGHT) {
-        BookmarksCard()
+        FeaturedPaywallCard(bookmarks)
     }
 }
 
@@ -205,7 +207,7 @@ private fun BookmarksCardPreview() {
 @Composable
 private fun DesktopWebAppCardPreview() {
     AppTheme(Theme.ThemeType.LIGHT) {
-        DesktopWebAppCard()
+        FeaturedPaywallCard(desktop)
     }
 }
 
@@ -213,7 +215,7 @@ private fun DesktopWebAppCardPreview() {
 @Composable
 private fun FoldersCardPreview() {
     AppTheme(Theme.ThemeType.LIGHT) {
-        FoldersCard()
+        FeaturedPaywallCard(folders)
     }
 }
 
@@ -221,7 +223,7 @@ private fun FoldersCardPreview() {
 @Composable
 private fun SlumberStudiosCardPreview() {
     AppTheme(Theme.ThemeType.LIGHT) {
-        SlumberStudiosCard()
+        FeaturedPaywallCard(slumber)
     }
 }
 
@@ -229,7 +231,7 @@ private fun SlumberStudiosCardPreview() {
 @Composable
 private fun StorageCardPreview() {
     AppTheme(Theme.ThemeType.LIGHT) {
-        StorageCard()
+        FeaturedPaywallCard(storage)
     }
 }
 
@@ -237,6 +239,6 @@ private fun StorageCardPreview() {
 @Composable
 private fun ThemesCardPreview() {
     AppTheme(Theme.ThemeType.LIGHT) {
-        ThemesCard()
+        FeaturedPaywallCard(themes)
     }
 }

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/paywallfeatures/FeaturesPaywallCards.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/paywallfeatures/FeaturesPaywallCards.kt
@@ -39,9 +39,9 @@ import au.com.shiftyjelly.pocketcasts.ui.R as UR
 @Composable
 fun FeaturedPaywallCards(modifier: Modifier = Modifier) {
     val featuredCards: List<CardData> = listOf(
-        bookmarks,
-        folders,
         desktop,
+        folders,
+        bookmarks,
         watch,
         slumber,
         storage,

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/paywallfeatures/FeaturesPaywallCards.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/paywallfeatures/FeaturesPaywallCards.kt
@@ -36,6 +36,8 @@ import au.com.shiftyjelly.pocketcasts.images.R as IR
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 import au.com.shiftyjelly.pocketcasts.ui.R as UR
 
+private const val PodcastCoverScaleFactor = 1.5f
+
 @Composable
 fun FeaturedPaywallCards(modifier: Modifier = Modifier) {
     val featuredCards: List<CardData> = listOf(
@@ -48,8 +50,10 @@ fun FeaturedPaywallCards(modifier: Modifier = Modifier) {
         themes,
     )
 
+    val spacedBy = (16 / PodcastCoverScaleFactor).dp
+
     LazyRow(
-        horizontalArrangement = Arrangement.spacedBy(16.dp),
+        horizontalArrangement = Arrangement.spacedBy(spacedBy),
         modifier = modifier,
     ) {
         items(

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/paywallfeatures/FeaturesPaywallCards.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/paywallfeatures/FeaturesPaywallCards.kt
@@ -98,6 +98,7 @@ fun FeaturedPaywallCard(cardData: CardData) {
                     textAlign = TextAlign.Start,
                     fontWeight = FontWeight.W600,
                     color = Color.White,
+                    disableScale = true,
                     modifier = Modifier
                         .padding(bottom = 4.dp)
                         .align(Alignment.Start),
@@ -107,6 +108,7 @@ fun FeaturedPaywallCard(cardData: CardData) {
                     text = stringResource(cardData.descriptionResourceId),
                     textAlign = TextAlign.Start,
                     fontWeight = FontWeight.W400,
+                    disableScale = true,
                     color = colorResource(UR.color.coolgrey_50),
                     modifier = Modifier.align(Alignment.Start),
                 )

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/paywallfeatures/UpgradeLayoutFeatures.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/paywallfeatures/UpgradeLayoutFeatures.kt
@@ -33,7 +33,6 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import au.com.shiftyjelly.pocketcasts.account.onboarding.upgrade.FeatureCards
 import au.com.shiftyjelly.pocketcasts.account.onboarding.upgrade.calculateMinimumHeightWithInsets
 import au.com.shiftyjelly.pocketcasts.account.viewmodel.OnboardingUpgradeFeaturesState
 import au.com.shiftyjelly.pocketcasts.compose.AppTheme
@@ -57,7 +56,6 @@ internal fun UpgradeLayoutFeatures(
     source: OnboardingUpgradeSource,
     scrollState: ScrollState,
     onNotNowPressed: () -> Unit,
-    onFeatureCardChanged: (Int) -> Unit,
     onClickSubscribe: () -> Unit,
     canUpgrade: Boolean,
     modifier: Modifier = Modifier,
@@ -143,11 +141,10 @@ internal fun UpgradeLayoutFeatures(
                                 )
                             }
 
-                            FeatureCards(
-                                // TODO: it will be replaced for the new one
-                                state = state,
-                                upgradeButton = state.currentUpgradeButton,
-                                onFeatureCardChanged = onFeatureCardChanged,
+                            FeaturedPaywallCards(
+                                modifier = modifier
+                                    .fillMaxWidth()
+                                    .padding(top = 40.dp, start = 20.dp, end = 20.dp, bottom = 40.dp),
                             )
                         }
                     }

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/paywallfeatures/UpgradeLayoutFeatures.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/paywallfeatures/UpgradeLayoutFeatures.kt
@@ -165,6 +165,7 @@ private fun Content(
                 displayMode = SubscriptionBadgeDisplayMode.ColoredWithBlackForeground,
                 fontSize = 16.sp,
                 padding = 8.dp,
+                hasGradientEffect = true,
             )
         }
 
@@ -230,6 +231,7 @@ private fun SmallDeviceContent(
             SubscriptionBadgeForTier(
                 tier = SubscriptionTier.PLUS,
                 displayMode = SubscriptionBadgeDisplayMode.ColoredWithBlackForeground,
+                hasGradientEffect = true,
                 fontSize = 16.sp,
                 padding = 4.dp,
             )

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/paywallfeatures/UpgradeLayoutFeatures.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/paywallfeatures/UpgradeLayoutFeatures.kt
@@ -33,6 +33,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import au.com.shiftyjelly.pocketcasts.account.onboarding.upgrade.OnboardingUpgradeHelper.plusGradientBrush
 import au.com.shiftyjelly.pocketcasts.account.onboarding.upgrade.calculateMinimumHeightWithInsets
 import au.com.shiftyjelly.pocketcasts.account.viewmodel.OnboardingUpgradeFeaturesState
 import au.com.shiftyjelly.pocketcasts.compose.AppTheme
@@ -40,11 +41,10 @@ import au.com.shiftyjelly.pocketcasts.compose.buttons.RowButton
 import au.com.shiftyjelly.pocketcasts.compose.buttons.RowTextButton
 import au.com.shiftyjelly.pocketcasts.compose.components.AutoResizeText
 import au.com.shiftyjelly.pocketcasts.compose.components.TextP50
-import au.com.shiftyjelly.pocketcasts.compose.images.SubscriptionBadgeDisplayMode
-import au.com.shiftyjelly.pocketcasts.compose.images.SubscriptionBadgeForTier
+import au.com.shiftyjelly.pocketcasts.compose.images.SubscriptionBadge
 import au.com.shiftyjelly.pocketcasts.compose.theme
+import au.com.shiftyjelly.pocketcasts.images.R
 import au.com.shiftyjelly.pocketcasts.models.type.Subscription
-import au.com.shiftyjelly.pocketcasts.models.type.Subscription.SubscriptionTier
 import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingUpgradeSource
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
@@ -160,12 +160,14 @@ private fun Content(
                 .padding(bottom = 12.dp, top = 24.dp),
             contentAlignment = Alignment.Center,
         ) {
-            SubscriptionBadgeForTier(
-                tier = SubscriptionTier.PLUS,
-                displayMode = SubscriptionBadgeDisplayMode.ColoredWithBlackForeground,
+            SubscriptionBadge(
                 fontSize = 16.sp,
                 padding = 8.dp,
-                hasGradientEffect = true,
+                iconRes = R.drawable.ic_plus,
+                shortNameRes = LR.string.pocket_casts_plus_short,
+                iconColor = Color.Black,
+                backgroundBrush = plusGradientBrush,
+                textColor = Color.Black,
             )
         }
 
@@ -228,12 +230,14 @@ private fun SmallDeviceContent(
                 .padding(bottom = 8.dp, top = 12.dp),
             contentAlignment = Alignment.Center,
         ) {
-            SubscriptionBadgeForTier(
-                tier = SubscriptionTier.PLUS,
-                displayMode = SubscriptionBadgeDisplayMode.ColoredWithBlackForeground,
-                hasGradientEffect = true,
+            SubscriptionBadge(
                 fontSize = 16.sp,
                 padding = 4.dp,
+                iconRes = R.drawable.ic_plus,
+                shortNameRes = LR.string.pocket_casts_plus_short,
+                iconColor = Color.Black,
+                backgroundBrush = plusGradientBrush,
+                textColor = Color.Black,
             )
         }
 

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/paywallfeatures/UpgradeLayoutFeatures.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/paywallfeatures/UpgradeLayoutFeatures.kt
@@ -50,6 +50,8 @@ import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 import au.com.shiftyjelly.pocketcasts.ui.R as UR
 
+private val SCREEN_HEIGHT_FOR_SMALL_DEVICES = 600.dp
+
 @Composable
 internal fun UpgradeLayoutFeatures(
     state: OnboardingUpgradeFeaturesState.Loaded,
@@ -62,6 +64,8 @@ internal fun UpgradeLayoutFeatures(
 ) {
     val configuration = LocalConfiguration.current
     val isLandscape = configuration.orientation == Configuration.ORIENTATION_LANDSCAPE
+    val screenHeight = configuration.screenHeightDp.dp
+    val isSmallDevice = screenHeight < SCREEN_HEIGHT_FOR_SMALL_DEVICES
 
     val offerText = when (state.currentSubscription) {
         is Subscription.Trial -> stringResource(LR.string.paywall_free_1_month_trial)
@@ -71,7 +75,7 @@ internal fun UpgradeLayoutFeatures(
 
     val shouldShowOffer = offerText != null && !isLandscape
 
-    AppTheme(Theme.ThemeType.DARK) { // We need to set Dark since this screen will have dark colors for all themes
+    AppTheme(Theme.ThemeType.DARK) {
         Box(
             modifier = modifier.fillMaxHeight(),
             contentAlignment = Alignment.BottomCenter,
@@ -89,63 +93,10 @@ internal fun UpgradeLayoutFeatures(
                             .heightIn(min = this@BoxWithConstraints.calculateMinimumHeightWithInsets())
                             .padding(bottom = 100.dp),
                     ) {
-                        Row(
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                .padding(top = 8.dp),
-                            horizontalArrangement = Arrangement.End,
-                        ) {
-                            RowTextButton(
-                                text = stringResource(LR.string.not_now),
-                                colors = ButtonDefaults.outlinedButtonColors(
-                                    backgroundColor = Color.Transparent,
-                                    contentColor = Color.White,
-                                ),
-                                fontSize = 18.sp,
-                                onClick = onNotNowPressed,
-                                fullWidth = false,
-                                includePadding = false,
-                            )
-                        }
-
-                        Column {
-                            Box(
-                                modifier = Modifier
-                                    .fillMaxWidth()
-                                    .padding(bottom = 12.dp, top = 24.dp),
-                                contentAlignment = Alignment.Center,
-                            ) {
-                                SubscriptionBadgeForTier(
-                                    tier = SubscriptionTier.PLUS,
-                                    displayMode = SubscriptionBadgeDisplayMode.ColoredWithBlackForeground,
-                                    fontSize = 16.sp,
-                                    padding = 8.dp,
-                                )
-                            }
-
-                            Box(
-                                modifier = Modifier.padding(bottom = 40.dp),
-                                contentAlignment = Alignment.Center,
-                            ) {
-                                AutoResizeText(
-                                    text = stringResource(state.currentFeatureCard.titleRes(source)),
-                                    color = Color.White,
-                                    maxFontSize = 22.sp,
-                                    lineHeight = 30.sp,
-                                    fontWeight = FontWeight.W700,
-                                    maxLines = 2,
-                                    textAlign = TextAlign.Center,
-                                    modifier = Modifier
-                                        .padding(horizontal = 24.dp)
-                                        .fillMaxWidth(),
-                                )
-                            }
-
-                            FeaturedPaywallCards(
-                                modifier = modifier
-                                    .fillMaxWidth()
-                                    .padding(top = 40.dp, start = 20.dp, end = 20.dp, bottom = 40.dp),
-                            )
+                        if (isSmallDevice) {
+                            SmallDeviceContent(onNotNowPressed, state, source, modifier)
+                        } else {
+                            Content(onNotNowPressed, state, source, modifier)
                         }
                     }
                 }
@@ -157,7 +108,7 @@ internal fun UpgradeLayoutFeatures(
                     verticalArrangement = Arrangement.Center,
                     horizontalAlignment = Alignment.CenterHorizontally,
                 ) {
-                    val bottomPadding = if (shouldShowOffer) 0.dp else 34.dp
+                    val bottomPadding = if (shouldShowOffer) 0.dp else if (isSmallDevice) 8.dp else 34.dp
 
                     SubscribeButton(onClickSubscribe, Modifier.padding(bottom = bottomPadding))
 
@@ -167,12 +118,146 @@ internal fun UpgradeLayoutFeatures(
                                 text = it,
                                 fontWeight = FontWeight.W400,
                             )
-                            Spacer(Modifier.height(50.dp))
+                            Spacer(Modifier.height(if (isSmallDevice) 12.dp else 50.dp))
                         }
                     }
                 }
             }
         }
+    }
+}
+
+@Composable
+private fun Content(
+    onNotNowPressed: () -> Unit,
+    state: OnboardingUpgradeFeaturesState.Loaded,
+    source: OnboardingUpgradeSource,
+    modifier: Modifier,
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(top = 8.dp),
+        horizontalArrangement = Arrangement.End,
+    ) {
+        RowTextButton(
+            text = stringResource(LR.string.not_now),
+            colors = ButtonDefaults.outlinedButtonColors(
+                backgroundColor = Color.Transparent,
+                contentColor = Color.White,
+            ),
+            fontSize = 18.sp,
+            onClick = onNotNowPressed,
+            fullWidth = false,
+            includePadding = false,
+        )
+    }
+
+    Column {
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(bottom = 12.dp, top = 24.dp),
+            contentAlignment = Alignment.Center,
+        ) {
+            SubscriptionBadgeForTier(
+                tier = SubscriptionTier.PLUS,
+                displayMode = SubscriptionBadgeDisplayMode.ColoredWithBlackForeground,
+                fontSize = 16.sp,
+                padding = 8.dp,
+            )
+        }
+
+        Box(
+            modifier = Modifier.padding(bottom = 40.dp),
+            contentAlignment = Alignment.Center,
+        ) {
+            AutoResizeText(
+                text = stringResource(state.currentFeatureCard.titleRes(source)),
+                color = Color.White,
+                maxFontSize = 22.sp,
+                lineHeight = 30.sp,
+                fontWeight = FontWeight.W700,
+                maxLines = 2,
+                textAlign = TextAlign.Center,
+                modifier = Modifier
+                    .padding(horizontal = 24.dp)
+                    .fillMaxWidth(),
+            )
+        }
+
+        FeaturedPaywallCards(
+            modifier = modifier
+                .fillMaxWidth()
+                .padding(top = 40.dp, start = 20.dp, end = 20.dp, bottom = 40.dp),
+        )
+    }
+}
+
+@Composable
+private fun SmallDeviceContent(
+    onNotNowPressed: () -> Unit,
+    state: OnboardingUpgradeFeaturesState.Loaded,
+    source: OnboardingUpgradeSource,
+    modifier: Modifier,
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(top = 4.dp),
+        horizontalArrangement = Arrangement.End,
+    ) {
+        RowTextButton(
+            text = stringResource(LR.string.not_now),
+            colors = ButtonDefaults.outlinedButtonColors(
+                backgroundColor = Color.Transparent,
+                contentColor = Color.White,
+            ),
+            fontSize = 18.sp,
+            onClick = onNotNowPressed,
+            fullWidth = false,
+            includePadding = false,
+        )
+    }
+
+    Column {
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(bottom = 8.dp, top = 12.dp),
+            contentAlignment = Alignment.Center,
+        ) {
+            SubscriptionBadgeForTier(
+                tier = SubscriptionTier.PLUS,
+                displayMode = SubscriptionBadgeDisplayMode.ColoredWithBlackForeground,
+                fontSize = 16.sp,
+                padding = 4.dp,
+            )
+        }
+
+        Box(
+            modifier = Modifier.padding(bottom = 4.dp),
+            contentAlignment = Alignment.Center,
+        ) {
+            AutoResizeText(
+                text = stringResource(state.currentFeatureCard.titleRes(source)),
+                color = Color.White,
+                maxFontSize = 22.sp,
+                lineHeight = 24.sp,
+                fontWeight = FontWeight.W700,
+                maxLines = 2,
+                textAlign = TextAlign.Center,
+                modifier = Modifier
+                    .padding(horizontal = 12.dp)
+                    .fillMaxWidth(),
+            )
+        }
+
+        FeaturedPaywallCards(
+            modifier = modifier
+                .fillMaxWidth()
+                .padding(vertical = 8.dp, horizontal = 8.dp),
+        )
     }
 }
 

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/OnboardingUpgradeFeaturesViewModel.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/OnboardingUpgradeFeaturesViewModel.kt
@@ -102,7 +102,7 @@ class OnboardingUpgradeFeaturesViewModel @Inject constructor(
         val showNotNow = source == OnboardingUpgradeSource.RECOMMENDATIONS
 
         val upgradeLayout = when {
-            FeatureFlag.isEnabled(Feature.PAYWALL_AB_EXPERIMENT) -> UpgradeLayout.Features
+            FeatureFlag.isEnabled(Feature.PAYWALL_AB_EXPERIMENT) && !showPatronOnly -> UpgradeLayout.Features
             FeatureFlag.isEnabled(Feature.PAYWALL_AA_EXPERIMENT) -> {
                 val variation = experimentProvider.getVariation(Experiment.PaywallAATest)
                 // For the A/A test show the same layout for both variations

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/OnboardingUpgradeFeaturesViewModel.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/OnboardingUpgradeFeaturesViewModel.kt
@@ -102,7 +102,7 @@ class OnboardingUpgradeFeaturesViewModel @Inject constructor(
         val showNotNow = source == OnboardingUpgradeSource.RECOMMENDATIONS
 
         val upgradeLayout = when {
-            FeatureFlag.isEnabled(Feature.PAYWALL_AB_EXPERIMENT) && !showPatronOnly -> UpgradeLayout.Features
+            FeatureFlag.isEnabled(Feature.PAYWALL_AB_EXPERIMENT) -> UpgradeLayout.Features
             FeatureFlag.isEnabled(Feature.PAYWALL_AA_EXPERIMENT) -> {
                 val variation = experimentProvider.getVariation(Experiment.PaywallAATest)
                 // For the A/A test show the same layout for both variations

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/TextStyles.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/TextStyles.kt
@@ -215,6 +215,7 @@ fun TextP50(
     textAlign: TextAlign? = null,
     fontWeight: FontWeight? = null,
     lineHeight: TextUnit? = null,
+    disableScale: Boolean = false,
 ) {
     TextP50(
         text = AnnotatedString(text),
@@ -224,6 +225,7 @@ fun TextP50(
         style = style,
         textAlign = textAlign,
         fontWeight = fontWeight,
+        disableScale = disableScale,
         lineHeight = lineHeight,
     )
 }
@@ -238,12 +240,16 @@ fun TextP50(
     textAlign: TextAlign? = null,
     fontWeight: FontWeight? = null,
     lineHeight: TextUnit? = null,
+    disableScale: Boolean = false,
 ) {
+    val fontSize = 14.sp
+    val lineHeightUpdated = lineHeight ?: 20.sp
+
     Text(
         text = text,
         color = color ?: MaterialTheme.theme.colors.primaryText01,
-        fontSize = 14.sp,
-        lineHeight = lineHeight ?: 20.sp,
+        fontSize = if (disableScale) fontSize.value.nonScaledSp else fontSize,
+        lineHeight = if (disableScale) lineHeightUpdated.value.nonScaledSp else lineHeightUpdated.value.sp,
         maxLines = maxLines ?: Int.MAX_VALUE,
         overflow = TextOverflow.Ellipsis,
         style = style ?: LocalTextStyle.current,

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/images/SubscriptionBadge.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/images/SubscriptionBadge.kt
@@ -3,6 +3,7 @@ package au.com.shiftyjelly.pocketcasts.compose.images
 import androidx.annotation.DrawableRes
 import androidx.annotation.StringRes
 import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -13,6 +14,7 @@ import androidx.compose.material.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.painterResource
@@ -44,35 +46,41 @@ fun SubscriptionBadge(
     padding: Dp = 4.dp,
     backgroundColor: Color? = null,
     textColor: Color? = null,
+    hasGradientEffect: Boolean = false,
 ) {
-    val bgColor = backgroundColor ?: Color.Black
+    val background = getBackground(backgroundColor ?: Color.Black, hasGradientEffect)
+
     Card(
         shape = RoundedCornerShape(pillCornerRadiusInDp),
-        backgroundColor = backgroundColor ?: bgColor,
-        modifier = modifier,
+        modifier = modifier
+            .background(Color.Transparent),
     ) {
-        Row(
+        Box(
             modifier = Modifier
-                .semantics(mergeDescendants = true) {}
+                .background(background)
                 .padding(horizontal = padding * 2, vertical = padding),
-            verticalAlignment = Alignment.CenterVertically,
         ) {
-            Icon(
-                painter = painterResource(iconRes),
-                contentDescription = null,
+            Row(
                 modifier = Modifier
-                    .size(iconSize)
-                    .background(bgColor),
-                tint = iconColor,
-            )
-            TextH50(
-                text = stringResource(shortNameRes),
-                color = textColor ?: Color.White,
-                fontSize = fontSize,
-                lineHeight = fontSize,
-                modifier = Modifier
-                    .padding(start = padding),
-            )
+                    .semantics(mergeDescendants = true) {},
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Icon(
+                    painter = painterResource(iconRes),
+                    contentDescription = null,
+                    modifier = Modifier
+                        .size(iconSize),
+                    tint = iconColor,
+                )
+                TextH50(
+                    text = stringResource(shortNameRes),
+                    color = textColor ?: Color.White,
+                    fontSize = fontSize,
+                    lineHeight = fontSize,
+                    modifier = Modifier
+                        .padding(start = padding),
+                )
+            }
         }
     }
 }
@@ -83,6 +91,7 @@ fun SubscriptionBadgeForTier(
     displayMode: SubscriptionBadgeDisplayMode,
     fontSize: TextUnit = 14.sp,
     padding: Dp = 4.dp,
+    hasGradientEffect: Boolean = false,
 ) {
     when (tier) {
         SubscriptionTier.PLUS -> SubscriptionBadge(
@@ -90,6 +99,7 @@ fun SubscriptionBadgeForTier(
             padding = padding,
             iconRes = IR.drawable.ic_plus,
             shortNameRes = LR.string.pocket_casts_plus_short,
+            hasGradientEffect = hasGradientEffect,
             iconColor = when (displayMode) {
                 SubscriptionBadgeDisplayMode.Black -> SubscriptionTierColor.plusGold
                 SubscriptionBadgeDisplayMode.ColoredWithWhiteForeground -> Color.White
@@ -196,6 +206,24 @@ fun OfferBadge(
     }
 }
 
+private fun getBackground(backgroundColor: Color, hasGradientEffect: Boolean): Brush = if (hasGradientEffect) {
+    when (backgroundColor) {
+        SubscriptionTierColor.patronPurple -> Brush.horizontalGradient(
+            colors = listOf(Color(0xFFAFA2fA), Color(0xFFAFA2fA)),
+        )
+        SubscriptionTierColor.plusGold -> Brush.horizontalGradient(
+            colors = listOf(Color(0xFFFED745), Color(0xFFFEB525)),
+        )
+        else -> Brush.horizontalGradient(
+            colors = listOf(backgroundColor),
+        )
+    }
+} else {
+    Brush.horizontalGradient(
+        colors = listOf(backgroundColor),
+    )
+}
+
 enum class SubscriptionBadgeDisplayMode {
     Black,
     ColoredWithWhiteForeground,
@@ -258,6 +286,17 @@ fun SubscriptionBadgePlusColoredWithBlackForegroundPreview() {
     )
 }
 
+@ShowkaseComposable(name = "SubscriptionBadge", group = "Images", styleName = "Plus - Colored with black foreground and gradient")
+@Preview(name = "ColoredWithBlackForeground")
+@Composable
+fun SubscriptionBadgePlusColoredWithBlackForegroundAndGradientPreview() {
+    SubscriptionBadgeForTier(
+        tier = SubscriptionTier.PLUS,
+        displayMode = SubscriptionBadgeDisplayMode.ColoredWithBlackForeground,
+        hasGradientEffect = true,
+    )
+}
+
 @ShowkaseComposable(name = "SubscriptionBadge", group = "Images", styleName = "Patron - Colored with black foreground")
 @Preview(name = "ColoredWithBlackForeground")
 @Composable
@@ -265,5 +304,16 @@ fun SubscriptionBadgePatronColoredWithBlackForegroundPreview() {
     SubscriptionBadgeForTier(
         tier = SubscriptionTier.PATRON,
         displayMode = SubscriptionBadgeDisplayMode.ColoredWithBlackForeground,
+    )
+}
+
+@ShowkaseComposable(name = "SubscriptionBadge", group = "Images", styleName = "Patron - Colored with black foreground and gradient")
+@Preview(name = "ColoredWithBlackForeground")
+@Composable
+fun SubscriptionBadgePatronColoredWithBlackForegroundAndGradientPreview() {
+    SubscriptionBadgeForTier(
+        tier = SubscriptionTier.PATRON,
+        displayMode = SubscriptionBadgeDisplayMode.ColoredWithBlackForeground,
+        hasGradientEffect = true,
     )
 }

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/images/SubscriptionBadge.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/images/SubscriptionBadge.kt
@@ -28,6 +28,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import au.com.shiftyjelly.pocketcasts.compose.components.TextH50
 import au.com.shiftyjelly.pocketcasts.compose.theme
+import au.com.shiftyjelly.pocketcasts.images.R
 import au.com.shiftyjelly.pocketcasts.models.type.Subscription.SubscriptionTier
 import com.airbnb.android.showkase.annotation.ShowkaseComposable
 import au.com.shiftyjelly.pocketcasts.images.R as IR
@@ -46,9 +47,8 @@ fun SubscriptionBadge(
     padding: Dp = 4.dp,
     backgroundColor: Color? = null,
     textColor: Color? = null,
-    hasGradientEffect: Boolean = false,
 ) {
-    val background = getBackground(backgroundColor ?: Color.Black, hasGradientEffect)
+    val background = backgroundColor ?: Color.Black
 
     Card(
         shape = RoundedCornerShape(pillCornerRadiusInDp),
@@ -60,28 +60,68 @@ fun SubscriptionBadge(
                 .background(background)
                 .padding(horizontal = padding * 2, vertical = padding),
         ) {
-            Row(
-                modifier = Modifier
-                    .semantics(mergeDescendants = true) {},
-                verticalAlignment = Alignment.CenterVertically,
-            ) {
-                Icon(
-                    painter = painterResource(iconRes),
-                    contentDescription = null,
-                    modifier = Modifier
-                        .size(iconSize),
-                    tint = iconColor,
-                )
-                TextH50(
-                    text = stringResource(shortNameRes),
-                    color = textColor ?: Color.White,
-                    fontSize = fontSize,
-                    lineHeight = fontSize,
-                    modifier = Modifier
-                        .padding(start = padding),
-                )
-            }
+            SubscriptionBadgeContent(iconRes, iconSize, iconColor, shortNameRes, textColor, fontSize, padding)
         }
+    }
+}
+
+@Composable
+fun SubscriptionBadge(
+    @DrawableRes iconRes: Int,
+    @StringRes shortNameRes: Int,
+    backgroundBrush: Brush,
+    modifier: Modifier = Modifier,
+    iconColor: Color = Color.Unspecified,
+    iconSize: Dp = 14.dp,
+    fontSize: TextUnit = 14.sp,
+    padding: Dp = 4.dp,
+    textColor: Color? = null,
+) {
+    Card(
+        shape = RoundedCornerShape(pillCornerRadiusInDp),
+        modifier = modifier
+            .background(Color.Transparent),
+    ) {
+        Box(
+            modifier = Modifier
+                .background(backgroundBrush)
+                .padding(horizontal = padding * 2, vertical = padding),
+        ) {
+            SubscriptionBadgeContent(iconRes, iconSize, iconColor, shortNameRes, textColor, fontSize, padding)
+        }
+    }
+}
+
+@Composable
+private fun SubscriptionBadgeContent(
+    iconRes: Int,
+    iconSize: Dp,
+    iconColor: Color,
+    shortNameRes: Int,
+    textColor: Color?,
+    fontSize: TextUnit,
+    padding: Dp,
+) {
+    Row(
+        modifier = Modifier
+            .semantics(mergeDescendants = true) {},
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Icon(
+            painter = painterResource(iconRes),
+            contentDescription = null,
+            modifier = Modifier
+                .size(iconSize),
+            tint = iconColor,
+        )
+        TextH50(
+            text = stringResource(shortNameRes),
+            color = textColor ?: Color.White,
+            fontSize = fontSize,
+            lineHeight = fontSize,
+            modifier = Modifier
+                .padding(start = padding),
+        )
     }
 }
 
@@ -91,7 +131,6 @@ fun SubscriptionBadgeForTier(
     displayMode: SubscriptionBadgeDisplayMode,
     fontSize: TextUnit = 14.sp,
     padding: Dp = 4.dp,
-    hasGradientEffect: Boolean = false,
 ) {
     when (tier) {
         SubscriptionTier.PLUS -> SubscriptionBadge(
@@ -99,7 +138,6 @@ fun SubscriptionBadgeForTier(
             padding = padding,
             iconRes = IR.drawable.ic_plus,
             shortNameRes = LR.string.pocket_casts_plus_short,
-            hasGradientEffect = hasGradientEffect,
             iconColor = when (displayMode) {
                 SubscriptionBadgeDisplayMode.Black -> SubscriptionTierColor.plusGold
                 SubscriptionBadgeDisplayMode.ColoredWithWhiteForeground -> Color.White
@@ -117,6 +155,7 @@ fun SubscriptionBadgeForTier(
                 SubscriptionBadgeDisplayMode.ColoredWithBlackForeground -> Color.Black
             },
         )
+
         SubscriptionTier.PATRON -> SubscriptionBadge(
             fontSize = fontSize,
             padding = padding,
@@ -139,6 +178,7 @@ fun SubscriptionBadgeForTier(
                 SubscriptionBadgeDisplayMode.ColoredWithBlackForeground -> Color.Black
             },
         )
+
         SubscriptionTier.UNKNOWN -> Unit
     }
 }
@@ -206,24 +246,6 @@ fun OfferBadge(
     }
 }
 
-private fun getBackground(backgroundColor: Color, hasGradientEffect: Boolean): Brush = if (hasGradientEffect) {
-    when (backgroundColor) {
-        SubscriptionTierColor.patronPurple -> Brush.horizontalGradient(
-            colors = listOf(Color(0xFFAFA2fA), Color(0xFFAFA2fA)),
-        )
-        SubscriptionTierColor.plusGold -> Brush.horizontalGradient(
-            colors = listOf(Color(0xFFFED745), Color(0xFFFEB525)),
-        )
-        else -> Brush.horizontalGradient(
-            colors = listOf(backgroundColor),
-        )
-    }
-} else {
-    Brush.horizontalGradient(
-        colors = listOf(backgroundColor),
-    )
-}
-
 enum class SubscriptionBadgeDisplayMode {
     Black,
     ColoredWithWhiteForeground,
@@ -286,17 +308,6 @@ fun SubscriptionBadgePlusColoredWithBlackForegroundPreview() {
     )
 }
 
-@ShowkaseComposable(name = "SubscriptionBadge", group = "Images", styleName = "Plus - Colored with black foreground and gradient")
-@Preview(name = "ColoredWithBlackForeground")
-@Composable
-fun SubscriptionBadgePlusColoredWithBlackForegroundAndGradientPreview() {
-    SubscriptionBadgeForTier(
-        tier = SubscriptionTier.PLUS,
-        displayMode = SubscriptionBadgeDisplayMode.ColoredWithBlackForeground,
-        hasGradientEffect = true,
-    )
-}
-
 @ShowkaseComposable(name = "SubscriptionBadge", group = "Images", styleName = "Patron - Colored with black foreground")
 @Preview(name = "ColoredWithBlackForeground")
 @Composable
@@ -307,13 +318,20 @@ fun SubscriptionBadgePatronColoredWithBlackForegroundPreview() {
     )
 }
 
-@ShowkaseComposable(name = "SubscriptionBadge", group = "Images", styleName = "Patron - Colored with black foreground and gradient")
-@Preview(name = "ColoredWithBlackForeground")
+@ShowkaseComposable(name = "SubscriptionBadge", group = "Images", styleName = "Plus - Colored with gradient background")
+@Preview(name = "ColoredWithBlackForegroundAndGradientBackground")
 @Composable
-fun SubscriptionBadgePatronColoredWithBlackForegroundAndGradientPreview() {
-    SubscriptionBadgeForTier(
-        tier = SubscriptionTier.PATRON,
-        displayMode = SubscriptionBadgeDisplayMode.ColoredWithBlackForeground,
-        hasGradientEffect = true,
+fun SubscriptionBadgeWithGradientBackgroundPreview() {
+    SubscriptionBadge(
+        fontSize = 16.sp,
+        padding = 4.dp,
+        iconRes = R.drawable.ic_plus,
+        shortNameRes = LR.string.pocket_casts_plus_short,
+        iconColor = Color.Black,
+        backgroundBrush = Brush.horizontalGradient(
+            0f to Color(0xFFFED745),
+            1f to Color(0xFFFEB525),
+        ),
+        textColor = Color.Black,
     )
 }


### PR DESCRIPTION
## Description
- Adds the new featured cards in the paywall experiment
- Updates the Plus pill to have gradient effect

Fixes #2631

## Testing Instructions

1. Apply this [paywall.patch](https://github.com/user-attachments/files/16612993/paywall.patch) and run in `debug`
2. Have `PAYWALL_AB_EXPERIMENT` feature flag enabled
3. Open paywall
4. ✅ Ensure plus pill has gradient effect
5. ✅ The new featured cards are displayed added here https://github.com/Automattic/pocket-casts-android/pull/2660

Try with different screen sizes and font sizes

## Screenshots or Screencast 

| Regular Device | Small Device |
|--------|--------|
| <img src="https://github.com/user-attachments/assets/cea97c62-ae69-4e00-9d39-07d0d9d4dcdb" width="400px"> | <img src="https://github.com/user-attachments/assets/a35b9d14-1a34-4745-991a-372879d6ae06"  width="400px"> |



## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
