### PR TITLE
Add dependency analysis step to default CI pipeline

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -57,6 +57,17 @@ steps:
     artifact_paths:
       - "**/build/instrumented-tests/**/*"
 
+  - label: "Dependency Analysis"
+    command: |
+      echo "--- 📊 Analyzing"
+      ./gradlew buildHealth
+    plugins: [$CI_TOOLKIT]
+    artifact_paths:
+      - "build/reports/dependency-analysis/build-health-report.*"
+    notify:
+      - slack: "#android-core-notifs"
+        if: build.state == "failed"
+
   - label: "Assemble release APK"
     command: |
       echo "--- :rubygems: Setting up Gems"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -65,6 +65,8 @@ steps:
     artifact_paths:
       - "build/reports/dependency-analysis/build-health-report.*"
     notify:
+      - github_commit_status:
+        context: Dependency Analysis
       - slack: "#android-core-notifs"
         if: build.state == "failed"
 

--- a/.buildkite/shared-pipeline-vars
+++ b/.buildkite/shared-pipeline-vars
@@ -3,6 +3,6 @@
 # This file is `source`'d before calling `buildkite-agent pipeline upload`, and can be used
 # to set up some variables that will be interpolated in the `.yml` pipeline before uploading it.
 
-CI_TOOLKIT_PLUGIN_VERSION='3.4.2'
+CI_TOOLKIT_PLUGIN_VERSION='3.5.1'
 
 export CI_TOOLKIT="automattic/a8c-ci-toolkit#$CI_TOOLKIT_PLUGIN_VERSION"

--- a/.buildkite/shared-pipeline-vars
+++ b/.buildkite/shared-pipeline-vars
@@ -1,6 +1,6 @@
 #!/bin/sh
 
- # This file is `source`'d before calling `buildkite-agent pipeline upload`, and can be used
- # to set up some variables that will be interpolated in the `.yml` pipeline before uploading it.
+# This file is `source`'d before calling `buildkite-agent pipeline upload`, and can be used
+# to set up some variables that will be interpolated in the `.yml` pipeline before uploading it.
 
- export CI_TOOLKIT="automattic/a8c-ci-toolkit#3.4.2"
+export CI_TOOLKIT="automattic/a8c-ci-toolkit#3.4.2"

--- a/.buildkite/shared-pipeline-vars
+++ b/.buildkite/shared-pipeline-vars
@@ -3,4 +3,6 @@
 # This file is `source`'d before calling `buildkite-agent pipeline upload`, and can be used
 # to set up some variables that will be interpolated in the `.yml` pipeline before uploading it.
 
-export CI_TOOLKIT="automattic/a8c-ci-toolkit#3.4.2"
+CI_TOOLKIT_PLUGIN_VERSION='3.4.2'
+
+export CI_TOOLKIT="automattic/a8c-ci-toolkit#$CI_TOOLKIT_PLUGIN_VERSION"


### PR DESCRIPTION
## Description

@MiSikora suggested running the dependency analysis check on every CI build, internal ref pdnsEh-1QL-p2, and there seemed to be appetite for it.

This draft PR aims to get the work started...

One argument _against_ adopting this, and which I guess was the rationale for running the check on a schedule, is that it takes a good 10+ minutes to run. If this were to become a requirement for the PR to be merged, it might slow down the dev cycle.

![image](https://github.com/user-attachments/assets/0a0b5d6a-94ee-4866-a721-530a4da0ef11)

Having said that, it's something that would be easy to try to find out directly, and revert if necessary. 


### Implemented

- Add the check to the default pipeline, that is, run the check on every standard CI build

### To Do

- Update the configuration to be as strict as possible – I don't actually know if that's required but the wording of the request made me think so. Plugin docs https://github.com/autonomousapps/dependency-analysis-gradle-plugin/wiki/Customizing-plugin-behavior
- Moving the check to run on every build makes the existing [schedule](https://github.com/Automattic/pocket-casts-android/blob/924c3df9c4fe6875d96d431c6a33515334b9d3f0/.buildkite/schedules/dependency-analysis.yml) redundant, so I would suggest removing it. This is a two step task:
  - Remove from this repo
  - Remove the schedule configuration on the Buildkite end
- If/when this PR lands on `main`, update the GitHub configuration to require the "Dependency Analysis" step check

## Testing Instructions
See CI build: TBD

## Screenshots or Screencast 
<!-- if applicable -->

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack