### PR TITLE
Referrals: claim pass page

### DIFF
--- a/modules/features/referrals/build.gradle.kts
+++ b/modules/features/referrals/build.gradle.kts
@@ -4,6 +4,7 @@ plugins {
     alias(libs.plugins.ksp)
     alias(libs.plugins.hilt)
     alias(libs.plugins.compose.compiler)
+    alias(libs.plugins.kotlin.parcelize)
 }
 
 android {

--- a/modules/features/referrals/src/main/kotlin/au/com/shiftyjelly/pocketcasts/referrals/ReferralsClaimGuestPassBannerCard.kt
+++ b/modules/features/referrals/src/main/kotlin/au/com/shiftyjelly/pocketcasts/referrals/ReferralsClaimGuestPassBannerCard.kt
@@ -18,6 +18,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.intl.Locale
 import androidx.compose.ui.tooling.preview.Preview
@@ -31,7 +32,10 @@ import au.com.shiftyjelly.pocketcasts.compose.components.TextC70
 import au.com.shiftyjelly.pocketcasts.compose.components.TextH40
 import au.com.shiftyjelly.pocketcasts.compose.preview.ThemePreviewParameterProvider
 import au.com.shiftyjelly.pocketcasts.compose.theme
+import au.com.shiftyjelly.pocketcasts.referrals.ReferralsGuestPassFragment.ReferralsPageType
+import au.com.shiftyjelly.pocketcasts.ui.helper.FragmentHostListener
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
+import au.com.shiftyjelly.pocketcasts.utils.extensions.getActivity
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 @Composable
@@ -40,9 +44,15 @@ fun ReferralsClaimGuestPassBannerCard(
     viewModel: ReferralsViewModel = hiltViewModel(),
 ) {
     val state by viewModel.state.collectAsStateWithLifecycle()
+    val activity = LocalContext.current.getActivity()
+
     ReferralsClaimGuestPassBannerCard(
         state = state,
         modifier = modifier,
+        onClick = {
+            val fragment = ReferralsGuestPassFragment.newInstance(ReferralsPageType.Claim)
+            (activity as FragmentHostListener).showBottomSheet(fragment)
+        },
     )
 }
 
@@ -50,6 +60,7 @@ fun ReferralsClaimGuestPassBannerCard(
 private fun ReferralsClaimGuestPassBannerCard(
     state: ReferralsViewModel.UiState,
     modifier: Modifier = Modifier,
+    onClick: () -> Unit,
 ) {
     if (state.showProfileBanner) {
         BoxWithConstraints(
@@ -58,7 +69,7 @@ private fun ReferralsClaimGuestPassBannerCard(
                 .padding(horizontal = 16.dp, vertical = 8.dp)
                 .clip(RoundedCornerShape(8.dp))
                 .clickable(
-                    onClick = {},
+                    onClick = onClick,
                 ),
         ) {
             Row(
@@ -112,6 +123,7 @@ private fun ReferralsClaimGuestPassBannerCardPreview(
     AppTheme(themeType) {
         ReferralsClaimGuestPassBannerCard(
             state = ReferralsViewModel.UiState(showProfileBanner = true),
+            onClick = {},
         )
     }
 }

--- a/modules/features/referrals/src/main/kotlin/au/com/shiftyjelly/pocketcasts/referrals/ReferralsClaimGuestPassPage.kt
+++ b/modules/features/referrals/src/main/kotlin/au/com/shiftyjelly/pocketcasts/referrals/ReferralsClaimGuestPassPage.kt
@@ -1,0 +1,250 @@
+package au.com.shiftyjelly.pocketcasts.referrals
+
+import android.app.Activity
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.wrapContentSize
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.Card
+import androidx.compose.material.TextButton
+import androidx.compose.material3.windowsizeclass.ExperimentalMaterial3WindowSizeClassApi
+import androidx.compose.material3.windowsizeclass.WindowHeightSizeClass
+import androidx.compose.material3.windowsizeclass.WindowWidthSizeClass
+import androidx.compose.material3.windowsizeclass.calculateWindowSizeClass
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.intl.Locale
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import au.com.shiftyjelly.pocketcasts.compose.AppTheme
+import au.com.shiftyjelly.pocketcasts.compose.Devices
+import au.com.shiftyjelly.pocketcasts.compose.buttons.GradientRowButton
+import au.com.shiftyjelly.pocketcasts.compose.components.TextH10
+import au.com.shiftyjelly.pocketcasts.compose.components.TextP30
+import au.com.shiftyjelly.pocketcasts.compose.components.TextP60
+import au.com.shiftyjelly.pocketcasts.compose.images.SubscriptionBadge
+import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
+import au.com.shiftyjelly.pocketcasts.utils.extensions.getActivity
+import au.com.shiftyjelly.pocketcasts.images.R as IR
+import au.com.shiftyjelly.pocketcasts.localization.R as LR
+
+private val plusBackgroundBrush = Brush.horizontalGradient(
+    0f to Color(0xFFFED745),
+    1f to Color(0xFFFEB525),
+)
+
+@OptIn(ExperimentalMaterial3WindowSizeClassApi::class)
+@Composable
+fun ReferralsClaimGuestPassPage(
+    onDismiss: () -> Unit,
+) {
+    AppTheme(Theme.ThemeType.DARK) {
+        val context = LocalContext.current
+        val windowSize = calculateWindowSizeClass(context.getActivity() as Activity)
+
+        ReferralsClaimGuestPassContent(
+            windowWidthSizeClass = windowSize.widthSizeClass,
+            windowHeightSizeClass = windowSize.heightSizeClass,
+            onDismiss = onDismiss,
+        )
+    }
+}
+
+@Composable
+private fun ReferralsClaimGuestPassContent(
+    windowWidthSizeClass: WindowWidthSizeClass,
+    windowHeightSizeClass: WindowHeightSizeClass,
+    onDismiss: () -> Unit,
+) {
+    BoxWithConstraints(
+        contentAlignment = Alignment.Center,
+        modifier = Modifier
+            .background(Color.Transparent)
+            .clickable(
+                indication = null,
+                interactionSource = remember { MutableInteractionSource() },
+                onClick = onDismiss,
+            )
+            .fillMaxSize(),
+    ) {
+        val showFullScreen = windowWidthSizeClass == WindowWidthSizeClass.Compact ||
+            windowHeightSizeClass == WindowHeightSizeClass.Compact
+        val cardCornerRadius = if (showFullScreen) 0.dp else 8.dp
+        val cardWidth = if (showFullScreen) maxWidth else (maxWidth.value * .5).dp
+        val cardModifier = if (showFullScreen) {
+            Modifier
+                .fillMaxSize()
+        } else {
+            Modifier
+                .width(cardWidth)
+                .wrapContentSize()
+        }
+
+        Card(
+            elevation = 8.dp,
+            shape = RoundedCornerShape(cardCornerRadius),
+            backgroundColor = Color.Black,
+            modifier = cardModifier
+                .clickable(
+                    indication = null,
+                    interactionSource = remember { MutableInteractionSource() },
+                    onClick = {},
+                ),
+        ) {
+            Column(
+                horizontalAlignment = Alignment.CenterHorizontally,
+                modifier = Modifier
+                    .verticalScroll(rememberScrollState())
+                    .padding(16.dp),
+            ) {
+                val language = Locale.current.language
+                val titleTextResId = if (language == "en") {
+                    LR.string.referrals_claim_guest_pass_title_english_only
+                } else {
+                    LR.string.referrals_claim_guest_pass_title
+                }
+                val price = "$39.99 USD" // TODO - Referrals: Make it dynamic
+
+                TextButton(
+                    modifier = Modifier
+                        .align(Alignment.End),
+                    onClick = onDismiss,
+                ) {
+                    TextP30(
+                        text = stringResource(LR.string.not_now),
+                    )
+                }
+
+                SubscriptionBadge(
+                    fontSize = 16.sp,
+                    padding = 4.dp,
+                    iconRes = IR.drawable.ic_plus,
+                    shortNameRes = LR.string.pocket_casts_plus_short,
+                    iconColor = Color.Black,
+                    backgroundBrush = plusBackgroundBrush,
+                    textColor = Color.Black,
+                )
+
+                Spacer(modifier = Modifier.height(24.dp))
+
+                TextH10(
+                    text = stringResource(titleTextResId),
+                    textAlign = TextAlign.Center,
+                )
+
+                if (windowHeightSizeClass != WindowHeightSizeClass.Compact) {
+                    Spacer(modifier = Modifier.height(24.dp))
+
+                    ReferralsPassCard(
+                        width = cardWidth,
+                    )
+                }
+
+                Spacer(modifier = Modifier.height(16.dp))
+
+                TextP60(
+                    text = stringResource(LR.string.referrals_claim_guest_pass_description, price),
+                    textAlign = TextAlign.Center,
+                    modifier = Modifier.width(cardWidth * 0.8f - 32.dp),
+                )
+
+                if (showFullScreen) {
+                    Spacer(modifier = Modifier.weight(1f))
+                } else {
+                    Spacer(modifier = Modifier.height(32.dp))
+                }
+
+                GradientRowButton(
+                    primaryText = stringResource(LR.string.referrals_activate_my_pass),
+                    textColor = Color.Black,
+                    gradientBackgroundColor = plusBackgroundBrush,
+                    modifier = Modifier.padding(16.dp),
+                    onClick = {},
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun ReferralsPassCard(
+    width: Dp,
+) {
+    val cardWidth = (width.value * 0.8).dp
+    val cardHeight = (cardWidth.value * ReferralGuestPassCardDefaults.cardAspectRatio).dp
+    ReferralGuestPassCardView(
+        modifier = Modifier
+            .size(cardWidth, cardHeight),
+        source = ReferralGuestPassCardViewSource.Send,
+    )
+}
+
+@Preview(device = Devices.PortraitRegular)
+@Composable
+fun ReferralsClaimGuestPassPortraitPhonePreview() {
+    ReferralsClaimGuestPassContentPreview(
+        windowWidthSizeClass = WindowWidthSizeClass.Compact,
+        windowHeightSizeClass = WindowHeightSizeClass.Medium,
+    )
+}
+
+@Preview(device = Devices.LandscapeRegular)
+@Composable
+fun ReferralsClaimGuestPassLandscapePhonePreview() {
+    ReferralsClaimGuestPassContentPreview(
+        windowWidthSizeClass = WindowWidthSizeClass.Compact,
+        windowHeightSizeClass = WindowHeightSizeClass.Compact,
+    )
+}
+
+@Preview(device = Devices.PortraitTablet)
+@Composable
+fun ReferralsClaimGuestPassPortraitTabletPreview() {
+    ReferralsClaimGuestPassContentPreview(
+        windowWidthSizeClass = WindowWidthSizeClass.Medium,
+        windowHeightSizeClass = WindowHeightSizeClass.Medium,
+    )
+}
+
+@Preview(device = Devices.LandscapeTablet)
+@Composable
+fun ReferralsClaimGuestPassLandscapeTabletPreview() {
+    ReferralsClaimGuestPassContentPreview(
+        windowWidthSizeClass = WindowWidthSizeClass.Medium,
+        windowHeightSizeClass = WindowHeightSizeClass.Expanded,
+    )
+}
+
+@Composable
+fun ReferralsClaimGuestPassContentPreview(
+    windowWidthSizeClass: WindowWidthSizeClass,
+    windowHeightSizeClass: WindowHeightSizeClass,
+) {
+    AppTheme(Theme.ThemeType.DARK) {
+        ReferralsClaimGuestPassContent(
+            windowWidthSizeClass = windowWidthSizeClass,
+            windowHeightSizeClass = windowHeightSizeClass,
+            onDismiss = {},
+        )
+    }
+}

--- a/modules/features/referrals/src/main/kotlin/au/com/shiftyjelly/pocketcasts/referrals/ReferralsClaimGuestPassPage.kt
+++ b/modules/features/referrals/src/main/kotlin/au/com/shiftyjelly/pocketcasts/referrals/ReferralsClaimGuestPassPage.kt
@@ -33,7 +33,6 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.intl.Locale
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import au.com.shiftyjelly.pocketcasts.compose.AppTheme
@@ -152,11 +151,15 @@ private fun ReferralsClaimGuestPassContent(
                     textAlign = TextAlign.Center,
                 )
 
+                val guestPassCardWidth = cardWidth * 0.8f
                 if (windowHeightSizeClass != WindowHeightSizeClass.Compact) {
                     Spacer(modifier = Modifier.height(24.dp))
 
-                    ReferralsPassCard(
-                        width = cardWidth,
+                    val guestPassCardHeight = (guestPassCardWidth.value * ReferralGuestPassCardDefaults.cardAspectRatio).dp
+                    ReferralGuestPassCardView(
+                        modifier = Modifier
+                            .size(guestPassCardWidth, guestPassCardHeight),
+                        source = ReferralGuestPassCardViewSource.Send,
                     )
                 }
 
@@ -165,7 +168,7 @@ private fun ReferralsClaimGuestPassContent(
                 TextP60(
                     text = stringResource(LR.string.referrals_claim_guest_pass_description, price),
                     textAlign = TextAlign.Center,
-                    modifier = Modifier.width(cardWidth * 0.8f - 32.dp),
+                    modifier = Modifier.width(guestPassCardWidth),
                 )
 
                 if (showFullScreen) {
@@ -184,19 +187,6 @@ private fun ReferralsClaimGuestPassContent(
             }
         }
     }
-}
-
-@Composable
-private fun ReferralsPassCard(
-    width: Dp,
-) {
-    val cardWidth = (width.value * 0.8).dp
-    val cardHeight = (cardWidth.value * ReferralGuestPassCardDefaults.cardAspectRatio).dp
-    ReferralGuestPassCardView(
-        modifier = Modifier
-            .size(cardWidth, cardHeight),
-        source = ReferralGuestPassCardViewSource.Send,
-    )
 }
 
 @Preview(device = Devices.PortraitRegular)

--- a/modules/features/referrals/src/main/kotlin/au/com/shiftyjelly/pocketcasts/referrals/ReferralsGuestPassFragment.kt
+++ b/modules/features/referrals/src/main/kotlin/au/com/shiftyjelly/pocketcasts/referrals/ReferralsGuestPassFragment.kt
@@ -89,6 +89,6 @@ class ReferralsGuestPassFragment : BaseFragment() {
 
     enum class ReferralsPageType {
         Send,
-        Claim
+        Claim,
     }
 }

--- a/modules/features/referrals/src/main/kotlin/au/com/shiftyjelly/pocketcasts/referrals/ReferralsIconWithTooltip.kt
+++ b/modules/features/referrals/src/main/kotlin/au/com/shiftyjelly/pocketcasts/referrals/ReferralsIconWithTooltip.kt
@@ -23,6 +23,7 @@ import au.com.shiftyjelly.pocketcasts.compose.ThemeColors
 import au.com.shiftyjelly.pocketcasts.compose.components.TextH40
 import au.com.shiftyjelly.pocketcasts.compose.components.Tooltip
 import au.com.shiftyjelly.pocketcasts.compose.preview.ThemePreviewParameterProvider
+import au.com.shiftyjelly.pocketcasts.referrals.ReferralsGuestPassFragment.ReferralsPageType
 import au.com.shiftyjelly.pocketcasts.ui.helper.FragmentHostListener
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import au.com.shiftyjelly.pocketcasts.utils.extensions.getActivity
@@ -38,7 +39,7 @@ fun ReferralsIconWithTooltip(
         state = state,
         onIconClick = {
             viewModel.onIconClick()
-            val fragment = ReferralsSendGuestPassFragment.newInstance()
+            val fragment = ReferralsGuestPassFragment.newInstance(ReferralsPageType.Send)
             (activity as FragmentHostListener).showBottomSheet(fragment)
         },
     )

--- a/modules/features/referrals/src/main/kotlin/au/com/shiftyjelly/pocketcasts/referrals/ReferralsViewModel.kt
+++ b/modules/features/referrals/src/main/kotlin/au/com/shiftyjelly/pocketcasts/referrals/ReferralsViewModel.kt
@@ -32,7 +32,7 @@ class ReferralsViewModel @Inject constructor(
                 settings.playerOrUpNextBottomSheetState,
             ) { signInState, playerBottomSheetState ->
                 val eligibleToSendPass = FeatureFlag.isEnabled(Feature.REFERRALS) && signInState.isSignedInAsPlusOrPatron
-                val eligibleToClaimPass = FeatureFlag.isEnabled(Feature.REFERRALS) // TODO: Fix condition to claim pass when it's implemented
+                val eligibleToClaimPass = FeatureFlag.isEnabled(Feature.REFERRALS) // TODO - Referrals: Fix condition to claim pass when it's implemented
                 _state.update {
                     it.copy(
                         showIcon = eligibleToSendPass,

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -2133,9 +2133,13 @@
 
     <!-- Referrals -->
     <string name="gift">Gift</string>
+    <string name="referrals_activate_my_pass">Activate my pass</string>
     <string name="referrals_claim_guess_pass_banner_card_title_english_only" translatable="false">Claim your 2-Month\nGuest Pass to Plus</string>
     <string name="referrals_claim_guess_pass_banner_card_title">Claim your 2-Month Guest Pass to Plus</string>
     <string name="referrals_claim_guess_pass_banner_card_subtitle">Unlock the full listening experience</string>
+    <string name="referrals_claim_guest_pass_description">This offer is for new members only. Membership will automatically renew to a paid annual membership at %s.</string>
+    <string name="referrals_claim_guest_pass_title_english_only" translatable="false">Claim your 2-Month\nGuest Pass</string>
+    <string name="referrals_claim_guest_pass_title">Claim your 2-Month Guest Pass</string>
     <string name="referrals_send_guest_pass_title">Gift 2 Months of Pocket&#160;Casts&#160;Plus</string>
     <string name="referrals_send_guest_pass_card_title">2-Month Guest Pass</string>
     <string name="referrals_share_guest_pass">Share Guest Pass</string>


### PR DESCRIPTION
## Description
This adds Referrals claim pass page.

## Testing Instructions
1. Go to Profile 
2. Tap Claim your 2-Month Guest Pass to Plus banner
3. ✅ Notice that claim guess pass page is shown (Figma: FVJPaWlRMlosEpsRhqxnSD-fi-2189_8613)

## Screenshots or Screencast 

|Phone|
|--|
|<img width=320 src="https://github.com/user-attachments/assets/80bb76ef-b24f-4379-99d7-228d0eb62a3d"/>|

|Tablet|
|--|
|<img width=400 src="https://github.com/user-attachments/assets/2f402c32-ba2c-41d6-b2ba-1f3e95c9335d"/>|

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack