### PR TITLE
Use showkase KSP processor in the :app module

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -51,6 +51,7 @@ android {
 dependencies {
     ksp(libs.dagger.hilt.compiler)
     ksp(libs.hilt.compiler)
+    ksp(libs.showkase.processor)
 
     implementation(platform(libs.compose.bom))
     implementation(platform(libs.firebase.bom))
@@ -105,6 +106,7 @@ dependencies {
     implementation(projects.modules.features.taskerplugin)
     implementation(projects.modules.features.widgets)
     implementation(projects.modules.services.analytics)
+    implementation(projects.modules.services.compose)
     implementation(projects.modules.services.crashlogging)
     implementation(projects.modules.services.deeplink)
     implementation(projects.modules.services.localization)
@@ -158,6 +160,5 @@ dependencies {
     androidTestImplementation(libs.turbine)
     androidTestImplementation(libs.work.test)
 
-    androidTestImplementation(projects.modules.services.compose)
     androidTestImplementation(projects.modules.services.sharedtest)
 }


### PR DESCRIPTION
## Description

Fixes missing Showkase preview in the app.

Context: p1725672825089339-slack-C07J5LNP4SF

## Testing Instructions

Check if you can preview Showkase components in the app.

## Checklist
- [x] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] ~I have considered whether it makes sense to add tests for my changes~
- [x] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [x] ~Any jetpack compose components I added or changed are covered by compose previews~
- [x] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack