### PR TITLE
Deep link the referral claim

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -101,6 +101,7 @@ dependencies {
     implementation(projects.modules.features.player)
     implementation(projects.modules.features.podcasts)
     implementation(projects.modules.features.profile)
+    implementation(projects.modules.features.referrals)
     implementation(projects.modules.features.reimagine)
     implementation(projects.modules.features.search)
     implementation(projects.modules.features.settings)

--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/deeplink/DeepLinkFactoryTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/deeplink/DeepLinkFactoryTest.kt
@@ -962,7 +962,7 @@ class DeepLinkFactoryTest {
     }
 
     @Test
-    fun pocketCastsWebsiteReferralDeepLink() {
+    fun referralDeepLink() {
         val intent = Intent()
             .setAction(ACTION_VIEW)
             .setData(Uri.parse("https://pocketcasts.com/redeem-guest-pass/abc"))

--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/deeplink/DeepLinkFactoryTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/deeplink/DeepLinkFactoryTest.kt
@@ -965,7 +965,7 @@ class DeepLinkFactoryTest {
     fun referralDeepLink() {
         val intent = Intent()
             .setAction(ACTION_VIEW)
-            .setData(Uri.parse("https://pocketcasts.com/redeem-guest-pass/abc"))
+            .setData(Uri.parse("https://pocketcasts.com/redeem/abc"))
 
         val deepLink = factory.create(intent)
 

--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/deeplink/DeepLinkFactoryTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/deeplink/DeepLinkFactoryTest.kt
@@ -246,24 +246,21 @@ class DeepLinkFactoryTest {
 
     @Test
     fun pocketCastsWebsiteGetDeepLink() {
-        val intent = Intent()
-            .setAction(ACTION_VIEW)
-            .setData(Uri.parse("https://pocketcasts.com/get"))
+        val urls = listOf(
+            "https://pocketcasts.com/get",
+            "https://pocketcasts.com/get/",
+            "https://pocketcasts.com/get/something?query=value",
+        )
 
-        val deepLink = factory.create(intent)
+        urls.forEach { url ->
+            val intent = Intent()
+                .setAction(ACTION_VIEW)
+                .setData(Uri.parse(url))
 
-        assertEquals(PocketCastsWebsiteGetDeepLink, deepLink)
-    }
+            val deepLink = factory.create(intent)
 
-    @Test
-    fun pocketCastsWebsiteGetSlashDeepLink() {
-        val intent = Intent()
-            .setAction(ACTION_VIEW)
-            .setData(Uri.parse("https://pocketcasts.com/get/"))
-
-        val deepLink = factory.create(intent)
-
-        assertEquals(PocketCastsWebsiteGetDeepLink, deepLink)
+            assertEquals(PocketCastsWebsiteGetDeepLink, deepLink)
+        }
     }
 
     @Test
@@ -972,6 +969,6 @@ class DeepLinkFactoryTest {
 
         val deepLink = factory.create(intent)
 
-        assertEquals(PocketCastsWebsiteReferralDeepLink(code = "abc"), deepLink)
+        assertEquals(ReferralsDeepLink(code = "abc"), deepLink)
     }
 }

--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/deeplink/DeepLinkFactoryTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/deeplink/DeepLinkFactoryTest.kt
@@ -245,14 +245,25 @@ class DeepLinkFactoryTest {
     }
 
     @Test
-    fun pocketCastsWebsiteDeepLink() {
+    fun pocketCastsWebsiteGetDeepLink() {
         val intent = Intent()
             .setAction(ACTION_VIEW)
-            .setData(Uri.parse("https://pocketcasts.com"))
+            .setData(Uri.parse("https://pocketcasts.com/get"))
 
         val deepLink = factory.create(intent)
 
-        assertEquals(PocketCastsWebsiteDeepLink, deepLink)
+        assertEquals(PocketCastsWebsiteGetDeepLink, deepLink)
+    }
+
+    @Test
+    fun pocketCastsWebsiteGetSlashDeepLink() {
+        val intent = Intent()
+            .setAction(ACTION_VIEW)
+            .setData(Uri.parse("https://pocketcasts.com/get/"))
+
+        val deepLink = factory.create(intent)
+
+        assertEquals(PocketCastsWebsiteGetDeepLink, deepLink)
     }
 
     @Test
@@ -951,5 +962,16 @@ class DeepLinkFactoryTest {
         val deepLink = factory.create(intent)
 
         assertEquals(SignInDeepLink(sourceView = "hello"), deepLink)
+    }
+
+    @Test
+    fun pocketCastsWebsiteReferralDeepLink() {
+        val intent = Intent()
+            .setAction(ACTION_VIEW)
+            .setData(Uri.parse("https://pocketcasts.com/redeem-guest-pass/abc"))
+
+        val deepLink = factory.create(intent)
+
+        assertEquals(PocketCastsWebsiteReferralDeepLink(code = "abc"), deepLink)
     }
 }

--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/deeplink/ReferralsDeepLinkTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/deeplink/ReferralsDeepLinkTest.kt
@@ -12,6 +12,6 @@ class ReferralsDeepLinkTest {
     fun createSignInUri() {
         val uri = ReferralsDeepLink("abc").toUri("pocketcasts.com")
 
-        assertEquals(Uri.parse("https://pocketcasts.com/redeem-guest-pass/abc"), uri)
+        assertEquals(Uri.parse("https://pocketcasts.com/redeem/abc"), uri)
     }
 }

--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/deeplink/ReferralsDeepLinkTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/deeplink/ReferralsDeepLinkTest.kt
@@ -1,0 +1,17 @@
+package au.com.shiftyjelly.pocketcasts.deeplink
+
+import android.net.Uri
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class ReferralsDeepLinkTest {
+    @Test
+    fun createSignInUri() {
+        val uri = ReferralsDeepLink("abc").toUri("pocketcasts.com")
+
+        assertEquals(Uri.parse("https://pocketcasts.com/redeem-guest-pass/abc"), uri)
+    }
+}

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -117,6 +117,24 @@
                     android:host="pcast.pocketcasts.net"
                     android:scheme="https"/>
             </intent-filter>
+            <intent-filter android:autoVerify="true">
+                <action android:name="android.intent.action.VIEW"/>
+                <category android:name="android.intent.category.DEFAULT"/>
+                <category android:name="android.intent.category.BROWSABLE"/>
+                <data
+                    android:host="pocket-casts-main-development.mystagingwebsite.com"
+                    android:scheme="https"
+                    android:pathPrefix="/redeem-guest-pass" />
+            </intent-filter>
+            <intent-filter android:autoVerify="true">
+                <action android:name="android.intent.action.VIEW"/>
+                <category android:name="android.intent.category.DEFAULT"/>
+                <category android:name="android.intent.category.BROWSABLE"/>
+                <data
+                    android:host="pocketcasts.com"
+                    android:scheme="https"
+                    android:pathPrefix="/redeem-guest-pass" />
+            </intent-filter>
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
                 <category android:name="android.intent.category.DEFAULT" />

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -124,7 +124,7 @@
                 <data
                     android:host="pocket-casts-main-development.mystagingwebsite.com"
                     android:scheme="https"
-                    android:pathPrefix="/redeem-guest-pass" />
+                    android:pathPrefix="/redeem" />
             </intent-filter>
             <intent-filter android:autoVerify="true">
                 <action android:name="android.intent.action.VIEW"/>
@@ -133,7 +133,7 @@
                 <data
                     android:host="pocketcasts.com"
                     android:scheme="https"
-                    android:pathPrefix="/redeem-guest-pass" />
+                    android:pathPrefix="/redeem" />
             </intent-filter>
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />

--- a/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
+++ b/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
@@ -57,7 +57,8 @@ import au.com.shiftyjelly.pocketcasts.deeplink.DownloadsDeepLink
 import au.com.shiftyjelly.pocketcasts.deeplink.NativeShareDeepLink
 import au.com.shiftyjelly.pocketcasts.deeplink.OpmlImportDeepLink
 import au.com.shiftyjelly.pocketcasts.deeplink.PlayFromSearchDeepLink
-import au.com.shiftyjelly.pocketcasts.deeplink.PocketCastsWebsiteDeepLink
+import au.com.shiftyjelly.pocketcasts.deeplink.PocketCastsWebsiteGetDeepLink
+import au.com.shiftyjelly.pocketcasts.deeplink.PocketCastsWebsiteReferralDeepLink
 import au.com.shiftyjelly.pocketcasts.deeplink.PromoCodeDeepLink
 import au.com.shiftyjelly.pocketcasts.deeplink.ShareListDeepLink
 import au.com.shiftyjelly.pocketcasts.deeplink.ShowBookmarkDeepLink
@@ -104,6 +105,7 @@ import au.com.shiftyjelly.pocketcasts.profile.TrialFinishedFragment
 import au.com.shiftyjelly.pocketcasts.profile.cloud.CloudFileBottomSheetFragment
 import au.com.shiftyjelly.pocketcasts.profile.cloud.CloudFilesFragment
 import au.com.shiftyjelly.pocketcasts.profile.sonos.SonosAppLinkActivity
+import au.com.shiftyjelly.pocketcasts.referrals.ReferralsGuestPassFragment
 import au.com.shiftyjelly.pocketcasts.repositories.bumpstats.BumpStatsTask
 import au.com.shiftyjelly.pocketcasts.repositories.di.ApplicationScope
 import au.com.shiftyjelly.pocketcasts.repositories.di.NotificationPermissionChecker
@@ -1286,8 +1288,11 @@ class MainActivity :
                         }
                     }
                 }
-                is PocketCastsWebsiteDeepLink -> {
+                is PocketCastsWebsiteGetDeepLink -> {
                     // Do nothing when the user goes to https://pocketcasts.com/get it should either open the play store or the user's app
+                }
+                is PocketCastsWebsiteReferralDeepLink -> {
+                    openReferralClaim(deepLink.code)
                 }
                 is ShowPodcastFromUrlDeepLink -> {
                     openPodcastUrl(deepLink.url)
@@ -1338,6 +1343,13 @@ class MainActivity :
             Timber.e(e)
             crashLogging.sendReport(e)
         }
+    }
+
+    private fun openReferralClaim(code: String) {
+        // TODO decide where to store the referral code
+        Timber.i("Referral code: $code")
+        val fragment = ReferralsGuestPassFragment.newInstance(ReferralsGuestPassFragment.ReferralsPageType.Claim)
+        showBottomSheet(fragment)
     }
 
     override fun onConfigurationChanged(newConfig: Configuration) {

--- a/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
+++ b/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
@@ -137,6 +137,8 @@ import au.com.shiftyjelly.pocketcasts.ui.helper.StatusBarColor
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import au.com.shiftyjelly.pocketcasts.ui.theme.ThemeColor
 import au.com.shiftyjelly.pocketcasts.utils.Network
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
 import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
 import au.com.shiftyjelly.pocketcasts.utils.observeOnce
 import au.com.shiftyjelly.pocketcasts.view.BottomNavHideManager
@@ -1346,6 +1348,9 @@ class MainActivity :
     }
 
     private fun openReferralClaim(code: String) {
+        if (!FeatureFlag.isEnabled(Feature.REFERRALS)) {
+            return
+        }
         // TODO decide where to store the referral code
         Timber.i("Referral code: $code")
         val fragment = ReferralsGuestPassFragment.newInstance(ReferralsGuestPassFragment.ReferralsPageType.Claim)

--- a/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
+++ b/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
@@ -58,8 +58,8 @@ import au.com.shiftyjelly.pocketcasts.deeplink.NativeShareDeepLink
 import au.com.shiftyjelly.pocketcasts.deeplink.OpmlImportDeepLink
 import au.com.shiftyjelly.pocketcasts.deeplink.PlayFromSearchDeepLink
 import au.com.shiftyjelly.pocketcasts.deeplink.PocketCastsWebsiteGetDeepLink
-import au.com.shiftyjelly.pocketcasts.deeplink.PocketCastsWebsiteReferralDeepLink
 import au.com.shiftyjelly.pocketcasts.deeplink.PromoCodeDeepLink
+import au.com.shiftyjelly.pocketcasts.deeplink.ReferralsDeepLink
 import au.com.shiftyjelly.pocketcasts.deeplink.ShareListDeepLink
 import au.com.shiftyjelly.pocketcasts.deeplink.ShowBookmarkDeepLink
 import au.com.shiftyjelly.pocketcasts.deeplink.ShowDiscoverDeepLink
@@ -1293,7 +1293,7 @@ class MainActivity :
                 is PocketCastsWebsiteGetDeepLink -> {
                     // Do nothing when the user goes to https://pocketcasts.com/get it should either open the play store or the user's app
                 }
-                is PocketCastsWebsiteReferralDeepLink -> {
+                is ReferralsDeepLink -> {
                     openReferralClaim(deepLink.code)
                 }
                 is ShowPodcastFromUrlDeepLink -> {

--- a/modules/services/deeplink/src/main/kotlin/au/com/shiftyjelly/pocketcasts/deeplink/DeepLink.kt
+++ b/modules/services/deeplink/src/main/kotlin/au/com/shiftyjelly/pocketcasts/deeplink/DeepLink.kt
@@ -246,7 +246,17 @@ data class SignInDeepLink(
 
 data class ReferralsDeepLink(
     val code: String,
-) : DeepLink
+) : UriDeepLink {
+    // Use the marketing website as the share host, for example https://pocketcsts.com/redeem-guest-pass/abc
+    override fun toUri(shareHost: String): Uri {
+        return Uri.Builder()
+            .scheme("https")
+            .authority(shareHost)
+            .appendPath("redeem-guest-pass")
+            .appendPath(code)
+            .build()
+    }
+}
 
 private val Context.launcherIntent get() = requireNotNull(packageManager.getLaunchIntentForPackage(packageName)) {
     "Missing launcher intent for $packageName"

--- a/modules/services/deeplink/src/main/kotlin/au/com/shiftyjelly/pocketcasts/deeplink/DeepLink.kt
+++ b/modules/services/deeplink/src/main/kotlin/au/com/shiftyjelly/pocketcasts/deeplink/DeepLink.kt
@@ -247,12 +247,12 @@ data class SignInDeepLink(
 data class ReferralsDeepLink(
     val code: String,
 ) : UriDeepLink {
-    // Use the marketing website as the share host, for example https://pocketcsts.com/redeem-guest-pass/abc
+    // Use the marketing website as the share host, for example https://pocketcsts.com/redeem/abc
     override fun toUri(shareHost: String): Uri {
         return Uri.Builder()
             .scheme("https")
             .authority(shareHost)
-            .appendPath("redeem-guest-pass")
+            .appendPath("redeem")
             .appendPath(code)
             .build()
     }

--- a/modules/services/deeplink/src/main/kotlin/au/com/shiftyjelly/pocketcasts/deeplink/DeepLink.kt
+++ b/modules/services/deeplink/src/main/kotlin/au/com/shiftyjelly/pocketcasts/deeplink/DeepLink.kt
@@ -244,7 +244,7 @@ data class SignInDeepLink(
     }
 }
 
-data class PocketCastsWebsiteReferralDeepLink(
+data class ReferralsDeepLink(
     val code: String,
 ) : DeepLink
 

--- a/modules/services/deeplink/src/main/kotlin/au/com/shiftyjelly/pocketcasts/deeplink/DeepLink.kt
+++ b/modules/services/deeplink/src/main/kotlin/au/com/shiftyjelly/pocketcasts/deeplink/DeepLink.kt
@@ -173,7 +173,7 @@ data class ShowFilterDeepLink(
         .putExtra(EXTRA_FILTER_ID, filterId)
 }
 
-data object PocketCastsWebsiteDeepLink : DeepLink
+data object PocketCastsWebsiteGetDeepLink : DeepLink
 
 data class ShowPodcastFromUrlDeepLink(
     val url: String,
@@ -243,6 +243,10 @@ data class SignInDeepLink(
             .build()
     }
 }
+
+data class PocketCastsWebsiteReferralDeepLink(
+    val code: String,
+) : DeepLink
 
 private val Context.launcherIntent get() = requireNotNull(packageManager.getLaunchIntentForPackage(packageName)) {
     "Missing launcher intent for $packageName"

--- a/modules/services/deeplink/src/main/kotlin/au/com/shiftyjelly/pocketcasts/deeplink/DeepLinkFactory.kt
+++ b/modules/services/deeplink/src/main/kotlin/au/com/shiftyjelly/pocketcasts/deeplink/DeepLinkFactory.kt
@@ -202,7 +202,7 @@ private class ReferralsAdapter(
         return if (intent.action == ACTION_VIEW &&
             data.host == webBaseHost &&
             pathSegments.size == 2 &&
-            pathSegments.first() == "redeem-guest-pass"
+            pathSegments.first() == "redeem"
         ) {
             ReferralsDeepLink(code = pathSegments.last())
         } else {

--- a/modules/services/deeplink/src/main/kotlin/au/com/shiftyjelly/pocketcasts/deeplink/DeepLinkFactory.kt
+++ b/modules/services/deeplink/src/main/kotlin/au/com/shiftyjelly/pocketcasts/deeplink/DeepLinkFactory.kt
@@ -41,7 +41,8 @@ class DeepLinkFactory(
         ShowPodcastAdapter(),
         ShowEpisodeAdapter(),
         ShowPageAdapter(),
-        PocketCastsWebsiteAdapter(webBaseHost),
+        PocketCastsWebsiteGetAdapter(webBaseHost),
+        PocketCastsWebsiteReferralAdapter(webBaseHost),
         PodloveAdapter(),
         SonosAdapter(),
         ShareListAdapter(listHost),
@@ -49,7 +50,7 @@ class DeepLinkFactory(
         SubscribeOnAndroidAdapter(),
         AppleAdapter(),
         CloudFilesAdapter(),
-        UpdageAccountAdapter(),
+        UpgradeAccountAdapter(),
         PromoCodeAdapter(),
         ShareLinkNativeAdapter(),
         SignInAdapter(shareHost),
@@ -176,13 +177,37 @@ private class ShowPageAdapter : DeepLinkAdapter {
     }
 }
 
-private class PocketCastsWebsiteAdapter(
+private class PocketCastsWebsiteGetAdapter(
     private val webBaseHost: String,
 ) : DeepLinkAdapter {
-    override fun create(intent: Intent) = if (intent.action == ACTION_VIEW && intent.data?.host == webBaseHost) {
-        PocketCastsWebsiteDeepLink
-    } else {
-        null
+    override fun create(intent: Intent): DeepLink? {
+        val data = intent.data ?: return null
+        val pathSegments = data.pathSegments
+
+        return if (intent.action == ACTION_VIEW && data.host == webBaseHost && pathSegments.isNotEmpty() && pathSegments.first() == "get") {
+            PocketCastsWebsiteGetDeepLink
+        } else {
+            null
+        }
+    }
+}
+
+private class PocketCastsWebsiteReferralAdapter(
+    private val webBaseHost: String,
+) : DeepLinkAdapter {
+    override fun create(intent: Intent): DeepLink? {
+        val data = intent.data ?: return null
+        val pathSegments = data.pathSegments
+
+        return if (intent.action == ACTION_VIEW &&
+            data.host == webBaseHost &&
+            pathSegments.size == 2 &&
+            pathSegments.first() == "redeem-guest-pass"
+        ) {
+            PocketCastsWebsiteReferralDeepLink(code = pathSegments.last())
+        } else {
+            null
+        }
     }
 }
 
@@ -300,7 +325,7 @@ private class CloudFilesAdapter : DeepLinkAdapter {
     }
 }
 
-private class UpdageAccountAdapter : DeepLinkAdapter {
+private class UpgradeAccountAdapter : DeepLinkAdapter {
     override fun create(intent: Intent): DeepLink? {
         val uriData = intent.data
         val scheme = uriData?.scheme

--- a/modules/services/deeplink/src/main/kotlin/au/com/shiftyjelly/pocketcasts/deeplink/DeepLinkFactory.kt
+++ b/modules/services/deeplink/src/main/kotlin/au/com/shiftyjelly/pocketcasts/deeplink/DeepLinkFactory.kt
@@ -56,7 +56,7 @@ class DeepLinkFactory(
         SignInAdapter(shareHost),
         ShareLinkAdapter(shareHost),
         OpmlAdapter(listOf(listHost, shareHost)),
-        PodcastUrlSchemeAdapter(listOf(listHost, shareHost)),
+        PodcastUrlSchemeAdapter(listOf(listHost, shareHost, webBaseHost)),
         PlayFromSearchAdapter(),
         AssistantAdapter(),
     )

--- a/modules/services/deeplink/src/main/kotlin/au/com/shiftyjelly/pocketcasts/deeplink/DeepLinkFactory.kt
+++ b/modules/services/deeplink/src/main/kotlin/au/com/shiftyjelly/pocketcasts/deeplink/DeepLinkFactory.kt
@@ -42,7 +42,7 @@ class DeepLinkFactory(
         ShowEpisodeAdapter(),
         ShowPageAdapter(),
         PocketCastsWebsiteGetAdapter(webBaseHost),
-        PocketCastsWebsiteReferralAdapter(webBaseHost),
+        ReferralsAdapter(webBaseHost),
         PodloveAdapter(),
         SonosAdapter(),
         ShareListAdapter(listHost),
@@ -192,7 +192,7 @@ private class PocketCastsWebsiteGetAdapter(
     }
 }
 
-private class PocketCastsWebsiteReferralAdapter(
+private class ReferralsAdapter(
     private val webBaseHost: String,
 ) : DeepLinkAdapter {
     override fun create(intent: Intent): DeepLink? {
@@ -204,7 +204,7 @@ private class PocketCastsWebsiteReferralAdapter(
             pathSegments.size == 2 &&
             pathSegments.first() == "redeem-guest-pass"
         ) {
-            PocketCastsWebsiteReferralDeepLink(code = pathSegments.last())
+            ReferralsDeepLink(code = pathSegments.last())
         } else {
             null
         }


### PR DESCRIPTION
## Description

This change adds support for the referral claim URL deep link. 

## Testing Instructions
1. Check the Referrals feature flag is on
2. Click on this link on the device https://pocket-casts-main-development.mystagingwebsite.com/redeem-guest-pass/secret-referral-code
3. ✅ Verify the claim screen is shown to the user
4. Click on this link https://pocket-casts-main-development.mystagingwebsite.com
5. ✅ Verify the website is opened and the app isn't
6. Click on this link https://pocket-casts-main-development.mystagingwebsite.com/get
7. ✅ Verify the app is opened
8. Turn off the Referrals feature flag
9. Click on this link on the device https://pocket-casts-main-development.mystagingwebsite.com/redeem-guest-pass/secret-referral-code
10. ✅ Verify the claim screen isn't shown to the user

## Screenshots or Screencast 

https://github.com/user-attachments/assets/99a6b097-35e0-4f54-92d7-6430572b146f

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.

