### PR TITLE
Transcripts - Reduce landscape search scroll offset

### DIFF
--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/transcripts/TranscriptDefaults.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/transcripts/TranscriptDefaults.kt
@@ -27,7 +27,7 @@ object TranscriptDefaults {
 
     @Composable
     fun scrollToHighlightedTextOffset() =
-        if (LocalConfiguration.current.orientation == Configuration.ORIENTATION_LANDSCAPE) 50.dp else 100.dp
+        if (LocalConfiguration.current.orientation == Configuration.ORIENTATION_LANDSCAPE) 0.dp else 100.dp
 
     data class TranscriptColors(
         val playerBackgroundColor: Color,

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/transcripts/TranscriptDefaults.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/transcripts/TranscriptDefaults.kt
@@ -20,11 +20,14 @@ object TranscriptDefaults {
     val TranscriptFontFamily = FontFamily(listOf(Font(R.font.roboto_serif)))
     val SearchOccurrenceDefaultSpanStyle = SpanStyle(fontSize = 16.sp, fontWeight = FontWeight.W500, fontFamily = TranscriptFontFamily, background = Color.White.copy(alpha = .2f), color = Color.White)
     val SearchOccurrenceSelectedSpanStyle = SpanStyle(fontSize = 16.sp, fontWeight = FontWeight.W500, fontFamily = TranscriptFontFamily, background = Color.White, color = Color.Black)
-    val ScrollToHighlightedTextOffset = 100.dp
 
     @Composable
     fun bottomPadding() =
         if (LocalConfiguration.current.orientation == Configuration.ORIENTATION_LANDSCAPE) 0.dp else 125.dp
+
+    @Composable
+    fun scrollToHighlightedTextOffset() =
+        if (LocalConfiguration.current.orientation == Configuration.ORIENTATION_LANDSCAPE) 50.dp else 100.dp
 
     data class TranscriptColors(
         val playerBackgroundColor: Color,

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/transcripts/TranscriptPage.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/transcripts/TranscriptPage.kt
@@ -53,10 +53,10 @@ import au.com.shiftyjelly.pocketcasts.compose.toolbars.textselection.CustomMenuI
 import au.com.shiftyjelly.pocketcasts.compose.toolbars.textselection.CustomTextToolbar
 import au.com.shiftyjelly.pocketcasts.models.to.Transcript
 import au.com.shiftyjelly.pocketcasts.models.to.TranscriptCuesInfo
-import au.com.shiftyjelly.pocketcasts.player.view.transcripts.TranscriptDefaults.ScrollToHighlightedTextOffset
 import au.com.shiftyjelly.pocketcasts.player.view.transcripts.TranscriptDefaults.TranscriptColors
 import au.com.shiftyjelly.pocketcasts.player.view.transcripts.TranscriptDefaults.TranscriptFontFamily
 import au.com.shiftyjelly.pocketcasts.player.view.transcripts.TranscriptDefaults.bottomPadding
+import au.com.shiftyjelly.pocketcasts.player.view.transcripts.TranscriptDefaults.scrollToHighlightedTextOffset
 import au.com.shiftyjelly.pocketcasts.player.view.transcripts.TranscriptSearchViewModel.SearchUiState
 import au.com.shiftyjelly.pocketcasts.player.view.transcripts.TranscriptViewModel.DisplayInfo
 import au.com.shiftyjelly.pocketcasts.player.view.transcripts.TranscriptViewModel.DisplayItem
@@ -258,6 +258,7 @@ private fun ScrollableTranscriptView(
     // Scroll to highlighted text
     if (searchState.searchResultIndices.isNotEmpty()) {
         val density = LocalDensity.current
+        val scrollToHighlightedTextOffset = density.run { scrollToHighlightedTextOffset().roundToPx() }
         LaunchedEffect(searchState.searchTerm, searchState.currentSearchIndex) {
             val displayItems = state.displayInfo.items
             val targetSearchResultIndexIndex = searchState.searchResultIndices[searchState.currentSearchIndex]
@@ -266,7 +267,7 @@ private fun ScrollableTranscriptView(
             }?.let { displayItemWithCurrentSearchText ->
                 scrollState.animateScrollToItem(
                     displayItems.indexOf(displayItemWithCurrentSearchText),
-                    scrollOffset = -(density.run { ScrollToHighlightedTextOffset.roundToPx() }),
+                    scrollOffset = -scrollToHighlightedTextOffset,
                 )
             }
         }


### PR DESCRIPTION
## Description
This reduces landscape search scroll offset to minimize hiding of text behind the keyboard (pdcxQM-43M-p2#comment-3190).

## Testing Instructions
1. Open transcript view in landscape mode
2. Search a term
3. ✅ Notice that the highlighted search item text offset from the top is reduced now

## Screenshots or Screencast 
Floating | Expanded
----|---
![Screenshot_20240826_163534](https://github.com/user-attachments/assets/37f63a36-0b7a-402b-a7c4-4a4ed2c5abbf)| ![Screenshot_20240826_163507](https://github.com/user-attachments/assets/490f43e6-e3ea-4529-b153-7214476704cc) 


## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack