### PR TITLE
Do not declare Compose compiler version

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -241,10 +241,6 @@ subprojects {
                 vectorDrawables.useSupportLibrary = true
             }
 
-            composeOptions {
-                kotlinCompilerExtensionVersion = libs.versions.compose.kotlin.compiler.get()
-            }
-
             testOptions {
                 animationsDisabled = true
             }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -21,7 +21,6 @@ android-gradle-plugin = "8.5.2"
 billing = "7.0.0"
 coil = "2.7.0"
 compose = "2024.09.01" # https://developer.android.com/jetpack/compose/bom/bom-mapping
-compose-kotlin-compiler = "1.5.14" # Compose compatibility map: https://developer.android.com/jetpack/androidx/releases/compose-kotlin
 dependency-analysis = "2.0.1"
 espresso = "3.6.1"
 firebase = "30.5.0"


### PR DESCRIPTION
## Description

Compose Compiler is now embedded into Kotlin and there is no need to declare it as a separate option.

## Testing Instructions

Smoke test running the app.

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [ ] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
