### PR TITLE
Transcripts -  decode html entities & update tracks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,9 @@
         ([#2832](https://github.com/Automattic/pocket-casts-android/pull/2832))
 *   Bug Fixes
     *   Fix issue when transcript type have an alternative valid mime type 
-        [#2926](https://github.com/Automattic/pocket-casts-ios/issues/2926)
+        [#2910](https://github.com/Automattic/pocket-casts-android/pull/2910)
+    *   Fix display of html entities in transcripts
+        [#2940](https://github.com/Automattic/pocket-casts-android/issues/2940)
 
 7.72
 -----

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/transcripts/TranscriptFilter.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/transcripts/TranscriptFilter.kt
@@ -12,7 +12,7 @@ private val endOfLineCharEndOfCue = "([.!?])\\z".toRegex()
 private val notEndOfLineCharEndOfCue = "([^.!?$])\\z".toRegex()
 private val nbspRegex = "&nbsp;".toRegex()
 private val breakLineRegex = "<br>|<BR>|<br/>|<BR/>|<BR />|<br />".toRegex()
-private val soundDescriptorRegex = "\\[[^]]*]".toRegex()
+private val soundDescriptorRegex = "\\\\?\\[[^]]*]".toRegex()
 private val htmlSpeakerRegex = "^ *\\w+:\\s*".toRegex()
 private val htmlSpeakerNewlineRegex = "\\n *\\w+:\\s*".toRegex()
 private val emptySpacesAtEndOfLinesRegex = " *\\n".toRegex()
@@ -53,6 +53,7 @@ class TranscriptRegexFilters(private val filters: List<TranscriptFilter>) : Tran
                 RegexFilters.emptySpacesAtEndOfLinesFilter,
                 RegexFilters.doubleOrMoreSpacesFilter,
                 RegexFilters.tripleOrMoreEmptyLinesFilter,
+                HTMLEntitiesFilter(),
             ),
         )
 
@@ -84,6 +85,31 @@ class RegexFilter(private val regex: Regex, private val replacement: String) : T
         } catch (e: PatternSyntaxException) {
             input
         }
+    }
+}
+
+class HTMLEntitiesFilter : TranscriptFilter {
+    private val htmlEntities = arrayOf(
+        Pair("&nbsp;", " "),
+        Pair("&#160;", " "),
+        Pair("&quot;", "\""),
+        Pair("&#34;", "\""),
+        Pair("&apos;", "'"),
+        Pair("&#39;", "'"),
+        Pair("&lt;", "<"),
+        Pair("&#60;", "<"),
+        Pair("&gt;", ">"),
+        Pair("&#62;", ">"),
+        Pair("&#38;", "&"),
+        Pair("&amp;", "&"), // Do this last so that, e.g. @"&amp;lt;" goes to @"&lt;" not @"<"
+    )
+
+    override fun filter(input: String): String {
+        var result = input
+        for (entity in htmlEntities) {
+            result = result.replace(entity.first, entity.second)
+        }
+        return result
     }
 }
 

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/transcripts/TranscriptViewModel.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/transcripts/TranscriptViewModel.kt
@@ -105,7 +105,7 @@ class TranscriptViewModel @Inject constructor(
                                 podcastAndEpisode = it,
                                 analyticsProp = buildMap {
                                     put("type", transcript.type)
-                                    put("show_in_webview", loaded.showInWebView.toString())
+                                    put("show_as_webpage", loaded.showAsWebPage.toString())
                                 }
                             )
                         }
@@ -230,12 +230,11 @@ class TranscriptViewModel @Inject constructor(
             val cuesInfo: List<TranscriptCuesInfo>,
         ) : UiState() {
             val isTranscriptEmpty: Boolean = cuesInfo.isEmpty()
-            val showInWebView: Boolean
+            val showAsWebPage: Boolean
                 get() = transcript.type == TranscriptFormat.HTML.mimeType &&
                         cuesInfo.isNotEmpty() && cuesInfo[0].cuesWithTiming.cues.any {
                     it.text?.contains("<script type=\"text/javascript\">") ?: false
                 }
-            val showSearch = !showInWebView
         }
 
         data class Error(

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/transcripts/TranscriptViewModel.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/transcripts/TranscriptViewModel.kt
@@ -92,7 +92,7 @@ class TranscriptViewModel @Inject constructor(
                     )
 
                     if (!pulledToRefresh) {
-                        podcastAndEpisode?.let { track(AnalyticsEvent.TRANSCRIPT_SHOWN, it) }
+                        podcastAndEpisode?.let { track(AnalyticsEvent.TRANSCRIPT_SHOWN, it, mapOf("type" to transcript.type)) }
                     }
 
                     UiState.TranscriptLoaded(

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/transcripts/TranscriptViewModel.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/transcripts/TranscriptViewModel.kt
@@ -106,7 +106,7 @@ class TranscriptViewModel @Inject constructor(
                                 analyticsProp = buildMap {
                                     put("type", transcript.type)
                                     put("show_as_webpage", loaded.showAsWebPage.toString())
-                                }
+                                },
                             )
                         }
                     }
@@ -232,9 +232,9 @@ class TranscriptViewModel @Inject constructor(
             val isTranscriptEmpty: Boolean = cuesInfo.isEmpty()
             val showAsWebPage: Boolean
                 get() = transcript.type == TranscriptFormat.HTML.mimeType &&
-                        cuesInfo.isNotEmpty() && cuesInfo[0].cuesWithTiming.cues.any {
-                    it.text?.contains("<script type=\"text/javascript\">") ?: false
-                }
+                    cuesInfo.isNotEmpty() && cuesInfo[0].cuesWithTiming.cues.any {
+                        it.text?.contains("<script type=\"text/javascript\">") ?: false
+                    }
         }
 
         data class Error(

--- a/modules/features/player/src/test/java/au/com/shiftyjelly/pocketcasts/player/view/transcripts/TranscriptFilterTest.kt
+++ b/modules/features/player/src/test/java/au/com/shiftyjelly/pocketcasts/player/view/transcripts/TranscriptFilterTest.kt
@@ -85,7 +85,7 @@ class TranscriptFilterTest {
 
     @Test
     fun `filter removes sound descriptors`() {
-        val input = "Hello, [laughs]"
+        val input = "Hello, \\[laughs\\]"
         val expected = "Hello, "
         val filter = RegexFilters.soundDescriptorFilter
         val result = filter.filter(input)
@@ -133,6 +133,15 @@ class TranscriptFilterTest {
         val input = "Hello, world!\n\n\nHow are you?"
         val expected = "Hello, world!\n\nHow are you?"
         val filter = RegexFilters.tripleOrMoreEmptyLinesFilter
+        val result = filter.filter(input)
+        assertEquals(expected, result)
+    }
+
+    @Test
+    fun `filter replaces input with multiple html entities with correct chars`() {
+        val input = "Hello,&nbsp;world!&#160;This&quot;is&#34;a&apos;test&#39;with&lt;multiple&#60;html&gt;entities&#62;and&#38;more&amp;."
+        val expected = "Hello, world! This\"is\"a'test'with<multiple<html>entities>and&more&."
+        val filter = HTMLEntitiesFilter()
         val result = filter.filter(input)
         assertEquals(expected, result)
     }


### PR DESCRIPTION
## Description
This 

- Cherry picks https://github.com/Automattic/pocket-casts-android/commit/2695c16362e8c8e1095b43b229951de1ec0f3bfe into `release/7.73` to match with iOS: https://github.com/Automattic/pocket-casts-ios/pull/2192
- Adds `type` and `show_as_webpage`  param to `transcript_shown` event (cherry-picks https://github.com/Automattic/pocket-casts-android/commit/5378c61d4dfe8b9f23ecf0f099cd491d9d300b29, https://github.com/Automattic/pocket-casts-android/commit/db4ff33123c58d6ca613aa155448729696b9b416)

## Testing Instructions
1. Open transcript for episode: https://pca.st/episode/dba650aa-f34b-453c-9e16-f4e73d2ef1e3
2. ✅ Notice that HTML entities like `&#39;` and `&quot;` are decoded properly
3. Open transcript for https://pca.st/episode/3abf8b43-0ed0-4713-b073-37b379418378
4. ✅ Notice in logs that `transcript_shown` event is tracked with `type` and `show_as_webpage` properties e.g.
`Tracked: transcript_shown, Properties: {"type":"text\/html","show_as_webpage":"true",`

## Screenshots or Screencast 

Before | After
---|----
<img  width=300 src="https://github.com/user-attachments/assets/0e3e7c26-6bf7-4ace-892f-a14488cccd28"/> | <img width=300 src="https://github.com/user-attachments/assets/2d1a426d-fc3c-4377-ab47-4c9b3ead4472"/>


## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
