### PR TITLE
Transcripts - Remove search leading icon

### DIFF
--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/transcripts/TranscriptPageWrapper.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/transcripts/TranscriptPageWrapper.kt
@@ -264,10 +264,6 @@ private fun SearchBarLeadingIcons(
                 contentDescription = stringResource(LR.string.done),
             )
         }
-        Icon(
-            painter = painterResource(R.drawable.ic_search),
-            contentDescription = null,
-        )
     }
 }
 

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/transcripts/TranscriptPageWrapper.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/transcripts/TranscriptPageWrapper.kt
@@ -175,72 +175,72 @@ fun TranscriptToolbar(
                     onClick = onCloseClick,
                     tintColor = TranscriptColors.iconColor(),
                 )
+            }
 
-                if (showSearch) {
-                    transition.AnimatedVisibility(
-                        visible = { !it },
-                        enter = fadeIn(),
-                        exit = fadeOut(),
+            if (showSearch) {
+                transition.AnimatedVisibility(
+                    visible = { !it },
+                    enter = fadeIn(),
+                    exit = fadeOut(),
+                ) {
+                    IconButton(
+                        onClick = onSearchClicked,
+                        modifier = Modifier
+                            .padding(end = 16.dp)
+                            .background(Color.White.copy(alpha = 0.2f), shape = RoundedCornerShape(SearchViewCornerRadius)),
                     ) {
-                        IconButton(
-                            onClick = onSearchClicked,
-                            modifier = Modifier
-                                .padding(end = 16.dp)
-                                .background(Color.White.copy(alpha = 0.2f), shape = RoundedCornerShape(SearchViewCornerRadius)),
-                        ) {
-                            Icon(
-                                imageVector = Icons.Default.Search,
-                                contentDescription = stringResource(LR.string.search),
-                                tint = Color.White,
-                            )
-                        }
-                    }
-
-                    transition.AnimatedVisibility(
-                        visible = { it },
-                        enter = expandHorizontally(),
-                        exit = shrinkHorizontally(targetWidth = { 50 }) + fadeOut(),
-                    ) {
-                        SearchBar(
-                            text = searchText,
-                            leadingIcon = {
-                                SearchBarLeadingIcons(
-                                    onDoneClicked = onSearchDoneClicked,
-                                )
-                            },
-                            trailingIcon = {
-                                SearchBarTrailingIcons(
-                                    text = searchText,
-                                    searchState = searchState,
-                                    onSearchCleared = onSearchCleared,
-                                    onPrevious = onSearchPreviousClicked,
-                                    onNext = onSearchNextClicked,
-                                )
-                            },
-                            placeholder = stringResource(LR.string.search),
-                            onTextChanged = onSearchQueryChanged,
-                            onSearch = {},
-                            cornerRadius = SearchViewCornerRadius,
-                            modifier = Modifier
-                                .width(SearchBarMaxWidth)
-                                .focusRequester(focusRequester)
-                                .padding(start = 56.dp, end = 16.dp),
-                            colors = SearchBarDefaults.colors(
-                                leadingIconColor = SearchBarIconColor,
-                                trailingIconColor = SearchBarIconColor,
-                                disabledTrailingIconColor = SearchBarIconColor.copy(alpha = 0.7f),
-                                placeholderColor = SearchBarPlaceholderColor,
-                            ),
+                        Icon(
+                            imageVector = Icons.Default.Search,
+                            contentDescription = stringResource(LR.string.search),
+                            tint = Color.White,
                         )
                     }
                 }
 
-                LaunchedEffect(expandSearch) {
-                    if (expandSearch) {
-                        focusRequester.requestFocus()
-                    } else {
-                        focusManager.clearFocus()
-                    }
+                transition.AnimatedVisibility(
+                    visible = { it },
+                    enter = expandHorizontally(),
+                    exit = shrinkHorizontally(targetWidth = { 50 }) + fadeOut(),
+                ) {
+                    SearchBar(
+                        text = searchText,
+                        leadingIcon = {
+                            SearchBarLeadingIcons(
+                                onDoneClicked = onSearchDoneClicked,
+                            )
+                        },
+                        trailingIcon = {
+                            SearchBarTrailingIcons(
+                                text = searchText,
+                                searchState = searchState,
+                                onSearchCleared = onSearchCleared,
+                                onPrevious = onSearchPreviousClicked,
+                                onNext = onSearchNextClicked,
+                            )
+                        },
+                        placeholder = stringResource(LR.string.search),
+                        onTextChanged = onSearchQueryChanged,
+                        onSearch = {},
+                        cornerRadius = SearchViewCornerRadius,
+                        modifier = Modifier
+                            .width(SearchBarMaxWidth)
+                            .focusRequester(focusRequester)
+                            .padding(start = 56.dp, end = 16.dp),
+                        colors = SearchBarDefaults.colors(
+                            leadingIconColor = SearchBarIconColor,
+                            trailingIconColor = SearchBarIconColor,
+                            disabledTrailingIconColor = SearchBarIconColor.copy(alpha = 0.7f),
+                            placeholderColor = SearchBarPlaceholderColor,
+                        ),
+                    )
+                }
+            }
+
+            LaunchedEffect(expandSearch) {
+                if (expandSearch) {
+                    focusRequester.requestFocus()
+                } else {
+                    focusManager.clearFocus()
                 }
             }
         }


### PR DESCRIPTION
## Description
This removes search leading icon from the search bar to make more space for search text (pdcxQM-43M-p2#comment-3201)

## Testing Instructions
1. Open search bar on the transcript view
2. ✅ Notice search leading icon is removed from the search bar 

## Screenshots or Screencast 
Before
![Before](https://github.com/user-attachments/assets/7a5407b7-9225-4edf-b056-aef66f39fdcb)
After
![now](https://github.com/user-attachments/assets/e3a022bd-2120-4744-b9cd-1060636226c5)
Touch ripple
![ripple](https://github.com/user-attachments/assets/b8e2f41d-8968-47c5-a875-d8ede19531f3)

The space between the cursor and the done arrow is to accommodate the ripple circle in touch mode. 

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack