### PR TITLE
[Ratings] Tweak to Ratings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 *   Updated
     *   Dark theme improvements on the podcast page
         ([#2811](https://github.com/Automattic/pocket-casts-android/pull/2811))
+    *   Add a visibility animation to the submit button on the rating screen
+        ([#2824](https://github.com/Automattic/pocket-casts-android/pull/2824))
 
 7.72
 -----

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/components/ratings/GiveRatingScreen.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/components/ratings/GiveRatingScreen.kt
@@ -1,6 +1,8 @@
 package au.com.shiftyjelly.pocketcasts.podcasts.view.components.ratings
 
 import android.content.res.Configuration
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.tween
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
@@ -12,6 +14,7 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.ButtonDefaults
 import androidx.compose.material.MaterialTheme
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
@@ -40,6 +43,12 @@ fun GiveRatingScreen(
 ) {
     val configuration = LocalConfiguration.current
     val isLandscape = configuration.orientation == Configuration.ORIENTATION_LANDSCAPE
+
+    val submitButtonAlphaAnimation by animateFloatAsState(
+        targetValue = if (state.previousRate != state.currentSelectedRate) 1f else 0f,
+        animationSpec = tween(durationMillis = 300),
+        label = "submit-button-alpha-animation",
+    )
 
     CallOnce {
         viewModel.trackOnGiveRatingScreenShown(state.podcastUuid)
@@ -97,7 +106,7 @@ fun GiveRatingScreen(
                     backgroundColor = MaterialTheme.theme.colors.primaryText01,
                     disabledBackgroundColor = MaterialTheme.theme.colors.primaryInteractive03,
                 ),
-                modifier = Modifier.alpha(if (state.previousRate != state.currentSelectedRate) 1f else 0f),
+                modifier = Modifier.alpha(submitButtonAlphaAnimation),
             )
         }
 

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/components/ratings/SwipeableStars.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/components/ratings/SwipeableStars.kt
@@ -51,8 +51,8 @@ private const val numStars = 5
 @Composable
 fun SwipeableStars(
     onStarsChanged: (Double) -> Unit,
-    initialRate: Int? = null,
     modifier: Modifier = Modifier,
+    initialRate: Int? = null,
 ) {
     val viewModel = hiltViewModel<SwipeableStarsViewModel>()
     val isTalkBackEnabled by viewModel.accessibilityActiveState.collectAsState()

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/components/ratings/SwipeableStars.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/components/ratings/SwipeableStars.kt
@@ -4,6 +4,7 @@ import androidx.compose.animation.core.Animatable
 import androidx.compose.animation.core.Spring
 import androidx.compose.animation.core.spring
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.focusable
 import androidx.compose.foundation.gestures.detectHorizontalDragGestures
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.Box
@@ -22,6 +23,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
@@ -59,7 +61,7 @@ fun SwipeableStars(
 
     var stopPointType by remember { mutableStateOf(StopPointType.InitialStars) }
     var changeType by remember { mutableStateOf(ChangeType.Animated) }
-    var touchX by remember { mutableStateOf(0f) }
+    var touchX by remember { mutableFloatStateOf(0f) }
     var iconPositions by remember { mutableStateOf(listOf<Position>()) }
 
     val stopPoints: List<Double> = stopPointsFromIconPositions(iconPositions)
@@ -139,7 +141,7 @@ fun SwipeableStars(
             Stars(
                 filled = true,
                 modifier = { index ->
-                    var right by remember { mutableStateOf(0f) }
+                    var right by remember { mutableFloatStateOf(0f) }
                     Modifier
                         // We could have applied this onGloballyPositioned modifier to the empty stars with the same effect
                         .onGloballyPositioned {
@@ -158,6 +160,7 @@ fun SwipeableStars(
                                     .clickable {
                                         touchX = right // select the full star
                                     }
+                                    .focusable()
                                     .semantics {
                                         contentDescription = "${index + 1} Stars"
                                         role = Role.Button


### PR DESCRIPTION
## Description
- This PR addresses the alpha animation to the submit rating button reported here https://github.com/Automattic/pocket-casts-android/issues/2656
- For the stars issue reported on #2656 I could not reproduce, so that's why this PR addresses only one part of the reported issue


## Testing Instructions
1. Open a podcast
2. Listen to some episodes to be able to rate this podcast
3. Rate the podcast
4. Open the rate screen to rate again the podcast
5. Select a different rate so the button can be visible again
6. Ensure the submit button has some animation when changing their visibility

## Screenshots or Screencast 
[Screen_recording_20240910_135652.webm](https://github.com/user-attachments/assets/0b75857a-a63b-435e-9245-09efde34efdb)


## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
