### PR TITLE
[Tech Debt] Remove deprecated onBackPressed from Account

### DIFF
--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/AccountActivity.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/AccountActivity.kt
@@ -6,6 +6,7 @@ import android.content.Context
 import android.content.Intent
 import android.os.Build
 import android.os.Bundle
+import androidx.activity.OnBackPressedCallback
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.content.IntentCompat
@@ -44,6 +45,15 @@ class AccountActivity : AppCompatActivity() {
         val view = binding.root
         setContentView(view)
 
+        onBackPressedDispatcher.addCallback(
+            this,
+            object : OnBackPressedCallback(true) {
+                override fun handleOnBackPressed() {
+                    handleBackPressed()
+                }
+            },
+        )
+
         val navController = findNavController(R.id.nav_host_fragment)
         binding.carHeader?.btnClose?.setOnClickListener {
             if (!navController.popBackStack()) {
@@ -77,7 +87,7 @@ class AccountActivity : AppCompatActivity() {
 
             val navConfiguration = AppBarConfiguration(navController.graph)
             binding.toolbar?.setupWithNavController(navController, navConfiguration)
-            binding.toolbar?.setNavigationOnClickListener { _ -> onBackPressed() }
+            binding.toolbar?.setNavigationOnClickListener { _ -> handleBackPressed() }
 
             navController.addOnDestinationChangedListener { _, destination, _ ->
                 destination.trackShown()
@@ -105,17 +115,17 @@ class AccountActivity : AppCompatActivity() {
         }
     }
 
-    override fun onBackPressed() {
+    private fun handleBackPressed() {
         val currentFragment = findNavController(R.id.nav_host_fragment).currentDestination
         currentFragment?.trackDismissed()
+
         if (currentFragment?.id == R.id.createDoneFragment) {
             finish()
             return
         }
 
         UiUtil.hideKeyboard(binding.root)
-        @Suppress("DEPRECATION")
-        super.onBackPressed()
+        onBackPressedDispatcher.onBackPressed()
     }
 
     private fun NavDestination.trackShown() {


### PR DESCRIPTION
## Description
- This removes the deprecated android onBackPressed
- https://developer.android.com/reference/androidx/activity/ComponentActivity#onBackPressed()

## Testing Instructions
1. Run the app
2. On the Sign Up / Log in screen
3. Press back
4. ✅ Ensure the screen is closed
5. Open the Sign Up and press back
6.  ✅ Ensure the screen is closed
7. Open Log in -> Forgot password and press back
8.  ✅ Ensure the screen is closed

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
