### PR TITLE
[Tech Debt] Remove deprecated onBackPressed from Automotive Settings

### DIFF
--- a/automotive/src/main/java/au/com/shiftyjelly/pocketcasts/AutomotiveSettingsActivity.kt
+++ b/automotive/src/main/java/au/com/shiftyjelly/pocketcasts/AutomotiveSettingsActivity.kt
@@ -3,6 +3,7 @@ package au.com.shiftyjelly.pocketcasts
 import android.os.Bundle
 import android.view.View
 import android.widget.ImageView
+import androidx.activity.OnBackPressedCallback
 import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.widget.Toolbar
 import androidx.fragment.app.Fragment
@@ -21,12 +22,21 @@ class AutomotiveSettingsActivity : AppCompatActivity(), FragmentHostListener {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_automotive_settings)
 
+        onBackPressedDispatcher.addCallback(
+            this,
+            object : OnBackPressedCallback(false) {
+                override fun handleOnBackPressed() {
+                    handleBackPressed()
+                }
+            },
+        )
+
         val settingsFragment = AutomotiveSettingsFragment()
         supportFragmentManager.beginTransaction().replace(R.id.frameMain, settingsFragment).commitNowAllowingStateLoss()
 
         val btnClose = findViewById<ImageView>(PR.id.btnClose)
         btnClose?.setImageResource(IR.drawable.ic_arrow_back)
-        btnClose?.setOnClickListener { onBackPressed() }
+        btnClose?.setOnClickListener { handleBackPressed() }
     }
 
     override fun setSupportActionBar(toolbar: Toolbar?) {
@@ -36,8 +46,7 @@ class AutomotiveSettingsActivity : AppCompatActivity(), FragmentHostListener {
     }
 
     override fun onSupportNavigateUp(): Boolean {
-        @Suppress("DEPRECATION")
-        onBackPressed()
+        handleBackPressed()
         return true
     }
 
@@ -48,14 +57,12 @@ class AutomotiveSettingsActivity : AppCompatActivity(), FragmentHostListener {
             .commitAllowingStateLoss()
     }
 
-    override fun onBackPressed() {
+    private fun handleBackPressed() {
         if (supportFragmentManager.backStackEntryCount > 0) {
             supportFragmentManager.popBackStack()
             return
         }
-
-        @Suppress("DEPRECATION")
-        super.onBackPressed()
+        onBackPressedDispatcher.onBackPressed()
     }
 
     // TODO: Refactor FragmentHostListener in to something more generic so it can be used
@@ -73,7 +80,7 @@ class AutomotiveSettingsActivity : AppCompatActivity(), FragmentHostListener {
     }
 
     override fun bottomSheetClosePressed(fragment: Fragment) {
-        onBackPressed()
+        handleBackPressed()
     }
 
     override fun openPlayer(source: String?) {
@@ -87,7 +94,7 @@ class AutomotiveSettingsActivity : AppCompatActivity(), FragmentHostListener {
     }
 
     override fun closeModal(fragment: Fragment) {
-        onBackPressed()
+        handleBackPressed()
     }
 
     override fun openTab(tabId: Int) {


### PR DESCRIPTION
## Description
- This removes the deprecated onBackPressed


## Testing Instructions
1. Run the Automotive App
2. Go to Automotive Settings
3. Press back
4. ✅ Ensure it returns to the previous screen
5. Go to Automotive Settings -> About
6. Press back
7. ✅ Ensure it returns to the previous screen
8. Press back again
9. ✅ Ensure it returns to the previous screen


## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 