### PR TITLE
Revert gradle-build-action to v2

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,10 @@ updates:
     labels:
       - "[Type] Tech Debt"
       - "[Area] Dependencies"
+    ignore:
+      # These dependencies cannot be updated beyond v2 for non-Enterpise clients
+      - dependency-name: "gradle-build-action"
+      - dependency-name: "wrapper-validation-action"
   - package-ecosystem: "gradle"
     open-pull-requests-limit: 8
     directory: "/"

--- a/.github/workflows/submit-gradle-dependencies.yml
+++ b/.github/workflows/submit-gradle-dependencies.yml
@@ -16,7 +16,7 @@ jobs:
           distribution: 'temurin'
           java-version: '17'
       - name: Setup Gradle to generate and submit dependency graphs
-        uses: gradle/gradle-build-action@v3
+        uses: gradle/gradle-build-action@v2
         with:
           dependency-graph: generate-and-submit
       - name: Generate the dependency graph which will be submitted post-job


### PR DESCRIPTION
## Description

`gradle-build-action` started failing because it is not available to us. It wasn't detected in the PR because the action is not used for pull requests and there was no mention of it in the release notes.

> Error: Bad request - gradle/actions/setup-gradle@v3.5.0 is not allowed to be used in Automattic/pocket-casts-android. Actions in this workflow must be: within a repository that belongs to your Enterprise account, created by GitHub, or matching the following: ruby/setup-ruby@*, gradle/wrapper-validation-action@*, gradle/gradle-build-action@*.

## Testing Instructions

CI check is fine.

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [ ] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
