### PR TITLE
Improved create issue screen

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,5 +1,5 @@
-name: Bug report
-description: Report a bug with the Pocket Casts Android app
+name: 🐞 Bug report
+description: Report a bug if something isn't working as expected in the Pocket Casts Android app.
 labels: ["[Type] Bug"]
 body:
 
@@ -31,7 +31,7 @@ body:
       attributes:
           label: Screenshots or screen recording
           description: |
-              If possible, please upload a screenshot or screen recording which demonstrates the bug.
+            Help us see what you see! Please upload a screenshot or screen recording, it really speeds up the fix.
       validations:
           required: false
 
@@ -47,7 +47,7 @@ body:
       attributes:
           label: Device, Operating system, and Pocket Casts app version
           placeholder: |
-              Google Pixel 6 wAndroid 12, Pocket Casts 7.19.0
+              Google Pixel 9, Android 14, Pocket Casts 7.72
           description: Pocket Casts app version can be found from the settings screen then scroll down to About
       validations:
           required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -3,7 +3,7 @@ contact_links:
   - name: 🚀 Feature request
     url: https://forums.pocketcasts.com/
     about: Suggest a new feature on the forum. We'll consider building it if it receives sufficient interest!
-  - name: 💬 Pocket Casts Forums
+  - name: 💬 Pocket Casts forums
     url: https://forums.pocketcasts.com/
     about: Get help with Pocket Casts at our public forum.
   - name: ❓Help FAQ

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,11 +1,11 @@
 blank_issues_enabled: true
 contact_links:
-  - name: Feature request
-    url: https://github.com/Automattic/pocket-casts-android/discussions
-    about: For feature requests, please use GitHub discussions.
-  - name: Help request
-    url: https://support.pocketcasts.com/android/
-    about: For general help requests, check the faq or get in touch with support.
-  - name: Pocket Casts Forums
+  - name: 🚀 Feature request
     url: https://forums.pocketcasts.com/
-    about: Get help with Pocket Casts at our public forum
+    about: Suggest a new feature on the forum. We'll consider building it if it receives sufficient interest!
+  - name: 💬 Pocket Casts Forums
+    url: https://forums.pocketcasts.com/
+    about: Get help with Pocket Casts at our public forum.
+  - name: ❓Help FAQ
+    url: https://support.pocketcasts.com/android/
+    about: Check the FAQ for solutions to common app issues.

--- a/.github/ISSUE_TEMPLATE/enhancement.yml
+++ b/.github/ISSUE_TEMPLATE/enhancement.yml
@@ -1,4 +1,4 @@
-name: ✨ New Enhancement
+name: ✨ New enhancement
 description: If you have a suggestion to improve an existing feature in the Android app please let us know.
 labels: ["[Type] Enhancement"]
 body:

--- a/.github/ISSUE_TEMPLATE/enhancement.yml
+++ b/.github/ISSUE_TEMPLATE/enhancement.yml
@@ -1,0 +1,34 @@
+name: ✨ New Enhancement
+description: If you have a suggestion to improve an existing feature in the Android app please let us know.
+labels: ["[Type] Enhancement"]
+body:
+
+  - type: markdown
+    attributes:
+      value: |
+        _Thanks for taking the time to send us your idea!_
+
+  - type: textarea
+    attributes:
+      label: Description
+      description: Please describe the enhancement you're suggesting, including the current behavior and how you envision the improvement.
+      placeholder: |
+        I'd like to improve '...' by adding/enhancing '...', so that '...' happens instead.”
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Screenshots or screen recording
+      description: |
+        Help us see what you see! Please upload a screenshot or screen recording, to help explain the improvement.
+    validations:
+      required: false
+
+  - type: checkboxes
+    attributes:
+      label: Did you search for existing list?
+      description: Please confirm that you searched for existing suggestion in https://github.com/Automattic/pocket-casts-android/issues before opening this issue.
+      options:
+        - label: I have searched for existing issues.
+          required: true


### PR DESCRIPTION
## Description

This change improves our create issue page. It will help with triaging new issues by not labelling everything as a bug, there is new an enhancement form. I have linked the feature request to the forums instead of the GitHub discussions. The HEs assist with answering these messages in the forums and feature requests can often be cross platform.

**🐞 Bug report**
Report a bug if something isn't working as expected in the Pocket Casts Android app.

**✨ New enhancement**
If you have a suggestion to improve an existing feature in the Android app please let us know.

**Report a security vulnerability**
Please review our [security policy](https://github.com/Automattic/pocket-casts-android/security/policy) for more details.

**🚀 Feature request**
Suggest a new feature on the forum. We'll consider building it if it receives sufficient interest!

**💬 Pocket Casts forums**
Get help with Pocket Casts at our public forum.

**❓Help FAQ**
Check the FAQ for solutions to common app issues.

## Testing Instructions

This is a bit hard to test without merging.