### PR TITLE
Referrals - Replace IDs, add failure logs

### DIFF
--- a/modules/features/referrals/src/main/kotlin/au/com/shiftyjelly/pocketcasts/referrals/ReferralsClaimGuestPassViewModel.kt
+++ b/modules/features/referrals/src/main/kotlin/au/com/shiftyjelly/pocketcasts/referrals/ReferralsClaimGuestPassViewModel.kt
@@ -89,11 +89,17 @@ class ReferralsClaimGuestPassViewModel @Inject constructor(
                                 offerInfo?.subscriptionWithOffer?.let { subscriptionWithOffer -> triggerBillingFlowAndObservePurchaseEvents(subscriptionWithOffer) }
                             }
 
-                            is ReferralResult.EmptyResult -> _navigationEvent.emit(NavigationEvent.InValidOffer)
-                            is ReferralResult.ErrorResult -> if (result.error is NoNetworkException) {
-                                _snackBarEvent.emit(SnackbarEvent.NoNetwork)
-                            } else {
+                            is ReferralResult.EmptyResult -> {
+                                LogBuffer.e(LogBuffer.TAG_INVALID_STATE, "Empty validation result for redeem code: ${settings.referralClaimCode.value}")
                                 _navigationEvent.emit(NavigationEvent.InValidOffer)
+                            }
+                            is ReferralResult.ErrorResult -> {
+                                if (result.error is NoNetworkException) {
+                                    _snackBarEvent.emit(SnackbarEvent.NoNetwork)
+                                } else {
+                                    LogBuffer.e(LogBuffer.TAG_INVALID_STATE, "Validation failed for redeem code: ${settings.referralClaimCode.value} ${result.error}")
+                                    _navigationEvent.emit(NavigationEvent.InValidOffer)
+                                }
                             }
                         }
                     } else {
@@ -158,11 +164,17 @@ class ReferralsClaimGuestPassViewModel @Inject constructor(
                 _navigationEvent.emit(NavigationEvent.Close)
             }
 
-            is ReferralResult.EmptyResult -> _snackBarEvent.emit(SnackbarEvent.RedeemFailed)
-            is ReferralResult.ErrorResult -> if (result.error is NoNetworkException) {
-                _snackBarEvent.emit(SnackbarEvent.NoNetwork)
-            } else {
+            is ReferralResult.EmptyResult -> {
+                LogBuffer.e(LogBuffer.TAG_INVALID_STATE, "Empty redemption result for redeem code: ${settings.referralClaimCode.value}")
                 _snackBarEvent.emit(SnackbarEvent.RedeemFailed)
+            }
+            is ReferralResult.ErrorResult -> {
+                if (result.error is NoNetworkException) {
+                    _snackBarEvent.emit(SnackbarEvent.NoNetwork)
+                } else {
+                    LogBuffer.e(LogBuffer.TAG_INVALID_STATE, "Redeem failed for redeem code: ${settings.referralClaimCode.value} ${result.error}")
+                    _snackBarEvent.emit(SnackbarEvent.RedeemFailed)
+                }
             }
         }
     }

--- a/modules/features/referrals/src/main/kotlin/au/com/shiftyjelly/pocketcasts/referrals/ReferralsClaimGuestPassViewModel.kt
+++ b/modules/features/referrals/src/main/kotlin/au/com/shiftyjelly/pocketcasts/referrals/ReferralsClaimGuestPassViewModel.kt
@@ -19,6 +19,7 @@ import au.com.shiftyjelly.pocketcasts.utils.exception.NoNetworkException
 import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
@@ -48,6 +49,8 @@ class ReferralsClaimGuestPassViewModel @Inject constructor(
     private val _snackBarEvent: MutableSharedFlow<SnackbarEvent> = MutableSharedFlow()
     val snackBarEvent: SharedFlow<SnackbarEvent> = _snackBarEvent
 
+    private var job: Job? = null
+
     init {
         loadReferralClaimOffer()
     }
@@ -72,7 +75,7 @@ class ReferralsClaimGuestPassViewModel @Inject constructor(
 
     fun onActivatePassClick() {
         analyticsTracker.track(AnalyticsEvent.REFERRAL_ACTIVATE_TAPPED)
-        viewModelScope.launch {
+        job = viewModelScope.launch {
             userManager.getSignInState().asFlow()
                 .stateIn(viewModelScope)
                 .collect {

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/type/Subscription.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/type/Subscription.kt
@@ -123,8 +123,7 @@ sealed interface Subscription {
         const val PATRON_YEARLY_PRODUCT_ID = "com.pocketcasts.yearly.patron"
         const val TRIAL_OFFER_ID = "plus-yearly-trial-30days"
         const val INTRO_OFFER_ID = "plus-yearly-intro-50percent"
-        const val TEST_PLUS_YEARLY_PRODUCT_ID = "$PLUS_PRODUCT_BASE.testfreetrialoffer"
-        const val TRIAL_TWO_MONTHS_OFFER_ID = "2-months-free"
+        const val REFERRAL_OFFER_ID = "plus-yearly-referral-two-months-free"
 
         fun fromProductDetails(
             productDetails: ProductDetails,

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/type/SubscriptionMapper.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/type/SubscriptionMapper.kt
@@ -4,7 +4,6 @@ import au.com.shiftyjelly.pocketcasts.models.type.Subscription.Companion.PATRON_
 import au.com.shiftyjelly.pocketcasts.models.type.Subscription.Companion.PATRON_YEARLY_PRODUCT_ID
 import au.com.shiftyjelly.pocketcasts.models.type.Subscription.Companion.PLUS_MONTHLY_PRODUCT_ID
 import au.com.shiftyjelly.pocketcasts.models.type.Subscription.Companion.PLUS_YEARLY_PRODUCT_ID
-import au.com.shiftyjelly.pocketcasts.models.type.Subscription.Companion.TEST_PLUS_YEARLY_PRODUCT_ID
 import au.com.shiftyjelly.pocketcasts.models.type.Subscription.SubscriptionTier
 import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
 import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
@@ -166,7 +165,7 @@ object SubscriptionMapper {
         }
 
     fun mapProductIdToTier(productId: String) = when (productId) {
-        in listOf(PLUS_MONTHLY_PRODUCT_ID, PLUS_YEARLY_PRODUCT_ID, TEST_PLUS_YEARLY_PRODUCT_ID) -> SubscriptionTier.PLUS
+        in listOf(PLUS_MONTHLY_PRODUCT_ID, PLUS_YEARLY_PRODUCT_ID) -> SubscriptionTier.PLUS
         in listOf(PATRON_MONTHLY_PRODUCT_ID, PATRON_YEARLY_PRODUCT_ID) -> SubscriptionTier.PATRON
         else -> SubscriptionTier.UNKNOWN
     }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/referrals/ReferralOfferInfoProvider.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/referrals/ReferralOfferInfoProvider.kt
@@ -14,9 +14,8 @@ import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.transformLatest
 import kotlinx.coroutines.reactive.asFlow
 
-// TODO - Referrals: Replace Product and offer Ids
-const val REFERRAL_SUBSCRIPTION_PRODUCT_ID = Subscription.TEST_PLUS_YEARLY_PRODUCT_ID
-const val REFERRAL_OFFER_ID = Subscription.TRIAL_TWO_MONTHS_OFFER_ID
+const val REFERRAL_SUBSCRIPTION_PRODUCT_ID = Subscription.PLUS_YEARLY_PRODUCT_ID
+const val REFERRAL_OFFER_ID = Subscription.REFERRAL_OFFER_ID
 
 class ReferralOfferInfoProvider @Inject constructor(
     private val subscriptionManager: SubscriptionManager,

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/subscription/SubscriptionManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/subscription/SubscriptionManagerImpl.kt
@@ -8,7 +8,6 @@ import au.com.shiftyjelly.pocketcasts.models.type.Subscription.Companion.PATRON_
 import au.com.shiftyjelly.pocketcasts.models.type.Subscription.Companion.PATRON_YEARLY_PRODUCT_ID
 import au.com.shiftyjelly.pocketcasts.models.type.Subscription.Companion.PLUS_MONTHLY_PRODUCT_ID
 import au.com.shiftyjelly.pocketcasts.models.type.Subscription.Companion.PLUS_YEARLY_PRODUCT_ID
-import au.com.shiftyjelly.pocketcasts.models.type.Subscription.Companion.TEST_PLUS_YEARLY_PRODUCT_ID
 import au.com.shiftyjelly.pocketcasts.models.type.SubscriptionFrequency
 import au.com.shiftyjelly.pocketcasts.models.type.SubscriptionMapper.mapProductIdToTier
 import au.com.shiftyjelly.pocketcasts.models.type.SubscriptionPlatform
@@ -22,8 +21,6 @@ import au.com.shiftyjelly.pocketcasts.servers.sync.SubscriptionPurchaseRequest
 import au.com.shiftyjelly.pocketcasts.servers.sync.SubscriptionResponse
 import au.com.shiftyjelly.pocketcasts.servers.sync.SubscriptionStatusResponse
 import au.com.shiftyjelly.pocketcasts.utils.Optional
-import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
-import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
 import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
 import com.android.billingclient.api.AcknowledgePurchaseParams
 import com.android.billingclient.api.AcknowledgePurchaseResponseListener
@@ -187,16 +184,7 @@ class SubscriptionManagerImpl @Inject constructor(
                     .setProductId(PATRON_YEARLY_PRODUCT_ID)
                     .setProductType(BillingClient.ProductType.SUBS)
                     .build(),
-            ).apply {
-                if (FeatureFlag.isEnabled(Feature.REFERRALS)) {
-                    add(
-                        QueryProductDetailsParams.Product.newBuilder()
-                            .setProductId(TEST_PLUS_YEARLY_PRODUCT_ID)
-                            .setProductType(BillingClient.ProductType.SUBS)
-                            .build(),
-                    )
-                }
-            }
+            )
 
         val params = QueryProductDetailsParams.newBuilder()
             .setProductList(productList)


### PR DESCRIPTION
## Description
This 
- replaces referral product and offer id
- adds failure logs in the referrals claim VM
- adds a check (00c3642483769f612510895a0c0828300ae9e6cf) so that after purchase when the sign-in state is updated, the redeem code is not re-validated and the user is not shown the invalid offer while the screen is closing in the view model scope. 

## Testing Instructions
Code review should be sufficient. 

## Screenshots or Screencast 


https://github.com/user-attachments/assets/23100ab2-cc05-4f8e-a7b2-431e413f8d90



## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
