### PR TITLE
Temporarily disable Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,7 @@
 version: 2
 updates:
   - package-ecosystem: "gradle"
-    open-pull-requests-limit: 6
+    open-pull-requests-limit: 0
     directory: "/"
     schedule:
       interval: "daily"


### PR DESCRIPTION
During the tech debt upgrade of the dependencies, it will be easiest if we turn off Dependabot. 