### PR TITLE
Referrals: update UI for unlimited passes

### DIFF
--- a/modules/features/referrals/build.gradle.kts
+++ b/modules/features/referrals/build.gradle.kts
@@ -3,7 +3,6 @@ plugins {
     alias(libs.plugins.kotlin.android)
     alias(libs.plugins.ksp)
     alias(libs.plugins.hilt)
-    alias(libs.plugins.kotlin.parcelize)
     alias(libs.plugins.compose.compiler)
 }
 

--- a/modules/features/referrals/src/main/kotlin/au/com/shiftyjelly/pocketcasts/referrals/ReferralsIconWithTooltip.kt
+++ b/modules/features/referrals/src/main/kotlin/au/com/shiftyjelly/pocketcasts/referrals/ReferralsIconWithTooltip.kt
@@ -2,13 +2,11 @@ package au.com.shiftyjelly.pocketcasts.referrals
 
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.Icon
 import androidx.compose.material.IconButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
@@ -24,8 +22,6 @@ import au.com.shiftyjelly.pocketcasts.compose.LocalColors
 import au.com.shiftyjelly.pocketcasts.compose.ThemeColors
 import au.com.shiftyjelly.pocketcasts.compose.components.TextC70
 import au.com.shiftyjelly.pocketcasts.compose.components.Tooltip
-import au.com.shiftyjelly.pocketcasts.compose.images.CountBadge
-import au.com.shiftyjelly.pocketcasts.compose.images.CountBadgeStyle
 import au.com.shiftyjelly.pocketcasts.compose.preview.ThemePreviewParameterProvider
 import au.com.shiftyjelly.pocketcasts.ui.helper.FragmentHostListener
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
@@ -42,8 +38,7 @@ fun ReferralsIconWithTooltip(
         state = state,
         onIconClick = {
             viewModel.onIconClick()
-            val fragment = ReferralsSendGuestPassFragment
-                .newInstance(viewModel.state.value.badgeCount)
+            val fragment = ReferralsSendGuestPassFragment.newInstance()
             (activity as FragmentHostListener).showBottomSheet(fragment)
         },
     )
@@ -55,41 +50,37 @@ private fun ReferralsIconWithTooltip(
     onIconClick: () -> Unit,
 ) {
     if (state.showIcon) {
-        IconWithBadge(
+        Icon(
             onIconClick = onIconClick,
             colors = LocalColors.current.colors,
-            state = state,
         )
 
         Tooltip(
             show = state.showTooltip,
         ) {
-            TooltipContent(state)
+            TooltipContent()
         }
     }
 }
 
 @Composable
-private fun TooltipContent(
-    state: ReferralsViewModel.UiState,
-) {
+private fun TooltipContent() {
     Column(
         modifier = Modifier
             .padding(horizontal = 16.dp)
             .padding(top = 24.dp, bottom = 16.dp),
     ) {
         TextC70(
-            text = stringResource(LR.string.referrals_tooltip_message, state.badgeCount),
+            text = stringResource(LR.string.referrals_tooltip_message),
             isUpperCase = false,
         )
     }
 }
 
 @Composable
-private fun IconWithBadge(
+private fun Icon(
     onIconClick: () -> Unit,
     colors: ThemeColors,
-    state: ReferralsViewModel.UiState,
 ) {
     Box {
         IconButton(onClick = onIconClick) {
@@ -97,21 +88,6 @@ private fun IconWithBadge(
                 painter = painterResource(id = R.drawable.ic_gift),
                 contentDescription = stringResource(LR.string.gift),
                 tint = colors.primaryIcon01,
-            )
-        }
-        if (state.showBadge) {
-            CountBadge(
-                count = state.badgeCount,
-                style = CountBadgeStyle.Custom(
-                    backgroundColor = colors.primaryIcon01,
-                    textColor = colors.primaryUi01,
-                    borderColor = colors.primaryUi02,
-                    size = 14.dp,
-                    borderWidth = 1.dp,
-                ),
-                modifier = Modifier
-                    .align(Alignment.TopEnd)
-                    .offset(-(6).dp, 8.dp),
             )
         }
     }
@@ -123,11 +99,7 @@ private fun IconWithBadgePreview(
     @PreviewParameter(ThemePreviewParameterProvider::class) themeType: Theme.ThemeType,
 ) {
     AppThemeWithBackground(themeType) {
-        IconWithBadge(
-            state = ReferralsViewModel.UiState(
-                showIcon = true,
-                badgeCount = 3,
-            ),
+        Icon(
             onIconClick = {},
             colors = LocalColors.current.colors,
         )
@@ -140,11 +112,6 @@ fun TooltipContentPreview(
     @PreviewParameter(ThemePreviewParameterProvider::class) themeType: Theme.ThemeType,
 ) {
     AppThemeWithBackground(themeType) {
-        TooltipContent(
-            state = ReferralsViewModel.UiState(
-                showIcon = true,
-                badgeCount = 3,
-            ),
-        )
+        TooltipContent()
     }
 }

--- a/modules/features/referrals/src/main/kotlin/au/com/shiftyjelly/pocketcasts/referrals/ReferralsIconWithTooltip.kt
+++ b/modules/features/referrals/src/main/kotlin/au/com/shiftyjelly/pocketcasts/referrals/ReferralsIconWithTooltip.kt
@@ -2,8 +2,6 @@ package au.com.shiftyjelly.pocketcasts.referrals
 
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.Icon
@@ -14,9 +12,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
-import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.dp
@@ -27,7 +23,6 @@ import au.com.shiftyjelly.pocketcasts.compose.Devices
 import au.com.shiftyjelly.pocketcasts.compose.LocalColors
 import au.com.shiftyjelly.pocketcasts.compose.ThemeColors
 import au.com.shiftyjelly.pocketcasts.compose.components.TextC70
-import au.com.shiftyjelly.pocketcasts.compose.components.TextH40
 import au.com.shiftyjelly.pocketcasts.compose.components.Tooltip
 import au.com.shiftyjelly.pocketcasts.compose.images.CountBadge
 import au.com.shiftyjelly.pocketcasts.compose.images.CountBadgeStyle
@@ -83,15 +78,6 @@ private fun TooltipContent(
             .padding(horizontal = 16.dp)
             .padding(top = 24.dp, bottom = 16.dp),
     ) {
-        TextH40(
-            text = pluralStringResource(
-                LR.plurals.referrals_remaining_passes,
-                state.badgeCount,
-                state.badgeCount,
-            ),
-            fontWeight = FontWeight.W700,
-        )
-        Spacer(modifier = Modifier.height(4.dp))
         TextC70(
             text = stringResource(LR.string.referrals_tooltip_message, state.badgeCount),
             isUpperCase = false,

--- a/modules/features/referrals/src/main/kotlin/au/com/shiftyjelly/pocketcasts/referrals/ReferralsIconWithTooltip.kt
+++ b/modules/features/referrals/src/main/kotlin/au/com/shiftyjelly/pocketcasts/referrals/ReferralsIconWithTooltip.kt
@@ -20,7 +20,6 @@ import au.com.shiftyjelly.pocketcasts.compose.AppThemeWithBackground
 import au.com.shiftyjelly.pocketcasts.compose.Devices
 import au.com.shiftyjelly.pocketcasts.compose.LocalColors
 import au.com.shiftyjelly.pocketcasts.compose.ThemeColors
-import au.com.shiftyjelly.pocketcasts.compose.components.TextC70
 import au.com.shiftyjelly.pocketcasts.compose.components.TextH40
 import au.com.shiftyjelly.pocketcasts.compose.components.Tooltip
 import au.com.shiftyjelly.pocketcasts.compose.preview.ThemePreviewParameterProvider

--- a/modules/features/referrals/src/main/kotlin/au/com/shiftyjelly/pocketcasts/referrals/ReferralsIconWithTooltip.kt
+++ b/modules/features/referrals/src/main/kotlin/au/com/shiftyjelly/pocketcasts/referrals/ReferralsIconWithTooltip.kt
@@ -21,6 +21,7 @@ import au.com.shiftyjelly.pocketcasts.compose.Devices
 import au.com.shiftyjelly.pocketcasts.compose.LocalColors
 import au.com.shiftyjelly.pocketcasts.compose.ThemeColors
 import au.com.shiftyjelly.pocketcasts.compose.components.TextC70
+import au.com.shiftyjelly.pocketcasts.compose.components.TextH40
 import au.com.shiftyjelly.pocketcasts.compose.components.Tooltip
 import au.com.shiftyjelly.pocketcasts.compose.preview.ThemePreviewParameterProvider
 import au.com.shiftyjelly.pocketcasts.ui.helper.FragmentHostListener
@@ -70,9 +71,8 @@ private fun TooltipContent() {
             .padding(horizontal = 16.dp)
             .padding(top = 24.dp, bottom = 16.dp),
     ) {
-        TextC70(
+        TextH40(
             text = stringResource(LR.string.referrals_tooltip_message),
-            isUpperCase = false,
         )
     }
 }

--- a/modules/features/referrals/src/main/kotlin/au/com/shiftyjelly/pocketcasts/referrals/ReferralsSendGuestPassFragment.kt
+++ b/modules/features/referrals/src/main/kotlin/au/com/shiftyjelly/pocketcasts/referrals/ReferralsSendGuestPassFragment.kt
@@ -3,7 +3,6 @@ package au.com.shiftyjelly.pocketcasts.referrals
 import android.app.Activity
 import android.graphics.Color
 import android.os.Bundle
-import android.os.Parcelable
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.compose.material3.windowsizeclass.ExperimentalMaterial3WindowSizeClassApi
@@ -13,8 +12,6 @@ import androidx.compose.material3.windowsizeclass.calculateWindowSizeClass
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.platform.LocalContext
-import androidx.core.os.BundleCompat
-import androidx.core.os.bundleOf
 import androidx.fragment.compose.content
 import au.com.shiftyjelly.pocketcasts.ui.helper.FragmentHostListener
 import au.com.shiftyjelly.pocketcasts.ui.helper.StatusBarColor
@@ -22,14 +19,10 @@ import au.com.shiftyjelly.pocketcasts.utils.extensions.getActivity
 import au.com.shiftyjelly.pocketcasts.views.fragments.BaseFragment
 import au.com.shiftyjelly.pocketcasts.views.helper.UiUtil.setBackgroundColor
 import dagger.hilt.android.AndroidEntryPoint
-import kotlinx.parcelize.Parcelize
 import androidx.compose.ui.graphics.Color as ComposeColor
-
-private const val NEW_INSTANCE_ARG = "ReferralsSendPassFragmentArgs"
 
 @AndroidEntryPoint
 class ReferralsSendGuestPassFragment : BaseFragment() {
-    private val args get() = requireNotNull(arguments?.let { BundleCompat.getParcelable(it, NEW_INSTANCE_ARG, Args::class.java) })
 
     @OptIn(ExperimentalMaterial3WindowSizeClassApi::class)
     override fun onCreateView(
@@ -42,7 +35,6 @@ class ReferralsSendGuestPassFragment : BaseFragment() {
 
         setBackgroundColor(view, ComposeColor.Transparent.toArgb())
         ReferralsSendGuestPassPage(
-            passCount = args.passCount,
             onDismiss = {
                 (activity as? FragmentHostListener)?.bottomSheetClosePressed(this)
             },
@@ -68,18 +60,7 @@ class ReferralsSendGuestPassFragment : BaseFragment() {
         }
     }
 
-    @Parcelize
-    private class Args(
-        val passCount: Int,
-    ) : Parcelable
-
     companion object {
-        fun newInstance(
-            passCount: Int,
-        ) = ReferralsSendGuestPassFragment().apply {
-            arguments = bundleOf(
-                NEW_INSTANCE_ARG to Args(passCount),
-            )
-        }
+        fun newInstance() = ReferralsSendGuestPassFragment()
     }
 }

--- a/modules/features/referrals/src/main/kotlin/au/com/shiftyjelly/pocketcasts/referrals/ReferralsSendGuestPassPage.kt
+++ b/modules/features/referrals/src/main/kotlin/au/com/shiftyjelly/pocketcasts/referrals/ReferralsSendGuestPassPage.kt
@@ -54,7 +54,6 @@ private val plusBackgroundBrush = Brush.horizontalGradient(
 @OptIn(ExperimentalMaterial3WindowSizeClassApi::class)
 @Composable
 fun ReferralsSendGuestPassPage(
-    passCount: Int,
     onDismiss: () -> Unit,
 ) {
     AppTheme(Theme.ThemeType.DARK) {
@@ -62,7 +61,6 @@ fun ReferralsSendGuestPassPage(
         val windowSize = calculateWindowSizeClass(context.getActivity() as Activity)
 
         ReferralsSendGuestPassContent(
-            passCount = passCount,
             windowWidthSizeClass = windowSize.widthSizeClass,
             windowHeightSizeClass = windowSize.heightSizeClass,
             onDismiss = onDismiss,
@@ -72,7 +70,6 @@ fun ReferralsSendGuestPassPage(
 
 @Composable
 private fun ReferralsSendGuestPassContent(
-    passCount: Int,
     windowWidthSizeClass: WindowWidthSizeClass,
     windowHeightSizeClass: WindowHeightSizeClass,
     onDismiss: () -> Unit,
@@ -145,7 +142,6 @@ private fun ReferralsSendGuestPassContent(
                     Spacer(modifier = Modifier.height(24.dp))
 
                     ReferralsPassCardsStack(
-                        passCount = passCount,
                         width = cardWidth,
                     )
                 }
@@ -170,7 +166,7 @@ private fun ReferralsSendGuestPassContent(
 
 @Composable
 private fun ReferralsPassCardsStack(
-    passCount: Int,
+    cardsCount: Int = 3,
     width: Dp,
 ) {
     BoxWithConstraints(
@@ -178,10 +174,10 @@ private fun ReferralsPassCardsStack(
         modifier = Modifier
             .width(width),
     ) {
-        (0..<passCount).reversed().forEach { index ->
+        (0..<cardsCount).reversed().forEach { index ->
             val cardWidth = (maxWidth.value * 0.8 * (1 - index * 0.125)).dp
             val cardHeight = (cardWidth.value * ReferralGuestPassCardDefaults.cardAspectRatio).dp
-            val cardOffset = (10 * ((passCount - 1) - index)).dp
+            val cardOffset = (10 * ((cardsCount - 1) - index)).dp
             ReferralGuestPassCardView(
                 modifier = Modifier
                     .padding(horizontal = 16.dp)
@@ -237,7 +233,6 @@ fun ReferralsSendGuestPassContentPreview(
         ReferralsSendGuestPassContent(
             windowWidthSizeClass = windowWidthSizeClass,
             windowHeightSizeClass = windowHeightSizeClass,
-            passCount = 3,
             onDismiss = {},
         )
     }

--- a/modules/features/referrals/src/main/kotlin/au/com/shiftyjelly/pocketcasts/referrals/ReferralsSendGuestPassPage.kt
+++ b/modules/features/referrals/src/main/kotlin/au/com/shiftyjelly/pocketcasts/referrals/ReferralsSendGuestPassPage.kt
@@ -29,7 +29,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
@@ -41,7 +40,6 @@ import au.com.shiftyjelly.pocketcasts.compose.Devices
 import au.com.shiftyjelly.pocketcasts.compose.buttons.CloseButton
 import au.com.shiftyjelly.pocketcasts.compose.buttons.GradientRowButton
 import au.com.shiftyjelly.pocketcasts.compose.components.TextH10
-import au.com.shiftyjelly.pocketcasts.compose.components.TextH50
 import au.com.shiftyjelly.pocketcasts.compose.images.SubscriptionBadge
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import au.com.shiftyjelly.pocketcasts.utils.extensions.getActivity
@@ -141,16 +139,6 @@ private fun ReferralsSendGuestPassContent(
                 TextH10(
                     text = stringResource(LR.string.referrals_send_guest_pass_title),
                     textAlign = TextAlign.Center,
-                )
-
-                Spacer(modifier = Modifier.height(24.dp))
-
-                TextH50(
-                    text = pluralStringResource(
-                        LR.plurals.referrals_remaining_passes,
-                        passCount,
-                        passCount,
-                    ),
                 )
 
                 if (windowHeightSizeClass != WindowHeightSizeClass.Compact) {

--- a/modules/features/referrals/src/main/kotlin/au/com/shiftyjelly/pocketcasts/referrals/ReferralsViewModel.kt
+++ b/modules/features/referrals/src/main/kotlin/au/com/shiftyjelly/pocketcasts/referrals/ReferralsViewModel.kt
@@ -52,7 +52,6 @@ class ReferralsViewModel @Inject constructor(
         }
         _state.update {
             it.copy(
-                badgeCount = if (it.badgeCount > 0) it.badgeCount - 1 else 3,
                 showTooltip = false,
             )
         }
@@ -61,9 +60,5 @@ class ReferralsViewModel @Inject constructor(
     data class UiState(
         val showIcon: Boolean = false,
         val showTooltip: Boolean = false,
-        val badgeCount: Int = 3,
-    ) {
-        val showBadge: Boolean
-            get() = showIcon && badgeCount > 0
-    }
+    )
 }

--- a/modules/features/referrals/src/test/kotlin/au/com/shiftyjelly/pocketcasts/referrals/ReferralsViewModelTest.kt
+++ b/modules/features/referrals/src/test/kotlin/au/com/shiftyjelly/pocketcasts/referrals/ReferralsViewModelTest.kt
@@ -121,45 +121,6 @@ class ReferralsViewModelTest {
     }
 
     @Test
-    fun `updateBadgeCount decreases badge count when greater than zero`() = runTest {
-        initViewModel() // badge count is 3 by default
-
-        viewModel.onIconClick()
-
-        assertEquals(2, viewModel.state.value.badgeCount)
-    }
-
-    @Test
-    fun `showBadge is true when showIcon is true and badgeCount is greater than zero`() = runTest {
-        initViewModel()
-
-        viewModel.state.test {
-            assertEquals(true, awaitItem().showBadge)
-        }
-    }
-
-    @Test
-    fun `showBadge is false when showIcon is false`() = runTest {
-        initViewModel(SignInState.SignedOut)
-
-        viewModel.state.test {
-            assertEquals(false, awaitItem().showBadge)
-        }
-    }
-
-    @Test
-    fun `showBadge is false when badgeCount is zero`() = runTest {
-        initViewModel()
-        viewModel.onIconClick()
-        viewModel.onIconClick()
-        viewModel.onIconClick()
-
-        viewModel.state.test {
-            assertEquals(false, awaitItem().showBadge)
-        }
-    }
-
-    @Test
     fun `tooltip is shown for paid account on launch`() = runTest {
         initViewModel()
 

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -2136,6 +2136,6 @@
     <string name="referrals_send_guest_pass_title">Gift 2 Months of Pocket&#160;Casts&#160;Plus</string>
     <string name="referrals_send_guest_pass_card_title">2-Month Guest Pass</string>
     <string name="referrals_share_guest_pass">Share Guest Pass</string>
-    <string name="referrals_tooltip_message">Give 2 months of Plus to friends and family!</string>
+    <string name="referrals_tooltip_message">Give 2 months of Pocket&#160;Casts&#160;Plus!</string>
 
 </resources>

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -2133,13 +2133,9 @@
 
     <!-- Referrals -->
     <string name="gift">Gift</string>
-    <plurals name="referrals_remaining_passes">
-        <item quantity="one">You have %d pass to share</item>
-        <item quantity="other">You have %d passes to share</item>
-    </plurals>
     <string name="referrals_send_guest_pass_title">Gift 2 Months of Pocket&#160;Casts&#160;Plus</string>
     <string name="referrals_send_guest_pass_card_title">2-Month Guest Pass</string>
     <string name="referrals_share_guest_pass">Share Guest Pass</string>
-    <string name="referrals_tooltip_message">Give 2 months of Plus to friends and family.</string>
+    <string name="referrals_tooltip_message">Give 2 months of Plus to friends and family!</string>
 
 </resources>

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -2136,6 +2136,6 @@
     <string name="referrals_send_guest_pass_title">Gift 2 Months of Pocket&#160;Casts&#160;Plus</string>
     <string name="referrals_send_guest_pass_card_title">2-Month Guest Pass</string>
     <string name="referrals_share_guest_pass">Share Guest Pass</string>
-    <string name="referrals_tooltip_message">Give 2 months of Pocket&#160;Casts&#160;Plus!</string>
+    <string name="referrals_tooltip_message">Gift 2 months of Pocket&#160;Casts&#160;Plus!</string>
 
 </resources>


### PR DESCRIPTION
## Description
This updates UI for unlimited passes (Internal Ref: pdeCcb-6Ac-p2#comment-5345)

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Tap on the Filters tab -->
<!-- 2. Tap on a filter -->
<!-- 3. etc. -->

## Screenshots or Screencast 

Phone

ToolTip | Send Pass
----|-----
<img width=320 src="https://github.com/user-attachments/assets/16383b7f-c392-4cb5-9544-48124f59b5c3"/> | <img width=320 src="https://github.com/user-attachments/assets/cf213ddc-cdbd-474b-b00d-341e8a8c47d1"/>


Phone Landscape

<img width=500 src="https://github.com/user-attachments/assets/66665b10-7161-489e-b2f3-c6ed731292f5"/>

Tablet

ToolTip | Send Pass
----|-----
<img width=500 src="https://github.com/user-attachments/assets/afae6cc1-82d5-43fa-a5be-144c919a2547"/> | <img width=500 src="https://github.com/user-attachments/assets/9666a158-196c-4866-b6af-3722ea03abd5"/>

Tablet Landscape

<img width=700 src="https://github.com/user-attachments/assets/c4f79479-aad5-467f-bbef-2df14f34b7d3"/>

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [x] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack