### PR TITLE
Stop the show notes web view jumping after loading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 *   Bug Fixes
     *   Fix search term persists when navigating to different podcast page
         ([#2908](https://github.com/Automattic/pocket-casts-android/pull/2908))
+    *   Fix the show notes web view jumping after loading
+        ([#2925](https://github.com/Automattic/pocket-casts-android/pull/2925))
     *   Fix play button local file getting set to pause after episode completion
         ([#1627](https://github.com/Automattic/pocket-casts-android/pull/1627))
 

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/NotesFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/NotesFragment.kt
@@ -123,6 +123,8 @@ class NotesFragment : BaseFragment() {
                 settings.loadsImagesAutomatically = true
                 isScrollbarFadingEnabled = false
                 isVerticalScrollBarEnabled = false
+                // stop the web view jumping after loading
+                isFocusable = false
                 setBackgroundColor(Color.TRANSPARENT)
                 webViewClient = object : WebViewClient() {
                     override fun shouldOverrideUrlLoading(view: WebView, request: WebResourceRequest): Boolean {

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/episode/EpisodeFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/episode/EpisodeFragment.kt
@@ -521,6 +521,8 @@ class EpisodeFragment : BaseFragment() {
                     // stopping the white flash on web player load
                     setBackgroundColor(Color.argb(1, 0, 0, 0))
                     isVerticalScrollBarEnabled = false
+                    // stop the web view jumping after loading
+                    isFocusable = false
                     webViewClient = object : WebViewClient() {
                         override fun shouldOverrideUrlLoading(view: WebView, request: WebResourceRequest): Boolean {
                             val url = request.url.toString()


### PR DESCRIPTION
## Description

The show notes web views have an issue that they jump after loading. I found the solution on Stackoverflow that seems to work https://stackoverflow.com/questions/18744743/android-webview-jumping-to-the-bottom. 

Fixes https://github.com/Automattic/pocket-casts-android/issues/2716

## Testing Instructions

1. Subscribe to "10% Happier with Dan Harris"
2. Tap on an episode row
3. Scroll down the page

✅ Verify the page doesn't jump.

4. Open the full screen player
5. Swipe to the show notes

✅ Verify the show notes page doesn't jump.

## Screencast 

https://github.com/user-attachments/assets/72775130-2d81-418f-8b65-bf891164515e

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack
