### PR TITLE
Fix showkase default style compilation error

### DIFF
--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/images/SubscriptionBadge.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/images/SubscriptionBadge.kt
@@ -281,7 +281,7 @@ fun SubscriptionBadgePlusColoredLightThemePreview() {
     }
 }
 
-@ShowkaseComposable(name = "SubscriptionBadge", group = "Images", styleName = "Plus - Colored on dark theme", defaultStyle = true)
+@ShowkaseComposable(name = "SubscriptionBadge", group = "Images", styleName = "Plus - Colored on dark theme")
 @Preview(name = "Colored")
 @Composable
 fun SubscriptionBadgePlusColoredDarkThemePreview() {
@@ -293,7 +293,7 @@ fun SubscriptionBadgePlusColoredDarkThemePreview() {
     }
 }
 
-@ShowkaseComposable(name = "SubscriptionBadge", group = "Images", styleName = "Plus - Colored with white foreground", defaultStyle = true)
+@ShowkaseComposable(name = "SubscriptionBadge", group = "Images", styleName = "Plus - Colored with white foreground")
 @Preview(name = "Colored")
 @Composable
 fun SubscriptionBadgePlusColoredWhiteForegroundPreview() {


### PR DESCRIPTION
## Description

Fixes showkase compilation issues introduced in 361590b7fe37d1ffbe8583d410808140ad0733dc.

## Testing Instructions

Green CI is enough.

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [ ] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
