### PR TITLE
Remove Engage integration

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -66,7 +66,6 @@ dependencies {
     // features
     implementation(project(":modules:features:account"))
     implementation(project(":modules:features:discover"))
-    implementation(project(":modules:features:engage"))
     implementation(project(":modules:features:endofyear"))
     implementation(project(":modules:features:filters"))
     implementation(project(":modules:features:navigation"))

--- a/app/src/main/java/au/com/shiftyjelly/pocketcasts/PocketCastsApplication.kt
+++ b/app/src/main/java/au/com/shiftyjelly/pocketcasts/PocketCastsApplication.kt
@@ -8,7 +8,6 @@ import androidx.work.Configuration
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTracker
 import au.com.shiftyjelly.pocketcasts.crashlogging.InitializeRemoteLogging
 import au.com.shiftyjelly.pocketcasts.discover.worker.CuratedPodcastsSyncWorker
-import au.com.shiftyjelly.pocketcasts.engage.EngageSdkBridge
 import au.com.shiftyjelly.pocketcasts.models.db.dao.UpNextDao
 import au.com.shiftyjelly.pocketcasts.models.type.EpisodeStatusEnum
 import au.com.shiftyjelly.pocketcasts.nova.NovaLauncherBridge
@@ -117,8 +116,6 @@ class PocketCastsApplication : Application(), Configuration.Provider {
     @Inject lateinit var initializeRemoteLogging: InitializeRemoteLogging
 
     @Inject lateinit var novaLauncherBridge: NovaLauncherBridge
-
-    @Inject lateinit var engageSdkBridge: EngageSdkBridge
 
     @Inject lateinit var databaseExportHelper: DatabaseExportHelper
 
@@ -263,7 +260,6 @@ class PocketCastsApplication : Application(), Configuration.Provider {
         downloadManager.beginMonitoringWorkManager(applicationContext)
         userManager.beginMonitoringAccountManager(playbackManager)
         novaLauncherBridge.monitorNovaLauncherIntegration()
-        engageSdkBridge.registerIntegration()
         CuratedPodcastsSyncWorker.enqueuPeriodicWork(this)
 
         settings.useDynamicColorsForWidget.flow


### PR DESCRIPTION
## Description

Remove Engage SDK integration for now. Until we get approval from Google it'd be better to not have it in the codebase to not include any unnecessary review checks.

## Testing Instructions

Code review is enough.

## Checklist
- [x] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] ~I have considered whether it makes sense to add tests for my changes~
- [x] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [x] ~Any jetpack compose components I added or changed are covered by compose previews~
- [x] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
