### PR TITLE
Fix: Crash when uploading file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,6 @@
         ([#1627](https://github.com/Automattic/pocket-casts-android/pull/1627))
     *   Fix volume that was not returning to the original level after restarting sleep timer by shaking the device
         ([#2930](https://github.com/Automattic/pocket-casts-android/pull/2930))
-    *   Fix crash when uploading file
-        ([#2938](https://github.com/Automattic/pocket-casts-android/pull/2938))
 *   New Features
     *   Add sleep timer settings to sleep timer bottom sheet
         ([#2829](https://github.com/Automattic/pocket-casts-android/pull/2829))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
         ([#1627](https://github.com/Automattic/pocket-casts-android/pull/1627))
     *   Fix volume that was not returning to the original level after restarting sleep timer by shaking the device
         ([#2930](https://github.com/Automattic/pocket-casts-android/pull/2930))
+    *   Fix crash when uploading file
+        ([#2938](https://github.com/Automattic/pocket-casts-android/pull/2938))
 *   New Features
     *   Add sleep timer settings to sleep timer bottom sheet
         ([#2829](https://github.com/Automattic/pocket-casts-android/pull/2829))

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/cloud/AddFileActivity.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/cloud/AddFileActivity.kt
@@ -530,6 +530,8 @@ class AddFileActivity :
                         }
                     }
                 } catch (e: Exception) {
+                    analyticsTracker.track(AnalyticsEvent.UPLOADED_FILES_UPLOAD_FAILED)
+
                     Timber.e(e, "Could not load file")
 
                     launch(Dispatchers.Main) {

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/cloud/AddFileActivity.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/cloud/AddFileActivity.kt
@@ -484,7 +484,7 @@ class AddFileActivity :
         }
 
         if (isUriInvalid(uri)) {
-            analyticsTracker.track(AnalyticsEvent.UPLOADED_FILES_INVALID_FILE_ERROR)
+            analyticsTracker.track(AnalyticsEvent.UPLOADED_FILES_INVALID_FILE_ERROR, mapOf("uri" to uri.toString()))
 
             Timber.e("Could not upload invalid file")
 
@@ -530,7 +530,7 @@ class AddFileActivity :
                         }
                     }
                 } catch (e: Exception) {
-                    analyticsTracker.track(AnalyticsEvent.UPLOADED_FILES_UPLOAD_FAILED)
+                    analyticsTracker.track(AnalyticsEvent.UPLOADED_FILES_UPLOAD_FAILED, mapOf("uri" to uri.toString()))
 
                     Timber.e(e, "Could not load file")
 

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/cloud/AddFileActivity.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/cloud/AddFileActivity.kt
@@ -36,6 +36,8 @@ import androidx.media3.extractor.mp3.Mp3Extractor
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import au.com.shiftyjelly.pocketcasts.account.onboarding.OnboardingActivity
+import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
+import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTracker
 import au.com.shiftyjelly.pocketcasts.deeplink.CloudFilesDeepLink
 import au.com.shiftyjelly.pocketcasts.models.entity.UserEpisode
 import au.com.shiftyjelly.pocketcasts.models.to.SignInState
@@ -142,6 +144,8 @@ class AddFileActivity :
     @Inject lateinit var playbackManager: PlaybackManager
 
     @Inject lateinit var settings: Settings
+
+    @Inject lateinit var analyticsTracker: AnalyticsTracker
 
     private val viewModel: AddFileViewModel by viewModels()
 
@@ -480,6 +484,10 @@ class AddFileActivity :
         }
 
         if (isUriInvalid(uri)) {
+            analyticsTracker.track(AnalyticsEvent.UPLOADED_FILES_INVALID_FILE_ERROR)
+
+            Timber.e("Could not upload invalid file")
+
             val message = getString(LR.string.profile_cloud_add_invalid_file)
             handleErrorWhenLoadingFile(errorMessage = message)
         } else {

--- a/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
+++ b/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
@@ -155,6 +155,7 @@ enum class AnalyticsEvent(val key: String) {
     UPLOADED_FILES_MULTI_SELECT_EXITED("uploaded_files_multi_select_exited"),
     UPLOADED_FILES_SORT_BY_CHANGED("uploaded_files_sort_by_changed"),
     UPLOADED_FILES_ADD_FILE_TAPPED("uploaded_files_add_file_tapped"),
+    UPLOADED_FILES_INVALID_FILE_ERROR("uploaded_files_invalid_file_error"),
 
     /* User File Details View */
     USER_FILE_DETAIL_SHOWN("user_file_detail_shown"),

--- a/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
+++ b/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
@@ -156,6 +156,7 @@ enum class AnalyticsEvent(val key: String) {
     UPLOADED_FILES_SORT_BY_CHANGED("uploaded_files_sort_by_changed"),
     UPLOADED_FILES_ADD_FILE_TAPPED("uploaded_files_add_file_tapped"),
     UPLOADED_FILES_INVALID_FILE_ERROR("uploaded_files_invalid_file_error"),
+    UPLOADED_FILES_UPLOAD_FAILED("uploaded_files_upload_failed"),
 
     /* User File Details View */
     USER_FILE_DETAIL_SHOWN("user_file_detail_shown"),

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -842,6 +842,7 @@
     <string name="profile_cloud_add_file">Add File</string>
     <string name="profile_cloud_edit_file">Edit File</string>
     <string name="profile_cloud_add_file_error">Error adding file: %s</string>
+    <string name="profile_cloud_add_invalid_file">Unable to load the selected file. Please try again or choose a different file.</string>
     <string name="profile_cloud_update_file_error">Sorry, something went wrong trying to update this file. Please try again.</string>
     <string name="profile_confirm">Confirm</string>
     <string name="profile_confirm_new_password">Confirm New Password</string>


### PR DESCRIPTION
## Description
- This is an attempt to fix the crash when the user uploads a file from files screen. After analyzing the code and googling about it I had 3 hypothesis:

1. This issue is caused a generic error when uploading a file. This generic error throws an exception that we are not catching inside the coroutine
2. The URI that we are trying to upload is invalid and we are not checking it. This could also be caused if the user removed or moved the file path after selecting this one to be downloaded. I was able to reproduce a crash with this scenario
3. I thought that it could be related to permissions because this issue is happening mostly on SDK 34, but since we are not trying to access others apps files I would say that we are good in terms of permission and we don't need to do anything else. See this [ref](https://developer.android.com/training/data-storage/shared/media#storage-permission) and this [ref](https://developer.android.com/about/versions/13/behavior-changes-13#granular-media-permissions)

So, for this PR I am addressing the first two hypothesis and also added tracks for both scenarios so we can check them in terms of data

Attempt to fix #2285

## Testing Instructions

### Happy Path
1. Go to Profile -> Files
2. Upload file 
3. ✅ Ensure you can upload a file without any error

### Error Path
1. Go to Profile -> Files
2. Tap o + button to upload a file
3. Select the file
4. You should see the screen to change the file name and colors
5. Put Pocket Casts app in background and delete this file
6. Go back to Pocket Casts app and tap to save
7.  ✅ Ensure you don't get any crash and see the dialog with error message


## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
