### PR TITLE
Referrals: Get referral code from endpoint

### DIFF
--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/sharing/SharingClientTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/sharing/SharingClientTest.kt
@@ -685,7 +685,7 @@ class SharingClientTest {
 
         assertEquals(ACTION_SEND, intent.action)
         assertEquals("text/plain", intent.type)
-        assertEquals("$text\n\nhttps://$WEB_BASE_HOST/redeem-guest-pass/$referralCode", intent.getStringExtra(EXTRA_TEXT))
+        assertEquals("$text\n\nhttps://$WEB_BASE_HOST/redeem/$referralCode", intent.getStringExtra(EXTRA_TEXT))
         assertEquals(subject, intent.getStringExtra(EXTRA_SUBJECT))
         assertEquals(FLAG_GRANT_READ_URI_PERMISSION, intent.flags and FLAG_GRANT_READ_URI_PERMISSION)
     }

--- a/modules/features/referrals/src/main/kotlin/au/com/shiftyjelly/pocketcasts/referrals/ReferralsGuestPassError.kt
+++ b/modules/features/referrals/src/main/kotlin/au/com/shiftyjelly/pocketcasts/referrals/ReferralsGuestPassError.kt
@@ -1,0 +1,95 @@
+package au.com.shiftyjelly.pocketcasts.referrals
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.Button
+import androidx.compose.material.ButtonDefaults
+import androidx.compose.material.Icon
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import au.com.shiftyjelly.pocketcasts.compose.AppTheme
+import au.com.shiftyjelly.pocketcasts.compose.buttons.CloseButton
+import au.com.shiftyjelly.pocketcasts.compose.components.TextP40
+import au.com.shiftyjelly.pocketcasts.images.R
+import au.com.shiftyjelly.pocketcasts.referrals.ReferralsSendGuestPassViewModel.ReferralSendGuestPassError
+import au.com.shiftyjelly.pocketcasts.referrals.ReferralsSendGuestPassViewModel.UiState
+import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
+import au.com.shiftyjelly.pocketcasts.localization.R as LR
+
+@Composable
+fun ReferralsGuestPassError(
+    errorState: UiState.Error,
+    onRetry: () -> Unit,
+    onDismiss: () -> Unit,
+) {
+    val errorMessage = when (errorState.error) {
+        ReferralSendGuestPassError.Empty,
+        ReferralSendGuestPassError.FailedToLoad,
+        -> stringResource(LR.string.error_generic_message)
+        ReferralSendGuestPassError.NoNetwork -> stringResource(LR.string.error_no_network)
+    }
+    Column(
+        horizontalAlignment = Alignment.CenterHorizontally,
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(16.dp),
+    ) {
+        CloseButton(
+            modifier = Modifier
+                .align(Alignment.End),
+            onClick = onDismiss,
+        )
+        Spacer(modifier = Modifier.weight(1f))
+        Icon(
+            painter = painterResource(R.drawable.ic_warning),
+            contentDescription = null,
+            tint = Color.White.copy(alpha = 0.5f),
+        )
+        Spacer(modifier = Modifier.height(16.dp))
+        TextP40(
+            text = errorMessage,
+            textAlign = TextAlign.Center,
+        )
+        Spacer(modifier = Modifier.height(16.dp))
+        Button(
+            onClick = onRetry,
+            shape = RoundedCornerShape(40.dp),
+            colors = ButtonDefaults.buttonColors(
+                backgroundColor = Color.White.copy(alpha = 0.5f),
+            ),
+        ) {
+            TextP40(
+                text = stringResource(LR.string.try_again),
+                color = Color.White,
+                fontSize = 15.sp,
+                fontWeight = FontWeight.W400,
+            )
+        }
+        Spacer(modifier = Modifier.weight(1f))
+    }
+}
+
+@Preview
+@Composable
+fun ReferralsSendGuestPassErrorPreview() {
+    AppTheme(Theme.ThemeType.DARK) {
+        ReferralsGuestPassError(
+            errorState = UiState.Error(ReferralSendGuestPassError.FailedToLoad),
+            onRetry = {},
+            onDismiss = {},
+        )
+    }
+}

--- a/modules/features/referrals/src/main/kotlin/au/com/shiftyjelly/pocketcasts/referrals/ReferralsGuestPassFragment.kt
+++ b/modules/features/referrals/src/main/kotlin/au/com/shiftyjelly/pocketcasts/referrals/ReferralsGuestPassFragment.kt
@@ -19,14 +19,12 @@ import androidx.fragment.compose.content
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
-import au.com.shiftyjelly.pocketcasts.sharing.SharingClient
 import au.com.shiftyjelly.pocketcasts.ui.helper.FragmentHostListener
 import au.com.shiftyjelly.pocketcasts.ui.helper.StatusBarColor
 import au.com.shiftyjelly.pocketcasts.utils.extensions.getActivity
 import au.com.shiftyjelly.pocketcasts.views.fragments.BaseFragment
 import au.com.shiftyjelly.pocketcasts.views.helper.UiUtil.setBackgroundColor
 import dagger.hilt.android.AndroidEntryPoint
-import javax.inject.Inject
 import kotlinx.coroutines.launch
 import kotlinx.parcelize.Parcelize
 import androidx.compose.ui.graphics.Color as ComposeColor
@@ -35,9 +33,6 @@ import androidx.compose.ui.graphics.Color as ComposeColor
 class ReferralsGuestPassFragment : BaseFragment() {
     private val args get() = requireNotNull(arguments?.let { BundleCompat.getParcelable(it, NEW_INSTANCE_ARG, Args::class.java) })
     private val pageType get() = args.pageType
-
-    @Inject
-    lateinit var sharingClient: SharingClient
 
     @OptIn(ExperimentalMaterial3WindowSizeClassApi::class)
     override fun onCreateView(
@@ -57,7 +52,6 @@ class ReferralsGuestPassFragment : BaseFragment() {
         when (pageType) {
             ReferralsPageType.Send -> {
                 ReferralsSendGuestPassPage(
-                    sharingClient = sharingClient,
                     onDismiss = { onDismiss() },
                 )
             }

--- a/modules/features/referrals/src/main/kotlin/au/com/shiftyjelly/pocketcasts/referrals/ReferralsSendGuestPassPage.kt
+++ b/modules/features/referrals/src/main/kotlin/au/com/shiftyjelly/pocketcasts/referrals/ReferralsSendGuestPassPage.kt
@@ -23,8 +23,8 @@ import androidx.compose.material3.windowsizeclass.WindowHeightSizeClass
 import androidx.compose.material3.windowsizeclass.WindowWidthSizeClass
 import androidx.compose.material3.windowsizeclass.calculateWindowSizeClass
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -35,7 +35,8 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import au.com.shiftyjelly.pocketcasts.analytics.SourceView
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import au.com.shiftyjelly.pocketcasts.compose.AppTheme
 import au.com.shiftyjelly.pocketcasts.compose.Devices
 import au.com.shiftyjelly.pocketcasts.compose.buttons.CloseButton
@@ -43,42 +44,33 @@ import au.com.shiftyjelly.pocketcasts.compose.buttons.GradientRowButton
 import au.com.shiftyjelly.pocketcasts.compose.components.TextH10
 import au.com.shiftyjelly.pocketcasts.compose.extensions.plusBackgroundBrush
 import au.com.shiftyjelly.pocketcasts.compose.images.SubscriptionBadge
+import au.com.shiftyjelly.pocketcasts.compose.loading.LoadingView
 import au.com.shiftyjelly.pocketcasts.referrals.ReferralPageDefaults.pageCornerRadius
 import au.com.shiftyjelly.pocketcasts.referrals.ReferralPageDefaults.pageWidthPercent
 import au.com.shiftyjelly.pocketcasts.referrals.ReferralPageDefaults.shouldShowFullScreen
-import au.com.shiftyjelly.pocketcasts.sharing.SharingClient
-import au.com.shiftyjelly.pocketcasts.sharing.SharingRequest
+import au.com.shiftyjelly.pocketcasts.referrals.ReferralsSendGuestPassViewModel.UiState
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import au.com.shiftyjelly.pocketcasts.utils.extensions.getActivity
-import kotlinx.coroutines.launch
 import au.com.shiftyjelly.pocketcasts.images.R as IR
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 @OptIn(ExperimentalMaterial3WindowSizeClassApi::class)
 @Composable
 fun ReferralsSendGuestPassPage(
-    sharingClient: SharingClient,
+    viewModel: ReferralsSendGuestPassViewModel = hiltViewModel(),
     onDismiss: () -> Unit,
 ) {
     AppTheme(Theme.ThemeType.DARK) {
         val context = LocalContext.current
         val windowSize = calculateWindowSizeClass(context.getActivity() as Activity)
-        val scope = rememberCoroutineScope()
-
+        val state by viewModel.state.collectAsStateWithLifecycle()
         ReferralsSendGuestPassContent(
             windowWidthSizeClass = windowSize.widthSizeClass,
             windowHeightSizeClass = windowSize.heightSizeClass,
+            state = state,
+            onRetry = viewModel::onRetry,
             onDismiss = onDismiss,
-            onShare = {
-                val referralCode = "test_code" // TODO - Referrals: Make it dynamic
-                val request = SharingRequest.referralLink(
-                    referralCode = referralCode,
-                ).setSourceView(SourceView.REFERRALS)
-                    .build()
-                scope.launch {
-                    sharingClient.share(request)
-                }
-            },
+            onShare = viewModel::onShareClick,
         )
     }
 }
@@ -87,8 +79,10 @@ fun ReferralsSendGuestPassPage(
 private fun ReferralsSendGuestPassContent(
     windowWidthSizeClass: WindowWidthSizeClass,
     windowHeightSizeClass: WindowHeightSizeClass,
+    state: UiState,
+    onRetry: () -> Unit,
     onDismiss: () -> Unit,
-    onShare: () -> Unit,
+    onShare: (String) -> Unit,
 ) {
     BoxWithConstraints(
         contentAlignment = Alignment.Center,
@@ -111,7 +105,6 @@ private fun ReferralsSendGuestPassContent(
                 .width(pageWidth)
                 .wrapContentSize()
         }
-
         Card(
             elevation = 8.dp,
             shape = RoundedCornerShape(pageCornerRadius(showFullScreen)),
@@ -123,58 +116,84 @@ private fun ReferralsSendGuestPassContent(
                     onClick = {},
                 ),
         ) {
-            Column(
-                horizontalAlignment = Alignment.CenterHorizontally,
-                modifier = Modifier
-                    .verticalScroll(rememberScrollState())
-                    .padding(16.dp),
-            ) {
-                CloseButton(
-                    modifier = Modifier
-                        .align(Alignment.End),
-                    onClick = onDismiss,
-                )
+            when (state) {
+                UiState.Loading ->
+                    LoadingView(color = Color.White)
 
-                SubscriptionBadge(
-                    fontSize = 16.sp,
-                    padding = 4.dp,
-                    iconRes = IR.drawable.ic_plus,
-                    shortNameRes = LR.string.pocket_casts_plus_short,
-                    iconColor = Color.Black,
-                    backgroundBrush = plusBackgroundBrush,
-                    textColor = Color.Black,
-                )
-
-                Spacer(modifier = Modifier.height(24.dp))
-
-                TextH10(
-                    text = stringResource(LR.string.referrals_send_guest_pass_title),
-                    textAlign = TextAlign.Center,
-                )
-
-                if (windowHeightSizeClass != WindowHeightSizeClass.Compact) {
-                    Spacer(modifier = Modifier.height(24.dp))
-
-                    ReferralsPassCardsStack(
-                        width = pageWidth,
+                is UiState.Loaded ->
+                    SendGuestPassContent(
+                        showFullScreen = showFullScreen,
+                        windowHeightSizeClass = windowHeightSizeClass,
+                        pageWidth = pageWidth,
+                        onDismiss = onDismiss,
+                        onShare = { onShare(state.code) },
                     )
-                }
 
-                if (showFullScreen) {
-                    Spacer(modifier = Modifier.weight(1f))
-                } else {
-                    Spacer(modifier = Modifier.height(32.dp))
-                }
-
-                GradientRowButton(
-                    primaryText = stringResource(LR.string.referrals_share_guest_pass),
-                    textColor = Color.Black,
-                    gradientBackgroundColor = plusBackgroundBrush,
-                    modifier = Modifier.padding(16.dp),
-                    onClick = onShare,
-                )
+                is UiState.Error ->
+                    ReferralsGuestPassError(state, onRetry, onDismiss)
             }
         }
+    }
+}
+
+@Composable
+private fun SendGuestPassContent(
+    showFullScreen: Boolean,
+    windowHeightSizeClass: WindowHeightSizeClass,
+    pageWidth: Dp,
+    onDismiss: () -> Unit,
+    onShare: () -> Unit,
+) {
+    Column(
+        horizontalAlignment = Alignment.CenterHorizontally,
+        modifier = Modifier
+            .verticalScroll(rememberScrollState())
+            .padding(16.dp),
+    ) {
+        CloseButton(
+            modifier = Modifier
+                .align(Alignment.End),
+            onClick = onDismiss,
+        )
+
+        SubscriptionBadge(
+            fontSize = 16.sp,
+            padding = 4.dp,
+            iconRes = IR.drawable.ic_plus,
+            shortNameRes = LR.string.pocket_casts_plus_short,
+            iconColor = Color.Black,
+            backgroundBrush = plusBackgroundBrush,
+            textColor = Color.Black,
+        )
+
+        Spacer(modifier = Modifier.height(24.dp))
+
+        TextH10(
+            text = stringResource(LR.string.referrals_send_guest_pass_title),
+            textAlign = TextAlign.Center,
+        )
+
+        if (windowHeightSizeClass != WindowHeightSizeClass.Compact) {
+            Spacer(modifier = Modifier.height(24.dp))
+
+            ReferralsPassCardsStack(
+                width = pageWidth,
+            )
+        }
+
+        if (showFullScreen) {
+            Spacer(modifier = Modifier.weight(1f))
+        } else {
+            Spacer(modifier = Modifier.height(32.dp))
+        }
+
+        GradientRowButton(
+            primaryText = stringResource(LR.string.referrals_share_guest_pass),
+            textColor = Color.Black,
+            gradientBackgroundColor = plusBackgroundBrush,
+            modifier = Modifier.padding(16.dp),
+            onClick = onShare,
+        )
     }
 }
 
@@ -248,8 +267,10 @@ fun ReferralsSendGuestPassContentPreview(
         ReferralsSendGuestPassContent(
             windowWidthSizeClass = windowWidthSizeClass,
             windowHeightSizeClass = windowHeightSizeClass,
+            state = UiState.Loaded(""),
             onDismiss = {},
             onShare = {},
+            onRetry = {},
         )
     }
 }

--- a/modules/features/referrals/src/main/kotlin/au/com/shiftyjelly/pocketcasts/referrals/ReferralsSendGuestPassViewModel.kt
+++ b/modules/features/referrals/src/main/kotlin/au/com/shiftyjelly/pocketcasts/referrals/ReferralsSendGuestPassViewModel.kt
@@ -3,10 +3,10 @@ package au.com.shiftyjelly.pocketcasts.referrals
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import au.com.shiftyjelly.pocketcasts.analytics.SourceView
+import au.com.shiftyjelly.pocketcasts.repositories.referrals.ReferralManager
 import au.com.shiftyjelly.pocketcasts.repositories.referrals.ReferralManager.ReferralResult.EmptyResult
 import au.com.shiftyjelly.pocketcasts.repositories.referrals.ReferralManager.ReferralResult.ErrorResult
 import au.com.shiftyjelly.pocketcasts.repositories.referrals.ReferralManager.ReferralResult.SuccessResult
-import au.com.shiftyjelly.pocketcasts.repositories.referrals.ReferralManager
 import au.com.shiftyjelly.pocketcasts.sharing.SharingClient
 import au.com.shiftyjelly.pocketcasts.sharing.SharingRequest
 import au.com.shiftyjelly.pocketcasts.utils.exception.NoNetworkException

--- a/modules/features/referrals/src/main/kotlin/au/com/shiftyjelly/pocketcasts/referrals/ReferralsSendGuestPassViewModel.kt
+++ b/modules/features/referrals/src/main/kotlin/au/com/shiftyjelly/pocketcasts/referrals/ReferralsSendGuestPassViewModel.kt
@@ -1,0 +1,86 @@
+package au.com.shiftyjelly.pocketcasts.referrals
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import au.com.shiftyjelly.pocketcasts.analytics.SourceView
+import au.com.shiftyjelly.pocketcasts.repositories.referrals.ReferralManager.ReferralResult.EmptyResult
+import au.com.shiftyjelly.pocketcasts.repositories.referrals.ReferralManager.ReferralResult.ErrorResult
+import au.com.shiftyjelly.pocketcasts.repositories.referrals.ReferralManager.ReferralResult.SuccessResult
+import au.com.shiftyjelly.pocketcasts.repositories.referrals.ReferralManager
+import au.com.shiftyjelly.pocketcasts.sharing.SharingClient
+import au.com.shiftyjelly.pocketcasts.sharing.SharingRequest
+import au.com.shiftyjelly.pocketcasts.utils.exception.NoNetworkException
+import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+
+@HiltViewModel
+class ReferralsSendGuestPassViewModel @Inject constructor(
+    private val referralsManager: ReferralManager,
+    private val sharingClient: SharingClient,
+) : ViewModel() {
+    private val _state: MutableStateFlow<UiState> = MutableStateFlow(UiState.Loading)
+    val state: StateFlow<UiState> = _state
+
+    init {
+        getReferralCode()
+    }
+
+    private fun getReferralCode() {
+        viewModelScope.launch {
+            val result = referralsManager.getReferralCode()
+            _state.value = when (result) {
+                is SuccessResult -> UiState.Loaded(result.body.code)
+                is EmptyResult -> {
+                    LogBuffer.e(
+                        LogBuffer.TAG_INVALID_STATE,
+                        "Empty result when getting referral code.",
+                    )
+                    UiState.Error(ReferralSendGuestPassError.Empty)
+                }
+
+                is ErrorResult -> {
+                    if (result.error is NoNetworkException) {
+                        UiState.Error(ReferralSendGuestPassError.NoNetwork)
+                    } else {
+                        LogBuffer.e(
+                            LogBuffer.TAG_INVALID_STATE,
+                            "Failed to get referral code ${result.errorMessage}",
+                        )
+                        UiState.Error(ReferralSendGuestPassError.FailedToLoad)
+                    }
+                }
+            }
+        }
+    }
+
+    fun onRetry() {
+        _state.value = UiState.Loading
+        getReferralCode()
+    }
+
+    fun onShareClick(referralCode: String) {
+        val request = SharingRequest.referralLink(
+            referralCode = referralCode,
+        ).setSourceView(SourceView.REFERRALS)
+            .build()
+        viewModelScope.launch {
+            sharingClient.share(request)
+        }
+    }
+
+    sealed class UiState {
+        data object Loading : UiState()
+        data class Loaded(val code: String) : UiState()
+        data class Error(val error: ReferralSendGuestPassError) : UiState()
+    }
+
+    sealed class ReferralSendGuestPassError {
+        data object FailedToLoad : ReferralSendGuestPassError()
+        data object NoNetwork : ReferralSendGuestPassError()
+        data object Empty : ReferralSendGuestPassError()
+    }
+}

--- a/modules/features/referrals/src/test/kotlin/au/com/shiftyjelly/pocketcasts/referrals/ReferralsSendGuestPassViewModelTest.kt
+++ b/modules/features/referrals/src/test/kotlin/au/com/shiftyjelly/pocketcasts/referrals/ReferralsSendGuestPassViewModelTest.kt
@@ -1,0 +1,122 @@
+package au.com.shiftyjelly.pocketcasts.referrals
+
+import app.cash.turbine.test
+import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
+import au.com.shiftyjelly.pocketcasts.analytics.SourceView
+import au.com.shiftyjelly.pocketcasts.referrals.ReferralsSendGuestPassViewModel.ReferralSendGuestPassError
+import au.com.shiftyjelly.pocketcasts.referrals.ReferralsSendGuestPassViewModel.UiState
+import au.com.shiftyjelly.pocketcasts.repositories.referrals.ReferralManager.ReferralResult.EmptyResult
+import au.com.shiftyjelly.pocketcasts.repositories.referrals.ReferralManager.ReferralResult.ErrorResult
+import au.com.shiftyjelly.pocketcasts.repositories.referrals.ReferralManager.ReferralResult.SuccessResult
+import au.com.shiftyjelly.pocketcasts.repositories.referrals.ReferralManager
+import au.com.shiftyjelly.pocketcasts.sharedtest.MainCoroutineRule
+import au.com.shiftyjelly.pocketcasts.sharing.SharingClient
+import au.com.shiftyjelly.pocketcasts.sharing.SharingRequest
+import au.com.shiftyjelly.pocketcasts.sharing.SocialPlatform
+import au.com.shiftyjelly.pocketcasts.utils.exception.NoNetworkException
+import com.pocketcasts.service.api.ReferralCodeResponse
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.times
+import org.mockito.Mockito.verify
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.whenever
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class ReferralsSendGuestPassViewModelTest {
+    @get:Rule
+    val coroutineRule = MainCoroutineRule()
+
+    private val referralManager = mock<ReferralManager>()
+    private val sharingClient = mock<SharingClient>()
+    private lateinit var viewModel: ReferralsSendGuestPassViewModel
+
+    private val referralCodeResponse = mock<ReferralCodeResponse>()
+    private val referralCodeSuccessResult = SuccessResult(referralCodeResponse)
+    private val referralCode = "referral_code"
+
+    @Before
+    fun setUp() = runTest {
+        whenever(referralCodeResponse.code).thenReturn(referralCode)
+        whenever(referralManager.getReferralCode()).thenReturn(referralCodeSuccessResult)
+    }
+
+    @Test
+    fun `given referral code success, when getting referral code, then state is loaded`() = runTest {
+        whenever(referralManager.getReferralCode()).thenReturn(referralCodeSuccessResult)
+
+        viewModel = ReferralsSendGuestPassViewModel(referralManager, sharingClient)
+
+        viewModel.state.test {
+            assertEquals(UiState.Loaded(referralCode), awaitItem())
+        }
+    }
+
+    @Test
+    fun `given empty result, when getting referral code, then state is empty error`() = runTest {
+        whenever(referralManager.getReferralCode()).thenReturn(EmptyResult())
+
+        viewModel = ReferralsSendGuestPassViewModel(referralManager, sharingClient)
+
+        viewModel.state.test {
+            assertTrue(awaitItem() == UiState.Error(ReferralSendGuestPassError.Empty))
+        }
+    }
+
+    @Test
+    fun `given network error, when getting referral code, then state is network error`() = runTest {
+        whenever(referralManager.getReferralCode()).thenReturn(ErrorResult(errorMessage = "", error = NoNetworkException()))
+
+        viewModel = ReferralsSendGuestPassViewModel(referralManager, sharingClient)
+
+        viewModel.state.test {
+            assertTrue(awaitItem() == UiState.Error(ReferralSendGuestPassError.NoNetwork))
+        }
+    }
+
+    @Test
+    fun `given unknown error, when getting referral code, then state is failed to load`() = runTest {
+        whenever(referralManager.getReferralCode()).thenReturn(ErrorResult(""))
+
+        viewModel = ReferralsSendGuestPassViewModel(referralManager, sharingClient)
+
+        viewModel.state.test {
+            assertTrue(awaitItem() == UiState.Error(ReferralSendGuestPassError.FailedToLoad))
+        }
+    }
+
+    @Test
+    fun `when retry clicked, then referral code is fetched again`() = runTest {
+        viewModel = ReferralsSendGuestPassViewModel(referralManager, sharingClient)
+
+        viewModel.onRetry()
+
+        verify(referralManager, times(2)).getReferralCode()
+    }
+
+    @Test
+    fun `given referral code, when share clicked, then referral code is shared`() = runTest {
+        val requestCaptor = argumentCaptor<SharingRequest>()
+        whenever(referralManager.getReferralCode()).thenReturn(referralCodeSuccessResult)
+
+        viewModel = ReferralsSendGuestPassViewModel(referralManager, sharingClient)
+        viewModel.onShareClick(referralCode)
+
+        verify(referralManager).getReferralCode()
+        verify(sharingClient).share(requestCaptor.capture())
+        val capturedRequest = requestCaptor.firstValue
+        with(capturedRequest) {
+            assertEquals(referralCode, (data as SharingRequest.Data.ReferralLink).referralCode)
+            assertEquals(SourceView.REFERRALS, source)
+            assertEquals(SocialPlatform.More, platform)
+            assertEquals(AnalyticsEvent.REFERRAL_LINK_SHARED, analyticsEvent)
+            assertEquals(mapOf("code" to referralCode), analyticsProperties)
+        }
+    }
+}

--- a/modules/features/referrals/src/test/kotlin/au/com/shiftyjelly/pocketcasts/referrals/ReferralsSendGuestPassViewModelTest.kt
+++ b/modules/features/referrals/src/test/kotlin/au/com/shiftyjelly/pocketcasts/referrals/ReferralsSendGuestPassViewModelTest.kt
@@ -5,10 +5,10 @@ import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
 import au.com.shiftyjelly.pocketcasts.analytics.SourceView
 import au.com.shiftyjelly.pocketcasts.referrals.ReferralsSendGuestPassViewModel.ReferralSendGuestPassError
 import au.com.shiftyjelly.pocketcasts.referrals.ReferralsSendGuestPassViewModel.UiState
+import au.com.shiftyjelly.pocketcasts.repositories.referrals.ReferralManager
 import au.com.shiftyjelly.pocketcasts.repositories.referrals.ReferralManager.ReferralResult.EmptyResult
 import au.com.shiftyjelly.pocketcasts.repositories.referrals.ReferralManager.ReferralResult.ErrorResult
 import au.com.shiftyjelly.pocketcasts.repositories.referrals.ReferralManager.ReferralResult.SuccessResult
-import au.com.shiftyjelly.pocketcasts.repositories.referrals.ReferralManager
 import au.com.shiftyjelly.pocketcasts.sharedtest.MainCoroutineRule
 import au.com.shiftyjelly.pocketcasts.sharing.SharingClient
 import au.com.shiftyjelly.pocketcasts.sharing.SharingRequest

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -128,6 +128,7 @@
     <string name="loading">Loading</string>
     <string name="please_wait">Please wait just a moment</string>
     <string name="error">Error</string>
+    <string name="error_generic_message">Something went wrong. Please try again later.</string>
     <string name="are_you_sure">Are you sure?</string>
     <string name="back">Back</string>
     <string name="retry">Retry</string>

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/referrals/ReferralManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/referrals/ReferralManager.kt
@@ -3,9 +3,40 @@ package au.com.shiftyjelly.pocketcasts.repositories.referrals
 import com.pocketcasts.service.api.ReferralCodeResponse
 import com.pocketcasts.service.api.ReferralRedemptionResponse
 import com.pocketcasts.service.api.ReferralValidationResponse
+import retrofit2.Response
 
 interface ReferralManager {
-    suspend fun getReferralCode(): ReferralCodeResponse
-    suspend fun validateReferralCode(code: String): ReferralValidationResponse
-    suspend fun redeemReferralCode(code: String): ReferralRedemptionResponse
+    suspend fun getReferralCode(): ReferralResult<ReferralCodeResponse>
+    suspend fun validateReferralCode(code: String): ReferralResult<ReferralValidationResponse>
+    suspend fun redeemReferralCode(code: String): ReferralResult<ReferralRedemptionResponse>
+
+    sealed class ReferralResult<T> {
+        companion object {
+            fun <T> create(error: Throwable): ErrorResult<T> {
+                return ErrorResult(error.message ?: "unknown error", error = error)
+            }
+
+            fun <T> create(response: Response<T>): ReferralResult<T> {
+                return if (response.isSuccessful) {
+                    val body = response.body()
+                    if (body == null || response.code() == 204) {
+                        EmptyResult()
+                    } else {
+                        SuccessResult(body = body)
+                    }
+                } else {
+                    val msg = response.errorBody()?.string()
+                    val errorMsg = if (msg.isNullOrEmpty()) {
+                        response.message()
+                    } else {
+                        msg
+                    }
+                    ErrorResult(errorMsg ?: "unknown error")
+                }
+            }
+        }
+        class EmptyResult<T> : ReferralResult<T>()
+        data class SuccessResult<T>(val body: T) : ReferralResult<T>()
+        data class ErrorResult<T>(val errorMessage: String, val error: Throwable? = null) : ReferralResult<T>()
+    }
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/referrals/ReferralManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/referrals/ReferralManagerImpl.kt
@@ -1,24 +1,34 @@
 package au.com.shiftyjelly.pocketcasts.repositories.referrals
 
+import au.com.shiftyjelly.pocketcasts.repositories.referrals.ReferralManager.ReferralResult
 import au.com.shiftyjelly.pocketcasts.repositories.sync.SyncManager
-import com.pocketcasts.service.api.ReferralCodeResponse
-import com.pocketcasts.service.api.ReferralRedemptionResponse
-import com.pocketcasts.service.api.ReferralValidationResponse
+import au.com.shiftyjelly.pocketcasts.utils.NetworkWrapper
+import au.com.shiftyjelly.pocketcasts.utils.exception.NoNetworkException
 import javax.inject.Inject
 
 class ReferralManagerImpl @Inject constructor(
     var syncManager: SyncManager,
+    private val networkWrapper: NetworkWrapper,
 ) : ReferralManager {
 
-    override suspend fun getReferralCode(): ReferralCodeResponse {
-        return syncManager.getReferralCode()
+    override suspend fun getReferralCode() = try {
+        if (!networkWrapper.isConnected()) throw NoNetworkException()
+        ReferralResult.create(syncManager.getReferralCode())
+    } catch (e: Exception) {
+        ReferralResult.create(e)
     }
 
-    override suspend fun validateReferralCode(code: String): ReferralValidationResponse {
-        return syncManager.validateReferralCode(code)
+    override suspend fun validateReferralCode(code: String) = try {
+        if (!networkWrapper.isConnected()) throw NoNetworkException()
+        ReferralResult.create(syncManager.validateReferralCode(code))
+    } catch (e: Exception) {
+        ReferralResult.create(e)
     }
 
-    override suspend fun redeemReferralCode(code: String): ReferralRedemptionResponse {
-        return syncManager.redeemReferralCode(code)
+    override suspend fun redeemReferralCode(code: String) = try {
+        if (!networkWrapper.isConnected()) throw NoNetworkException()
+        ReferralResult.create(syncManager.redeemReferralCode(code))
+    } catch (e: Exception) {
+        ReferralResult.create(e)
     }
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/SyncManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/SyncManager.kt
@@ -104,7 +104,7 @@ interface SyncManager : NamedSettingsCaller {
     suspend fun sendFeedback(subject: String, inbox: String, message: String): Response<Void>
 
     // Referral
-    suspend fun getReferralCode(): ReferralCodeResponse
-    suspend fun validateReferralCode(code: String): ReferralValidationResponse
-    suspend fun redeemReferralCode(code: String): ReferralRedemptionResponse
+    suspend fun getReferralCode(): Response<ReferralCodeResponse>
+    suspend fun validateReferralCode(code: String): Response<ReferralValidationResponse>
+    suspend fun redeemReferralCode(code: String): Response<ReferralRedemptionResponse>
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/SyncManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/SyncManagerImpl.kt
@@ -432,19 +432,19 @@ class SyncManagerImpl @Inject constructor(
         }
 
     // Referral
-    override suspend fun getReferralCode(): ReferralCodeResponse {
+    override suspend fun getReferralCode(): Response<ReferralCodeResponse> {
         return getCacheTokenOrLogin { token ->
             syncServiceManager.getReferralCode(token)
         }
     }
 
-    override suspend fun validateReferralCode(code: String): ReferralValidationResponse {
+    override suspend fun validateReferralCode(code: String): Response<ReferralValidationResponse> {
         return getCacheTokenOrLogin { token ->
             syncServiceManager.validateReferralCode(token, code)
         }
     }
 
-    override suspend fun redeemReferralCode(code: String): ReferralRedemptionResponse {
+    override suspend fun redeemReferralCode(code: String): Response<ReferralRedemptionResponse> {
         return getCacheTokenOrLogin { token ->
             syncServiceManager.redeemReferralCode(token, code)
         }

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/referrals/ReferralManagerImplTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/referrals/ReferralManagerImplTest.kt
@@ -1,79 +1,143 @@
 package au.com.shiftyjelly.pocketcasts.repositories.referrals
 
+import au.com.shiftyjelly.pocketcasts.repositories.referrals.ReferralManager.ReferralResult.SuccessResult
+import au.com.shiftyjelly.pocketcasts.repositories.referrals.ReferralManager.ReferralResult.ErrorResult
 import au.com.shiftyjelly.pocketcasts.repositories.sync.SyncManager
+import au.com.shiftyjelly.pocketcasts.utils.NetworkWrapper
+import au.com.shiftyjelly.pocketcasts.utils.exception.NoNetworkException
 import com.pocketcasts.service.api.ReferralCodeResponse
 import com.pocketcasts.service.api.ReferralRedemptionResponse
 import com.pocketcasts.service.api.ReferralValidationResponse
 import kotlinx.coroutines.test.runTest
-import org.junit.Assert.assertEquals
+import okhttp3.ResponseBody
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.mockito.Mockito.mock
 import org.mockito.kotlin.whenever
+import retrofit2.Response
 
 class ReferralManagerImplTest {
 
-    private lateinit var syncManager: SyncManager
+    private var syncManager: SyncManager = mock()
+    private var networkWrapper: NetworkWrapper = mock()
     private lateinit var referralManager: ReferralManagerImpl
 
     @Before
     fun setUp() {
-        syncManager = mock(SyncManager::class.java)
-        referralManager = ReferralManagerImpl(syncManager)
+        whenever(networkWrapper.isConnected()).thenReturn(true)
+        referralManager = ReferralManagerImpl(
+            syncManager,
+            networkWrapper,
+        )
     }
 
     @Test
-    fun `given no error, when referrals code is called, then returns referral code response`() = runTest {
-        val expectedResponse = mock<ReferralCodeResponse>()
-        whenever(syncManager.getReferralCode()).thenReturn(expectedResponse)
+    fun `given no error, when referral code is called, then returns success code result`() = runTest {
+        val httpResponse = mockHttpResponse(true, ReferralCodeResponse::class.java)
+        whenever(syncManager.getReferralCode()).thenReturn(httpResponse)
 
         val result = referralManager.getReferralCode()
 
-        assertEquals(expectedResponse, result)
-    }
-
-    @Test(expected = Exception::class)
-    fun `given server error, when referrals code is called, then throws exception`() = runTest {
-        whenever(syncManager.getReferralCode()).thenThrow(Exception::class.java)
-
-        referralManager.getReferralCode()
+        assertTrue(result is SuccessResult<ReferralCodeResponse>)
     }
 
     @Test
-    fun `given valid code, when referral code is validated, then returns validation response`() = runTest {
+    fun `given unsuccessful response, when referral code is called, then returns error result`() = runTest {
+        val httpResponse = mockHttpResponse(false, ReferralCodeResponse::class.java)
+        whenever(syncManager.getReferralCode()).thenReturn(httpResponse)
+
+        val result = referralManager.getReferralCode()
+
+        assertTrue(result is ErrorResult<ReferralCodeResponse>)
+    }
+
+    @Test
+    fun `given no network, when referral code is called, then returns error result with NoNetworkException`() = runTest {
+        whenever(networkWrapper.isConnected()).thenReturn(false)
+        referralManager = ReferralManagerImpl(syncManager, networkWrapper)
+
+        val result = referralManager.getReferralCode()
+
+        assertTrue((result as ErrorResult).error is NoNetworkException)
+    }
+
+    @Test
+    fun `given valid code, when referral code is validated, then returns validation success result`() = runTest {
         val code = "valid_code"
-        val expectedResponse = mock<ReferralValidationResponse>()
-        whenever(syncManager.validateReferralCode(code)).thenReturn(expectedResponse)
+        val httpResponse = mockHttpResponse(true, ReferralValidationResponse::class.java)
+        whenever(syncManager.validateReferralCode(code)).thenReturn(httpResponse)
 
         val result = referralManager.validateReferralCode(code)
 
-        assertEquals(expectedResponse, result)
-    }
-
-    @Test(expected = Exception::class)
-    fun `given invalid code, when referral code is validated, then throws exception`() = runTest {
-        val code = "invalid_code"
-        whenever(syncManager.validateReferralCode(code)).thenThrow(Exception::class.java)
-
-        referralManager.validateReferralCode(code)
+        assertTrue(result is SuccessResult<ReferralValidationResponse>)
     }
 
     @Test
-    fun `given valid code, when referral code is redeemed, then returns redemption response`() = runTest {
+    fun `given invalid code, when referral code is validated, then error result`() = runTest {
+        val code = "invalid_code"
+        val httpResponse = mockHttpResponse(false, ReferralValidationResponse::class.java)
+        whenever(syncManager.validateReferralCode(code)).thenReturn(httpResponse)
+
+        val result = referralManager.validateReferralCode(code)
+
+        assertTrue(result is ErrorResult<ReferralValidationResponse>)
+    }
+
+    @Test
+    fun `given no network, when referral code is validated, then returns error result with NoNetworkException`() = runTest {
         val code = "valid_code"
-        val expectedResponse = mock<ReferralRedemptionResponse>()
-        whenever(syncManager.redeemReferralCode(code)).thenReturn(expectedResponse)
+        whenever(networkWrapper.isConnected()).thenReturn(false)
+        referralManager = ReferralManagerImpl(syncManager, networkWrapper)
+
+        val result = referralManager.validateReferralCode(code)
+
+        assertTrue((result as ErrorResult).error is NoNetworkException)
+    }
+
+    @Test
+    fun `given valid code, when referral code is redeemed, then returns redemption success result`() = runTest {
+        val code = "valid_code"
+        val httpResponse = mockHttpResponse(true, ReferralRedemptionResponse::class.java)
+        whenever(syncManager.redeemReferralCode(code)).thenReturn(httpResponse)
 
         val result = referralManager.redeemReferralCode(code)
 
-        assertEquals(expectedResponse, result)
+        assertTrue(result is SuccessResult<ReferralRedemptionResponse>)
     }
 
-    @Test(expected = Exception::class)
-    fun `given invalid code, when referral code is redeemed, then throws exception`() = runTest {
+    @Test
+    fun `given invalid code, when referral code is redeemed, then error result`() = runTest {
         val code = "invalid_code"
-        whenever(syncManager.redeemReferralCode(code)).thenThrow(Exception::class.java)
+        val httpResponse = mockHttpResponse(false, ReferralRedemptionResponse::class.java)
+        whenever(syncManager.redeemReferralCode(code)).thenReturn(httpResponse)
 
-        referralManager.redeemReferralCode(code)
+        val result = referralManager.redeemReferralCode(code)
+
+        assertTrue(result is ErrorResult<ReferralRedemptionResponse>)
+    }
+
+    @Test
+    fun `given no network, when referral code is redeemed, then returns error result with NoNetworkException`() = runTest {
+        val code = "valid_code"
+        whenever(networkWrapper.isConnected()).thenReturn(false)
+        referralManager = ReferralManagerImpl(syncManager, networkWrapper)
+
+        val result = referralManager.redeemReferralCode(code)
+
+        assertTrue((result as ErrorResult).error is NoNetworkException)
+    }
+
+    private fun <T> mockHttpResponse(success: Boolean, responseClass: Class<T>): Response<T> {
+        val httpResponse = mock<Response<T>>()
+        whenever(httpResponse.isSuccessful).thenReturn(success)
+        if (success) {
+            val expectedResponse = mock(responseClass)
+            whenever(httpResponse.body()).thenReturn(expectedResponse)
+        } else {
+            val expectedResponse = mock<ResponseBody>()
+            whenever(httpResponse.errorBody()).thenReturn(expectedResponse)
+        }
+        return httpResponse
     }
 }

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/referrals/ReferralManagerImplTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/referrals/ReferralManagerImplTest.kt
@@ -1,7 +1,7 @@
 package au.com.shiftyjelly.pocketcasts.repositories.referrals
 
-import au.com.shiftyjelly.pocketcasts.repositories.referrals.ReferralManager.ReferralResult.SuccessResult
 import au.com.shiftyjelly.pocketcasts.repositories.referrals.ReferralManager.ReferralResult.ErrorResult
+import au.com.shiftyjelly.pocketcasts.repositories.referrals.ReferralManager.ReferralResult.SuccessResult
 import au.com.shiftyjelly.pocketcasts.repositories.sync.SyncManager
 import au.com.shiftyjelly.pocketcasts.utils.NetworkWrapper
 import au.com.shiftyjelly.pocketcasts.utils.exception.NoNetworkException

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/SyncService.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/SyncService.kt
@@ -176,13 +176,13 @@ interface SyncService {
     // Referral
     @Headers("Content-Type: application/octet-stream")
     @GET("/referrals/code")
-    suspend fun getReferralCode(@Header("Authorization") authorization: String): ReferralCodeResponse
+    suspend fun getReferralCode(@Header("Authorization") authorization: String): Response<ReferralCodeResponse>
 
     @Headers("Content-Type: application/octet-stream")
     @GET("/referrals/validate")
-    suspend fun validateReferralCode(@Header("Authorization") authorization: String, @Query("code") code: String): ReferralValidationResponse
+    suspend fun validateReferralCode(@Header("Authorization") authorization: String, @Query("code") code: String): Response<ReferralValidationResponse>
 
     @Headers("Content-Type: application/octet-stream")
     @POST("/referrals/redeem")
-    suspend fun redeemReferralCode(@Header("Authorization") authorization: String, @Body request: ReferralRedemptionRequest): ReferralRedemptionResponse
+    suspend fun redeemReferralCode(@Header("Authorization") authorization: String, @Body request: ReferralRedemptionRequest): Response<ReferralRedemptionResponse>
 }

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/SyncServiceManager.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/SyncServiceManager.kt
@@ -296,15 +296,15 @@ open class SyncServiceManager @Inject constructor(
     }
 
     // Referral
-    suspend fun getReferralCode(token: AccessToken): ReferralCodeResponse {
+    suspend fun getReferralCode(token: AccessToken): Response<ReferralCodeResponse> {
         return service.getReferralCode(addBearer(token))
     }
 
-    suspend fun validateReferralCode(token: AccessToken, code: String): ReferralValidationResponse {
+    suspend fun validateReferralCode(token: AccessToken, code: String): Response<ReferralValidationResponse> {
         return service.validateReferralCode(addBearer(token), code)
     }
 
-    suspend fun redeemReferralCode(token: AccessToken, code: String): ReferralRedemptionResponse {
+    suspend fun redeemReferralCode(token: AccessToken, code: String): Response<ReferralRedemptionResponse> {
         val request = ReferralRedemptionRequest.newBuilder()
             .setCode(code)
             .build()

--- a/modules/services/sharing/build.gradle.kts
+++ b/modules/services/sharing/build.gradle.kts
@@ -21,6 +21,7 @@ dependencies {
     api(libs.dagger.hilt.android)
 
     api(projects.modules.services.analytics)
+    api(projects.modules.services.deeplink)
     api(projects.modules.services.model)
     api(projects.modules.services.repositories)
 

--- a/modules/services/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/SharingClient.kt
+++ b/modules/services/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/SharingClient.kt
@@ -17,6 +17,7 @@ import androidx.core.content.getSystemService
 import androidx.core.graphics.drawable.toBitmap
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
 import au.com.shiftyjelly.pocketcasts.analytics.SourceView
+import au.com.shiftyjelly.pocketcasts.deeplink.ReferralsDeepLink
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.repositories.images.PocketCastsImageRequestFactory
@@ -128,7 +129,7 @@ class SharingClient(
         }
 
         is SharingRequest.Data.ReferralLink -> {
-            val shareText = "${context.getString(LR.string.referrals_share_text)}\n\n${data.sharingUrl("https://$webBasedHost")}"
+            val shareText = "${context.getString(LR.string.referrals_share_text)}\n\n${data.sharingUrl(webBasedHost)}"
             val shareSubject = context.getString(LR.string.referrals_share_subject)
             Intent()
                 .setAction(Intent.ACTION_SEND)
@@ -470,11 +471,11 @@ data class SharingRequest internal constructor(
         }
 
         class ReferralLink internal constructor(
-            private val referralCode: String,
+            val referralCode: String,
         ) : Data {
             override val podcast: PodcastModel? = null
 
-            fun sharingUrl(host: String) = "$host/redeem-guest-pass/$referralCode"
+            fun sharingUrl(host: String) = ReferralsDeepLink(code = referralCode).toUri(host)
 
             override fun toString() = "ReferralLink(referralCode=$referralCode"
         }


### PR DESCRIPTION
## Description
This gets referral code using the endpoint while displaying the send guest pass screen.

## Testing Instructions

1. Switch to "debug" build variant
2. Launch the app and login as a paid user
3. Go to `Profile` tab
4. Tap on gift icon
5. Notice that send guest pass screen is shown
6. Tap "Share Guest Pass" and copy the share text
7. ✅ Notice that there is a real referral code appended to the share URL
8. Close the screen
9. Disable internet
10. Tap on gift icon again
11. ✅ Notice that you see an error screen (this is just a placeholder)
12. Enable internet
13. Tap try again
14. ✅ Notice that data is loaded again.


## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
