### PR TITLE
Transcripts - Disable transcript from shelf more options if transcript not available

### DIFF
--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/PlayerHeaderFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/PlayerHeaderFragment.kt
@@ -567,7 +567,10 @@ class PlayerHeaderFragment : BaseFragment(), PlayerClickListener {
             return
         }
         analyticsTracker.track(AnalyticsEvent.PLAYER_SHELF_OVERFLOW_MENU_SHOWN)
-        ShelfBottomSheet.newInstance(sourceView).show(childFragmentManager, "shelf_bottom_sheet")
+        ShelfBottomSheet.newInstance(
+            sourceView = sourceView,
+            episodeId = viewModel.episode?.uuid,
+        ).show(childFragmentManager, "shelf_bottom_sheet")
     }
 
     override fun onPlayClicked() {

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/ShelfFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/ShelfFragment.kt
@@ -304,7 +304,7 @@ class ShelfAdapter(val editable: Boolean, val listener: ((ShelfItem) -> Unit)? =
 
             val isEnabled = item != ShelfItem.Transcript || isTranscriptAvailable
             binding.root.isEnabled = isEnabled
-            binding.root.alpha = if (isEnabled) 1f else 0.5f
+            binding.root.alpha = if (isEnabled || editable) 1f else 0.5f
 
             binding.dragHandle.isVisible = editable
 

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/ShelfFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/ShelfFragment.kt
@@ -236,6 +236,11 @@ class ShelfAdapter(val editable: Boolean, val listener: ((ShelfItem) -> Unit)? =
             field = value
             notifyDataSetChanged()
         }
+    var isTranscriptAvailable: Boolean = false
+        set(value) {
+            field = value
+            notifyDataSetChanged()
+        }
 
     var normalBackground = Color.TRANSPARENT
     var selectedBackground = Color.BLACK
@@ -296,6 +301,11 @@ class ShelfAdapter(val editable: Boolean, val listener: ((ShelfItem) -> Unit)? =
 
             binding.lblTitle.setText(item.titleId(episode))
             binding.imgIcon.setImageResource(item.iconId(episode))
+
+            val isEnabled = item != ShelfItem.Transcript || isTranscriptAvailable
+            binding.root.isEnabled = isEnabled
+            binding.root.alpha = if (isEnabled) 1f else 0.5f
+
             binding.dragHandle.isVisible = editable
 
             if (listener != null) {

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/ShelfBottomSheetViewModel.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/ShelfBottomSheetViewModel.kt
@@ -11,7 +11,7 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.collectLatest
-import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.distinctUntilChangedBy
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
@@ -28,7 +28,7 @@ class ShelfBottomSheetViewModel @AssistedInject constructor(
         viewModelScope.launch {
             episodeId?.let {
                 transcriptsManager.observerTranscriptForEpisode(episodeId)
-                    .distinctUntilChanged { t1, t2 -> t1?.episodeUuid == t2?.episodeUuid }
+                    .distinctUntilChangedBy { it?.episodeUuid }
                     .stateIn(viewModelScope)
                     .collectLatest { transcript ->
                         _uiState.update { it.copy(transcript = transcript) }

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/ShelfBottomSheetViewModel.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/ShelfBottomSheetViewModel.kt
@@ -1,0 +1,48 @@
+package au.com.shiftyjelly.pocketcasts.player.viewmodel
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import au.com.shiftyjelly.pocketcasts.models.to.Transcript
+import au.com.shiftyjelly.pocketcasts.repositories.podcast.TranscriptsManager
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedFactory
+import dagger.assisted.AssistedInject
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+@HiltViewModel(assistedFactory = ShelfBottomSheetViewModel.Factory::class)
+class ShelfBottomSheetViewModel @AssistedInject constructor(
+    @Assisted private val episodeId: String?,
+    private val transcriptsManager: TranscriptsManager,
+) : ViewModel() {
+    private var _uiState: MutableStateFlow<UiState> = MutableStateFlow(UiState())
+    val uiState: StateFlow<UiState> = _uiState
+
+    init {
+        viewModelScope.launch {
+            episodeId?.let {
+                transcriptsManager.observerTranscriptForEpisode(episodeId)
+                    .distinctUntilChanged { t1, t2 -> t1?.episodeUuid == t2?.episodeUuid }
+                    .stateIn(viewModelScope)
+                    .collectLatest { transcript ->
+                        _uiState.update { it.copy(transcript = transcript) }
+                    }
+            } ?: _uiState.update { it.copy(transcript = null) }
+        }
+    }
+
+    data class UiState(
+        val transcript: Transcript? = null,
+    )
+
+    @AssistedFactory
+    interface Factory {
+        fun create(episodeId: String?): ShelfBottomSheetViewModel
+    }
+}


### PR DESCRIPTION
## Description
This disables the transcript shelf menu item if transcript is not available for an episode


## Testing Instructions
1. Launch the app
2. Play an episode
3. Move transcript icon in the mini player to shelf menu
4. Play an episode with transcript
5. ✅ Notice that transcript icon in shelf menu is enabled
6. Play another episode without transcript
7. ✅ Notice that transcript shelf menu is disabled

## Screenshots or Screencast 

https://github.com/user-attachments/assets/f6cbbe27-dc00-4b1e-9b74-5fcbc667c269

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
