### PR TITLE
Listening History: Add search analytics, enable feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 7.73
 -----
+*   New Features
+    *   Add local search in listening history
+        ([#2794](https://github.com/Automattic/pocket-casts-android/pull/2794))
 *   Updated
     *   Dark theme improvements on the podcast page
         ([#2811](https://github.com/Automattic/pocket-casts-android/pull/2811))

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/ProfileEpisodeListFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/ProfileEpisodeListFragment.kt
@@ -66,10 +66,15 @@ private const val ARG_MODE = "profile_list_mode"
 
 @AndroidEntryPoint
 class ProfileEpisodeListFragment : BaseFragment(), Toolbar.OnMenuItemClickListener {
-    sealed class Mode(val index: Int, val showMenu: Boolean, val showSearch: Boolean) {
-        data object Downloaded : Mode(0, true, false)
-        data object Starred : Mode(1, false, false)
-        data object History : Mode(2, true, true)
+    sealed class Mode(
+        val index: Int,
+        val showMenu: Boolean,
+        val showSearch: Boolean,
+        val source: SourceView = SourceView.UNKNOWN,
+    ) {
+        data object Downloaded : Mode(0, true, false, SourceView.DOWNLOADS)
+        data object Starred : Mode(1, false, false, SourceView.STARRED)
+        data object History : Mode(2, true, true, SourceView.LISTENING_HISTORY)
     }
 
     companion object {
@@ -193,8 +198,8 @@ class ProfileEpisodeListFragment : BaseFragment(), Toolbar.OnMenuItemClickListen
 
         imageRequestFactory = PocketCastsImageRequestFactory(context, cornerRadius = 4).smallSize().themed()
 
-        playButtonListener.source = getAnalyticsEventSource()
-        multiSelectHelper.source = getAnalyticsEventSource()
+        playButtonListener.source = mode.source
+        multiSelectHelper.source = mode.source
     }
 
     override fun onPause() {
@@ -508,11 +513,5 @@ class ProfileEpisodeListFragment : BaseFragment(), Toolbar.OnMenuItemClickListen
             Mode.Starred -> AnalyticsEvent.STARRED_MULTI_SELECT_EXITED
         }
         analyticsTracker.track(analyticsEvent)
-    }
-
-    private fun getAnalyticsEventSource() = when (mode) {
-        Mode.Downloaded -> SourceView.DOWNLOADS
-        Mode.Starred -> SourceView.STARRED
-        Mode.History -> SourceView.LISTENING_HISTORY
     }
 }

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/ProflieEpisodeListSearchBar.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/ProflieEpisodeListSearchBar.kt
@@ -30,7 +30,7 @@ fun ProfileEpisodeListSearchBar(
             SearchBar(
                 text = searchQueryFlow,
                 placeholder = stringResource(R.string.search),
-                onTextChanged = { viewModel.updateSearchQuery(it) },
+                onTextChanged = { viewModel.onSearchQueryChanged(it) },
                 onSearch = {},
                 modifier = Modifier
                     .fillMaxWidth()

--- a/modules/features/podcasts/src/test/java/au/com/shiftyjelly/pocketcasts/podcasts/view/ProfileEpisodeListViewModelTest.kt
+++ b/modules/features/podcasts/src/test/java/au/com/shiftyjelly/pocketcasts/podcasts/view/ProfileEpisodeListViewModelTest.kt
@@ -146,11 +146,11 @@ class ProfileEpisodeListViewModelTest {
     }
 
     @Test
-    fun `updateSearchQuery updates search query flow`() = runTest {
+    fun `onSearchQueryChanged updates search query flow`() = runTest {
         initViewModel()
 
         val searchQuery = "test query"
-        viewModel.updateSearchQuery(searchQuery)
+        viewModel.onSearchQueryChanged(searchQuery)
 
         viewModel.searchQueryFlow.test {
             assertEquals(searchQuery, awaitItem())
@@ -164,7 +164,7 @@ class ProfileEpisodeListViewModelTest {
         whenever(episodeManager.filteredPlaybackHistoryEpisodesFlow("query")).thenReturn(flowOf(filteredEpisodes))
         viewModel.setup(Mode.History)
 
-        viewModel.updateSearchQuery("query")
+        viewModel.onSearchQueryChanged("query")
 
         viewModel.state.test {
             assertEquals(filteredEpisodes, (awaitItem() as State.Loaded).results)
@@ -178,7 +178,7 @@ class ProfileEpisodeListViewModelTest {
         whenever(episodeManager.filteredPlaybackHistoryEpisodesFlow("query")).thenReturn(flowOf(filteredEpisodes))
         viewModel.setup(Mode.History)
 
-        viewModel.updateSearchQuery("query")
+        viewModel.onSearchQueryChanged("query")
 
         viewModel.state.test {
             assertEquals(

--- a/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
+++ b/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
@@ -563,6 +563,7 @@ enum class AnalyticsEvent(val key: String) {
     SEARCH_PERFORMED("search_performed"),
     SEARCH_FAILED("search_failed"),
     SEARCH_RESULT_TAPPED("search_result_tapped"),
+    SEARCH_CLEARED("search_cleared"),
 
     /* Search - Full List */
     SEARCH_LIST_SHOWN("search_list_shown"),

--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/Feature.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/Feature.kt
@@ -126,9 +126,9 @@ enum class Feature(
     SEARCH_IN_LISTENING_HISTORY(
         key = "search_in_listening_history",
         title = "Search in listening history",
-        defaultValue = BuildConfig.DEBUG,
+        defaultValue = true,
         tier = FeatureTier.Free,
-        hasFirebaseRemoteFlag = false,
+        hasFirebaseRemoteFlag = true,
         hasDevToggle = true,
     ),
     ;


### PR DESCRIPTION
## Description
This adds search analytics in Listening History.


## Testing Instructions
1. Login with an account with some listening history
2. Go to Profile -> Listening History
3. Search for an episode
4. ✅ Notice in logs `Tracked: search_performed, Properties: {"source":"listening_history"`
5. Clear search query
6. ✅ Notice in logs `Tracked: search_cleared, Properties: {"source":"listening_history"`

Also, code review feature flag changes: 9492ea3f6a806cb3a539cb3ae9c26f91e159a488

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
