### PR TITLE
Transcripts -  Fallback to alternative formats if main format fails - Part 1

### DIFF
--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/transcripts/TranscriptError.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/transcripts/TranscriptError.kt
@@ -45,6 +45,9 @@ fun TranscriptError(
     modifier: Modifier,
 ) {
     val errorMessage = when (val error = state.error) {
+        is TranscriptError.Empty ->
+            stringResource(LR.string.transcript_empty)
+
         is TranscriptError.NotSupported ->
             stringResource(LR.string.error_transcript_format_not_supported, error.format)
 

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/transcripts/TranscriptPage.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/transcripts/TranscriptPage.kt
@@ -139,7 +139,7 @@ fun TranscriptPage(
         }
     }
 
-    LaunchedEffect(uiState.value.transcript?.episodeUuid + transitionState.value) {
+    LaunchedEffect(uiState.value.transcript?.episodeUuid, uiState.value.transcript?.type, transitionState.value) {
         transcriptViewModel.parseAndLoadTranscript(transitionState.value is TransitionState.OpenTranscript)
     }
 

--- a/modules/features/player/src/test/java/au/com/shiftyjelly/pocketcasts/player/view/transcripts/TranscriptViewModelTest.kt
+++ b/modules/features/player/src/test/java/au/com/shiftyjelly/pocketcasts/player/view/transcripts/TranscriptViewModelTest.kt
@@ -98,7 +98,7 @@ class TranscriptViewModelTest {
     }
 
     @Test
-    fun `given transcript is supported, when transcript load invoked, then loaded state is returned`() = runTest {
+    fun `given transcript is supported but blank, when transcript load invoked, then error state is returned`() = runTest {
         whenever(transcriptsManager.observerTranscriptForEpisode(any())).thenReturn(flowOf(transcript))
         whenever(subtitleParserFactory.supportsFormat(any())).thenReturn(true)
         val parser = mock<SubtitleParser>()
@@ -109,7 +109,7 @@ class TranscriptViewModelTest {
         viewModel.parseAndLoadTranscript(isTranscriptViewOpen = true)
 
         viewModel.uiState.test {
-            assertEquals(transcript, (awaitItem() as UiState.TranscriptLoaded).transcript)
+            assertEquals((awaitItem() as UiState.Error).error, TranscriptError.Empty)
         }
     }
 

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/TranscriptsManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/TranscriptsManager.kt
@@ -18,6 +18,13 @@ interface TranscriptsManager {
         source: LoadTranscriptSource = LoadTranscriptSource.DEFAULT,
         forceRefresh: Boolean = false,
     ): ResponseBody?
+
+    suspend fun updateAlternativeTranscript(
+        podcastUuid: String,
+        episodeUuid: String,
+        failedFormats: List<TranscriptFormat>,
+        source: LoadTranscriptSource,
+    )
 }
 
 enum class LoadTranscriptSource {

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/shownotes/ShowNotesProcessor.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/shownotes/ShowNotesProcessor.kt
@@ -102,11 +102,11 @@ class ShowNotesProcessor @Inject constructor(
         url = url,
         isEmbedded = false,
     )
-
-    private fun ShowNotesTranscript.toTranscript(episodeUuid: String) = Transcript(
-        episodeUuid = episodeUuid,
-        url = requireNotNull(url),
-        type = requireNotNull(type),
-        language = language,
-    )
 }
+
+fun ShowNotesTranscript.toTranscript(episodeUuid: String) = Transcript(
+    episodeUuid = episodeUuid,
+    url = requireNotNull(url),
+    type = requireNotNull(type),
+    language = language,
+)

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/TranscriptsManagerImplTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/TranscriptsManagerImplTest.kt
@@ -25,7 +25,13 @@ class TranscriptsManagerImplTest {
     private val transcriptDao: TranscriptDao = mock()
     private val transcriptCacheServer: TranscriptCacheServer = mock()
     private val networkWrapper: NetworkWrapper = mock()
-    private val transcriptsManager = TranscriptsManagerImpl(transcriptDao, transcriptCacheServer, networkWrapper)
+    private val transcriptsManager = TranscriptsManagerImpl(
+        transcriptDao = transcriptDao,
+        service = transcriptCacheServer,
+        networkWrapper = networkWrapper,
+        serverShowNotesManager = mock(),
+        scope = mock(),
+    )
 
     @Test
     fun `findBestTranscript returns first supported transcript`() = runTest {


### PR DESCRIPTION
## Description
This fallbacks to alternative format if main format fails while loading a transcript.

** Changes to fallback to alternative format for downloaded episodes require extracting parsing from the view model to another class that we can inject into the transcript manager and parse the transcript. I'll submit another PR for it. 

## Testing Instructions
1. Play an episode from chaosRadio (eg. https://pca.st/r2ct46up)
2. Open transcript view
3. ✅ Notice that an alternative format (`application/json`) is loaded if the main (`text/vtt`) one fails or is empty. 

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
