### PR TITLE
Fix the developer page new episode notification

### DIFF
--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/developer/DeveloperViewModel.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/developer/DeveloperViewModel.kt
@@ -12,7 +12,6 @@ import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
 import com.automattic.android.tracks.crashlogging.CrashLogging
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
-import io.reactivex.disposables.CompositeDisposable
 import javax.inject.Inject
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -35,11 +34,8 @@ class DeveloperViewModel
     private val crashLogging: CrashLogging,
 ) : ViewModel() {
 
-    private val disposables = CompositeDisposable()
-
     fun forceRefresh() {
         podcastManager.refreshPodcasts(fromLog = "dev")
-        Toast.makeText(context, "Refresh started", Toast.LENGTH_LONG).show()
     }
 
     fun triggerNotification() {
@@ -73,6 +69,9 @@ class DeveloperViewModel
                         }
                     }
                     forceRefresh()
+                    withContext(Dispatchers.Main) {
+                        Toast.makeText(context, "Refresh started", Toast.LENGTH_LONG).show()
+                    }
                 }
             } catch (e: Exception) {
                 Timber.e(e)
@@ -116,11 +115,6 @@ class DeveloperViewModel
                 }
             }
         }
-    }
-
-    override fun onCleared() {
-        super.onCleared()
-        disposables.clear()
     }
 
     @OptIn(ExperimentalCoroutinesApi::class)


### PR DESCRIPTION
## Description

The developer page feature to test episode notifications shows a toast error as it was being sent on the wrong thread.

```
java.lang.NullPointerException: Can't toast on a thread that has not called Looper.prepare()
	at com.android.internal.util.Preconditions.checkNotNull(Preconditions.java:168)
	at android.widget.Toast.getLooper(Toast.java:186)
	at android.widget.Toast.<init>(Toast.java:171)
	at android.widget.Toast.makeText(Toast.java:502)
	at android.widget.Toast.makeText(Toast.java:491)
	at au.com.shiftyjelly.pocketcasts.settings.developer.DeveloperViewModel.forceRefresh(DeveloperViewModel.kt:42)
	at au.com.shiftyjelly.pocketcasts.settings.developer.DeveloperViewModel$triggerNotification$1.invokeSuspend(DeveloperViewModel.kt:75)
	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
	at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:104)
	at kotlinx.coroutines.internal.LimitedDispatcher$Worker.run(LimitedDispatcher.kt:111)
	at kotlinx.coroutines.scheduling.TaskImpl.run(Tasks.kt:99)
	at kotlinx.coroutines.scheduling.CoroutineScheduler.runSafely(CoroutineScheduler.kt:584)
	at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.executeTask(CoroutineScheduler.kt:811)
	at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.runWorker(CoroutineScheduler.kt:715)
	at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.run(CoroutineScheduler.kt:702)
```

## Testing Instructions
1. Subscribe to some podcasts
2. Go to Profile -> Settings -> Notifications
3. Toggle on "Notify me"
4. Go back
5. Tap "Developer"
6. Tap "Trigger new episode notification"
7. ✅ Verify the error isn't shown

## Screenshots or Screencast 

| Before | After |
| --- | --- |
| ![Screenshot_20240918_201153](https://github.com/user-attachments/assets/7ac3ff2b-f8dc-4060-a4e9-15b61afee3f8) | ![Screenshot_20240918_200238](https://github.com/user-attachments/assets/3d6243fb-1af2-4d4f-ab75-8a557e9e99c7) | 

