### PR TITLE
Fix multi-select tool bar action order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
         ([#2677](https://github.com/Automattic/pocket-casts-android/pull/2677))
     *   Fix playback and download failures due to an insecure connection
         ([#2717](https://github.com/Automattic/pocket-casts-android/pull/2717))
+    *   Fix multi-select toolbar action order
+        ([#2737](https://github.com/Automattic/pocket-casts-android/pull/2737))
 
 7.71
 -----

--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/repositories/jobs/VersionMigrationsJobTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/repositories/jobs/VersionMigrationsJobTest.kt
@@ -1,0 +1,39 @@
+package au.com.shiftyjelly.pocketcasts.repositories.jobs
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import au.com.shiftyjelly.pocketcasts.preferences.Settings
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mockito.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+
+@RunWith(AndroidJUnit4::class)
+class VersionMigrationsJobTest {
+
+    @Test
+    fun testUpgradeMultiSelectItems() {
+        val resourceIds = listOf("2131362851", "2131362827", "2131362859", "2131362857", "2131362838", "2131362836", "2131362843")
+        val expectedItems = listOf("play_last", "play_next", "star", "share", "download", "archive", "mark_as_played")
+
+        val settings = mock<Settings>()
+        whenever(settings.getMultiSelectItems()).thenReturn(resourceIds)
+
+        VersionMigrationsJob.upgradeMultiSelectItems(settings)
+
+        verify(settings).setMultiSelectItems(expectedItems)
+    }
+
+    @Test
+    fun testUpgradeMultiSelectItemsNotRequired() {
+        val items = listOf("play_last", "play_next", "star", "share", "download", "archive", "mark_as_played")
+
+        val settings = mock<Settings>()
+        whenever(settings.getMultiSelectItems()).thenReturn(items)
+
+        VersionMigrationsJob.upgradeMultiSelectItems(settings)
+
+        verify(settings, never()).setMultiSelectItems(items)
+    }
+}

--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/views/multiselect/MultiSelectEpisodeActionTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/views/multiselect/MultiSelectEpisodeActionTest.kt
@@ -1,0 +1,26 @@
+package au.com.shiftyjelly.pocketcasts.views.multiselect
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class MultiSelectEpisodeActionTest {
+
+    @Test
+    fun testListFromIds() {
+        val ids = listOf("star", "play_last", "play_next", "download", "archive", "share", "mark_as_played")
+        val result = MultiSelectEpisodeAction.listFromIds(ids)
+        val expectedActions = listOf(
+            MultiSelectEpisodeAction.Star,
+            MultiSelectEpisodeAction.PlayLast,
+            MultiSelectEpisodeAction.PlayNext,
+            MultiSelectEpisodeAction.Download,
+            MultiSelectEpisodeAction.Archive,
+            MultiSelectEpisodeAction.Share,
+            MultiSelectEpisodeAction.MarkAsPlayed,
+        )
+        assertEquals(expectedActions, result)
+    }
+}

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
@@ -253,7 +253,7 @@ interface Settings {
 
     val selectPodcastSortTypeObservable: Observable<PodcastsSortType>
     val refreshStateObservable: Observable<RefreshState>
-    val multiSelectItemsObservable: Observable<List<Int>>
+    val multiSelectItemsObservable: Observable<List<String>>
 
     val shelfItems: UserSetting<List<ShelfItem>>
 
@@ -437,7 +437,8 @@ interface Settings {
     val mediaControlItems: UserSetting<List<MediaNotificationControls>>
     val shakeToResetSleepTimer: UserSetting<Boolean>
     val autoSleepTimerRestart: UserSetting<Boolean>
-    fun setMultiSelectItems(items: List<Int>)
+    fun getMultiSelectItems(): List<String>
+    fun setMultiSelectItems(items: List<String>)
     fun setLastPauseTime(date: Date)
     fun getLastPauseTime(): Date?
     fun setLastPausedUUID(uuid: String)

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
@@ -89,7 +89,7 @@ class SettingsImpl @Inject constructor(
     private var languageCode: String? = null
 
     override val selectPodcastSortTypeObservable = BehaviorRelay.create<PodcastsSortType>().apply { accept(getSelectPodcastsSortType()) }
-    override val multiSelectItemsObservable = BehaviorRelay.create<List<Int>>().apply { accept(getMultiSelectItems()) }
+    override val multiSelectItemsObservable = BehaviorRelay.create<List<String>>().apply { accept(getMultiSelectItems()) }
 
     override val shelfItems = UserSetting.PrefFromString(
         sharedPrefKey = "shelfItems",
@@ -1160,12 +1160,12 @@ class SettingsImpl @Inject constructor(
         setInt("WhatsNewVersionCode", value)
     }
 
-    private fun getMultiSelectItems(): List<Int> {
-        return getStringList("multi_select_items").map { it.toInt() }
+    override fun getMultiSelectItems(): List<String> {
+        return getStringList("multi_select_items")
     }
 
-    override fun setMultiSelectItems(items: List<Int>) {
-        setStringList("multi_select_items", items.map { it.toString() })
+    override fun setMultiSelectItems(items: List<String>) {
+        setStringList("multi_select_items", items)
         multiSelectItemsObservable.accept(items)
     }
 

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/jobs/VersionMigrationsJob.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/jobs/VersionMigrationsJob.kt
@@ -7,6 +7,7 @@ import android.app.job.JobScheduler
 import android.app.job.JobService
 import android.content.ComponentName
 import android.content.Context
+import androidx.core.text.isDigitsOnly
 import au.com.shiftyjelly.pocketcasts.analytics.SourceView
 import au.com.shiftyjelly.pocketcasts.models.db.AppDatabase
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
@@ -81,6 +82,40 @@ class VersionMigrationsJob : JobService() {
                     .setOverrideDeadline(500) // don't let Android wait for more than 500ms before kicking this off
                     .build(),
             )
+        }
+
+        /**
+         * Convert the shared preference multi_select_items from resource ids to strings.
+         * From: <string name="multi_select_items">2131362844,2131362845,2131362852,2131362850,2131362831,2131362829,2131362836</string>
+         * To: <string name="multi_select_items">star,play_last,play_next,download,archive,share,mark_as_played</string>
+         */
+        fun upgradeMultiSelectItems(settings: Settings) {
+            val items = settings.getMultiSelectItems()
+            if (items.isEmpty() || !items.first().isDigitsOnly()) {
+                return
+            }
+
+            val resourceToSetting = hashMapOf(
+                // 7.70
+                "2131362859" to "star",
+                "2131362851" to "play_last",
+                "2131362852" to "play_next",
+                "2131362838" to "download",
+                "2131362836" to "archive",
+                "2131362857" to "share",
+                "2131362843" to "mark_as_played",
+                // 7.71-rc-1 and 7.71-rc-2
+                "2131362834" to "star",
+                "2131362826" to "play_last",
+                "2131362827" to "play_next",
+                "2131362813" to "download",
+                "2131362811" to "archive",
+                "2131362832" to "share",
+                "2131362818" to "mark_as_played",
+            )
+
+            val itemsUpdated = items.map { resourceToSetting[it] ?: it }
+            settings.setMultiSelectItems(itemsUpdated)
         }
     }
 
@@ -173,6 +208,8 @@ class VersionMigrationsJob : JobService() {
         if (previousVersionCode < 9235) {
             enableDynamicColors()
         }
+
+        upgradeMultiSelectItems(settings)
     }
 
     private fun removeOldTempPodcastDirectory() {

--- a/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/multiselect/MultiSelectAction.kt
+++ b/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/multiselect/MultiSelectAction.kt
@@ -7,7 +7,7 @@ import au.com.shiftyjelly.pocketcasts.images.R as IR
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 sealed class MultiSelectAction(
-    open val groupId: Int,
+    open val groupId: String,
     open val actionId: Int,
     @StringRes open val title: Int,
     @DrawableRes open val iconRes: Int,
@@ -15,10 +15,10 @@ sealed class MultiSelectAction(
     open val isVisible: Boolean = true,
 ) {
     object SelectAll : MultiSelectAction(
-        R.id.menu_select_all,
-        R.id.menu_select_all,
-        LR.string.select_all,
-        IR.drawable.ic_selectall_up,
-        "select_all",
+        groupId = "select_all",
+        actionId = R.id.menu_select_all,
+        title = LR.string.select_all,
+        iconRes = IR.drawable.ic_selectall_up,
+        analyticsValue = "select_all",
     )
 }

--- a/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/multiselect/MultiSelectBookmarkAction.kt
+++ b/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/multiselect/MultiSelectBookmarkAction.kt
@@ -8,7 +8,7 @@ import au.com.shiftyjelly.pocketcasts.localization.R as LR
 import au.com.shiftyjelly.pocketcasts.ui.R as UR
 
 sealed class MultiSelectBookmarkAction(
-    override val groupId: Int,
+    override val groupId: String,
     override val actionId: Int,
     @StringRes override val title: Int,
     @DrawableRes override val iconRes: Int,
@@ -23,27 +23,27 @@ sealed class MultiSelectBookmarkAction(
     isVisible,
 ) {
     data object DeleteBookmark : MultiSelectBookmarkAction(
-        R.id.menu_delete,
-        R.id.menu_delete,
-        LR.string.delete,
-        R.drawable.ic_delete,
-        "delete",
+        groupId = "delete",
+        actionId = R.id.menu_delete,
+        title = LR.string.delete,
+        iconRes = R.drawable.ic_delete,
+        analyticsValue = "delete",
     )
 
     data class EditBookmark(override val isVisible: Boolean) : MultiSelectBookmarkAction(
-        UR.id.menu_edit,
-        UR.id.menu_edit,
-        LR.string.edit,
-        IR.drawable.ic_edit,
-        "edit",
+        groupId = "edit",
+        actionId = UR.id.menu_edit,
+        title = LR.string.edit,
+        iconRes = IR.drawable.ic_edit,
+        analyticsValue = "edit",
         isVisible = isVisible,
     )
 
     data class ShareBookmark(override val isVisible: Boolean) : MultiSelectBookmarkAction(
-        R.id.menu_share,
-        R.id.menu_share,
-        LR.string.share,
-        IR.drawable.ic_share,
-        "share",
+        groupId = "share",
+        actionId = R.id.menu_share,
+        title = LR.string.share,
+        iconRes = IR.drawable.ic_share,
+        analyticsValue = "share",
     )
 }

--- a/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/multiselect/MultiSelectBottomSheet.kt
+++ b/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/multiselect/MultiSelectBottomSheet.kt
@@ -67,7 +67,7 @@ class MultiSelectBottomSheet : BaseDialogFragment() {
         recyclerView.layoutManager = LinearLayoutManager(recyclerView.context, LinearLayoutManager.VERTICAL, false)
         recyclerView.addItemDecoration(DividerItemDecoration(recyclerView.context, LinearLayoutManager.VERTICAL))
 
-        val items = arguments?.getIntArray(ARG_ACTION_IDS)?.map { MultiSelectEpisodeAction.ALL_BY_ID[it] } ?: emptyList()
+        val items = arguments?.getIntArray(ARG_ACTION_IDS)?.map { MultiSelectEpisodeAction.ALL_BY_ACTION_ID[it] } ?: emptyList()
         adapter.submitList(items + listOf(MultiSelectAction.SelectAll))
 
         multiSelectHelper?.selectedCount?.observe(viewLifecycleOwner) {

--- a/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/multiselect/MultiSelectEpisodeAction.kt
+++ b/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/multiselect/MultiSelectEpisodeAction.kt
@@ -11,7 +11,7 @@ import au.com.shiftyjelly.pocketcasts.localization.R as LR
 import au.com.shiftyjelly.pocketcasts.ui.R as UR
 
 sealed class MultiSelectEpisodeAction(
-    override val groupId: Int,
+    override val groupId: String,
     override val actionId: Int,
     @StringRes override val title: Int,
     @DrawableRes override val iconRes: Int,
@@ -26,105 +26,105 @@ sealed class MultiSelectEpisodeAction(
     isVisible,
 ) {
     object DeleteDownload : MultiSelectEpisodeAction(
-        R.id.menu_download,
-        UR.id.menu_undownload,
-        LR.string.delete_download,
-        IR.drawable.ic_undownload,
-        "remove_download",
+        groupId = "download",
+        actionId = UR.id.menu_undownload,
+        title = LR.string.delete_download,
+        iconRes = IR.drawable.ic_undownload,
+        analyticsValue = "remove_download",
     )
     object Download : MultiSelectEpisodeAction(
-        R.id.menu_download,
-        R.id.menu_download,
-        LR.string.download,
-        IR.drawable.ic_download,
-        "download",
+        groupId = "download",
+        actionId = R.id.menu_download,
+        title = LR.string.download,
+        iconRes = IR.drawable.ic_download,
+        analyticsValue = "download",
     )
     object Archive : MultiSelectEpisodeAction(
-        R.id.menu_archive,
-        R.id.menu_archive,
-        LR.string.archive,
-        IR.drawable.ic_archive,
-        "archive",
+        groupId = "archive",
+        actionId = R.id.menu_archive,
+        title = LR.string.archive,
+        iconRes = IR.drawable.ic_archive,
+        analyticsValue = "archive",
     )
     object Unarchive : MultiSelectEpisodeAction(
-        R.id.menu_archive,
-        UR.id.menu_unarchive,
-        LR.string.unarchive,
-        IR.drawable.ic_unarchive,
-        "unarchive",
+        groupId = "archive",
+        actionId = UR.id.menu_unarchive,
+        title = LR.string.unarchive,
+        iconRes = IR.drawable.ic_unarchive,
+        analyticsValue = "unarchive",
     )
     object DeleteUserEpisode : MultiSelectEpisodeAction(
-        R.id.menu_archive,
-        R.id.menu_delete,
-        LR.string.delete,
-        R.drawable.ic_delete,
-        "delete",
+        groupId = "archive",
+        actionId = R.id.menu_delete,
+        title = LR.string.delete,
+        iconRes = R.drawable.ic_delete,
+        analyticsValue = "delete",
     )
     object Share : MultiSelectEpisodeAction(
-        groupId = R.id.menu_share,
+        groupId = "share",
         actionId = R.id.menu_share,
         title = LR.string.share,
         iconRes = IR.drawable.ic_share,
         analyticsValue = "share",
     )
     object MarkAsUnplayed : MultiSelectEpisodeAction(
-        R.id.menu_mark_played,
-        UR.id.menu_markasunplayed,
-        LR.string.mark_as_unplayed,
-        IR.drawable.ic_markasunplayed,
-        "mark_as_unplayed",
+        groupId = "mark_as_played",
+        actionId = UR.id.menu_markasunplayed,
+        title = LR.string.mark_as_unplayed,
+        iconRes = IR.drawable.ic_markasunplayed,
+        analyticsValue = "mark_as_unplayed",
     )
     object MarkAsPlayed : MultiSelectEpisodeAction(
-        R.id.menu_mark_played,
-        R.id.menu_mark_played,
-        LR.string.mark_as_played,
-        IR.drawable.ic_markasplayed,
-        "mark_as_played",
+        groupId = "mark_as_played",
+        actionId = R.id.menu_mark_played,
+        title = LR.string.mark_as_played,
+        iconRes = IR.drawable.ic_markasplayed,
+        analyticsValue = "mark_as_played",
     )
     object PlayNext : MultiSelectEpisodeAction(
-        R.id.menu_playnext,
-        R.id.menu_playnext,
-        LR.string.play_next,
-        IR.drawable.ic_upnext_playnext,
-        "play_next",
+        groupId = "play_next",
+        actionId = R.id.menu_playnext,
+        title = LR.string.play_next,
+        iconRes = IR.drawable.ic_upnext_playnext,
+        analyticsValue = "play_next",
     )
     object PlayLast : MultiSelectEpisodeAction(
-        R.id.menu_playlast,
-        R.id.menu_playlast,
-        LR.string.play_last,
-        IR.drawable.ic_upnext_playlast,
-        "play_last",
+        groupId = "play_last",
+        actionId = R.id.menu_playlast,
+        title = LR.string.play_last,
+        iconRes = IR.drawable.ic_upnext_playlast,
+        analyticsValue = "play_last",
     )
     object Unstar : MultiSelectEpisodeAction(
-        R.id.menu_star,
-        UR.id.menu_unstar,
-        LR.string.unstar,
-        IR.drawable.ic_unstar,
-        "unstar",
+        groupId = "star",
+        actionId = UR.id.menu_unstar,
+        title = LR.string.unstar,
+        iconRes = IR.drawable.ic_unstar,
+        analyticsValue = "unstar",
     )
     object Star : MultiSelectEpisodeAction(
-        R.id.menu_star,
-        R.id.menu_star,
-        LR.string.star,
-        IR.drawable.ic_star,
-        "star",
+        groupId = "star",
+        actionId = R.id.menu_star,
+        title = LR.string.star,
+        iconRes = IR.drawable.ic_star,
+        analyticsValue = "star",
     )
 
     companion object {
-        val STANDARD = listOf(Download, Archive, MarkAsPlayed, PlayNext, PlayLast, Star, Share)
-        val ALL = STANDARD + listOf(DeleteDownload, DeleteUserEpisode, MarkAsUnplayed, Unstar, Unarchive)
-        val STANDARD_BY_ID = STANDARD.associateBy { it.actionId }
-        val ALL_BY_ID = ALL.associateBy { it.actionId }
+        private val STANDARD = listOf(Download, Archive, MarkAsPlayed, PlayNext, PlayLast, Star, Share)
+        private val ALL = STANDARD + listOf(DeleteDownload, DeleteUserEpisode, MarkAsUnplayed, Unstar, Unarchive)
+        private val STANDARD_BY_GROUP_ID = STANDARD.associateBy { it.groupId }
+        val ALL_BY_ACTION_ID = ALL.associateBy { it.actionId }
 
-        fun listFromIds(list: List<Int>): List<MultiSelectEpisodeAction> {
-            val loadedItems = list.mapNotNull { STANDARD_BY_ID[it] }
-            val missingItems = STANDARD.subtract(loadedItems) // We need to add on any missing items in case we add actions in the future
+        fun listFromIds(list: List<String>): List<MultiSelectEpisodeAction> {
+            val loadedItems = list.mapNotNull { STANDARD_BY_GROUP_ID[it] }
+            val missingItems = STANDARD.subtract(loadedItems.toHashSet()) // We need to add on any missing items in case we add actions in the future
             return loadedItems + missingItems
         }
 
-        fun actionForGroup(groupId: Int, selected: List<BaseEpisode>): MultiSelectEpisodeAction? {
+        fun actionForGroup(groupId: String, selected: List<BaseEpisode>): MultiSelectEpisodeAction? {
             when (groupId) {
-                R.id.menu_download -> {
+                Download.groupId -> {
                     for (episode in selected) {
                         if (!episode.isDownloaded) {
                             return Download
@@ -133,7 +133,7 @@ sealed class MultiSelectEpisodeAction(
 
                     return DeleteDownload
                 }
-                R.id.menu_archive -> {
+                Archive.groupId -> {
                     for (episode in selected) {
                         if (episode is PodcastEpisode && !episode.isArchived) {
                             return Archive
@@ -142,7 +142,7 @@ sealed class MultiSelectEpisodeAction(
 
                     return if (selected.filterIsInstance<UserEpisode>().size == selected.size) DeleteUserEpisode else Unarchive
                 }
-                R.id.menu_mark_played -> {
+                MarkAsPlayed.groupId -> {
                     for (episode in selected) {
                         if (!episode.isFinished) {
                             return MarkAsPlayed
@@ -151,7 +151,7 @@ sealed class MultiSelectEpisodeAction(
 
                     return MarkAsUnplayed
                 }
-                R.id.menu_star -> {
+                Star.groupId -> {
                     if (selected.filterIsInstance<UserEpisode>().isNotEmpty()) return null
                     for (episode in selected) {
                         if (episode is PodcastEpisode && !episode.isStarred) {
@@ -161,9 +161,9 @@ sealed class MultiSelectEpisodeAction(
 
                     return Unstar
                 }
-                R.id.menu_playnext -> return PlayNext
-                R.id.menu_playlast -> return PlayLast
-                R.id.menu_share -> {
+                PlayNext.groupId -> return PlayNext
+                PlayLast.groupId -> return PlayLast
+                Share.groupId -> {
                     if (selected.size == 1 &&
                         selected.firstOrNull() is PodcastEpisode
                     ) {


### PR DESCRIPTION
## Description

We have received user feedback that their re-ordering of the multi-select toolbar action is getting reset. This happens after a new version is released, as the resource IDs change with the new build. This change switches to using a hardcoded string ID, and there is a migration to make sure the users action orders aren't changed again. 

Fixes https://github.com/Automattic/pocket-casts-android/issues/2492

## Testing Instructions

1. Subscribe to a podcast
2. Open the podcast page
3. Long press an episode 
4. Tap the three dots in the toolbar
5. Tap the pencil to edit the order
6. Change the order
7. Tap the back arrow

✅ In the "Device Explorer" open the shared preference file `/data/data/au.com.shiftyjelly.pocketcasts.debug/shared_prefs/au.com.shiftyjelly.pocketcasts.debug_preferences.xml`.
Check the `multi_select_items` value is string name instead of ids. For example:
```
<string name="multi_select_items">share,download,archive,mark_as_played,play_next,play_last,star</string>
```

8. Kill the app
9. Open the toolbar again

✅ Check the order of the actions is correct

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes

