### PR TITLE
Do not optimize PlaybackService class

### DIFF
--- a/proguard-rules.pro
+++ b/proguard-rules.pro
@@ -16,9 +16,11 @@
 #   public *;
 #}
 
-# Without this the playback notification doesn't show up on fresh launch
+# Do not optimize PlaybackService class.
+# It causes na issue where the media notification is not displayed in some cases.
 # https://github.com/shiftyjelly/pocketcasts-android/issues/1656
--keep class au.com.shiftyjelly.pocketcasts.core.player.** { *; }
+# https://github.com/shiftyjelly/pocketcasts-android/pulls/2921
+-keep,allowobfuscation,allowshrinking class au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackService { *; }
 
 -dontwarn android.test.**
 -dontwarn org.junit.internal.runners.statements.**


### PR DESCRIPTION
## Description

This fixes an issue where the media notification might not appear and keep playback alive. I was able to replicate it only during the initial playback but we have different reports of it in the wild: https://www.reddit.com/r/pocketcasts/comments/1fk8cx2/background_playback/

We had this old R8 rule which was supposed to handle it

```
-keep class au.com.shiftyjelly.pocketcasts.core.player.** { *; }
```

However, this package no longer exists and it is hard to determine what the rule is supposed to guard against since it is very broad. Most likely it is an optimization step as I discovered while investigating this issue. Using R8 optimization on the `PlaybackService` class creates the issue.

I haven't investigated deep enough to determine which methods of the `PlaybackService` shouldn't be optimized. I just applied a rule to the whole class and its content.

## Testing Instructions

1. Make a clean installation of the `release` variant of the app.
2. Open the app.
3. Accept notifications.
4. Close the sign in page.
5. Open any podcast.
6. Play any episode.
7. Check media notification center.
8. Pocket Casts notification should be present.

## Screenshots or Screencast 

### Before

https://github.com/user-attachments/assets/08b72d28-aa52-47e4-889d-f6d2b3907de6

### After 

https://github.com/user-attachments/assets/46942f5a-052e-4e64-b3a5-e271149c2cea

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [ ] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
