### PR TITLE
Rename servers to services

### DIFF
--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/models/db/AutoArchiveTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/models/db/AutoArchiveTest.kt
@@ -25,7 +25,7 @@ import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManagerImpl
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.UserEpisodeManager
 import au.com.shiftyjelly.pocketcasts.repositories.sync.SyncManager
-import au.com.shiftyjelly.pocketcasts.servers.podcast.PodcastCacheServerManager
+import au.com.shiftyjelly.pocketcasts.servers.podcast.PodcastCacheServiceManager
 import com.squareup.moshi.Moshi
 import java.util.Calendar
 import java.util.Date
@@ -51,7 +51,7 @@ class AutoArchiveTest {
     val context = InstrumentationRegistry.getInstrumentation().targetContext
     val fileStorage = mock<FileStorage> {}
     val downloadManager = mock<DownloadManager> {}
-    val podcastCacheServerManager = mock<PodcastCacheServerManager> {}
+    val podcastCacheServiceManager = mock<PodcastCacheServiceManager> {}
     val userEpisodeManager = mock<UserEpisodeManager> {}
     val episodeAnalytics = EpisodeAnalytics(mock())
 
@@ -90,7 +90,7 @@ class AutoArchiveTest {
             downloadManager = downloadManager,
             context = context,
             appDatabase = db,
-            podcastCacheServerManager = podcastCacheServerManager,
+            podcastCacheServiceManager = podcastCacheServiceManager,
             userEpisodeManager = userEpisodeManager,
             ioDispatcher = testDispatcher,
             episodeAnalytics = episodeAnalytics,

--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/models/db/PodcastManagerTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/models/db/PodcastManagerTest.kt
@@ -17,9 +17,9 @@ import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManagerImpl
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.SubscribeManager
 import au.com.shiftyjelly.pocketcasts.repositories.sync.SyncManager
-import au.com.shiftyjelly.pocketcasts.servers.cdn.StaticServerManager
-import au.com.shiftyjelly.pocketcasts.servers.podcast.PodcastCacheServerManager
-import au.com.shiftyjelly.pocketcasts.servers.refresh.RefreshServerManager
+import au.com.shiftyjelly.pocketcasts.servers.cdn.StaticServiceManager
+import au.com.shiftyjelly.pocketcasts.servers.podcast.PodcastCacheServiceManager
+import au.com.shiftyjelly.pocketcasts.servers.refresh.RefreshServiceManager
 import au.com.shiftyjelly.pocketcasts.sharedtest.FakeCrashLogging
 import au.com.shiftyjelly.pocketcasts.utils.Optional
 import com.squareup.moshi.Moshi
@@ -64,10 +64,10 @@ class PodcastManagerTest {
         }
 
         val application = context
-        val podcastCacheServer = mock<PodcastCacheServerManager> {
+        val podcastCacheService = mock<PodcastCacheServiceManager> {
             on { getPodcast(uuid) } doReturn Single.just(Podcast(uuid))
         }
-        val staticServerManager = mock<StaticServerManager> {
+        val staticServiceManager = mock<StaticServiceManager> {
             on { getColorsSingle(uuid) } doReturn Single.just(Optional.empty())
         }
 
@@ -75,8 +75,8 @@ class PodcastManagerTest {
             .addTypeConverters(ModelModule.provideRoomConverters(Moshi.Builder().build()))
             .build()
 
-        val refreshServerManager = mock<RefreshServerManager> {}
-        val subscribeManager = SubscribeManager(appDatabase, podcastCacheServer, staticServerManager, syncManagerSignedOut, application, settings)
+        val refreshServiceManager = mock<RefreshServiceManager> {}
+        val subscribeManager = SubscribeManager(appDatabase, podcastCacheService, staticServiceManager, syncManagerSignedOut, application, settings)
         podcastDao = appDatabase.podcastDao()
         podcastManagerSignedOut = PodcastManagerImpl(
             episodeManager = episodeManager,
@@ -84,8 +84,8 @@ class PodcastManagerTest {
             settings = settings,
             context = application,
             subscribeManager = subscribeManager,
-            cacheServerManager = podcastCacheServer,
-            refreshServerManager = refreshServerManager,
+            cacheServiceManager = podcastCacheService,
+            refreshServiceManager = refreshServiceManager,
             syncManager = syncManagerSignedOut,
             appDatabase = appDatabase,
             applicationScope = CoroutineScope(Dispatchers.Default),
@@ -97,8 +97,8 @@ class PodcastManagerTest {
             settings = settings,
             context = application,
             subscribeManager = subscribeManager,
-            cacheServerManager = podcastCacheServer,
-            refreshServerManager = refreshServerManager,
+            cacheServiceManager = podcastCacheService,
+            refreshServiceManager = refreshServiceManager,
             syncManager = syncManagerSignedIn,
             applicationScope = CoroutineScope(Dispatchers.Default),
             appDatabase = appDatabase,

--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/profile/accountmanager/PocketCastsAccountAuthenticatorTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/profile/accountmanager/PocketCastsAccountAuthenticatorTest.kt
@@ -14,7 +14,7 @@ import au.com.shiftyjelly.pocketcasts.repositories.sync.SyncAccountManagerImpl
 import au.com.shiftyjelly.pocketcasts.repositories.sync.SyncManagerImpl
 import au.com.shiftyjelly.pocketcasts.repositories.sync.TokenErrorNotification
 import au.com.shiftyjelly.pocketcasts.servers.di.ServersModule
-import au.com.shiftyjelly.pocketcasts.servers.sync.SyncServerManager
+import au.com.shiftyjelly.pocketcasts.servers.sync.SyncServiceManager
 import java.io.File
 import java.net.HttpURLConnection
 import java.util.concurrent.TimeUnit
@@ -65,14 +65,14 @@ class PocketCastsAccountAuthenticatorTest {
         }
         val tokenErrorNotification = mock<TokenErrorNotification>()
         val syncAccountManager = SyncAccountManagerImpl(tokenErrorNotification, accountManager)
-        val syncServerManager = SyncServerManager(retrofit, mock(), okhttpCache)
+        val syncServiceManager = SyncServiceManager(retrofit, mock(), okhttpCache)
 
         val syncManager = SyncManagerImpl(
             analyticsTracker = AnalyticsTracker.test(),
             context = context,
             settings = mock(),
             syncAccountManager = syncAccountManager,
-            syncServerManager = syncServerManager,
+            syncServiceManager = syncServiceManager,
             moshi = moshi,
         )
         // make sure the test device is signed out

--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/repositories/download/UpdateEpisodeTaskTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/repositories/download/UpdateEpisodeTaskTest.kt
@@ -12,7 +12,7 @@ import au.com.shiftyjelly.pocketcasts.models.db.dao.EpisodeDao
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.repositories.download.task.UpdateEpisodeTask
-import au.com.shiftyjelly.pocketcasts.servers.podcast.PodcastCacheServerManager
+import au.com.shiftyjelly.pocketcasts.servers.podcast.PodcastCacheServiceManager
 import java.util.Date
 import java.util.UUID
 import kotlinx.coroutines.test.runTest
@@ -78,7 +78,7 @@ class UpdateEpisodeTaskTest {
             episodes.add(serverEpisode)
         }
 
-        val podcastCacheServerManager = mock<PodcastCacheServerManager> {
+        val podcastCacheServiceManager = mock<PodcastCacheServiceManager> {
             onBlocking { getPodcastAndEpisode(podcastUuid, episodeUuid) } doReturn serverPodcast
         }
         val episodeDao = mock<EpisodeDao> {
@@ -89,7 +89,7 @@ class UpdateEpisodeTaskTest {
         }
         val inputData = UpdateEpisodeTask.buildInputData(deviceEpisode)
         val worker = TestListenableWorkerBuilder<UpdateEpisodeTask>(context = context, inputData = inputData)
-            .setWorkerFactory(TestWorkerFactory(podcastCacheServerManager, appDatabase))
+            .setWorkerFactory(TestWorkerFactory(podcastCacheServiceManager, appDatabase))
             .build()
 
         runTest {
@@ -106,12 +106,12 @@ class UpdateEpisodeTaskTest {
         }
     }
 
-    class TestWorkerFactory(private val podcastCacheServerManager: PodcastCacheServerManager, private val appDatabase: AppDatabase) : WorkerFactory() {
+    class TestWorkerFactory(private val podcastCacheServiceManager: PodcastCacheServiceManager, private val appDatabase: AppDatabase) : WorkerFactory() {
         override fun createWorker(context: Context, workerClassName: String, workerParameters: WorkerParameters): ListenableWorker? {
             return UpdateEpisodeTask(
                 context = context,
                 params = workerParameters,
-                podcastCacheServerManager = podcastCacheServerManager,
+                podcastCacheServiceManager = podcastCacheServiceManager,
                 appDatabase = appDatabase,
             )
         }

--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/repositories/sync/PodcastSyncProcessTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/repositories/sync/PodcastSyncProcessTest.kt
@@ -19,7 +19,7 @@ import au.com.shiftyjelly.pocketcasts.repositories.podcast.PlaylistManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
 import au.com.shiftyjelly.pocketcasts.repositories.user.StatsManager
 import au.com.shiftyjelly.pocketcasts.servers.di.ServersModule
-import au.com.shiftyjelly.pocketcasts.servers.sync.SyncServerManager
+import au.com.shiftyjelly.pocketcasts.servers.sync.SyncServiceManager
 import au.com.shiftyjelly.pocketcasts.sharedtest.FakeCrashLogging
 import au.com.shiftyjelly.pocketcasts.utils.extensions.toIsoString
 import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
@@ -142,7 +142,7 @@ class PodcastSyncProcessTest {
             whenever(syncAccountManager.isLoggedIn()) doReturn true
             whenever(syncAccountManager.getAccessToken()) doReturn AccessToken("access_token")
 
-            val syncServerManager = SyncServerManager(
+            val syncServiceManager = SyncServiceManager(
                 retrofit = retrofit,
                 settings = settings,
                 cache = okhttpCache,
@@ -153,7 +153,7 @@ class PodcastSyncProcessTest {
                 context = context,
                 settings = settings,
                 syncAccountManager = syncAccountManager,
-                syncServerManager = syncServerManager,
+                syncServiceManager = syncServiceManager,
                 moshi = moshi,
             )
 
@@ -168,7 +168,7 @@ class PodcastSyncProcessTest {
                 statsManager = statsManager,
                 fileStorage = mock(),
                 playbackManager = mock(),
-                podcastCacheServerManager = mock(),
+                podcastCacheServiceManager = mock(),
                 userEpisodeManager = mock(),
                 subscriptionManager = mock(),
                 folderManager = folderManager,

--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/servers/ShareServiceManagerImplTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/servers/ShareServiceManagerImplTest.kt
@@ -2,7 +2,7 @@ package au.com.shiftyjelly.pocketcasts.servers
 
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.servers.di.ServersModule
-import au.com.shiftyjelly.pocketcasts.servers.list.ListServerManagerImpl
+import au.com.shiftyjelly.pocketcasts.servers.list.ListServiceManagerImpl
 import java.net.HttpURLConnection
 import java.time.LocalDateTime
 import java.time.ZoneId
@@ -20,7 +20,7 @@ import org.skyscreamer.jsonassert.JSONAssert
 import retrofit2.Retrofit
 import retrofit2.converter.moshi.MoshiConverterFactory
 
-class ShareServerManagerImplTest {
+class ShareServiceManagerImplTest {
 
     private lateinit var mockWebServer: MockWebServer
     private lateinit var retrofit: Retrofit
@@ -45,7 +45,7 @@ class ShareServerManagerImplTest {
 
     @Test
     fun buildSecurityHash() {
-        val hash = ListServerManagerImpl.buildSecurityHash(date = "20160913144421", serverSecret = "APP_SERVER_SECRET")
+        val hash = ListServiceManagerImpl.buildSecurityHash(date = "20160913144421", serverSecret = "APP_SERVER_SECRET")
         assertEquals("f91e649642ffb53813a79f816f2ef1ac36a52c4e", hash)
     }
 
@@ -69,7 +69,7 @@ class ShareServerManagerImplTest {
         val instant = LocalDateTime.parse("2021-11-25T15:20").atZone(ZoneId.systemDefault()).toInstant()
 
         runTest {
-            val url = ListServerManagerImpl(uploadRetrofit = retrofit, downloadRetrofit = retrofit)
+            val url = ListServiceManagerImpl(uploadRetrofit = retrofit, downloadRetrofit = retrofit)
                 .createPodcastList(
                     title = "A fun title",
                     description = "A even funnier description",
@@ -130,7 +130,7 @@ class ShareServerManagerImplTest {
         mockWebServer.enqueue(response)
 
         runTest {
-            val podcastList = ListServerManagerImpl(uploadRetrofit = retrofit, downloadRetrofit = retrofit)
+            val podcastList = ListServiceManagerImpl(uploadRetrofit = retrofit, downloadRetrofit = retrofit)
                 .openPodcastList(listId = "85c4bc9c-d905-40b1-96de-50c197803e4b")
 
             assertEquals("Android Development", podcastList.title)
@@ -146,15 +146,15 @@ class ShareServerManagerImplTest {
     @Test
     fun extractShareListIdFromWebUrl() {
         var websiteUrl = "${BuildConfig.SERVER_LIST_URL}/981d8691-5e1f-4009-adf4-ee5a204bd00c"
-        var id = ListServerManagerImpl.extractShareListIdFromWebUrl(websiteUrl)
+        var id = ListServiceManagerImpl.extractShareListIdFromWebUrl(websiteUrl)
         assertEquals("981d8691-5e1f-4009-adf4-ee5a204bd00c", id)
 
         websiteUrl = "/${BuildConfig.SERVER_LIST_HOST}/fddf52be-6058-48c4-a821-09edc8ad023d"
-        id = ListServerManagerImpl.extractShareListIdFromWebUrl(websiteUrl)
+        id = ListServiceManagerImpl.extractShareListIdFromWebUrl(websiteUrl)
         assertEquals("fddf52be-6058-48c4-a821-09edc8ad023d", id)
 
         websiteUrl = "/share-and-explore"
-        id = ListServerManagerImpl.extractShareListIdFromWebUrl(websiteUrl)
+        id = ListServiceManagerImpl.extractShareListIdFromWebUrl(websiteUrl)
         assertEquals("share-and-explore", id)
     }
 }

--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/servers/account/SyncAccountTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/servers/account/SyncAccountTest.kt
@@ -12,7 +12,7 @@ import au.com.shiftyjelly.pocketcasts.repositories.sync.SyncAccountManagerImpl
 import au.com.shiftyjelly.pocketcasts.repositories.sync.SyncManager
 import au.com.shiftyjelly.pocketcasts.repositories.sync.SyncManagerImpl
 import au.com.shiftyjelly.pocketcasts.servers.di.ServersModule
-import au.com.shiftyjelly.pocketcasts.servers.sync.SyncServerManager
+import au.com.shiftyjelly.pocketcasts.servers.sync.SyncServiceManager
 import java.net.HttpURLConnection
 import kotlinx.coroutines.runBlocking
 import okhttp3.Cache
@@ -46,7 +46,7 @@ internal class SyncAccountTest {
         okhttpCache = ServersModule.createCache(folder = "TestCache", context = context, cacheSizeInMB = 10)
 
         val accountManager = AccountManager.get(context)
-        val syncServerManager = SyncServerManager(retrofit, mock(), okhttpCache)
+        val syncServiceManager = SyncServiceManager(retrofit, mock(), okhttpCache)
         val syncAccountManager = SyncAccountManagerImpl(mock(), accountManager)
 
         syncManager = SyncManagerImpl(
@@ -54,7 +54,7 @@ internal class SyncAccountTest {
             context = context,
             settings = mock(),
             syncAccountManager = syncAccountManager,
-            syncServerManager = syncServerManager,
+            syncServiceManager = syncServiceManager,
             moshi = moshi,
         )
         syncManager.signOut()

--- a/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
+++ b/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
@@ -122,7 +122,7 @@ import au.com.shiftyjelly.pocketcasts.repositories.subscription.SubscriptionMana
 import au.com.shiftyjelly.pocketcasts.repositories.sync.SyncManager
 import au.com.shiftyjelly.pocketcasts.search.SearchFragment
 import au.com.shiftyjelly.pocketcasts.servers.ServerCallback
-import au.com.shiftyjelly.pocketcasts.servers.ServerManager
+import au.com.shiftyjelly.pocketcasts.servers.ServiceManager
 import au.com.shiftyjelly.pocketcasts.servers.discover.PodcastSearch
 import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingFlow
 import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingLauncher
@@ -208,7 +208,7 @@ class MainActivity :
 
     @Inject lateinit var episodeManager: EpisodeManager
 
-    @Inject lateinit var serverManager: ServerManager
+    @Inject lateinit var serviceManager: ServiceManager
 
     @Inject lateinit var theme: Theme
 
@@ -1394,7 +1394,7 @@ class MainActivity :
                 }
                 null -> {
                     val dialog = android.app.ProgressDialog.show(this@MainActivity, getString(LR.string.loading), getString(LR.string.please_wait), true)
-                    val searchResult = serverManager.getSharedItemDetailsSuspend("/social/share/show/$episodeUuid")
+                    val searchResult = serviceManager.getSharedItemDetailsSuspend("/social/share/show/$episodeUuid")
                     dialog.hide()
                     searchResult?.episode?.let {
                         EpisodeContainerFragment.newInstance(
@@ -1417,7 +1417,7 @@ class MainActivity :
         url ?: return
 
         val dialog = android.app.ProgressDialog.show(this, getString(LR.string.loading), getString(LR.string.please_wait), true)
-        serverManager.searchForPodcasts(
+        serviceManager.searchForPodcasts(
             url,
             object : ServerCallback<PodcastSearch> {
                 override fun dataReturned(result: PodcastSearch?) {
@@ -1458,7 +1458,7 @@ class MainActivity :
         }
 
         val dialog = android.app.ProgressDialog.show(this, getString(LR.string.loading), getString(LR.string.please_wait), true)
-        serverManager.getSharedItemDetails(
+        serviceManager.getSharedItemDetails(
             deepLink.sharePath,
             object : ServerCallback<au.com.shiftyjelly.pocketcasts.models.to.Share> {
                 override fun dataReturned(result: au.com.shiftyjelly.pocketcasts.models.to.Share?) {

--- a/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/DiscoverAdapter.kt
+++ b/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/DiscoverAdapter.kt
@@ -50,7 +50,7 @@ import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.repositories.images.PocketCastsImageRequestFactory
 import au.com.shiftyjelly.pocketcasts.repositories.images.loadInto
 import au.com.shiftyjelly.pocketcasts.servers.cdn.ArtworkColors
-import au.com.shiftyjelly.pocketcasts.servers.cdn.StaticServerManagerImpl
+import au.com.shiftyjelly.pocketcasts.servers.cdn.StaticServiceManagerImpl
 import au.com.shiftyjelly.pocketcasts.servers.model.DiscoverCategory
 import au.com.shiftyjelly.pocketcasts.servers.model.DiscoverCategory.Companion.ALL_CATEGORIES_ID
 import au.com.shiftyjelly.pocketcasts.servers.model.DiscoverEpisode
@@ -109,7 +109,7 @@ internal data class CategoryAdRow(val categoryId: Int, val categoryName: String,
 internal class DiscoverAdapter(
     val context: Context,
     val service: ListRepository,
-    val staticServerManager: StaticServerManagerImpl,
+    val staticServiceManager: StaticServiceManagerImpl,
     val listener: Listener,
     val theme: Theme,
     loadPodcastList: (source: String) -> Flowable<PodcastList>,
@@ -619,7 +619,7 @@ internal class DiscoverAdapter(
                                         podcast.color = backgroundColor
                                         podcast
                                     }
-                                    Single.zip(Single.just(discoverPodcast), staticServerManager.getColorsSingle(discoverPodcast.uuid).subscribeOn(Schedulers.io()), zipper).toFlowable()
+                                    Single.zip(Single.just(discoverPodcast), staticServiceManager.getColorsSingle(discoverPodcast.uuid).subscribeOn(Schedulers.io()), zipper).toFlowable()
                                 }
                                 .toList().toFlowable()
                         }

--- a/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/DiscoverFragment.kt
+++ b/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/DiscoverFragment.kt
@@ -24,7 +24,7 @@ import au.com.shiftyjelly.pocketcasts.podcasts.view.episode.EpisodeContainerFrag
 import au.com.shiftyjelly.pocketcasts.podcasts.view.podcast.PodcastFragment
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.search.SearchFragment
-import au.com.shiftyjelly.pocketcasts.servers.cdn.StaticServerManagerImpl
+import au.com.shiftyjelly.pocketcasts.servers.cdn.StaticServiceManagerImpl
 import au.com.shiftyjelly.pocketcasts.servers.model.DiscoverCategory
 import au.com.shiftyjelly.pocketcasts.servers.model.DiscoverEpisode
 import au.com.shiftyjelly.pocketcasts.servers.model.DiscoverPodcast
@@ -46,7 +46,7 @@ class DiscoverFragment : BaseFragment(), DiscoverAdapter.Listener, RegionSelectF
 
     @Inject lateinit var settings: Settings
 
-    @Inject lateinit var staticServerManager: StaticServerManagerImpl
+    @Inject lateinit var staticServiceManager: StaticServiceManagerImpl
 
     @Inject lateinit var analyticsTracker: AnalyticsTracker
 
@@ -194,7 +194,7 @@ class DiscoverFragment : BaseFragment(), DiscoverAdapter.Listener, RegionSelectF
             adapter = DiscoverAdapter(
                 context = requireContext(),
                 service = viewModel.repository,
-                staticServerManager = staticServerManager,
+                staticServiceManager = staticServiceManager,
                 listener = this,
                 theme = theme,
                 loadPodcastList = viewModel::loadPodcastList,

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/ShareableTextProvider.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/ShareableTextProvider.kt
@@ -11,7 +11,7 @@ import au.com.shiftyjelly.pocketcasts.repositories.endofyear.stories.StoryLonges
 import au.com.shiftyjelly.pocketcasts.repositories.endofyear.stories.StoryTopFivePodcasts
 import au.com.shiftyjelly.pocketcasts.repositories.endofyear.stories.StoryTopPodcast
 import au.com.shiftyjelly.pocketcasts.repositories.endofyear.stories.StoryYearOverYear
-import au.com.shiftyjelly.pocketcasts.servers.list.ListServerManager
+import au.com.shiftyjelly.pocketcasts.servers.list.ListServiceManager
 import au.com.shiftyjelly.pocketcasts.settings.stats.StatsHelper
 import dagger.hilt.android.qualifiers.ApplicationContext
 import javax.inject.Inject
@@ -22,7 +22,7 @@ import au.com.shiftyjelly.pocketcasts.localization.R as LR
 @Singleton
 class ShareableTextProvider @Inject constructor(
     @ApplicationContext private val context: Context,
-    private val listServerManager: ListServerManager,
+    private val listServiceManager: ListServiceManager,
 ) {
     var chosenActivity: String? = null
     private var shortURL: String = Settings.SERVER_SHORT_URL
@@ -35,7 +35,7 @@ class ShareableTextProvider @Inject constructor(
         val shareableLink: String = when (story) {
             is StoryTopFivePodcasts -> {
                 try {
-                    listServerManager.createPodcastList(
+                    listServiceManager.createPodcastList(
                         title = context.resources.getString(
                             LR.string.end_of_year_story_top_podcasts_share_text,
                             "",

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/helper/search/EpisodeSearchHandler.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/helper/search/EpisodeSearchHandler.kt
@@ -4,7 +4,7 @@ import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTracker
 import au.com.shiftyjelly.pocketcasts.models.entity.BaseEpisode
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
-import au.com.shiftyjelly.pocketcasts.servers.podcast.PodcastCacheServerManagerImpl
+import au.com.shiftyjelly.pocketcasts.servers.podcast.PodcastCacheServiceManagerImpl
 import io.reactivex.Observable
 import io.reactivex.Single
 import java.util.concurrent.TimeUnit
@@ -14,7 +14,7 @@ import javax.inject.Singleton
 @Singleton
 class EpisodeSearchHandler @Inject constructor(
     settings: Settings,
-    private val cacheServerManager: PodcastCacheServerManagerImpl,
+    private val cacheServiceManager: PodcastCacheServiceManagerImpl,
     private val analyticsTracker: AnalyticsTracker,
 ) : SearchHandler<BaseEpisode>() {
     private val searchDebounce = settings.getEpisodeSearchDebounceMs()
@@ -28,7 +28,7 @@ class EpisodeSearchHandler @Inject constructor(
             }
         }.switchMapSingle { searchTerm ->
             if (searchTerm.length > 2) {
-                cacheServerManager.searchEpisodes(podcastUuid, searchTerm)
+                cacheServiceManager.searchEpisodes(podcastUuid, searchTerm)
                     .map { SearchResult(searchTerm, it) }
                     .onErrorReturnItem(noSearchResult)
             } else {

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/share/ShareListCreateViewModel.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/share/ShareListCreateViewModel.kt
@@ -9,7 +9,7 @@ import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTracker
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
-import au.com.shiftyjelly.pocketcasts.servers.list.ListServerManager
+import au.com.shiftyjelly.pocketcasts.servers.list.ListServiceManager
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -20,7 +20,7 @@ import timber.log.Timber
 @HiltViewModel
 class ShareListCreateViewModel @Inject constructor(
     private val podcastManager: PodcastManager,
-    private val listServerManager: ListServerManager,
+    private val listServiceManager: ListServiceManager,
     private val analyticsTracker: AnalyticsTracker,
 ) : ViewModel() {
     var isFragmentChangingConfigurations: Boolean = false
@@ -89,7 +89,7 @@ class ShareListCreateViewModel @Inject constructor(
         onBefore()
         viewModelScope.launch {
             try {
-                val url = listServerManager.createPodcastList(
+                val url = listServiceManager.createPodcastList(
                     title = title,
                     description = description,
                     podcasts = selectedPodcasts,

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/share/ShareListIncomingFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/share/ShareListIncomingFragment.kt
@@ -15,7 +15,7 @@ import au.com.shiftyjelly.pocketcasts.podcasts.databinding.FragmentShareIncoming
 import au.com.shiftyjelly.pocketcasts.podcasts.view.podcast.PodcastFragment
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
-import au.com.shiftyjelly.pocketcasts.servers.ServerManager
+import au.com.shiftyjelly.pocketcasts.servers.ServiceManager
 import au.com.shiftyjelly.pocketcasts.ui.extensions.getThemeTintedDrawable
 import au.com.shiftyjelly.pocketcasts.ui.helper.FragmentHostListener
 import au.com.shiftyjelly.pocketcasts.views.dialog.OptionsDialog
@@ -33,7 +33,7 @@ class ShareListIncomingFragment : BaseFragment(), ShareListIncomingAdapter.Click
 
     @Inject lateinit var podcastManager: PodcastManager
 
-    @Inject lateinit var serverManager: ServerManager
+    @Inject lateinit var serviceManager: ServiceManager
 
     @Inject lateinit var settings: Settings
 

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/share/ShareListIncomingViewModel.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/share/ShareListIncomingViewModel.kt
@@ -9,7 +9,7 @@ import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTracker
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
-import au.com.shiftyjelly.pocketcasts.servers.list.ListServerManager
+import au.com.shiftyjelly.pocketcasts.servers.list.ListServiceManager
 import dagger.hilt.android.lifecycle.HiltViewModel
 import io.reactivex.schedulers.Schedulers
 import javax.inject.Inject
@@ -22,7 +22,7 @@ import kotlinx.coroutines.launch
 class ShareListIncomingViewModel
 @Inject constructor(
     val podcastManager: PodcastManager,
-    val listServerManager: ListServerManager,
+    val listServiceManager: ListServiceManager,
     val playbackManager: PlaybackManager,
     val analyticsTracker: AnalyticsTracker,
 ) : ViewModel(), CoroutineScope {
@@ -40,10 +40,10 @@ class ShareListIncomingViewModel
 
     fun loadShareUrl(url: String) {
         share.postValue(ShareState.Loading)
-        val id = listServerManager.extractShareListIdFromWebUrl(url)
+        val id = listServiceManager.extractShareListIdFromWebUrl(url)
         viewModelScope.launch {
             try {
-                val list = listServerManager.openPodcastList(id)
+                val list = listServiceManager.openPodcastList(id)
                 share.postValue(ShareState.Loaded(title = list.title, description = list.description, podcasts = list.fullPodcasts))
             } catch (ex: Exception) {
                 share.postValue(ShareState.Error)

--- a/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/SearchHandler.kt
+++ b/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/SearchHandler.kt
@@ -13,9 +13,9 @@ import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.FolderManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
 import au.com.shiftyjelly.pocketcasts.repositories.user.UserManager
-import au.com.shiftyjelly.pocketcasts.servers.ServerManager
+import au.com.shiftyjelly.pocketcasts.servers.ServiceManager
 import au.com.shiftyjelly.pocketcasts.servers.discover.GlobalServerSearch
-import au.com.shiftyjelly.pocketcasts.servers.podcast.PodcastCacheServerManager
+import au.com.shiftyjelly.pocketcasts.servers.podcast.PodcastCacheServiceManager
 import com.jakewharton.rxrelay2.BehaviorRelay
 import io.reactivex.BackpressureStrategy
 import io.reactivex.Observable
@@ -28,11 +28,11 @@ import javax.inject.Inject
 import timber.log.Timber
 
 class SearchHandler @Inject constructor(
-    val serverManager: ServerManager,
+    val serviceManager: ServiceManager,
     val podcastManager: PodcastManager,
     val userManager: UserManager,
     val settings: Settings,
-    private val cacheServerManager: PodcastCacheServerManager,
+    private val cacheServiceManager: PodcastCacheServiceManager,
     private val analyticsTracker: AnalyticsTracker,
     folderManager: FolderManager,
 ) {
@@ -122,7 +122,7 @@ class SearchHandler @Inject constructor(
                 loadingObservable.accept(true)
 
                 var globalSearch = GlobalServerSearch(searchTerm = it)
-                val podcastServerSearch = serverManager
+                val podcastServerSearch = serviceManager
                     .searchForPodcastsRx(it)
                     .map { podcastSearch ->
                         globalSearch = globalSearch.copy(podcastSearch = podcastSearch)
@@ -131,7 +131,7 @@ class SearchHandler @Inject constructor(
                     .toObservable()
 
                 if (!it.startsWith("http")) {
-                    val episodesServerSearch = cacheServerManager
+                    val episodesServerSearch = cacheServiceManager
                         .searchEpisodes(it)
                         .map { episodeSearch ->
                             globalSearch = globalSearch.copy(episodeSearch = episodeSearch)

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/ExportSettingsFragment.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/ExportSettingsFragment.kt
@@ -17,7 +17,7 @@ import au.com.shiftyjelly.pocketcasts.repositories.di.ApplicationScope
 import au.com.shiftyjelly.pocketcasts.repositories.opml.OpmlImportTask
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
 import au.com.shiftyjelly.pocketcasts.repositories.sync.SyncManager
-import au.com.shiftyjelly.pocketcasts.servers.ServerManager
+import au.com.shiftyjelly.pocketcasts.servers.ServiceManager
 import au.com.shiftyjelly.pocketcasts.settings.viewmodel.ExportSettingsViewModel
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import au.com.shiftyjelly.pocketcasts.views.extensions.findToolbar
@@ -33,7 +33,7 @@ import au.com.shiftyjelly.pocketcasts.localization.R as LR
 @AndroidEntryPoint
 class ExportSettingsFragment : PreferenceFragmentCompat() {
 
-    @Inject lateinit var serverManager: ServerManager
+    @Inject lateinit var serviceManager: ServiceManager
 
     @Inject lateinit var settings: Settings
 
@@ -97,7 +97,7 @@ class ExportSettingsFragment : PreferenceFragmentCompat() {
             viewModel.onExportByEmail()
             exporter = OpmlExporter(
                 fragment = this@ExportSettingsFragment,
-                serverManager = serverManager,
+                serviceManager = serviceManager,
                 podcastManager = podcastManager,
                 syncManager = syncManager,
                 context = activity,
@@ -113,7 +113,7 @@ class ExportSettingsFragment : PreferenceFragmentCompat() {
             viewModel.onExportFile()
             exporter = OpmlExporter(
                 fragment = this@ExportSettingsFragment,
-                serverManager = serverManager,
+                serviceManager = serviceManager,
                 podcastManager = podcastManager,
                 syncManager = syncManager,
                 context = activity,

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/bumpstats/BumpStatsTask.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/bumpstats/BumpStatsTask.kt
@@ -10,7 +10,7 @@ import androidx.work.OneTimeWorkRequestBuilder
 import androidx.work.WorkManager
 import androidx.work.WorkerParameters
 import au.com.shiftyjelly.pocketcasts.models.db.AppDatabase
-import au.com.shiftyjelly.pocketcasts.servers.bumpstats.WpComServerManager
+import au.com.shiftyjelly.pocketcasts.servers.bumpstats.WpComServiceManager
 import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedInject
@@ -21,7 +21,7 @@ class BumpStatsTask @AssistedInject constructor(
     @Assisted context: Context,
     @Assisted params: WorkerParameters,
     private val appDatabase: AppDatabase,
-    private val wpComServerManager: WpComServerManager,
+    private val wpComServiceManager: WpComServiceManager,
 ) : CoroutineWorker(context, params) {
 
     override suspend fun doWork(): Result {
@@ -29,7 +29,7 @@ class BumpStatsTask @AssistedInject constructor(
         val bumpStats = bumpStatsDao.get()
 
         return if (bumpStats.isNotEmpty()) {
-            val response = wpComServerManager.bumpStatAnonymously(bumpStats)
+            val response = wpComServiceManager.bumpStatAnonymously(bumpStats)
             if (response.isSuccessful && response.body() == "Accepted") {
                 Timber.i("$TAG, successfully sent bump stats")
 

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/colors/ColorManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/colors/ColorManager.kt
@@ -3,7 +3,7 @@ package au.com.shiftyjelly.pocketcasts.repositories.colors
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
 import au.com.shiftyjelly.pocketcasts.servers.cdn.ArtworkColors
-import au.com.shiftyjelly.pocketcasts.servers.cdn.StaticServerManagerImpl
+import au.com.shiftyjelly.pocketcasts.servers.cdn.StaticServiceManagerImpl
 import au.com.shiftyjelly.pocketcasts.utils.Optional
 import io.reactivex.Single
 import javax.inject.Inject
@@ -13,7 +13,7 @@ import timber.log.Timber
 
 @Singleton
 class ColorManager @Inject constructor(
-    private val staticServerManager: StaticServerManagerImpl,
+    private val staticServiceManager: StaticServiceManagerImpl,
     private val podcastManager: PodcastManager,
 ) {
 
@@ -35,7 +35,7 @@ class ColorManager @Inject constructor(
     }
 
     fun downloadColors(podcastUuid: String): Single<Optional<ArtworkColors>> {
-        return staticServerManager.getColorsSingle(podcastUuid)
+        return staticServiceManager.getColorsSingle(podcastUuid)
     }
 
     suspend fun updateColors(podcasts: List<Podcast>) {
@@ -50,7 +50,7 @@ class ColorManager @Inject constructor(
         }
 
         try {
-            val colors = staticServerManager.getColors(podcast.uuid) ?: return
+            val colors = staticServiceManager.getColors(podcast.uuid) ?: return
             podcastManager.updateColors(
                 podcast.uuid,
                 colors.background,

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/di/CastsWorkerFactory.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/di/CastsWorkerFactory.kt
@@ -17,7 +17,7 @@ import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.UserEpisodeManager
 import au.com.shiftyjelly.pocketcasts.repositories.sync.SyncHistoryTask
 import au.com.shiftyjelly.pocketcasts.repositories.sync.SyncManager
-import au.com.shiftyjelly.pocketcasts.servers.refresh.RefreshServerManager
+import au.com.shiftyjelly.pocketcasts.servers.refresh.RefreshServiceManager
 import au.com.shiftyjelly.pocketcasts.servers.sync.SyncSettingsTask
 import javax.inject.Inject
 
@@ -27,7 +27,7 @@ class CastsWorkerFactory @Inject constructor(
     val syncManager: SyncManager,
     val downloadManager: DownloadManager,
     val playbackManager: PlaybackManager,
-    val refreshServerManager: RefreshServerManager,
+    val refreshServiceManager: RefreshServiceManager,
     val notificationHelper: NotificationHelper,
     val settings: Settings,
     val userEpisodeManager: UserEpisodeManager,
@@ -59,7 +59,7 @@ class CastsWorkerFactory @Inject constructor(
             }
             is OpmlImportTask -> {
                 instance.podcastManager = podcastManager
-                instance.refreshServerManager = refreshServerManager
+                instance.refreshServiceManager = refreshServiceManager
                 instance.notificationHelper = notificationHelper
             }
             is UpdateEpisodeDetailsTask -> {

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/download/task/UpdateEpisodeTask.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/download/task/UpdateEpisodeTask.kt
@@ -7,7 +7,7 @@ import androidx.work.Data
 import androidx.work.WorkerParameters
 import au.com.shiftyjelly.pocketcasts.models.db.AppDatabase
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
-import au.com.shiftyjelly.pocketcasts.servers.podcast.PodcastCacheServerManager
+import au.com.shiftyjelly.pocketcasts.servers.podcast.PodcastCacheServiceManager
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedInject
 import timber.log.Timber
@@ -19,7 +19,7 @@ import timber.log.Timber
 class UpdateEpisodeTask @AssistedInject constructor(
     @Assisted val context: Context,
     @Assisted val params: WorkerParameters,
-    val podcastCacheServerManager: PodcastCacheServerManager,
+    val podcastCacheServiceManager: PodcastCacheServiceManager,
     val appDatabase: AppDatabase,
 ) : CoroutineWorker(context, params) {
     companion object {
@@ -44,7 +44,7 @@ class UpdateEpisodeTask @AssistedInject constructor(
                 return Result.success()
             }
 
-            val serverPodcast = podcastCacheServerManager.getPodcastAndEpisode(podcastUuid, episodeUuid)
+            val serverPodcast = podcastCacheServiceManager.getPodcastAndEpisode(podcastUuid, episodeUuid)
 
             val episode = episodeDao.findByUuid(episodeUuid)
             val serverEpisodeUrl = serverPodcast.episodes.firstOrNull()?.downloadUrl

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/opml/OpmlImportTask.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/opml/OpmlImportTask.kt
@@ -23,7 +23,7 @@ import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.repositories.notification.NotificationHelper
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
 import au.com.shiftyjelly.pocketcasts.servers.refresh.ImportOpmlResponse
-import au.com.shiftyjelly.pocketcasts.servers.refresh.RefreshServerManager
+import au.com.shiftyjelly.pocketcasts.servers.refresh.RefreshServiceManager
 import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedInject
@@ -56,7 +56,7 @@ class OpmlImportTask @AssistedInject constructor(
     @Assisted context: Context,
     @Assisted parameters: WorkerParameters,
     var podcastManager: PodcastManager,
-    var refreshServerManager: RefreshServerManager,
+    var refreshServiceManager: RefreshServiceManager,
     var notificationHelper: NotificationHelper,
     private val analyticsTracker: AnalyticsTracker,
 ) : CoroutineWorker(context, parameters) {
@@ -321,12 +321,12 @@ class OpmlImportTask @AssistedInject constructor(
      * - failed: the number of podcast creates that have failed
      */
     suspend fun callServer(urls: List<String>): ImportOpmlResponse? {
-        val response = refreshServerManager.importOpml(urls)
+        val response = refreshServiceManager.importOpml(urls)
         return response.body()?.result
     }
 
     suspend fun pollServer(pollUuids: List<String>): ImportOpmlResponse? {
-        val response = refreshServerManager.pollImportOpml(pollUuids)
+        val response = refreshServiceManager.pollImportOpml(pollUuids)
         return response.body()?.result
     }
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackService.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackService.kt
@@ -40,9 +40,9 @@ import au.com.shiftyjelly.pocketcasts.repositories.podcast.PlaylistManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.UserEpisodeManager
 import au.com.shiftyjelly.pocketcasts.repositories.subscription.SubscriptionManager
-import au.com.shiftyjelly.pocketcasts.servers.ServerManager
-import au.com.shiftyjelly.pocketcasts.servers.list.ListServerManager
-import au.com.shiftyjelly.pocketcasts.servers.podcast.PodcastCacheServerManager
+import au.com.shiftyjelly.pocketcasts.servers.ServiceManager
+import au.com.shiftyjelly.pocketcasts.servers.list.ListServiceManager
+import au.com.shiftyjelly.pocketcasts.servers.podcast.PodcastCacheServiceManager
 import au.com.shiftyjelly.pocketcasts.utils.IS_RUNNING_UNDER_TEST
 import au.com.shiftyjelly.pocketcasts.utils.SchedulerProvider
 import au.com.shiftyjelly.pocketcasts.utils.Util
@@ -117,15 +117,15 @@ open class PlaybackService : MediaBrowserServiceCompat(), CoroutineScope {
 
     @Inject lateinit var settings: Settings
 
-    @Inject lateinit var serverManager: ServerManager
+    @Inject lateinit var serviceManager: ServiceManager
 
     @Inject lateinit var notificationHelper: NotificationHelper
 
     @Inject lateinit var subscriptionManager: SubscriptionManager
 
-    @Inject lateinit var listServerManager: ListServerManager
+    @Inject lateinit var listServiceManager: ListServiceManager
 
-    @Inject lateinit var podcastCacheServerManager: PodcastCacheServerManager
+    @Inject lateinit var podcastCacheServiceManager: PodcastCacheServiceManager
 
     @Inject lateinit var analyticsTracker: AnalyticsTracker
 
@@ -648,7 +648,7 @@ open class PlaybackService : MediaBrowserServiceCompat(), CoroutineScope {
             if (termCleaned.length <= 1) {
                 emptyList()
             } else {
-                serverManager.searchForPodcastsSuspend(searchTerm = term, resources = resources).searchResults
+                serviceManager.searchForPodcastsSuspend(searchTerm = term, resources = resources).searchResults
             }
         } catch (ex: Exception) {
             Timber.e(ex)

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManagerImpl.kt
@@ -32,7 +32,7 @@ import au.com.shiftyjelly.pocketcasts.repositories.download.UpdateEpisodeDetails
 import au.com.shiftyjelly.pocketcasts.repositories.file.FileStorage
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlayerEvent
-import au.com.shiftyjelly.pocketcasts.servers.podcast.PodcastCacheServerManager
+import au.com.shiftyjelly.pocketcasts.servers.podcast.PodcastCacheServiceManager
 import au.com.shiftyjelly.pocketcasts.utils.FileUtil
 import au.com.shiftyjelly.pocketcasts.utils.Network
 import au.com.shiftyjelly.pocketcasts.utils.days
@@ -68,7 +68,7 @@ class EpisodeManagerImpl @Inject constructor(
     private val downloadManager: DownloadManager,
     @ApplicationContext private val context: Context,
     private val appDatabase: AppDatabase,
-    private val podcastCacheServerManager: PodcastCacheServerManager,
+    private val podcastCacheServiceManager: PodcastCacheServiceManager,
     private val userEpisodeManager: UserEpisodeManager,
     @IoDispatcher private val ioDispatcher: CoroutineDispatcher,
     private val episodeAnalytics: EpisodeAnalytics,
@@ -1008,7 +1008,7 @@ class EpisodeManagerImpl @Inject constructor(
                 if (episodeExists || podcastUuid == Podcast.userPodcast.uuid) {
                     observeEpisodeByUuidRx(episodeUuid).firstElement()
                 } else {
-                    podcastCacheServerManager.getPodcastAndEpisodeSingle(podcastUuid, episodeUuid).flatMapMaybe { response ->
+                    podcastCacheServiceManager.getPodcastAndEpisodeSingle(podcastUuid, episodeUuid).flatMapMaybe { response ->
                         val episode = response.episodes.firstOrNull() ?: skeletonEpisode
                         add(episode, downloadMetaData = downloadMetaData)
 
@@ -1089,7 +1089,7 @@ class EpisodeManagerImpl @Inject constructor(
      */
     override suspend fun updateDownloadUrl(episode: PodcastEpisode): String? =
         withContext(Dispatchers.IO) {
-            val newDownloadUrl = podcastCacheServerManager.getEpisodeUrl(episode)
+            val newDownloadUrl = podcastCacheServiceManager.getEpisodeUrl(episode)
             if (newDownloadUrl != null && episode.downloadUrl != newDownloadUrl) {
                 Timber.i("Updating PodcastEpisode url in database for ${episode.uuid} to $newDownloadUrl")
                 episodeDao.updateDownloadUrl(newDownloadUrl, episode.uuid)

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PodcastManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PodcastManagerImpl.kt
@@ -29,8 +29,8 @@ import au.com.shiftyjelly.pocketcasts.repositories.refresh.RefreshPodcastsTask
 import au.com.shiftyjelly.pocketcasts.repositories.refresh.RefreshPodcastsThread
 import au.com.shiftyjelly.pocketcasts.repositories.sync.SyncManager
 import au.com.shiftyjelly.pocketcasts.servers.extensions.wasCached
-import au.com.shiftyjelly.pocketcasts.servers.podcast.PodcastCacheServerManager
-import au.com.shiftyjelly.pocketcasts.servers.refresh.RefreshServerManager
+import au.com.shiftyjelly.pocketcasts.servers.podcast.PodcastCacheServiceManager
+import au.com.shiftyjelly.pocketcasts.servers.refresh.RefreshServiceManager
 import au.com.shiftyjelly.pocketcasts.utils.DateUtil
 import au.com.shiftyjelly.pocketcasts.utils.Optional
 import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
@@ -62,8 +62,8 @@ class PodcastManagerImpl @Inject constructor(
     private val settings: Settings,
     @ApplicationContext private val context: Context,
     private val subscribeManager: SubscribeManager,
-    private val cacheServerManager: PodcastCacheServerManager,
-    private val refreshServerManager: RefreshServerManager,
+    private val cacheServiceManager: PodcastCacheServiceManager,
+    private val refreshServiceManager: RefreshServiceManager,
     private val syncManager: SyncManager,
     @ApplicationScope private val applicationScope: CoroutineScope,
     appDatabase: AppDatabase,
@@ -231,7 +231,7 @@ class PodcastManagerImpl @Inject constructor(
                     LogBuffer.TAG_BACKGROUND_TASKS,
                     "Refreshing podcast ${existingPodcast.uuid}",
                 )
-                val updatedPodcast = cacheServerManager.getPodcastResponse(existingPodcast.uuid)
+                val updatedPodcast = cacheServiceManager.getPodcastResponse(existingPodcast.uuid)
                     .map {
                         val responsePodcast = it.body()?.toPodcast()
                         if (it.wasCached()) {
@@ -812,7 +812,7 @@ class PodcastManagerImpl @Inject constructor(
     }
 
     override suspend fun refreshPodcastFeed(podcastUuid: String): Boolean {
-        return refreshServerManager.refreshPodcastFeed(podcastUuid).isSuccessful
+        return refreshServiceManager.refreshPodcastFeed(podcastUuid).isSuccessful
     }
 
     override suspend fun findTopPodcasts(fromEpochMs: Long, toEpochMs: Long, limit: Int): List<TopPodcast> =

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/SubscribeManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/SubscribeManager.kt
@@ -12,8 +12,8 @@ import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.repositories.images.PocketCastsImageRequestFactory
 import au.com.shiftyjelly.pocketcasts.repositories.sync.SyncManager
 import au.com.shiftyjelly.pocketcasts.servers.cdn.ArtworkColors
-import au.com.shiftyjelly.pocketcasts.servers.cdn.StaticServerManager
-import au.com.shiftyjelly.pocketcasts.servers.podcast.PodcastCacheServerManager
+import au.com.shiftyjelly.pocketcasts.servers.cdn.StaticServiceManager
+import au.com.shiftyjelly.pocketcasts.servers.podcast.PodcastCacheServiceManager
 import au.com.shiftyjelly.pocketcasts.servers.sync.PodcastEpisodesResponse
 import au.com.shiftyjelly.pocketcasts.utils.Optional
 import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
@@ -37,8 +37,8 @@ import timber.log.Timber
 @Singleton
 class SubscribeManager @Inject constructor(
     val appDatabase: AppDatabase,
-    val podcastCacheServerManager: PodcastCacheServerManager,
-    private val staticServerManager: StaticServerManager,
+    val podcastCacheServiceManager: PodcastCacheServiceManager,
+    private val staticServiceManager: StaticServiceManager,
     private val syncManager: SyncManager,
     @ApplicationContext val context: Context,
     val settings: Settings,
@@ -160,11 +160,11 @@ class SubscribeManager @Inject constructor(
 
     private fun downloadPodcast(podcastUuid: String): Single<Podcast> {
         // download the podcast
-        val serverPodcastObservable = podcastCacheServerManager.getPodcast(podcastUuid)
+        val serverPodcastObservable = podcastCacheServiceManager.getPodcast(podcastUuid)
             .subscribeOn(Schedulers.io())
             .doOnSuccess { Timber.i("Downloaded episodes success podcast $podcastUuid") }
         // download the colors
-        val colorObservable = staticServerManager.getColorsSingle(podcastUuid)
+        val colorObservable = staticServiceManager.getColorsSingle(podcastUuid)
             .subscribeOn(Schedulers.io())
             .doOnSuccess { Timber.i("Downloaded colors success podcast $podcastUuid") }
             .onErrorReturn { Optional.empty() }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/TranscriptsManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/TranscriptsManagerImpl.kt
@@ -7,8 +7,8 @@ import au.com.shiftyjelly.pocketcasts.models.db.dao.TranscriptDao
 import au.com.shiftyjelly.pocketcasts.models.to.Transcript
 import au.com.shiftyjelly.pocketcasts.repositories.di.ApplicationScope
 import au.com.shiftyjelly.pocketcasts.repositories.shownotes.toTranscript
-import au.com.shiftyjelly.pocketcasts.servers.ServerShowNotesManager
-import au.com.shiftyjelly.pocketcasts.servers.podcast.TranscriptCacheServer
+import au.com.shiftyjelly.pocketcasts.servers.ShowNotesServiceManager
+import au.com.shiftyjelly.pocketcasts.servers.podcast.TranscriptCacheService
 import au.com.shiftyjelly.pocketcasts.utils.NetworkWrapper
 import au.com.shiftyjelly.pocketcasts.utils.exception.EmptyDataException
 import au.com.shiftyjelly.pocketcasts.utils.exception.NoNetworkException
@@ -30,9 +30,9 @@ import timber.log.Timber
 @OptIn(UnstableApi::class)
 class TranscriptsManagerImpl @Inject constructor(
     private val transcriptDao: TranscriptDao,
-    private val service: TranscriptCacheServer,
+    private val service: TranscriptCacheService,
     private val networkWrapper: NetworkWrapper,
-    private val serverShowNotesManager: ServerShowNotesManager,
+    private val showNotesServiceManager: ShowNotesServiceManager,
     @ApplicationScope private val scope: CoroutineScope,
     private val transcriptCuesInfoBuilder: TranscriptCuesInfoBuilder,
 ) : TranscriptsManager {
@@ -152,7 +152,7 @@ class TranscriptsManagerImpl @Inject constructor(
             val episodeFailedFormats = _failedTranscriptFormats.value[transcript.episodeUuid]
             if (!episodeFailedFormats.isNullOrEmpty()) {
                 // Get available transcripts from show notes
-                serverShowNotesManager.loadShowNotes(
+                showNotesServiceManager.loadShowNotes(
                     podcastUuid = podcastUuid,
                     episodeUuid = transcript.episodeUuid,
                 ) { showNotes ->

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/ratings/RatingsManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/ratings/RatingsManagerImpl.kt
@@ -3,7 +3,7 @@ package au.com.shiftyjelly.pocketcasts.repositories.ratings
 import au.com.shiftyjelly.pocketcasts.models.db.AppDatabase
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastRatings
 import au.com.shiftyjelly.pocketcasts.repositories.sync.SyncManager
-import au.com.shiftyjelly.pocketcasts.servers.podcast.PodcastCacheServerManager
+import au.com.shiftyjelly.pocketcasts.servers.podcast.PodcastCacheServiceManager
 import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
 import java.io.IOException
 import javax.inject.Inject
@@ -15,7 +15,7 @@ import retrofit2.HttpException
 import timber.log.Timber
 
 class RatingsManagerImpl @Inject constructor(
-    private val cacheServerManager: PodcastCacheServerManager,
+    private val cacheServiceManager: PodcastCacheServiceManager,
     private val syncManager: SyncManager,
     appDatabase: AppDatabase,
 ) : RatingsManager, CoroutineScope {
@@ -31,7 +31,7 @@ class RatingsManagerImpl @Inject constructor(
     override suspend fun refreshPodcastRatings(podcastUuid: String, useCache: Boolean) {
         try {
             // The server asks for the ratings to be cached for a period of time. After a user rates ignore the cache to get the new rating.
-            val ratings = cacheServerManager.getPodcastRatings(podcastUuid, useCache)
+            val ratings = cacheServiceManager.getPodcastRatings(podcastUuid, useCache)
             podcastRatingsDao.insert(
                 PodcastRatings(
                     podcastUuid = podcastUuid,

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/refresh/RefreshPodcastsThread.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/refresh/RefreshPodcastsThread.kt
@@ -45,9 +45,9 @@ import au.com.shiftyjelly.pocketcasts.repositories.sync.SyncManager
 import au.com.shiftyjelly.pocketcasts.repositories.user.StatsManager
 import au.com.shiftyjelly.pocketcasts.repositories.user.UserManager
 import au.com.shiftyjelly.pocketcasts.servers.RefreshResponse
-import au.com.shiftyjelly.pocketcasts.servers.ServerManager
 import au.com.shiftyjelly.pocketcasts.servers.ServerResponseException
-import au.com.shiftyjelly.pocketcasts.servers.podcast.PodcastCacheServerManagerImpl
+import au.com.shiftyjelly.pocketcasts.servers.ServiceManager
+import au.com.shiftyjelly.pocketcasts.servers.podcast.PodcastCacheServiceManagerImpl
 import au.com.shiftyjelly.pocketcasts.servers.sync.exception.RefreshTokenExpiredException
 import au.com.shiftyjelly.pocketcasts.utils.Network
 import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
@@ -76,13 +76,13 @@ class RefreshPodcastsThread(
     @EntryPoint
     @InstallIn(SingletonComponent::class)
     interface RefreshPodcastsThreadEntryPoint {
-        fun serverManager(): ServerManager
+        fun serviceManager(): ServiceManager
         fun podcastManager(): PodcastManager
         fun playlistManager(): PlaylistManager
         fun bookmarkManager(): BookmarkManager
         fun statsManager(): StatsManager
         fun fileStorage(): FileStorage
-        fun podcastCacheServerManager(): PodcastCacheServerManagerImpl
+        fun podcastCacheServiceManager(): PodcastCacheServiceManagerImpl
         fun userEpisodeManager(): UserEpisodeManager
         fun subscriptionManager(): SubscriptionManager
         fun folderManager(): FolderManager
@@ -170,10 +170,10 @@ class RefreshPodcastsThread(
     private fun refresh() {
         val entryPoint = getEntryPoint()
         val podcastManager = entryPoint.podcastManager()
-        val serverManager = entryPoint.serverManager()
+        val serviceManager = entryPoint.serviceManager()
         val podcasts = podcastManager.findSubscribed()
         val startTime = SystemClock.elapsedRealtime()
-        runBlocking { serverManager.refreshPodcastsSync(podcasts) }
+        runBlocking { serviceManager.refreshPodcastsSync(podcasts) }
             .onSuccess { response ->
                 val elapsedTime = String.format("%d ms", SystemClock.elapsedRealtime() - startTime)
                 LogBuffer.i(LogBuffer.TAG_BACKGROUND_TASKS, "Refresh - podcasts response - $elapsedTime")
@@ -252,7 +252,7 @@ class RefreshPodcastsThread(
             statsManager = entryPoint.statsManager(),
             fileStorage = entryPoint.fileStorage(),
             playbackManager = playbackManager,
-            podcastCacheServerManager = entryPoint.podcastCacheServerManager(),
+            podcastCacheServiceManager = entryPoint.podcastCacheServiceManager(),
             userEpisodeManager = entryPoint.userEpisodeManager(),
             subscriptionManager = entryPoint.subscriptionManager(),
             folderManager = entryPoint.folderManager(),

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/shownotes/ShowNotesManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/shownotes/ShowNotesManager.kt
@@ -1,32 +1,32 @@
 package au.com.shiftyjelly.pocketcasts.repositories.shownotes
 
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.LoadTranscriptSource
-import au.com.shiftyjelly.pocketcasts.servers.ServerShowNotesManager
+import au.com.shiftyjelly.pocketcasts.servers.ShowNotesServiceManager
 import au.com.shiftyjelly.pocketcasts.servers.shownotes.ShowNotesState
 import javax.inject.Inject
 import kotlinx.coroutines.flow.Flow
 
 class ShowNotesManager @Inject constructor(
-    private val serverShowNotesManager: ServerShowNotesManager,
+    private val showNotesServiceManager: ShowNotesServiceManager,
     private val showNotesProcessor: ShowNotesProcessor,
 ) {
 
     fun loadShowNotesFlow(podcastUuid: String, episodeUuid: String): Flow<ShowNotesState> =
-        serverShowNotesManager.loadShowNotesFlow(
+        showNotesServiceManager.loadShowNotesFlow(
             podcastUuid = podcastUuid,
             episodeUuid = episodeUuid,
             processShowNotes = { showNotesProcessor.process(episodeUuid, it) },
         )
 
     suspend fun loadShowNotes(podcastUuid: String, episodeUuid: String): ShowNotesState =
-        serverShowNotesManager.loadShowNotes(
+        showNotesServiceManager.loadShowNotes(
             podcastUuid = podcastUuid,
             episodeUuid = episodeUuid,
             processShowNotes = { showNotesProcessor.process(episodeUuid, it) },
         )
 
     suspend fun downloadToCacheShowNotes(podcastUuid: String, episodeUuid: String) {
-        serverShowNotesManager.downloadToCacheShowNotes(
+        showNotesServiceManager.downloadToCacheShowNotes(
             podcastUuid = podcastUuid,
             processShowNotes = { showNotesProcessor.process(episodeUuid, it, LoadTranscriptSource.DOWNLOAD_EPISODE) },
         )

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/shownotes/ShowNotesProcessor.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/shownotes/ShowNotesProcessor.kt
@@ -7,7 +7,7 @@ import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.ImageUrlUpdate
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.LoadTranscriptSource
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.TranscriptsManager
-import au.com.shiftyjelly.pocketcasts.servers.podcast.PodcastCacheServer
+import au.com.shiftyjelly.pocketcasts.servers.podcast.PodcastCacheService
 import au.com.shiftyjelly.pocketcasts.servers.podcast.ShowNotesChapter
 import au.com.shiftyjelly.pocketcasts.servers.podcast.ShowNotesResponse
 import au.com.shiftyjelly.pocketcasts.servers.podcast.ShowNotesTranscript
@@ -25,7 +25,7 @@ class ShowNotesProcessor @Inject constructor(
     private val episodeManager: EpisodeManager,
     private val chapterManager: ChapterManager,
     private val transcriptsManager: TranscriptsManager,
-    private val service: PodcastCacheServer,
+    private val service: PodcastCacheService,
 ) {
     fun process(
         episodeUuid: String,

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/PodcastSyncProcess.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/PodcastSyncProcess.kt
@@ -38,7 +38,7 @@ import au.com.shiftyjelly.pocketcasts.repositories.shortcuts.PocketCastsShortcut
 import au.com.shiftyjelly.pocketcasts.repositories.subscription.SubscriptionManager
 import au.com.shiftyjelly.pocketcasts.repositories.user.StatsManager
 import au.com.shiftyjelly.pocketcasts.servers.extensions.toDate
-import au.com.shiftyjelly.pocketcasts.servers.podcast.PodcastCacheServerManager
+import au.com.shiftyjelly.pocketcasts.servers.podcast.PodcastCacheServiceManager
 import au.com.shiftyjelly.pocketcasts.servers.sync.SyncSettingsTask
 import au.com.shiftyjelly.pocketcasts.servers.sync.update.SyncUpdateResponse
 import au.com.shiftyjelly.pocketcasts.utils.Util
@@ -106,7 +106,7 @@ class PodcastSyncProcess(
     var statsManager: StatsManager,
     var fileStorage: FileStorage,
     var playbackManager: PlaybackManager,
-    var podcastCacheServerManager: PodcastCacheServerManager,
+    var podcastCacheServiceManager: PodcastCacheServiceManager,
     var userEpisodeManager: UserEpisodeManager,
     var subscriptionManager: SubscriptionManager,
     var folderManager: FolderManager,

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/UpNextSyncJob.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/UpNextSyncJob.kt
@@ -23,7 +23,7 @@ import au.com.shiftyjelly.pocketcasts.repositories.playback.UpNextQueue
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.UserEpisodeManager
-import au.com.shiftyjelly.pocketcasts.servers.podcast.PodcastCacheServerManagerImpl
+import au.com.shiftyjelly.pocketcasts.servers.podcast.PodcastCacheServiceManagerImpl
 import au.com.shiftyjelly.pocketcasts.servers.sync.UpNextSyncRequest
 import au.com.shiftyjelly.pocketcasts.servers.sync.UpNextSyncResponse
 import au.com.shiftyjelly.pocketcasts.utils.extensions.parseIsoDate
@@ -63,7 +63,7 @@ class UpNextSyncJob : JobService() {
 
     @Inject lateinit var downloadManager: DownloadManager
 
-    @Inject lateinit var podcastCacheServerManager: PodcastCacheServerManagerImpl
+    @Inject lateinit var podcastCacheServiceManager: PodcastCacheServiceManagerImpl
 
     @Inject lateinit var userEpisodeManager: UserEpisodeManager
 

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManagerImplTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManagerImplTest.kt
@@ -45,7 +45,7 @@ class EpisodeManagerImplTest {
             fileStorage = mock(),
             downloadManager = mock(),
             context = mock(),
-            podcastCacheServerManager = mock(),
+            podcastCacheServiceManager = mock(),
             userEpisodeManager = mock(),
             ioDispatcher = mock(),
             episodeAnalytics = mock(),

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/shownotes/ShowNotesProcessTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/shownotes/ShowNotesProcessTest.kt
@@ -6,7 +6,7 @@ import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.ImageUrlUpdate
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.LoadTranscriptSource
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.TranscriptsManager
-import au.com.shiftyjelly.pocketcasts.servers.podcast.PodcastCacheServer
+import au.com.shiftyjelly.pocketcasts.servers.podcast.PodcastCacheService
 import au.com.shiftyjelly.pocketcasts.servers.podcast.RawChaptersResponse
 import au.com.shiftyjelly.pocketcasts.servers.podcast.ShowNotesChapter
 import au.com.shiftyjelly.pocketcasts.servers.podcast.ShowNotesEpisode
@@ -34,7 +34,7 @@ class ShowNotesProcessTest {
     private val episodeManager = mock<EpisodeManager>()
     private val chapterManager = mock<ChapterManager>()
     private val transcriptsManager = mock<TranscriptsManager>()
-    private val service = mock<PodcastCacheServer>()
+    private val service = mock<PodcastCacheService>()
 
     @Test
     fun `update episodes with image URLs`() = runTest(coroutineRule.testDispatcher) {

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/sync/PodcastSyncProcessTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/sync/PodcastSyncProcessTest.kt
@@ -300,7 +300,7 @@ class PodcastSyncProcessTest {
         statsManager = statsManager,
         fileStorage = mock(),
         playbackManager = mock(),
-        podcastCacheServerManager = mock(),
+        podcastCacheServiceManager = mock(),
         userEpisodeManager = mock(),
         subscriptionManager = mock(),
         folderManager = mock(),

--- a/modules/services/servers/lint-baseline.xml
+++ b/modules/services/servers/lint-baseline.xml
@@ -7,7 +7,7 @@
         errorLine1="                val responseDebug = String.format(&quot;Post response %d %s&quot;, response.code, call.request().url)"
         errorLine2="                                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
-            file="src/main/java/au/com/shiftyjelly/pocketcasts/servers/ServerManager.kt"
+            file="src/main/java/au/com/shiftyjelly/pocketcasts/servers/ServiceManager.kt"
             line="239"
             column="37"/>
     </issue>

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/ServiceManager.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/ServiceManager.kt
@@ -32,7 +32,7 @@ import okhttp3.Response
 import timber.log.Timber
 
 @Singleton
-open class ServerManager @Inject constructor(
+open class ServiceManager @Inject constructor(
     @NoCacheTokened private val httpClientNoCache: OkHttpClient,
     private val settings: Settings,
 ) {

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/ShowNotesServiceManager.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/ShowNotesServiceManager.kt
@@ -1,6 +1,6 @@
 package au.com.shiftyjelly.pocketcasts.servers
 
-import au.com.shiftyjelly.pocketcasts.servers.podcast.PodcastCacheServerManager
+import au.com.shiftyjelly.pocketcasts.servers.podcast.PodcastCacheServiceManager
 import au.com.shiftyjelly.pocketcasts.servers.podcast.ShowNotesResponse
 import au.com.shiftyjelly.pocketcasts.servers.shownotes.ShowNotesState
 import javax.inject.Inject
@@ -10,8 +10,8 @@ import kotlinx.coroutines.flow.flow
 import timber.log.Timber
 
 @Singleton
-class ServerShowNotesManager @Inject constructor(
-    private val podcastCacheServerManager: PodcastCacheServerManager,
+class ShowNotesServiceManager @Inject constructor(
+    private val podcastCacheServiceManager: PodcastCacheServiceManager,
 ) {
 
     /**
@@ -92,7 +92,7 @@ class ServerShowNotesManager @Inject constructor(
     }
 
     private suspend fun findShowNotesInCache(podcastUuid: String, episodeUuid: String): String? {
-        val response = podcastCacheServerManager.getShowNotesCache(podcastUuid = podcastUuid) ?: return null
+        val response = podcastCacheServiceManager.getShowNotesCache(podcastUuid = podcastUuid) ?: return null
         return response.findEpisode(episodeUuid)?.showNotes
     }
 
@@ -104,7 +104,7 @@ class ServerShowNotesManager @Inject constructor(
         if (podcastUuid.isBlank() || episodeUuid.isBlank()) {
             return null
         }
-        val response = podcastCacheServerManager.getShowNotes(podcastUuid = podcastUuid)
+        val response = podcastCacheServiceManager.getShowNotes(podcastUuid = podcastUuid)
         processShowNotes(response)
         return response.findEpisode(episodeUuid)?.showNotes
     }
@@ -116,7 +116,7 @@ class ServerShowNotesManager @Inject constructor(
         if (podcastUuid.isBlank()) {
             return
         }
-        val response = podcastCacheServerManager.getShowNotes(podcastUuid = podcastUuid)
+        val response = podcastCacheServiceManager.getShowNotes(podcastUuid = podcastUuid)
         processShowNotes(response)
     }
 }

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/bumpstats/WpComService.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/bumpstats/WpComService.kt
@@ -4,7 +4,7 @@ import retrofit2.Response
 import retrofit2.http.Body
 import retrofit2.http.POST
 
-interface WpComServer {
+interface WpComService {
 
     @POST("/rest/v1.1/tracks/record")
     suspend fun bumpStatAnonymously(@Body request: AnonymousBumpStatsRequest): Response<String>

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/bumpstats/WpComServiceManager.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/bumpstats/WpComServiceManager.kt
@@ -1,18 +1,18 @@
 package au.com.shiftyjelly.pocketcasts.servers.bumpstats
 
 import au.com.shiftyjelly.pocketcasts.models.entity.AnonymousBumpStat
-import au.com.shiftyjelly.pocketcasts.servers.di.WpComServerRetrofit
+import au.com.shiftyjelly.pocketcasts.servers.di.WpComServiceRetrofit
 import javax.inject.Inject
 import retrofit2.Response
 import retrofit2.Retrofit
 
-class WpComServerManager @Inject constructor(
-    @WpComServerRetrofit retrofit: Retrofit,
+class WpComServiceManager @Inject constructor(
+    @WpComServiceRetrofit retrofit: Retrofit,
 ) {
-    private val server: WpComServer = retrofit.create(WpComServer::class.java)
+    private val service: WpComService = retrofit.create(WpComService::class.java)
 
     suspend fun bumpStatAnonymously(bumpStats: List<AnonymousBumpStat>): Response<String> {
         val request = AnonymousBumpStatsRequest(bumpStats)
-        return server.bumpStatAnonymously(request)
+        return service.bumpStatAnonymously(request)
     }
 }

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/cdn/StaticService.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/cdn/StaticService.kt
@@ -5,7 +5,7 @@ import io.reactivex.Observable
 import retrofit2.http.GET
 import retrofit2.http.Path
 
-interface StaticServer {
+interface StaticService {
 
     @GET("/discover/images/metadata/{podcastUuid}.json")
     fun getColorsMaybe(@Path("podcastUuid") podcastUuid: String): Maybe<ColorsResponse>

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/cdn/StaticServiceManager.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/cdn/StaticServiceManager.kt
@@ -3,7 +3,7 @@ package au.com.shiftyjelly.pocketcasts.servers.cdn
 import au.com.shiftyjelly.pocketcasts.utils.Optional
 import io.reactivex.Single
 
-interface StaticServerManager {
+interface StaticServiceManager {
     fun getColorsSingle(podcastUuid: String): Single<Optional<ArtworkColors>>
     suspend fun getColors(podcastUuid: String): ArtworkColors?
 }

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/cdn/StaticServiceManagerImpl.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/cdn/StaticServiceManagerImpl.kt
@@ -1,16 +1,16 @@
 package au.com.shiftyjelly.pocketcasts.servers.cdn
 
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
-import au.com.shiftyjelly.pocketcasts.servers.di.StaticServerRetrofit
+import au.com.shiftyjelly.pocketcasts.servers.di.StaticServiceRetrofit
 import au.com.shiftyjelly.pocketcasts.utils.Optional
 import io.reactivex.Observable
 import io.reactivex.Single
 import javax.inject.Inject
 import retrofit2.Retrofit
 
-class StaticServerManagerImpl @Inject constructor(@StaticServerRetrofit retrofit: Retrofit) : StaticServerManager {
+class StaticServiceManagerImpl @Inject constructor(@StaticServiceRetrofit retrofit: Retrofit) : StaticServiceManager {
 
-    val server = retrofit.create(StaticServer::class.java)
+    val server = retrofit.create(StaticService::class.java)
 
     override fun getColorsSingle(podcastUuid: String): Single<Optional<ArtworkColors>> {
         return server.getColorsMaybe(podcastUuid)

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/di/ServersModule.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/di/ServersModule.kt
@@ -16,8 +16,8 @@ import au.com.shiftyjelly.pocketcasts.servers.addInterceptors
 import au.com.shiftyjelly.pocketcasts.servers.model.DisplayStyleMoshiAdapter
 import au.com.shiftyjelly.pocketcasts.servers.model.ExpandedStyleMoshiAdapter
 import au.com.shiftyjelly.pocketcasts.servers.model.ListTypeMoshiAdapter
-import au.com.shiftyjelly.pocketcasts.servers.podcast.PodcastCacheServer
-import au.com.shiftyjelly.pocketcasts.servers.podcast.TranscriptCacheServer
+import au.com.shiftyjelly.pocketcasts.servers.podcast.PodcastCacheService
+import au.com.shiftyjelly.pocketcasts.servers.podcast.TranscriptCacheService
 import au.com.shiftyjelly.pocketcasts.servers.server.ListRepository
 import au.com.shiftyjelly.pocketcasts.servers.server.ListWebService
 import au.com.shiftyjelly.pocketcasts.servers.sync.LoginIdentity
@@ -187,14 +187,14 @@ class ServersModule {
     }
 
     @Provides
-    @SyncServerRetrofit
+    @SyncServiceRetrofit
     @Singleton
     internal fun provideApiRetrofit(@Cached okHttpClient: OkHttpClient, moshi: Moshi): Retrofit {
         return provideRetrofit(baseUrl = Settings.SERVER_API_URL, okHttpClient = okHttpClient, moshi = moshi)
     }
 
     @Provides
-    @WpComServerRetrofit
+    @WpComServiceRetrofit
     @Singleton
     internal fun provideWpComApiRetrofit(@Cached okHttpClient: OkHttpClient, moshi: Moshi): Retrofit {
         return Retrofit.Builder()
@@ -205,42 +205,42 @@ class ServersModule {
     }
 
     @Provides
-    @RefreshServerRetrofit
+    @RefreshServiceRetrofit
     @Singleton
     internal fun provideRefreshRetrofit(@NoCacheTokened okHttpClient: OkHttpClient, moshi: Moshi): Retrofit {
         return provideRetrofit(baseUrl = Settings.SERVER_MAIN_URL, okHttpClient = okHttpClient, moshi = moshi)
     }
 
     @Provides
-    @PodcastCacheServerRetrofit
+    @PodcastCacheServiceRetrofit
     @Singleton
     internal fun providePodcastRetrofit(@Cached okHttpClient: OkHttpClient, moshi: Moshi): Retrofit {
         return provideRetrofit(baseUrl = Settings.SERVER_CACHE_URL, okHttpClient = okHttpClient, moshi = moshi)
     }
 
     @Provides
-    @StaticServerRetrofit
+    @StaticServiceRetrofit
     @Singleton
     internal fun provideStaticRetrofit(@Cached okHttpClient: OkHttpClient, moshi: Moshi): Retrofit {
         return provideRetrofit(baseUrl = Settings.SERVER_STATIC_URL, okHttpClient = okHttpClient, moshi = moshi)
     }
 
     @Provides
-    @ListDownloadServerRetrofit
+    @ListDownloadServiceRetrofit
     @Singleton
     internal fun provideListDownloadRetrofit(@NoCache okHttpClient: OkHttpClient, moshi: Moshi): Retrofit {
         return provideRetrofit(baseUrl = Settings.SERVER_LIST_URL, okHttpClient = okHttpClient, moshi = moshi)
     }
 
     @Provides
-    @ListUploadServerRetrofit
+    @ListUploadServiceRetrofit
     @Singleton
     internal fun provideListUploadRetrofit(@NoCache okHttpClient: OkHttpClient, moshi: Moshi): Retrofit {
         return provideRetrofit(baseUrl = Settings.SERVER_SHARING_URL, okHttpClient = okHttpClient, moshi = moshi)
     }
 
     @Provides
-    @DiscoverServerRetrofit
+    @DiscoverServiceRetrofit
     @Singleton
     internal fun provideDiscoverRetrofit(@Cached okHttpClient: OkHttpClient, moshi: Moshi): Retrofit {
         return provideRetrofit(baseUrl = Settings.SERVER_STATIC_URL, okHttpClient = okHttpClient, moshi = moshi)
@@ -248,7 +248,7 @@ class ServersModule {
 
     @Provides
     @Singleton
-    internal fun provideListWebService(@DiscoverServerRetrofit retrofit: Retrofit): ListWebService {
+    internal fun provideListWebService(@DiscoverServiceRetrofit retrofit: Retrofit): ListWebService {
         return retrofit.create(ListWebService::class.java)
     }
 
@@ -280,11 +280,11 @@ class ServersModule {
 
     @Provides
     @Singleton
-    fun provideCacheServer(@PodcastCacheServerRetrofit retrofit: Retrofit): PodcastCacheServer = retrofit.create()
+    fun provideCacheServer(@PodcastCacheServiceRetrofit retrofit: Retrofit): PodcastCacheService = retrofit.create()
 
     @Provides
     @Singleton
-    fun provideTranscriptCacheServer(@TranscriptRetrofit retrofit: Retrofit): TranscriptCacheServer = retrofit.create()
+    fun provideTranscriptCacheServer(@TranscriptRetrofit retrofit: Retrofit): TranscriptCacheService = retrofit.create()
 }
 
 @Qualifier
@@ -317,35 +317,35 @@ annotation class Transcripts
 
 @Qualifier
 @Retention(AnnotationRetention.BINARY)
-annotation class SyncServerRetrofit
+annotation class SyncServiceRetrofit
 
 @Qualifier
 @Retention(AnnotationRetention.BINARY)
-annotation class WpComServerRetrofit
+annotation class WpComServiceRetrofit
 
 @Qualifier
 @Retention(AnnotationRetention.BINARY)
-annotation class RefreshServerRetrofit
+annotation class RefreshServiceRetrofit
 
 @Qualifier
 @Retention(AnnotationRetention.BINARY)
-annotation class PodcastCacheServerRetrofit
+annotation class PodcastCacheServiceRetrofit
 
 @Qualifier
 @Retention(AnnotationRetention.BINARY)
-annotation class StaticServerRetrofit
+annotation class StaticServiceRetrofit
 
 @Qualifier
 @Retention(AnnotationRetention.BINARY)
-annotation class ListDownloadServerRetrofit
+annotation class ListDownloadServiceRetrofit
 
 @Qualifier
 @Retention(AnnotationRetention.BINARY)
-annotation class ListUploadServerRetrofit
+annotation class ListUploadServiceRetrofit
 
 @Qualifier
 @Retention(AnnotationRetention.BINARY)
-annotation class DiscoverServerRetrofit
+annotation class DiscoverServiceRetrofit
 
 @Qualifier
 @Retention(AnnotationRetention.BINARY)

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/di/ServersModuleBinds.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/di/ServersModuleBinds.kt
@@ -1,13 +1,13 @@
 package au.com.shiftyjelly.pocketcasts.servers.di
 
-import au.com.shiftyjelly.pocketcasts.servers.cdn.StaticServerManager
-import au.com.shiftyjelly.pocketcasts.servers.cdn.StaticServerManagerImpl
-import au.com.shiftyjelly.pocketcasts.servers.list.ListServerManager
-import au.com.shiftyjelly.pocketcasts.servers.list.ListServerManagerImpl
-import au.com.shiftyjelly.pocketcasts.servers.podcast.PodcastCacheServerManager
-import au.com.shiftyjelly.pocketcasts.servers.podcast.PodcastCacheServerManagerImpl
-import au.com.shiftyjelly.pocketcasts.servers.refresh.RefreshServerManager
-import au.com.shiftyjelly.pocketcasts.servers.refresh.RefreshServerManagerImpl
+import au.com.shiftyjelly.pocketcasts.servers.cdn.StaticServiceManager
+import au.com.shiftyjelly.pocketcasts.servers.cdn.StaticServiceManagerImpl
+import au.com.shiftyjelly.pocketcasts.servers.list.ListServiceManager
+import au.com.shiftyjelly.pocketcasts.servers.list.ListServiceManagerImpl
+import au.com.shiftyjelly.pocketcasts.servers.podcast.PodcastCacheServiceManager
+import au.com.shiftyjelly.pocketcasts.servers.podcast.PodcastCacheServiceManagerImpl
+import au.com.shiftyjelly.pocketcasts.servers.refresh.RefreshServiceManager
+import au.com.shiftyjelly.pocketcasts.servers.refresh.RefreshServiceManagerImpl
 import dagger.Binds
 import dagger.Module
 import dagger.hilt.InstallIn
@@ -20,17 +20,17 @@ abstract class ServersModuleBinds {
 
     @Binds
     @Singleton
-    abstract fun provideRefreshServerManager(refreshServerManagerImpl: RefreshServerManagerImpl): RefreshServerManager
+    abstract fun provideRefreshServiceManager(refreshServiceManagerImpl: RefreshServiceManagerImpl): RefreshServiceManager
 
     @Binds
     @Singleton
-    abstract fun provideStaticManager(staticServerManagerImpl: StaticServerManagerImpl): StaticServerManager
+    abstract fun provideStaticManager(staticServiceManagerImpl: StaticServiceManagerImpl): StaticServiceManager
 
     @Binds
     @Singleton
-    abstract fun provideShareServerManager(shareServerManagerImpl: ListServerManagerImpl): ListServerManager
+    abstract fun provideShareServiceManager(shareServiceManagerImpl: ListServiceManagerImpl): ListServiceManager
 
     @Binds
     @Singleton
-    abstract fun providePodcastCacheServerManager(podcastCacheServerManagerImpl: PodcastCacheServerManagerImpl): PodcastCacheServerManager
+    abstract fun providePodcastCacheServiceManager(podcastCacheServiceManagerImpl: PodcastCacheServiceManagerImpl): PodcastCacheServiceManager
 }

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/list/ListDownloadService.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/list/ListDownloadService.kt
@@ -3,7 +3,7 @@ package au.com.shiftyjelly.pocketcasts.servers.list
 import retrofit2.http.GET
 import retrofit2.http.Path
 
-interface ListDownloadServer {
+interface ListDownloadService {
 
     @GET("{listId}.json")
     suspend fun getPodcastList(@Path("listId") listId: String): PodcastList

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/list/ListServiceManager.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/list/ListServiceManager.kt
@@ -4,7 +4,7 @@ import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import java.util.Date
 
-interface ListServerManager {
+interface ListServiceManager {
     suspend fun createPodcastList(title: String, description: String, podcasts: List<Podcast>, date: Date = Date(), serverSecret: String = Settings.SHARING_SERVER_SECRET): String?
     suspend fun openPodcastList(listId: String): PodcastList
     fun extractShareListIdFromWebUrl(webUrl: String): String

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/list/ListServiceManagerImpl.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/list/ListServiceManagerImpl.kt
@@ -2,8 +2,8 @@ package au.com.shiftyjelly.pocketcasts.servers.list
 
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
-import au.com.shiftyjelly.pocketcasts.servers.di.ListDownloadServerRetrofit
-import au.com.shiftyjelly.pocketcasts.servers.di.ListUploadServerRetrofit
+import au.com.shiftyjelly.pocketcasts.servers.di.ListDownloadServiceRetrofit
+import au.com.shiftyjelly.pocketcasts.servers.di.ListUploadServiceRetrofit
 import au.com.shiftyjelly.pocketcasts.utils.extensions.sha1
 import java.text.SimpleDateFormat
 import java.util.Date
@@ -11,13 +11,13 @@ import java.util.Locale
 import javax.inject.Inject
 import retrofit2.Retrofit
 
-class ListServerManagerImpl @Inject constructor(
-    @ListUploadServerRetrofit uploadRetrofit: Retrofit,
-    @ListDownloadServerRetrofit downloadRetrofit: Retrofit,
-) : ListServerManager {
+class ListServiceManagerImpl @Inject constructor(
+    @ListUploadServiceRetrofit uploadRetrofit: Retrofit,
+    @ListDownloadServiceRetrofit downloadRetrofit: Retrofit,
+) : ListServiceManager {
 
-    private val uploadServer: ListUploadServer = uploadRetrofit.create(ListUploadServer::class.java)
-    private val downloadServer: ListDownloadServer = downloadRetrofit.create(ListDownloadServer::class.java)
+    private val uploadService: ListUploadService = uploadRetrofit.create(ListUploadService::class.java)
+    private val downloadService: ListDownloadService = downloadRetrofit.create(ListDownloadService::class.java)
 
     companion object {
         private val DATE_FORMAT = SimpleDateFormat("yyyyMMddHHmmss", Locale.US)
@@ -48,12 +48,12 @@ class ListServerManagerImpl @Inject constructor(
             date = dateString,
             podcasts = podcasts.map { podcast -> ListPodcast.fromPodcast(podcast) },
         )
-        val response = uploadServer.createPodcastList(request)
+        val response = uploadService.createPodcastList(request)
         return response.result?.shareUrl
     }
 
     override suspend fun openPodcastList(listId: String): PodcastList {
-        return downloadServer.getPodcastList(listId)
+        return downloadService.getPodcastList(listId)
     }
 
     override fun extractShareListIdFromWebUrl(webUrl: String): String {

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/list/ListUploadService.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/list/ListUploadService.kt
@@ -4,7 +4,7 @@ import au.com.shiftyjelly.pocketcasts.servers.refresh.StatusResponse
 import retrofit2.http.Body
 import retrofit2.http.POST
 
-interface ListUploadServer {
+interface ListUploadService {
 
     @POST("/share/list")
     suspend fun createPodcastList(@Body request: PodcastList): StatusResponse<ListUploadResponse>

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/podcast/PodcastCacheService.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/podcast/PodcastCacheService.kt
@@ -64,7 +64,7 @@ data class PodcastRatingsResponse(
     )
 }
 
-interface PodcastCacheServer {
+interface PodcastCacheService {
     @GET("/mobile/podcast/full/{podcastUuid}")
     fun getPodcastAndEpisodesRaw(@Path("podcastUuid") podcastUuid: String): Single<Response<PodcastResponse>>
 

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/podcast/PodcastCacheServiceManager.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/podcast/PodcastCacheServiceManager.kt
@@ -7,7 +7,7 @@ import au.com.shiftyjelly.pocketcasts.servers.discover.EpisodeSearch
 import io.reactivex.Single
 import retrofit2.Response
 
-interface PodcastCacheServerManager {
+interface PodcastCacheServiceManager {
     fun getPodcast(podcastUuid: String): Single<Podcast>
     fun getPodcastAndEpisodeSingle(podcastUuid: String, episodeUuid: String): Single<Podcast>
     suspend fun getPodcastAndEpisode(podcastUuid: String, episodeUuid: String): Podcast

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/podcast/TranscriptCacheService.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/podcast/TranscriptCacheService.kt
@@ -7,7 +7,7 @@ import retrofit2.http.GET
 import retrofit2.http.Header
 import retrofit2.http.Url
 
-interface TranscriptCacheServer {
+interface TranscriptCacheService {
     @GET
     suspend fun getTranscript(
         @Url url: String,

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/refresh/RefreshPodcastBatcher.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/refresh/RefreshPodcastBatcher.kt
@@ -2,7 +2,7 @@ package au.com.shiftyjelly.pocketcasts.servers.refresh
 
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.servers.RefreshResponse
-import au.com.shiftyjelly.pocketcasts.servers.ServerManager.Parameters
+import au.com.shiftyjelly.pocketcasts.servers.ServiceManager.Parameters
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/refresh/RefreshService.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/refresh/RefreshService.kt
@@ -4,7 +4,7 @@ import retrofit2.Response
 import retrofit2.http.Body
 import retrofit2.http.POST
 
-interface RefreshServer {
+interface RefreshService {
 
     @POST("import/opml")
     suspend fun importOpml(@Body request: ImportOpmlRequest): Response<StatusResponse<ImportOpmlResponse>>

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/refresh/RefreshServiceManager.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/refresh/RefreshServiceManager.kt
@@ -2,7 +2,7 @@ package au.com.shiftyjelly.pocketcasts.servers.refresh
 
 import retrofit2.Response
 
-interface RefreshServerManager {
+interface RefreshServiceManager {
 
     suspend fun importOpml(urls: List<String>): Response<StatusResponse<ImportOpmlResponse>>
 

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/refresh/RefreshServiceManagerImpl.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/refresh/RefreshServiceManagerImpl.kt
@@ -2,40 +2,40 @@ package au.com.shiftyjelly.pocketcasts.servers.refresh
 
 import android.os.Build
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
-import au.com.shiftyjelly.pocketcasts.servers.di.RefreshServerRetrofit
+import au.com.shiftyjelly.pocketcasts.servers.di.RefreshServiceRetrofit
 import java.text.SimpleDateFormat
 import java.util.Locale
 import javax.inject.Inject
 import retrofit2.Response
 import retrofit2.Retrofit
 
-class RefreshServerManagerImpl @Inject constructor(
-    @RefreshServerRetrofit retrofit: Retrofit,
+class RefreshServiceManagerImpl @Inject constructor(
+    @RefreshServiceRetrofit retrofit: Retrofit,
     private val settings: Settings,
-) : RefreshServerManager {
+) : RefreshServiceManager {
 
     companion object {
         private val DATE_FORMAT = SimpleDateFormat("yyyyMMddHHmmss", Locale.US)
     }
 
-    private val server: RefreshServer = retrofit.create(RefreshServer::class.java)
+    private val service: RefreshService = retrofit.create(RefreshService::class.java)
 
     override suspend fun importOpml(urls: List<String>): Response<StatusResponse<ImportOpmlResponse>> {
         val request = ImportOpmlRequest(urls = urls)
         addDeviceParameters(request)
-        return server.importOpml(request)
+        return service.importOpml(request)
     }
 
     override suspend fun pollImportOpml(pollUuids: List<String>): Response<StatusResponse<ImportOpmlResponse>> {
         val request = ImportOpmlRequest(pollUuids = pollUuids)
         addDeviceParameters(request)
-        return server.importOpml(request)
+        return service.importOpml(request)
     }
 
     override suspend fun refreshPodcastFeed(podcastUuid: String): Response<StatusResponse<BasicResponse>> {
         val request = RefreshPodcastFeedRequest(podcastUuid = podcastUuid)
         addDeviceParameters(request)
-        return server.refreshPodcastFeed(request)
+        return service.refreshPodcastFeed(request)
     }
 
     private fun addDeviceParameters(request: BaseRequest) {

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/SyncService.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/SyncService.kt
@@ -39,7 +39,7 @@ import retrofit2.http.PUT
 import retrofit2.http.Path
 import retrofit2.http.Url
 
-interface SyncServer {
+interface SyncService {
     @POST("/user/login_pocket_casts")
     suspend fun loginPocketCasts(@Body request: LoginPocketCastsRequest): LoginTokenResponse
 

--- a/modules/services/servers/src/test/kotlin/au/com/shiftyjelly/pocketcasts/servers/refresh/RefreshPodcastBatcherTest.kt
+++ b/modules/services/servers/src/test/kotlin/au/com/shiftyjelly/pocketcasts/servers/refresh/RefreshPodcastBatcherTest.kt
@@ -3,7 +3,7 @@ package au.com.shiftyjelly.pocketcasts.servers.refresh
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.servers.RefreshResponse
-import au.com.shiftyjelly.pocketcasts.servers.ServerManager.Parameters
+import au.com.shiftyjelly.pocketcasts.servers.ServiceManager.Parameters
 import java.lang.RuntimeException
 import java.util.Date
 import java.util.UUID

--- a/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/helper/OpmlExporter.kt
+++ b/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/helper/OpmlExporter.kt
@@ -15,7 +15,7 @@ import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTracker
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
 import au.com.shiftyjelly.pocketcasts.repositories.sync.SyncManager
 import au.com.shiftyjelly.pocketcasts.servers.ServerCallback
-import au.com.shiftyjelly.pocketcasts.servers.ServerManager
+import au.com.shiftyjelly.pocketcasts.servers.ServiceManager
 import au.com.shiftyjelly.pocketcasts.utils.FileUtil
 import java.io.File
 import java.io.FileInputStream
@@ -30,7 +30,7 @@ import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 class OpmlExporter(
     private val fragment: PreferenceFragmentCompat,
-    private val serverManager: ServerManager,
+    private val serviceManager: ServiceManager,
     private val podcastManager: PodcastManager,
     private val syncManager: SyncManager,
     private val context: Context,
@@ -42,7 +42,7 @@ class OpmlExporter(
         const val EXPORT_PICKER_REQUEST_CODE = 43
     }
 
-    private var serverTask: Call? = null
+    private var serviceTask: Call? = null
     private var progressDialog: ProgressDialog? = null
     private var sendAsEmail: Boolean = false
     private var opmlFile: File? = null
@@ -101,7 +101,7 @@ class OpmlExporter(
             val uuidToTitle = podcastManager.findSubscribed().associateBy({ it.uuid }, { it.title })
             val uuids = uuidToTitle.keys.toList()
 
-            serverTask = serverManager.exportFeedUrls(
+            serviceTask = serviceManager.exportFeedUrls(
                 uuids,
                 object : ServerCallback<Map<String, String>> {
                     override fun onFailed(
@@ -182,7 +182,7 @@ class OpmlExporter(
     fun showProgressDialog() {
         UiUtil.hideProgressDialog(progressDialog)
         progressDialog = ProgressDialog.show(context, "", context.getString(LR.string.settings_opml_exporting), true, true) {
-            serverTask?.cancel()
+            serviceTask?.cancel()
         }.apply {
             show()
         }


### PR DESCRIPTION
## Description

This PR doesn't change any logic. It's more of a pet peeve and only changes the naming convention from `Server` to `Service`. As clients we don't have servers and we do not mange them. We have services.

## Testing Instructions

Green CI is enough.

## Checklist
- [x] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] ~Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)~
- [x] ~I have considered whether it makes sense to add tests for my changes~
- [x] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [x] ~Any jetpack compose components I added or changed are covered by compose previews~
- [x] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
