### PR TITLE
Remove Glide dependency

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -69,14 +69,6 @@
 -keep class androidx.mediarouter.app.MediaRouteActionProvider { *; }
 -keep class au.com.shiftyjelly.pocketcasts.CastOptionsProvider { *; }
 
-# glide
--keep class com.bumptech.glide.integration.okhttp3.OkHttpGlideModule
--keep public class * implements com.bumptech.glide.module.GlideModule
--keep public enum com.bumptech.glide.load.resource.bitmap.ImageHeaderParser$** {
-  **[] $VALUES;
-  public *;
-}
-
 -keepclassmembers enum * {
     <fields>;
     public static **[] values();

--- a/base.gradle
+++ b/base.gradle
@@ -232,8 +232,6 @@ dependencies {
     implementation libs.core.ktx
     implementation libs.device.names
     implementation libs.flexbox
-    implementation libs.glide
-    implementation libs.glide.okhttp
     implementation libs.guava
     implementation libs.material
     implementation libs.material.dialogs
@@ -255,7 +253,6 @@ dependencies {
     implementation libs.viewpager
 
     ksp libs.moshi.kotlin.codegen
-    ksp libs.glide.compiler
     ksp libs.showkase.processor
     ksp libs.hilt.compiler
     ksp libs.dagger.hilt.compiler

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -30,7 +30,6 @@ espresso = "3.4.0"
 firebase = "30.5.0"
 fragment = "1.8.2"
 glance = "1.1.0"
-glide = "4.13.2"
 google-services = "4.3.14"
 hilt = "2.52"
 hilt-compiler = "1.2.0"
@@ -121,11 +120,6 @@ firebase-config = { module = "com.google.firebase:firebase-config-ktx" }
 # Fragments
 fragment-ktx = { module = "androidx.fragment:fragment-ktx", version.ref = "fragment" }
 fragment-compose = { module = "androidx.fragment:fragment-compose", version.ref = "fragment" }
-
-# Glide
-glide = { module = "com.github.bumptech.glide:glide", version.ref = "glide" }
-glide-compiler = { module = "com.github.bumptech.glide:compiler", version.ref = "glide" }
-glide-okhttp = { module = "com.github.bumptech.glide:okhttp3-integration", version.ref = "glide" }
 
 # Google Play Services OSS Licenses - (The following line is still needed as there is no plugin marker available as of yet)
 ossLicenses-plugin = "com.google.android.gms:oss-licenses-plugin:0.10.5"

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastAdapter.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastAdapter.kt
@@ -270,7 +270,7 @@ class PodcastAdapter(
         }
 
         val imageView = holder.binding.top.artwork
-        // stopping the artwork flickering when Glide reloads the image
+        // stopping the artwork flickering when the image is reloaded
         if (imageView.drawable == null || holder.lastImagePodcastUuid == null || holder.lastImagePodcastUuid != podcast.uuid) {
             holder.lastImagePodcastUuid = podcast.uuid
             imageRequestFactory.create(podcast).loadInto(imageView)

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/auto/AutoConverter.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/auto/AutoConverter.kt
@@ -11,7 +11,6 @@ import android.support.v4.media.MediaDescriptionCompat
 import android.support.v4.media.MediaDescriptionCompat.EXTRA_DOWNLOAD_STATUS
 import android.support.v4.media.MediaDescriptionCompat.STATUS_DOWNLOADED
 import android.support.v4.media.MediaDescriptionCompat.STATUS_NOT_DOWNLOADED
-import android.util.Log
 import androidx.annotation.DrawableRes
 import androidx.core.graphics.drawable.toBitmap
 import androidx.core.os.bundleOf
@@ -38,11 +37,6 @@ import au.com.shiftyjelly.pocketcasts.repositories.playback.FOLDER_ROOT_PREFIX
 import au.com.shiftyjelly.pocketcasts.utils.Util
 import coil.executeBlocking
 import coil.imageLoader
-import com.bumptech.glide.load.DataSource
-import com.bumptech.glide.load.engine.GlideException
-import com.bumptech.glide.request.RequestListener
-import com.bumptech.glide.request.target.Target
-import java.io.File
 import au.com.shiftyjelly.pocketcasts.images.R as IR
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
@@ -170,17 +164,6 @@ object AutoConverter {
         if (folder == null) return null
 
         return getBitmapUri(drawable = folder.automotiveDrawableId, context = context)
-    }
-
-    val autoImageLoaderListener = object : RequestListener<File> {
-        override fun onLoadFailed(e: GlideException?, model: Any?, target: Target<File>?, isFirstResource: Boolean): Boolean {
-            Log.e("AutoConverter", "Could not load image in automotive $e")
-            return false
-        }
-
-        override fun onResourceReady(resource: File?, model: Any?, target: Target<File>?, dataSource: DataSource?, isFirstResource: Boolean): Boolean {
-            return true
-        }
     }
 
     /**

--- a/modules/services/ui/src/main/java/au/com/shiftyjelly/pocketcasts/ui/images/ThemedImageTintTransformation.kt
+++ b/modules/services/ui/src/main/java/au/com/shiftyjelly/pocketcasts/ui/images/ThemedImageTintTransformation.kt
@@ -9,32 +9,17 @@ import android.graphics.ColorMatrixColorFilter
 import android.graphics.Paint
 import android.graphics.PorterDuff
 import android.graphics.PorterDuffXfermode
-import android.os.Build
 import au.com.shiftyjelly.pocketcasts.ui.R
 import au.com.shiftyjelly.pocketcasts.ui.extensions.getThemeColor
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import coil.size.Size
 import coil.transform.Transformation
-import com.bumptech.glide.load.engine.bitmap_recycle.BitmapPool
-import com.bumptech.glide.load.resource.bitmap.BitmapTransformation
-import java.security.MessageDigest
-import timber.log.Timber
 
-class ThemedImageTintTransformation(context: Context) : BitmapTransformation(), Transformation {
+class ThemedImageTintTransformation(context: Context) : Transformation {
     private val isActive = Theme.isImageTintEnabled(context)
     private val themeTag = Theme.imageTintThemeTag(context)
 
-    private val density = context.resources.displayMetrics.density
     private val id = "au.com.shiftyjelly.pocketcasts.ui.images.ThemedImageTintTransformation.$themeTag" // + Date().time
-    private val idBytes: ByteArray = id.toByteArray()
-    private val paint = Paint().apply {
-        color = 0xFF119B00.toInt()
-        alpha = 58
-    }
-
-    override fun updateDiskCacheKey(messageDigest: MessageDigest) {
-        messageDigest.update(idBytes)
-    }
 
     override val cacheKey: String
         get() = id
@@ -90,17 +75,5 @@ class ThemedImageTintTransformation(context: Context) : BitmapTransformation(), 
         canvas.drawRect(0f, 0f, canvas.width.toFloat(), canvas.height.toFloat(), darkenPaint)
         canvas.drawRect(0f, 0f, canvas.width.toFloat(), canvas.height.toFloat(), paintBlendColor)
         canvas.drawRect(0f, 0f, canvas.width.toFloat(), canvas.height.toFloat(), paintBlend2Color)
-    }
-
-    override fun transform(bitmapPool: BitmapPool, original: Bitmap, width: Int, height: Int): Bitmap {
-        val result: Bitmap = bitmapPool.get(width, height, Bitmap.Config.ARGB_8888)
-        if (!isActive) return original
-
-        Timber.i("Transform width $width height $height density $density q? ${Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q} sdk ${Build.VERSION.SDK_INT}")
-
-        // Create a Canvas backed by the result Bitmap.
-        val canvas = Canvas(result)
-        version1(original, canvas)
-        return result
     }
 }

--- a/wear/proguard-rules.pro
+++ b/wear/proguard-rules.pro
@@ -67,14 +67,6 @@
 -keep class androidx.mediarouter.app.MediaRouteActionProvider { *; }
 -keep class au.com.shiftyjelly.pocketcasts.CastOptionsProvider { *; }
 
-# glide
--keep class com.bumptech.glide.integration.okhttp3.OkHttpGlideModule
--keep public class * implements com.bumptech.glide.module.GlideModule
--keep public enum com.bumptech.glide.load.resource.bitmap.ImageHeaderParser$** {
-  **[] $VALUES;
-  public *;
-}
-
 -keepclassmembers enum * {
     <fields>;
     public static **[] values();


### PR DESCRIPTION
## Description

We have a pending Glide update in #2755. But I think it is pointless to keep this library. The only real place where it is used is `AlbumArtContentProvider`, which is used for integration with the notification center, Auto, and Automotive. This can be easily replaced with simply downloading a file. The other uses have been long replaced with `Coil`.

There also a Glide transformation but the code is shared with a Coil transformation and we don't load images with Glide anywhere so AFAIK it is safe to remove.

## Testing Instructions

1. Install clean version of the app so nothing is cached.
2. Test that images in the media notification center are not low quality.
4. Test that images in Android Auto load.
5. Test that images in Android Automotive load.

## Checklist
- [x] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] ~I have considered whether it makes sense to add tests for my changes~
- [x] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [x] ~Any jetpack compose components I added or changed are covered by compose previews~
- [x] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
