### PR TITLE
Use spaces instead of underscores in clip file names

### DIFF
--- a/modules/services/media-ffmpeg/src/main/kotlin/au/com/shiftyjelly/pocketcasts/media/FFmpegMediaService.kt
+++ b/modules/services/media-ffmpeg/src/main/kotlin/au/com/shiftyjelly/pocketcasts/media/FFmpegMediaService.kt
@@ -124,7 +124,7 @@ internal class FFmpegMediaService(
         podcast: Podcast,
         episode: PodcastEpisode,
         clipRange: Clip.Range,
-        cardType: VisualCardType?
+        cardType: VisualCardType?,
     ) = buildString {
         append(podcast.title.replace(sanitizedFileNameRegex, " "))
         append(" - ")

--- a/modules/services/media-ffmpeg/src/main/kotlin/au/com/shiftyjelly/pocketcasts/media/FFmpegMediaService.kt
+++ b/modules/services/media-ffmpeg/src/main/kotlin/au/com/shiftyjelly/pocketcasts/media/FFmpegMediaService.kt
@@ -25,7 +25,7 @@ internal class FFmpegMediaService(
     private val sessionFiles = LinkedHashSet<File>()
 
     override suspend fun clipAudio(podcast: Podcast, episode: PodcastEpisode, clipRange: Clip.Range): Result<File> = withContext(Dispatchers.IO) {
-        val outputFile = File(context.cacheDir, "${sanitizedFileName(podcast, episode, clipRange)}.mp3")
+        val outputFile = File(context.cacheDir, "${sanitizedFileName(podcast, episode, clipRange, cardType = null)}.mp3")
         if (outputFile in sessionFiles && outputFile.exists()) {
             return@withContext Result.success(outputFile)
         }
@@ -120,12 +120,23 @@ internal class FFmpegMediaService(
         return executeAsyncCommand(command).map { outputFile }.getOrNull()
     }
 
-    private fun sanitizedFileName(podcast: Podcast, episode: PodcastEpisode, clipRange: Clip.Range): String {
-        return "${podcast.title} - ${episode.title} - ${clipRange.start.toSecondsWithSingleMilli()}–${clipRange.end.toSecondsWithSingleMilli()}".replace("""\W+""".toRegex(), "_")
-    }
-
-    private fun sanitizedFileName(podcast: Podcast, episode: PodcastEpisode, clipRange: Clip.Range, cardType: VisualCardType): String {
-        return "${podcast.title} - ${episode.title} - ${clipRange.start.toSecondsWithSingleMilli()}–${clipRange.end.toSecondsWithSingleMilli()}-${cardType.id}".replace("""\W+""".toRegex(), "_")
+    private fun sanitizedFileName(
+        podcast: Podcast,
+        episode: PodcastEpisode,
+        clipRange: Clip.Range,
+        cardType: VisualCardType?
+    ) = buildString {
+        append(podcast.title.replace(sanitizedFileNameRegex, " "))
+        append(" - ")
+        append(episode.title.replace(sanitizedFileNameRegex, " "))
+        append(" - ")
+        append(clipRange.start.toSecondsWithSingleMilli())
+        append('-')
+        append(clipRange.end.toSecondsWithSingleMilli())
+        if (cardType != null) {
+            append('-')
+            append(cardType.id)
+        }
     }
 
     private val VisualCardType.id get() = when (this) {
@@ -156,5 +167,9 @@ internal class FFmpegMediaService(
             },
         )
         continuation.invokeOnCancellation { session.cancel() }
+    }
+
+    private companion object {
+        val sanitizedFileNameRegex = """\W+ *""".toRegex()
     }
 }

--- a/modules/services/media-ffmpeg/src/main/kotlin/au/com/shiftyjelly/pocketcasts/media/FFmpegMediaService.kt
+++ b/modules/services/media-ffmpeg/src/main/kotlin/au/com/shiftyjelly/pocketcasts/media/FFmpegMediaService.kt
@@ -134,15 +134,15 @@ internal class FFmpegMediaService(
         append('-')
         append(clipRange.end.toSecondsWithSingleMilli())
         if (cardType != null) {
-            append('-')
+            append(" - ")
             append(cardType.id)
         }
     }
 
     private val VisualCardType.id get() = when (this) {
-        CardType.Horizontal -> "h"
-        CardType.Square -> "s"
-        CardType.Vertical -> "v"
+        CardType.Horizontal -> "horizontal"
+        CardType.Square -> "square"
+        CardType.Vertical -> "vertical"
     }
 
     private suspend fun executeAsyncCommand(command: String): Result<Unit> = suspendCancellableCoroutine { continuation ->


### PR DESCRIPTION
## Description

This makes exported file names prettier. Previously we replaced all non word characters with and underscore. This keeps blank space in the file name.

## Testing Instructions

1. Share an audio or video clip as a file somewhere.
2. The file name should have a format of `<podcast> <episode> <timestamps>(optional card type)`.

## Checklist
- [x] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] ~I have considered whether it makes sense to add tests for my changes~
- [x] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [x] ~Any jetpack compose components I added or changed are covered by compose previews~
- [x] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
