### PR TITLE
[Paywall Experiment] Exclude patron from experiment

### DIFF
--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/OnboardingUpgradeFeaturesViewModel.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/OnboardingUpgradeFeaturesViewModel.kt
@@ -102,6 +102,7 @@ class OnboardingUpgradeFeaturesViewModel @Inject constructor(
         val showNotNow = source == OnboardingUpgradeSource.RECOMMENDATIONS
 
         val upgradeLayout = when {
+            showPatronOnly -> UpgradeLayout.Original
             FeatureFlag.isEnabled(Feature.PAYWALL_AB_EXPERIMENT) -> UpgradeLayout.Features
             FeatureFlag.isEnabled(Feature.PAYWALL_AA_EXPERIMENT) -> {
                 val variation = experimentProvider.getVariation(Experiment.PaywallAATest)


### PR DESCRIPTION
## Description
- This excludes the Patron subscription upgrade flow from the paywall experiment, which means when the user tries to upgrade their account and have the A/B test enabled we are going to keep displaying the original paywall layout for Patron
- See: p1724680026883349/1724675119.013999-slack-C07G1MH890E

Fixes #2719

## Testing Instructions
1. Have an Pocket Casts Champion account. See how to get it set PdNHOb-2Q-p2
2. Have `PAYWALL_AB_EXPERIMENT` and `PAYWALL_AA_EXPERIMENT` feature flag enabled
3. Go to Profile -> Account -> Tap on `Upgrade to Patron`
4. ✅ Ensure the original Patron paywall is shown
5. Repeat the steps above with `PAYWALL_AB_EXPERIMENT` and `PAYWALL_AA_EXPERIMENT` feature flag disabled
6. ✅ Ensure the original Patron paywall is shown

## Screenshot 

<img width=500 src="https://github.com/user-attachments/assets/5ab17764-fb99-4dfc-9ae6-a911740c26a2"/>


## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack