### PR TITLE
Referrals - Update strings for translations

### DIFF
--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/sharing/SharingClientTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/sharing/SharingClientTest.kt
@@ -17,6 +17,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
+import au.com.shiftyjelly.pocketcasts.models.type.ReferralsOfferInfoMock
 import au.com.shiftyjelly.pocketcasts.sharing.BuildConfig.WEB_BASE_HOST
 import au.com.shiftyjelly.pocketcasts.utils.FileUtil
 import java.io.File
@@ -671,10 +672,12 @@ class SharingClientTest {
     @Test
     fun shareReferralLink() = runTest {
         val referralCode = "referral-code"
-        val text = context.getString(LR.string.referrals_share_text)
-        val subject = context.getString(LR.string.referrals_share_subject)
+        val referralsOfferInfo = ReferralsOfferInfoMock
+        val text = context.getString(LR.string.referrals_share_text, referralsOfferInfo.localizedOfferDurationAdjective.lowercase())
+        val subject = context.getString(LR.string.referrals_share_subject, referralsOfferInfo.localizedOfferDurationNoun)
         val request = SharingRequest.referralLink(
             referralCode = referralCode,
+            referralsOfferInfo = referralsOfferInfo,
         ).build()
 
         val response = client.share(request)

--- a/modules/features/referrals/src/main/kotlin/au/com/shiftyjelly/pocketcasts/referrals/ReferralGuestPassCardView.kt
+++ b/modules/features/referrals/src/main/kotlin/au/com/shiftyjelly/pocketcasts/referrals/ReferralGuestPassCardView.kt
@@ -22,6 +22,8 @@ import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
 import au.com.shiftyjelly.pocketcasts.compose.Devices
 import au.com.shiftyjelly.pocketcasts.compose.components.TextH60
+import au.com.shiftyjelly.pocketcasts.models.type.ReferralsOfferInfo
+import au.com.shiftyjelly.pocketcasts.models.type.ReferralsOfferInfoMock
 import au.com.shiftyjelly.pocketcasts.images.R as IR
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
@@ -50,8 +52,9 @@ object ReferralGuestPassCardDefaults {
 fun ReferralGuestPassCardView(
     modifier: Modifier = Modifier,
     source: ReferralGuestPassCardViewSource,
+    referralsOfferInfo: ReferralsOfferInfo,
 ) {
-    val cardTitle = stringResource(LR.string.referrals_send_guest_pass_card_title)
+    val cardTitle = stringResource(LR.string.referrals_guest_pass_card_title, referralsOfferInfo.localizedOfferDurationAdjective)
     Box(
         modifier = modifier
             .clip(RoundedCornerShape(ReferralGuestPassCardDefaults.cardRadius(source)))
@@ -106,6 +109,7 @@ fun ReferralPassCardSendViewPreview() {
         modifier = Modifier
             .size(DpSize(315.dp, 200.dp)),
         source = ReferralGuestPassCardViewSource.Send,
+        referralsOfferInfo = ReferralsOfferInfoMock,
     )
 }
 
@@ -116,6 +120,7 @@ fun ReferralPassCardProfileBannerViewPreview() {
         modifier = Modifier
             .size(DpSize(150.dp, 150.dp * ReferralGuestPassCardDefaults.cardAspectRatio)),
         source = ReferralGuestPassCardViewSource.ProfileBanner,
+        referralsOfferInfo = ReferralsOfferInfoMock,
     )
 }
 

--- a/modules/features/referrals/src/main/kotlin/au/com/shiftyjelly/pocketcasts/referrals/ReferralsClaimGuestPassBannerCard.kt
+++ b/modules/features/referrals/src/main/kotlin/au/com/shiftyjelly/pocketcasts/referrals/ReferralsClaimGuestPassBannerCard.kt
@@ -95,7 +95,7 @@ private fun ReferralsClaimGuestPassBannerCard(
                         LR.string.referrals_claim_guess_pass_banner_card_title
                     }
                     TextH40(
-                        text = stringResource(textResId),
+                        text = stringResource(textResId, state.referralsOfferInfo.localizedOfferDurationAdjective),
                     )
 
                     Spacer(modifier = modifier.height(8.dp))
@@ -113,6 +113,7 @@ private fun ReferralsClaimGuestPassBannerCard(
                         .width(guestPassCardWidth)
                         .height(guestPassCardWidth * ReferralGuestPassCardDefaults.cardAspectRatio),
                     source = ReferralGuestPassCardViewSource.ProfileBanner,
+                    referralsOfferInfo = state.referralsOfferInfo,
                 )
             }
         }

--- a/modules/features/referrals/src/main/kotlin/au/com/shiftyjelly/pocketcasts/referrals/ReferralsClaimGuestPassPage.kt
+++ b/modules/features/referrals/src/main/kotlin/au/com/shiftyjelly/pocketcasts/referrals/ReferralsClaimGuestPassPage.kt
@@ -42,6 +42,8 @@ import au.com.shiftyjelly.pocketcasts.compose.components.TextP30
 import au.com.shiftyjelly.pocketcasts.compose.components.TextP60
 import au.com.shiftyjelly.pocketcasts.compose.extensions.plusBackgroundBrush
 import au.com.shiftyjelly.pocketcasts.compose.images.SubscriptionBadge
+import au.com.shiftyjelly.pocketcasts.models.type.ReferralsOfferInfo
+import au.com.shiftyjelly.pocketcasts.models.type.ReferralsOfferInfoMock
 import au.com.shiftyjelly.pocketcasts.referrals.ReferralPageDefaults.pageCornerRadius
 import au.com.shiftyjelly.pocketcasts.referrals.ReferralPageDefaults.pageWidthPercent
 import au.com.shiftyjelly.pocketcasts.referrals.ReferralPageDefaults.shouldShowFullScreen
@@ -54,6 +56,7 @@ import au.com.shiftyjelly.pocketcasts.localization.R as LR
 @Composable
 fun ReferralsClaimGuestPassPage(
     onDismiss: () -> Unit,
+    referralsOfferInfo: ReferralsOfferInfo = ReferralsOfferInfoMock,
 ) {
     AppTheme(Theme.ThemeType.DARK) {
         val context = LocalContext.current
@@ -62,6 +65,7 @@ fun ReferralsClaimGuestPassPage(
         ReferralsClaimGuestPassContent(
             windowWidthSizeClass = windowSize.widthSizeClass,
             windowHeightSizeClass = windowSize.heightSizeClass,
+            referralsOfferInfo = referralsOfferInfo,
             onDismiss = onDismiss,
         )
     }
@@ -71,6 +75,7 @@ fun ReferralsClaimGuestPassPage(
 private fun ReferralsClaimGuestPassContent(
     windowWidthSizeClass: WindowWidthSizeClass,
     windowHeightSizeClass: WindowHeightSizeClass,
+    referralsOfferInfo: ReferralsOfferInfo,
     onDismiss: () -> Unit,
 ) {
     BoxWithConstraints(
@@ -118,7 +123,7 @@ private fun ReferralsClaimGuestPassContent(
                 } else {
                     LR.string.referrals_claim_guest_pass_title
                 }
-                val price = "$39.99 USD" // TODO - Referrals: Make it dynamic
+                val price = referralsOfferInfo.localizedPriceAfterOffer
 
                 TextButton(
                     modifier = Modifier
@@ -143,7 +148,7 @@ private fun ReferralsClaimGuestPassContent(
                 Spacer(modifier = Modifier.height(24.dp))
 
                 TextH10(
-                    text = stringResource(titleTextResId),
+                    text = stringResource(titleTextResId, referralsOfferInfo.localizedOfferDurationAdjective),
                     textAlign = TextAlign.Center,
                 )
 
@@ -156,6 +161,7 @@ private fun ReferralsClaimGuestPassContent(
                         modifier = Modifier
                             .size(guestPassCardWidth, guestPassCardHeight),
                         source = ReferralGuestPassCardViewSource.Claim,
+                        referralsOfferInfo = referralsOfferInfo,
                     )
                 }
 
@@ -230,6 +236,7 @@ fun ReferralsClaimGuestPassContentPreview(
         ReferralsClaimGuestPassContent(
             windowWidthSizeClass = windowWidthSizeClass,
             windowHeightSizeClass = windowHeightSizeClass,
+            referralsOfferInfo = ReferralsOfferInfoMock,
             onDismiss = {},
         )
     }

--- a/modules/features/referrals/src/main/kotlin/au/com/shiftyjelly/pocketcasts/referrals/ReferralsIconWithTooltip.kt
+++ b/modules/features/referrals/src/main/kotlin/au/com/shiftyjelly/pocketcasts/referrals/ReferralsIconWithTooltip.kt
@@ -23,6 +23,8 @@ import au.com.shiftyjelly.pocketcasts.compose.ThemeColors
 import au.com.shiftyjelly.pocketcasts.compose.components.TextH40
 import au.com.shiftyjelly.pocketcasts.compose.components.Tooltip
 import au.com.shiftyjelly.pocketcasts.compose.preview.ThemePreviewParameterProvider
+import au.com.shiftyjelly.pocketcasts.models.type.ReferralsOfferInfo
+import au.com.shiftyjelly.pocketcasts.models.type.ReferralsOfferInfoMock
 import au.com.shiftyjelly.pocketcasts.referrals.ReferralsGuestPassFragment.ReferralsPageType
 import au.com.shiftyjelly.pocketcasts.ui.helper.FragmentHostListener
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
@@ -59,20 +61,24 @@ private fun ReferralsIconWithTooltip(
         Tooltip(
             show = state.showTooltip,
         ) {
-            TooltipContent()
+            TooltipContent(
+                referralsOfferInfo = state.referralsOfferInfo,
+            )
         }
     }
 }
 
 @Composable
-private fun TooltipContent() {
+private fun TooltipContent(
+    referralsOfferInfo: ReferralsOfferInfo,
+) {
     Column(
         modifier = Modifier
             .padding(horizontal = 16.dp)
             .padding(top = 24.dp, bottom = 16.dp),
     ) {
         TextH40(
-            text = stringResource(LR.string.referrals_tooltip_message),
+            text = stringResource(LR.string.referrals_tooltip_message, referralsOfferInfo.localizedOfferDurationNoun.lowercase()),
         )
     }
 }
@@ -112,6 +118,8 @@ fun TooltipContentPreview(
     @PreviewParameter(ThemePreviewParameterProvider::class) themeType: Theme.ThemeType,
 ) {
     AppThemeWithBackground(themeType) {
-        TooltipContent()
+        TooltipContent(
+            referralsOfferInfo = ReferralsOfferInfoMock,
+        )
     }
 }

--- a/modules/features/referrals/src/main/kotlin/au/com/shiftyjelly/pocketcasts/referrals/ReferralsSendGuestPassPage.kt
+++ b/modules/features/referrals/src/main/kotlin/au/com/shiftyjelly/pocketcasts/referrals/ReferralsSendGuestPassPage.kt
@@ -122,6 +122,7 @@ private fun ReferralsSendGuestPassContent(
 
                 is UiState.Loaded ->
                     SendGuestPassContent(
+                        state = state,
                         showFullScreen = showFullScreen,
                         windowHeightSizeClass = windowHeightSizeClass,
                         pageWidth = pageWidth,
@@ -138,6 +139,7 @@ private fun ReferralsSendGuestPassContent(
 
 @Composable
 private fun SendGuestPassContent(
+    state: UiState.Loaded,
     showFullScreen: Boolean,
     windowHeightSizeClass: WindowHeightSizeClass,
     pageWidth: Dp,
@@ -169,7 +171,7 @@ private fun SendGuestPassContent(
         Spacer(modifier = Modifier.height(24.dp))
 
         TextH10(
-            text = stringResource(LR.string.referrals_send_guest_pass_title),
+            text = stringResource(LR.string.referrals_send_guest_pass_title, state.referralsOfferInfo.localizedOfferDurationNoun),
             textAlign = TextAlign.Center,
         )
 
@@ -177,6 +179,7 @@ private fun SendGuestPassContent(
             Spacer(modifier = Modifier.height(24.dp))
 
             ReferralsPassCardsStack(
+                state = state,
                 width = pageWidth,
             )
         }
@@ -199,6 +202,7 @@ private fun SendGuestPassContent(
 
 @Composable
 private fun ReferralsPassCardsStack(
+    state: UiState.Loaded,
     cardsCount: Int = 3,
     width: Dp,
 ) {
@@ -217,6 +221,7 @@ private fun ReferralsPassCardsStack(
                     .size(cardWidth, cardHeight)
                     .offset(y = cardOffset),
                 source = ReferralGuestPassCardViewSource.Send,
+                referralsOfferInfo = state.referralsOfferInfo,
             )
         }
     }

--- a/modules/features/referrals/src/main/kotlin/au/com/shiftyjelly/pocketcasts/referrals/ReferralsSendGuestPassViewModel.kt
+++ b/modules/features/referrals/src/main/kotlin/au/com/shiftyjelly/pocketcasts/referrals/ReferralsSendGuestPassViewModel.kt
@@ -3,6 +3,8 @@ package au.com.shiftyjelly.pocketcasts.referrals
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import au.com.shiftyjelly.pocketcasts.analytics.SourceView
+import au.com.shiftyjelly.pocketcasts.models.type.ReferralsOfferInfo
+import au.com.shiftyjelly.pocketcasts.models.type.ReferralsOfferInfoMock
 import au.com.shiftyjelly.pocketcasts.repositories.referrals.ReferralManager
 import au.com.shiftyjelly.pocketcasts.repositories.referrals.ReferralManager.ReferralResult.EmptyResult
 import au.com.shiftyjelly.pocketcasts.repositories.referrals.ReferralManager.ReferralResult.ErrorResult
@@ -63,8 +65,10 @@ class ReferralsSendGuestPassViewModel @Inject constructor(
     }
 
     fun onShareClick(referralCode: String) {
+        if (_state.value !is UiState.Loaded) return
         val request = SharingRequest.referralLink(
             referralCode = referralCode,
+            referralsOfferInfo = (_state.value as UiState.Loaded).referralsOfferInfo,
         ).setSourceView(SourceView.REFERRALS)
             .build()
         viewModelScope.launch {
@@ -74,7 +78,10 @@ class ReferralsSendGuestPassViewModel @Inject constructor(
 
     sealed class UiState {
         data object Loading : UiState()
-        data class Loaded(val code: String) : UiState()
+        data class Loaded(
+            val code: String,
+            val referralsOfferInfo: ReferralsOfferInfo = ReferralsOfferInfoMock,
+        ) : UiState()
         data class Error(val error: ReferralSendGuestPassError) : UiState()
     }
 

--- a/modules/features/referrals/src/main/kotlin/au/com/shiftyjelly/pocketcasts/referrals/ReferralsViewModel.kt
+++ b/modules/features/referrals/src/main/kotlin/au/com/shiftyjelly/pocketcasts/referrals/ReferralsViewModel.kt
@@ -2,6 +2,8 @@ package au.com.shiftyjelly.pocketcasts.referrals
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import au.com.shiftyjelly.pocketcasts.models.type.ReferralsOfferInfo
+import au.com.shiftyjelly.pocketcasts.models.type.ReferralsOfferInfoMock
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.repositories.user.UserManager
 import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
@@ -63,5 +65,6 @@ class ReferralsViewModel @Inject constructor(
         val showIcon: Boolean = false,
         val showTooltip: Boolean = false,
         val showProfileBanner: Boolean = false,
+        val referralsOfferInfo: ReferralsOfferInfo = ReferralsOfferInfoMock,
     )
 }

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -2136,19 +2136,26 @@
     <!-- Referrals -->
     <string name="gift">Gift</string>
     <string name="referrals_activate_my_pass">Activate my pass</string>
-    <string name="referrals_claim_guess_pass_banner_card_title_english_only" translatable="false">Claim your 2-Month\nGuest Pass to Plus</string>
-    <string name="referrals_claim_guess_pass_banner_card_title">Claim your 2-Month Guest Pass to Plus</string>
+    <string name="referrals_claim_guess_pass_banner_card_title_english_only" translatable="false">Claim your %1$s\nGuest Pass to Plus</string>
+    <!-- Referrals claim guess pass banner card title, `%1$s' is a placeholder for the offer duration on the Plus subscription -->
+    <string name="referrals_claim_guess_pass_banner_card_title">Claim your %1$s Guest Pass to Plus</string>
     <string name="referrals_claim_guess_pass_banner_card_subtitle">Unlock the full listening experience</string>
-    <string name="referrals_claim_guest_pass_description">This offer is for new members only. Membership will automatically renew to a paid annual membership at %s.</string>
-    <string name="referrals_claim_guest_pass_title_english_only" translatable="false">Claim your 2-Month\nGuest Pass</string>
-    <string name="referrals_claim_guest_pass_title">Claim your 2-Month Guest Pass</string>
+    <string name="referrals_claim_guest_pass_description">Membership will automatically renew to a paid annual membership at %s.</string>
+    <string name="referrals_claim_guest_pass_title_english_only" translatable="false">Claim your %1$s\nGuest Pass</string>
+    <!-- Referrals claim guest pass title, `%1$s' is a placeholder for the offer duration on the Plus subscription -->
+    <string name="referrals_claim_guest_pass_title">Claim your %1$s Guest Pass</string>
+    <!-- Referrals guest pass card title, `%1$s' is a placeholder for the offer duration on the Plus subscription -->
+    <string name="referrals_guest_pass_card_title">%1$s Guest Pass</string>
     <string name="referrals_invalid_offer_description">This guest pass can only be redeemed once and is available for those without an active Plus or Patron subscription. Thanks for listening!</string>
     <string name="referrals_invalid_offer_title">This offer isn\'t available</string>
-    <string name="referrals_send_guest_pass_title">Gift 2 Months of Pocket&#160;Casts&#160;Plus</string>
-    <string name="referrals_send_guest_pass_card_title">2-Month Guest Pass</string>
+    <!-- Referrals send guest pass title, `%1$s' is a placeholder for the offer duration on the Plus subscription -->
+    <string name="referrals_send_guest_pass_title">Gift %1$s of Pocket&#160;Casts&#160;Plus</string>
     <string name="referrals_share_guest_pass">Share Guest Pass</string>
-    <string name="referrals_share_subject">2-Month Guest Pass for Pocket&#160;Casts</string>
-    <string name="referrals_share_text">Hey! Use the link below to claim your 2-month guest pass for Pocket&#160;Casts&#160;Plus and enjoy podcasts across all your devices!</string>
-    <string name="referrals_tooltip_message">Gift 2 months of Pocket&#160;Casts&#160;Plus!</string>
+    <!-- Referrals share subject, `%1$s' is a placeholder for the offer duration on the Plus subscription -->
+    <string name="referrals_share_subject">%1$s Guest Pass for Pocket&#160;Casts</string>
+    <!-- Referrals share text, `%1$s' is a placeholder for the offer duration on the Plus subscription -->
+    <string name="referrals_share_text">Hey! Use the link below to claim your %1$s guest pass for Pocket&#160;Casts&#160;Plus and enjoy podcasts across all your devices!</string>
+    <!-- Referrals tooltip message, `%1$s' is a placeholder for the offer duration on the Plus subscription -->
+    <string name="referrals_tooltip_message">Gift %1$s of Pocket&#160;Casts&#160;Plus!</string>
 
 </resources>

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/type/ReferralsOfferInfo.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/type/ReferralsOfferInfo.kt
@@ -1,0 +1,13 @@
+package au.com.shiftyjelly.pocketcasts.models.type
+
+interface ReferralsOfferInfo {
+    val localizedOfferDurationNoun: String
+    val localizedOfferDurationAdjective: String
+    val localizedPriceAfterOffer: String
+}
+
+data object ReferralsOfferInfoMock : ReferralsOfferInfo {
+    override val localizedOfferDurationNoun = "2 Months"
+    override val localizedOfferDurationAdjective = "2-Month"
+    override val localizedPriceAfterOffer = "$39.99 USD"
+}

--- a/modules/services/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/SharingClient.kt
+++ b/modules/services/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/SharingClient.kt
@@ -20,6 +20,7 @@ import au.com.shiftyjelly.pocketcasts.analytics.SourceView
 import au.com.shiftyjelly.pocketcasts.deeplink.ReferralsDeepLink
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
+import au.com.shiftyjelly.pocketcasts.models.type.ReferralsOfferInfo
 import au.com.shiftyjelly.pocketcasts.repositories.images.PocketCastsImageRequestFactory
 import au.com.shiftyjelly.pocketcasts.sharing.BuildConfig.META_APP_ID
 import au.com.shiftyjelly.pocketcasts.sharing.BuildConfig.SERVER_SHORT_URL
@@ -129,8 +130,8 @@ class SharingClient(
         }
 
         is SharingRequest.Data.ReferralLink -> {
-            val shareText = "${context.getString(LR.string.referrals_share_text)}\n\n${data.sharingUrl(webBasedHost)}"
-            val shareSubject = context.getString(LR.string.referrals_share_subject)
+            val shareText = "${context.getString(LR.string.referrals_share_text, data.referralsOfferInfo.localizedOfferDurationAdjective.lowercase())}\n\n${data.sharingUrl(webBasedHost)}"
+            val shareSubject = context.getString(LR.string.referrals_share_subject, data.referralsOfferInfo.localizedOfferDurationNoun)
             Intent()
                 .setAction(Intent.ACTION_SEND)
                 .setType("text/plain")
@@ -327,9 +328,11 @@ data class SharingRequest internal constructor(
 
         fun referralLink(
             referralCode: String,
+            referralsOfferInfo: ReferralsOfferInfo,
         ) = Builder(
             Data.ReferralLink(
                 referralCode = referralCode,
+                referralsOfferInfo = referralsOfferInfo,
             ),
         )
             .setAnalyticsEvent(AnalyticsEvent.REFERRAL_LINK_SHARED)
@@ -472,6 +475,7 @@ data class SharingRequest internal constructor(
 
         class ReferralLink internal constructor(
             val referralCode: String,
+            val referralsOfferInfo: ReferralsOfferInfo,
         ) : Data {
             override val podcast: PodcastModel? = null
 

--- a/modules/services/sharing/src/test/kotlin/au/com/shiftyjelly/pocketcasts/sharing/SharingAnalyticsTest.kt
+++ b/modules/services/sharing/src/test/kotlin/au/com/shiftyjelly/pocketcasts/sharing/SharingAnalyticsTest.kt
@@ -6,6 +6,7 @@ import au.com.shiftyjelly.pocketcasts.analytics.SourceView
 import au.com.shiftyjelly.pocketcasts.analytics.Tracker
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
+import au.com.shiftyjelly.pocketcasts.models.type.ReferralsOfferInfoMock
 import java.util.Date
 import kotlin.time.Duration.Companion.seconds
 import org.junit.Assert.assertEquals
@@ -440,7 +441,8 @@ class SharingAnalyticsTest {
     @Test
     fun `log referral link sharing`() {
         val referralCode = "TEST_CODE"
-        val request = SharingRequest.referralLink(referralCode)
+        val referralsOfferInfo = ReferralsOfferInfoMock
+        val request = SharingRequest.referralLink(referralCode, referralsOfferInfo)
             .setSourceView(SourceView.REFERRALS)
             .build()
 


### PR DESCRIPTION
## Description
This updates referral strings (for dynamic duration) for translations before the `7.74` code-freeze.

## Testing Instructions


## Screenshots or Screencast 

ToolTip FVJPaWlRMlosEpsRhqxnSD-fi-2189_9583 | Send Pass FVJPaWlRMlosEpsRhqxnSD-fi-2189_9583|  Claim Pass Banner FVJPaWlRMlosEpsRhqxnSD-fi-2189_8773 | Claim Pass Page FVJPaWlRMlosEpsRhqxnSD-fi-2189_8613 | Share Text FVJPaWlRMlosEpsRhqxnSD-fi-2189_9583
----|---|---|---|----
![tooltip](https://github.com/user-attachments/assets/74b11530-df55-4cf9-8e8e-a9d4ddb0c521)| ![send_pass](https://github.com/user-attachments/assets/1e3f575e-9842-43c5-9da1-fd76f221f060) | ![banner](https://github.com/user-attachments/assets/d5a5038c-8ce2-4977-adcb-6445af68d40c) | ![claim_pass](https://github.com/user-attachments/assets/33803ddd-dda3-42da-970f-df377cc30e92) | ![email_2](https://github.com/user-attachments/assets/4f4c55d8-9761-46ef-bb3b-8764ed06593f)

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack