### PR TITLE
[Paywall Experiments] Refresh Experiments

### DIFF
--- a/modules/services/analytics/build.gradle.kts
+++ b/modules/services/analytics/build.gradle.kts
@@ -38,4 +38,5 @@ dependencies {
     testImplementation(libs.mockito.core)
     testImplementation(libs.mockito.kotlin)
     testImplementation(projects.modules.services.sharedtest)
+    testImplementation(libs.coroutines.test)
 }

--- a/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/experiments/ExperimentProvider.kt
+++ b/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/experiments/ExperimentProvider.kt
@@ -10,11 +10,15 @@ import com.automattic.android.experimentation.domain.Variation.Control
 import com.automattic.android.experimentation.domain.Variation.Treatment
 import java.util.UUID
 import javax.inject.Inject
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import au.com.shiftyjelly.pocketcasts.analytics.experiments.Experiment as ExperimentModel
 
 class ExperimentProvider @Inject constructor(
     private val accountStatusInfo: AccountStatusInfo,
     private val repository: VariationsRepository,
+    private val iODispatcher: CoroutineDispatcher = Dispatchers.IO,
 ) {
     companion object {
         const val TAG = "ExperimentsProvider"
@@ -31,11 +35,9 @@ class ExperimentProvider @Inject constructor(
         }
     }
 
-    fun clear() {
-        if (FeatureFlag.isEnabled(Feature.EXPLAT_EXPERIMENT)) {
-            LogBuffer.i(TAG, "Clearing experiments")
-            repository.clear()
-        }
+    suspend fun refreshExperiments() = withContext(iODispatcher) {
+        clear()
+        initialize()
     }
 
     fun getVariation(experiment: ExperimentModel): Variation? {
@@ -45,6 +47,13 @@ class ExperimentProvider @Inject constructor(
             is Control -> Variation.Control
             is Treatment -> Variation.Treatment(variation.name)
             else -> null
+        }
+    }
+
+    private fun clear() {
+        if (FeatureFlag.isEnabled(Feature.EXPLAT_EXPERIMENT)) {
+            LogBuffer.i(TAG, "Clearing experiments")
+            repository.clear()
         }
     }
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/user/UserManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/user/UserManager.kt
@@ -126,7 +126,9 @@ class UserManagerImpl @Inject constructor(
                 analyticsTracker.flush()
                 analyticsTracker.clearAllData()
                 analyticsTracker.refreshMetadata()
-                experimentProvider.clear()
+                applicationScope.launch {
+                    experimentProvider.refreshExperiments()
+                }
             }
         }
         settings.setFullySignedOut(true)


### PR DESCRIPTION
## Description
- This is to avoid issues after the user signs out and tap on any of our paywalls after that without restart the app. 
- This PR initializes the experiments again after the user signs out

## Testing Instructions
1. Have a fresh install
2. Open any paywall
3. Ensure you don't see any crash
4. Log in using a free account
5. Open any paywall again
6. Ensure you don't see any crash
7. Sign out
8. Open any paywall again (last time)
9. Ensure you don't see any crash


## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.

