### PR TITLE
[Tech Debt] Remove deprecated onBackPressed from WebView

### DIFF
--- a/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/activity/WebViewActivity.kt
+++ b/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/activity/WebViewActivity.kt
@@ -13,7 +13,6 @@ import android.webkit.WebViewClient
 import androidx.activity.OnBackPressedCallback
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.view.isVisible
-import au.com.shiftyjelly.pocketcasts.localization.BuildConfig
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.views.databinding.ActivityWebViewBinding
 import dagger.hilt.android.AndroidEntryPoint
@@ -50,8 +49,6 @@ class WebViewActivity : AppCompatActivity(), CoroutineScope {
             val intent = newInstance(context, title, url)
             context.startActivity(intent)
         }
-
-        val INTERNAL_HOSTS = listOf(BuildConfig.WEB_BASE_HOST)
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -67,12 +64,11 @@ class WebViewActivity : AppCompatActivity(), CoroutineScope {
 
         onBackPressedDispatcher.addCallback(
             this,
-            object : OnBackPressedCallback(true) {
+            object : OnBackPressedCallback(false) {
                 override fun handleOnBackPressed() {
                     if (binding.webview.canGoBack()) {
                         binding.webview.goBack()
                     } else {
-                        isEnabled = false
                         onBackPressedDispatcher.onBackPressed()
                     }
                 }

--- a/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/activity/WebViewActivity.kt
+++ b/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/activity/WebViewActivity.kt
@@ -10,6 +10,7 @@ import android.view.MenuItem
 import android.webkit.WebResourceRequest
 import android.webkit.WebView
 import android.webkit.WebViewClient
+import androidx.activity.OnBackPressedCallback
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.view.isVisible
 import au.com.shiftyjelly.pocketcasts.localization.BuildConfig
@@ -64,6 +65,20 @@ class WebViewActivity : AppCompatActivity(), CoroutineScope {
         setSupportActionBar(binding.toolbar)
         supportActionBar?.setDisplayHomeAsUpEnabled(true)
 
+        onBackPressedDispatcher.addCallback(
+            this,
+            object : OnBackPressedCallback(true) {
+                override fun handleOnBackPressed() {
+                    if (binding.webview.canGoBack()) {
+                        binding.webview.goBack()
+                    } else {
+                        isEnabled = false
+                        onBackPressedDispatcher.onBackPressed()
+                    }
+                }
+            },
+        )
+
         binding.webview.webViewClient = object : WebViewClient() {
             override fun onPageStarted(view: WebView?, url: String?, favicon: Bitmap?) {
                 super.onPageStarted(view, url, favicon)
@@ -103,15 +118,6 @@ class WebViewActivity : AppCompatActivity(), CoroutineScope {
             extraUrl?.let { url ->
                 binding.webview.loadUrl(url)
             }
-        }
-    }
-
-    override fun onBackPressed() {
-        if (binding.webview.canGoBack()) {
-            binding.webview.goBack()
-        } else {
-            @Suppress("DEPRECATION")
-            super.onBackPressed()
         }
     }
 


### PR DESCRIPTION
## Description
- Removes the onBackpressed from WebView and clean up unused variable


## Testing Instructions


> [!note]
> Before starting the test make sure in the settings that the app is able to intercept the links.

![Screenshot_20240521-092556](https://github.com/Automattic/pocket-casts-android/assets/30936061/75c5182d-230b-4cff-a4d0-2f71073daab2)

1. Install the app in debugProd and sign in.
2. Close the app.
3. Send intent via ADB with start and end timestamps. For example: `adb shell am start -a android.intent.action.VIEW -d https://pca.st/y0ebrkcc\?t=20,60`.
4. Press back button
5. ✅ Ensure the screen is closed


## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.

