### PR TITLE
Listening History - Allow spaces in search

### DIFF
--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/ProfileEpisodeListViewModel.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/ProfileEpisodeListViewModel.kt
@@ -96,13 +96,12 @@ class ProfileEpisodeListViewModel @Inject constructor(
 
     fun onSearchQueryChanged(searchQuery: String) {
         val oldValue = _searchQueryFlow.value
-        val newValue = searchQuery.trim()
-        _searchQueryFlow.value = newValue
+        _searchQueryFlow.value = searchQuery
 
         // Track search events
-        if (oldValue.isEmpty() && newValue.isNotEmpty()) {
+        if (oldValue.isEmpty() && searchQuery.isNotEmpty()) {
             track(AnalyticsEvent.SEARCH_PERFORMED)
-        } else if (oldValue.isNotEmpty() && newValue.isEmpty()) {
+        } else if (oldValue.isNotEmpty() && searchQuery.isEmpty()) {
             track(AnalyticsEvent.SEARCH_CLEARED)
         }
     }


### PR DESCRIPTION
## Description
This removes `trim() `function in the search query changes to allow spaces. I accidentally added it while adding tracks thinking it will remove leading and trailing spaces for the entire search string.


## Testing Instructions
1. Go to Profile
2. Login with an account with some listening history
3. Search for an episode title with in-between spaces
4. ✅ Notice that the episode is listed in the search results

## Screenshots or Screencast 
<img width=300 src="https://github.com/user-attachments/assets/bc9620f1-9dd1-4310-9d76-f0f8e13ad7fc"/>


## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
