### PR TITLE
Make search handlers non-singletons to fix persisting search text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 7.74
 -----
-
+*   Bug Fixes
+    *   Fix search term persists when navigating to different podcast page
+        ([#2908](https://github.com/Automattic/pocket-casts-android/pull/2908))
 
 7.73
 -----

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/helper/search/BookmarkSearchHandler.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/helper/search/BookmarkSearchHandler.kt
@@ -4,10 +4,8 @@ import au.com.shiftyjelly.pocketcasts.models.entity.Bookmark
 import au.com.shiftyjelly.pocketcasts.repositories.bookmark.BookmarkManager
 import io.reactivex.Observable
 import javax.inject.Inject
-import javax.inject.Singleton
 import kotlinx.coroutines.rx2.rxSingle
 
-@Singleton
 class BookmarkSearchHandler @Inject constructor(
     private val bookmarkManager: BookmarkManager,
 ) : SearchHandler<Bookmark>() {

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/helper/search/EpisodeSearchHandler.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/helper/search/EpisodeSearchHandler.kt
@@ -9,9 +9,7 @@ import io.reactivex.Observable
 import io.reactivex.Single
 import java.util.concurrent.TimeUnit
 import javax.inject.Inject
-import javax.inject.Singleton
 
-@Singleton
 class EpisodeSearchHandler @Inject constructor(
     settings: Settings,
     private val cacheServiceManager: PodcastCacheServiceManagerImpl,


### PR DESCRIPTION
## Description
There are other ways to fix this. For example, both handlers can be cleared in the viewModel's `onCleared` method. But to me, these two handlers shouldn't have been singletons in the first place.

Fixes #1320

## Testing Instructions

See the original issue

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [ ] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
