### PR TITLE
Include feature flags state in reports

### DIFF
--- a/modules/services/crashlogging/build.gradle.kts
+++ b/modules/services/crashlogging/build.gradle.kts
@@ -17,4 +17,6 @@ android {
 dependencies {
     api(libs.crashlogging)
     api(libs.encryptedlogging)
+
+    implementation(project(":modules:services:utils"))
 }

--- a/modules/services/crashlogging/src/main/java/au/com/shiftyjelly/pocketcasts/crashlogging/FilteringCrashLogging.kt
+++ b/modules/services/crashlogging/src/main/java/au/com/shiftyjelly/pocketcasts/crashlogging/FilteringCrashLogging.kt
@@ -1,14 +1,24 @@
 package au.com.shiftyjelly.pocketcasts.crashlogging
 
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
 import com.automattic.android.tracks.crashlogging.CrashLogging
 
 class FilteringCrashLogging(private val crashLogging: CrashLogging) : CrashLogging by crashLogging {
-
     override fun sendReport(exception: Throwable?, tags: Map<String, String>, message: String?) {
         if (exception != null && ExceptionsFilter.shouldIgnoreExceptions(exception)) {
             return
         }
-        crashLogging.sendReport(exception, tags, message)
+        val tagsWithFeatures = buildMap {
+            putAll(tags)
+            runCatching {
+                val featuresMap = Feature.entries.associate { feature ->
+                    "feature_${feature.key}" to FeatureFlag.isEnabled(feature).toString()
+                }
+                putAll(featuresMap)
+            }
+        }
+        crashLogging.sendReport(exception, tagsWithFeatures, message)
     }
 
     override fun recordException(exception: Throwable, category: String?) {

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/support/Support.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/support/Support.kt
@@ -30,6 +30,8 @@ import au.com.shiftyjelly.pocketcasts.utils.FileUtil
 import au.com.shiftyjelly.pocketcasts.utils.Network
 import au.com.shiftyjelly.pocketcasts.utils.SystemBatteryRestrictions
 import au.com.shiftyjelly.pocketcasts.utils.Util
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
 import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
 import com.jaredrummler.android.device.DeviceName
 import dagger.hilt.android.qualifiers.ApplicationContext
@@ -268,6 +270,13 @@ class Support @Inject constructor(
                     }
                     output.append(eol)
                 }
+            }
+
+            runCatching {
+                val features = Feature.entries.map { "${it.key}: ${FeatureFlag.isEnabled(it)}" }
+                output.append("Feature flags").append(eol)
+                features.forEach { output.append(it).append(eol) }
+                output.append(eol)
             }
 
             val podcastsOutput = StringBuilder()


### PR DESCRIPTION
## Description

This PR include feature flags state in Sentry reports and in user logs.

## Testing Instructions

1. Go to our developer settings and long press "Report a crash".
2. Set a custom message.
3. Tap a couple of time on "Report a crash" to send a report to Sentry. You need to tap a couple of times due to sampling.
4. Go to Sentry and find your crash.
5. You should see `feature_` tags.
6. Go back to the app.
7. Go to "Help & feedback".
8. Open logs.
9. Notice feature flag entries in the logs.

## Checklist
- [x] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] ~I have considered whether it makes sense to add tests for my changes~
- [x] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [x] ~Any jetpack compose components I added or changed are covered by compose previews~
- [x] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
