### PR TITLE
Transcripts - Extract cue building to builder and load cues from manager

### DIFF
--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/transcripts/TranscriptError.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/transcripts/TranscriptError.kt
@@ -45,6 +45,9 @@ fun TranscriptError(
     modifier: Modifier,
 ) {
     val errorMessage = when (val error = state.error) {
+        is TranscriptError.Empty ->
+            stringResource(LR.string.transcript_empty)
+
         is TranscriptError.NotSupported ->
             stringResource(LR.string.error_transcript_format_not_supported, error.format)
 

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/transcripts/TranscriptJsonConverter.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/transcripts/TranscriptJsonConverter.kt
@@ -19,10 +19,10 @@ data class TranscriptCue(
     @field:Json(name = "speaker") var speaker: String?,
 )
 
-class TranscriptJsonParser @Inject constructor(
+class TranscriptJsonConverter @Inject constructor(
     private val moshi: Moshi,
 ) {
-    fun parse(jsonString: String): List<TranscriptCue> {
+    fun fromString(jsonString: String): List<TranscriptCue> {
         val jsonAdapter: JsonAdapter<TranscriptSegments> =
             moshi.adapter(TranscriptSegments::class.java)
         val transcriptJson =

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/transcripts/TranscriptPage.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/transcripts/TranscriptPage.kt
@@ -52,6 +52,7 @@ import au.com.shiftyjelly.pocketcasts.compose.loading.LoadingView
 import au.com.shiftyjelly.pocketcasts.compose.toolbars.textselection.CustomMenuItemOption
 import au.com.shiftyjelly.pocketcasts.compose.toolbars.textselection.CustomTextToolbar
 import au.com.shiftyjelly.pocketcasts.models.to.Transcript
+import au.com.shiftyjelly.pocketcasts.models.to.TranscriptCuesInfo
 import au.com.shiftyjelly.pocketcasts.player.view.transcripts.TranscriptDefaults.ScrollToHighlightedTextOffset
 import au.com.shiftyjelly.pocketcasts.player.view.transcripts.TranscriptDefaults.TranscriptColors
 import au.com.shiftyjelly.pocketcasts.player.view.transcripts.TranscriptDefaults.TranscriptFontFamily
@@ -386,7 +387,7 @@ private fun TranscriptContentPreview(
                     url = "url",
                 ),
                 cuesInfo = ImmutableList.of(
-                    TranscriptViewModel.TranscriptCuesInfo(
+                    TranscriptCuesInfo(
                         CuesWithTiming(
                             ImmutableList.of(
                                 Cue.Builder().setText(

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/transcripts/TranscriptViewModel.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/transcripts/TranscriptViewModel.kt
@@ -10,6 +10,7 @@ import androidx.media3.extractor.text.CuesWithTiming
 import androidx.media3.extractor.text.SubtitleParser
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTracker
+import au.com.shiftyjelly.pocketcasts.models.converter.TranscriptJsonConverter
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.to.Transcript
 import au.com.shiftyjelly.pocketcasts.repositories.di.IoDispatcher

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/transcripts/TranscriptViewModel.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/transcripts/TranscriptViewModel.kt
@@ -45,7 +45,7 @@ class TranscriptViewModel @Inject constructor(
     private val subtitleParserFactory: SubtitleParser.Factory,
     private val analyticsTracker: AnalyticsTracker,
     @IoDispatcher private val ioDispatcher: CoroutineDispatcher,
-    private val transcriptJsonParser: TranscriptJsonParser,
+    private val transcriptJsonConverter: TranscriptJsonConverter,
 ) : ViewModel() {
     private var _uiState: MutableStateFlow<UiState> = MutableStateFlow(UiState.Empty())
     val uiState: StateFlow<UiState> = _uiState
@@ -159,7 +159,7 @@ class TranscriptViewModel @Inject constructor(
                     emptyList()
                 } else {
                     // Parse json following PodcastIndex.org transcript json spec: https://github.com/Podcastindex-org/podcast-namespace/blob/main/transcripts/transcripts.md#json
-                    val transcriptCues = transcriptJsonParser.parse(jsonString)
+                    val transcriptCues = transcriptJsonConverter.fromString(jsonString)
                     transcriptCues.map { cue ->
                         val startTimeUs = cue.startTime?.toMicroSeconds ?: 0
                         val endTimeUs = cue.endTime?.toMicroSeconds ?: 0

--- a/modules/features/player/src/test/java/au/com/shiftyjelly/pocketcasts/player/view/transcripts/TranscriptViewModelTest.kt
+++ b/modules/features/player/src/test/java/au/com/shiftyjelly/pocketcasts/player/view/transcripts/TranscriptViewModelTest.kt
@@ -39,7 +39,7 @@ class TranscriptViewModelTest {
     private val transcriptsManager: TranscriptsManager = mock()
     private val playbackManager: PlaybackManager = mock()
     private val subtitleParserFactory: SubtitleParser.Factory = mock()
-    private val transcriptJsonParser: TranscriptJsonParser = mock()
+    private val transcriptJsonConverter: TranscriptJsonConverter = mock()
     private val transcript: Transcript = Transcript("episode_id", "url", "type")
     private val playbackStateFlow = MutableStateFlow(PlaybackState(podcast = Podcast("podcast_id"), episodeUuid = "episode_id"))
     private lateinit var viewModel: TranscriptViewModel
@@ -195,7 +195,7 @@ class TranscriptViewModelTest {
             {"version":"1.0.0","segments":[{"speaker":"Speaker 1","startTime":0,"endTime":10,"body":"Hello."},{"speaker":null,"startTime":11,"endTime":20,"body":"World!"}]}
         """.trimIndent()
         whenever(transcriptsManager.observerTranscriptForEpisode(any())).thenReturn(flowOf(transcript.copy(type = "application/json")))
-        whenever(transcriptJsonParser.parse(jsonString)).thenReturn(
+        whenever(transcriptJsonConverter.fromString(jsonString)).thenReturn(
             listOf(
                 TranscriptCue(speaker = "Speaker 1", startTime = 0.0, endTime = 10.0, body = "Hello."),
                 TranscriptCue(speaker = null, startTime = 11.0, endTime = 20.0, body = "World!"),
@@ -244,7 +244,7 @@ class TranscriptViewModelTest {
             subtitleParserFactory = subtitleParserFactory,
             ioDispatcher = UnconfinedTestDispatcher(),
             analyticsTracker = mock(),
-            transcriptJsonParser = transcriptJsonParser,
+            transcriptJsonConverter = transcriptJsonConverter,
         )
     }
 }

--- a/modules/features/player/src/test/java/au/com/shiftyjelly/pocketcasts/player/view/transcripts/TranscriptViewModelTest.kt
+++ b/modules/features/player/src/test/java/au/com/shiftyjelly/pocketcasts/player/view/transcripts/TranscriptViewModelTest.kt
@@ -2,6 +2,8 @@ package au.com.shiftyjelly.pocketcasts.player.view.transcripts
 
 import androidx.media3.extractor.text.SubtitleParser
 import app.cash.turbine.test
+import au.com.shiftyjelly.pocketcasts.models.converter.TranscriptCue
+import au.com.shiftyjelly.pocketcasts.models.converter.TranscriptJsonConverter
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.to.Transcript
 import au.com.shiftyjelly.pocketcasts.player.view.transcripts.TranscriptViewModel.TranscriptError

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/converter/TranscriptJsonConverter.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/converter/TranscriptJsonConverter.kt
@@ -1,4 +1,4 @@
-package au.com.shiftyjelly.pocketcasts.player.view.transcripts
+package au.com.shiftyjelly.pocketcasts.models.converter
 
 import com.squareup.moshi.Json
 import com.squareup.moshi.JsonAdapter

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/to/TranscriptCuesInfo.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/to/TranscriptCuesInfo.kt
@@ -1,0 +1,15 @@
+@file:UnstableApi
+
+package au.com.shiftyjelly.pocketcasts.models.to
+
+import androidx.media3.common.util.UnstableApi
+import androidx.media3.extractor.text.CuesWithTiming
+
+data class TranscriptCuesInfo(
+    val cuesWithTiming: CuesWithTiming,
+    val cuesAdditionalInfo: CuesAdditionalInfo? = null,
+)
+
+data class CuesAdditionalInfo(
+    val speaker: String?,
+)

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/TranscriptCuesInfoBuilder.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/TranscriptCuesInfoBuilder.kt
@@ -1,0 +1,104 @@
+package au.com.shiftyjelly.pocketcasts.repositories.podcast
+
+import androidx.media3.common.Format
+import androidx.media3.common.text.Cue
+import androidx.media3.common.util.UnstableApi
+import androidx.media3.extractor.text.CuesWithTiming
+import androidx.media3.extractor.text.SubtitleParser
+import au.com.shiftyjelly.pocketcasts.models.converter.TranscriptJsonConverter
+import au.com.shiftyjelly.pocketcasts.models.to.CuesAdditionalInfo
+import au.com.shiftyjelly.pocketcasts.models.to.Transcript
+import au.com.shiftyjelly.pocketcasts.models.to.TranscriptCuesInfo
+import au.com.shiftyjelly.pocketcasts.utils.exception.EmptyDataException
+import au.com.shiftyjelly.pocketcasts.utils.exception.ParsingException
+import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
+import com.google.common.collect.ImmutableList
+import javax.inject.Inject
+import kotlin.time.DurationUnit
+import kotlin.time.toDuration
+import okhttp3.ResponseBody
+import okhttp3.internal.toImmutableList
+
+@UnstableApi
+class TranscriptCuesInfoBuilder @Inject constructor(
+    private val subtitleParserFactory: SubtitleParser.Factory,
+    private val transcriptJsonConverter: TranscriptJsonConverter,
+) {
+    fun build(
+        transcript: Transcript,
+        transcriptResponse: ResponseBody?,
+    ): List<TranscriptCuesInfo> =
+        when (transcript.type) {
+            TranscriptFormat.HTML.mimeType -> {
+                val content = transcriptResponse?.string() ?: ""
+                if (content.trim().isEmpty()) {
+                    throw EmptyDataException("Transcript content is empty ${transcript.url}")
+                } else {
+                    // Html content is added as single large cue
+                    ImmutableList.of(
+                        CuesWithTiming(
+                            ImmutableList.of(Cue.Builder().setText(content).build()),
+                            0,
+                            0,
+                        ).toTranscriptCuesInfo(),
+                    )
+                }
+            }
+
+            TranscriptFormat.JSON_PODCAST_INDEX.mimeType -> {
+                val jsonString = transcriptResponse?.string() ?: ""
+                if (jsonString.trim().isEmpty()) {
+                    throw EmptyDataException("Transcript content is empty ${transcript.url}")
+                } else {
+                    // Parse json following PodcastIndex.org transcript json spec: https://github.com/Podcastindex-org/podcast-namespace/blob/main/transcripts/transcripts.md#json
+                    val transcriptCues = transcriptJsonConverter.fromString(jsonString)
+                    transcriptCues.map { cue ->
+                        val startTimeUs = cue.startTime?.toMicroSeconds ?: 0
+                        val endTimeUs = cue.endTime?.toMicroSeconds ?: 0
+                        CuesWithTiming(
+                            ImmutableList.of(Cue.Builder().setText(cue.body ?: "").build()),
+                            startTimeUs,
+                            endTimeUs - startTimeUs,
+                        ).toTranscriptCuesInfo(
+                            cuesAdditionalInfo = CuesAdditionalInfo(speaker = cue.speaker),
+                        )
+                    }.toImmutableList()
+                }
+            }
+
+            else -> {
+                val format = Format.Builder()
+                    .setSampleMimeType(transcript.type)
+                    .build()
+                if (subtitleParserFactory.supportsFormat(format).not()) {
+                    throw UnsupportedOperationException("Unsupported MIME type: ${transcript.type}")
+                } else {
+                    val result = ImmutableList.builder<CuesWithTiming>()
+                    transcriptResponse?.bytes()?.let { data ->
+                        try {
+                            val parser = subtitleParserFactory.create(format)
+                            parser.parse(
+                                data,
+                                SubtitleParser.OutputOptions.allCues(),
+                            ) { element: CuesWithTiming? ->
+                                element?.let { result.add(it) }
+                            }
+                        } catch (e: Exception) {
+                            val message = "Failed to parse transcript: ${transcript.url}"
+                            LogBuffer.e(LogBuffer.TAG_INVALID_STATE, e, message)
+                            throw ParsingException(message)
+                        }
+                    }
+                    val cuesInfo = result.build().map { it.toTranscriptCuesInfo() }
+                    cuesInfo.ifEmpty { throw throw EmptyDataException("Transcript content is empty ${transcript.url}") }
+                }
+            }
+        }
+
+    private val Double.toMicroSeconds: Long
+        get() = toDuration(DurationUnit.SECONDS).inWholeMicroseconds
+
+    private fun CuesWithTiming.toTranscriptCuesInfo(
+        cuesAdditionalInfo: CuesAdditionalInfo? = null,
+    ) = TranscriptCuesInfo(this, cuesAdditionalInfo)
+}

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/TranscriptsManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/TranscriptsManager.kt
@@ -1,8 +1,10 @@
 package au.com.shiftyjelly.pocketcasts.repositories.podcast
 
+import androidx.annotation.OptIn
+import androidx.media3.common.util.UnstableApi
 import au.com.shiftyjelly.pocketcasts.models.to.Transcript
+import au.com.shiftyjelly.pocketcasts.models.to.TranscriptCuesInfo
 import kotlinx.coroutines.flow.Flow
-import okhttp3.ResponseBody
 
 interface TranscriptsManager {
     suspend fun updateTranscripts(
@@ -13,11 +15,12 @@ interface TranscriptsManager {
 
     fun observerTranscriptForEpisode(episodeUuid: String): Flow<Transcript?>
 
-    suspend fun loadTranscript(
-        url: String,
+    @OptIn(UnstableApi::class)
+    suspend fun loadTranscriptCuesInfo(
+        transcript: Transcript,
         source: LoadTranscriptSource = LoadTranscriptSource.DEFAULT,
         forceRefresh: Boolean = false,
-    ): ResponseBody?
+    ): List<TranscriptCuesInfo>
 }
 
 enum class LoadTranscriptSource {

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/TranscriptsManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/TranscriptsManagerImpl.kt
@@ -71,7 +71,7 @@ class TranscriptsManagerImpl @Inject constructor(
     private suspend fun fetchTranscript(
         forceRefresh: Boolean,
         transcript: Transcript,
-        source: LoadTranscriptSource
+        source: LoadTranscriptSource,
     ) = try {
         var response = if (forceRefresh && networkWrapper.isConnected()) {
             service.getTranscript(transcript.url, CacheControl.FORCE_NETWORK)

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/TranscriptsManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/TranscriptsManagerImpl.kt
@@ -1,23 +1,32 @@
 package au.com.shiftyjelly.pocketcasts.repositories.podcast
 
+import androidx.annotation.OptIn
 import androidx.annotation.VisibleForTesting
+import androidx.media3.common.util.UnstableApi
 import au.com.shiftyjelly.pocketcasts.models.db.dao.TranscriptDao
 import au.com.shiftyjelly.pocketcasts.models.to.Transcript
+import au.com.shiftyjelly.pocketcasts.repositories.di.ApplicationScope
+import au.com.shiftyjelly.pocketcasts.servers.ServerShowNotesManager
 import au.com.shiftyjelly.pocketcasts.servers.podcast.TranscriptCacheServer
 import au.com.shiftyjelly.pocketcasts.utils.NetworkWrapper
 import au.com.shiftyjelly.pocketcasts.utils.exception.NoNetworkException
 import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
 import java.net.UnknownHostException
 import javax.inject.Inject
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import okhttp3.CacheControl
 import okhttp3.Headers
 
+@OptIn(UnstableApi::class)
 class TranscriptsManagerImpl @Inject constructor(
     private val transcriptDao: TranscriptDao,
     private val service: TranscriptCacheServer,
     private val networkWrapper: NetworkWrapper,
+    private val serverShowNotesManager: ServerShowNotesManager,
+    @ApplicationScope private val scope: CoroutineScope,
+    private val transcriptCuesInfoBuilder: TranscriptCuesInfoBuilder,
 ) : TranscriptsManager {
     private val supportedFormats = listOf(TranscriptFormat.SRT, TranscriptFormat.VTT, TranscriptFormat.JSON_PODCAST_INDEX, TranscriptFormat.HTML)
 
@@ -30,7 +39,7 @@ class TranscriptsManagerImpl @Inject constructor(
         findBestTranscript(transcripts)?.let { bestTranscript ->
             transcriptDao.insert(bestTranscript)
             if (loadTranscriptSource == LoadTranscriptSource.DOWNLOAD_EPISODE) {
-                loadTranscript(bestTranscript.url, loadTranscriptSource, forceRefresh = true)
+                loadTranscriptCuesInfo(bestTranscript, loadTranscriptSource, forceRefresh = true)
             }
         }
     }
@@ -49,39 +58,47 @@ class TranscriptsManagerImpl @Inject constructor(
         return availableTranscripts.firstOrNull()
     }
 
-    override suspend fun loadTranscript(
-        url: String,
+    @OptIn(UnstableApi::class)
+    override suspend fun loadTranscriptCuesInfo(
+        transcript: Transcript,
         source: LoadTranscriptSource,
         forceRefresh: Boolean,
     ) = withContext(Dispatchers.IO) {
-        try {
-            var response = if (forceRefresh && networkWrapper.isConnected()) {
-                service.getTranscript(url, CacheControl.FORCE_NETWORK)
+        val result = fetchTranscript(forceRefresh, transcript, source)
+        transcriptCuesInfoBuilder.build(transcript, result)
+    }
+
+    private suspend fun fetchTranscript(
+        forceRefresh: Boolean,
+        transcript: Transcript,
+        source: LoadTranscriptSource
+    ) = try {
+        var response = if (forceRefresh && networkWrapper.isConnected()) {
+            service.getTranscript(transcript.url, CacheControl.FORCE_NETWORK)
+        } else {
+            service.getTranscript(transcript.url, CacheControl.parse(Headers.headersOf("Cache-Control", "only-if-cached, max-stale=7776000")))
+        }
+        if (response.isSuccessful) {
+            response.body()
+        } else {
+            if (!networkWrapper.isConnected()) {
+                throw NoNetworkException()
             } else {
-                service.getTranscript(url, CacheControl.parse(Headers.headersOf("Cache-Control", "only-if-cached, max-stale=7776000")))
-            }
-            if (response.isSuccessful) {
-                response.body()
-            } else {
-                if (!networkWrapper.isConnected()) {
-                    throw NoNetworkException()
+                response = service.getTranscript(transcript.url, CacheControl.FORCE_NETWORK)
+                if (response.isSuccessful) {
+                    response.body()
                 } else {
-                    response = service.getTranscript(url, CacheControl.FORCE_NETWORK)
-                    if (response.isSuccessful) {
-                        response.body()
-                    } else {
-                        LogBuffer.e(LogBuffer.TAG_INVALID_STATE, "Failed to load transcript from $url: ${response.errorBody()}")
-                        response.errorBody()
-                    }
+                    LogBuffer.e(LogBuffer.TAG_INVALID_STATE, "Failed to load transcript from ${transcript.url}: ${response.errorBody()}")
+                    response.errorBody()
                 }
             }
-        } catch (e: UnknownHostException) {
-            LogBuffer.e(LogBuffer.TAG_INVALID_STATE, "Failed to load transcript from $url", e)
-            if (source == LoadTranscriptSource.DOWNLOAD_EPISODE) null else throw NoNetworkException() // fail silently if loaded as part of episode download
-        } catch (e: Exception) {
-            LogBuffer.e(LogBuffer.TAG_INVALID_STATE, "Failed to load transcript from $url", e)
-            if (source == LoadTranscriptSource.DOWNLOAD_EPISODE) null else throw e // fail silently if loaded as part of episode download
         }
+    } catch (e: UnknownHostException) {
+        LogBuffer.e(LogBuffer.TAG_INVALID_STATE, "Failed to load transcript from $${transcript.url}", e)
+        if (source == LoadTranscriptSource.DOWNLOAD_EPISODE) null else throw NoNetworkException() // fail silently if loaded as part of episode download
+    } catch (e: Exception) {
+        LogBuffer.e(LogBuffer.TAG_INVALID_STATE, "Failed to load transcript from $${transcript.url}", e)
+        if (source == LoadTranscriptSource.DOWNLOAD_EPISODE) null else throw e // fail silently if loaded as part of episode download
     }
 }
 

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/shownotes/ShowNotesProcessor.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/shownotes/ShowNotesProcessor.kt
@@ -102,11 +102,11 @@ class ShowNotesProcessor @Inject constructor(
         url = url,
         isEmbedded = false,
     )
-
-    private fun ShowNotesTranscript.toTranscript(episodeUuid: String) = Transcript(
-        episodeUuid = episodeUuid,
-        url = requireNotNull(url),
-        type = requireNotNull(type),
-        language = language,
-    )
 }
+
+fun ShowNotesTranscript.toTranscript(episodeUuid: String) = Transcript(
+    episodeUuid = episodeUuid,
+    url = requireNotNull(url),
+    type = requireNotNull(type),
+    language = language,
+)

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/TranscriptCuesInfoBuilderTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/TranscriptCuesInfoBuilderTest.kt
@@ -1,0 +1,101 @@
+package au.com.shiftyjelly.pocketcasts.repositories.podcast
+
+import androidx.media3.extractor.text.SubtitleParser
+import au.com.shiftyjelly.pocketcasts.models.converter.TranscriptCue
+import au.com.shiftyjelly.pocketcasts.models.converter.TranscriptJsonConverter
+import au.com.shiftyjelly.pocketcasts.models.to.Transcript
+import au.com.shiftyjelly.pocketcasts.utils.exception.EmptyDataException
+import au.com.shiftyjelly.pocketcasts.utils.exception.ParsingException
+import kotlinx.coroutines.test.runTest
+import okhttp3.ResponseBody
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertThrows
+import org.junit.Before
+import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+
+class TranscriptCuesInfoBuilderTest {
+    private val subtitleParserFactory: SubtitleParser.Factory = mock()
+    private val transcriptJsonConverter: TranscriptJsonConverter = mock()
+    private val transcript: Transcript = Transcript("episode_id", "url", "type")
+    private lateinit var transcriptCuesInfoBuilder: TranscriptCuesInfoBuilder
+
+    @Before
+    fun setUp() {
+        transcriptCuesInfoBuilder = TranscriptCuesInfoBuilder(subtitleParserFactory, transcriptJsonConverter)
+    }
+
+    @Test
+    fun `html transcript is parsed correctly`() = runTest {
+        val response = mock<ResponseBody>()
+        whenever(response.string()).thenReturn("<p>Hello World</p>")
+
+        val result = transcriptCuesInfoBuilder.build(transcript.copy(type = TranscriptFormat.HTML.mimeType), response)
+
+        assertEquals("<p>Hello World</p>", result.first().cuesWithTiming.cues.first().text.toString())
+    }
+
+    @Test
+    fun `json podcast index transcript is parsed correctly`() = runTest {
+        val response = mock<ResponseBody>()
+        val jsonString = """[{"startTime": 0.0, "endTime": 5.0, "body": "Hello World", "speaker": "John"}]"""
+        whenever(response.string()).thenReturn(jsonString)
+        whenever(transcriptJsonConverter.fromString(jsonString)).thenReturn(listOf(TranscriptCue(startTime = 0.0, endTime = 5.0, body = "Hello World", speaker = "John")))
+
+        val result = transcriptCuesInfoBuilder.build(transcript.copy(type = TranscriptFormat.JSON_PODCAST_INDEX.mimeType), response)
+
+        assertEquals("Hello World", result.first().cuesWithTiming.cues.first().text.toString())
+        assertEquals("John", result.first().cuesAdditionalInfo?.speaker)
+    }
+
+    @Test
+    fun `unsupported mime type throws exception`() = runTest {
+        val response = mock<ResponseBody>()
+        val unsupportedTranscript = transcript.copy(type = "unsupported/type")
+
+        assertThrows(UnsupportedOperationException::class.java) {
+            transcriptCuesInfoBuilder.build(unsupportedTranscript, response)
+        }
+    }
+
+    @Test
+    fun `empty html transcript throws EmptyDataException`() = runTest {
+        val response = mock<ResponseBody>()
+        whenever(response.string()).thenReturn("")
+        val emptyHtmlTranscript = transcript.copy(type = TranscriptFormat.HTML.mimeType)
+
+        assertThrows(EmptyDataException::class.java) {
+            transcriptCuesInfoBuilder.build(emptyHtmlTranscript, response)
+        }
+    }
+
+    @Test
+    fun `empty json podcast index transcript throws EmptyDataException`() = runTest {
+        val response = mock<ResponseBody>()
+        whenever(response.string()).thenReturn("")
+        val emptyJsonTranscript = transcript.copy(type = TranscriptFormat.JSON_PODCAST_INDEX.mimeType)
+
+        assertThrows(EmptyDataException::class.java) {
+            transcriptCuesInfoBuilder.build(emptyJsonTranscript, response)
+        }
+    }
+
+    @Test
+    fun `parsing exception is thrown for invalid subtitle data`() = runTest {
+        whenever(subtitleParserFactory.supportsFormat(any())).thenReturn(true)
+        val response = mock<ResponseBody>()
+        whenever(response.bytes()).thenReturn(byteArrayOf(1.toByte()))
+        val parser = mock<SubtitleParser>()
+        whenever(subtitleParserFactory.create(anyOrNull())).thenReturn(parser)
+        whenever(parser.parse(any(), any(), any())).thenThrow(RuntimeException("Parsing error"))
+
+        val invalidSubtitleTranscript = transcript
+
+        assertThrows(ParsingException::class.java) {
+            transcriptCuesInfoBuilder.build(invalidSubtitleTranscript, response)
+        }
+    }
+}

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/TranscriptsManagerImplTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/TranscriptsManagerImplTest.kt
@@ -25,7 +25,15 @@ class TranscriptsManagerImplTest {
     private val transcriptDao: TranscriptDao = mock()
     private val transcriptCacheServer: TranscriptCacheServer = mock()
     private val networkWrapper: NetworkWrapper = mock()
-    private val transcriptsManager = TranscriptsManagerImpl(transcriptDao, transcriptCacheServer, networkWrapper)
+    private val transcript = Transcript("1", "url_1", "application/srt")
+    private val transcriptsManager = TranscriptsManagerImpl(
+        transcriptDao = transcriptDao,
+        service = transcriptCacheServer,
+        networkWrapper = networkWrapper,
+        serverShowNotesManager = mock(),
+        scope = mock(),
+        transcriptCuesInfoBuilder = mock(),
+    )
 
     @Test
     fun `findBestTranscript returns first supported transcript`() = runTest {
@@ -79,7 +87,7 @@ class TranscriptsManagerImplTest {
         whenever(response.isSuccessful).thenReturn(true)
         whenever(transcriptCacheServer.getTranscript(any(), any())).thenReturn(response)
 
-        transcriptsManager.loadTranscript("url_1", forceRefresh = true)
+        transcriptsManager.loadTranscriptCuesInfo(transcript, forceRefresh = true)
 
         verify(transcriptCacheServer).getTranscript("url_1", CacheControl.FORCE_NETWORK)
     }
@@ -91,7 +99,7 @@ class TranscriptsManagerImplTest {
         whenever(response.isSuccessful).thenReturn(true)
         whenever(transcriptCacheServer.getTranscript(any(), any())).thenReturn(response)
 
-        transcriptsManager.loadTranscript("url_1", forceRefresh = true)
+        transcriptsManager.loadTranscriptCuesInfo(transcript, forceRefresh = true)
 
         verify(transcriptCacheServer).getTranscript(eq("url_1"), argWhere { it.onlyIfCached })
     }
@@ -102,7 +110,7 @@ class TranscriptsManagerImplTest {
         whenever(response.isSuccessful).thenReturn(true)
         whenever(transcriptCacheServer.getTranscript(any(), any())).thenReturn(response)
 
-        transcriptsManager.loadTranscript("url_1")
+        transcriptsManager.loadTranscriptCuesInfo(transcript)
 
         verify(transcriptCacheServer).getTranscript(eq("url_1"), argWhere { it.onlyIfCached })
     }
@@ -114,7 +122,7 @@ class TranscriptsManagerImplTest {
         whenever(response.isSuccessful).thenReturn(false)
         whenever(transcriptCacheServer.getTranscript(any(), any())).thenReturn(response)
 
-        transcriptsManager.loadTranscript("url_1")
+        transcriptsManager.loadTranscriptCuesInfo(transcript)
 
         verify(transcriptCacheServer).getTranscript("url_1", CacheControl.FORCE_NETWORK)
     }
@@ -127,7 +135,7 @@ class TranscriptsManagerImplTest {
         whenever(transcriptCacheServer.getTranscript(any(), any())).thenReturn(response)
 
         try {
-            transcriptsManager.loadTranscript("url_1")
+            transcriptsManager.loadTranscriptCuesInfo(transcript)
         } catch (e: Exception) {
             assertTrue(e is NoNetworkException)
         }

--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/exception/EmptyDataException.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/exception/EmptyDataException.kt
@@ -1,0 +1,3 @@
+package au.com.shiftyjelly.pocketcasts.utils.exception
+
+class EmptyDataException(message: String) : Exception(message)

--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/exception/ParsingException.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/exception/ParsingException.kt
@@ -1,0 +1,3 @@
+package au.com.shiftyjelly.pocketcasts.utils.exception
+
+class ParsingException(message: String) : Exception(message)


### PR DESCRIPTION
## Description
This extracts cue building from the VM to a builder and loads cues from the manager. 
This will help us know empty transcripts while downloading episodes, allowing fallback to alternative transcripts later ([PR](https://github.com/Automattic/pocket-casts-android/pull/2704)). 

## Testing Instructions
1. CI should be green
2. Smoke test that you can still load transcripts as before
3. Notice that currently, you see an empty transcript error for any episodes from chaosRadio (eg. https://pca.st/r2ct46up)

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
