### PR TITLE
RubyGems: Fix rexml vulnerability

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,3 @@ gem 'fastlane', '~> 2.216'
 gem 'fastlane-plugin-wpmreleasetoolkit', '~> 11.0'
 # gem 'fastlane-plugin-wpmreleasetoolkit', path: '../../release-toolkit'
 # gem 'fastlane-plugin-wpmreleasetoolkit', git: 'https://github.com/wordpress-mobile/release-toolkit', branch: ''
-
-plugins_path = File.join(File.dirname(__FILE__), 'fastlane', 'Pluginfile')
-eval_gemfile(plugins_path) if File.exist?(plugins_path)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -277,7 +277,7 @@ GEM
       trailblazer-option (>= 0.1.1, < 0.2.0)
       uber (< 0.2.0)
     retriable (3.1.2)
-    rexml (3.3.4)
+    rexml (3.3.6)
       strscan
     rouge (2.0.7)
     rubocop (1.65.1)


### PR DESCRIPTION
This PR: 
1. Updates the `rexml` gem to `3.3.6` to fix the recent CVE. 
2. Removes the `pluginfile` section from the `Gemfile` since we don't use `pluginfile`s. The `pluginfile` section was also producing an error for Dependabot's PR auto-creation: https://github.com/Automattic/pocket-casts-android/security/dependabot/66

<img width="940" alt="Screenshot 2024-08-30 at 6 14 25 PM" src="https://github.com/user-attachments/assets/17d74d20-0572-429e-a331-d957cea30cb8">

