### PR TITLE
Improve performance of discover grid layout

### DIFF
--- a/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/GridListAdapter.kt
+++ b/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/GridListAdapter.kt
@@ -25,26 +25,24 @@ class GridListAdapter(
     private val imageSize: Int = 200,
 ) : ListAdapter<DiscoverPodcast, GridListAdapter.PodcastViewHolder>(differ) {
     class PodcastViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
-        val podcastGridRow: PodcastGridRow
-            get() = this.itemView as PodcastGridRow
+        private val podcastGridRow get() = itemView as PodcastGridRow
+
+        fun bind(podcast: DiscoverPodcast) {
+            podcastGridRow.podcast = podcast
+        }
     }
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): PodcastViewHolder {
         val podcastGridRow = PodcastGridRow(context = parent.context).apply {
             updatePadding(bottom = 16.dpToPx(parent.context))
             updateImageSize(imageSize = imageSize)
+            onSubscribeClickedListener = onPodcastSubscribe
+            onPodcastClickedListener = onPodcastClicked
         }
         return PodcastViewHolder(podcastGridRow)
     }
 
     override fun onBindViewHolder(holder: PodcastViewHolder, position: Int) {
-        val podcast = getItem(position)
-        holder.podcastGridRow.podcast = podcast
-        holder.podcastGridRow.onPodcastClicked = {
-            onPodcastClicked(podcast)
-        }
-        holder.podcastGridRow.onSubscribeClicked = {
-            onPodcastSubscribe(podcast.uuid)
-        }
+        holder.bind(getItem(position))
     }
 }

--- a/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/GridListAdapter.kt
+++ b/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/GridListAdapter.kt
@@ -11,7 +11,7 @@ import au.com.shiftyjelly.pocketcasts.utils.extensions.dpToPx
 
 private val differ = object : DiffUtil.ItemCallback<DiscoverPodcast>() {
     override fun areItemsTheSame(oldItem: DiscoverPodcast, newItem: DiscoverPodcast): Boolean {
-        return oldItem == newItem
+        return oldItem.uuid == newItem.uuid
     }
 
     override fun areContentsTheSame(oldItem: DiscoverPodcast, newItem: DiscoverPodcast): Boolean {

--- a/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/GridListAdapter.kt
+++ b/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/GridListAdapter.kt
@@ -19,12 +19,11 @@ private val differ = object : DiffUtil.ItemCallback<DiscoverPodcast>() {
     }
 }
 
-class GridListAdapter(private val imageSize: Int, val onPodcastClicked: ((DiscoverPodcast) -> Unit), val onPodcastSubscribe: ((String) -> Unit)) : ListAdapter<DiscoverPodcast, GridListAdapter.PodcastViewHolder>(differ) {
-
-    companion object {
-        const val defaultImageSize = 200
-    }
-
+class GridListAdapter(
+    private val onPodcastClicked: ((DiscoverPodcast) -> Unit),
+    private val onPodcastSubscribe: ((String) -> Unit),
+    private val imageSize: Int = 200,
+) : ListAdapter<DiscoverPodcast, GridListAdapter.PodcastViewHolder>(differ) {
     class PodcastViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
         val podcastGridRow: PodcastGridRow
             get() = this.itemView as PodcastGridRow

--- a/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/PodcastGridFragment.kt
+++ b/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/PodcastGridFragment.kt
@@ -121,7 +121,7 @@ class PodcastGridFragment : PodcastGridListFragment() {
 
         recyclerView.addItemDecoration(SpaceItemDecoration())
         val imageSize = UiUtil.getDiscoverGridImageWidthPx(context = recyclerView.context)
-        adapter = GridListAdapter(imageSize, onPodcastClicked, onPodcastSubscribe)
+        adapter = GridListAdapter(onPodcastClicked, onPodcastSubscribe, imageSize)
         recyclerView.adapter = adapter
     }
 

--- a/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/PodcastGridRow.kt
+++ b/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/PodcastGridRow.kt
@@ -30,6 +30,34 @@ class PodcastGridRow @JvmOverloads constructor(
     private val imagePodcast: ImageView
     private var imageSize: Int? = null
 
+    var onSubscribeClickedListener: ((String) -> Unit)? = null
+        set(value) {
+            field = value
+            val listener = if (value != null) {
+                OnClickListener {
+                    val uuid = podcast?.uuid ?: return@OnClickListener
+                    btnSubscribe.updateSubscribeButtonIcon(subscribed = true, colorSubscribed = UR.attr.contrast_01, colorUnsubscribed = UR.attr.contrast_01)
+                    value(uuid)
+                }
+            } else {
+                null
+            }
+            btnSubscribe.setOnClickListener(listener)
+        }
+
+    var onPodcastClickedListener: ((DiscoverPodcast) -> Unit)? = null
+        set(value) {
+            field = value
+            val listener = if (value != null) {
+                OnClickListener {
+                    podcast?.let(value::invoke)
+                }
+            } else {
+                null
+            }
+            setOnClickListener(listener)
+        }
+
     init {
         LayoutInflater.from(context).inflate(R.layout.item_grid, this, true)
         lblTitle = findViewById(R.id.lblTitle)
@@ -71,23 +99,6 @@ class PodcastGridRow @JvmOverloads constructor(
             imageRequestFactory.copy(size = imageSize).createForPodcast(podcast.uuid).loadInto(imagePodcast)
         }
     }
-
-    var onSubscribeClicked: (() -> Unit)? = null
-        set(value) {
-            field = value
-            btnSubscribe.setOnClickListener {
-                btnSubscribe.updateSubscribeButtonIcon(subscribed = true, colorSubscribed = UR.attr.contrast_01, colorUnsubscribed = UR.attr.contrast_01)
-                onSubscribeClicked?.invoke()
-            }
-        }
-
-    var onPodcastClicked: (() -> Unit)? = null
-        set(value) {
-            field = value
-            this.setOnClickListener {
-                onPodcastClicked?.invoke()
-            }
-        }
 
     fun clear() {
         lblTitle.text = null

--- a/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/PodcastGridRow.kt
+++ b/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/PodcastGridRow.kt
@@ -23,7 +23,7 @@ class PodcastGridRow @JvmOverloads constructor(
     defStyleAttr: Int = 0,
 ) : LinearLayout(context, attrs, defStyleAttr) {
 
-    private val imageRequestFactory = PocketCastsImageRequestFactory(context).themed()
+    private var imageRequestFactory = PocketCastsImageRequestFactory(context).themed()
     private val lblTitle: TextView
     private val lblSubtitle: TextView
     private val btnSubscribe: ImageButton
@@ -89,6 +89,7 @@ class PodcastGridRow @JvmOverloads constructor(
 
     fun updateImageSize(imageSize: Int) {
         this.imageSize = imageSize
+        this.imageRequestFactory = imageRequestFactory.copy(size = imageSize)
         loadImage()
     }
 
@@ -96,7 +97,7 @@ class PodcastGridRow @JvmOverloads constructor(
         val podcast = podcast
         val imageSize = imageSize
         if (podcast != null && imageSize != null) {
-            imageRequestFactory.copy(size = imageSize).createForPodcast(podcast.uuid).loadInto(imagePodcast)
+            imageRequestFactory.createForPodcast(podcast.uuid).loadInto(imagePodcast)
         }
     }
 

--- a/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/PodcastListFragment.kt
+++ b/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/PodcastListFragment.kt
@@ -176,7 +176,7 @@ class PodcastListFragment : PodcastGridListFragment() {
             is ExpandedStyle.PlainList -> PlainListAdapter(onPodcastClicked, onPodcastSubscribe, onPromotionClick, onEpisodeClick, onEpisodePlayClick, onEpisodeStopClick)
             is ExpandedStyle.RankedList -> RankedListAdapter(onPodcastClicked, onPodcastSubscribe, tagline, theme)
             is ExpandedStyle.DescriptiveList -> DescriptiveListAdapter(onPodcastClicked, onPodcastSubscribe) as ListAdapter<Any, RecyclerView.ViewHolder>
-            is ExpandedStyle.GridList -> GridListAdapter(GridListAdapter.defaultImageSize, onPodcastClicked, onPodcastSubscribe) as ListAdapter<Any, RecyclerView.ViewHolder>
+            is ExpandedStyle.GridList -> GridListAdapter(onPodcastClicked, onPodcastSubscribe) as ListAdapter<Any, RecyclerView.ViewHolder>
             else -> PlainListAdapter(onPodcastClicked, onPodcastSubscribe, onPromotionClick, onEpisodeClick, onEpisodePlayClick, onEpisodeStopClick)
         }
         recyclerView.adapter = adapter


### PR DESCRIPTION
## Description

Some small improvements to the grid layout I didn't want to include in #2932.

1. Compare identity using UUID instead of the whole object.
2. Do not instantiate listeners on bind and instead do it in the constructor.
3. Do not copy image request factory on bind and instead do it when image size changes.

## Testing Instructions

1. Go to the Discover page.
2. Open "Podcasts with Transcripts".
3. Tapping on a podcast should open it.
4. Tapping on a subscribe button should subscribe to a podcast.


## Checklist
- [x] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] ~I have considered whether it makes sense to add tests for my changes~
- [x] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [x] ~Any jetpack compose components I added or changed are covered by compose previews~
- [x] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~