### PR TITLE
Reduce the Dependabot interval to weekly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,10 +1,10 @@
 version: 2
 updates:
   - package-ecosystem: "gradle"
-    open-pull-requests-limit: 6
+    open-pull-requests-limit: 8
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
     labels:
       - "[Type] Tech Debt"
       - "[Area] Dependencies"


### PR DESCRIPTION
We are keeping Dependabot on to help us keep the libraries up to date, but to help us organise our work, we are going to reduce the interval of the updates to weekly. 
