### PR TITLE
Enable Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,7 @@
 version: 2
 updates:
   - package-ecosystem: "gradle"
-    open-pull-requests-limit: 0
+    open-pull-requests-limit: 6
     directory: "/"
     schedule:
       interval: "daily"


### PR DESCRIPTION
Now the [Gradle dependencies have been cleaned up](https://github.com/Automattic/pocket-casts-android/pull/2791) we can turn on the Dependabot upgrades again. 