### PR TITLE
Change the labels for new issues and Dependabot PRs

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,6 +1,6 @@
 name: Bug report
 description: Report a bug with the Pocket Casts Android app
-labels: ["bug", "triage"]
+labels: ["[Type] Bug"]
 body:
 
     - type: markdown
@@ -51,4 +51,3 @@ body:
           description: Pocket Casts app version can be found from the settings screen then scroll down to About
       validations:
           required: false
-

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,9 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    labels:
+      - "[Type] Tech Debt"
+      - "[Area] Dependencies"
     ignore:
       # Automattic libraries have a custom versioning scheme which doesn't work with Dependabot.
       - dependency-name: "com.automattic:Automattic-Tracks-Android"


### PR DESCRIPTION
## Description

As we are reorganising the project labels, this changes the default label for new issues and for Dependabot PRs.

## Testing Instructions

I don't think we can test this until we merge it.

1. Go to the issues tab
2. Click "New issue"
3. Next to Bug report click "Get started"

✅  Verify the label added is `[Type] Bug` 
