### PR TITLE
Transcripts - Display player controls on landscape large screens 

### DIFF
--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/PlayerHeaderFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/PlayerHeaderFragment.kt
@@ -4,7 +4,6 @@ import android.animation.LayoutTransition
 import android.content.ActivityNotFoundException
 import android.content.Intent
 import android.content.res.ColorStateList
-import android.content.res.Configuration
 import android.graphics.Color
 import android.net.Uri
 import android.os.Bundle
@@ -380,10 +379,11 @@ class PlayerHeaderFragment : BaseFragment(), PlayerClickListener {
         playerGroup.layoutTransition = LayoutTransition()
         transcriptPage.isVisible = true
         shelf.isVisible = false
-        seekBar.isVisible = resources.configuration.orientation != Configuration.ORIENTATION_LANDSCAPE
-        playerControls.root.isVisible = resources.configuration.orientation != Configuration.ORIENTATION_LANDSCAPE
+        val transcriptShowSeekbarAndPlayerControls = resources.getBoolean(R.bool.transcript_show_seekbar_and_player_controls)
+        seekBar.isVisible = transcriptShowSeekbarAndPlayerControls
+        playerControls.root.isVisible = transcriptShowSeekbarAndPlayerControls
         playerControls.scale(0.6f)
-        if (resources.configuration.orientation == Configuration.ORIENTATION_PORTRAIT) {
+        if (transcriptShowSeekbarAndPlayerControls) {
             (seekBar.layoutParams as ViewGroup.MarginLayoutParams).bottomMargin = resources.getDimensionPixelSize(R.dimen.seekbar_margin_bottom_transcript)
         }
         val containerFragment = parentFragment as? PlayerContainerFragment
@@ -401,7 +401,8 @@ class PlayerHeaderFragment : BaseFragment(), PlayerClickListener {
         seekBar.isVisible = true
         playerControls.root.isVisible = true
         playerControls.scale(1f)
-        if (resources.configuration.orientation == Configuration.ORIENTATION_PORTRAIT) {
+        val transcriptShowSeekbarAndPlayerControls = resources.getBoolean(R.bool.transcript_show_seekbar_and_player_controls)
+        if (transcriptShowSeekbarAndPlayerControls) {
             (seekBar.layoutParams as ViewGroup.MarginLayoutParams).bottomMargin = resources.getDimensionPixelSize(R.dimen.seekbar_margin_bottom)
         }
         val containerFragment = parentFragment as? PlayerContainerFragment

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/transcripts/TranscriptDefaults.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/transcripts/TranscriptDefaults.kt
@@ -5,6 +5,7 @@ import androidx.compose.material.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.font.Font
 import androidx.compose.ui.text.font.FontFamily
@@ -12,18 +13,18 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import au.com.shiftyjelly.pocketcasts.compose.theme
-import au.com.shiftyjelly.pocketcasts.ui.R
+import au.com.shiftyjelly.pocketcasts.player.R
+import au.com.shiftyjelly.pocketcasts.ui.R as UR
 
 object TranscriptDefaults {
     val ContentOffsetTop = 64.dp
     val ContentOffsetBottom = 80.dp
-    val TranscriptFontFamily = FontFamily(listOf(Font(R.font.roboto_serif)))
+    val TranscriptFontFamily = FontFamily(listOf(Font(UR.font.roboto_serif)))
     val SearchOccurrenceDefaultSpanStyle = SpanStyle(fontSize = 16.sp, fontWeight = FontWeight.W500, fontFamily = TranscriptFontFamily, background = Color.White.copy(alpha = .2f), color = Color.White)
     val SearchOccurrenceSelectedSpanStyle = SpanStyle(fontSize = 16.sp, fontWeight = FontWeight.W500, fontFamily = TranscriptFontFamily, background = Color.White, color = Color.Black)
 
     @Composable
-    fun bottomPadding() =
-        if (LocalConfiguration.current.orientation == Configuration.ORIENTATION_LANDSCAPE) 0.dp else 125.dp
+    fun bottomPadding() = dimensionResource(id = R.dimen.transcript_text_bottom_padding)
 
     @Composable
     fun scrollToHighlightedTextOffset() =

--- a/modules/features/player/src/main/res/layout-sw600dp/adapter_player_header.xml
+++ b/modules/features/player/src/main/res/layout-sw600dp/adapter_player_header.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?><!-- Large screens use default layout instead of the landscape one to match iOS design.
+This layout has full screen seekbar and player controls which makes them easier to transition to the Transcript screen.  -->
 <au.com.shiftyjelly.pocketcasts.views.component.LockableNestedScrollView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"

--- a/modules/features/player/src/main/res/layout-sw600dp/adapter_player_header.xml
+++ b/modules/features/player/src/main/res/layout-sw600dp/adapter_player_header.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?><!-- Large screens use default layout instead of the landscape one to match iOS design.
-This layout has full screen seekbar and player controls which makes them easier to transition to the Transcript screen.  -->
+Player controls and seekbar are centered horizontally on this layout, which makes them easier to transition to the Transcript screen.  -->
 <au.com.shiftyjelly.pocketcasts.views.component.LockableNestedScrollView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"

--- a/modules/features/player/src/main/res/layout-sw600dp/adapter_player_header.xml
+++ b/modules/features/player/src/main/res/layout-sw600dp/adapter_player_header.xml
@@ -1,0 +1,377 @@
+<?xml version="1.0" encoding="utf-8"?>
+<au.com.shiftyjelly.pocketcasts.views.component.LockableNestedScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:importantForAccessibility="no"
+    android:fillViewport="true">
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/playerGroup"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:clipChildren="false"
+        android:clipToPadding="false"
+        android:theme="@style/PlayerTheme">
+
+        <ImageView
+            android:id="@+id/artwork"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            android:layout_marginStart="16dp"
+            android:layout_marginTop="16dp"
+            android:layout_marginEnd="16dp"
+            android:layout_marginBottom="16dp"
+            android:importantForAccessibility="no"
+            android:clickable="true"
+            android:scaleType="fitCenter"
+            app:layout_constraintBottom_toTopOf="@+id/episodeTitle"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            tools:src="@tools:sample/avatars" />
+
+        <ImageView
+            android:id="@+id/chapterArtwork"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            android:layout_marginStart="16dp"
+            android:layout_marginTop="16dp"
+            android:layout_marginEnd="16dp"
+            android:layout_marginBottom="16dp"
+            android:importantForAccessibility="no"
+            android:clickable="true"
+            app:layout_constraintBottom_toTopOf="@+id/episodeTitle"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            tools:src="@tools:sample/avatars" />
+
+        <androidx.constraintlayout.widget.Barrier
+            android:id="@+id/artworkTopBarrier"
+            android:layout_width="match_parent"
+            android:layout_height="1dp"
+            app:barrierAllowsGoneWidgets="true"
+            app:barrierDirection="top"
+            app:constraint_referenced_ids="artwork,chapterArtwork" />
+
+        <androidx.constraintlayout.widget.Barrier
+            android:id="@+id/artworkEndBarrier"
+            android:layout_width="1dp"
+            android:layout_height="match_parent"
+            app:barrierAllowsGoneWidgets="true"
+            app:barrierDirection="end"
+            app:constraint_referenced_ids="artwork,chapterArtwork" />
+
+        <ImageView
+            android:id="@+id/chapterUrl"
+            android:layout_width="36dp"
+            android:layout_height="36dp"
+            android:layout_marginTop="8dp"
+            android:layout_marginEnd="8dp"
+            android:background="?android:attr/actionBarItemBackground"
+            android:clickable="true"
+            android:contentDescription="@string/player_chapter_url"
+            android:focusable="true"
+            android:scaleType="fitCenter"
+            android:src="@drawable/ic_link_back"
+            app:layout_constraintEnd_toEndOf="@+id/artworkEndBarrier"
+            app:layout_constraintTop_toTopOf="@+id/artworkTopBarrier" />
+
+        <ImageView
+            android:id="@+id/chapterUrlFront"
+            android:layout_width="20dp"
+            android:layout_height="20dp"
+            android:scaleType="fitCenter"
+            android:src="@drawable/ic_link"
+            app:layout_constraintBottom_toBottomOf="@+id/chapterUrl"
+            app:layout_constraintEnd_toEndOf="@+id/chapterUrl"
+            app:layout_constraintStart_toStartOf="@+id/chapterUrl"
+            app:layout_constraintTop_toTopOf="@+id/chapterUrl" />
+
+        <au.com.shiftyjelly.pocketcasts.player.view.video.VideoView
+            android:id="@+id/videoView"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            android:layout_marginStart="16dp"
+            android:layout_marginTop="16dp"
+            android:layout_marginEnd="16dp"
+            android:layout_marginBottom="16dp"
+            app:layout_constraintBottom_toTopOf="@+id/episodeTitle"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <TextView
+            android:id="@+id/episodeTitle"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center_vertical"
+            android:layout_marginStart="16dp"
+            android:layout_marginEnd="16dp"
+            android:layout_marginBottom="4dp"
+            android:ellipsize="end"
+            android:fontFamily="sans-serif-medium"
+            android:gravity="center"
+            android:includeFontPadding="false"
+            android:lineSpacingMultiplier="1.2"
+            android:maxLines="2"
+            android:textColor="#FFFFFFFF"
+            android:textSize="18sp"
+            app:layout_constraintBottom_toTopOf="@+id/subtitleBarrier"
+            app:layout_constraintEnd_toStartOf="@+id/nextChapter"
+            app:layout_constraintStart_toEndOf="@+id/previousChapter"
+            tools:text="@tools:sample/lorem" />
+
+        <androidx.constraintlayout.widget.Barrier
+            android:id="@+id/subtitleBarrier"
+            android:layout_width="1dp"
+            android:layout_height="match_parent"
+            app:barrierAllowsGoneWidgets="true"
+            app:barrierDirection="top"
+            app:constraint_referenced_ids="podcastTitle,chapterSummary" />
+
+        <TextView
+            android:id="@+id/podcastTitle"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center_vertical"
+            android:layout_marginStart="16dp"
+            android:layout_marginEnd="16dp"
+            android:layout_marginBottom="16dp"
+            android:ellipsize="end"
+            android:fontFamily="sans-serif-medium"
+            android:gravity="center"
+            android:includeFontPadding="false"
+            android:maxLines="1"
+            android:textColor="?attr/player_contrast_02"
+            android:textSize="14sp"
+            app:layout_constraintBottom_toTopOf="@+id/chapterSummary"
+            app:layout_constraintEnd_toStartOf="@+id/nextChapter"
+            app:layout_constraintStart_toEndOf="@+id/previousChapter"
+            tools:text="Invisibilia" />
+
+        <TextView
+            android:id="@+id/chapterSummary"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center_vertical"
+            android:layout_marginStart="16dp"
+            android:layout_marginEnd="16dp"
+            android:layout_marginBottom="16dp"
+            android:gravity="center"
+            android:textAppearance="?attr/textCaption"
+            app:layout_constraintBottom_toTopOf="@+id/seekBar"
+            app:layout_constraintEnd_toStartOf="@+id/nextChapter"
+            app:layout_constraintStart_toEndOf="@+id/previousChapter"
+            tools:text="@tools:sample/lorem" />
+
+        <ImageButton
+            android:id="@+id/previousChapter"
+            android:layout_width="44dp"
+            android:layout_height="44dp"
+            android:layout_marginStart="8dp"
+            android:background="?android:attr/actionBarItemBackground"
+            android:contentDescription="@string/player_action_previous_chapter"
+            android:src="@drawable/ic_chapter_skipbackwards"
+            app:layout_constraintBottom_toBottomOf="@+id/episodeTitle"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="@+id/episodeTitle" />
+
+        <ImageButton
+            android:id="@+id/nextChapter"
+            android:layout_width="44dp"
+            android:layout_height="44dp"
+            android:layout_marginEnd="8dp"
+            android:background="?android:attr/actionBarItemBackground"
+            android:contentDescription="@string/player_action_next_chapter"
+            android:src="@drawable/ic_chapter_skipforward"
+            app:layout_constraintBottom_toBottomOf="@+id/episodeTitle"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toTopOf="@+id/episodeTitle" />
+
+        <au.com.shiftyjelly.pocketcasts.player.view.ChapterProgressCircle
+            android:id="@+id/chapterProgressCircle"
+            android:layout_width="30dp"
+            android:layout_height="30dp"
+            app:layout_constraintBottom_toBottomOf="@+id/nextChapter"
+            app:layout_constraintEnd_toEndOf="@+id/nextChapter"
+            app:layout_constraintStart_toStartOf="@+id/nextChapter"
+            app:layout_constraintTop_toTopOf="@+id/nextChapter" />
+
+        <TextView
+            android:id="@+id/chapterTimeRemaining"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="6dp"
+            android:alpha="0.4"
+            android:textAppearance="@style/H70"
+            android:textColor="@color/white"
+            app:layout_constraintEnd_toEndOf="@+id/nextChapter"
+            app:layout_constraintStart_toStartOf="@+id/nextChapter"
+            app:layout_constraintTop_toBottomOf="@+id/nextChapter"
+            tools:text="9m" />
+
+        <androidx.compose.ui.platform.ComposeView
+            android:id="@+id/transcriptPage"
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:visibility="gone"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent" />
+
+        <au.com.shiftyjelly.pocketcasts.player.view.PlayerSeekBar
+            android:id="@+id/seekBar"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="10dp"
+            app:layout_constraintBottom_toTopOf="@+id/playerControls"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintWidth_percent="@dimen/seekbar_width_percentage" />
+
+        <include
+            layout="@layout/player_controls"
+            android:id="@+id/playerControls"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintBottom_toTopOf="@+id/shelf" />
+
+        <LinearLayout
+            android:id="@+id/shelf"
+            android:layout_width="0dp"
+            android:layout_height="56dp"
+            android:layout_marginStart="20dp"
+            android:layout_marginTop="30dp"
+            android:layout_marginEnd="20dp"
+            android:layout_marginBottom="16dp"
+            android:background="@drawable/player_shelf"
+            android:gravity="center"
+            android:orientation="horizontal"
+            android:paddingLeft="8dp"
+            android:paddingRight="8dp"
+            android:weightSum="5"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent">
+
+            <ImageButton
+                android:id="@+id/effects"
+                android:layout_width="0dp"
+                android:layout_height="48dp"
+                android:layout_marginBottom="2dp"
+                android:layout_weight="1"
+                android:background="?android:attr/actionBarItemBackground"
+                android:contentDescription="@string/player_effects"
+                app:srcCompat="@drawable/ic_effects_off_32"
+                app:tint="?attr/player_contrast_03" />
+
+            <com.airbnb.lottie.LottieAnimationView
+                android:id="@+id/sleep"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:background="?android:attr/actionBarItemBackground"
+                android:clickable="true"
+                android:contentDescription="@string/player_sleep_timer"
+                android:focusable="true"
+                android:scaleType="centerInside"
+                app:lottie_loop="true"
+                app:lottie_progress="0.5"
+                app:lottie_rawRes="@raw/sleep_button" />
+
+            <ImageButton
+                android:id="@+id/star"
+                android:layout_width="0dp"
+                android:layout_height="48dp"
+                android:layout_weight="1"
+                android:background="?android:attr/actionBarItemBackground"
+                android:contentDescription="@string/player_star"
+                app:tint="?attr/player_contrast_03" />
+
+            <ImageButton
+                android:id="@+id/transcript"
+                android:contentDescription="@string/transcript"
+                app:srcCompat="@drawable/ic_transcript_24"
+                app:tint="?attr/player_contrast_03"
+                style="@style/shelf_item" />
+
+            <ImageButton
+                android:id="@+id/share"
+                android:contentDescription="@string/share_podcast"
+                app:srcCompat="@drawable/ic_share_android_32"
+                app:tint="?attr/player_contrast_03"
+                style="@style/shelf_item" />
+
+            <ImageButton
+                android:id="@+id/podcast"
+                android:contentDescription="@string/go_to_podcast"
+                app:srcCompat="@drawable/ic_goto_32"
+                app:tint="?attr/player_contrast_03"
+                style="@style/shelf_item" />
+
+            <FrameLayout
+                android:id="@+id/cast"
+                android:layout_width="0dp"
+                android:layout_height="48dp"
+                android:layout_weight="1">
+
+                <androidx.mediarouter.app.MediaRouteButton
+                    android:id="@+id/castButton"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="center"
+                    android:mediaRouteTypes="user" />
+
+            </FrameLayout>
+
+            <ImageButton
+                android:id="@+id/played"
+                android:contentDescription="@string/mark_as_played"
+                app:srcCompat="@drawable/ic_tick_circle_ol_32"
+                app:tint="?attr/player_contrast_03"
+                style="@style/shelf_item" />
+
+            <ImageButton
+                android:id="@+id/bookmark"
+                android:contentDescription="@string/add_bookmark"
+                app:srcCompat="@drawable/ic_bookmark"
+                app:tint="?attr/player_contrast_03"
+                style="@style/shelf_item" />
+
+            <ImageButton
+                android:id="@+id/archive"
+                android:contentDescription="@string/archive_episode"
+                app:srcCompat="@drawable/ic_archive_32"
+                app:tint="?attr/player_contrast_03"
+                style="@style/shelf_item" />
+
+            <ImageButton
+                android:id="@+id/report"
+                android:contentDescription="@string/report"
+                app:srcCompat="@drawable/ic_flag"
+                app:tint="?attr/player_contrast_03"
+                style="@style/shelf_item" />
+
+            <ImageButton
+                android:id="@+id/playerActions"
+                android:layout_width="0dp"
+                android:layout_height="48dp"
+                android:layout_weight="1"
+                android:background="?android:attr/actionBarItemBackground"
+                android:contentDescription="@string/more"
+                android:scaleX="1.2"
+                android:scaleY="1.2"
+                app:srcCompat="@drawable/ic_more"
+                app:tint="?attr/player_contrast_03" />
+
+        </LinearLayout>
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+</au.com.shiftyjelly.pocketcasts.views.component.LockableNestedScrollView>

--- a/modules/features/player/src/main/res/values-land/bools.xml
+++ b/modules/features/player/src/main/res/values-land/bools.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <bool name="transcript_show_seekbar_and_player_controls">false</bool>
+</resources>

--- a/modules/features/player/src/main/res/values-land/dimens.xml
+++ b/modules/features/player/src/main/res/values-land/dimens.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <dimen name="large_play_button_margin_bottom">00dp</dimen>
+    <dimen name="large_play_button_margin_bottom">0dp</dimen>
+    <dimen name="transcript_text_bottom_padding">0dp</dimen>
 </resources>

--- a/modules/features/player/src/main/res/values-sw600dp/bools.xml
+++ b/modules/features/player/src/main/res/values-sw600dp/bools.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <bool name="transcript_show_seekbar_and_player_controls">true</bool>
+</resources>

--- a/modules/features/player/src/main/res/values-sw600dp/dimens.xml
+++ b/modules/features/player/src/main/res/values-sw600dp/dimens.xml
@@ -1,4 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <item name="seekbar_width_percentage" format="float" type="dimen">0.8</item>
+    <dimen name="large_play_button_margin_bottom">40dp</dimen>
+    <dimen name="transcript_text_bottom_padding">125dp</dimen>
+    <dimen name="seekbar_margin_bottom">0dp</dimen>
 </resources>

--- a/modules/features/player/src/main/res/values/bools.xml
+++ b/modules/features/player/src/main/res/values/bools.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <bool name="transcript_show_seekbar_and_player_controls">true</bool>
+</resources>

--- a/modules/features/player/src/main/res/values/dimens.xml
+++ b/modules/features/player/src/main/res/values/dimens.xml
@@ -17,4 +17,5 @@
     <dimen name="mini_player_play_button_size_48">48dp</dimen>
     <dimen name="mini_player_skip_button_size_68">68dp</dimen>
     <dimen name="mini_player_skip_button_size_56">56dp</dimen>
+    <dimen name="transcript_text_bottom_padding">125dp</dimen>
 </resources>


### PR DESCRIPTION
## Description

This updates large screens landscape layout to be the same as the portrait layout so that player controls and seek bar are centered horizontally, similar to iOS. This helps in reusing the same transition we use for the portrait mode when going to the transcript screen and enabling the player controls (pdcxQM-43M-p2#comment-3193).

## Testing Instructions
1. Open the app on a tablet in landscape mode
2. Play an episode having transcript (e.g. [Cautionary tales](https://pca.st/episode/1a31aba0-9d4f-416c-abb3-0945431fc2c9))
3. ✅ Notice that the landscape mode layout is same the portrait one
4. Open transcript view
5. ✅ Notice the player controls are transitioned to the transcript view

## Screenshots or Screencast 

**Before**

https://github.com/user-attachments/assets/faf1a01a-889e-4678-b8f3-922c68dcb579

**After**

https://github.com/user-attachments/assets/1b44bfb2-6de8-4dd3-99dc-0c2b484953e3

**Phone (remains same as before)**

https://github.com/user-attachments/assets/508c2cd5-4d93-440f-9d74-4b7f6be10a07

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack