### PR TITLE
[Sleep Timer] Fix - Volume doesn't return to original level if device is shaken during fade-out

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
         ([#2925](https://github.com/Automattic/pocket-casts-android/pull/2925))
     *   Fix play button local file getting set to pause after episode completion
         ([#1627](https://github.com/Automattic/pocket-casts-android/pull/1627))
+    *   Fix volume that was not returning to the original level after restarting sleep timer by shaking the device
+        ([#2930](https://github.com/Automattic/pocket-casts-android/pull/2930))
 *   New Features
     *   Add sleep timer settings to sleep timer bottom sheet
         ([#2829](https://github.com/Automattic/pocket-casts-android/pull/2829))

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
@@ -2546,6 +2546,10 @@ open class PlaybackManager @Inject constructor(
 
     fun isSleepAfterChapterEnabled(): Boolean = chaptersUntilSleep != 0
 
+    fun restorePlayerVolume() {
+        (player as? SimplePlayer)?.restoreVolume()
+    }
+
     private fun getCurrentChapterUuidForSleepTime(playbackState: PlaybackState): String? {
         val currentChapter = playbackState.chapters.getChapter(playbackState.positionMs.milliseconds)
 

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/SimplePlayer.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/SimplePlayer.kt
@@ -172,6 +172,14 @@ class SimplePlayer(
         return player?.volume
     }
 
+    /**
+     * 1.0 represents the maximum/default volume,
+     * while 0.0 represents complete silence
+     */
+    fun restoreVolume() {
+        player?.volume = 1.0f
+    }
+
     override fun setPodcast(podcast: Podcast?) {}
 
     @OptIn(UnstableApi::class)

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/SleepTimerRestartWhenShakingDevice.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/SleepTimerRestartWhenShakingDevice.kt
@@ -66,6 +66,7 @@ class SleepTimerRestartWhenShakingDevice @Inject constructor(
         if (settings.shakeToResetSleepTimer.value) {
             val time = sleepTimer.restartTimerIfIsRunning onSuccess@{
                 playbackManager.updateSleepTimerStatus(sleepTimeRunning = true)
+                playbackManager.restorePlayerVolume()
 
                 if (context.isAppForeground()) {
                     Toast.makeText(


### PR DESCRIPTION
## Description
- This restore the original player volume after restarting sleep timer by shaking the device


Fixes #2440

## Testing Instructions

1. Set timer and start episode. I would set 1 minute for this step
2. When time starts to fade out, shake device. It starts fading out when have 5 seconds left, but to see the issue I recommend to shake the device when it has 2 or 3 seconds left
3. Wait for sleep timer being restarted
4. ✅ Ensure the player volume returns to the original one before shaking the device


## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.

