### PR TITLE
Fix illegal state exception in filteredPlaybackHistoryFlow

### DIFF
--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/ProfileEpisodeListViewModel.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/ProfileEpisodeListViewModel.kt
@@ -22,6 +22,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.reactive.asFlow
@@ -55,7 +56,11 @@ class ProfileEpisodeListViewModel @Inject constructor(
         viewModelScope.launch {
             val searchResultsFlow = _searchQueryFlow
                 .flatMapLatest { searchQuery ->
-                    episodeManager.filteredPlaybackHistoryEpisodesFlow(searchQuery)
+                    if (searchQuery.isNotEmpty()) {
+                        episodeManager.filteredPlaybackHistoryEpisodesFlow(searchQuery)
+                    } else {
+                        flowOf(emptyList())
+                    }
                 }
             combine(
                 episodeListFlowable.asFlow(),

--- a/modules/features/podcasts/src/test/java/au/com/shiftyjelly/pocketcasts/podcasts/view/ProfileEpisodeListViewModelTest.kt
+++ b/modules/features/podcasts/src/test/java/au/com/shiftyjelly/pocketcasts/podcasts/view/ProfileEpisodeListViewModelTest.kt
@@ -24,6 +24,8 @@ import org.mockito.kotlin.any
 import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.doNothing
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 
 @OptIn(ExperimentalCoroutinesApi::class)
@@ -169,6 +171,15 @@ class ProfileEpisodeListViewModelTest {
         viewModel.state.test {
             assertEquals(filteredEpisodes, (awaitItem() as State.Loaded).results)
         }
+    }
+
+    @Test
+    fun `playback history records are not filtered on setup when search query is empty`() = runTest {
+        initViewModel()
+
+        viewModel.setup(Mode.History)
+
+        verify(episodeManager, never()).filteredPlaybackHistoryEpisodesFlow("")
     }
 
     @Test

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/EpisodeDao.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/EpisodeDao.kt
@@ -277,6 +277,7 @@ abstract class EpisodeDao {
     @Query("SELECT * FROM podcast_episodes WHERE last_playback_interaction_date IS NOT NULL AND last_playback_interaction_date > 0 ORDER BY last_playback_interaction_date DESC LIMIT 1000")
     abstract fun observePlaybackHistory(): Flowable<List<PodcastEpisode>>
 
+    @Transaction
     @Query(
         """
         SELECT podcast_episodes.*


### PR DESCRIPTION
## Description

[This Sentry issue:](https://a8c.sentry.io/share/issue/ff59c3ae1092401c91210d2ba28cf390/) points to `au.com.shiftyjelly.pocketcasts.models.db.dao.EpisodeDao_Impl$65 in call at line 11261` which is at `EpisodeDao`'s `filteredPlaybackHistoryFlow()`. It is an `IllegalStateException` while possibly reading a large list. 

To fix the issue, I'm annotating the query with `Transaction` based on this recommendation: https://issuetracker.google.com/issues/73859920#comment2
and added a check for an empty search term in 6f03d19.

## Testing Instructions
Smoke test that you can search properly in `Listening History`.

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
