### PR TITLE
Update transcripts search bar

### DIFF
--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/transcripts/TranscriptPageWrapper.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/transcripts/TranscriptPageWrapper.kt
@@ -238,7 +238,7 @@ fun TranscriptToolbar(
                             top = 0.dp,
                             bottom = 0.dp,
                             start = 0.dp,
-                        )
+                        ),
                     )
                 }
             }

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/transcripts/TranscriptPageWrapper.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/transcripts/TranscriptPageWrapper.kt
@@ -234,7 +234,7 @@ fun TranscriptToolbar(
                             .width(SearchBarMaxWidth)
                             .height(SearchBarHeight)
                             .focusRequester(focusRequester)
-                            .padding(start = 56.dp, end = 16.dp),
+                            .padding(start = 85.dp, end = 16.dp),
                         colors = SearchBarDefaults.colors(
                             leadingIconColor = SearchBarIconColor,
                             trailingIconColor = SearchBarIconColor,

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/transcripts/TranscriptPageWrapper.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/transcripts/TranscriptPageWrapper.kt
@@ -63,6 +63,7 @@ import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 private val SearchBarMaxWidth = 500.dp
+private val SearchBarHeight = 43.dp
 private val SearchViewCornerRadius = 38.dp
 private val SearchBarIconColor = Color.Gray.copy(alpha = 0.8f)
 private val SearchBarPlaceholderColor = SearchBarIconColor
@@ -231,6 +232,7 @@ fun TranscriptToolbar(
                         cornerRadius = SearchViewCornerRadius,
                         modifier = Modifier
                             .width(SearchBarMaxWidth)
+                            .height(SearchBarHeight)
                             .focusRequester(focusRequester)
                             .padding(start = 56.dp, end = 16.dp),
                         colors = SearchBarDefaults.colors(

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/transcripts/TranscriptPageWrapper.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/transcripts/TranscriptPageWrapper.kt
@@ -113,12 +113,7 @@ fun TranscriptPageWrapper(
 
             TranscriptToolbar(
                 onCloseClick = {
-                    if (expandSearch) {
-                        expandSearch = false
-                        searchViewModel.onSearchDone()
-                    } else {
-                        playerViewModel.closeTranscript(withTransition = true)
-                    }
+                    playerViewModel.closeTranscript(withTransition = true)
                 },
                 showSearch = showSearch,
                 onSearchDoneClicked = {

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/transcripts/TranscriptPageWrapper.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/transcripts/TranscriptPageWrapper.kt
@@ -16,10 +16,12 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.material.Icon
 import androidx.compose.material.IconButton
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
+import androidx.compose.material.TextFieldDefaults
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
 import androidx.compose.material.icons.filled.KeyboardArrowDown
@@ -144,7 +146,7 @@ fun TranscriptPageWrapper(
     }
 }
 
-@OptIn(ExperimentalAnimationApi::class)
+@OptIn(ExperimentalAnimationApi::class, ExperimentalMaterialApi::class)
 @Composable
 fun TranscriptToolbar(
     onCloseClick: () -> Unit,
@@ -241,6 +243,11 @@ fun TranscriptToolbar(
                             disabledTrailingIconColor = SearchBarIconColor.copy(alpha = 0.7f),
                             placeholderColor = SearchBarPlaceholderColor,
                         ),
+                        contentPadding = TextFieldDefaults.textFieldWithoutLabelPadding(
+                            top = 0.dp,
+                            bottom = 0.dp,
+                            start = 0.dp,
+                        )
                     )
                 }
             }

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/transcripts/TranscriptPageWrapper.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/transcripts/TranscriptPageWrapper.kt
@@ -174,11 +174,7 @@ fun TranscriptToolbar(
                         .padding(start = 16.dp),
                     onClick = onCloseClick,
                     tintColor = TranscriptColors.iconColor(),
-                    contentDescription = if (expandSearch) {
-                        stringResource(LR.string.transcript_search_close)
-                    } else {
-                        stringResource(LR.string.transcript_close)
-                    },
+                    contentDescription = stringResource(LR.string.transcript_close),
                 )
             }
 

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/transcripts/TranscriptPageWrapper.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/transcripts/TranscriptPageWrapper.kt
@@ -10,6 +10,7 @@ import androidx.compose.animation.shrinkHorizontally
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -49,6 +50,7 @@ import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import au.com.shiftyjelly.pocketcasts.compose.AppTheme
 import au.com.shiftyjelly.pocketcasts.compose.buttons.CloseButton
+import au.com.shiftyjelly.pocketcasts.compose.buttons.IconButtonSmall
 import au.com.shiftyjelly.pocketcasts.compose.components.SearchBar
 import au.com.shiftyjelly.pocketcasts.compose.components.SearchBarDefaults
 import au.com.shiftyjelly.pocketcasts.compose.preview.ThemePreviewParameterProvider
@@ -259,7 +261,7 @@ private fun SearchBarLeadingIcons(
     Row(
         verticalAlignment = Alignment.CenterVertically,
     ) {
-        IconButton(
+        IconButtonSmall(
             onClick = {
                 onDoneClicked()
             },
@@ -288,7 +290,7 @@ private fun SearchBarTrailingIcons(
                 text = searchState.searchOccurrencesText,
                 color = SearchBarIconColor,
             )
-            IconButton(
+            IconButtonSmall(
                 onClick = {
                     onSearchCleared()
                 },
@@ -300,7 +302,7 @@ private fun SearchBarTrailingIcons(
             }
         }
 
-        IconButton(
+        IconButtonSmall(
             onClick = onPrevious,
             enabled = searchState.prevNextArrowButtonsEnabled,
         ) {
@@ -309,7 +311,7 @@ private fun SearchBarTrailingIcons(
                 contentDescription = stringResource(LR.string.go_to_previous),
             )
         }
-        IconButton(
+        IconButtonSmall(
             onClick = onNext,
             enabled = searchState.prevNextArrowButtonsEnabled,
         ) {
@@ -318,6 +320,7 @@ private fun SearchBarTrailingIcons(
                 contentDescription = stringResource(LR.string.go_to_next),
             )
         }
+        Spacer(modifier = Modifier.width(8.dp))
     }
 }
 

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/buttons/IconButtonSmall.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/buttons/IconButtonSmall.kt
@@ -20,13 +20,14 @@ object IconButtonDefaults {
     val RippleRadius = 20.dp
     val ComponentSize: DpSize = DpSize(32.dp, 32.dp)
 }
+
 @Composable
 fun IconButtonSmall(
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
     enabled: Boolean = true,
     interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
-    content: @Composable () -> Unit
+    content: @Composable () -> Unit,
 ) {
     Box(
         modifier = modifier
@@ -36,9 +37,9 @@ fun IconButtonSmall(
                 enabled = enabled,
                 role = Role.Button,
                 interactionSource = interactionSource,
-                indication = rememberRipple(bounded = false, radius = IconButtonDefaults.RippleRadius)
+                indication = rememberRipple(bounded = false, radius = IconButtonDefaults.RippleRadius),
             ),
-        contentAlignment = Alignment.Center
+        contentAlignment = Alignment.Center,
     ) {
         val contentAlpha = if (enabled) LocalContentAlpha.current else ContentAlpha.disabled
         CompositionLocalProvider(LocalContentAlpha provides contentAlpha, content = content)

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/buttons/IconButtonSmall.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/buttons/IconButtonSmall.kt
@@ -17,7 +17,7 @@ import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
 
 object IconButtonDefaults {
-    val RippleRadius = 24.dp
+    val RippleRadius = 20.dp
     val ComponentSize: DpSize = DpSize(32.dp, 32.dp)
 }
 @Composable

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/buttons/IconButtonSmall.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/buttons/IconButtonSmall.kt
@@ -1,0 +1,46 @@
+package au.com.shiftyjelly.pocketcasts.compose.buttons
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.ContentAlpha
+import androidx.compose.material.LocalContentAlpha
+import androidx.compose.material.ripple.rememberRipple
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.unit.DpSize
+import androidx.compose.ui.unit.dp
+
+object IconButtonDefaults {
+    val RippleRadius = 24.dp
+    val ComponentSize: DpSize = DpSize(32.dp, 32.dp)
+}
+@Composable
+fun IconButtonSmall(
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    enabled: Boolean = true,
+    interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
+    content: @Composable () -> Unit
+) {
+    Box(
+        modifier = modifier
+            .size(IconButtonDefaults.ComponentSize)
+            .clickable(
+                onClick = onClick,
+                enabled = enabled,
+                role = Role.Button,
+                interactionSource = interactionSource,
+                indication = rememberRipple(bounded = false, radius = IconButtonDefaults.RippleRadius)
+            ),
+        contentAlignment = Alignment.Center
+    ) {
+        val contentAlpha = if (enabled) LocalContentAlpha.current else ContentAlpha.disabled
+        CompositionLocalProvider(LocalContentAlpha provides contentAlpha, content = content)
+    }
+}

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/SearchBar.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/SearchBar.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -98,6 +99,10 @@ fun SearchBar(
     textStyle: TextStyle = LocalTextStyle.current,
     cornerRadius: Dp = 10.dp,
     colors: TextFieldColors = SearchBarDefaults.colors(),
+    contentPadding: PaddingValues = TextFieldDefaults.textFieldWithoutLabelPadding(
+        top = 0.dp,
+        bottom = 0.dp,
+    ),
 ) {
     val focusManager = LocalFocusManager.current
     val textColor = textStyle.color.takeOrElse {
@@ -174,10 +179,7 @@ fun SearchBar(
                 singleLine = true,
                 interactionSource = remember { MutableInteractionSource() },
                 visualTransformation = VisualTransformation.None,
-                contentPadding = TextFieldDefaults.textFieldWithoutLabelPadding(
-                    top = 0.dp,
-                    bottom = 0.dp,
-                ),
+                contentPadding = contentPadding,
             )
         },
     )

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -1902,7 +1902,6 @@
     <string name="transcript_empty">Transcript is empty.</string>
     <string name="transcript_close">Close transcript</string>
     <string name="transcript_search">Search transcript</string>
-    <string name="transcript_search_close">Close search</string>
 
     <!--    Tasker Plugin-->
 


### PR DESCRIPTION
## Description
This updates
- Transcripts search bar (tzuqhOmpPVu5TjKK1XMhf5-fi-598_1999) icon size and height
- Close button action to only close the screen

Internal Ref: pdcxQM-43M-p2#comment-3215

## Testing Instructions
1. Open transcript view
2. Tap the search icon
3. ✅ Notice that search bar leading and trailing icons size** is reduced, along with spacing between the close button and search bar 
4. Tap close (x) button
5. ✅  Notice that it closes the screen instead of the expanded search bar 

** I reduced search bar leading and trailing icon size from default `48dp` to `32dp`. Reducing it further made them too close but it might just be me. 

## Screenshots or Screencast 

Before | After
----|----
![before_tr](https://github.com/user-attachments/assets/5d3fe309-181b-4746-91ea-de3d1dacd1c1)|![now_tr](https://github.com/user-attachments/assets/79d9cf0c-1199-480f-ac50-bd3180cf01bd)

Ripple

Before | After
----|---
![before_rippl_tr](https://github.com/user-attachments/assets/c1018f59-2c2d-4edd-a0f6-9ab32edd0512)| ![now_rippl_tr](https://github.com/user-attachments/assets/47999856-e854-46b2-b994-45620c7a7846)

|Landscape|
|-----|
|<img width=800 src="https://github.com/user-attachments/assets/2471a748-a7c2-4f6a-90aa-dbbd9f2a96a8"/>|

pdcxQM-43M-p2#comment-3215
## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [x] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [x] for accessibility with TalkBack