### PR TITLE
Add Pocket Casts logo to all cards

### DIFF
--- a/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/ui/HorizontalCard.kt
+++ b/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/ui/HorizontalCard.kt
@@ -2,6 +2,7 @@ package au.com.shiftyjelly.pocketcasts.sharing.ui
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -22,6 +23,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
+import au.com.shiftyjelly.pocketcasts.compose.components.PocketCastsLogo
 import au.com.shiftyjelly.pocketcasts.compose.components.TextH40
 import au.com.shiftyjelly.pocketcasts.compose.components.TextH70
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
@@ -109,52 +111,66 @@ private fun HorizontalCard(
     } else {
         size.width to size.width * CardType.Horizontal.aspectRatio
     }
-    Row(
-        verticalAlignment = Alignment.CenterVertically,
+    Box(
+        contentAlignment = Alignment.Center,
         modifier = Modifier
             .capturable(captureController)
             .background(backgroundGradient, RoundedCornerShape(12.dp))
             .width(width)
             .height(height),
     ) {
-        Spacer(
-            modifier = Modifier.width(height * 0.15f),
-        )
-        data.Image(
-            modifier = Modifier
-                .size(height * 0.7f)
-                .clip(RoundedCornerShape(8.dp)),
-        )
-        Spacer(
-            modifier = Modifier.width(height * 0.15f),
-        )
-        Column(
-            verticalArrangement = Arrangement.Center,
-            modifier = Modifier.padding(end = height * 0.15f),
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
         ) {
-            TextH70(
-                text = data.topText(),
-                disableScale = true,
-                color = shareColors.cardTextSecondary,
-                maxLines = 1,
+            Spacer(
+                modifier = Modifier.width(height * 0.15f),
+            )
+            data.Image(
+                modifier = Modifier
+                    .size(height * 0.7f)
+                    .clip(RoundedCornerShape(8.dp)),
             )
             Spacer(
-                modifier = Modifier.height(6.dp),
+                modifier = Modifier.width(height * 0.10f),
             )
-            TextH40(
-                text = data.middleText(),
-                disableScale = true,
-                color = shareColors.cardTextPrimary,
-                maxLines = 3,
-            )
-            Spacer(
-                modifier = Modifier.height(6.dp),
-            )
-            TextH70(
-                text = data.bottomText(),
-                disableScale = true,
-                maxLines = 2,
-                color = shareColors.cardTextSecondary,
+            Column(
+                verticalArrangement = Arrangement.Center,
+                modifier = Modifier.padding(end = height * 0.15f),
+            ) {
+                TextH70(
+                    text = data.topText(),
+                    disableScale = true,
+                    color = shareColors.cardTextSecondary,
+                    maxLines = 1,
+                    modifier = Modifier.padding(end = height * 0.08f),
+                )
+                Spacer(
+                    modifier = Modifier.height(6.dp),
+                )
+                TextH40(
+                    text = data.middleText(),
+                    disableScale = true,
+                    color = shareColors.cardTextPrimary,
+                    maxLines = 3,
+                )
+                Spacer(
+                    modifier = Modifier.height(6.dp),
+                )
+                TextH70(
+                    text = data.bottomText(),
+                    disableScale = true,
+                    maxLines = 2,
+                    color = shareColors.cardTextSecondary,
+                )
+            }
+        }
+        Box(
+            modifier = Modifier
+                .align(Alignment.TopEnd)
+                .padding(top = height * 0.08f, end = height * 0.08f),
+        ) {
+            PocketCastsLogo(
+                modifier = Modifier.size(height * 0.15f),
             )
         }
     }

--- a/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/ui/SquareCard.kt
+++ b/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/ui/SquareCard.kt
@@ -20,6 +20,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
+import au.com.shiftyjelly.pocketcasts.compose.components.PocketCastsPill
 import au.com.shiftyjelly.pocketcasts.compose.components.TextH40
 import au.com.shiftyjelly.pocketcasts.compose.components.TextH70
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
@@ -91,6 +92,7 @@ private fun SquareCard(
     )
     val size = constrainedSize(maxWidth, maxHeight)
     val minDimension = minOf(size.width, size.height)
+    val isCardSmall = minDimension < 280.dp
     Column(
         horizontalAlignment = Alignment.CenterHorizontally,
         modifier = Modifier
@@ -99,7 +101,7 @@ private fun SquareCard(
             .size(minDimension),
     ) {
         Spacer(
-            modifier = Modifier.height(42.dp),
+            modifier = Modifier.height(if (isCardSmall) 26.dp else 32.dp),
         )
         data.Image(
             modifier = Modifier
@@ -107,14 +109,14 @@ private fun SquareCard(
                 .clip(RoundedCornerShape(8.dp)),
         )
         Spacer(
-            modifier = Modifier.height(24.dp),
+            modifier = Modifier.height(if (isCardSmall) 12.dp else 16.dp),
         )
         TextH70(
             text = data.topText(),
             disableScale = true,
             maxLines = 1,
             color = shareColors.cardTextSecondary,
-            modifier = Modifier.padding(horizontal = 64.dp),
+            modifier = Modifier.padding(horizontal = 24.dp),
         )
         Spacer(
             modifier = Modifier.height(6.dp),
@@ -125,7 +127,7 @@ private fun SquareCard(
             maxLines = 2,
             textAlign = TextAlign.Center,
             color = shareColors.cardTextPrimary,
-            modifier = Modifier.padding(horizontal = 42.dp),
+            modifier = Modifier.padding(horizontal = 24.dp),
         )
         Spacer(
             modifier = Modifier.height(6.dp),
@@ -133,10 +135,19 @@ private fun SquareCard(
         TextH70(
             text = data.bottomText(),
             disableScale = true,
-            maxLines = 2,
+            maxLines = 1,
             textAlign = TextAlign.Center,
             color = shareColors.cardTextSecondary,
-            modifier = Modifier.padding(horizontal = 64.dp),
+            modifier = Modifier.padding(horizontal = 24.dp),
+        )
+        Spacer(
+            modifier = Modifier.weight(1f),
+        )
+        PocketCastsPill(
+            disableScale = true,
+        )
+        Spacer(
+            modifier = Modifier.weight(2f),
         )
     }
 }

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/PocketCastsPill.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/PocketCastsPill.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -47,6 +48,18 @@ fun PocketCastsPill(
     )
 }
 
+@Composable
+fun PocketCastsLogo(
+    modifier: Modifier = Modifier,
+) = Image(
+    painter = painterResource(id = IR.drawable.ic_logo_foreground),
+    contentDescription = null,
+    modifier = Modifier
+        .background(Color(0xFFF43E37), CircleShape)
+        .size(24.dp)
+        .then(modifier),
+)
+
 @Preview
 @Composable
 private fun PocketCastsPillPreview() = Box(
@@ -56,4 +69,15 @@ private fun PocketCastsPillPreview() = Box(
         .size(180.dp, 90.dp),
 ) {
     PocketCastsPill()
+}
+
+@Preview
+@Composable
+private fun PocketCastsLogoPreview() = Box(
+    contentAlignment = Alignment.Center,
+    modifier = Modifier
+        .background(Color.White)
+        .size(32.dp, 32.dp),
+) {
+    PocketCastsLogo()
 }


### PR DESCRIPTION
## Description

This PR adds logo to shared horizontal and square cards. See: pdeCcb-50w-p2#comment-5190

## Testing Instructions

1. Share something to IG with a horizontal card. It should contain PC logo.
2. Share something to IG with a square card. It should contain PC logo.

## Screenshots or Screencast 

| Horizontal | Square |
| - | - |
| ![h](https://github.com/user-attachments/assets/6d3b3acc-7498-4509-8dc4-84b9c7615341) | ![s](https://github.com/user-attachments/assets/911b892c-003a-4913-9c03-34b74729f7aa) |

## Checklist
- [x] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] ~I have considered whether it makes sense to add tests for my changes~
- [x] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack