### PR TITLE
Upgrade libraries with Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  - package-ecosystem: "gradle"
+    open-pull-requests-limit: 6
+    directory: "/"
+    schedule:
+      interval: "daily"
+    ignore:
+      # The Android Gradle Plugin is a dependency we'd like to upgrade manually.
+      - dependency-name: "com.android.tools.build:gradle"
+      - dependency-name: "com.android.application"
+      - dependency-name: "com.android.library"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,8 @@ updates:
     schedule:
       interval: "daily"
     ignore:
-      # The Android Gradle Plugin is a dependency we'd like to upgrade manually.
-      - dependency-name: "com.android.tools.build:gradle"
-      - dependency-name: "com.android.application"
-      - dependency-name: "com.android.library"
+      # Automattic libraries have a custom versioning scheme which doesn't work with Dependabot.
+      - dependency-name: "com.automattic:Automattic-Tracks-Android"
+      - dependency-name: "com.automattic:encryptedlogging"
+      - dependency-name: "com.automattic.tracks:crashlogging"
+      - dependency-name: "com.automattic.android.measure-builds"


### PR DESCRIPTION
## Description

It would be good to use GitHub Dependabot to help us keep the project libraries up to date. This PR adds the configuration file. 

I asked the apps infrastructure team for some advice setting this up.  p1724292683965449-slack-CC7L49W13 

## Testing

We might have to test this by trying it. If the pull requests are too noisy or incorrect, we can change this configuration.