### PR TITLE
Referrals - validate claim offer

### DIFF
--- a/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
+++ b/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
@@ -1352,8 +1352,13 @@ class MainActivity :
             return
         }
         settings.referralClaimCode.set(code, false)
-        val fragment = ReferralsGuestPassFragment.newInstance(ReferralsGuestPassFragment.ReferralsPageType.Claim)
-        showBottomSheet(fragment)
+        launch {
+            delay(1000) // To allow loading tabs and prevent race condition in updating activity's status bar color
+            withContext(Dispatchers.Main) {
+                val fragment = ReferralsGuestPassFragment.newInstance(ReferralsGuestPassFragment.ReferralsPageType.Claim)
+                showBottomSheet(fragment)
+            }
+        }
     }
 
     override fun onConfigurationChanged(newConfig: Configuration) {

--- a/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
+++ b/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
@@ -1351,8 +1351,7 @@ class MainActivity :
         if (!FeatureFlag.isEnabled(Feature.REFERRALS)) {
             return
         }
-        // TODO decide where to store the referral code
-        Timber.i("Referral code: $code")
+        settings.referralClaimCode.set(code, false)
         val fragment = ReferralsGuestPassFragment.newInstance(ReferralsGuestPassFragment.ReferralsPageType.Claim)
         showBottomSheet(fragment)
     }

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/OnboardingFlowComposable.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/OnboardingFlowComposable.kt
@@ -72,6 +72,7 @@ private fun Content(
         is OnboardingFlow.PlusAccountUpgradeNeedsLogin,
         OnboardingFlow.InitialOnboarding,
         OnboardingFlow.EngageSdk,
+        OnboardingFlow.ReferralLoginOrSignUp,
         -> OnboardingNavRoute.logInOrSignUp
 
         // Cannot use OnboardingNavRoute.PlusUpgrade.routeWithSource here, it is set as a defaultValue in the PlusUpgrade composable,
@@ -82,10 +83,14 @@ private fun Content(
     }
 
     val onAccountCreated = {
-        navController.navigate(OnboardingRecommendationsFlow.route) {
-            // clear backstack after account is created
-            popUpTo(OnboardingNavRoute.logInOrSignUp) {
-                inclusive = true
+        if (flow is OnboardingFlow.ReferralLoginOrSignUp) {
+            exitOnboarding(OnboardingExitInfo())
+        } else {
+            navController.navigate(OnboardingRecommendationsFlow.route) {
+                // clear backstack after account is created
+                popUpTo(OnboardingNavRoute.logInOrSignUp) {
+                    inclusive = true
+                }
             }
         }
     }
@@ -133,6 +138,7 @@ private fun Content(
                         OnboardingFlow.InitialOnboarding,
                         OnboardingFlow.LoggedOut,
                         OnboardingFlow.EngageSdk,
+                        OnboardingFlow.ReferralLoginOrSignUp,
                         -> exitOnboarding(OnboardingExitInfo())
                     }
                 },
@@ -285,7 +291,8 @@ private fun onLoginToExistingAccount(
         OnboardingFlow.LoggedOut,
         OnboardingFlow.EngageSdk,
         -> exitOnboarding(OnboardingExitInfo(showPlusPromotionForFreeUser = true))
-
+        OnboardingFlow.ReferralLoginOrSignUp,
+        -> exitOnboarding(OnboardingExitInfo(showPlusPromotionForFreeUser = false))
         is OnboardingFlow.PlusAccountUpgrade,
         is OnboardingFlow.PatronAccountUpgrade,
         OnboardingFlow.PlusAccountUpgradeNeedsLogin,

--- a/modules/features/referrals/build.gradle.kts
+++ b/modules/features/referrals/build.gradle.kts
@@ -35,6 +35,7 @@ dependencies {
     implementation(libs.hilt.navigation.compose)
     implementation(libs.lifecycle.runtime.compose)
 
+    implementation(projects.modules.features.account)
     implementation(projects.modules.services.compose)
     implementation(projects.modules.services.images)
     implementation(projects.modules.services.localization)

--- a/modules/features/referrals/src/main/kotlin/au/com/shiftyjelly/pocketcasts/referrals/ReferralsClaimGuestPassPage.kt
+++ b/modules/features/referrals/src/main/kotlin/au/com/shiftyjelly/pocketcasts/referrals/ReferralsClaimGuestPassPage.kt
@@ -57,6 +57,8 @@ import au.com.shiftyjelly.pocketcasts.referrals.ReferralsClaimGuestPassViewModel
 import au.com.shiftyjelly.pocketcasts.referrals.ReferralsClaimGuestPassViewModel.ReferralsClaimGuestPassError
 import au.com.shiftyjelly.pocketcasts.referrals.ReferralsClaimGuestPassViewModel.UiState
 import au.com.shiftyjelly.pocketcasts.referrals.ReferralsGuestPassFragment.ReferralsPageType
+import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingFlow
+import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingLauncher.Companion.openOnboardingFlow
 import au.com.shiftyjelly.pocketcasts.ui.helper.FragmentHostListener
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import au.com.shiftyjelly.pocketcasts.utils.extensions.getActivity
@@ -92,7 +94,10 @@ fun ReferralsClaimGuestPassPage(
                         (activity as FragmentHostListener).showBottomSheet(fragment)
                     }
 
-                    NavigationEvent.LoginOrSignup -> Unit // TODO - Referrals: Start Login or Signup flow
+                    NavigationEvent.LoginOrSignup -> openOnboardingFlow(
+                        activity = activity,
+                        onboardingFlow = OnboardingFlow.ReferralLoginOrSignUp,
+                    )
                 }
             }
         }

--- a/modules/features/referrals/src/main/kotlin/au/com/shiftyjelly/pocketcasts/referrals/ReferralsClaimGuestPassViewModel.kt
+++ b/modules/features/referrals/src/main/kotlin/au/com/shiftyjelly/pocketcasts/referrals/ReferralsClaimGuestPassViewModel.kt
@@ -2,24 +2,40 @@ package au.com.shiftyjelly.pocketcasts.referrals
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import androidx.lifecycle.viewmodel.compose.viewModel
 import au.com.shiftyjelly.pocketcasts.models.type.ReferralsOfferInfo
 import au.com.shiftyjelly.pocketcasts.models.type.ReferralsOfferInfoPlayStore
+import au.com.shiftyjelly.pocketcasts.preferences.Settings
+import au.com.shiftyjelly.pocketcasts.repositories.referrals.ReferralManager
+import au.com.shiftyjelly.pocketcasts.repositories.referrals.ReferralManager.ReferralResult
 import au.com.shiftyjelly.pocketcasts.repositories.referrals.ReferralOfferInfoProvider
+import au.com.shiftyjelly.pocketcasts.repositories.user.UserManager
+import au.com.shiftyjelly.pocketcasts.utils.exception.NoNetworkException
 import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.reactive.asFlow
 import timber.log.Timber
 
 @HiltViewModel
 class ReferralsClaimGuestPassViewModel @Inject constructor(
     private val referralOfferInfoProvider: ReferralOfferInfoProvider,
+    private val referralManager: ReferralManager,
+    private val userManager: UserManager,
+    private val settings: Settings,
 ) : ViewModel() {
     private val _state: MutableStateFlow<UiState> = MutableStateFlow(UiState.Loading)
     val state: StateFlow<UiState> = _state
+
+    private val _navigationEvent: MutableSharedFlow<NavigationEvent> = MutableSharedFlow()
+    val navigationEvent: SharedFlow<NavigationEvent> = _navigationEvent
 
     init {
         loadReferralClaimOffer()
@@ -27,7 +43,7 @@ class ReferralsClaimGuestPassViewModel @Inject constructor(
 
     private fun loadReferralClaimOffer() {
         viewModelScope.launch {
-            val referralsOfferInfo = referralOfferInfoProvider.referralOfferInfo() as? ReferralsOfferInfoPlayStore?
+            val referralsOfferInfo = referralOfferInfoProvider.referralOfferInfo() as? ReferralsOfferInfoPlayStore
             referralsOfferInfo?.subscriptionWithOffer?.let {
                 _state.update {
                     UiState.Loaded(
@@ -38,18 +54,71 @@ class ReferralsClaimGuestPassViewModel @Inject constructor(
                 val message = "Failed to load referral offer info"
                 LogBuffer.e(LogBuffer.TAG_INVALID_STATE, message)
                 Timber.e(message)
-                _state.update { UiState.Error }
+                _state.update { UiState.Error(ReferralsClaimGuestPassError.FailedToLoadOffer) }
             }
         }
     }
 
+    fun onActivatePassClick() {
+        viewModelScope.launch {
+            userManager.getSignInState().asFlow()
+                .stateIn(viewModelScope)
+                .collect {
+                    if (it.isSignedIn) {
+                        val loadedState = _state.value as? UiState.Loaded
+                        loadedState?.let { _state.update { loadedState.copy(isValidating = true) } }
+                        val referralClaimCode = settings.referralClaimCode.value
+                        val result = referralManager.validateReferralCode(referralClaimCode)
+                        loadedState?.let { _state.update { loadedState.copy(isValidating = false) } }
+                        when (result) {
+                            is ReferralResult.SuccessResult -> startIAPFlow()
+                            is ReferralResult.EmptyResult -> _navigationEvent.emit(NavigationEvent.InValidOffer)
+                            is ReferralResult.ErrorResult -> if (result.error is NoNetworkException) {
+                                _state.update { UiState.Error(ReferralsClaimGuestPassError.NoNetwork) }
+                            } else {
+                                _navigationEvent.emit(NavigationEvent.InValidOffer)
+                            }
+                        }
+                    } else {
+                        _navigationEvent.emit(NavigationEvent.LoginOrSignup)
+                    }
+                }
+        }
+    }
+
+    private fun startIAPFlow() {
+        // TODO - Referrals: Implement IAP flow
+    }
+
     fun retry() {
-        loadReferralClaimOffer()
+        val errorState = _state.value as? UiState.Error ?: return
+        when (errorState.error) {
+            ReferralsClaimGuestPassError.FailedToLoadOffer -> {
+                _state.value = UiState.Loading
+                loadReferralClaimOffer()
+            }
+
+            else -> Unit // This shouldn't happen in the ideal world
+        }
+    }
+
+    sealed class NavigationEvent {
+        data object LoginOrSignup : NavigationEvent()
+        data object InValidOffer : NavigationEvent()
     }
 
     sealed class UiState {
         data object Loading : UiState()
-        data class Loaded(val referralsOfferInfo: ReferralsOfferInfo) : UiState()
-        data object Error : UiState()
+        data class Loaded(
+            val referralsOfferInfo: ReferralsOfferInfo,
+            val isValidating: Boolean = false,
+        ) : UiState()
+
+        data class Error(val error: ReferralsClaimGuestPassError) : UiState()
+    }
+
+    sealed class ReferralsClaimGuestPassError {
+        data object NoNetwork : ReferralsClaimGuestPassError()
+        data object FailedToLoadOffer : ReferralsClaimGuestPassError()
     }
 }

--- a/modules/features/referrals/src/main/kotlin/au/com/shiftyjelly/pocketcasts/referrals/ReferralsClaimGuestPassViewModel.kt
+++ b/modules/features/referrals/src/main/kotlin/au/com/shiftyjelly/pocketcasts/referrals/ReferralsClaimGuestPassViewModel.kt
@@ -2,7 +2,6 @@ package au.com.shiftyjelly.pocketcasts.referrals
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import androidx.lifecycle.viewmodel.compose.viewModel
 import au.com.shiftyjelly.pocketcasts.models.type.ReferralsOfferInfo
 import au.com.shiftyjelly.pocketcasts.models.type.ReferralsOfferInfoPlayStore
 import au.com.shiftyjelly.pocketcasts.preferences.Settings

--- a/modules/features/referrals/src/main/kotlin/au/com/shiftyjelly/pocketcasts/referrals/ReferralsClaimGuestPassViewModel.kt
+++ b/modules/features/referrals/src/main/kotlin/au/com/shiftyjelly/pocketcasts/referrals/ReferralsClaimGuestPassViewModel.kt
@@ -36,6 +36,9 @@ class ReferralsClaimGuestPassViewModel @Inject constructor(
     private val _navigationEvent: MutableSharedFlow<NavigationEvent> = MutableSharedFlow()
     val navigationEvent: SharedFlow<NavigationEvent> = _navigationEvent
 
+    private val _snackBarEvent: MutableSharedFlow<SnackbarEvent> = MutableSharedFlow()
+    val snackBarEvent: SharedFlow<SnackbarEvent> = _snackBarEvent
+
     init {
         loadReferralClaimOffer()
     }
@@ -73,7 +76,7 @@ class ReferralsClaimGuestPassViewModel @Inject constructor(
                             is ReferralResult.SuccessResult -> startIAPFlow()
                             is ReferralResult.EmptyResult -> _navigationEvent.emit(NavigationEvent.InValidOffer)
                             is ReferralResult.ErrorResult -> if (result.error is NoNetworkException) {
-                                _state.update { UiState.Error(ReferralsClaimGuestPassError.NoNetwork) }
+                                _snackBarEvent.emit(SnackbarEvent.NoNetwork)
                             } else {
                                 _navigationEvent.emit(NavigationEvent.InValidOffer)
                             }
@@ -96,14 +99,16 @@ class ReferralsClaimGuestPassViewModel @Inject constructor(
                 _state.value = UiState.Loading
                 loadReferralClaimOffer()
             }
-
-            else -> Unit // This shouldn't happen in the ideal world
         }
     }
 
     sealed class NavigationEvent {
         data object LoginOrSignup : NavigationEvent()
         data object InValidOffer : NavigationEvent()
+    }
+
+    sealed class SnackbarEvent {
+        data object NoNetwork : SnackbarEvent()
     }
 
     sealed class UiState {
@@ -117,7 +122,6 @@ class ReferralsClaimGuestPassViewModel @Inject constructor(
     }
 
     sealed class ReferralsClaimGuestPassError {
-        data object NoNetwork : ReferralsClaimGuestPassError()
         data object FailedToLoadOffer : ReferralsClaimGuestPassError()
     }
 }

--- a/modules/features/referrals/src/main/kotlin/au/com/shiftyjelly/pocketcasts/referrals/ReferralsViewModel.kt
+++ b/modules/features/referrals/src/main/kotlin/au/com/shiftyjelly/pocketcasts/referrals/ReferralsViewModel.kt
@@ -40,7 +40,9 @@ class ReferralsViewModel @Inject constructor(
                     settings.playerOrUpNextBottomSheetState,
                 ) { signInState, playerBottomSheetState ->
                     val eligibleToSendPass = FeatureFlag.isEnabled(Feature.REFERRALS) && signInState.isSignedInAsPlusOrPatron
-                    val eligibleToClaimPass = FeatureFlag.isEnabled(Feature.REFERRALS) // TODO - Referrals: Fix condition to claim pass when it's implemented
+                    val eligibleToClaimPass = FeatureFlag.isEnabled(Feature.REFERRALS) &&
+                        (!signInState.isSignedIn || signInState.isSignedInAsFree) &&
+                        settings.referralClaimCode.value.isNotEmpty()
                     _state.update {
                         UiState.Loaded(
                             showIcon = eligibleToSendPass,

--- a/modules/features/referrals/src/test/kotlin/au/com/shiftyjelly/pocketcasts/referrals/ReferralsClaimGuestPassViewModelTest.kt
+++ b/modules/features/referrals/src/test/kotlin/au/com/shiftyjelly/pocketcasts/referrals/ReferralsClaimGuestPassViewModelTest.kt
@@ -1,12 +1,26 @@
 package au.com.shiftyjelly.pocketcasts.referrals
 
 import app.cash.turbine.test
+import au.com.shiftyjelly.pocketcasts.models.to.SignInState
+import au.com.shiftyjelly.pocketcasts.models.to.SubscriptionStatus
 import au.com.shiftyjelly.pocketcasts.models.type.ReferralsOfferInfo
 import au.com.shiftyjelly.pocketcasts.models.type.ReferralsOfferInfoPlayStore
 import au.com.shiftyjelly.pocketcasts.models.type.Subscription
+import au.com.shiftyjelly.pocketcasts.preferences.Settings
+import au.com.shiftyjelly.pocketcasts.preferences.UserSetting
+import au.com.shiftyjelly.pocketcasts.referrals.ReferralsClaimGuestPassViewModel.NavigationEvent
+import au.com.shiftyjelly.pocketcasts.referrals.ReferralsClaimGuestPassViewModel.ReferralsClaimGuestPassError
 import au.com.shiftyjelly.pocketcasts.referrals.ReferralsClaimGuestPassViewModel.UiState
+import au.com.shiftyjelly.pocketcasts.repositories.referrals.ReferralManager
+import au.com.shiftyjelly.pocketcasts.repositories.referrals.ReferralManager.ReferralResult.EmptyResult
+import au.com.shiftyjelly.pocketcasts.repositories.referrals.ReferralManager.ReferralResult.ErrorResult
+import au.com.shiftyjelly.pocketcasts.repositories.referrals.ReferralManager.ReferralResult.SuccessResult
 import au.com.shiftyjelly.pocketcasts.repositories.referrals.ReferralOfferInfoProvider
+import au.com.shiftyjelly.pocketcasts.repositories.user.UserManager
 import au.com.shiftyjelly.pocketcasts.sharedtest.MainCoroutineRule
+import au.com.shiftyjelly.pocketcasts.utils.exception.NoNetworkException
+import com.pocketcasts.service.api.ReferralValidationResponse
+import io.reactivex.Flowable
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
@@ -14,6 +28,7 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.mockito.Mockito.mock
+import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 
 @OptIn(ExperimentalCoroutinesApi::class)
@@ -23,7 +38,11 @@ class ReferralsClaimGuestPassViewModelTest {
 
     private val referralOfferInfoProvider = mock<ReferralOfferInfoProvider>()
     private val referralOfferInfo = mock<ReferralsOfferInfoPlayStore>()
+    private val referralManager = mock<ReferralManager>()
+    private val userManager = mock<UserManager>()
+    private val settings = mock<Settings>()
     private lateinit var viewModel: ReferralsClaimGuestPassViewModel
+    private val referralCode = "referral_code"
 
     @Before
     fun setUp() = runTest {
@@ -45,16 +64,87 @@ class ReferralsClaimGuestPassViewModelTest {
         initViewModel(offerInfo = referralOfferInfo)
 
         viewModel.state.test {
-            assertEquals(UiState.Error, awaitItem())
+            assertEquals(UiState.Error(ReferralsClaimGuestPassError.FailedToLoadOffer), awaitItem())
+        }
+    }
+
+    @Test
+    fun `given user not signed-in, when activate pass button is clicked, then navigate to login or signup`() = runTest {
+        initViewModel(
+            signInState = SignInState.SignedOut,
+        )
+
+        viewModel.navigationEvent.test {
+            viewModel.onActivatePassClick()
+            assertEquals(NavigationEvent.LoginOrSignup, awaitItem())
+        }
+    }
+
+    @Test
+    fun `given user signed-in, when activate pass button is clicked, then referral code is validated`() = runTest {
+        initViewModel(
+            signInState = SignInState.SignedIn("email", SubscriptionStatus.Free()),
+        )
+
+        viewModel.onActivatePassClick()
+
+        verify(referralManager).validateReferralCode(referralCode)
+    }
+
+    @Test
+    fun `given validation error, when activate pass button is clicked, then invalid offer is shown`() = runTest {
+        initViewModel(
+            signInState = SignInState.SignedIn("email", SubscriptionStatus.Free()),
+            referralResult = ErrorResult(""),
+        )
+
+        viewModel.navigationEvent.test {
+            viewModel.onActivatePassClick()
+            assertEquals(NavigationEvent.InValidOffer, awaitItem())
+        }
+    }
+
+    @Test
+    fun `given validation empty result, when activate pass button is clicked, then invalid offer is shown`() = runTest {
+        initViewModel(
+            signInState = SignInState.SignedIn("email", SubscriptionStatus.Free()),
+            referralResult = EmptyResult(),
+        )
+
+        viewModel.navigationEvent.test {
+            viewModel.onActivatePassClick()
+            assertEquals(NavigationEvent.InValidOffer, awaitItem())
+        }
+    }
+
+    @Test
+    fun `given no network, when activate pass button is clicked, then no network error is shown`() = runTest {
+        initViewModel(
+            signInState = SignInState.SignedIn("email", SubscriptionStatus.Free()),
+            referralResult = ErrorResult(errorMessage = "", error = NoNetworkException()),
+        )
+
+        viewModel.onActivatePassClick()
+
+        viewModel.state.test {
+            assertEquals(UiState.Error(ReferralsClaimGuestPassError.NoNetwork), awaitItem())
         }
     }
 
     private suspend fun initViewModel(
         offerInfo: ReferralsOfferInfo? = referralOfferInfo,
+        signInState: SignInState = SignInState.SignedOut,
+        referralResult: ReferralManager.ReferralResult<ReferralValidationResponse> = SuccessResult(mock()),
     ) {
         whenever(referralOfferInfoProvider.referralOfferInfo()).thenReturn(offerInfo)
+        whenever(settings.referralClaimCode).thenReturn(UserSetting.Mock(referralCode, mock()))
+        whenever(referralManager.validateReferralCode(referralCode)).thenReturn(referralResult)
+        whenever(userManager.getSignInState()).thenReturn(Flowable.just(signInState))
         viewModel = ReferralsClaimGuestPassViewModel(
             referralOfferInfoProvider = referralOfferInfoProvider,
+            referralManager = referralManager,
+            userManager = userManager,
+            settings = settings,
         )
     }
 }

--- a/modules/features/referrals/src/test/kotlin/au/com/shiftyjelly/pocketcasts/referrals/ReferralsClaimGuestPassViewModelTest.kt
+++ b/modules/features/referrals/src/test/kotlin/au/com/shiftyjelly/pocketcasts/referrals/ReferralsClaimGuestPassViewModelTest.kt
@@ -124,10 +124,9 @@ class ReferralsClaimGuestPassViewModelTest {
             referralResult = ErrorResult(errorMessage = "", error = NoNetworkException()),
         )
 
-        viewModel.onActivatePassClick()
-
-        viewModel.state.test {
-            assertEquals(UiState.Error(ReferralsClaimGuestPassError.NoNetwork), awaitItem())
+        viewModel.snackBarEvent.test {
+            viewModel.onActivatePassClick()
+            assertEquals(ReferralsClaimGuestPassViewModel.SnackbarEvent.NoNetwork, awaitItem())
         }
     }
 

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/onboarding/OnboardingFlow.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/onboarding/OnboardingFlow.kt
@@ -15,6 +15,8 @@ sealed class OnboardingFlow(val analyticsValue: String) : Parcelable {
 
     @Parcelize object PlusAccountUpgradeNeedsLogin : OnboardingFlow("plus_account_upgrade_needs_login")
 
+    @Parcelize object ReferralLoginOrSignUp : OnboardingFlow("referral_login_or_signup")
+
     @Parcelize class Upsell(
         override val source: OnboardingUpgradeSource,
         val showPatronOnly: Boolean = false,

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
@@ -544,4 +544,6 @@ interface Settings {
 
     val playerOrUpNextBottomSheetState: Flow<Int>
     fun updatePlayerOrUpNextBottomSheetState(state: Int)
+
+    val referralClaimCode: UserSetting<String>
 }

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
@@ -1475,6 +1475,12 @@ class SettingsImpl @Inject constructor(
         sharedPrefs = sharedPreferences,
     )
 
+    override val referralClaimCode = UserSetting.StringPref(
+        sharedPrefKey = "referralCode",
+        defaultValue = "",
+        sharedPrefs = sharedPreferences,
+    )
+
     private val _playerOrUpNextBottomSheetState = MutableSharedFlow<Int>(onBufferOverflow = BufferOverflow.DROP_OLDEST, replay = 1)
     override val playerOrUpNextBottomSheetState: Flow<Int>
         get() = _playerOrUpNextBottomSheetState.asSharedFlow().distinctUntilChanged()

--- a/modules/services/protobuf/src/main/proto/sync_api.proto
+++ b/modules/services/protobuf/src/main/proto/sync_api.proto
@@ -88,6 +88,8 @@ message ReferralCodeResponse {
 
 message ReferralValidationResponse {
     string offer = 1;
+    int32 platform = 2;
+    string details = 3;
 }
 
 message ReferralRedemptionRequest {


### PR DESCRIPTION
## Description
This validates the referral claim offer. It is validated after login or sign-up if the user is not signed in.

** It does not yet start the IAP flow

## Testing Instructions

Prerequisites
#### Get referral share URL

1. Login as a paid user
2. Go to the `Profile` tab
3. Notice that referral profile banner is not shown
4. Tap gift icon to open `Send Guest Pass` screen
5. Tap `Share Guest Pass`
6. Copy the share URL 
7. Logout

#### Test.1 Validate offer - Logged out state, then login

1. Tap the share URL to open the referral claim screen 
2. Tap `Activate my pass`
3. Notice that login or sign-up screen is shown
4. Login with a free account
5. ✅ At the end of login, notice that a loading view is shown, this is when the referral code is validated

#### Test.3 Validate offer - Logged out state, then sign up

1. Tap the share URL to open the referral claim screen 
2. Tap `Activate my pass`
3. Notice that login or sign-up screen is shown
4. Sign up
5. ✅ At the end of sign up, notice that a loading view is shown, this is when the referral code is validated

#### Test.3 Invalid offer - Login with the account with which URL was generated

1. Convert account with which the referral code was generated to a free account
2. Login with that account
3. Tap the share URL to open the referral claim screen 
4. Tap `Activate my pass`
5. ✅ Notice that an invalid offer screen is shown

## Screenshots or Screencast 


https://github.com/user-attachments/assets/575a25e7-1bac-4dff-9239-751516331af1




## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
