### PR TITLE
Add lint results artifacts to release build step

### DIFF
--- a/.buildkite/release-builds.yml
+++ b/.buildkite/release-builds.yml
@@ -21,5 +21,7 @@ steps:
     command: ".buildkite/commands/release-build.sh"
     priority: 1
     plugins: [$CI_TOOLKIT]
+    artifact_paths:
+      - "**/build/reports/lint-results*.*"
     notify:
       - slack: "#build-and-ship"


### PR DESCRIPTION
For easier debugging if release build fails
