### PR TITLE
Improve the podcast page background color

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 7.73
 -----
-
+*   Updated
+    *   Dark theme improvements on the podcast page
+        ([#2811](https://github.com/Automattic/pocket-casts-android/pull/2811))
 
 7.72
 -----

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/bookmark/components/UpsellView.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/bookmark/components/UpsellView.kt
@@ -26,6 +26,7 @@ import au.com.shiftyjelly.pocketcasts.models.type.Subscription.SubscriptionTier
 import au.com.shiftyjelly.pocketcasts.player.view.bookmark.components.UpsellViewModel.UiState
 import au.com.shiftyjelly.pocketcasts.repositories.subscription.FreeTrial
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
+import com.airbnb.android.showkase.annotation.ShowkaseComposable
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 @Composable
@@ -72,7 +73,7 @@ private fun UpsellViewContent(
                 Spacer(modifier = Modifier.width(8.dp))
                 SubscriptionBadgeForTier(
                     tier = state.freeTrial.subscriptionTier,
-                    displayMode = SubscriptionBadgeDisplayMode.ColoredWithWhiteForeground,
+                    displayMode = SubscriptionBadgeDisplayMode.Colored,
                 )
             }
         },
@@ -104,9 +105,10 @@ private fun getMessage(
     stringResource(LR.string.bookmarks_upsell_instructions)
 }
 
+@ShowkaseComposable(name = "UpsellView", group = "Subscriptions")
 @Preview
 @Composable
-private fun UpsellPreview(
+private fun UpsellViewPreview(
     @PreviewParameter(ThemePreviewParameterProvider::class) themeType: Theme.ThemeType,
 ) {
     AppTheme(themeType) {
@@ -115,7 +117,7 @@ private fun UpsellPreview(
             state = UiState.Loaded(
                 freeTrial = FreeTrial(
                     exists = false,
-                    subscriptionTier = SubscriptionTier.PATRON,
+                    subscriptionTier = SubscriptionTier.PLUS,
                 ),
                 showEarlyAccessMessage = false,
             ),

--- a/modules/features/podcasts/src/main/res/layout/fragment_podcast.xml
+++ b/modules/features/podcasts/src/main/res/layout/fragment_podcast.xml
@@ -4,7 +4,8 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:orientation="vertical">
+    android:orientation="vertical"
+    android:background="?attr/primary_ui_02">
 
     <androidx.appcompat.widget.Toolbar
         android:id="@+id/toolbar"

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/images/SubscriptionBadge.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/images/SubscriptionBadge.kt
@@ -26,10 +26,12 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.TextUnit
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import au.com.shiftyjelly.pocketcasts.compose.AppThemeWithBackground
 import au.com.shiftyjelly.pocketcasts.compose.components.TextH50
 import au.com.shiftyjelly.pocketcasts.compose.theme
 import au.com.shiftyjelly.pocketcasts.images.R
 import au.com.shiftyjelly.pocketcasts.models.type.Subscription.SubscriptionTier
+import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import com.airbnb.android.showkase.annotation.ShowkaseComposable
 import au.com.shiftyjelly.pocketcasts.images.R as IR
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
@@ -140,17 +142,20 @@ fun SubscriptionBadgeForTier(
             shortNameRes = LR.string.pocket_casts_plus_short,
             iconColor = when (displayMode) {
                 SubscriptionBadgeDisplayMode.Black -> SubscriptionTierColor.plusGold
+                SubscriptionBadgeDisplayMode.Colored -> MaterialTheme.theme.colors.primaryUi01
                 SubscriptionBadgeDisplayMode.ColoredWithWhiteForeground -> Color.White
                 SubscriptionBadgeDisplayMode.ColoredWithBlackForeground -> Color.Black
             },
             backgroundColor = when (displayMode) {
                 SubscriptionBadgeDisplayMode.Black -> Color.Black
+                SubscriptionBadgeDisplayMode.Colored,
                 SubscriptionBadgeDisplayMode.ColoredWithWhiteForeground,
                 SubscriptionBadgeDisplayMode.ColoredWithBlackForeground,
                 -> SubscriptionTierColor.plusGold
             },
             textColor = when (displayMode) {
                 SubscriptionBadgeDisplayMode.Black -> SubscriptionTierColor.plusGold
+                SubscriptionBadgeDisplayMode.Colored -> MaterialTheme.theme.colors.primaryUi01
                 SubscriptionBadgeDisplayMode.ColoredWithWhiteForeground -> Color.White
                 SubscriptionBadgeDisplayMode.ColoredWithBlackForeground -> Color.Black
             },
@@ -163,18 +168,23 @@ fun SubscriptionBadgeForTier(
             shortNameRes = LR.string.pocket_casts_patron_short,
             iconColor = when (displayMode) {
                 SubscriptionBadgeDisplayMode.Black -> SubscriptionTierColor.patronPurpleLight
-                SubscriptionBadgeDisplayMode.ColoredWithWhiteForeground -> Color.White
+                SubscriptionBadgeDisplayMode.Colored,
+                SubscriptionBadgeDisplayMode.ColoredWithWhiteForeground,
+                -> Color.White
                 SubscriptionBadgeDisplayMode.ColoredWithBlackForeground -> Color.Black
             },
             backgroundColor = when (displayMode) {
                 SubscriptionBadgeDisplayMode.Black -> Color.Black
+                SubscriptionBadgeDisplayMode.Colored,
                 SubscriptionBadgeDisplayMode.ColoredWithWhiteForeground,
                 SubscriptionBadgeDisplayMode.ColoredWithBlackForeground,
                 -> SubscriptionTierColor.patronPurple
             },
             textColor = when (displayMode) {
                 SubscriptionBadgeDisplayMode.Black -> Color.White
-                SubscriptionBadgeDisplayMode.ColoredWithWhiteForeground -> Color.White
+                SubscriptionBadgeDisplayMode.Colored,
+                SubscriptionBadgeDisplayMode.ColoredWithWhiteForeground,
+                -> Color.White
                 SubscriptionBadgeDisplayMode.ColoredWithBlackForeground -> Color.Black
             },
         )
@@ -248,6 +258,7 @@ fun OfferBadge(
 
 enum class SubscriptionBadgeDisplayMode {
     Black,
+    Colored,
     ColoredWithWhiteForeground,
     ColoredWithBlackForeground,
 }
@@ -258,10 +269,34 @@ object SubscriptionTierColor {
     val patronPurpleLight = Color(0xFFAFA2FA)
 }
 
-@ShowkaseComposable(name = "SubscriptionBadge", group = "Images", styleName = "Plus - Colored", defaultStyle = true)
+@ShowkaseComposable(name = "SubscriptionBadge", group = "Images", styleName = "Plus - Colored on light theme", defaultStyle = true)
 @Preview(name = "Colored")
 @Composable
-fun SubscriptionBadgePlusColoredPreview() {
+fun SubscriptionBadgePlusColoredLightThemePreview() {
+    AppThemeWithBackground(Theme.ThemeType.LIGHT) {
+        SubscriptionBadgeForTier(
+            tier = SubscriptionTier.PLUS,
+            displayMode = SubscriptionBadgeDisplayMode.Colored,
+        )
+    }
+}
+
+@ShowkaseComposable(name = "SubscriptionBadge", group = "Images", styleName = "Plus - Colored on dark theme", defaultStyle = true)
+@Preview(name = "Colored")
+@Composable
+fun SubscriptionBadgePlusColoredDarkThemePreview() {
+    AppThemeWithBackground(Theme.ThemeType.DARK) {
+        SubscriptionBadgeForTier(
+            tier = SubscriptionTier.PLUS,
+            displayMode = SubscriptionBadgeDisplayMode.Colored,
+        )
+    }
+}
+
+@ShowkaseComposable(name = "SubscriptionBadge", group = "Images", styleName = "Plus - Colored with white foreground", defaultStyle = true)
+@Preview(name = "Colored")
+@Composable
+fun SubscriptionBadgePlusColoredWhiteForegroundPreview() {
     SubscriptionBadgeForTier(
         tier = SubscriptionTier.PLUS,
         displayMode = SubscriptionBadgeDisplayMode.ColoredWithWhiteForeground,
@@ -278,7 +313,7 @@ fun SubscriptionBadgePlusBlackPreview() {
     )
 }
 
-@ShowkaseComposable(name = "SubscriptionBadge", group = "Images", styleName = "Patron - Colored")
+@ShowkaseComposable(name = "SubscriptionBadge", group = "Images", styleName = "Patron - Colored with white foreground")
 @Preview(name = "Colored")
 @Composable
 fun SubscriptionBadgePatronColoredPreview() {


### PR DESCRIPTION
## Description

The background colors on the podcast page didn't look right in the dark theme so I have improved them. I have also changed the Plus text from white to black.

## Testing Instructions

1. Change the theme to dark
2. Subscribe to a podcast with only a few episodes such as "How to do everything" by NPR
3. Open a podcast page
4. ✅ Verify the loading background is the same color as the final page
5. ✅ Verify the bottom of the episodes and bookmarks tab are the same color

## Screenshots

| Before | After |
| --- | --- |
| ![Screenshot_20240907_101707](https://github.com/user-attachments/assets/6b76e111-214b-410b-9acf-2b906ccd059c) | ![Screenshot_20240907_101852](https://github.com/user-attachments/assets/38dd5d22-55fe-44c6-9dc2-11f432078918) | 
| ![Screenshot_20240907_101730](https://github.com/user-attachments/assets/6e66d255-d4db-44b1-a02c-ade52dfa41b4) | ![Screenshot_20240907_105842](https://github.com/user-attachments/assets/0881c7f4-c5df-4e3f-8bb2-8ff8bc8b658e) |

Other themes

|  |  |
| --- | --- |
| ![Screenshot_20240907_110001](https://github.com/user-attachments/assets/c952f013-0815-4e84-bdf6-1df7979a993f) | ![Screenshot_20240907_110035](https://github.com/user-attachments/assets/ae81d639-dd2d-4403-bd69-e7d0663f439f) |


## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack
