### PR TITLE
Transcripts - Misc fixes

### DIFF
--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/PlayerHeaderFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/PlayerHeaderFragment.kt
@@ -405,6 +405,7 @@ class PlayerHeaderFragment : BaseFragment(), PlayerClickListener {
         val containerFragment = parentFragment as? PlayerContainerFragment
         containerFragment?.updateTabsVisibility(true)
         (root as? LockableNestedScrollView)?.setScrollingEnabled(true)
+        playerGroup.layoutTransition = null // Reset to null to avoid animation when changing children visibility anytime later
     }
 
     private fun setupUpNextDrag(binding: AdapterPlayerHeaderBinding) {

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/di/ServersModule.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/di/ServersModule.kt
@@ -81,9 +81,12 @@ class ServersModule {
             val originalResponse = chain.proceed(request)
             var responseBuilder = originalResponse.newBuilder()
             if (request.cacheControl.noCache) {
-                responseBuilder = responseBuilder.header(HEADER_CACHE_CONTROL, "public, max-age=$CACHE_FIVE_MINUTES")
+                responseBuilder = responseBuilder
+                    .header(HEADER_CACHE_CONTROL, "public, max-age=$CACHE_FIVE_MINUTES")
+                    .removeHeader("Pragma")
             } else if (request.cacheControl.onlyIfCached) {
                 responseBuilder.header(HEADER_CACHE_CONTROL, "public, only-if-cached, max-stale=${request.cacheControl.maxStaleSeconds}")
+                    .removeHeader("Pragma")
             }
             responseBuilder.build()
         }


### PR DESCRIPTION
## Description
This fixes following two issues:

1. Flicker when selecting another episode with transcript
2. 301 redirect cache issue


## Testing Instructions

#### Flicker
1. Play an episode with a transcript
2. Open transcript view
3. Close transcript view
4. Go to the podcast 
5. Select another episode from the podcast
6. ✅ Notice there's no flicker

#### HTTPS 301 redirect 
1. Play this episode https://pcast.pocketcasts.net/c8nzu6xo
2. Open transcript view
3. Notice that the transcript is cached for HTTP URL as well as the 301 redirect HTTPS URL 
4. Go to the podcast 
5. Play another episode and open transcript view
6. Go to the podcast 
7. Disable internet
8. Play previous episode and open transcript view
9.  ✅ Notice that the transcript is loaded from HTTPS URL cache (earlier it displayed network error)

## Screenshots or Screencast 
#### Flicker 

Before

https://github.com/user-attachments/assets/b5340acc-d02a-4334-a86b-161b5d18508e

After

https://github.com/user-attachments/assets/22e3bf75-2c49-4731-baf6-ae15559dee78

#### HTTPS 301 redirect 


https://github.com/user-attachments/assets/bd4664aa-8615-4a54-bc0d-c0c2504dbedd



## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
