### PR TITLE
Android Auto: Update the progress bar in the browse view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@
         ([#2829](https://github.com/Automattic/pocket-casts-android/pull/2829))
     *   Add Google Engage SDK integration 
         ([#2847](https://github.com/Automattic/pocket-casts-android/pull/2847))
+    *   Add a progress bar in the browse view on Android Auto
+        ([#2945](https://github.com/Automattic/pocket-casts-android/pull/2945))
 
 7.73
 -----

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@
         ([#2923](https://github.com/Automattic/pocket-casts-android/pull/2923))
     *   Display web-page based HTML transcripts in web view
         ([#2910](https://github.com/Automattic/pocket-casts-android/pull/2910))
+*   New Features
+    *   Add a progress bar in the browse view on Android Auto
+        ([#2945](https://github.com/Automattic/pocket-casts-android/pull/2945))
 
 7.74
 -----
@@ -29,8 +32,6 @@
         ([#2829](https://github.com/Automattic/pocket-casts-android/pull/2829))
     *   Add Google Engage SDK integration 
         ([#2847](https://github.com/Automattic/pocket-casts-android/pull/2847))
-    *   Add a progress bar in the browse view on Android Auto
-        ([#2945](https://github.com/Automattic/pocket-casts-android/pull/2945))
 
 7.73
 -----

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/MediaSessionManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/MediaSessionManager.kt
@@ -16,6 +16,7 @@ import android.view.KeyEvent
 import androidx.annotation.DrawableRes
 import androidx.core.content.IntentCompat
 import androidx.core.os.bundleOf
+import androidx.media.utils.MediaConstants.PLAYBACK_STATE_EXTRAS_KEY_MEDIA_ID
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
 import au.com.shiftyjelly.pocketcasts.analytics.EpisodeAnalytics
 import au.com.shiftyjelly.pocketcasts.analytics.SourceView
@@ -249,7 +250,12 @@ class MediaSessionManager(
         val stateBuilder = PlaybackStateCompat.Builder()
             .setState(state, playbackState.positionMs.toLong(), currentSpeed.toFloat(), SystemClock.elapsedRealtime())
             .setActions(getSupportedActions(playbackState))
-            .setExtras(bundleOf(EXTRA_TRANSIENT to playbackState.transientLoss))
+            .setExtras(
+                bundleOf(
+                    PLAYBACK_STATE_EXTRAS_KEY_MEDIA_ID to currentEpisode.uuid,
+                    EXTRA_TRANSIENT to playbackState.transientLoss,
+                ),
+            )
 
         // Do not add custom actions on Wear OS because there is a bug in Wear 3.5 that causes
         // this to make the Wear OS media notification stop working. This bug was fixed

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/auto/AutoConverter.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/auto/AutoConverter.kt
@@ -14,6 +14,7 @@ import android.support.v4.media.MediaDescriptionCompat.STATUS_NOT_DOWNLOADED
 import androidx.annotation.DrawableRes
 import androidx.core.graphics.drawable.toBitmap
 import androidx.core.os.bundleOf
+import androidx.media.utils.MediaConstants.DESCRIPTION_EXTRAS_KEY_COMPLETION_PERCENTAGE
 import androidx.media.utils.MediaConstants.DESCRIPTION_EXTRAS_KEY_COMPLETION_STATUS
 import androidx.media.utils.MediaConstants.DESCRIPTION_EXTRAS_VALUE_COMPLETION_STATUS_FULLY_PLAYED
 import androidx.media.utils.MediaConstants.DESCRIPTION_EXTRAS_VALUE_COMPLETION_STATUS_NOT_PLAYED
@@ -213,15 +214,27 @@ object AutoConverter {
     private fun extrasForEpisode(episode: BaseEpisode): Bundle {
         val downloadStatus = if (episode.isDownloaded) STATUS_DOWNLOADED else STATUS_NOT_DOWNLOADED
 
-        val completionStatus = when (episode.playingStatus) {
-            EpisodePlayingStatus.NOT_PLAYED -> DESCRIPTION_EXTRAS_VALUE_COMPLETION_STATUS_NOT_PLAYED
-            EpisodePlayingStatus.IN_PROGRESS -> DESCRIPTION_EXTRAS_VALUE_COMPLETION_STATUS_PARTIALLY_PLAYED
-            EpisodePlayingStatus.COMPLETED -> DESCRIPTION_EXTRAS_VALUE_COMPLETION_STATUS_FULLY_PLAYED
+        val completionStatus: Int
+        val completionPercentage: Double
+        when (episode.playingStatus) {
+            EpisodePlayingStatus.NOT_PLAYED -> {
+                completionStatus = DESCRIPTION_EXTRAS_VALUE_COMPLETION_STATUS_NOT_PLAYED
+                completionPercentage = 0.0
+            }
+            EpisodePlayingStatus.IN_PROGRESS -> {
+                completionStatus = DESCRIPTION_EXTRAS_VALUE_COMPLETION_STATUS_PARTIALLY_PLAYED
+                completionPercentage = if (episode.duration == 0.0) 0.0 else (episode.playedUpTo / episode.duration).coerceIn(0.0, 1.0)
+            }
+            EpisodePlayingStatus.COMPLETED -> {
+                completionStatus = DESCRIPTION_EXTRAS_VALUE_COMPLETION_STATUS_FULLY_PLAYED
+                completionPercentage = 1.0
+            }
         }
 
         return bundleOf(
             EXTRA_DOWNLOAD_STATUS to downloadStatus,
             DESCRIPTION_EXTRAS_KEY_COMPLETION_STATUS to completionStatus,
+            DESCRIPTION_EXTRAS_KEY_COMPLETION_PERCENTAGE to completionPercentage,
         )
     }
 }


### PR DESCRIPTION
## Description

An automotive manufacturer asked if we could add the progress bar to the browse view. There is a [Google guide for this](https://developer.android.com/training/cars/media#browse-progress-bar).

## Testing Instructions
1. Start the Android Auto emulator. 
```
cd /Applications/android-sdk/extras/google/auto/
chmod +x ./desktop-head-unit
./desktop-head-unit --usb
```
2. Plugin in your device over USB
3. Play an episode and skip to move progress along
4. Open the podcast page
✅  Verify the episode row now shows a progress bar

You may need to go to one level higher in the menu and back again for the episode row to update. I don't believe there is a way to fix this in Android Auto or Automotive. 

## Screenshots

Before
<img width="912" alt="Screenshot 2024-09-28 at 9 16 58 AM" src="https://github.com/user-attachments/assets/9dfec3a5-f7e1-4bb1-9452-28b208dfc1d6">

After

<img width="912" alt="Screenshot 2024-09-28 at 9 15 07 AM" src="https://github.com/user-attachments/assets/db6388da-5414-4e40-b821-48867014f1e0">

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack
