### PR TITLE
Display episode artwork in the podcast view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 7.75
 -----
+*   Updates
+    *   Add an advanced setting to display artwork in episode listing
+        ([#2958](https://github.com/Automattic/pocket-casts-android/pull/2958))
 *   Bug Fixes
     *   Fix search podcast results scroll back to the start after subscribing
         ([#2923](https://github.com/Automattic/pocket-casts-android/pull/2923))

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastAdapter.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastAdapter.kt
@@ -53,6 +53,7 @@ import au.com.shiftyjelly.pocketcasts.podcasts.view.podcast.adapter.TabsViewHold
 import au.com.shiftyjelly.pocketcasts.podcasts.viewmodel.PodcastRatingsViewModel
 import au.com.shiftyjelly.pocketcasts.podcasts.viewmodel.PodcastViewModel.PodcastTab
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
+import au.com.shiftyjelly.pocketcasts.preferences.model.ArtworkConfiguration
 import au.com.shiftyjelly.pocketcasts.preferences.model.ArtworkConfiguration.Element
 import au.com.shiftyjelly.pocketcasts.repositories.download.DownloadManager
 import au.com.shiftyjelly.pocketcasts.repositories.images.PocketCastsImageRequestFactory
@@ -226,14 +227,18 @@ class PodcastAdapter(
             VIEW_TYPE_NO_BOOKMARK -> NoBookmarkViewHolder(ComposeView(parent.context), theme, onHeadsetSettingsClicked)
             else -> EpisodeViewHolder(
                 binding = AdapterEpisodeBinding.inflate(inflater, parent, false),
-                viewMode = EpisodeViewHolder.ViewMode.NoArtwork,
+                viewMode = if (settings.artworkConfiguration.value.useEpisodeArtwork(ArtworkConfiguration.Element.Podcasts)) {
+                    EpisodeViewHolder.ViewMode.Artwork
+                } else {
+                    EpisodeViewHolder.ViewMode.NoArtwork
+                },
                 downloadProgressUpdates = downloadManager.progressUpdateRelay,
                 playbackStateUpdates = playbackManager.playbackStateRelay,
                 upNextChangesObservable = upNextQueue.changesObservable,
                 imageRequestFactory = imageRequestFactory.smallSize(),
                 settings = settings,
                 swipeButtonLayoutFactory = swipeButtonLayoutFactory,
-                artworkContext = null,
+                artworkContext = ArtworkConfiguration.Element.Podcasts,
             )
         }
     }

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/EpisodeArtworkConfigurationFragment.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/EpisodeArtworkConfigurationFragment.kt
@@ -129,5 +129,6 @@ class EpisodeArtworkConfigurationFragment : BaseFragment() {
         ArtworkConfiguration.Element.Starred -> LR.string.profile_navigation_starred
         ArtworkConfiguration.Element.Bookmarks -> LR.string.bookmarks
         ArtworkConfiguration.Element.ListeningHistory -> LR.string.profile_navigation_listening_history
+        ArtworkConfiguration.Element.Podcasts -> LR.string.podcasts
     }
 }

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/model/ArtworkConfiguration.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/model/ArtworkConfiguration.kt
@@ -20,6 +20,7 @@ data class ArtworkConfiguration(
         Starred("starred"),
         Bookmarks("bookmarks"),
         ListeningHistory("listening_history"),
+        Podcasts("podcasts"),
         ;
 
         companion object {


### PR DESCRIPTION
## Description

This PR displays artwork (including episode one) in the podcast view. If the setting is disabled no artwork is displayed.

We had a GH discussion about it but it is now gone since we closed the discussions. But there was a follow up on the forums here: https://forums.pocketcasts.com/forums/topic/show-episode-artwork-in-podcast-view/#post-5955

## Testing Instructions

1. Go to the `Appearance` settings.
2. Go to the `Advanced episode artwork settings`.
3. Enable `Podcasts` setting.
4. Go to a podcast that uses episode artwork like [Darknet Diaries](https://pca.st/darknetdiaries).
5. Notice that you see artwork. You might not see episode artwork immediately due to missing image URLs. If you don't see them go to any episode details so that the show notes are parsed.
6. Disable `Podcasts` setting in the `Advanced episode artwork settings`.
7. Go back to the podcast view.
8. Artwork should no longer be displayed.

## Screenshots or Screencast 

![Screenshot_20240930-190316](https://github.com/user-attachments/assets/9c28f016-506b-46b0-9542-676a75b9fa7b)

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] ~I have considered whether it makes sense to add tests for my changes~
- [x] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [x] ~Any jetpack compose components I added or changed are covered by compose previews~
- [x] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] ~with the device set to have a large display and font size~
- [x] ~for accessibility with TalkBack~
