### PR TITLE
Clean up Moshi configuration

### DIFF
--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/models/db/AppDatabaseTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/models/db/AppDatabaseTest.kt
@@ -6,9 +6,12 @@ import androidx.room.testing.MigrationTestHelper
 import androidx.sqlite.db.SupportSQLiteDatabase
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
+import au.com.shiftyjelly.pocketcasts.models.di.ModelModule
+import au.com.shiftyjelly.pocketcasts.models.di.addTypeConverters
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.type.EpisodesSortType
 import au.com.shiftyjelly.pocketcasts.models.type.TrimMode
+import com.squareup.moshi.Moshi
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
@@ -111,7 +114,7 @@ class AppDatabaseTest {
             InstrumentationRegistry.getInstrumentation().targetContext,
             AppDatabase::class.java,
             TEST_DB,
-        )
+        ).addTypeConverters(ModelModule.provideRoomConveretrs(Moshi.Builder().build()))
             .addMigrations(
                 AppDatabase.MIGRATION_45_46,
                 AppDatabase.MIGRATION_46_47,

--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/models/db/AppDatabaseTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/models/db/AppDatabaseTest.kt
@@ -114,7 +114,7 @@ class AppDatabaseTest {
             InstrumentationRegistry.getInstrumentation().targetContext,
             AppDatabase::class.java,
             TEST_DB,
-        ).addTypeConverters(ModelModule.provideRoomConveretrs(Moshi.Builder().build()))
+        ).addTypeConverters(ModelModule.provideRoomConverters(Moshi.Builder().build()))
             .addMigrations(
                 AppDatabase.MIGRATION_45_46,
                 AppDatabase.MIGRATION_46_47,

--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/models/db/AutoArchiveTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/models/db/AutoArchiveTest.kt
@@ -62,7 +62,7 @@ class AutoArchiveTest {
     fun setupDb() {
         val context = InstrumentationRegistry.getInstrumentation().targetContext
         testDb = Room.inMemoryDatabaseBuilder(context, AppDatabase::class.java)
-            .addTypeConverters(ModelModule.provideRoomConveretrs(Moshi.Builder().build()))
+            .addTypeConverters(ModelModule.provideRoomConverters(Moshi.Builder().build()))
             .build()
         episodeDao = testDb.episodeDao()
     }

--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/models/db/AutoArchiveTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/models/db/AutoArchiveTest.kt
@@ -6,6 +6,8 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import au.com.shiftyjelly.pocketcasts.analytics.EpisodeAnalytics
 import au.com.shiftyjelly.pocketcasts.models.db.dao.EpisodeDao
+import au.com.shiftyjelly.pocketcasts.models.di.ModelModule
+import au.com.shiftyjelly.pocketcasts.models.di.addTypeConverters
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.models.to.AutoArchiveAfterPlaying
@@ -24,6 +26,7 @@ import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.UserEpisodeManager
 import au.com.shiftyjelly.pocketcasts.repositories.sync.SyncManager
 import au.com.shiftyjelly.pocketcasts.servers.podcast.PodcastCacheServerManager
+import com.squareup.moshi.Moshi
 import java.util.Calendar
 import java.util.Date
 import java.util.UUID
@@ -58,7 +61,9 @@ class AutoArchiveTest {
     @Before
     fun setupDb() {
         val context = InstrumentationRegistry.getInstrumentation().targetContext
-        testDb = Room.inMemoryDatabaseBuilder(context, AppDatabase::class.java).build()
+        testDb = Room.inMemoryDatabaseBuilder(context, AppDatabase::class.java)
+            .addTypeConverters(ModelModule.provideRoomConveretrs(Moshi.Builder().build()))
+            .build()
         episodeDao = testDb.episodeDao()
     }
 

--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/models/db/BookmarkDaoTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/models/db/BookmarkDaoTest.kt
@@ -35,7 +35,7 @@ class BookmarkDaoTest {
     fun setupDatabase() {
         val context = InstrumentationRegistry.getInstrumentation().targetContext
         testDatabase = Room.inMemoryDatabaseBuilder(context, AppDatabase::class.java)
-            .addTypeConverters(ModelModule.provideRoomConveretrs(Moshi.Builder().build()))
+            .addTypeConverters(ModelModule.provideRoomConverters(Moshi.Builder().build()))
             .build()
         bookmarkDao = testDatabase.bookmarkDao()
         episodeDao = testDatabase.episodeDao()

--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/models/db/BookmarkDaoTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/models/db/BookmarkDaoTest.kt
@@ -6,9 +6,12 @@ import androidx.test.filters.LargeTest
 import androidx.test.platform.app.InstrumentationRegistry
 import au.com.shiftyjelly.pocketcasts.models.db.dao.BookmarkDao
 import au.com.shiftyjelly.pocketcasts.models.db.dao.EpisodeDao
+import au.com.shiftyjelly.pocketcasts.models.di.ModelModule
+import au.com.shiftyjelly.pocketcasts.models.di.addTypeConverters
 import au.com.shiftyjelly.pocketcasts.models.entity.Bookmark
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.models.type.SyncStatus
+import com.squareup.moshi.Moshi
 import java.util.Date
 import java.util.UUID
 import kotlinx.coroutines.flow.first
@@ -31,7 +34,9 @@ class BookmarkDaoTest {
     @Before
     fun setupDatabase() {
         val context = InstrumentationRegistry.getInstrumentation().targetContext
-        testDatabase = Room.inMemoryDatabaseBuilder(context, AppDatabase::class.java).build()
+        testDatabase = Room.inMemoryDatabaseBuilder(context, AppDatabase::class.java)
+            .addTypeConverters(ModelModule.provideRoomConveretrs(Moshi.Builder().build()))
+            .build()
         bookmarkDao = testDatabase.bookmarkDao()
         episodeDao = testDatabase.episodeDao()
     }

--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/models/db/ChapterDaoSelectionTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/models/db/ChapterDaoSelectionTest.kt
@@ -6,9 +6,12 @@ import androidx.test.platform.app.InstrumentationRegistry
 import au.com.shiftyjelly.pocketcasts.models.db.dao.ChapterDao
 import au.com.shiftyjelly.pocketcasts.models.db.dao.EpisodeDao
 import au.com.shiftyjelly.pocketcasts.models.db.dao.UserEpisodeDao
+import au.com.shiftyjelly.pocketcasts.models.di.ModelModule
+import au.com.shiftyjelly.pocketcasts.models.di.addTypeConverters
 import au.com.shiftyjelly.pocketcasts.models.entity.ChapterIndices
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.models.entity.UserEpisode
+import com.squareup.moshi.Moshi
 import java.util.Date
 import kotlinx.coroutines.test.runTest
 import org.junit.After
@@ -27,7 +30,9 @@ class ChapterDaoSelectionTest {
     @Before
     fun setupDb() {
         val context = InstrumentationRegistry.getInstrumentation().targetContext
-        testDb = Room.inMemoryDatabaseBuilder(context, AppDatabase::class.java).build()
+        testDb = Room.inMemoryDatabaseBuilder(context, AppDatabase::class.java)
+            .addTypeConverters(ModelModule.provideRoomConveretrs(Moshi.Builder().build()))
+            .build()
         chapterDao = testDb.chapterDao()
         episodeDao = testDb.episodeDao()
         userEpisodeDao = testDb.userEpisodeDao()

--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/models/db/ChapterDaoSelectionTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/models/db/ChapterDaoSelectionTest.kt
@@ -31,7 +31,7 @@ class ChapterDaoSelectionTest {
     fun setupDb() {
         val context = InstrumentationRegistry.getInstrumentation().targetContext
         testDb = Room.inMemoryDatabaseBuilder(context, AppDatabase::class.java)
-            .addTypeConverters(ModelModule.provideRoomConveretrs(Moshi.Builder().build()))
+            .addTypeConverters(ModelModule.provideRoomConverters(Moshi.Builder().build()))
             .build()
         chapterDao = testDb.chapterDao()
         episodeDao = testDb.episodeDao()

--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/models/db/ChapterDaoTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/models/db/ChapterDaoTest.kt
@@ -25,7 +25,7 @@ class ChapterDaoTest {
     fun setupDb() {
         val context = InstrumentationRegistry.getInstrumentation().targetContext
         testDb = Room.inMemoryDatabaseBuilder(context, AppDatabase::class.java)
-            .addTypeConverters(ModelModule.provideRoomConveretrs(Moshi.Builder().build()))
+            .addTypeConverters(ModelModule.provideRoomConverters(Moshi.Builder().build()))
             .build()
         chapterDao = testDb.chapterDao()
     }

--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/models/db/ChapterDaoTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/models/db/ChapterDaoTest.kt
@@ -5,6 +5,9 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import app.cash.turbine.test
 import au.com.shiftyjelly.pocketcasts.models.db.dao.ChapterDao
+import au.com.shiftyjelly.pocketcasts.models.di.ModelModule
+import au.com.shiftyjelly.pocketcasts.models.di.addTypeConverters
+import com.squareup.moshi.Moshi
 import kotlinx.coroutines.runBlocking
 import org.junit.After
 import org.junit.Assert.assertEquals
@@ -21,7 +24,9 @@ class ChapterDaoTest {
     @Before
     fun setupDb() {
         val context = InstrumentationRegistry.getInstrumentation().targetContext
-        testDb = Room.inMemoryDatabaseBuilder(context, AppDatabase::class.java).build()
+        testDb = Room.inMemoryDatabaseBuilder(context, AppDatabase::class.java)
+            .addTypeConverters(ModelModule.provideRoomConveretrs(Moshi.Builder().build()))
+            .build()
         chapterDao = testDb.chapterDao()
     }
 

--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/models/db/EpisodeDaoTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/models/db/EpisodeDaoTest.kt
@@ -30,7 +30,7 @@ class EpisodeDaoTest {
     fun setupDb() {
         val context = InstrumentationRegistry.getInstrumentation().targetContext
         testDb = Room.inMemoryDatabaseBuilder(context, AppDatabase::class.java)
-            .addTypeConverters(ModelModule.provideRoomConveretrs(Moshi.Builder().build()))
+            .addTypeConverters(ModelModule.provideRoomConverters(Moshi.Builder().build()))
             .build()
         episodeDao = testDb.episodeDao()
         podcastDao = testDb.podcastDao()

--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/models/db/EpisodeDaoTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/models/db/EpisodeDaoTest.kt
@@ -5,9 +5,12 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import au.com.shiftyjelly.pocketcasts.models.db.dao.EpisodeDao
 import au.com.shiftyjelly.pocketcasts.models.db.dao.PodcastDao
+import au.com.shiftyjelly.pocketcasts.models.di.ModelModule
+import au.com.shiftyjelly.pocketcasts.models.di.addTypeConverters
 import au.com.shiftyjelly.pocketcasts.models.entity.EpisodeDownloadFailureStatistics
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.models.type.EpisodeStatusEnum
+import com.squareup.moshi.Moshi
 import java.time.Instant
 import java.util.Date
 import kotlinx.coroutines.runBlocking
@@ -26,7 +29,9 @@ class EpisodeDaoTest {
     @Before
     fun setupDb() {
         val context = InstrumentationRegistry.getInstrumentation().targetContext
-        testDb = Room.inMemoryDatabaseBuilder(context, AppDatabase::class.java).build()
+        testDb = Room.inMemoryDatabaseBuilder(context, AppDatabase::class.java)
+            .addTypeConverters(ModelModule.provideRoomConveretrs(Moshi.Builder().build()))
+            .build()
         episodeDao = testDb.episodeDao()
         podcastDao = testDb.podcastDao()
     }

--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/models/db/ExternalDataDaoTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/models/db/ExternalDataDaoTest.kt
@@ -7,6 +7,8 @@ import au.com.shiftyjelly.pocketcasts.models.db.dao.ExternalDataDao
 import au.com.shiftyjelly.pocketcasts.models.db.dao.PodcastDao
 import au.com.shiftyjelly.pocketcasts.models.db.dao.UpNextDao
 import au.com.shiftyjelly.pocketcasts.models.db.dao.UserEpisodeDao
+import au.com.shiftyjelly.pocketcasts.models.di.ModelModule
+import au.com.shiftyjelly.pocketcasts.models.di.addTypeConverters
 import au.com.shiftyjelly.pocketcasts.models.entity.CuratedPodcast
 import au.com.shiftyjelly.pocketcasts.models.entity.ExternalEpisode
 import au.com.shiftyjelly.pocketcasts.models.entity.ExternalPodcast
@@ -19,6 +21,7 @@ import au.com.shiftyjelly.pocketcasts.models.entity.UserEpisode
 import au.com.shiftyjelly.pocketcasts.models.type.EpisodePlayingStatus
 import au.com.shiftyjelly.pocketcasts.models.type.EpisodeStatusEnum
 import au.com.shiftyjelly.pocketcasts.models.type.PodcastsSortType
+import com.squareup.moshi.Moshi
 import java.time.Instant
 import java.time.temporal.ChronoUnit
 import java.util.Date
@@ -41,7 +44,9 @@ class ExternalDataDaoTest {
     @Before
     fun setupDb() {
         val context = InstrumentationRegistry.getInstrumentation().targetContext
-        testDb = Room.inMemoryDatabaseBuilder(context, AppDatabase::class.java).build()
+        testDb = Room.inMemoryDatabaseBuilder(context, AppDatabase::class.java)
+            .addTypeConverters(ModelModule.provideRoomConveretrs(Moshi.Builder().build()))
+            .build()
         podcastDao = testDb.podcastDao()
         podcastEpisodeDao = testDb.episodeDao()
         userEpisodeDao = testDb.userEpisodeDao()

--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/models/db/ExternalDataDaoTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/models/db/ExternalDataDaoTest.kt
@@ -45,7 +45,7 @@ class ExternalDataDaoTest {
     fun setupDb() {
         val context = InstrumentationRegistry.getInstrumentation().targetContext
         testDb = Room.inMemoryDatabaseBuilder(context, AppDatabase::class.java)
-            .addTypeConverters(ModelModule.provideRoomConveretrs(Moshi.Builder().build()))
+            .addTypeConverters(ModelModule.provideRoomConverters(Moshi.Builder().build()))
             .build()
         podcastDao = testDb.podcastDao()
         podcastEpisodeDao = testDb.episodeDao()

--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/models/db/FolderDaoTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/models/db/FolderDaoTest.kt
@@ -5,8 +5,11 @@ import androidx.room.Room
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import au.com.shiftyjelly.pocketcasts.models.db.dao.FolderDao
+import au.com.shiftyjelly.pocketcasts.models.di.ModelModule
+import au.com.shiftyjelly.pocketcasts.models.di.addTypeConverters
 import au.com.shiftyjelly.pocketcasts.models.type.PodcastsSortType
 import au.com.shiftyjelly.pocketcasts.utils.FakeFileGenerator.fakeFolder
+import com.squareup.moshi.Moshi
 import junit.framework.TestCase.assertEquals
 import junit.framework.TestCase.assertNotNull
 import junit.framework.TestCase.assertNull
@@ -25,7 +28,9 @@ class FolderDaoTest {
     @Before
     fun setupDatabase() {
         val context = InstrumentationRegistry.getInstrumentation().targetContext
-        testDatabase = Room.inMemoryDatabaseBuilder(context, AppDatabase::class.java).build()
+        testDatabase = Room.inMemoryDatabaseBuilder(context, AppDatabase::class.java)
+            .addTypeConverters(ModelModule.provideRoomConveretrs(Moshi.Builder().build()))
+            .build()
         folderDao = testDatabase.folderDao()
     }
 

--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/models/db/FolderDaoTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/models/db/FolderDaoTest.kt
@@ -29,7 +29,7 @@ class FolderDaoTest {
     fun setupDatabase() {
         val context = InstrumentationRegistry.getInstrumentation().targetContext
         testDatabase = Room.inMemoryDatabaseBuilder(context, AppDatabase::class.java)
-            .addTypeConverters(ModelModule.provideRoomConveretrs(Moshi.Builder().build()))
+            .addTypeConverters(ModelModule.provideRoomConverters(Moshi.Builder().build()))
             .build()
         folderDao = testDatabase.folderDao()
     }

--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/models/db/PodcastDaoTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/models/db/PodcastDaoTest.kt
@@ -6,7 +6,10 @@ import androidx.test.filters.LargeTest
 import androidx.test.platform.app.InstrumentationRegistry
 import au.com.shiftyjelly.pocketcasts.models.db.dao.EpisodeDao
 import au.com.shiftyjelly.pocketcasts.models.db.dao.PodcastDao
+import au.com.shiftyjelly.pocketcasts.models.di.ModelModule
+import au.com.shiftyjelly.pocketcasts.models.di.addTypeConverters
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
+import com.squareup.moshi.Moshi
 import java.util.UUID
 import org.junit.After
 import org.junit.Assert.assertEquals
@@ -26,7 +29,9 @@ class PodcastDaoTest {
     @Before
     fun setupDb() {
         val context = InstrumentationRegistry.getInstrumentation().targetContext
-        testDb = Room.inMemoryDatabaseBuilder(context, AppDatabase::class.java).build()
+        testDb = Room.inMemoryDatabaseBuilder(context, AppDatabase::class.java)
+            .addTypeConverters(ModelModule.provideRoomConveretrs(Moshi.Builder().build()))
+            .build()
         podcastDao = testDb.podcastDao()
         episodeDao = testDb.episodeDao()
     }

--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/models/db/PodcastDaoTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/models/db/PodcastDaoTest.kt
@@ -30,7 +30,7 @@ class PodcastDaoTest {
     fun setupDb() {
         val context = InstrumentationRegistry.getInstrumentation().targetContext
         testDb = Room.inMemoryDatabaseBuilder(context, AppDatabase::class.java)
-            .addTypeConverters(ModelModule.provideRoomConveretrs(Moshi.Builder().build()))
+            .addTypeConverters(ModelModule.provideRoomConverters(Moshi.Builder().build()))
             .build()
         podcastDao = testDb.podcastDao()
         episodeDao = testDb.episodeDao()

--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/models/db/PodcastManagerTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/models/db/PodcastManagerTest.kt
@@ -4,6 +4,8 @@ import androidx.room.Room
 import androidx.test.internal.runner.junit4.AndroidJUnit4ClassRunner
 import androidx.test.platform.app.InstrumentationRegistry
 import au.com.shiftyjelly.pocketcasts.models.db.dao.PodcastDao
+import au.com.shiftyjelly.pocketcasts.models.di.ModelModule
+import au.com.shiftyjelly.pocketcasts.models.di.addTypeConverters
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.to.PodcastGrouping
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
@@ -20,6 +22,7 @@ import au.com.shiftyjelly.pocketcasts.servers.podcast.PodcastCacheServerManager
 import au.com.shiftyjelly.pocketcasts.servers.refresh.RefreshServerManager
 import au.com.shiftyjelly.pocketcasts.sharedtest.FakeCrashLogging
 import au.com.shiftyjelly.pocketcasts.utils.Optional
+import com.squareup.moshi.Moshi
 import io.reactivex.Single
 import java.util.UUID
 import kotlinx.coroutines.CoroutineScope
@@ -68,7 +71,9 @@ class PodcastManagerTest {
             on { getColorsSingle(uuid) } doReturn Single.just(Optional.empty())
         }
 
-        appDatabase = Room.inMemoryDatabaseBuilder(context, AppDatabase::class.java).build()
+        appDatabase = Room.inMemoryDatabaseBuilder(context, AppDatabase::class.java)
+            .addTypeConverters(ModelModule.provideRoomConveretrs(Moshi.Builder().build()))
+            .build()
 
         val refreshServerManager = mock<RefreshServerManager> {}
         val subscribeManager = SubscribeManager(appDatabase, podcastCacheServer, staticServerManager, syncManagerSignedOut, application, settings)

--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/models/db/PodcastManagerTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/models/db/PodcastManagerTest.kt
@@ -72,7 +72,7 @@ class PodcastManagerTest {
         }
 
         appDatabase = Room.inMemoryDatabaseBuilder(context, AppDatabase::class.java)
-            .addTypeConverters(ModelModule.provideRoomConveretrs(Moshi.Builder().build()))
+            .addTypeConverters(ModelModule.provideRoomConverters(Moshi.Builder().build()))
             .build()
 
         val refreshServerManager = mock<RefreshServerManager> {}

--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/models/db/SearchHistoryDaoTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/models/db/SearchHistoryDaoTest.kt
@@ -33,7 +33,7 @@ class SearchHistoryDaoTest {
     fun setupDb() {
         val context = InstrumentationRegistry.getInstrumentation().targetContext
         testDb = Room.inMemoryDatabaseBuilder(context, AppDatabase::class.java)
-            .addTypeConverters(ModelModule.provideRoomConveretrs(Moshi.Builder().build()))
+            .addTypeConverters(ModelModule.provideRoomConverters(Moshi.Builder().build()))
             .build()
         searchHistoryDao = testDb.searchHistoryDao()
     }

--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/models/db/SearchHistoryDaoTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/models/db/SearchHistoryDaoTest.kt
@@ -4,9 +4,12 @@ import androidx.room.Room
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import au.com.shiftyjelly.pocketcasts.models.db.dao.SearchHistoryDao
+import au.com.shiftyjelly.pocketcasts.models.di.ModelModule
+import au.com.shiftyjelly.pocketcasts.models.di.addTypeConverters
 import au.com.shiftyjelly.pocketcasts.models.entity.SearchHistoryItem
 import au.com.shiftyjelly.pocketcasts.models.entity.SearchHistoryItem.Folder
 import au.com.shiftyjelly.pocketcasts.models.entity.SearchHistoryItem.Podcast
+import com.squareup.moshi.Moshi
 import java.util.UUID
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
@@ -29,7 +32,9 @@ class SearchHistoryDaoTest {
     @Before
     fun setupDb() {
         val context = InstrumentationRegistry.getInstrumentation().targetContext
-        testDb = Room.inMemoryDatabaseBuilder(context, AppDatabase::class.java).build()
+        testDb = Room.inMemoryDatabaseBuilder(context, AppDatabase::class.java)
+            .addTypeConverters(ModelModule.provideRoomConveretrs(Moshi.Builder().build()))
+            .build()
         searchHistoryDao = testDb.searchHistoryDao()
     }
 

--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/models/db/UpNextQueueTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/models/db/UpNextQueueTest.kt
@@ -3,6 +3,8 @@ package au.com.shiftyjelly.pocketcasts.models.db
 import androidx.room.Room
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
+import au.com.shiftyjelly.pocketcasts.models.di.ModelModule
+import au.com.shiftyjelly.pocketcasts.models.di.addTypeConverters
 import au.com.shiftyjelly.pocketcasts.models.entity.BaseEpisode
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
@@ -13,6 +15,7 @@ import au.com.shiftyjelly.pocketcasts.repositories.playback.UpNextQueue
 import au.com.shiftyjelly.pocketcasts.repositories.playback.UpNextQueueImpl
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
 import au.com.shiftyjelly.pocketcasts.repositories.sync.SyncManager
+import com.squareup.moshi.Moshi
 import java.util.Date
 import java.util.UUID
 import kotlinx.coroutines.runBlocking
@@ -32,7 +35,9 @@ class UpNextQueueTest {
     @Before
     fun setup() {
         val context = InstrumentationRegistry.getInstrumentation().targetContext
-        appDatabase = Room.inMemoryDatabaseBuilder(context, AppDatabase::class.java).build()
+        appDatabase = Room.inMemoryDatabaseBuilder(context, AppDatabase::class.java)
+            .addTypeConverters(ModelModule.provideRoomConveretrs(Moshi.Builder().build()))
+            .build()
         downloadManager = mock {}
         val episodeManager = mock<EpisodeManager> {}
         val settings = mock<Settings> {

--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/models/db/UpNextQueueTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/models/db/UpNextQueueTest.kt
@@ -36,7 +36,7 @@ class UpNextQueueTest {
     fun setup() {
         val context = InstrumentationRegistry.getInstrumentation().targetContext
         appDatabase = Room.inMemoryDatabaseBuilder(context, AppDatabase::class.java)
-            .addTypeConverters(ModelModule.provideRoomConveretrs(Moshi.Builder().build()))
+            .addTypeConverters(ModelModule.provideRoomConverters(Moshi.Builder().build()))
             .build()
         downloadManager = mock {}
         val episodeManager = mock<EpisodeManager> {}

--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/models/db/UserEpisodeDaoTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/models/db/UserEpisodeDaoTest.kt
@@ -4,7 +4,10 @@ import androidx.room.Room
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import au.com.shiftyjelly.pocketcasts.models.db.dao.UserEpisodeDao
+import au.com.shiftyjelly.pocketcasts.models.di.ModelModule
+import au.com.shiftyjelly.pocketcasts.models.di.addTypeConverters
 import au.com.shiftyjelly.pocketcasts.models.entity.UserEpisode
+import com.squareup.moshi.Moshi
 import java.util.Date
 import java.util.UUID
 import kotlinx.coroutines.runBlocking
@@ -22,7 +25,9 @@ class UserEpisodeDaoTest {
     @Before
     fun setupDb() {
         val context = InstrumentationRegistry.getInstrumentation().targetContext
-        testDb = Room.inMemoryDatabaseBuilder(context, AppDatabase::class.java).build()
+        testDb = Room.inMemoryDatabaseBuilder(context, AppDatabase::class.java)
+            .addTypeConverters(ModelModule.provideRoomConveretrs(Moshi.Builder().build()))
+            .build()
         userEpisodeDao = testDb.userEpisodeDao()
     }
 

--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/models/db/UserEpisodeDaoTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/models/db/UserEpisodeDaoTest.kt
@@ -26,7 +26,7 @@ class UserEpisodeDaoTest {
     fun setupDb() {
         val context = InstrumentationRegistry.getInstrumentation().targetContext
         testDb = Room.inMemoryDatabaseBuilder(context, AppDatabase::class.java)
-            .addTypeConverters(ModelModule.provideRoomConveretrs(Moshi.Builder().build()))
+            .addTypeConverters(ModelModule.provideRoomConverters(Moshi.Builder().build()))
             .build()
         userEpisodeDao = testDb.userEpisodeDao()
     }

--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/profile/accountmanager/PocketCastsAccountAuthenticatorTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/profile/accountmanager/PocketCastsAccountAuthenticatorTest.kt
@@ -9,14 +9,12 @@ import androidx.core.os.BundleCompat
 import androidx.test.platform.app.InstrumentationRegistry
 import au.com.shiftyjelly.pocketcasts.account.AccountActivity
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTracker
-import au.com.shiftyjelly.pocketcasts.preferences.AccessToken
 import au.com.shiftyjelly.pocketcasts.preferences.AccountConstants
-import au.com.shiftyjelly.pocketcasts.preferences.RefreshToken
 import au.com.shiftyjelly.pocketcasts.repositories.sync.SyncAccountManagerImpl
 import au.com.shiftyjelly.pocketcasts.repositories.sync.SyncManagerImpl
 import au.com.shiftyjelly.pocketcasts.repositories.sync.TokenErrorNotification
+import au.com.shiftyjelly.pocketcasts.servers.di.ServersModule
 import au.com.shiftyjelly.pocketcasts.servers.sync.SyncServerManager
-import com.squareup.moshi.Moshi
 import java.io.File
 import java.net.HttpURLConnection
 import java.util.concurrent.TimeUnit
@@ -49,10 +47,7 @@ class PocketCastsAccountAuthenticatorTest {
         mockWebServer = MockWebServer()
         mockWebServer.start()
 
-        val moshi = Moshi.Builder()
-            .add(AccessToken::class.java, AccessToken.Adapter)
-            .add(RefreshToken::class.java, RefreshToken.Adapter)
-            .build()
+        val moshi = ServersModule().provideMoshi()
 
         val retrofit = Retrofit.Builder()
             .baseUrl(mockWebServer.url("/"))
@@ -78,6 +73,7 @@ class PocketCastsAccountAuthenticatorTest {
             settings = mock(),
             syncAccountManager = syncAccountManager,
             syncServerManager = syncServerManager,
+            moshi = moshi,
         )
         // make sure the test device is signed out
         syncManager.signOut()

--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/repositories/bookmark/BookmarkManagerTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/repositories/bookmark/BookmarkManagerTest.kt
@@ -33,7 +33,7 @@ class BookmarkManagerTest {
     fun setup() {
         val context = InstrumentationRegistry.getInstrumentation().targetContext
         appDatabase = Room.inMemoryDatabaseBuilder(context, AppDatabase::class.java)
-            .addTypeConverters(ModelModule.provideRoomConveretrs(Moshi.Builder().build()))
+            .addTypeConverters(ModelModule.provideRoomConverters(Moshi.Builder().build()))
             .build()
         bookmarkManager = BookmarkManagerImpl(
             appDatabase = appDatabase,

--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/repositories/bookmark/BookmarkManagerTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/repositories/bookmark/BookmarkManagerTest.kt
@@ -5,9 +5,12 @@ import androidx.test.platform.app.InstrumentationRegistry
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTracker
 import au.com.shiftyjelly.pocketcasts.models.db.AppDatabase
 import au.com.shiftyjelly.pocketcasts.models.db.dao.EpisodeDao
+import au.com.shiftyjelly.pocketcasts.models.di.ModelModule
+import au.com.shiftyjelly.pocketcasts.models.di.addTypeConverters
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.models.type.SyncStatus
 import au.com.shiftyjelly.pocketcasts.preferences.model.BookmarksSortTypeDefault
+import com.squareup.moshi.Moshi
 import java.time.Instant
 import java.util.Date
 import java.util.UUID
@@ -29,7 +32,9 @@ class BookmarkManagerTest {
     @Before
     fun setup() {
         val context = InstrumentationRegistry.getInstrumentation().targetContext
-        appDatabase = Room.inMemoryDatabaseBuilder(context, AppDatabase::class.java).build()
+        appDatabase = Room.inMemoryDatabaseBuilder(context, AppDatabase::class.java)
+            .addTypeConverters(ModelModule.provideRoomConveretrs(Moshi.Builder().build()))
+            .build()
         bookmarkManager = BookmarkManagerImpl(
             appDatabase = appDatabase,
             analyticsTracker = AnalyticsTracker.test(),

--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/repositories/sync/PodcastSyncProcessTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/repositories/sync/PodcastSyncProcessTest.kt
@@ -68,7 +68,7 @@ class PodcastSyncProcessTest {
         mockWebServer.start()
 
         appDatabase = Room.inMemoryDatabaseBuilder(context, AppDatabase::class.java)
-            .addTypeConverters(ModelModule.provideRoomConveretrs(Moshi.Builder().build()))
+            .addTypeConverters(ModelModule.provideRoomConverters(Moshi.Builder().build()))
             .build()
 
         FeatureFlag.initialize(

--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/servers/ShareServerManagerImplTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/servers/ShareServerManagerImplTest.kt
@@ -1,8 +1,8 @@
 package au.com.shiftyjelly.pocketcasts.servers
 
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
+import au.com.shiftyjelly.pocketcasts.servers.di.ServersModule
 import au.com.shiftyjelly.pocketcasts.servers.list.ListServerManagerImpl
-import com.squareup.moshi.Moshi
 import java.net.HttpURLConnection
 import java.time.LocalDateTime
 import java.time.ZoneId
@@ -38,7 +38,7 @@ class ShareServerManagerImplTest {
 
         retrofit = Retrofit.Builder()
             .baseUrl(mockWebServer.url("/"))
-            .addConverterFactory(MoshiConverterFactory.create(Moshi.Builder().build()))
+            .addConverterFactory(MoshiConverterFactory.create(ServersModule().provideMoshi()))
             .client(client)
             .build()
     }

--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/servers/account/SyncAccountTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/servers/account/SyncAccountTest.kt
@@ -40,7 +40,7 @@ internal class SyncAccountTest {
         mockWebServer = MockWebServer()
         mockWebServer.start()
 
-        val moshi = ServersModule.provideMoshiBuilder().build()
+        val moshi = ServersModule().provideMoshi()
         val okHttpClient = OkHttpClient.Builder().build()
         retrofit = ServersModule.provideRetrofit(baseUrl = mockWebServer.url("/").toString(), okHttpClient = okHttpClient, moshi = moshi)
         okhttpCache = ServersModule.provideCache(folder = "TestCache", context = context, cacheSizeInMB = 10)
@@ -55,6 +55,7 @@ internal class SyncAccountTest {
             settings = mock(),
             syncAccountManager = syncAccountManager,
             syncServerManager = syncServerManager,
+            moshi = moshi,
         )
         syncManager.signOut()
     }

--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/settings/advanced/AdvancedSettingsTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/settings/advanced/AdvancedSettingsTest.kt
@@ -8,9 +8,9 @@ import au.com.shiftyjelly.pocketcasts.preferences.SettingsImpl
 import au.com.shiftyjelly.pocketcasts.preferences.model.ArtworkConfiguration
 import au.com.shiftyjelly.pocketcasts.preferences.model.ArtworkConfiguration.Element
 import au.com.shiftyjelly.pocketcasts.preferences.model.ShelfItem
+import au.com.shiftyjelly.pocketcasts.servers.di.ServersModule
 import au.com.shiftyjelly.pocketcasts.utils.featureflag.BookmarkFeatureControl
 import com.google.firebase.remoteconfig.FirebaseRemoteConfig
-import com.squareup.moshi.Moshi
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
@@ -27,7 +27,7 @@ class AdvancedSettingsTest {
 
         val sharedPreferences = context.getSharedPreferences(fileName, Context.MODE_PRIVATE)
         sharedPreferences.edit().clear().commit()
-        val moshi = Moshi.Builder().build()
+        val moshi = ServersModule().provideMoshi()
         val firebaseRemoteConfig = FirebaseRemoteConfig.getInstance()
         settings = SettingsImpl(
             sharedPreferences = sharedPreferences,

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/PromoCodeViewModel.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/PromoCodeViewModel.kt
@@ -9,6 +9,7 @@ import au.com.shiftyjelly.pocketcasts.repositories.subscription.SubscriptionMana
 import au.com.shiftyjelly.pocketcasts.repositories.sync.SyncManager
 import au.com.shiftyjelly.pocketcasts.servers.sync.PromoCodeResponse
 import au.com.shiftyjelly.pocketcasts.servers.sync.parseErrorResponse
+import com.squareup.moshi.Moshi
 import dagger.hilt.android.lifecycle.HiltViewModel
 import io.reactivex.BackpressureStrategy
 import io.reactivex.Single
@@ -23,6 +24,7 @@ import retrofit2.HttpException
 class PromoCodeViewModel @Inject constructor(
     private val syncManager: SyncManager,
     private val subscriptionManager: SubscriptionManager,
+    private val moshi: Moshi,
 ) : ViewModel() {
     sealed class ViewState {
         object Loading : ViewState()
@@ -76,7 +78,7 @@ class PromoCodeViewModel @Inject constructor(
         return Function {
             when (it) {
                 is HttpException -> {
-                    val errorResponse = it.parseErrorResponse()
+                    val errorResponse = it.parseErrorResponse(moshi)
                     var message = errorResponse?.messageLocalized(resources) ?: "Unknown error"
                     if (it.code() == 404) {
                         message = if (isSignedIn) {

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/di/AuthPhoneModule.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/di/AuthPhoneModule.kt
@@ -22,11 +22,12 @@ object AuthPhoneModule {
     fun providesTokenBundleRepository(
         wearDataLayerRegistry: WearDataLayerRegistry,
         @ApplicationScope coroutineScope: CoroutineScope,
+        serializer: WatchSyncAuthDataSerializer,
     ): TokenBundleRepository<WatchSyncAuthData?> {
         return TokenBundleRepositoryImpl(
             registry = wearDataLayerRegistry,
             coroutineScope = coroutineScope,
-            serializer = WatchSyncAuthDataSerializer,
+            serializer = serializer,
         )
     }
 }

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/watchsync/WatchSyncAuthData.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/watchsync/WatchSyncAuthData.kt
@@ -2,13 +2,14 @@ package au.com.shiftyjelly.pocketcasts.account.watchsync
 
 import androidx.datastore.core.Serializer
 import au.com.shiftyjelly.pocketcasts.preferences.RefreshToken
-import au.com.shiftyjelly.pocketcasts.repositories.sync.LoginIdentity
+import au.com.shiftyjelly.pocketcasts.servers.sync.LoginIdentity
 import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
 import com.squareup.moshi.Moshi
 import java.io.InputStream
 import java.io.InputStreamReader
 import java.io.OutputStream
+import javax.inject.Inject
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 
@@ -18,14 +19,10 @@ data class WatchSyncAuthData(
     @field:Json(name = "loginIdentity") val loginIdentity: LoginIdentity,
 )
 
-object WatchSyncAuthDataSerializer : Serializer<WatchSyncAuthData?> {
-
-    private val adapter = WatchSyncAuthDataJsonAdapter(
-        Moshi.Builder()
-            .add(RefreshToken::class.java, RefreshToken.Adapter)
-            .add(LoginIdentity.Adapter)
-            .build(),
-    )
+class WatchSyncAuthDataSerializer @Inject constructor(
+    moshi: Moshi,
+) : Serializer<WatchSyncAuthData?> {
+    private val adapter = moshi.adapter(WatchSyncAuthData::class.java)
 
     override val defaultValue: WatchSyncAuthData? = null
 

--- a/modules/features/discover/src/test/kotlin/au/com/shiftyjelly/pocketcasts/discover/worker/CuratedPodcastsCrawlerTest.kt
+++ b/modules/features/discover/src/test/kotlin/au/com/shiftyjelly/pocketcasts/discover/worker/CuratedPodcastsCrawlerTest.kt
@@ -1,13 +1,8 @@
 package au.com.shiftyjelly.pocketcasts.discover.worker
 
 import au.com.shiftyjelly.pocketcasts.models.entity.CuratedPodcast
-import au.com.shiftyjelly.pocketcasts.servers.model.DisplayStyleMoshiAdapter
-import au.com.shiftyjelly.pocketcasts.servers.model.ExpandedStyleMoshiAdapter
-import au.com.shiftyjelly.pocketcasts.servers.model.ListTypeMoshiAdapter
+import au.com.shiftyjelly.pocketcasts.servers.di.ServersModule
 import au.com.shiftyjelly.pocketcasts.servers.server.ListWebService
-import com.squareup.moshi.Moshi
-import com.squareup.moshi.adapters.Rfc3339DateJsonAdapter
-import java.util.Date
 import kotlinx.coroutines.test.runTest
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
@@ -29,12 +24,7 @@ class CuratedPodcastsCrawlerTest {
 
     @Before
     fun setup() {
-        val moshi = Moshi.Builder()
-            .add(ListTypeMoshiAdapter())
-            .add(DisplayStyleMoshiAdapter())
-            .add(ExpandedStyleMoshiAdapter())
-            .add(Date::class.java, Rfc3339DateJsonAdapter())
-            .build()
+        val moshi = ServersModule().provideMoshi()
         val service = Retrofit.Builder()
             .baseUrl(server.url("/"))
             .addConverterFactory(MoshiConverterFactory.create(moshi))

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/AppDatabase.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/AppDatabase.kt
@@ -8,13 +8,11 @@ import androidx.room.AutoMigration
 import androidx.room.Database
 import androidx.room.DeleteColumn
 import androidx.room.OnConflictStrategy
-import androidx.room.Room
 import androidx.room.RoomDatabase
 import androidx.room.TypeConverters
 import androidx.room.migration.AutoMigrationSpec
 import androidx.room.migration.Migration
 import androidx.sqlite.db.SupportSQLiteDatabase
-import au.com.shiftyjelly.pocketcasts.model.BuildConfig
 import au.com.shiftyjelly.pocketcasts.models.converter.AutoArchiveAfterPlayingTypeConverter
 import au.com.shiftyjelly.pocketcasts.models.converter.AutoArchiveInactiveTypeConverter
 import au.com.shiftyjelly.pocketcasts.models.converter.AutoArchiveLimitTypeConverter
@@ -140,21 +138,6 @@ abstract class AppDatabase : RoomDatabase() {
         }
 
     companion object {
-        // This seems dodgy but I got it from Google, https://github.com/googlesamples/android-sunflower/blob/master/app/src/main/java/com/google/samples/apps/sunflower/data/AppDatabase.kt
-        @Volatile private var instance: AppDatabase? = null
-        fun getInstance(context: Context): AppDatabase {
-            return instance ?: buildDatabase(context).also { instance = it }
-        }
-
-        private fun buildDatabase(context: Context): AppDatabase {
-            val databaseBuilder = Room.databaseBuilder(context, AppDatabase::class.java, "pocketcasts")
-            AppDatabase.addMigrations(databaseBuilder, context)
-            if (BuildConfig.DEBUG) {
-                databaseBuilder.fallbackToDestructiveMigration()
-            }
-            return databaseBuilder.build()
-        }
-
         val MIGRATION_45_46 = addMigration(45, 46) { database ->
             database.execSQL("CREATE TABLE IF NOT EXISTS `podcasts` (`uuid` TEXT NOT NULL, `added_date` INTEGER, `thumbnail_url` TEXT, `title` TEXT NOT NULL, `podcast_url` TEXT, `podcast_description` TEXT NOT NULL, `podcast_category` TEXT NOT NULL, `podcast_language` TEXT NOT NULL, `media_type` TEXT, `latest_episode_uuid` TEXT, `author` TEXT NOT NULL, `sort_order` INTEGER NOT NULL, `episodes_sort_order` INTEGER NOT NULL, `latest_episode_date` INTEGER, `episodes_to_keep` INTEGER NOT NULL, `override_global_settings` INTEGER NOT NULL, `start_from` INTEGER NOT NULL, `playback_speed` REAL NOT NULL, `silence_removed` INTEGER NOT NULL, `volume_boosted` INTEGER NOT NULL, `is_folder` INTEGER NOT NULL, `subscribed` INTEGER NOT NULL, `show_notifications` INTEGER NOT NULL, `auto_download_status` INTEGER NOT NULL, `auto_add_to_up_next` INTEGER NOT NULL, `most_popular_color` INTEGER NOT NULL, `primary_color` INTEGER NOT NULL, `secondary_color` INTEGER NOT NULL, `light_overlay_color` INTEGER NOT NULL, `fab_for_light_bg` INTEGER NOT NULL, `link_for_dark_bg` INTEGER NOT NULL, `link_for_light_bg` INTEGER NOT NULL, `color_version` INTEGER NOT NULL, `color_last_downloaded` INTEGER NOT NULL, `sync_status` INTEGER NOT NULL, PRIMARY KEY(`uuid`))")
             database.execSQL("CREATE TABLE IF NOT EXISTS `episodes` (`uuid` TEXT NOT NULL, `episode_description` TEXT NOT NULL, `published_date` INTEGER NOT NULL, `title` TEXT NOT NULL, `size_in_bytes` INTEGER NOT NULL, `episode_status` INTEGER NOT NULL, `file_type` TEXT, `duration` REAL NOT NULL, `download_url` TEXT, `downloaded_file_path` TEXT, `downloaded_error_details` TEXT, `play_error_details` TEXT, `played_up_to` REAL NOT NULL, `playing_status` INTEGER NOT NULL, `podcast_id` TEXT NOT NULL, `added_date` INTEGER NOT NULL, `auto_download_status` INTEGER NOT NULL, `starred` INTEGER NOT NULL, `thumbnail_status` INTEGER NOT NULL, `archived` INTEGER NOT NULL, `last_download_attempt_date` INTEGER, `playing_status_modified` INTEGER, `played_up_to_modified` INTEGER, `duration_modified` INTEGER, `archived_modified` INTEGER, `starred_modified` INTEGER, PRIMARY KEY(`uuid`))")

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/di/ModelModule.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/di/ModelModule.kt
@@ -1,6 +1,9 @@
 package au.com.shiftyjelly.pocketcasts.models.di
 
 import android.app.Application
+import androidx.room.Room
+import androidx.room.RoomDatabase
+import au.com.shiftyjelly.pocketcasts.model.BuildConfig
 import au.com.shiftyjelly.pocketcasts.models.db.AppDatabase
 import au.com.shiftyjelly.pocketcasts.models.db.dao.ChapterDao
 import au.com.shiftyjelly.pocketcasts.models.db.dao.EpisodeDao
@@ -8,17 +11,40 @@ import au.com.shiftyjelly.pocketcasts.models.db.dao.ExternalDataDao
 import au.com.shiftyjelly.pocketcasts.models.db.dao.PodcastDao
 import au.com.shiftyjelly.pocketcasts.models.db.dao.TranscriptDao
 import au.com.shiftyjelly.pocketcasts.models.db.dao.UpNextDao
+import au.com.shiftyjelly.pocketcasts.models.entity.AnonymousBumpStat
+import com.squareup.moshi.Moshi
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
+import javax.inject.Qualifier
+import javax.inject.Singleton
 
 @Module
 @InstallIn(SingletonComponent::class)
 object ModelModule {
     @Provides
-    fun providesAppDatabase(application: Application): AppDatabase {
-        return AppDatabase.getInstance(application)
+    @RoomConverters
+    fun provideRoomConveretrs(moshi: Moshi): List<Any> {
+        return listOf(
+            AnonymousBumpStat.CustomEventPropsTypeConverter(moshi),
+        )
+    }
+
+    @Provides
+    @Singleton
+    fun providesAppDatabase(
+        application: Application,
+        @RoomConverters converters: List<@JvmSuppressWildcards Any>,
+    ): AppDatabase {
+        val databaseBuilder = Room.databaseBuilder(application, AppDatabase::class.java, "pocketcasts")
+        AppDatabase.addMigrations(databaseBuilder, application)
+        if (BuildConfig.DEBUG) {
+            databaseBuilder.fallbackToDestructiveMigration()
+        }
+        return databaseBuilder
+            .addTypeConverters(converters)
+            .build()
     }
 
     @Provides
@@ -38,4 +64,12 @@ object ModelModule {
 
     @Provides
     fun provideExternalDataDao(database: AppDatabase): ExternalDataDao = database.externalDataDao()
+}
+
+@Qualifier
+@Retention(AnnotationRetention.BINARY)
+annotation class RoomConverters
+
+fun <T : RoomDatabase> RoomDatabase.Builder<T>.addTypeConverters(converters: List<Any>) = converters.fold(this) { builder, converter ->
+    builder.addTypeConverter(converter)
 }

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/di/ModelModule.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/di/ModelModule.kt
@@ -25,7 +25,7 @@ import javax.inject.Singleton
 object ModelModule {
     @Provides
     @RoomConverters
-    fun provideRoomConveretrs(moshi: Moshi): List<Any> {
+    fun provideRoomConverters(moshi: Moshi): List<Any> {
         return listOf(
             AnonymousBumpStat.CustomEventPropsTypeConverter(moshi),
         )

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/entity/AnonymousBumpStat.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/entity/AnonymousBumpStat.kt
@@ -2,6 +2,7 @@ package au.com.shiftyjelly.pocketcasts.models.entity
 
 import androidx.room.ColumnInfo
 import androidx.room.Entity
+import androidx.room.ProvidedTypeConverter
 import androidx.room.TypeConverter
 import com.squareup.moshi.FromJson
 import com.squareup.moshi.Moshi
@@ -46,26 +47,26 @@ data class AnonymousBumpStat(
         const val uuidValue = "ANONYMOUS"
     }
 
-    class CustomEventPropsTypeConverter {
-
-        private val moshi = Moshi.Builder()
-            .build()
-            .adapter<Map<String, Any>>(
-                Types.newParameterizedType(
-                    Map::class.java,
-                    String::class.java,
-                    Any::class.java,
-                ),
-            )
+    @ProvidedTypeConverter
+    class CustomEventPropsTypeConverter(
+        moshi: Moshi,
+    ) {
+        private val adapter = moshi.adapter<Map<String, Any>>(
+            Types.newParameterizedType(
+                Map::class.java,
+                String::class.java,
+                Any::class.java,
+            ),
+        )
 
         @TypeConverter
         fun toCustomEventProps(value: String?): Map<String, Any>? =
             value?.let {
-                moshi.fromJson(it)
+                adapter.fromJson(it)
             }
 
         @TypeConverter
-        fun toJsonString(value: Map<String, Any>?): String? = moshi.toJson(value)
+        fun toJsonString(value: Map<String, Any>?): String? = adapter.toJson(value)
     }
 
     object Adapter {

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/AccountConstants.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/AccountConstants.kt
@@ -35,8 +35,7 @@ data class AccessToken(val value: String) {
     }
 }
 
-@JvmInline
-value class RefreshToken(val value: String) {
+data class RefreshToken(val value: String) {
     object Adapter : JsonAdapter<RefreshToken>() {
         override fun fromJson(reader: JsonReader) = RefreshToken(reader.nextString())
 

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/download/task/UploadEpisodeTask.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/download/task/UploadEpisodeTask.kt
@@ -9,6 +9,7 @@ import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.UserEpisodeManager
 import au.com.shiftyjelly.pocketcasts.servers.sync.parseErrorResponse
 import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
+import com.squareup.moshi.Moshi
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedInject
 import io.reactivex.Single
@@ -20,6 +21,7 @@ class UploadEpisodeTask @AssistedInject constructor(
     @Assisted params: WorkerParameters,
     var userEpisodeManager: UserEpisodeManager,
     var playbackManager: PlaybackManager,
+    private val moshi: Moshi,
 ) : RxWorker(context, params) {
 
     companion object {
@@ -48,7 +50,7 @@ class UploadEpisodeTask @AssistedInject constructor(
                 val retry: Boolean
 
                 if (it is HttpException) {
-                    val errorResponse = it.parseErrorResponse()
+                    val errorResponse = it.parseErrorResponse(moshi)
                     errorMessage = errorResponse?.messageLocalized(context.resources)
 
                     if (errorMessage == null) {

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/SyncAccountManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/SyncAccountManager.kt
@@ -4,6 +4,7 @@ import android.accounts.Account
 import au.com.shiftyjelly.pocketcasts.preferences.AccessToken
 import au.com.shiftyjelly.pocketcasts.preferences.AccountConstants
 import au.com.shiftyjelly.pocketcasts.preferences.RefreshToken
+import au.com.shiftyjelly.pocketcasts.servers.sync.LoginIdentity
 import au.com.shiftyjelly.pocketcasts.servers.sync.TokenHandler
 
 /**

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/SyncAccountManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/SyncAccountManagerImpl.kt
@@ -11,6 +11,7 @@ import androidx.core.os.bundleOf
 import au.com.shiftyjelly.pocketcasts.preferences.AccessToken
 import au.com.shiftyjelly.pocketcasts.preferences.AccountConstants
 import au.com.shiftyjelly.pocketcasts.preferences.RefreshToken
+import au.com.shiftyjelly.pocketcasts.servers.sync.LoginIdentity
 import au.com.shiftyjelly.pocketcasts.servers.sync.TokenHandler
 import au.com.shiftyjelly.pocketcasts.servers.sync.exception.RefreshTokenExpiredException
 import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/SyncManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/SyncManager.kt
@@ -13,6 +13,7 @@ import au.com.shiftyjelly.pocketcasts.servers.sync.EpisodeSyncRequest
 import au.com.shiftyjelly.pocketcasts.servers.sync.FileAccount
 import au.com.shiftyjelly.pocketcasts.servers.sync.FilePost
 import au.com.shiftyjelly.pocketcasts.servers.sync.FilesResponse
+import au.com.shiftyjelly.pocketcasts.servers.sync.LoginIdentity
 import au.com.shiftyjelly.pocketcasts.servers.sync.NamedSettingsCaller
 import au.com.shiftyjelly.pocketcasts.servers.sync.PodcastEpisodesResponse
 import au.com.shiftyjelly.pocketcasts.servers.sync.PromoCodeResponse

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/SyncManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/SyncManagerImpl.kt
@@ -25,6 +25,7 @@ import au.com.shiftyjelly.pocketcasts.servers.sync.FileAccount
 import au.com.shiftyjelly.pocketcasts.servers.sync.FileImageUploadData
 import au.com.shiftyjelly.pocketcasts.servers.sync.FilePost
 import au.com.shiftyjelly.pocketcasts.servers.sync.FilesResponse
+import au.com.shiftyjelly.pocketcasts.servers.sync.LoginIdentity
 import au.com.shiftyjelly.pocketcasts.servers.sync.NamedSettingsCaller
 import au.com.shiftyjelly.pocketcasts.servers.sync.NamedSettingsResponse
 import au.com.shiftyjelly.pocketcasts.servers.sync.PodcastEpisodesResponse
@@ -47,6 +48,7 @@ import com.pocketcasts.service.api.PodcastRatingResponse
 import com.pocketcasts.service.api.SyncUpdateRequest
 import com.pocketcasts.service.api.SyncUpdateResponse
 import com.pocketcasts.service.api.UserPodcastListResponse
+import com.squareup.moshi.Moshi
 import dagger.hilt.android.qualifiers.ApplicationContext
 import io.reactivex.Completable
 import io.reactivex.Maybe
@@ -69,6 +71,7 @@ class SyncManagerImpl @Inject constructor(
     private val settings: Settings,
     private val syncAccountManager: SyncAccountManager,
     private val syncServerManager: SyncServerManager,
+    private val moshi: Moshi,
 ) : NamedSettingsCaller, SyncManager {
 
     override val isLoggedInObservable = BehaviorRelay.create<Boolean>().apply {
@@ -448,7 +451,7 @@ class SyncManagerImpl @Inject constructor(
         var message: String? = null
         var messageId: String? = null
         if (exception is HttpException) {
-            val errorResponse = exception.parseErrorResponse()
+            val errorResponse = exception.parseErrorResponse(moshi)
             message = errorResponse?.messageLocalized(resources)
             messageId = errorResponse?.messageId
         }

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/HttpExceptionMessage.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/HttpExceptionMessage.kt
@@ -8,11 +8,10 @@ import com.squareup.moshi.Moshi
 import retrofit2.HttpException
 import timber.log.Timber
 
-fun HttpException.parseErrorResponse(): ErrorResponse? {
+fun HttpException.parseErrorResponse(moshi: Moshi): ErrorResponse? {
     val errorBody = this.response()?.errorBody() ?: return null
     return try {
-        val errorMoshi = Moshi.Builder().build()
-        errorMoshi.adapter(ErrorResponse::class.java).fromJson(errorBody.source())
+        moshi.adapter(ErrorResponse::class.java).fromJson(errorBody.source())
     } catch (e: Exception) {
         Timber.e(e)
         null

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/LoginIdentity.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/LoginIdentity.kt
@@ -1,4 +1,4 @@
-package au.com.shiftyjelly.pocketcasts.repositories.sync
+package au.com.shiftyjelly.pocketcasts.servers.sync
 
 import com.squareup.moshi.FromJson
 import com.squareup.moshi.ToJson

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/di/AuthWatchModule.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/di/AuthWatchModule.kt
@@ -23,10 +23,11 @@ object AuthWatchModule {
     @Provides
     fun providesTokenBundleRepository(
         wearDataLayerRegistry: WearDataLayerRegistry,
+        serializer: WatchSyncAuthDataSerializer,
     ): TokenBundleRepository<WatchSyncAuthData?> {
         return TokenBundleRepositoryImpl.create(
             registry = wearDataLayerRegistry,
-            serializer = WatchSyncAuthDataSerializer,
+            serializer = serializer,
         )
     }
 


### PR DESCRIPTION
## Description

This PR cleans up Moshi configuration and makes sure that we use a single instance of it that is injected.

I also discovered a potential issue with handling refresh token on Wear OS. We used a `value class` for it, which isn't supported by Moshi.

## Testing Instructions

1. Smoke test the phone app.
2. Test signing in on the Wear OS app.

## Checklist
- [x] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml``
- [x] ~Any jetpack compose components I added or changed are covered by compose previews~
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
