### PR TITLE
Change the background animation of referral cards

### DIFF
--- a/modules/features/referrals/src/main/kotlin/au/com/shiftyjelly/pocketcasts/referrals/ReferralCardAnimatedGradientView.kt
+++ b/modules/features/referrals/src/main/kotlin/au/com/shiftyjelly/pocketcasts/referrals/ReferralCardAnimatedGradientView.kt
@@ -1,22 +1,16 @@
 package au.com.shiftyjelly.pocketcasts.referrals
 
+import android.content.Context
 import android.os.Build
-import androidx.compose.animation.core.AnimationVector2D
-import androidx.compose.animation.core.LinearOutSlowInEasing
-import androidx.compose.animation.core.RepeatMode
-import androidx.compose.animation.core.Spring
-import androidx.compose.animation.core.TwoWayConverter
+import androidx.compose.animation.core.AnimationSpec
 import androidx.compose.animation.core.animateIntOffsetAsState
-import androidx.compose.animation.core.animateValue
-import androidx.compose.animation.core.infiniteRepeatable
-import androidx.compose.animation.core.keyframes
-import androidx.compose.animation.core.rememberInfiniteTransition
 import androidx.compose.animation.core.spring
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.requiredSize
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.runtime.Composable
@@ -26,7 +20,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.blur
-import androidx.compose.ui.draw.clipToBounds
 import androidx.compose.ui.draw.rotate
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Brush
@@ -35,43 +28,63 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewParameter
+import androidx.compose.ui.tooling.preview.PreviewParameterProvider
 import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.dp
 import androidx.compose.ui.util.lerp
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import au.com.shiftyjelly.pocketcasts.compose.extensions.rainbowBrush
 import au.com.shiftyjelly.pocketcasts.utils.DeviceOrientationDetector
 import au.com.shiftyjelly.pocketcasts.utils.OrientationData
-import kotlin.math.absoluteValue
-import kotlin.math.roundToInt
+import kotlin.coroutines.coroutineContext
+import kotlin.math.atan
 import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.FlowPreview
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.sample
+import kotlinx.coroutines.isActive
 import au.com.shiftyjelly.pocketcasts.images.R as IR
 
 @Composable
 fun ReferralCardAnimatedBackgroundView(
     modifier: Modifier = Modifier,
+) = ReferralCardAnimatedBackgroundView(
+    initialOrientation = OrientationData(roll = 0f, pitch = 0f),
+    modifier = modifier,
+)
+
+@Composable
+private fun ReferralCardAnimatedBackgroundView(
+    initialOrientation: OrientationData,
+    modifier: Modifier = Modifier,
 ) {
     BoxWithConstraints(
         modifier = modifier,
     ) {
+        val maxWidth = maxWidth
+        val maxHeight = maxHeight
+
         Box(
             contentAlignment = Alignment.Center,
             modifier = modifier
-                .blur(maxWidth / 3)
-                .background(Color.Black)
-                .clipToBounds(),
+                .blur(maxWidth / 10)
+                .background(Color.Black),
         ) {
             val density = LocalDensity.current
-            val circleSize = this@BoxWithConstraints.maxHeight
+            val circleSize = maxHeight * 1.3f
             val circleSizePx = density.run { circleSize.toPx() }
-            val maxWidthPx = density.run { this@BoxWithConstraints.maxWidth.roundToPx() }
-            val maxHeightPx = density.run { this@BoxWithConstraints.maxHeight.roundToPx() }
+            val maxWidthPx = density.run { maxWidth.roundToPx() }
+            val maxHeightPx = density.run { maxHeight.roundToPx() }
 
-            val animationData = updateAnimationData(maxWidthPx, maxHeightPx)
+            val animationData = updateAnimationData(initialOrientation, maxWidthPx, maxHeightPx)
 
             GradientCircle(
                 circleSize = circleSize,
@@ -79,7 +92,9 @@ fun ReferralCardAnimatedBackgroundView(
                     start = Offset(0.12f * circleSizePx, 0f * circleSizePx),
                     end = Offset(0.89f * circleSizePx, 0.95f * circleSizePx),
                 ),
-                offset = animationData.offset,
+                modifier = Modifier
+                    .offset(x = -maxWidth / 1.8f, y = -maxHeight / 4f)
+                    .offset { animationData.topLeftOffset },
             )
 
             GradientCircle(
@@ -88,8 +103,10 @@ fun ReferralCardAnimatedBackgroundView(
                     start = Offset(0.29f * circleSizePx, 0.19f * circleSizePx),
                     end = Offset(0.87f * circleSizePx, 1.18f * circleSizePx),
                 ),
-                offset = IntOffset(-animationData.offset.x, -animationData.offset.y),
                 rotation = 45f,
+                modifier = Modifier
+                    .offset(x = maxWidth / 1.7f, y = maxHeight / 3.5f)
+                    .offset { animationData.bottomRightOffset },
             )
         }
     }
@@ -98,17 +115,14 @@ fun ReferralCardAnimatedBackgroundView(
 @Composable
 private fun GradientCircle(
     circleSize: Dp,
-    offset: IntOffset,
     backgroundBrush: Brush,
+    modifier: Modifier = Modifier,
     rotation: Float = 0f,
 ) {
-    val modifier = Modifier
-        .offset { offset }
-
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
         Box(
             modifier = modifier
-                .size(circleSize)
+                .requiredSize(circleSize)
                 .background(
                     brush = backgroundBrush,
                     shape = CircleShape,
@@ -121,135 +135,187 @@ private fun GradientCircle(
             contentScale = ContentScale.Crop,
             modifier = modifier
                 .rotate(rotation)
-                .size(circleSize * 1.25f),
+                .requiredSize(circleSize * 1.25f),
         )
     }
 }
 
-@OptIn(FlowPreview::class)
 @Composable
 private fun updateAnimationData(
+    initialOrientation: OrientationData,
     maxWidthPx: Int,
     maxHeightPx: Int,
 ): AnimationData {
     val context = LocalContext.current
-    val sensorOrientationFlow = remember { DeviceOrientationDetector.create(context)?.orientationData()?.sample(100.milliseconds) }
-
-    return if (sensorOrientationFlow == null) {
-        infinityAnimationData(maxWidthPx, maxHeightPx)
-    } else {
-        sensorAnimationData(sensorOrientationFlow, maxWidthPx, maxHeightPx)
+    val (orientationFlow, animationSpec) = remember {
+        val sensorFlow = sensorOrientationFlow(context)
+        if (sensorFlow != null) {
+            sensorFlow to sensorAnimationSpec
+        } else {
+            computedOrientationFlow to computedAnimationSpec
+        }
     }
+    return orientationAnimationData(
+        initialOrientation,
+        orientationFlow,
+        animationSpec,
+        maxWidthPx,
+        maxHeightPx,
+    )
 }
 
 private class AnimationData(
-    offset: State<IntOffset>,
+    topLeftOffset: State<IntOffset>,
+    bottomRightOffset: State<IntOffset>,
 ) {
-    val offset by offset
+    val topLeftOffset by topLeftOffset
+    val bottomRightOffset by bottomRightOffset
 }
 
 @Composable
-private fun infinityAnimationData(
-    maxWidthPx: Int,
-    maxHeightPx: Int,
-): AnimationData {
-    val infinityTransition = rememberInfiniteTransition(label = "infinite transition")
-    val animatedOffset = infinityTransition.animateValue(
-        initialValue = Position.BottomLeading.vector.toInOffset(maxWidthPx, maxHeightPx),
-        targetValue = Position.TopLeading.vector.toInOffset(maxWidthPx, maxHeightPx),
-        typeConverter = TwoWayConverter(
-            convertToVector = { offset -> offset.toVector(maxWidthPx, maxHeightPx) },
-            convertFromVector = { vector -> vector.toInOffset(maxWidthPx, maxHeightPx) },
-        ),
-        animationSpec = infiniteRepeatable(
-            animation = keyframes {
-                durationMillis = animationDuration.toInt()
-                Position.entries.forEachIndexed { index, position ->
-                    val timeStamp = index * (animationDuration.toInt() / Position.entries.size)
-                    position.next().vector.toInOffset(maxWidthPx, maxHeightPx) at timeStamp using LinearOutSlowInEasing
-                }
-            },
-            repeatMode = RepeatMode.Restart,
-        ),
-        label = "referral-card-background-animation",
-    )
-    return remember(infinityTransition) { AnimationData(animatedOffset) }
-}
-
-private enum class Position(val vector: AnimationVector2D) {
-    BottomLeading(AnimationVector2D(1f, -1f)),
-    TopLeading(AnimationVector2D(-1f, -1f)),
-    TopTrailing(AnimationVector2D(-1f, 1f)),
-    BottomTrailing(AnimationVector2D(1f, 1f)),
-    ;
-
-    fun next() = when (this) {
-        BottomLeading -> TopLeading
-        TopLeading -> TopTrailing
-        TopTrailing -> BottomTrailing
-        BottomTrailing -> BottomLeading
-    }
-}
-
-private val animationDuration = 5000L * Position.entries.size
-
-private fun IntOffset.toVector(maxWidthPx: Int, maxHeightPx: Int) = AnimationVector2D(
-    v1 = 2f * x / maxWidthPx,
-    v2 = 2f * y / maxHeightPx,
-)
-
-private fun AnimationVector2D.toInOffset(maxWidthPx: Int, maxHeightPx: Int) = IntOffset(
-    x = (v1 * maxWidthPx / 2f).roundToInt(),
-    y = (v2 * maxHeightPx / 2f).roundToInt(),
-)
-
-@Composable
-private fun sensorAnimationData(
+private fun orientationAnimationData(
+    initialOrientation: OrientationData,
     sensorOrientationFlow: Flow<OrientationData>,
+    animationSpec: AnimationSpec<IntOffset>,
     maxWidthPx: Int,
     maxHeightPx: Int,
 ): AnimationData {
-    val orientationData by sensorOrientationFlow.collectAsStateWithLifecycle(initialValue = null, minActiveState = Lifecycle.State.RESUMED)
-    val offset = animateIntOffsetAsState(
+    val orientationData by sensorOrientationFlow.collectAsStateWithLifecycle(
+        initialValue = initialOrientation,
+        minActiveState = Lifecycle.State.RESUMED,
+    )
+    val topLeftOffset = animateIntOffsetAsState(
         targetValue = IntOffset(
             x = lerp(
                 start = 0,
-                stop = maxWidthPx / 2,
-                fraction = orientationData?.rollOffsetFraction() ?: -1f,
+                stop = maxWidthPx,
+                fraction = -angleToFraction(
+                    angle = orientationData.roll,
+                    positiveFactor = 4f,
+                    negativeFactor = 8f,
+                ),
             ),
             y = lerp(
                 start = 0,
-                stop = maxHeightPx / 2,
-                fraction = orientationData?.pitchOffsetFraction() ?: -1f,
+                stop = maxHeightPx,
+                fraction = angleToFraction(
+                    angle = -orientationData.pitch,
+                    positiveFactor = 12f,
+                    negativeFactor = 4f,
+                ),
             ),
         ),
-        animationSpec = sensorAnimationSpec,
-        label = "referral-card-background-animation",
+        animationSpec = animationSpec,
+        label = "top-left-offset",
     )
-    return remember(sensorOrientationFlow) { AnimationData(offset) }
+    val bottomRightOffset = animateIntOffsetAsState(
+        targetValue = IntOffset(
+            x = lerp(
+                start = 0,
+                stop = maxWidthPx,
+                fraction = -angleToFraction(
+                    angle = -orientationData.roll,
+                    positiveFactor = 6f,
+                    negativeFactor = 8f,
+                ),
+            ),
+            y = lerp(
+                start = 0,
+                stop = maxHeightPx,
+                fraction = angleToFraction(
+                    angle = orientationData.pitch,
+                    positiveFactor = 3f,
+                    negativeFactor = 6f,
+                ),
+            ),
+        ),
+        animationSpec = animationSpec,
+        label = "bottom-right-offset",
+    )
+    return remember(sensorOrientationFlow) { AnimationData(topLeftOffset, bottomRightOffset) }
 }
 
+private fun angleToFraction(
+    angle: Float,
+    positiveFactor: Float,
+    negativeFactor: Float,
+): Float {
+    val fraction = (angle / maxValueAngle).coerceIn(-1f, 1f)
+    val scaledAngle = lerp(0f, Math.PI.toFloat(), fraction)
+    val factor = if (scaledAngle >= 0) positiveFactor else negativeFactor
+    return (atan(scaledAngle) / (factor * Math.PI)).toFloat()
+}
+
+private val maxValueAngle = (Math.PI / 4).toFloat()
+
+@OptIn(FlowPreview::class)
+private fun sensorOrientationFlow(context: Context) = DeviceOrientationDetector.create(context)
+    ?.orientationData()
+    ?.sample(100.milliseconds)
+
 private val sensorAnimationSpec = spring(
-    stiffness = Spring.StiffnessVeryLow,
+    stiffness = 20f,
     visibilityThreshold = IntOffset(1, 1),
 )
 
-private fun OrientationData.rollOffsetFraction(): Float {
-    val fraction = (roll / (2 * Math.PI)).toFloat().absoluteValue
-    return when (fraction) {
-        in 0f..0.25f -> cubic(a = 303.7037, b = -157.4603, c = 28.3519, d = -1.0, value = fraction.toDouble()).toFloat()
-        else -> 1f
+private val computedOrientationFlow = flow {
+    var angle = -maxValueAngle
+    while (coroutineContext.isActive) {
+        emit(OrientationData(angle, angle))
+        angle = if (angle > 0) -maxValueAngle else maxValueAngle
+        delay(4.seconds)
     }
 }
 
-private fun OrientationData.pitchOffsetFraction(): Float {
-    val fraction = (pitch / Math.PI).toFloat().absoluteValue
-    return when (fraction) {
-        in 0f..0.25f -> cubic(a = 303.7037, b = -157.4603, c = 28.3519, d = -1.0, value = fraction.toDouble()).toFloat()
-        else -> 1f
-    }
+private val computedAnimationSpec = spring(
+    stiffness = 2f,
+    visibilityThreshold = IntOffset(1, 1),
+)
+
+@Preview
+@Composable
+fun CardBackgroundPreview(
+    @PreviewParameter(OrientationDataProvider::class) data: OrientationData,
+) {
+    ReferralCardAnimatedBackgroundView(
+        initialOrientation = data,
+        modifier = Modifier.size(DpSize(150.dp, 150.dp * ReferralGuestPassCardDefaults.cardAspectRatio)),
+    )
 }
 
-private fun cubic(a: Double, b: Double, c: Double, d: Double, value: Double): Double {
-    return a * value * value * value + b * value * value + c * value + d
+private class OrientationDataProvider : PreviewParameterProvider<OrientationData> {
+    override val values = sequenceOf(
+        OrientationData(
+            roll = 0f,
+            pitch = 0f,
+        ),
+        OrientationData(
+            roll = Math.PI.toFloat(),
+            pitch = 0f,
+        ),
+        OrientationData(
+            roll = Math.PI.toFloat(),
+            pitch = Math.PI.toFloat() / 2,
+        ),
+        OrientationData(
+            roll = 0f,
+            pitch = Math.PI.toFloat() / 2,
+        ),
+        OrientationData(
+            roll = -Math.PI.toFloat(),
+            pitch = Math.PI.toFloat() / 2,
+        ),
+        OrientationData(
+            roll = -Math.PI.toFloat(),
+            pitch = 0f,
+        ),
+        OrientationData(
+            roll = -Math.PI.toFloat(),
+            pitch = -Math.PI.toFloat() / 2,
+        ),
+        OrientationData(
+            roll = 0f,
+            pitch = -Math.PI.toFloat() / 2,
+        ),
+    )
 }


### PR DESCRIPTION
## Description

This PR addresses designers feedback about the animation:

* Reduce blur to increase vibrancy of blobs.
* Make animation less chaotic and lightly move the blobs.

Other notable code changes:

* When sensor data is not available on the device the blobs no longer roll around the card. Instead I fake sensor data and move the blobs in and out.
* Animation is now driven by arc tangent function instead of a cubic one. It fits the floating animation better.

Context: p1726669050569879/1724256575.844749-slack-C07HDV91FBQ

## Testing Instructions

### Gyroscope

1. Install the app on a device with accelerometer and magnetometer. Most devices should have the,
2. Play around with referral cards and notice that the blobs correspond to device's orientation.

### Fake animation

1. Install the app on a device without accelerometer and magnetometer. It might be hard to do so alternatively you can apply [this patch](https://github.com/user-attachments/files/17055663/anim.patch).
2. The fake offset animation should play without any issues.

## Screenshots or Screencast 

### Fake animation

![screen-20240919-093410-ezgif com-optimize](https://github.com/user-attachments/assets/515e71c8-7a9d-46bf-a32d-b73f98f08827)

### Preview of different states

![Screenshot 2024-09-19 at 09 06 53](https://github.com/user-attachments/assets/d01a9963-baa1-45c3-82dc-43ddfb00f2c6)

## Checklist
- [x] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] ~I have considered whether it makes sense to add tests for my changes~
- [x] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [x] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack