### PR TITLE
Upgrade to Fragment 1.8.2

### DIFF
--- a/base.gradle
+++ b/base.gradle
@@ -197,6 +197,7 @@ dependencies {
     implementation libs.bundles.billing
     implementation libs.bundles.coroutines
     implementation libs.bundles.firebase
+    implementation libs.bundles.fragment
     implementation libs.bundles.hilt
     implementation libs.bundles.lifecycle
     implementation libs.bundles.lottie
@@ -227,7 +228,6 @@ dependencies {
     implementation libs.core.ktx
     implementation libs.device.names
     implementation libs.flexbox
-    implementation libs.fragment.ktx
     implementation libs.glide
     implementation libs.glide.okhttp
     implementation libs.guava

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -28,6 +28,7 @@ compose-kotlin-compiler = "1.5.9"
 dependency-analysis = "1.28.0"
 espresso = "3.4.0"
 firebase = "30.5.0"
+fragment = "1.8.2"
 glance = "1.0.0"
 glide = "4.13.2"
 google-services = "4.3.14"
@@ -116,6 +117,10 @@ espresso-idling-resource = { module = "androidx.test.espresso:espresso-idling-re
 firebase-bom = { module = "com.google.firebase:firebase-bom", version.ref = "firebase" }
 firebase-analytics = { module = "com.google.firebase:firebase-analytics-ktx" }
 firebase-config = { module = "com.google.firebase:firebase-config-ktx" }
+
+# Fragments
+fragment-ktx = { module = "androidx.fragment:fragment-ktx", version.ref = "fragment" }
+fragment-compose = { module = "androidx.fragment:fragment-compose", version.ref = "fragment" }
 
 # Glide
 glide = { module = "com.github.bumptech.glide:glide", version.ref = "glide" }
@@ -258,7 +263,6 @@ encryptedlogging = "com.automattic:encryptedlogging:0.0.1"
 engage = "com.google.android.engage:engage-core:1.5.4"
 ffmpeg = "com.arthenica:ffmpeg-kit-full:6.0-2"
 flexbox = "com.google.android.flexbox:flexbox:3.0.0"
-fragment-ktx = "androidx.fragment:fragment-ktx:1.5.2"
 guava = "com.google.guava:guava:33.1.0-android" # Required to fix conflict between versions in exoplayer and workmanager
 jsonassert = "org.skyscreamer:jsonassert:1.5.0"
 junit = "junit:junit:4.13.2"
@@ -327,6 +331,11 @@ firebase = [
     "firebase-bom",
     "firebase-analytics",
     "firebase-config"
+]
+
+fragment = [
+    "fragment-ktx",
+    "fragment-compose"
 ]
 
 hilt = [

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/AdvancedSettingsFragment.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/AdvancedSettingsFragment.kt
@@ -2,13 +2,11 @@ package au.com.shiftyjelly.pocketcasts.settings
 
 import android.os.Bundle
 import android.view.LayoutInflater
-import android.view.View
 import android.view.ViewGroup
-import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.compose.ui.unit.dp
 import androidx.fragment.app.viewModels
+import androidx.fragment.compose.content
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import au.com.shiftyjelly.pocketcasts.compose.AppThemeWithBackground
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
@@ -27,22 +25,17 @@ class AdvancedSettingsFragment : BaseFragment() {
         inflater: LayoutInflater,
         container: ViewGroup?,
         savedInstanceState: Bundle?,
-    ): View {
-        return ComposeView(requireContext()).apply {
-            setContent {
-                val bottomInset = setting.bottomInset.collectAsStateWithLifecycle(initialValue = 0)
-                AppThemeWithBackground(theme.activeTheme) {
-                    setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
-                    AdvancedSettingsPage(
-                        viewModel = viewModel,
-                        onBackPressed = {
-                            @Suppress("DEPRECATION")
-                            activity?.onBackPressed()
-                        },
-                        bottomInset = bottomInset.value.pxToDp(LocalContext.current).dp,
-                    )
-                }
-            }
+    ) = content {
+        val bottomInset = setting.bottomInset.collectAsStateWithLifecycle(initialValue = 0)
+        AppThemeWithBackground(theme.activeTheme) {
+            AdvancedSettingsPage(
+                viewModel = viewModel,
+                onBackPressed = {
+                    @Suppress("DEPRECATION")
+                    activity?.onBackPressed()
+                },
+                bottomInset = bottomInset.value.pxToDp(LocalContext.current).dp,
+            )
         }
     }
 }

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/BetaFeaturesFragment.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/BetaFeaturesFragment.kt
@@ -2,7 +2,6 @@ package au.com.shiftyjelly.pocketcasts.settings
 
 import android.os.Bundle
 import android.view.LayoutInflater
-import android.view.View
 import android.view.ViewGroup
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.lazy.LazyColumn
@@ -11,9 +10,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.tooling.preview.Preview
@@ -21,6 +18,7 @@ import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.fragment.app.viewModels
+import androidx.fragment.compose.content
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import au.com.shiftyjelly.pocketcasts.compose.AppTheme
 import au.com.shiftyjelly.pocketcasts.compose.AppThemeWithBackground
@@ -50,24 +48,19 @@ class BetaFeaturesFragment : BaseFragment() {
         inflater: LayoutInflater,
         container: ViewGroup?,
         savedInstanceState: Bundle?,
-    ): View {
-        return ComposeView(requireContext()).apply {
-            setContent {
-                AppThemeWithBackground(theme.activeTheme) {
-                    setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
-                    val state by viewModel.state.collectAsState()
-                    val bottomInset = settings.bottomInset.collectAsStateWithLifecycle(0)
-                    BetaFeaturesPage(
-                        state = state,
-                        onFeatureEnabled = viewModel::setFeatureEnabled,
-                        onBackClick = {
-                            @Suppress("DEPRECATION")
-                            activity?.onBackPressed()
-                        },
-                        bottomInset = bottomInset.value.pxToDp(LocalContext.current).dp,
-                    )
-                }
-            }
+    ) = content {
+        AppThemeWithBackground(theme.activeTheme) {
+            val state by viewModel.state.collectAsState()
+            val bottomInset = settings.bottomInset.collectAsStateWithLifecycle(0)
+            BetaFeaturesPage(
+                state = state,
+                onFeatureEnabled = viewModel::setFeatureEnabled,
+                onBackClick = {
+                    @Suppress("DEPRECATION")
+                    activity?.onBackPressed()
+                },
+                bottomInset = bottomInset.value.pxToDp(LocalContext.current).dp,
+            )
         }
     }
 }

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/HeadphoneControlsSettingsFragment.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/HeadphoneControlsSettingsFragment.kt
@@ -17,9 +17,7 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.toArgb
-import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
@@ -27,6 +25,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import androidx.fragment.compose.content
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import au.com.shiftyjelly.pocketcasts.compose.AppThemeWithBackground
@@ -64,26 +63,23 @@ class HeadphoneControlsSettingsFragment : BaseFragment() {
         inflater: LayoutInflater,
         container: ViewGroup?,
         savedInstanceState: Bundle?,
-    ) = ComposeView(requireContext()).apply {
-        setContent {
-            val bottomInset = settings.bottomInset.collectAsStateWithLifecycle(initialValue = 0)
-            AppThemeWithBackground(theme.activeTheme) {
-                setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
-                val previousAction = settings.headphoneControlsPreviousAction.flow.collectAsState().value
-                val nextAction = settings.headphoneControlsNextAction.flow.collectAsState().value
-                val confirmationSound = settings.headphoneControlsPlayBookmarkConfirmationSound.flow.collectAsState().value
+    ) = content {
+        val bottomInset = settings.bottomInset.collectAsStateWithLifecycle(initialValue = 0)
+        AppThemeWithBackground(theme.activeTheme) {
+            val previousAction = settings.headphoneControlsPreviousAction.flow.collectAsState().value
+            val nextAction = settings.headphoneControlsNextAction.flow.collectAsState().value
+            val confirmationSound = settings.headphoneControlsPlayBookmarkConfirmationSound.flow.collectAsState().value
 
-                HeadphoneControlsSettingsPage(
-                    previousAction = previousAction,
-                    nextAction = nextAction,
-                    confirmationSound = confirmationSound,
-                    onBackPressed = {
-                        @Suppress("DEPRECATION")
-                        activity?.onBackPressed()
-                    },
-                    bottomInset = bottomInset.value.pxToDp(LocalContext.current).dp,
-                )
-            }
+            HeadphoneControlsSettingsPage(
+                previousAction = previousAction,
+                nextAction = nextAction,
+                confirmationSound = confirmationSound,
+                onBackPressed = {
+                    @Suppress("DEPRECATION")
+                    activity?.onBackPressed()
+                },
+                bottomInset = bottomInset.value.pxToDp(LocalContext.current).dp,
+            )
         }
     }
 

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/ManualCleanupFragment.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/ManualCleanupFragment.kt
@@ -4,9 +4,8 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import androidx.compose.ui.platform.ComposeView
-import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.fragment.app.viewModels
+import androidx.fragment.compose.content
 import au.com.shiftyjelly.pocketcasts.compose.AppThemeWithBackground
 import au.com.shiftyjelly.pocketcasts.settings.viewmodel.ManualCleanupViewModel
 import au.com.shiftyjelly.pocketcasts.views.fragments.BaseFragment
@@ -25,20 +24,15 @@ class ManualCleanupFragment : BaseFragment() {
         inflater: LayoutInflater,
         container: ViewGroup?,
         savedInstanceState: Bundle?,
-    ): View {
-        return ComposeView(requireContext()).apply {
-            setContent {
-                AppThemeWithBackground(theme.activeTheme) {
-                    setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
-                    ManualCleanupPage(
-                        viewModel = viewModel,
-                        onBackClick = {
-                            @Suppress("DEPRECATION")
-                            activity?.onBackPressed()
-                        },
-                    )
-                }
-            }
+    ) = content {
+        AppThemeWithBackground(theme.activeTheme) {
+            ManualCleanupPage(
+                viewModel = viewModel,
+                onBackClick = {
+                    @Suppress("DEPRECATION")
+                    activity?.onBackPressed()
+                },
+            )
         }
     }
 

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/StorageSettingsFragment.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/StorageSettingsFragment.kt
@@ -7,12 +7,11 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.activity.result.contract.ActivityResultContracts
-import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.compose.ui.unit.dp
 import androidx.core.content.ContextCompat
 import androidx.fragment.app.viewModels
+import androidx.fragment.compose.content
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.lifecycleScope
@@ -45,23 +44,18 @@ class StorageSettingsFragment : BaseFragment() {
         inflater: LayoutInflater,
         container: ViewGroup?,
         savedInstanceState: Bundle?,
-    ): View {
-        return ComposeView(requireContext()).apply {
-            setContent {
-                AppThemeWithBackground(theme.activeTheme) {
-                    setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
-                    val bottomInset = settings.bottomInset.collectAsStateWithLifecycle(0)
-                    StorageSettingsPage(
-                        viewModel = viewModel,
-                        onBackPressed = {
-                            @Suppress("DEPRECATION")
-                            activity?.onBackPressed()
-                        },
-                        onManageDownloadedFilesClick = { (activity as? FragmentHostListener)?.addFragment(ManualCleanupFragment.newInstance()) },
-                        bottomInset = bottomInset.value.pxToDp(LocalContext.current).dp,
-                    )
-                }
-            }
+    ) = content {
+        AppThemeWithBackground(theme.activeTheme) {
+            val bottomInset = settings.bottomInset.collectAsStateWithLifecycle(0)
+            StorageSettingsPage(
+                viewModel = viewModel,
+                onBackPressed = {
+                    @Suppress("DEPRECATION")
+                    activity?.onBackPressed()
+                },
+                onManageDownloadedFilesClick = { (activity as? FragmentHostListener)?.addFragment(ManualCleanupFragment.newInstance()) },
+                bottomInset = bottomInset.value.pxToDp(LocalContext.current).dp,
+            )
         }
     }
 

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/developer/DeveloperFragment.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/developer/DeveloperFragment.kt
@@ -3,13 +3,11 @@ package au.com.shiftyjelly.pocketcasts.settings.developer
 import android.content.Intent
 import android.os.Bundle
 import android.view.LayoutInflater
-import android.view.View
 import android.view.ViewGroup
-import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.compose.ui.unit.dp
 import androidx.fragment.app.viewModels
+import androidx.fragment.compose.content
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import au.com.shiftyjelly.pocketcasts.compose.AppThemeWithBackground
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
@@ -30,25 +28,20 @@ class DeveloperFragment : BaseFragment() {
         inflater: LayoutInflater,
         container: ViewGroup?,
         savedInstanceState: Bundle?,
-    ): View {
-        return ComposeView(requireContext()).apply {
-            setContent {
-                AppThemeWithBackground(theme.activeTheme) {
-                    setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
-                    val bottomInset = settings.bottomInset.collectAsStateWithLifecycle(0)
-                    DeveloperPage(
-                        onBackClick = ::onBackClick,
-                        onShowkaseClick = ::onShowkaseClick,
-                        onForceRefreshClick = viewModel::forceRefresh,
-                        onTriggerNotificationClick = viewModel::triggerNotification,
-                        onDeleteFirstEpisodeClick = viewModel::deleteFirstEpisode,
-                        onTriggerUpdateEpisodeDetails = viewModel::triggerUpdateEpisodeDetails,
-                        onTriggerResetEoYModalProfileBadge = viewModel::resetEoYModalProfileBadge,
-                        bottomInset = bottomInset.value.pxToDp(LocalContext.current).dp,
-                        onSendCrash = viewModel::onSendCrash,
-                    )
-                }
-            }
+    ) = content {
+        AppThemeWithBackground(theme.activeTheme) {
+            val bottomInset = settings.bottomInset.collectAsStateWithLifecycle(0)
+            DeveloperPage(
+                onBackClick = ::onBackClick,
+                onShowkaseClick = ::onShowkaseClick,
+                onForceRefreshClick = viewModel::forceRefresh,
+                onTriggerNotificationClick = viewModel::triggerNotification,
+                onDeleteFirstEpisodeClick = viewModel::deleteFirstEpisode,
+                onTriggerUpdateEpisodeDetails = viewModel::triggerUpdateEpisodeDetails,
+                onTriggerResetEoYModalProfileBadge = viewModel::resetEoYModalProfileBadge,
+                bottomInset = bottomInset.value.pxToDp(LocalContext.current).dp,
+                onSendCrash = viewModel::onSendCrash,
+            )
         }
     }
 


### PR DESCRIPTION
## Description

This change upgrades the fragment library to 1.8.2. Starting with the Fragment 1.7 release, a new `content` extension removes some of the old boilerplate code, so I have applied this to some classes to try it out. 

## Testing Instructions
1. Go to the Profile tab
2. Tap Bookmarks
3. Go back
4. Tap on the settings cog
5. Tap on Advanced
6. Go back
7. Tap on Beta features
8. Go back
9. Tap on Headphone controls
10. Go back
11. Tap on Storage settings
12. Go back to the Profile page
13. Tap on Downloads
14. Tap the three dots in the toolbar
15. Tap Clean up

✅  Verify all the pages load correclty.