### PR TITLE
Clean up R8 configuration

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -11,7 +11,6 @@
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
 #Mon Mar 30 10:47:43 AEDT 2020
-android.nonTransitiveRClass=true
 android.useAndroidX=true
 
 # Disable unused Android Gradle Plugin features

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/type/SubscriptionFrequency.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/type/SubscriptionFrequency.kt
@@ -1,8 +1,10 @@
 package au.com.shiftyjelly.pocketcasts.models.type
 
 import androidx.annotation.StringRes
+import com.squareup.moshi.JsonClass
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
+@JsonClass(generateAdapter = false)
 enum class SubscriptionFrequency(val label: String, @StringRes val localisedLabelRes: Int) {
     NONE("none", LR.string.none),
     MONTHLY("monthly", LR.string.plus_monthly),

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/type/SubscriptionPlatform.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/type/SubscriptionPlatform.kt
@@ -1,5 +1,8 @@
 package au.com.shiftyjelly.pocketcasts.models.type
 
+import com.squareup.moshi.JsonClass
+
+@JsonClass(generateAdapter = false)
 enum class SubscriptionPlatform(val label: String) {
     NONE("none"),
     IOS("ios"),

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/type/SubscriptionTier.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/type/SubscriptionTier.kt
@@ -1,7 +1,9 @@
 package au.com.shiftyjelly.pocketcasts.models.type
 
 import au.com.shiftyjelly.pocketcasts.utils.featureflag.UserTier
+import com.squareup.moshi.JsonClass
 
+@JsonClass(generateAdapter = false)
 enum class SubscriptionTier(val label: String) {
     NONE("none"),
     PLUS("plus"),

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/type/SubscriptionType.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/type/SubscriptionType.kt
@@ -1,10 +1,13 @@
 package au.com.shiftyjelly.pocketcasts.models.type
 
- /* pdeCcb-2fL-p2#comment-2074
+import com.squareup.moshi.JsonClass
+
+/* pdeCcb-2fL-p2#comment-2074
 The SubscriptionType field will always be Plus.
 It is being replaced by SubscriptionTier with Plus and Patron tiers but currently not supported in production.
 This can be removed once SubscriptionTier is supported.
 */
+@JsonClass(generateAdapter = false)
 enum class SubscriptionType(val label: String) {
     NONE("none"),
     PLUS("plus"),

--- a/proguard-rules.pro
+++ b/proguard-rules.pro
@@ -43,7 +43,7 @@
 # ███████ ███████  ██████  ██   ██  ██████    ██         ██████  ██████  ██   ████ ██      ██  ██████
 #
 # Configuration under this block is a legacy config that needs to be properly tested before removing.
-# If work on any of the entries please move it to above and add an appropriate comment on what it does and why do we keep it.
+# If you work on any of the entries please move them above and add an appropriate comment on what they do and why do we keep them.
 
 # No explanation was provided for this rule
 -keep public class android.support.v4.media.session.** { *; }

--- a/proguard-rules.pro
+++ b/proguard-rules.pro
@@ -1,189 +1,66 @@
-# Add project specific ProGuard rules here.
-# By default, the flags in this file are appended to flags specified
-# in /Applications/android-sdk/tools/proguard/proguard-android.txt
-# You can edit the include path and order by changing the proguardFiles
-# directive in build.gradle.
-#
-# For more details, see
-#   http://developer.android.com/guide/developing/tools/proguard.html
+# Output more information during processing
+-verbose
 
-# Add any project specific keep options here:
+# Make sure that the class loading doesn't fail if the file system is case-insesitive
+-dontusemixedcaseclassnames
 
-# If your project uses WebView with JS, uncomment the following
-# and specify the fully qualified class name to the JavaScript interface
-# class:
-#-keepclassmembers class fqcn.of.javascript.interface.for.webview {
-#   public *;
-#}
+# Preserve some attributes that may be required for reflection
+-keepattributes *Annotation*,Signature,InnerClasses,EnclosingMethod
 
-# Without this the playback notification doesn't show up on fresh launch
-# https://github.com/shiftyjelly/pocketcasts-android/issues/1656
--keep class au.com.shiftyjelly.pocketcasts.core.player.** { *; }
-
--dontwarn android.test.**
--dontwarn org.junit.internal.runners.statements.**
--dontwarn org.junit.rules.**
--dontwarn org.hamcrest.SelfDescribing
--dontwarn org.hamcrest.StringDescription
-# retrolambda
--dontwarn java.lang.invoke.*
-# okhttp
--dontwarn com.squareup.okhttp.**
--dontwarn org.conscrypt.**
--dontwarn okio.**
-# Platform calls Class.forName on types which do not exist on Android to determine platform.
--dontnote retrofit2.Platform
-# Platform used when running on Java 8 VMs. Will not be used at runtime.
--dontwarn retrofit2.Platform$Java8
-# Retain generic type information for use by reflection by converters and adapters.
--keepattributes Signature
-# Retain declared checked exceptions for use by a Proxy instance.
--keepattributes Exceptions
--keepattributes *Annotation*
-
-# kotlin
--keepclassmembernames class kotlinx.** {
-    volatile <fields>;
+# Assume isInEditMode() always return false in release builds so they can be pruned
+-assumevalues public class * extends android.view.View {
+  boolean isInEditMode() return false;
 }
 
-# appcompat
--keep public class android.support.v7.widget.** { *; }
--keep public class android.support.v7.internal.widget.** { *; }
--keep public class android.support.v7.internal.view.menu.** { *; }
--keep public class android.support.v4.media.session.** { *; }
--keep public class * extends android.support.v4.view.ActionProvider {
-    public <init>(android.content.Context);
+# Ensure the custom, fast service loader implementation is removed. R8 will fold these for us
+-assumenosideeffects class kotlinx.coroutines.internal.MainDispatcherLoader {
+    boolean FAST_SERVICE_LOADER_ENABLED return false;
 }
-
-# dagger 2
--dontwarn com.google.errorprone.annotations.*
-
--keepattributes *Annotation*
--keepattributes SourceFile,LineNumberTable
--keep public class * extends java.lang.Exception
--keep class com.google.android.gms.measurement.** { *; }
--dontwarn com.google.android.gms.measurement.**
-
-# chrome cast
--keep class androidx.media3.cast.DefaultCastOptionsProvider { *; }
--keep class androidx.mediarouter.app.MediaRouteActionProvider { *; }
--keep class au.com.shiftyjelly.pocketcasts.CastOptionsProvider { *; }
-
--keepclassmembers enum * {
-    <fields>;
-    public static **[] values();
-    public static ** valueOf(java.lang.String);
+-assumenosideeffects class kotlinx.coroutines.internal.FastServiceLoader {
+    boolean ANDROID_DETECTED return true;
 }
-
-# retrofit
--dontwarn retrofit2.**
--keep class retrofit2.** { *; }
--keepattributes Signature
--keepattributes Exceptions
--keepclasseswithmembers class * {
-    @retrofit2.http.* <methods>;
-}
--dontwarn okhttp3.**
--dontwarn retrofit2.Platform$Java8
--dontwarn javax.annotation.**
-
-# moshi
--dontwarn okio.**
--dontwarn javax.annotation.**
--keepclasseswithmembers class * {
-    @com.squareup.moshi.* <methods>;
-}
--keep @com.squareup.moshi.JsonQualifier interface *
--keep class **JsonAdapter {
-    <init>(...);
-    <fields>;
-}
--keepnames @com.squareup.moshi.JsonClass class *
-
-# Enum field names are used by the integrated EnumJsonAdapter.
-# Annotate enums with @JsonClass(generateAdapter = false) to use them with Moshi.
--keepclassmembers @com.squareup.moshi.JsonClass class * extends java.lang.Enum {
-    <fields>;
-}
-
-# Retain generated JsonAdapters if annotated type is retained.
--if @com.squareup.moshi.JsonClass class *
--keep class <1>JsonAdapter {
-    <init>(...);
-    <fields>;
-}
-
-# Keep layout classes
--keep class * extends android.view.View
-
-# clean up notes
--dontnote io.reactivex.**
--dontnote com.facebook.stetho.**
--dontnote com.afollestad.materialdialogs.internal.**
--dontnote com.astuetz.**
--dontnote com.google.android.gms.**
--dontnote com.google.android.material.**
--dontnote io.fabric.sdk.**
--dontnote com.google.firebase.**
--dontnote okhttp3.**
--dontnote retrofit2.**
--dontwarn com.google.common.**
-
-# requested by Adam for MediaCompat and Android Auto
--keep class android.support.v4.media.** implements android.os.Parcelable {
-   public static final ** CREATOR;
-}
-
-# corountines
--keepnames class kotlinx.coroutines.experimental.internal.MainDispatcherFactory {}
--dontwarn kotlinx.coroutines.**
-
-## remove our logs
-#-assumenosideeffects class timber.log.Timber {
-#    public static *** e(...);
-#    public static *** d(...);
-#    public static *** w(...);
-#    public static *** i(...);
-#}
-#
-#-assumenosideeffects class au.com.shiftyjelly.pocketcasts.core.helper.log.TimberHelper {
-#    public static *** sql(...);
-#}
-
-# Resolve AGP 8.0 update missing class errors by keeping the current behavior
-# Example failure:
-#
-# > Task :modules:services:model:minifyReleaseWithR8 FAILED
-# ERROR: Missing classes detected while running R8. Please add the missing classes or apply additional keep rules that are generated in ~/pocket-casts-android/modules/services/model/build/outputs/mapping/release/missing_rules.txt.
-# ERROR: R8: Missing class au.com.shiftyjelly.pocketcasts.localization.R$string (referenced from: void au.com.shiftyjelly.pocketcasts.models.type.SubscriptionFrequency.<clinit>())
--dontwarn au.com.shiftyjelly.pocketcasts.*.R$array
--dontwarn au.com.shiftyjelly.pocketcasts.*.R$attr
--dontwarn au.com.shiftyjelly.pocketcasts.*.R$color
--dontwarn au.com.shiftyjelly.pocketcasts.*.R$drawable
--dontwarn au.com.shiftyjelly.pocketcasts.*.R$id
--dontwarn au.com.shiftyjelly.pocketcasts.*.R$layout
--dontwarn au.com.shiftyjelly.pocketcasts.*.R$string
--dontwarn au.com.shiftyjelly.pocketcasts.*.R$style
--dontwarn au.com.shiftyjelly.pocketcasts.*.R$styleable
--dontwarn com.google.android.material.R$attr
--dontwarn com.google.android.material.R$dimen
--dontwarn com.google.android.material.R$style
--dontwarn com.google.android.material.R$styleable
-
-# The following Retrofit rules are only be required until Retrofit 2.10.0 is released as it's included https://github.com/square/retrofit/blob/master/retrofit/src/main/resources/META-INF/proguard/retrofit2.pro
-
-# With R8 full mode generic signatures are stripped for classes that are not kept.
-# Suspend functions are wrapped in continuations where the type argument is used.
--keep,allowobfuscation,allowshrinking class kotlin.coroutines.Continuation
-
-# R8 full mode strips generic signatures from return types if not kept.
--if interface * { @retrofit2.http.* public *** *(...); }
--keep,allowoptimization,allowshrinking,allowobfuscation class <3>
+-checkdiscard class kotlinx.coroutines.internal.FastServiceLoader
 
 # Protocol Buffers - keep the field names
 -keep class * extends com.google.protobuf.GeneratedMessageLite { *; }
 
-# Hilt, https://github.com/google/dagger/issues/4323
+# https://github.com/google/dagger/issues/4323
 -keepclasseswithmembers,includedescriptorclasses class * {
    @dagger.internal.KeepFieldType <fields>;
 }
+
+# https://github.com/square/retrofit/issues/4134
+-if interface *
+-keepclasseswithmembers,allowobfuscation interface <1> {
+  @retrofit2.http.* <methods>;
+}
+
+#
+# ██      ███████  ██████   █████   ██████ ██    ██      ██████  ██████  ███    ██ ███████ ██  ██████
+# ██      ██      ██       ██   ██ ██       ██  ██      ██      ██    ██ ████   ██ ██      ██ ██
+# ██      █████   ██   ███ ███████ ██        ████       ██      ██    ██ ██ ██  ██ █████   ██ ██   ███
+# ██      ██      ██    ██ ██   ██ ██         ██        ██      ██    ██ ██  ██ ██ ██      ██ ██    ██
+# ███████ ███████  ██████  ██   ██  ██████    ██         ██████  ██████  ██   ████ ██      ██  ██████
+#
+# Configuration under this block is a legacy config that needs to be properly tested before removing.
+# If work on any of the entries please move it to above and add an appropriate comment on what it does and why do we keep it.
+
+# No explanation was provided for this rule
+-keep public class android.support.v4.media.session.** { *; }
+
+# Requested by Adam for MediaCompat and Android Auto
+-keep class android.support.v4.media.** implements android.os.Parcelable {
+   public static final ** CREATOR;
+}
+
+# Chrome cast
+-keep class androidx.media3.cast.DefaultCastOptionsProvider { *; }
+-keep class androidx.mediarouter.app.MediaRouteActionProvider { *; }
+-keep class au.com.shiftyjelly.pocketcasts.CastOptionsProvider { *; }
+
+# Keep layout classes
+-keep class * extends android.view.View
+
+# Without this the playback notification doesn't show up on fresh launch
+# https://github.com/shiftyjelly/pocketcasts-android/issues/1656
+-keep class au.com.shiftyjelly.pocketcasts.core.player.** { *; }


### PR DESCRIPTION
## Description

This PR cleans up our R8 configuration by removing several rules that are now provided by the libraries themselves. I’ve added descriptions for all the applied rules or linked them to the relevant issues.

The main risk involves missing the `@JsonClass(generateAdapter = false)` annotation on some classes. However, I have extensively tested the app and analyzed the code to the best of my ability to identify any issues. The core flows are functioning correctly. If any issues arise, they should be easy to detect and resolve once users engage with the app.

## Testing Instructions

Test the release variants of the app. I have tested the following:

* All three apps
* Major features:
   * Signing in
   * Subscriptions
   * Playback
   * Google Cast
   * Sharing
   * Bookmarks
   * Folders
   * Chapters
   * Discover
   * Filters

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
