### PR TITLE
[Give Rating] Add new source for rate tapping event 

### DIFF
--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/components/ratings/StarRatingView.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/components/ratings/StarRatingView.kt
@@ -32,6 +32,7 @@ import au.com.shiftyjelly.pocketcasts.localization.R
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastRatings
 import au.com.shiftyjelly.pocketcasts.podcasts.viewmodel.PodcastRatingsViewModel
 import au.com.shiftyjelly.pocketcasts.podcasts.viewmodel.PodcastRatingsViewModel.RatingState
+import au.com.shiftyjelly.pocketcasts.podcasts.viewmodel.PodcastRatingsViewModel.RatingTappedSource
 import au.com.shiftyjelly.pocketcasts.podcasts.viewmodel.PodcastRatingsViewModel.Star
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import au.com.shiftyjelly.pocketcasts.utils.extensions.abbreviated
@@ -52,10 +53,11 @@ fun StarRatingView(
             val loadedState = state as RatingState.Loaded
             Content(
                 state = loadedState,
-                onClick = {
+                onClick = { source ->
                     viewModel.onRatingStarsTapped(
                         podcastUuid = loadedState.podcastUuid,
                         fragmentManager = fragmentManager,
+                        source = source,
                     )
                 },
             )
@@ -70,7 +72,7 @@ fun StarRatingView(
 @Composable
 private fun Content(
     state: RatingState.Loaded,
-    onClick: () -> Unit,
+    onClick: (RatingTappedSource) -> Unit,
 ) {
     val starsContentDescription = stringResource(LR.string.podcast_star_rating_content_description)
 
@@ -86,7 +88,7 @@ private fun Content(
         Row(
             verticalAlignment = Alignment.CenterVertically,
             modifier = Modifier
-                .clickable { onClick() }
+                .clickable { onClick(RatingTappedSource.STARS) }
                 .padding(8.dp)
                 .semantics {
                     this.contentDescription = starsContentDescription
@@ -116,7 +118,7 @@ private fun Content(
         if (FeatureFlag.isEnabled(Feature.GIVE_RATINGS)) {
             RowOutlinedButton(
                 text = stringResource(R.string.rate_button),
-                onClick = { onClick() },
+                onClick = { onClick(RatingTappedSource.BUTTON) },
                 includePadding = false,
                 fontSize = 16.sp,
                 textPadding = 0.dp,

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/PodcastRatingsViewModel.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/PodcastRatingsViewModel.kt
@@ -67,10 +67,14 @@ class PodcastRatingsViewModel
     fun onRatingStarsTapped(
         podcastUuid: String,
         fragmentManager: FragmentManager,
+        source: RatingTappedSource,
     ) {
         analyticsTracker.track(
             AnalyticsEvent.RATING_STARS_TAPPED,
-            AnalyticsProp.ratingStarsTapped(podcastUuid),
+            mapOf(
+                "uuid" to podcastUuid,
+                "source" to source.analyticsValue,
+            ),
         )
         if (FeatureFlag.isEnabled(Feature.GIVE_RATINGS)) {
             val fragment = GiveRatingFragment.newInstance(podcastUuid)
@@ -129,11 +133,8 @@ class PodcastRatingsViewModel
         BorderedStar(PocketCastsIcons.StarEmpty),
     }
 
-    companion object {
-        private object AnalyticsProp {
-            private const val UUID_KEY = "uuid"
-            fun ratingStarsTapped(podcastUuid: String) =
-                mapOf(UUID_KEY to podcastUuid)
-        }
+    enum class RatingTappedSource(val analyticsValue: String) {
+        BUTTON("button"),
+        STARS("stars"),
     }
 }


### PR DESCRIPTION
## Description
- Adds source to rating tapped event
- See slack thread: p1724418630334649/1723689598.833749-slack-C077XU4GF9D
- See iOS PR: https://github.com/Automattic/pocket-casts-ios/pull/2090


Fixes #2721

## Testing Instructions

1. Run the App
2. Open a podcast
3. Expand the header
4. Tap on Rate Button
5. Make sure you see 🔵 Tracked: rating_stars_tapped ["source": "button", "uuid": PODCAST_UUID]
6. Close the rate screen
7. Tap on the stars
8. Make sure you see 🔵 Tracked: rating_stars_tapped ["source": "stars", "uuid": PODCAST_UUID]

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack