### PR TITLE
Support multiple possible mimetypes for a transcript format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,14 @@
 *   New Features
     *   Add local search in listening history
         ([#2794](https://github.com/Automattic/pocket-casts-android/pull/2794))
-*   Updated
+*   Updates
     *   Dark theme improvements on the podcast page
         ([#2811](https://github.com/Automattic/pocket-casts-android/pull/2811))
     *   Add a visibility animation to the submit button on the rating screen
         ([#2824](https://github.com/Automattic/pocket-casts-android/pull/2824))
+*   Bug Fixes
+    *   Fix issue when transcript type have an alternative valid mime type 
+        [#2926](https://github.com/Automattic/pocket-casts-ios/issues/2926)
 
 7.72
 -----

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/di/PlayerModule.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/di/PlayerModule.kt
@@ -21,8 +21,8 @@ object PlayerModule {
         return object : SubtitleParser.Factory {
             override fun supportsFormat(format: Format): Boolean {
                 return when (format.sampleMimeType) {
-                    TranscriptFormat.VTT.mimeType,
-                    TranscriptFormat.SRT.mimeType,
+                    in TranscriptFormat.VTT.possibleMimeTypes(),
+                    in TranscriptFormat.SRT.possibleMimeTypes(),
                     -> true
 
                     else -> false
@@ -31,16 +31,16 @@ object PlayerModule {
 
             override fun getCueReplacementBehavior(format: Format): Int {
                 return when (val mimeType = format.sampleMimeType) {
-                    TranscriptFormat.VTT.mimeType -> WebvttParser.CUE_REPLACEMENT_BEHAVIOR
-                    TranscriptFormat.SRT.mimeType -> SubripParser.CUE_REPLACEMENT_BEHAVIOR
+                    in TranscriptFormat.VTT.possibleMimeTypes() -> WebvttParser.CUE_REPLACEMENT_BEHAVIOR
+                    in TranscriptFormat.SRT.possibleMimeTypes() -> SubripParser.CUE_REPLACEMENT_BEHAVIOR
                     else -> throw IllegalArgumentException("Unsupported MIME type: $mimeType")
                 }
             }
 
             override fun create(format: Format): SubtitleParser {
                 return when (val mimeType = format.sampleMimeType) {
-                    TranscriptFormat.VTT.mimeType -> WebvttParser()
-                    TranscriptFormat.SRT.mimeType -> SubripParser()
+                    in TranscriptFormat.VTT.possibleMimeTypes() -> WebvttParser()
+                    in TranscriptFormat.SRT.possibleMimeTypes() -> SubripParser()
                     else -> throw IllegalArgumentException("Unsupported MIME type: $mimeType")
                 }
             }

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/TranscriptsManagerImplTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/TranscriptsManagerImplTest.kt
@@ -105,6 +105,17 @@ class TranscriptsManagerImplTest {
     }
 
     @Test
+    fun `findBestTranscript returns first supported transcript for a format with multiple mimetypes`() = runTest {
+        val transcripts = listOf(
+            Transcript("1", "url_1", "application/x-subrip"),
+            Transcript("1", "url_2", "application/srt"),
+        )
+        val result = transcriptsManager.findBestTranscript(transcripts)
+
+        assertEquals(transcripts[0], result)
+    }
+
+    @Test
     fun `findBestTranscript returns null when no transcripts available`() = runTest {
         val transcripts = emptyList<Transcript>()
 


### PR DESCRIPTION
## Description

This PR updates the code so that a transcript format can have multiple valid mime types.
Internal ref: p1727088168724749-slack-C078746V6UX

## Testing Instructions
1. Start the app
2. Open the following podcast (SRT mimetype: "application/application/x-subrip"): https://pca.st/episode/2cb385e0-e8f2-4b5d-be50-69b203630174
3. Play it and open the full screen player
4. Tap on the Transcript icon
5. Check if the transcript shows correctly
6. Smoke test that the other SRT mimetype ("application/srt") format transcript loads properly: https://pca.st/cqw2vgr7

** Target 7.73 but we can wait a few days and release it with other possible fixes. 

## Screenshot

<img  width= 200 src="https://github.com/user-attachments/assets/46a75d33-15ff-4505-9c1e-6de952581a4a"/>


## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack