### PR TITLE
Change labels required on a PR

### DIFF
--- a/Dangerfile
+++ b/Dangerfile
@@ -28,8 +28,8 @@ end
 
 labels_checker.check(
   do_not_merge_labels: ['do not merge'],
-  required_labels: [//],
-  required_labels_error: 'PR requires at least one label.'
+  required_labels: [/^\[Type\]/, /^(\[Area\]|\[Project\])/],
+  required_labels_error: 'PR requires a [Type] label and either a [Area] or [Project] label.',
 )
 
 milestone_checker.check_milestone_due_date(days_before_due: 2)

--- a/Dangerfile
+++ b/Dangerfile
@@ -29,7 +29,7 @@ end
 labels_checker.check(
   do_not_merge_labels: ['do not merge'],
   required_labels: [/^\[Type\]/, /^(\[Area\]|\[Project\])/],
-  required_labels_error: 'PR requires a [Type] label and either a [Area] or [Project] label.',
+  required_labels_error: 'PR requires a [Type] label and either a [Area] or [Project] label.'
 )
 
 milestone_checker.check_milestone_due_date(days_before_due: 2)


### PR DESCRIPTION
## Description

To help with our QA reports, all our pull requests should have a `[Type]` label and either an `[Area]` or `[Project]` label. This PR changes Danger to remind us. 

Documentation on the Danger labels checker [can be found here](https://gemdocs.org/gems/danger-dangermattic/1.1.2/Danger/LabelsChecker.html).

## Testing Instructions

It worked on this PR.

<img width="648" alt="Screenshot 2024-08-30 at 8 08 53 PM" src="https://github.com/user-attachments/assets/6ac0e738-8702-4fd8-b65f-63639acc1066">




