### PR TITLE
Speed up listening history search by limiting the number of results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
     *   Add an advanced setting to display artwork in episode listing
         ([#2958](https://github.com/Automattic/pocket-casts-android/pull/2958))
 *   Bug Fixes
+    *   Speed up listening history search
+        ([#2979](https://github.com/Automattic/pocket-casts-android/pull/2979))
     *   Fix search podcast results scroll back to the start after subscribing
         ([#2923](https://github.com/Automattic/pocket-casts-android/pull/2923))
 

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/EpisodeDao.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/EpisodeDao.kt
@@ -288,6 +288,7 @@ abstract class EpisodeDao {
           AND (UPPER(podcast_episodes.title) LIKE '%' || UPPER(:query) || '%'  ESCAPE '\'
                OR UPPER(podcasts.title) LIKE '%' || UPPER(:query) || '%'  ESCAPE '\')
         ORDER BY last_playback_interaction_date DESC
+        LIMIT 100
     """,
     )
     abstract fun filteredPlaybackHistoryFlow(query: String): Flow<List<PodcastEpisode>>


### PR DESCRIPTION
## Description

We had a report that searching over a large listening history was very slow. The cause of this was that it could return a large number of results. I have added a limit to the search results query to speed up this. 

## Testing Instructions
1. Subscribe to lots of podcasts
2. Run the following query in the Android Studio window "App Inspection" `UPDATE podcast_episodes SET last_playback_interaction_date = 1700000000000`
3. In the app open the Profile tab
4. Tap on Listening History
4. Search using a simple term so lots of results are return

✅ Verify the search results load quickly.

## Video

https://github.com/user-attachments/assets/a4f8fe4f-7e19-4143-9b37-712cd56aefea


## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack
