### PR TITLE
[Auto Downloading] Update UI for Global Auto Downloading

### DIFF
--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/AutoDownloadSettingsFragment.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/AutoDownloadSettingsFragment.kt
@@ -348,6 +348,9 @@ class AutoDownloadSettingsFragment :
         upNextPreference.isChecked = viewModel.getAutoDownloadUpNext()
         autoDownloadOnlyDownloadOnWifi.isChecked = viewModel.getAutoDownloadUnmeteredOnly()
         autoDownloadOnlyWhenCharging.isChecked = viewModel.getAutoDownloadOnlyWhenCharging()
+        if (FeatureFlag.isEnabled(Feature.AUTO_DOWNLOAD)) {
+            newEpisodesPreference?.summary = getString(LR.string.settings_auto_download_new_episodes_description)
+        }
     }
 
     private fun countPodcastsAutoDownloading(): Single<Int> {

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/AutoDownloadSettingsFragment.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/AutoDownloadSettingsFragment.kt
@@ -67,6 +67,7 @@ class AutoDownloadSettingsFragment :
         const val PREFERENCE_PODCASTS_CATEGORY = "podcasts_category"
         const val PREFERENCE_NEW_EPISODES = "autoDownloadNewEpisodes"
         const val PREFERENCE_CHOOSE_PODCASTS = "autoDownloadPodcastsPreference"
+        const val PREFERENCE_AUTO_DOWNLOAD_PODCAST_LIMIT = "autoDownloadPodcastsLimit"
         const val PREFERENCE_CHOOSE_FILTERS = "autoDownloadPlaylists"
 
         private const val PREFERENCE_CANCEL_ALL = "cancelAll"
@@ -98,6 +99,7 @@ class AutoDownloadSettingsFragment :
     private lateinit var upNextPreference: SwitchPreference
     private var newEpisodesPreference: SwitchPreference? = null
     private var podcastsPreference: Preference? = null
+    private var podcastsAutoDownloadLimitPreference: Preference? = null
     private var filtersPreference: Preference? = null
     private lateinit var autoDownloadOnlyDownloadOnWifi: SwitchPreference
     private lateinit var autoDownloadOnlyWhenCharging: SwitchPreference
@@ -158,6 +160,13 @@ class AutoDownloadSettingsFragment :
             ?.apply {
                 setOnPreferenceClickListener {
                     openPodcastsActivity()
+                    true
+                }
+            }
+        podcastsAutoDownloadLimitPreference = preferenceManager.findPreference<Preference>(PREFERENCE_AUTO_DOWNLOAD_PODCAST_LIMIT)
+            ?.apply {
+                setOnPreferenceClickListener {
+                    // TODO DO
                     true
                 }
             }
@@ -226,11 +235,14 @@ class AutoDownloadSettingsFragment :
 
     private fun updateNewEpisodesSwitch(on: Boolean) {
         val podcastsPreference = podcastsPreference ?: return
+        val podcastsLimitPreference = podcastsAutoDownloadLimitPreference ?: return
         val podcastsCategory = podcastsCategory ?: return
         if (on) {
             podcastsCategory.addPreference(podcastsPreference)
+            podcastsCategory.addPreference(podcastsLimitPreference)
         } else {
             podcastsCategory.removePreference(podcastsPreference)
+            podcastsCategory.removePreference(podcastsLimitPreference)
         }
     }
 

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/AutoDownloadSettingsFragment.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/AutoDownloadSettingsFragment.kt
@@ -412,15 +412,7 @@ class AutoDownloadSettingsFragment :
 
     private fun setupAutoDownloadLimitOptions() {
         podcastsAutoDownloadLimitPreference?.apply {
-            val options = listOf(
-                AutoDownloadLimitSetting.OFF,
-                AutoDownloadLimitSetting.LATEST_EPISODE,
-                AutoDownloadLimitSetting.TWO_LATEST_EPISODE,
-                AutoDownloadLimitSetting.THREE_LATEST_EPISODE,
-                AutoDownloadLimitSetting.FIVE_LATEST_EPISODE,
-                AutoDownloadLimitSetting.TEN_LATEST_EPISODE,
-                AutoDownloadLimitSetting.ALL_LATEST_EPISODES,
-            )
+            val options = AutoDownloadLimitSetting.entries
             entries = options.map { getString(it.titleRes) }.toTypedArray()
             entryValues = options.map { it.preferenceInt.toString() }.toTypedArray()
             value = settings.autoDownloadLimit.value.preferenceInt.toString()

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/AutoDownloadSettingsFragment.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/AutoDownloadSettingsFragment.kt
@@ -174,11 +174,9 @@ class AutoDownloadSettingsFragment :
                 setOnPreferenceChangeListener { _, newValue ->
                     val autoDownloadLimitSetting = (newValue as? String)
                         ?.let { AutoDownloadLimitSetting.fromPreferenceString(it) }
-                        ?: throw IllegalStateException("Invalid value for auto download limit preference: $newValue")
+                        ?: AutoDownloadLimitSetting.TWO_LATEST_EPISODE
 
-                    settings.autoDownloadLimit.set(autoDownloadLimitSetting, updateModifiedAt = true)
-
-                    viewModel.onLimitDownloadsChange(autoDownloadLimitSetting.analyticsString)
+                    viewModel.onLimitDownloadsChange(autoDownloadLimitSetting)
 
                     changeAutoDownloadLimitSummary()
                     true

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/AutoDownloadSettingsFragment.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/AutoDownloadSettingsFragment.kt
@@ -178,6 +178,8 @@ class AutoDownloadSettingsFragment :
 
                     settings.autoDownloadLimit.set(autoDownloadLimitSetting, updateModifiedAt = true)
 
+                    viewModel.onLimitDownloadsChange(autoDownloadLimitSetting.analyticsString)
+
                     changeAutoDownloadLimitSummary()
                     true
                 }

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/AutoDownloadSettingsFragment.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/AutoDownloadSettingsFragment.kt
@@ -31,6 +31,8 @@ import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.UserPlaylistUpdate
 import au.com.shiftyjelly.pocketcasts.settings.viewmodel.AutoDownloadSettingsViewModel
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
 import au.com.shiftyjelly.pocketcasts.views.extensions.setup
 import au.com.shiftyjelly.pocketcasts.views.fragments.FilterSelectFragment
 import au.com.shiftyjelly.pocketcasts.views.fragments.PodcastSelectFragment
@@ -117,6 +119,8 @@ class AutoDownloadSettingsFragment :
 
         toolbar?.setup(title = getString(LR.string.settings_title_auto_download), navigationIcon = BackArrow, activity = activity, theme = theme)
         toolbar?.isVisible = showToolbar
+
+        podcastsAutoDownloadLimitPreference?.isVisible = FeatureFlag.isEnabled(Feature.AUTO_DOWNLOAD)
 
         if (!showToolbar) {
             val listContainer = view.findViewById<View>(android.R.id.list_container)

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/viewmodel/AutoDownloadSettingsViewModel.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/viewmodel/AutoDownloadSettingsViewModel.kt
@@ -50,6 +50,13 @@ class AutoDownloadSettingsViewModel @Inject constructor(
         )
     }
 
+    fun onLimitDownloadsChange(newValue: String) {
+        analyticsTracker.track(
+            AnalyticsEvent.SETTINGS_AUTO_DOWNLOAD_LIMIT_DOWNLOADS_TOGGLED,
+            mapOf("value" to newValue),
+        )
+    }
+
     fun stopAllDownloads() {
         downloadManager.stopAllDownloads()
         analyticsTracker.track(AnalyticsEvent.SETTINGS_AUTO_DOWNLOAD_STOP_ALL_DOWNLOADS)

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/viewmodel/AutoDownloadSettingsViewModel.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/viewmodel/AutoDownloadSettingsViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.ViewModel
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTracker
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
+import au.com.shiftyjelly.pocketcasts.preferences.model.AutoDownloadLimitSetting
 import au.com.shiftyjelly.pocketcasts.repositories.download.DownloadManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -50,10 +51,12 @@ class AutoDownloadSettingsViewModel @Inject constructor(
         )
     }
 
-    fun onLimitDownloadsChange(newValue: String) {
+    fun onLimitDownloadsChange(autoDownloadLimitSetting: AutoDownloadLimitSetting) {
+        settings.autoDownloadLimit.set(autoDownloadLimitSetting, updateModifiedAt = true)
+
         analyticsTracker.track(
             AnalyticsEvent.SETTINGS_AUTO_DOWNLOAD_LIMIT_DOWNLOADS_TOGGLED,
-            mapOf("value" to newValue),
+            mapOf("value" to autoDownloadLimitSetting.analyticsString),
         )
     }
 

--- a/modules/features/settings/src/main/res/xml/preferences_auto_download.xml
+++ b/modules/features/settings/src/main/res/xml/preferences_auto_download.xml
@@ -17,12 +17,19 @@
         <SwitchPreference
             android:key="autoDownloadNewEpisodes"
             android:title="@string/settings_auto_download_new_episodes"
+            android:summary="@string/settings_auto_download_new_episodes_description"
             android:persistent="false" />
 
         <Preference
             android:key="autoDownloadPodcastsPreference"
             android:title="@string/settings_choose_podcasts"
             android:summary="@string/settings_podcasts_selected_zero"
+            android:persistent="false" />
+
+        <Preference
+            android:key="autoDownloadPodcastsLimit"
+            android:title="@string/settings_auto_download_limit"
+            android:summary="@string/settings_auto_download_limit_off"
             android:persistent="false" />
 
     </PreferenceCategory>

--- a/modules/features/settings/src/main/res/xml/preferences_auto_download.xml
+++ b/modules/features/settings/src/main/res/xml/preferences_auto_download.xml
@@ -17,7 +17,6 @@
         <SwitchPreference
             android:key="autoDownloadNewEpisodes"
             android:title="@string/settings_auto_download_new_episodes"
-            android:summary="@string/settings_auto_download_new_episodes_description"
             android:persistent="false" />
 
         <Preference

--- a/modules/features/settings/src/main/res/xml/preferences_auto_download.xml
+++ b/modules/features/settings/src/main/res/xml/preferences_auto_download.xml
@@ -26,10 +26,10 @@
             android:summary="@string/settings_podcasts_selected_zero"
             android:persistent="false" />
 
-        <Preference
+        <ListPreference
             android:key="autoDownloadPodcastsLimit"
+            android:dialogTitle="@string/settings_auto_download_limit_auto_downloads"
             android:title="@string/settings_auto_download_limit"
-            android:summary="@string/settings_auto_download_limit_off"
             android:persistent="false" />
 
     </PreferenceCategory>

--- a/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
+++ b/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
@@ -474,6 +474,7 @@ enum class AnalyticsEvent(val key: String) {
     SETTINGS_AUTO_DOWNLOAD_SHOWN("settings_auto_download_shown"),
     SETTINGS_AUTO_DOWNLOAD_UP_NEXT_TOGGLED("settings_auto_download_up_next_toggled"),
     SETTINGS_AUTO_DOWNLOAD_NEW_EPISODES_TOGGLED("settings_auto_download_new_episodes_toggled"),
+    SETTINGS_AUTO_DOWNLOAD_LIMIT_DOWNLOADS_TOGGLED("settings_auto_download_limit_downloads_toggled"),
     SETTINGS_AUTO_DOWNLOAD_PODCASTS_CHANGED("settings_auto_download_podcasts_changed"),
     SETTINGS_AUTO_DOWNLOAD_FILTERS_CHANGED("settings_auto_download_filters_changed"),
     SETTINGS_AUTO_DOWNLOAD_ONLY_ON_WIFI_TOGGLED("settings_auto_download_only_on_wifi_toggled"),

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -1145,7 +1145,7 @@
     <string name="settings_auto_download_filters_episodes">All filter episodes</string>
     <string name="settings_auto_download_new_episodes">New episodes</string>
     <string name="settings_auto_download_podcasts">Auto download podcasts</string>
-    <string name="settings_auto_download_new_episodes_description">Download new episodes as they’re released, and manage your storage by setting a limit on how many episodes are saved</string>
+    <string name="settings_auto_download_new_episodes_description">Download new episodes as they’re released, and manage your storage by setting a limit on how many episodes are saved.</string>
     <string name="settings_auto_download_limit">Limit downloads</string>
     <string name="settings_auto_download_limit_off">Off</string>
     <string name="settings_auto_download_limit_latest_episode">Latest Episode</string>

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -1148,6 +1148,13 @@
     <string name="settings_auto_download_new_episodes_description">Download new episodes as they’re released, and manage your storage by setting a limit on how many episodes are saved</string>
     <string name="settings_auto_download_limit">Limit downloads</string>
     <string name="settings_auto_download_limit_off">Off</string>
+    <string name="settings_auto_download_limit_latest_episode">Latest Episode</string>
+    <string name="settings_auto_download_limit_two_latest_episode">2 Latest Episodes</string>
+    <string name="settings_auto_download_limit_three_latest_episode">3 Latest Episodes</string>
+    <string name="settings_auto_download_limit_five_latest_episode">5 Latest Episodes</string>
+    <string name="settings_auto_download_limit_ten_latest_episode">10 Latest Episodes</string>
+    <string name="settings_auto_download_limit_all_latest_episodes">All Latest Episode</string>
+    <string name="settings_auto_download_limit_auto_downloads">Limit auto downloads</string>
     <string name="settings_auto_download_unmetered">Only on unmetered WiFi</string>
     <string name="settings_auto_download_unmetered_summary">Turning this off will allow downloads on cellular as well as other metered networks. Check your network settings for more info.</string>
     <string name="settings_auto_download_up_next">Episodes added to Up Next</string>

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -1145,6 +1145,9 @@
     <string name="settings_auto_download_filters_episodes">All filter episodes</string>
     <string name="settings_auto_download_new_episodes">New episodes</string>
     <string name="settings_auto_download_podcasts">Auto download podcasts</string>
+    <string name="settings_auto_download_new_episodes_description">Download new episodes as they’re released, and manage your storage by setting a limit on how many episodes are saved</string>
+    <string name="settings_auto_download_limit">Limit downloads</string>
+    <string name="settings_auto_download_limit_off">Off</string>
     <string name="settings_auto_download_unmetered">Only on unmetered WiFi</string>
     <string name="settings_auto_download_unmetered_summary">Turning this off will allow downloads on cellular as well as other metered networks. Check your network settings for more info.</string>
     <string name="settings_auto_download_up_next">Episodes added to Up Next</string>

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
@@ -15,6 +15,7 @@ import au.com.shiftyjelly.pocketcasts.models.type.SubscriptionFrequency
 import au.com.shiftyjelly.pocketcasts.preferences.model.AppIconSetting
 import au.com.shiftyjelly.pocketcasts.preferences.model.ArtworkConfiguration
 import au.com.shiftyjelly.pocketcasts.preferences.model.AutoAddUpNextLimitBehaviour
+import au.com.shiftyjelly.pocketcasts.preferences.model.AutoDownloadLimitSetting
 import au.com.shiftyjelly.pocketcasts.preferences.model.AutoPlaySource
 import au.com.shiftyjelly.pocketcasts.preferences.model.BadgeType
 import au.com.shiftyjelly.pocketcasts.preferences.model.BookmarksSortTypeDefault
@@ -305,6 +306,8 @@ interface Settings {
     val warnOnMeteredNetwork: UserSetting<Boolean>
 
     val playOverNotification: UserSetting<PlayOverNotificationSetting>
+
+    val autoDownloadLimit: UserSetting<AutoDownloadLimitSetting>
 
     fun setLastModified(lastModified: String?)
     fun getLastModified(): String?

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
@@ -26,6 +26,7 @@ import au.com.shiftyjelly.pocketcasts.preferences.di.PublicSharedPreferences
 import au.com.shiftyjelly.pocketcasts.preferences.model.AppIconSetting
 import au.com.shiftyjelly.pocketcasts.preferences.model.ArtworkConfiguration
 import au.com.shiftyjelly.pocketcasts.preferences.model.AutoAddUpNextLimitBehaviour
+import au.com.shiftyjelly.pocketcasts.preferences.model.AutoDownloadLimitSetting
 import au.com.shiftyjelly.pocketcasts.preferences.model.AutoPlaySource
 import au.com.shiftyjelly.pocketcasts.preferences.model.BadgeType
 import au.com.shiftyjelly.pocketcasts.preferences.model.BookmarksSortTypeDefault
@@ -382,6 +383,14 @@ class SettingsImpl @Inject constructor(
         },
         sharedPrefs = sharedPreferences,
         fromString = { PlayOverNotificationSetting.fromPreferenceString(it) },
+        toString = { it.preferenceInt.toString() },
+    )
+
+    override val autoDownloadLimit = UserSetting.PrefFromString(
+        sharedPrefKey = "autoDownloadLimit",
+        defaultValue = AutoDownloadLimitSetting.TWO_LATEST_EPISODE,
+        sharedPrefs = sharedPreferences,
+        fromString = { AutoDownloadLimitSetting.fromPreferenceString(it) },
         toString = { it.preferenceInt.toString() },
     )
 

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/model/AutoDownloadLimitSetting.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/model/AutoDownloadLimitSetting.kt
@@ -50,9 +50,9 @@ enum class AutoDownloadLimitSetting(
         fun fromPreferenceString(stringValue: String): AutoDownloadLimitSetting {
             return try {
                 val intValue = stringValue.toInt()
-                entries.firstOrNull { it.preferenceInt == intValue } ?: OFF
+                entries.firstOrNull { it.preferenceInt == intValue } ?: TWO_LATEST_EPISODE
             } catch (e: Exception) {
-                OFF
+                TWO_LATEST_EPISODE
             }
         }
     }

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/model/AutoDownloadLimitSetting.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/model/AutoDownloadLimitSetting.kt
@@ -48,11 +48,11 @@ enum class AutoDownloadLimitSetting(
     companion object {
 
         fun fromPreferenceString(stringValue: String): AutoDownloadLimitSetting {
-            try {
+            return try {
                 val intValue = stringValue.toInt()
-                return entries.first { it.preferenceInt == intValue }
+                entries.firstOrNull { it.preferenceInt == intValue } ?: OFF
             } catch (e: Exception) {
-                throw IllegalStateException("Unknown auto download setting: $stringValue")
+                OFF
             }
         }
     }

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/model/AutoDownloadLimitSetting.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/model/AutoDownloadLimitSetting.kt
@@ -1,0 +1,51 @@
+package au.com.shiftyjelly.pocketcasts.preferences.model
+
+import androidx.annotation.StringRes
+import au.com.shiftyjelly.pocketcasts.localization.R as LR
+
+enum class AutoDownloadLimitSetting(
+    val preferenceInt: Int,
+    @StringRes val titleRes: Int,
+) {
+    OFF(
+        preferenceInt = 0,
+        titleRes = LR.string.settings_auto_download_limit_off,
+    ),
+    LATEST_EPISODE(
+        preferenceInt = 1,
+        titleRes = LR.string.settings_auto_download_limit_latest_episode,
+    ),
+    TWO_LATEST_EPISODE(
+        preferenceInt = 2,
+        titleRes = LR.string.settings_auto_download_limit_two_latest_episode,
+    ),
+    THREE_LATEST_EPISODE(
+        preferenceInt = 3,
+        titleRes = LR.string.settings_auto_download_limit_three_latest_episode,
+    ),
+    FIVE_LATEST_EPISODE(
+        preferenceInt = 4,
+        titleRes = LR.string.settings_auto_download_limit_five_latest_episode,
+    ),
+    TEN_LATEST_EPISODE(
+        preferenceInt = 5,
+        titleRes = LR.string.settings_auto_download_limit_ten_latest_episode,
+    ),
+    ALL_LATEST_EPISODES(
+        preferenceInt = 6,
+        titleRes = LR.string.settings_auto_download_limit_all_latest_episodes,
+    ),
+    ;
+
+    companion object {
+
+        fun fromPreferenceString(stringValue: String): AutoDownloadLimitSetting {
+            try {
+                val intValue = stringValue.toInt()
+                return entries.first { it.preferenceInt == intValue }
+            } catch (e: Exception) {
+                throw IllegalStateException("Unknown auto download setting: $stringValue")
+            }
+        }
+    }
+}

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/model/AutoDownloadLimitSetting.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/model/AutoDownloadLimitSetting.kt
@@ -6,34 +6,42 @@ import au.com.shiftyjelly.pocketcasts.localization.R as LR
 enum class AutoDownloadLimitSetting(
     val preferenceInt: Int,
     @StringRes val titleRes: Int,
+    val analyticsString: String,
 ) {
     OFF(
         preferenceInt = 0,
         titleRes = LR.string.settings_auto_download_limit_off,
+        analyticsString = "off",
     ),
     LATEST_EPISODE(
         preferenceInt = 1,
         titleRes = LR.string.settings_auto_download_limit_latest_episode,
+        analyticsString = "latest_episode",
     ),
     TWO_LATEST_EPISODE(
         preferenceInt = 2,
         titleRes = LR.string.settings_auto_download_limit_two_latest_episode,
+        analyticsString = "two_latest_episode",
     ),
     THREE_LATEST_EPISODE(
         preferenceInt = 3,
         titleRes = LR.string.settings_auto_download_limit_three_latest_episode,
+        analyticsString = "three_latest_episode",
     ),
     FIVE_LATEST_EPISODE(
         preferenceInt = 4,
         titleRes = LR.string.settings_auto_download_limit_five_latest_episode,
+        analyticsString = "five_latest_episode",
     ),
     TEN_LATEST_EPISODE(
         preferenceInt = 5,
         titleRes = LR.string.settings_auto_download_limit_ten_latest_episode,
+        analyticsString = "ten_latest_episode",
     ),
     ALL_LATEST_EPISODES(
         preferenceInt = 6,
         titleRes = LR.string.settings_auto_download_limit_all_latest_episodes,
+        analyticsString = "all_latest_episodes",
     ),
     ;
 

--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/Feature.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/Feature.kt
@@ -123,6 +123,14 @@ enum class Feature(
         hasFirebaseRemoteFlag = true,
         hasDevToggle = true,
     ),
+    AUTO_DOWNLOAD(
+        key = "auto_download",
+        title = "Auto download episodes",
+        defaultValue = BuildConfig.DEBUG,
+        tier = FeatureTier.Free,
+        hasFirebaseRemoteFlag = false,
+        hasDevToggle = true,
+    ),
     ;
 
     companion object {


### PR DESCRIPTION
## Description
- This PR updates the UI for auto downloading settings (global) by adding the limit setting
- Adds local feature flag to wrap this change
- Add tracks for when the user selects a limit downloading
- Context: pdeCcb-744-p2
- Figma: VvERCFIopLjFL8Fnczsf8r-fi-1_756

Fixes #2970

## Testing Instructions

### AUTO_DOWNLOAD feature flag OFF
1. Have the FF disabled
2. Go to Profile -> Settings -> Auto Download
3. ✅ Ensure that New Episodes toggle does not have description
4. ✅ Ensure you don't see the limit download section

### AUTO_DOWNLOAD feature flag ON
1. Have the FF enabled
2. Go to Profile -> Settings -> Auto Download
3. ✅ Ensure that New Episodes toggle has description
4. ✅ Ensure you see the limit download section
5. Tap on limit downloads label and select one option
6. ✅ Ensure your option is selected
7. ✅ Ensure 🔵 Tracked: settings_auto_download_limit_downloads_toggled, Properties: {"value":"value"... is tracked

## Screenshots or Screencast 

<img src="https://github.com/user-attachments/assets/b8b30c0b-8f0a-4e6f-b201-ad0f7fa5a844" width="300">




## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack