### PR TITLE
Improve clip timeline interactions

### DIFF
--- a/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/ui/ClipSelector.kt
+++ b/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/ui/ClipSelector.kt
@@ -1,8 +1,10 @@
 package au.com.shiftyjelly.pocketcasts.sharing.ui
 
+import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.gestures.Orientation
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.gestures.draggable
@@ -43,6 +45,7 @@ import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -91,6 +94,7 @@ import kotlin.time.Duration.Companion.hours
 import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Duration.Companion.seconds
 import kotlin.time.DurationUnit
+import kotlinx.coroutines.launch
 import au.com.shiftyjelly.pocketcasts.images.R as IR
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
@@ -128,6 +132,7 @@ internal fun ClipSelector(
     }
 }
 
+@OptIn(ExperimentalFoundationApi::class)
 @Composable
 private fun TouchClipSelector(
     episodeDuration: Duration,
@@ -139,6 +144,7 @@ private fun TouchClipSelector(
     modifier: Modifier = Modifier,
     state: ClipSelectorState,
 ) {
+    val coroutineScope = rememberCoroutineScope()
     val density = LocalDensity.current
     LaunchedEffect(state.scale) {
         state.refreshItemWidth(density)
@@ -190,6 +196,10 @@ private fun TouchClipSelector(
             TextH70(
                 text = stringResource(LR.string.share_clip_start_position, clipRange.start.toHhMmSs()),
                 color = shareColors.onBackgroundSecondary,
+                modifier = Modifier.combinedClickable(
+                    onClick = {},
+                    onLongClick = { coroutineScope.launch { state.scrollTo(clipRange.start) } },
+                ),
             )
             Spacer(
                 modifier = Modifier.weight(1f),
@@ -197,6 +207,10 @@ private fun TouchClipSelector(
             TextH70(
                 text = stringResource(LR.string.share_clip_duration, clipRange.duration.toHhMmSs()),
                 color = shareColors.onBackgroundSecondary,
+                modifier = Modifier.combinedClickable(
+                    onClick = {},
+                    onLongClick = { coroutineScope.launch { state.scrollTo(clipRange.end) } },
+                ),
             )
         }
     }

--- a/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/ui/ClipSelector.kt
+++ b/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/ui/ClipSelector.kt
@@ -302,8 +302,9 @@ private fun BoxWithConstraintsScope.ClipTimeline(
                 )
             },
     ) {
+        val tickCount = episodeDuration.inWholeSeconds.toInt().ceilDiv(state.secondsPerTick)
         items(
-            count = episodeDuration.inWholeSeconds.toInt().ceilDiv(state.secondsPerTick) + 1,
+            count = tickCount,
             key = { index -> index },
         ) { index ->
             val heightIndex = when (index % 10) {
@@ -317,6 +318,9 @@ private fun BoxWithConstraintsScope.ClipTimeline(
                     .height(heightIndex)
                     .background(shareColors.onBackgroundSecondary),
             )
+            if (index == tickCount - 1) {
+                Spacer(modifier = Modifier.width(32.dp))
+            }
         }
     }
 }

--- a/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/ui/ClipSelectorState.kt
+++ b/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/ui/ClipSelectorState.kt
@@ -132,7 +132,7 @@ internal class ClipSelectorState(
 
     suspend fun scrollTo(duration: Duration) {
         val index = duration.inWholeSeconds / secondsPerTick
-        val offset = durationToPixels(15.seconds)
+        val offset = durationToPixels(15.seconds * secondsPerTick)
         listState.animateScrollToItem(index.toInt(), scrollOffset = -offset.roundToInt())
     }
 

--- a/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/ui/ClipSelectorState.kt
+++ b/modules/features/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/ui/ClipSelectorState.kt
@@ -15,6 +15,7 @@ import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import au.com.shiftyjelly.pocketcasts.sharing.clip.Clip
+import kotlin.math.roundToInt
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
 import kotlin.time.DurationUnit
@@ -127,6 +128,12 @@ internal class ClipSelectorState(
                 onTimelineScaleUpdate(scale, secondsPerTick)
             }
         }
+    }
+
+    suspend fun scrollTo(duration: Duration) {
+        val index = duration.inWholeSeconds / secondsPerTick
+        val offset = durationToPixels(15.seconds)
+        listState.animateScrollToItem(index.toInt(), scrollOffset = -offset.roundToInt())
     }
 
     fun refreshItemWidth(density: Density) {


### PR DESCRIPTION
## Description

Some small improvements to clip sharing:
- Added scrolling to timeline handles on long pressing the time label.
- Added small empty space at the end of the timeline to provide easier end handle grabbing.

## Testing Instructions

1. Start clip sharing.
2. Put handles in some positions and scroll them out of your view.
3. Long press start label. It should scroll you back to the start handle.
4. Scroll timeline selector out of your view.
5. Long press end label. It should scroll you back to the end handle.
6. Scroll to the very and of the timeline. There should be small empty space.

## Screenshots or Screencast 

![screen-20240823-112735-ezgif com-optimize](https://github.com/user-attachments/assets/3c0a7b51-6d17-4307-b17d-b5724d8a73f6)

## Checklist
- [x] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] ~I have considered whether it makes sense to add tests for my changes~
- [x] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
