### PR TITLE
Referrals: add share

### DIFF
--- a/modules/features/referrals/build.gradle.kts
+++ b/modules/features/referrals/build.gradle.kts
@@ -39,6 +39,7 @@ dependencies {
     implementation(projects.modules.services.images)
     implementation(projects.modules.services.localization)
     implementation(projects.modules.services.model)
+    implementation(projects.modules.services.sharing)
     implementation(projects.modules.services.utils)
 
     testImplementation(libs.coroutines.test)

--- a/modules/features/referrals/src/main/kotlin/au/com/shiftyjelly/pocketcasts/referrals/ReferralsClaimGuestPassBannerCard.kt
+++ b/modules/features/referrals/src/main/kotlin/au/com/shiftyjelly/pocketcasts/referrals/ReferralsClaimGuestPassBannerCard.kt
@@ -54,6 +54,10 @@ fun ReferralsClaimGuestPassBannerCard(
             (activity as FragmentHostListener).showBottomSheet(fragment)
         },
     )
+
+    activity?.supportFragmentManager?.findFragmentByTag(ReferralsGuestPassFragment::class.java.name)?.let {
+        (activity as FragmentHostListener).showBottomSheet(it)
+    }
 }
 
 @Composable

--- a/modules/features/referrals/src/main/kotlin/au/com/shiftyjelly/pocketcasts/referrals/ReferralsGuestPassFragment.kt
+++ b/modules/features/referrals/src/main/kotlin/au/com/shiftyjelly/pocketcasts/referrals/ReferralsGuestPassFragment.kt
@@ -16,12 +16,14 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.core.os.BundleCompat
 import androidx.core.os.bundleOf
 import androidx.fragment.compose.content
+import au.com.shiftyjelly.pocketcasts.sharing.SharingClient
 import au.com.shiftyjelly.pocketcasts.ui.helper.FragmentHostListener
 import au.com.shiftyjelly.pocketcasts.ui.helper.StatusBarColor
 import au.com.shiftyjelly.pocketcasts.utils.extensions.getActivity
 import au.com.shiftyjelly.pocketcasts.views.fragments.BaseFragment
 import au.com.shiftyjelly.pocketcasts.views.helper.UiUtil.setBackgroundColor
 import dagger.hilt.android.AndroidEntryPoint
+import javax.inject.Inject
 import kotlinx.parcelize.Parcelize
 import androidx.compose.ui.graphics.Color as ComposeColor
 
@@ -29,6 +31,9 @@ import androidx.compose.ui.graphics.Color as ComposeColor
 class ReferralsGuestPassFragment : BaseFragment() {
     private val args get() = requireNotNull(arguments?.let { BundleCompat.getParcelable(it, NEW_INSTANCE_ARG, Args::class.java) })
     private val pageType get() = args.pageType
+
+    @Inject
+    lateinit var sharingClient: SharingClient
 
     @OptIn(ExperimentalMaterial3WindowSizeClassApi::class)
     override fun onCreateView(
@@ -46,9 +51,12 @@ class ReferralsGuestPassFragment : BaseFragment() {
         }
 
         when (pageType) {
-            ReferralsPageType.Send -> ReferralsSendGuestPassPage(
-                onDismiss = { onDismiss() },
-            )
+            ReferralsPageType.Send -> {
+                ReferralsSendGuestPassPage(
+                    sharingClient = sharingClient,
+                    onDismiss = { onDismiss() },
+                )
+            }
 
             ReferralsPageType.Claim -> ReferralsClaimGuestPassPage(
                 onDismiss = { onDismiss() },

--- a/modules/features/referrals/src/main/kotlin/au/com/shiftyjelly/pocketcasts/referrals/ReferralsGuestPassFragment.kt
+++ b/modules/features/referrals/src/main/kotlin/au/com/shiftyjelly/pocketcasts/referrals/ReferralsGuestPassFragment.kt
@@ -16,6 +16,9 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.core.os.BundleCompat
 import androidx.core.os.bundleOf
 import androidx.fragment.compose.content
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
 import au.com.shiftyjelly.pocketcasts.sharing.SharingClient
 import au.com.shiftyjelly.pocketcasts.ui.helper.FragmentHostListener
 import au.com.shiftyjelly.pocketcasts.ui.helper.StatusBarColor
@@ -24,6 +27,7 @@ import au.com.shiftyjelly.pocketcasts.views.fragments.BaseFragment
 import au.com.shiftyjelly.pocketcasts.views.helper.UiUtil.setBackgroundColor
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
+import kotlinx.coroutines.launch
 import kotlinx.parcelize.Parcelize
 import androidx.compose.ui.graphics.Color as ComposeColor
 
@@ -68,10 +72,14 @@ class ReferralsGuestPassFragment : BaseFragment() {
         }
 
         LaunchedEffect(Unit) {
-            if (windowSize.widthSizeClass == WindowWidthSizeClass.Compact ||
-                windowSize.heightSizeClass == WindowHeightSizeClass.Compact
-            ) {
-                updateStatusAndNavColors()
+            viewLifecycleOwner.lifecycleScope.launch {
+                viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.RESUMED) {
+                    if (windowSize.widthSizeClass == WindowWidthSizeClass.Compact ||
+                        windowSize.heightSizeClass == WindowHeightSizeClass.Compact
+                    ) {
+                        updateStatusAndNavColors()
+                    }
+                }
             }
         }
     }

--- a/modules/features/referrals/src/main/kotlin/au/com/shiftyjelly/pocketcasts/referrals/ReferralsSendGuestPassPage.kt
+++ b/modules/features/referrals/src/main/kotlin/au/com/shiftyjelly/pocketcasts/referrals/ReferralsSendGuestPassPage.kt
@@ -24,6 +24,7 @@ import androidx.compose.material3.windowsizeclass.WindowWidthSizeClass
 import androidx.compose.material3.windowsizeclass.calculateWindowSizeClass
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -44,24 +45,41 @@ import au.com.shiftyjelly.pocketcasts.compose.images.SubscriptionBadge
 import au.com.shiftyjelly.pocketcasts.referrals.ReferralPageDefaults.pageCornerRadius
 import au.com.shiftyjelly.pocketcasts.referrals.ReferralPageDefaults.pageWidthPercent
 import au.com.shiftyjelly.pocketcasts.referrals.ReferralPageDefaults.shouldShowFullScreen
+import au.com.shiftyjelly.pocketcasts.sharing.SharingClient
+import au.com.shiftyjelly.pocketcasts.sharing.SharingRequest
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import au.com.shiftyjelly.pocketcasts.utils.extensions.getActivity
+import kotlinx.coroutines.launch
 import au.com.shiftyjelly.pocketcasts.images.R as IR
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 @OptIn(ExperimentalMaterial3WindowSizeClassApi::class)
 @Composable
 fun ReferralsSendGuestPassPage(
+    sharingClient: SharingClient,
     onDismiss: () -> Unit,
 ) {
     AppTheme(Theme.ThemeType.DARK) {
         val context = LocalContext.current
         val windowSize = calculateWindowSizeClass(context.getActivity() as Activity)
+        val scope = rememberCoroutineScope()
+
+        val shareSubject = stringResource(LR.string.referrals_share_subject)
+        val shareTextWitUrl = stringResource(LR.string.referrals_share_text_with_url, "https://pocketcasts.com")
 
         ReferralsSendGuestPassContent(
             windowWidthSizeClass = windowSize.widthSizeClass,
             windowHeightSizeClass = windowSize.heightSizeClass,
             onDismiss = onDismiss,
+            onShare = {
+                val request = SharingRequest.webLink(
+                    textWithUrl = shareTextWitUrl,
+                    subject = shareSubject,
+                ).build()
+                scope.launch {
+                    sharingClient.share(request)
+                }
+            },
         )
     }
 }
@@ -71,6 +89,7 @@ private fun ReferralsSendGuestPassContent(
     windowWidthSizeClass: WindowWidthSizeClass,
     windowHeightSizeClass: WindowHeightSizeClass,
     onDismiss: () -> Unit,
+    onShare: () -> Unit,
 ) {
     BoxWithConstraints(
         contentAlignment = Alignment.Center,
@@ -153,7 +172,7 @@ private fun ReferralsSendGuestPassContent(
                     textColor = Color.Black,
                     gradientBackgroundColor = plusBackgroundBrush,
                     modifier = Modifier.padding(16.dp),
-                    onClick = {},
+                    onClick = onShare,
                 )
             }
         }
@@ -231,6 +250,7 @@ fun ReferralsSendGuestPassContentPreview(
             windowWidthSizeClass = windowWidthSizeClass,
             windowHeightSizeClass = windowHeightSizeClass,
             onDismiss = {},
+            onShare = {},
         )
     }
 }

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -2146,7 +2146,7 @@
     <string name="referrals_send_guest_pass_card_title">2-Month Guest Pass</string>
     <string name="referrals_share_guest_pass">Share Guest Pass</string>
     <string name="referrals_share_subject">2-Month Guest Pass for Pocket&#160;Casts</string>
-    <string name="referrals_share_text_with_url">Hey, check out Pocket&#160;Casts! Use the link below to get a 2-month guest pass for Pocket&#160;Casts&#160;Plus and enjoy podcasts across all your devices!\n\n%1$s</string>
+    <string name="referrals_share_text_with_url">Hey! Use the link below to claim your 2-month guest pass for Pocket&#160;Casts&#160;Plus and enjoy podcasts across all your devices!\n\n%1$s</string>
     <string name="referrals_tooltip_message">Gift 2 months of Pocket&#160;Casts&#160;Plus!</string>
 
 </resources>

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -2145,6 +2145,8 @@
     <string name="referrals_send_guest_pass_title">Gift 2 Months of Pocket&#160;Casts&#160;Plus</string>
     <string name="referrals_send_guest_pass_card_title">2-Month Guest Pass</string>
     <string name="referrals_share_guest_pass">Share Guest Pass</string>
+    <string name="referrals_share_subject">2-Month Guest Pass for Pocket&#160;Casts</string>
+    <string name="referrals_share_text_with_url">Hey, check out Pocket&#160;Casts! Use the link below to get a 2-month guest pass for Pocket&#160;Casts&#160;Plus and enjoy podcasts across all your devices!\n\n%1$s</string>
     <string name="referrals_tooltip_message">Gift 2 months of Pocket&#160;Casts&#160;Plus!</string>
 
 </resources>

--- a/modules/services/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/SharingAnalytics.kt
+++ b/modules/services/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/SharingAnalytics.kt
@@ -31,6 +31,7 @@ internal class SharingAnalytics(
         is SharingRequest.Data.ClipLink -> "clip_link"
         is SharingRequest.Data.ClipAudio -> "clip_audio"
         is SharingRequest.Data.ClipVideo -> "clip_video"
+        is SharingRequest.Data.WebLink -> "web_link"
     }
 
     private val SocialPlatform.analyticsValue get() = when (this) {


### PR DESCRIPTION
## Description
This adds Referrals share dialog with a placeholder url.

## Testing Instructions
1. Login with a paid account
2. Goto Profile tab
3. Tap Gift icon and open send guest pass screen
4. Rotate the device
5. ✅  Notice that send guest pass screen keeps showing
6. Tap Share guest pass button
7. ✅  Notice that share dialog is shown
8. ✅ Notice that share text is shown with a placeholder URL on different platforms

## Screenshots or Screencast 

Dialog | Gmail | Twitter | Telegram | Whatsapp
--|--|--|---|---
<img width=200 src="https://github.com/user-attachments/assets/8cb8f744-5622-4299-b837-6fdfaab50cc2"/>|<img width=200 src="https://github.com/user-attachments/assets/7a858188-9ad1-45c3-ac7e-c4a8b8da281f"/>|<img width=200 src="https://github.com/user-attachments/assets/e08604b4-cf15-4d48-9145-322cf6e36ca8"/>|<img width=200 src="https://github.com/user-attachments/assets/23d229a4-2015-4a24-a6e5-8c9abcdf445e"/>|<img width=200 src="https://github.com/user-attachments/assets/5f33b7bf-3aa5-48a0-bf3e-f5bd3cb5a3b6"/>


## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [x] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
