### PR TITLE
Referrals: add feature flag

### DIFF
--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/ProfileFragment.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/ProfileFragment.kt
@@ -203,6 +203,7 @@ class ProfileFragment : BaseFragment() {
 
         viewModel.signInState.observe(viewLifecycleOwner) { state ->
             binding.userView.signedInState = state
+            binding.btnGift.isVisible = FeatureFlag.isEnabled(Feature.REFERRALS) && state.isSignedInAsPlusOrPatron
 
             binding.upgradeLayout.root.isInvisible = settings.getUpgradeClosedProfile() || state.isSignedInAsPlusOrPatron
             if (binding.upgradeLayout.root.isInvisible) {

--- a/modules/features/profile/src/main/res/drawable/ic_gift.xml
+++ b/modules/features/profile/src/main/res/drawable/ic_gift.xml
@@ -1,0 +1,52 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:pathData="M19.778,7H4.222C2.995,7 2,8.045 2,9.333V11.667C2,12.481 2.398,13.198 3,13.616V18C3,20.209 4.791,22 7,22H11H17C19.209,22 21,20.209 21,18V13.616C21.603,13.198 22,12.481 22,11.667V9.333C22,8.045 21.005,7 19.778,7ZM19,14H13V20H17C18.105,20 19,19.105 19,18V14ZM5,14H11V20H7C5.895,20 5,19.105 5,18V14ZM4,12V9H20V12H4Z"
+        android:fillColor="#000"
+        android:fillType="evenOdd" />
+    <path
+        android:pathData="M7.595,6.611C8.673,7.733 10.37,7.999 11.193,7.999"
+        android:strokeLineJoin="round"
+        android:strokeWidth="2"
+        android:fillColor="#00000000"
+        android:strokeColor="#000"
+        android:strokeLineCap="round" />
+    <path
+        android:pathData="M11.193,8C11.193,8 11.687,4.884 10.472,3.62"
+        android:strokeLineJoin="round"
+        android:strokeWidth="2"
+        android:fillColor="#00000000"
+        android:strokeColor="#000"
+        android:strokeLineCap="round" />
+    <path
+        android:pathData="M7.595,6.611C6.801,5.786 6.801,4.445 7.595,3.619C8.389,2.793 9.677,2.793 10.47,3.619"
+        android:strokeLineJoin="round"
+        android:strokeWidth="2"
+        android:fillColor="#00000000"
+        android:strokeColor="#000"
+        android:strokeLineCap="round" />
+    <path
+        android:pathData="M16.404,6.611C15.326,7.733 13.63,7.999 12.807,7.999"
+        android:strokeLineJoin="round"
+        android:strokeWidth="2"
+        android:fillColor="#00000000"
+        android:strokeColor="#000"
+        android:strokeLineCap="round" />
+    <path
+        android:pathData="M12.807,8C12.807,8 12.313,4.884 13.528,3.62"
+        android:strokeLineJoin="round"
+        android:strokeWidth="2"
+        android:fillColor="#00000000"
+        android:strokeColor="#000"
+        android:strokeLineCap="round" />
+    <path
+        android:pathData="M16.404,6.611C17.198,5.786 17.198,4.445 16.404,3.619C15.611,2.793 14.323,2.793 13.53,3.619"
+        android:strokeLineJoin="round"
+        android:strokeWidth="2"
+        android:fillColor="#00000000"
+        android:strokeColor="#000"
+        android:strokeLineCap="round" />
+</vector>

--- a/modules/features/profile/src/main/res/layout-land/fragment_profile.xml
+++ b/modules/features/profile/src/main/res/layout-land/fragment_profile.xml
@@ -194,7 +194,7 @@
             android:visibility="gone"
             app:layout_constraintEnd_toStartOf="@id/btnSettings"
             app:layout_constraintTop_toTopOf="parent"
-            app:tint="?attr/primary_text_01"
+            app:tint="?attr/secondary_icon_01"
             tools:visibility="visible" />
 
         <ImageButton
@@ -207,7 +207,7 @@
             android:src="@drawable/ic_profile_settings"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintTop_toTopOf="parent"
-            app:tint="?attr/primary_text_01" />
+            app:tint="?attr/secondary_icon_01" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 

--- a/modules/features/profile/src/main/res/layout-land/fragment_profile.xml
+++ b/modules/features/profile/src/main/res/layout-land/fragment_profile.xml
@@ -174,17 +174,41 @@
 
     </androidx.core.widget.NestedScrollView>
 
-    <ImageButton
-        android:id="@+id/btnSettings"
-        android:layout_width="44dp"
-        android:layout_height="44dp"
-        android:layout_gravity="right"
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="end"
         android:layout_marginTop="7dp"
         android:layout_marginEnd="6dp"
-        android:layout_marginBottom="10dp"
-        android:background="?android:attr/actionBarItemBackground"
-        android:contentDescription="@string/settings"
-        android:src="@drawable/ic_profile_settings"
-        android:tint="?attr/primary_text_01" />
+        android:layout_marginBottom="10dp">
+
+        <ImageButton
+            android:id="@+id/btnGift"
+            android:layout_width="44dp"
+            android:layout_height="44dp"
+            android:layout_gravity="end"
+            android:layout_marginEnd="8dp"
+            android:background="?android:attr/actionBarItemBackground"
+            android:contentDescription="@string/gift"
+            android:src="@drawable/ic_gift"
+            android:visibility="gone"
+            app:layout_constraintEnd_toStartOf="@id/btnSettings"
+            app:layout_constraintTop_toTopOf="parent"
+            app:tint="?attr/primary_text_01"
+            tools:visibility="visible" />
+
+        <ImageButton
+            android:id="@+id/btnSettings"
+            android:layout_width="44dp"
+            android:layout_height="44dp"
+            android:layout_marginBottom="10dp"
+            android:background="?android:attr/actionBarItemBackground"
+            android:contentDescription="@string/settings"
+            android:src="@drawable/ic_profile_settings"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:tint="?attr/primary_text_01" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
 
 </FrameLayout>

--- a/modules/features/profile/src/main/res/layout-land/fragment_profile.xml
+++ b/modules/features/profile/src/main/res/layout-land/fragment_profile.xml
@@ -194,7 +194,7 @@
             android:visibility="gone"
             app:layout_constraintEnd_toStartOf="@id/btnSettings"
             app:layout_constraintTop_toTopOf="parent"
-            app:tint="?attr/secondary_icon_01"
+            app:tint="?attr/primary_icon_01"
             tools:visibility="visible" />
 
         <ImageButton
@@ -207,7 +207,7 @@
             android:src="@drawable/ic_profile_settings"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintTop_toTopOf="parent"
-            app:tint="?attr/secondary_icon_01" />
+            app:tint="?attr/primary_icon_01" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 

--- a/modules/features/profile/src/main/res/layout/fragment_profile.xml
+++ b/modules/features/profile/src/main/res/layout/fragment_profile.xml
@@ -182,7 +182,7 @@
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toTopOf="parent"
                 android:visibility="gone"
-                app:tint="?attr/primary_text_01"
+                app:tint="?attr/secondary_icon_01"
                 tools:visibility="visible" />
 
             <ImageButton
@@ -196,7 +196,7 @@
                 android:src="@drawable/ic_profile_settings"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintTop_toTopOf="parent"
-                app:tint="?attr/primary_text_01" />
+                app:tint="?attr/secondary_icon_01" />
 
         </androidx.constraintlayout.widget.ConstraintLayout>
 

--- a/modules/features/profile/src/main/res/layout/fragment_profile.xml
+++ b/modules/features/profile/src/main/res/layout/fragment_profile.xml
@@ -171,6 +171,21 @@
                 app:layout_constraintBottom_toBottomOf="parent"/>
 
             <ImageButton
+                android:id="@+id/btnGift"
+                android:layout_width="44dp"
+                android:layout_height="44dp"
+                android:layout_marginTop="7dp"
+                android:layout_marginEnd="7dp"
+                android:background="?android:attr/actionBarItemBackground"
+                android:contentDescription="@string/gift"
+                android:src="@drawable/ic_gift"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent"
+                android:visibility="gone"
+                app:tint="?attr/primary_text_01"
+                tools:visibility="visible" />
+
+            <ImageButton
                 android:id="@+id/btnSettings"
                 android:layout_width="44dp"
                 android:layout_height="44dp"

--- a/modules/features/profile/src/main/res/layout/fragment_profile.xml
+++ b/modules/features/profile/src/main/res/layout/fragment_profile.xml
@@ -194,7 +194,7 @@
                 android:background="?android:attr/actionBarItemBackground"
                 android:contentDescription="@string/settings"
                 android:src="@drawable/ic_profile_settings"
-                app:layout_constraintRight_toRightOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintTop_toTopOf="parent"
                 app:tint="?attr/primary_text_01" />
 

--- a/modules/features/profile/src/main/res/layout/fragment_profile.xml
+++ b/modules/features/profile/src/main/res/layout/fragment_profile.xml
@@ -182,7 +182,7 @@
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toTopOf="parent"
                 android:visibility="gone"
-                app:tint="?attr/secondary_icon_01"
+                app:tint="?attr/primary_icon_01"
                 tools:visibility="visible" />
 
             <ImageButton
@@ -196,7 +196,7 @@
                 android:src="@drawable/ic_profile_settings"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintTop_toTopOf="parent"
-                app:tint="?attr/secondary_icon_01" />
+                app:tint="?attr/primary_icon_01" />
 
         </androidx.constraintlayout.widget.ConstraintLayout>
 

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -2093,4 +2093,7 @@ up    <string name="player_sleep_in_one_chapter">Sleeping in 1 chapter</string>
     <string name="engage_sdk_new_releases" translatable="false">@string/nova_launcher_new_releases</string>
     <string name="engage_sdk_trending" translatable="false">@string/discover_trending</string>
 
+    <!-- Referrals -->
+    <string name="gift">Gift</string>
+
 </resources>

--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/Feature.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/Feature.kt
@@ -179,6 +179,14 @@ enum class Feature(
         hasFirebaseRemoteFlag = false,
         hasDevToggle = false,
     ),
+    REFERRALS(
+        key = "referrals",
+        title = "Referrals",
+        defaultValue = BuildConfig.DEBUG,
+        tier = FeatureTier.Free,
+        hasFirebaseRemoteFlag = false,
+        hasDevToggle = true,
+    ),
     ;
 
     companion object {


### PR DESCRIPTION
## Description
This adds a local feature flag for the referrals project and a gift icon on the Profile screen to test it.

**Figma**: FVJPaWlRMlosEpsRhqxnSD-fi-2189_9583 (there's an open question about screen title)

** active passes icon count added in https://github.com/Automattic/pocket-casts-android/pull/2746

Closes #2728

## Testing Instructions
1. Launch app without sign in or sign in as free account
2. Go to `Profile` -> `Settings` -> `Beta features`
3. ✅ Notice that `Referrals` beta feature flag is enabled for debug build
4. Go back to the `Profile` screen
5. ✅ Notice that a gift icon is not present
6. Sign in with a paid account (plus or patron)
7. ✅ Notice that a gift icon is present
    - on the top start of the screen in portrait mode
    - before settings icon in landscape mode
8. Disable `Referrals` beta feature flag through `Profile` -> `Settings` -> `Beta features`
9. Go back to the `Profile` screen
10. ✅ Notice that the gift icon is hidden

## Screenshots or Screencast 

![icons](https://github.com/user-attachments/assets/29c44f1f-f218-40e8-9309-3fcb24066762)


|Landscape|
|---|
|<img width=500 src="https://github.com/user-attachments/assets/c07a3be3-07f3-4edb-9721-029a712fa0a8"/>

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack