### PR TITLE
Do not apply rounded corners transformation if radius is 0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
         ([#2811](https://github.com/Automattic/pocket-casts-android/pull/2811))
     *   Add a visibility animation to the submit button on the rating screen
         ([#2824](https://github.com/Automattic/pocket-casts-android/pull/2824))
+    *   Improve performance of rendering artwork
+        ([#2832](https://github.com/Automattic/pocket-casts-android/pull/2832))
 *   Bug Fixes
     *   Fix issue when transcript type have an alternative valid mime type 
         [#2926](https://github.com/Automattic/pocket-casts-ios/issues/2926)

--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/images/RoundedCornersTransformation.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/images/RoundedCornersTransformation.kt
@@ -43,6 +43,10 @@ class RoundedCornersTransformation(
     override val cacheKey = "${javaClass.name}-$topLeft,$topRight,$bottomLeft,$bottomRight"
 
     override suspend fun transform(input: Bitmap, size: Size): Bitmap {
+        if (topLeft == 0f && topRight == 0f && bottomLeft == 0f && bottomRight == 0f) {
+            return input
+        }
+
         val paint = Paint(Paint.ANTI_ALIAS_FLAG or Paint.FILTER_BITMAP_FLAG)
 
         // Do not crop to target's size to avoid scaling issues.


### PR DESCRIPTION
## Description

`RoundedCornersTransformation` performs poorly with large bitmaps, especially in conjunction with `RecyclerView`, resulting in a subpar experience. The `PodcastGridRow` component uses a corner radius of 0, which triggers unnecessary calculations. This PR omits those calculations.

I plan to remove `RoundedCornersTransformation` altogether, as it seems unnecessary except for widget support on older devices (but I think we can live without that). However, I didn't want to make such a significant change here. Since this PR targets `7.73`, I aimed to make the smallest impact possible.

Context: p1727269586207829-slack-C02A333D8LQ

## Testing Instructions

1. Open the Discover section.
2. Got to "Podcasts with Transcripts"
3. Scrolling should not stutter.

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] ~I have considered whether it makes sense to add tests for my changes~
- [x] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [x] ~Any jetpack compose components I added or changed are covered by compose previews~
- [x] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~