### PR TITLE
Media - Update buffer position for cached episode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
         ([#2958](https://github.com/Automattic/pocket-casts-android/pull/2958))
     *   Display remaining playback time using skipped chapters and playback speed
         ([#2955](https://github.com/Automattic/pocket-casts-android/pull/2955))
+    *   Display buffer position more accurately for cached episode 
+        ([#2987](https://github.com/Automattic/pocket-casts-android/pull/2987))
 *   Bug Fixes
     *   Speed up listening history search
         ([#2979](https://github.com/Automattic/pocket-casts-android/pull/2979))

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/CacheWorker.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/CacheWorker.kt
@@ -121,6 +121,16 @@ class CacheWorker @AssistedInject constructor(
                         if (workInfo?.state == WorkInfo.State.SUCCEEDED &&
                             workInfo.outputData.getString(EPISODE_UUID_KEY) == episodeUuid
                         ) {
+                            /* For fully cached media, ExoPlayer's buffer position might not reach the end,
+                            even when the entire media is cached. This is due to ExoPlayer's LoadControl
+                            mechanism, which might not request the entire media to be buffered even when it's
+                            fully cached.
+
+                            This callback is triggered when the media is fully cached and is used to
+                            manually update the buffer position to the end of the media, ensuring more accurate
+                            buffer status tracking.
+
+                            See https://rb.gy/333bzt for more details. */
                             onCachingComplete(episodeUuid)
                         }
                     }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/CacheWorker.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/CacheWorker.kt
@@ -130,7 +130,7 @@ class CacheWorker @AssistedInject constructor(
                             manually update the buffer position to the end of the media, ensuring more accurate
                             buffer status tracking.
 
-                            See https://rb.gy/333bzt for more details. */
+                            See https://github.com/google/ExoPlayer/issues/9172#issuecomment-877250396 for more details. */
                             onCachingComplete(episodeUuid)
                         }
                     }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/ExoPlayerDataSourceFactory.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/ExoPlayerDataSourceFactory.kt
@@ -72,6 +72,7 @@ class ExoPlayerDataSourceFactory @Inject constructor(
     fun createMediaSource(
         episodeLocation: EpisodeLocation,
         clipRange: ClosedRange<Long>? = null,
+        onCachingComplete: (String) -> Unit = {},
     ): MediaSource? {
         val episodeUri = episodeLocation.uri ?: return null
         val mediaItem = MediaItem.Builder()
@@ -95,7 +96,12 @@ class ExoPlayerDataSourceFactory @Inject constructor(
             .setCacheWriteDataSinkFactory(null)
             .takeIf { episodeLocation.episode.shouldUseCache() }
         if (cacheFactory != null) {
-            CacheWorker.startCachingEntireEpisode(context, episodeUri.toString(), episodeLocation.episode.uuid)
+            CacheWorker.startCachingEntireEpisode(
+                context = context,
+                url = episodeUri,
+                episodeUuid = episodeLocation.episode.uuid,
+                onCachingComplete = onCachingComplete,
+            )
         }
 
         val dataFactory = cacheFactory ?: defaultFactory

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlayerEvent.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlayerEvent.kt
@@ -16,4 +16,5 @@ sealed class PlayerEvent {
     class MetadataAvailable(val metaData: EpisodeFileMetadata) : PlayerEvent()
     class RemoteMetadataNotMatched(val remoteEpisodeUuid: String) : PlayerEvent()
     class EpisodeChanged(val episodeUuid: String) : PlayerEvent()
+    data class CachingComplete(val episodeUuid: String) : PlayerEvent()
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/SimplePlayer.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/SimplePlayer.kt
@@ -253,7 +253,9 @@ class SimplePlayer(
             onError(PlayerEvent.PlayerError("No episode location found"))
             return
         }
-        val source = dataSourceFactory.createMediaSource(episodeLocation)
+        val source = dataSourceFactory.createMediaSource(episodeLocation) {
+            onPlayerEvent(this, PlayerEvent.CachingComplete(it))
+        }
         if (source == null) {
             onError(PlayerEvent.PlayerError("Episode has no source"))
             return


### PR DESCRIPTION
## Description
This correctly updates the buffer position for a cached episode and disposes of the buffer update timer when caching is complete.

Fixes https://github.com/Automattic/pocket-casts-android/issues/2861

## Testing Instructions

1. Apply [this patch](https://github.com/user-attachments/files/17304506/caching.patch)
2. Search for `tag:Test` in Android Studio log viewer
3. Play an episode that you haven't played before and open full-screen player
4. ✅ Notice that you see that episode is buffering
5. Wait until you see "Caching complete" in the logs
6. ✅ Notice that you see the buffer position updated to the end of episode duration

## Screenshots or Screencast 

https://github.com/user-attachments/assets/ca1dbfdb-13c6-4b75-b45c-4b5d9e869110

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
