### PR TITLE
Fix: Upgrade bottom sheet was not opening with the last selected tier

### DIFF
--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/OnboardingUpgradeBottomSheetViewModel.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/OnboardingUpgradeBottomSheetViewModel.kt
@@ -162,7 +162,7 @@ class OnboardingUpgradeBottomSheetViewModel @Inject constructor(
                 frequency = lastSelectedFrequency,
             )
         } else {
-            subscriptionManager.getDefaultSubscription(subscriptions = subscriptions)
+            subscriptionManager.getDefaultSubscription(subscriptions = subscriptions, tier = lastSelectedTier)
         }
 
         return if (defaultSelected == null) {


### PR DESCRIPTION
## Description
- Opens the upgrade bottom sheet dialog with the last selected tier from Profile

Fixes #2675

## Testing Instructions
1. Run the app in `debug`
2. Disable `PAYWALL_AB_EXPERIMENT ` feature flag
3. Log with a free user account
4. Go to Profile -> Account
5. Tap on `Subscribe to Plus` button
6. ✅ Ensure bottom sheet dialog opens with Plus option
7. Back to Account -> Swipe right on upgrade view
8. Tap on `Subscribe to Patron` button
9. ✅ Ensure bottom sheet dialog opens with Patron option

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
