### PR TITLE
Enable Engage SDK in production

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 *   New Features
     *   Add sleep timer settings to sleep timer bottom sheet
         ([#2829](https://github.com/Automattic/pocket-casts-android/pull/2829))
+    *   Add Google Engage SDK integration 
+        ([#2847](https://github.com/Automattic/pocket-casts-android/pull/2847))
 
 7.73
 -----

--- a/modules/features/engage/src/main/AndroidManifest.xml
+++ b/modules/features/engage/src/main/AndroidManifest.xml
@@ -3,7 +3,11 @@
     xmlns:tools="http://schemas.android.com/tools">
 
     <application>
-       <!-- ignore exported receiver warning beacuse there is no recommendation from Google about app ID -->
+        <meta-data
+            android:name="com.google.android.engage.service.ENV"
+            android:value="PRODUCTION" />
+
+        <!-- ignore exported receiver warning beacuse there is no recommendation from Google about app ID -->
         <receiver
             android:name=".EngageSdkBroadcastReceiver"
             android:enabled="true"

--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/Feature.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/Feature.kt
@@ -94,9 +94,9 @@ enum class Feature(
     ENGAGE_SDK(
         key = "engage_sdk",
         title = "Integrate Pocket Casts with Engage SDK",
-        defaultValue = BuildConfig.DEBUG,
+        defaultValue = true,
         tier = FeatureTier.Free,
-        hasFirebaseRemoteFlag = false,
+        hasFirebaseRemoteFlag = true,
         hasDevToggle = false,
     ),
     REFERRALS(


### PR DESCRIPTION
## Description

This enable Engage SDK in our app. I'll still need to contact Google once we rollout in production to 100%.

Context: pdeCcb-6Ck-p2#comment-5525

## Testing Instructions

Code review is enough.

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] ~I have considered whether it makes sense to add tests for my changes~
- [x] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [x] ~Any jetpack compose components I added or changed are covered by compose previews~
- [x] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~