### PR TITLE
Fix deep link auto play crash

### DIFF
--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/episode/EpisodeFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/episode/EpisodeFragment.kt
@@ -224,15 +224,13 @@ class EpisodeFragment : BaseFragment() {
 
         binding?.loadingGroup?.isInvisible = true
 
-        if (savedInstanceState == null) {
-            viewModel.setup(
-                episodeUuid = episodeUUID,
-                podcastUuid = podcastUuid,
-                timestamp = timestamp,
-                autoPlay = autoPlay,
-                forceDark = forceDarkTheme,
-            )
-        }
+        viewModel.setup(
+            episodeUuid = episodeUUID,
+            podcastUuid = podcastUuid,
+            timestamp = timestamp,
+            autoPlay = autoPlay && savedInstanceState == null,
+            forceDark = forceDarkTheme,
+        )
         viewModel.state.observe(
             viewLifecycleOwner,
             Observer { state ->


### PR DESCRIPTION
## Description

I've noticed [this issue](https://a8c.sentry.io/issues/5790904916/?project=6711064&query=release%3Aau.com.shiftyjelly.pocketcasts) in Sentry. It is related to my changes introducing auto play through deep link. When trying to avoid auto playing on configuration changes I inadvertently prevented view model from being set up during process death.

## Testing Instructions

### Fix

1. Start the app.
2. Go to any episode details.
3. Minimize the app.
4. Run `adb shell am kill au.com.shiftyjelly.pocketcasts.debug`.
5. Reopen the app.
6. There should be no crash.

### Auto play

1. Run `adb shell am start -n au.com.shiftyjelly.pocketcasts.debug/au.com.shiftyjelly.pocketcasts.ui.MainActivity -a android.intent.action.VIEW -d "https://pca.st/episode/49900dc4-d6de-4673-b894-2da321b307d0?auto_play=true"`
2. The episode should start playing.
3. Pause the episode in the episode details view.
4. Rotate the screen.
5. The episode should not start playing again.
6. Run again `adb shell am start -n au.com.shiftyjelly.pocketcasts.debug/au.com.shiftyjelly.pocketcasts.ui.MainActivity -a android.intent.action.VIEW -d "https://pca.st/episode/49900dc4-d6de-4673-b894-2da321b307d0?auto_play=true"`.
7. The episode should start playing again.
8. Pause the episode.
9. Minimize the app.
10. Run `adb shell am kill au.com.shiftyjelly.pocketcasts.debug`.
11. Reopen the app.
12. The episode should not start playing.

## Checklist
- [x] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] ~I have considered whether it makes sense to add tests for my changes~
- [x] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [x] ~Any jetpack compose components I added or changed are covered by compose previews~
- [x] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
