### PR TITLE
Referrals - Hide banner on validation failure and long press

### DIFF
--- a/modules/features/referrals/src/main/kotlin/au/com/shiftyjelly/pocketcasts/referrals/ReferralsClaimGuestPassBannerCard.kt
+++ b/modules/features/referrals/src/main/kotlin/au/com/shiftyjelly/pocketcasts/referrals/ReferralsClaimGuestPassBannerCard.kt
@@ -1,8 +1,11 @@
 package au.com.shiftyjelly.pocketcasts.referrals
 
+import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -12,10 +15,14 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.DropdownMenu
 import androidx.compose.material.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -24,6 +31,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.intl.Locale
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
+import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.min
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -65,6 +73,7 @@ fun ReferralsClaimGuestPassBannerCard(
                     val fragment = ReferralsGuestPassFragment.newInstance(ReferralsPageType.Claim)
                     (activity as FragmentHostListener).showBottomSheet(fragment)
                 },
+                onHideBannerClick = viewModel::onHideBannerClick,
             )
         }
     }
@@ -76,20 +85,25 @@ fun ReferralsClaimGuestPassBannerCard(
     }
 }
 
+@OptIn(ExperimentalFoundationApi::class)
 @Composable
 private fun ReferralsClaimGuestPassBannerCard(
     state: UiState.Loaded,
     modifier: Modifier = Modifier,
     onClick: () -> Unit,
+    onHideBannerClick: () -> Unit,
 ) {
     if (state.showProfileBanner) {
+        var showPopupToHideBanner by remember { mutableStateOf(false) }
         BoxWithConstraints(
             modifier = Modifier
                 .fillMaxWidth()
                 .padding(horizontal = 16.dp, vertical = 8.dp)
                 .clip(RoundedCornerShape(8.dp))
-                .clickable(
+                .combinedClickable(
                     onClick = onClick,
+                    onLongClick = { showPopupToHideBanner = true },
+                    onLongClickLabel = stringResource(LR.string.referrals_banner_long_press_label),
                 ),
         ) {
             Row(
@@ -135,6 +149,21 @@ private fun ReferralsClaimGuestPassBannerCard(
                     referralsOfferInfo = requireNotNull(state.referralsOfferInfo),
                 )
             }
+            Box(modifier = Modifier.align(Alignment.BottomEnd)) {
+                DropdownMenu(
+                    expanded = showPopupToHideBanner,
+                    onDismissRequest = { showPopupToHideBanner = false },
+                    offset = DpOffset(8.dp, -(32).dp),
+                    modifier = Modifier
+                        .padding(horizontal = 16.dp)
+                        .clickable {
+                            showPopupToHideBanner = false
+                            onHideBannerClick()
+                        },
+                ) {
+                    TextH40(stringResource(LR.string.referrals_banner_hide_label))
+                }
+            }
         }
     }
 }
@@ -151,6 +180,7 @@ private fun ReferralsClaimGuestPassBannerCardPreview(
                 referralsOfferInfo = ReferralsOfferInfoMock,
             ),
             onClick = {},
+            onHideBannerClick = {},
         )
     }
 }

--- a/modules/features/referrals/src/main/kotlin/au/com/shiftyjelly/pocketcasts/referrals/ReferralsClaimGuestPassViewModel.kt
+++ b/modules/features/referrals/src/main/kotlin/au/com/shiftyjelly/pocketcasts/referrals/ReferralsClaimGuestPassViewModel.kt
@@ -93,6 +93,7 @@ class ReferralsClaimGuestPassViewModel @Inject constructor(
                             }
 
                             is ReferralResult.EmptyResult -> {
+                                settings.referralClaimCode.set("", false)
                                 LogBuffer.e(LogBuffer.TAG_INVALID_STATE, "Empty validation result for redeem code: ${settings.referralClaimCode.value}")
                                 _navigationEvent.emit(NavigationEvent.InValidOffer)
                             }
@@ -100,6 +101,7 @@ class ReferralsClaimGuestPassViewModel @Inject constructor(
                                 if (result.error is NoNetworkException) {
                                     _snackBarEvent.emit(SnackbarEvent.NoNetwork)
                                 } else {
+                                    settings.referralClaimCode.set("", false)
                                     LogBuffer.e(LogBuffer.TAG_INVALID_STATE, "Validation failed for redeem code: ${settings.referralClaimCode.value} ${result.error}")
                                     _navigationEvent.emit(NavigationEvent.InValidOffer)
                                 }

--- a/modules/features/referrals/src/main/kotlin/au/com/shiftyjelly/pocketcasts/referrals/ReferralsViewModel.kt
+++ b/modules/features/referrals/src/main/kotlin/au/com/shiftyjelly/pocketcasts/referrals/ReferralsViewModel.kt
@@ -103,6 +103,7 @@ class ReferralsViewModel @Inject constructor(
     fun onHideBannerClick() {
         (_state.value as? UiState.Loaded)?.let { loadedState ->
             settings.referralClaimCode.set("", updateModifiedAt = false)
+            analyticsTracker.track(AnalyticsEvent.REFERRAL_PASS_BANNER_HIDE_TAPPED)
             _state.update {
                 loadedState.copy(
                     showProfileBanner = false,

--- a/modules/features/referrals/src/main/kotlin/au/com/shiftyjelly/pocketcasts/referrals/ReferralsViewModel.kt
+++ b/modules/features/referrals/src/main/kotlin/au/com/shiftyjelly/pocketcasts/referrals/ReferralsViewModel.kt
@@ -100,12 +100,25 @@ class ReferralsViewModel @Inject constructor(
         }
     }
 
+    fun onHideBannerClick() {
+        (_state.value as? UiState.Loaded)?.let { loadedState ->
+            settings.referralClaimCode.set("", updateModifiedAt = false)
+            _state.update {
+                loadedState.copy(
+                    showProfileBanner = false,
+                    showHideBannerPopup = false,
+                )
+            }
+        }
+    }
+
     sealed class UiState {
         data object Loading : UiState()
         data class Loaded(
             val showIcon: Boolean = false,
             val showTooltip: Boolean = false,
             val showProfileBanner: Boolean = false,
+            val showHideBannerPopup: Boolean = false,
             val referralsOfferInfo: ReferralsOfferInfo? = null,
         ) : UiState()
     }

--- a/modules/features/referrals/src/test/kotlin/au/com/shiftyjelly/pocketcasts/referrals/ReferralsViewModelTest.kt
+++ b/modules/features/referrals/src/test/kotlin/au/com/shiftyjelly/pocketcasts/referrals/ReferralsViewModelTest.kt
@@ -225,6 +225,20 @@ class ReferralsViewModelTest {
         }
     }
 
+    @Test
+    fun `profile banner is hidden on hide banner click`() = runTest {
+        initViewModel(
+            signInState = SignInState.SignedOut,
+            referralCode = referralClaimCode,
+        )
+
+        viewModel.onHideBannerClick()
+
+        viewModel.state.test {
+            assertEquals(false, (awaitItem() as UiState.Loaded).showProfileBanner)
+        }
+    }
+
     private suspend fun initViewModel(
         signInState: SignInState = SignInState.SignedIn(email, statusAndroidPaidSubscription),
         offerInfo: ReferralsOfferInfo = referralOfferInfo,

--- a/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
+++ b/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
@@ -665,6 +665,7 @@ enum class AnalyticsEvent(val key: String) {
     REFERRAL_ACTIVATE_TAPPED("referral_activate_tapped"),
     REFERRAL_NOT_NOW_TAPPED("referral_not_now_tapped"),
     REFERRAL_PASS_BANNER_SHOWN("referral_pass_banner_shown"),
+    REFERRAL_PASS_BANNER_HIDE_TAPPED("referral_pass_banner_hide_tapped"),
     REFERRAL_PURCHASE_SHOWN("referral_purchase_shown"),
     REFERRAL_PURCHASE_SUCCESS("referral_purchase_success"),
 }

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -2146,6 +2146,8 @@
     <!-- Referrals -->
     <string name="gift">Gift</string>
     <string name="referrals_activate_my_pass">Activate my pass</string>
+    <string name="referrals_banner_long_press_label">Hide referral claim pass banner.</string>
+    <string name="referrals_banner_hide_label">Hide this banner</string>
     <string name="referrals_claim_guess_pass_banner_card_title_english_only" translatable="false">Claim your %1$s\nGuest Pass to Plus</string>
     <!-- Referrals claim guess pass banner card title, `%1$s' is a placeholder for the offer duration on the Plus subscription -->
     <string name="referrals_claim_guess_pass_banner_card_title">Claim your %1$s Guest Pass to Plus</string>

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/type/SubscriptionMapper.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/type/SubscriptionMapper.kt
@@ -18,6 +18,7 @@ class SubscriptionMapper @Inject constructor() {
         val matchingSubscriptionOfferDetails = if (isOfferEligible || referralProductDetails != null) {
             productDetails
                 .subscriptionOfferDetails
+                ?.filter { referralProductDetails == null && !it.offerTags.contains(REFERRAL_OFFER_TAG) } // get SubscriptionOfferDetails with offers
                 ?.filter { it.offerSubscriptionPricingPhase != null } // get SubscriptionOfferDetails with offers
                 ?.ifEmpty { productDetails.subscriptionOfferDetails } // if no special offers, return all offers available
                 ?: productDetails.subscriptionOfferDetails // if null, return all offers
@@ -31,7 +32,7 @@ class SubscriptionMapper @Inject constructor() {
             matchingSubscriptionOfferDetails.find { it.offerId == referralProductDetails.offerId }
         } else {
             val matchingSubscriptionOfferDetailsWithoutReferralOffer = matchingSubscriptionOfferDetails
-                .filter { !it.offerTags.contains("referral-offer") }
+                .filter { !it.offerTags.contains(REFERRAL_OFFER_TAG) }
             // TODO handle multiple matching SubscriptionOfferDetails
             if (matchingSubscriptionOfferDetailsWithoutReferralOffer.size > 1) {
                 LogBuffer.w(LogBuffer.TAG_SUBSCRIPTIONS, "Multiple matching SubscriptionOfferDetails found. Only using the first.")
@@ -161,4 +162,8 @@ class SubscriptionMapper @Inject constructor() {
             )
             null
         }
+
+    companion object {
+        private const val REFERRAL_OFFER_TAG = "referral-offer"
+    }
 }

--- a/modules/services/repositories/src/debug/kotlin/com/android/billingclient/api/ProductDetailsModule.kt
+++ b/modules/services/repositories/src/debug/kotlin/com/android/billingclient/api/ProductDetailsModule.kt
@@ -30,67 +30,11 @@ private class MockingProductDetailsInterceptor : ProductDetailsInterceptor {
             .build()
         private val products
             get() = listOf(
-                yearlyTestPlusProduct,
                 yearlyPlusProduct,
                 yearlyPatronProduct,
                 monthlyPlusProduct,
                 monthlyPatronProduct,
             )
-        val yearlyTestPlusProduct = ProductDetails(
-            """
-            |{
-            |  "productId": "com.pocketcasts.plus.testfreetrialoffer",
-            |  "type": "subs",
-            |  "title": "Test Subscription (Pocket Casts - Podcast Player)",
-            |   "name": "Test Subscription",
-            |   "localizedIn": [
-            |    "en-US"
-            |  ],
-            |  "skuDetailsToken": "test-yearly-plus-sku-details-token",
-            |  "subscriptionOfferDetails": [
-            |    {
-            |      "offerIdToken": "test-yearly-plus-offer-id-token",
-            |      "basePlanId": "testyearly",
-            |      "offerId": "2-months-free",
-            |      "pricingPhases": [
-            |        {
-            |          "priceAmountMicros": 0,
-            |          "priceCurrencyCode": "USD",
-            |          "formattedPrice": "Free",
-            |          "billingPeriod": "P2M",
-            |          "recurrenceMode": 2,
-            |          "billingCycleCount": 1
-            |        },
-            |        {
-            |          "priceAmountMicros": 39990000,
-            |          "priceCurrencyCode": "USD",
-            |          "formattedPrice": "$39.99",
-            |          "billingPeriod": "P1Y",
-            |          "recurrenceMode": 1
-            |        }
-            |      ],
-            |      "offerTags": [
-            |        "referral-offer"
-            |      ]
-            |    },
-            |    {
-            |      "offerIdToken": "test-yearly-plus-base-offer-id-token",
-            |      "basePlanId": "testyearly",
-            |      "pricingPhases": [
-            |        {
-            |          "priceAmountMicros": 39990000,
-            |          "priceCurrencyCode": "USD",
-            |          "formattedPrice": "$39.99",
-            |          "billingPeriod": "P1Y",
-            |          "recurrenceMode": 1
-            |        }
-            |      ],
-            |      "offerTags": []
-            |    }
-            |  ]
-            |}
-        """.trimMargin("|"),
-        )
         val yearlyPlusProduct = ProductDetails(
             """
             |{
@@ -104,6 +48,31 @@ private class MockingProductDetailsInterceptor : ProductDetailsInterceptor {
             |  ],
             |  "skuDetailsToken": "yearly-plus-sku-details-token",
             |  "subscriptionOfferDetails": [
+            |    {
+            |      "offerIdToken": "yearly-plus-offer-id-token",
+            |      "basePlanId": "p1y",
+            |      "offerId": "plus-yearly-referral-two-months-free",
+            |      "pricingPhases": [
+            |        {
+            |          "priceAmountMicros": 0,
+            |          "priceCurrencyCode": "USD",
+            |          "formattedPrice": "Free",
+            |          "billingPeriod": "P2M",
+            |          "recurrenceMode": 2,
+            |          "billingCycleCount": 1
+            |        },
+            |        {
+            |          "priceAmountMicros": 420690000,
+            |          "priceCurrencyCode": "USD",
+            |          "formattedPrice": "$ 420.69",
+            |          "billingPeriod": "P1Y",
+            |          "recurrenceMode": 1
+            |        }
+            |      ],
+            |      "offerTags": [
+            |        "referral-offer"
+            |      ]
+            |    },
             |    {
             |      "offerIdToken": "yearly-plus-offer-id-token",
             |      "basePlanId": "p1y",

--- a/modules/services/repositories/src/debugProd/kotlin/com/android/billingclient/api/ProductDetailsModule.kt
+++ b/modules/services/repositories/src/debugProd/kotlin/com/android/billingclient/api/ProductDetailsModule.kt
@@ -30,67 +30,11 @@ private class MockingProductDetailsInterceptor : ProductDetailsInterceptor {
             .build()
         private val products
             get() = listOf(
-                yearlyTestPlusProduct,
                 yearlyPlusProduct,
                 yearlyPatronProduct,
                 monthlyPlusProduct,
                 monthlyPatronProduct,
             )
-        val yearlyTestPlusProduct = ProductDetails(
-            """
-            |{
-            |  "productId": "com.pocketcasts.plus.testfreetrialoffer",
-            |  "type": "subs",
-            |  "title": "Test Subscription (Pocket Casts - Podcast Player)",
-            |   "name": "Test Subscription",
-            |   "localizedIn": [
-            |    "en-US"
-            |  ],
-            |  "skuDetailsToken": "test-yearly-plus-sku-details-token",
-            |  "subscriptionOfferDetails": [
-            |    {
-            |      "offerIdToken": "test-yearly-plus-offer-id-token",
-            |      "basePlanId": "testyearly",
-            |      "offerId": "2-months-free",
-            |      "pricingPhases": [
-            |        {
-            |          "priceAmountMicros": 0,
-            |          "priceCurrencyCode": "USD",
-            |          "formattedPrice": "Free",
-            |          "billingPeriod": "P2M",
-            |          "recurrenceMode": 2,
-            |          "billingCycleCount": 1
-            |        },
-            |        {
-            |          "priceAmountMicros": 39990000,
-            |          "priceCurrencyCode": "USD",
-            |          "formattedPrice": "$39.99",
-            |          "billingPeriod": "P1Y",
-            |          "recurrenceMode": 1
-            |        }
-            |      ],
-            |      "offerTags": [
-            |        "referral-offer"
-            |      ]
-            |    },
-            |    {
-            |      "offerIdToken": "test-yearly-plus-base-offer-id-token",
-            |      "basePlanId": "testyearly",
-            |      "pricingPhases": [
-            |        {
-            |          "priceAmountMicros": 39990000,
-            |          "priceCurrencyCode": "USD",
-            |          "formattedPrice": "$39.99",
-            |          "billingPeriod": "P1Y",
-            |          "recurrenceMode": 1
-            |        }
-            |      ],
-            |      "offerTags": []
-            |    }
-            |  ]
-            |}
-        """.trimMargin("|"),
-        )
         val yearlyPlusProduct = ProductDetails(
             """
             |{
@@ -104,6 +48,31 @@ private class MockingProductDetailsInterceptor : ProductDetailsInterceptor {
             |  ],
             |  "skuDetailsToken": "yearly-plus-sku-details-token",
             |  "subscriptionOfferDetails": [
+            |    {
+            |      "offerIdToken": "yearly-plus-offer-id-token",
+            |      "basePlanId": "p1y",
+            |      "offerId": "plus-yearly-referral-two-months-free",
+            |      "pricingPhases": [
+            |        {
+            |          "priceAmountMicros": 0,
+            |          "priceCurrencyCode": "USD",
+            |          "formattedPrice": "Free",
+            |          "billingPeriod": "P2M",
+            |          "recurrenceMode": 2,
+            |          "billingCycleCount": 1
+            |        },
+            |        {
+            |          "priceAmountMicros": 420690000,
+            |          "priceCurrencyCode": "USD",
+            |          "formattedPrice": "$ 420.69",
+            |          "billingPeriod": "P1Y",
+            |          "recurrenceMode": 1
+            |        }
+            |      ],
+            |      "offerTags": [
+            |        "referral-offer"
+            |      ]
+            |    },
             |    {
             |      "offerIdToken": "yearly-plus-offer-id-token",
             |      "basePlanId": "p1y",


### PR DESCRIPTION
## Description
This hides the Profile tab referral banner on validation failure and long press.

p1728384201675269/1728383119.381479-slack-C07HDV91FBQ

## Testing Instructions
1. Launch the app and open a referral link
2. Go to `Profile` tab
3. Long press on the referral banner
4. Notice that a pop-up is shown to hide the banner
5. Tap on the banner
6. ✅ Notice that referral banner is hidden
7. ✅ Notice that `referral_pass_banner_hide_tapped` is tracked

## Screenshots or Screencast 

https://github.com/user-attachments/assets/0870328e-3bc8-47d0-97ee-77fd42e4bad0

https://github.com/user-attachments/assets/59c0b8df-6c93-4ced-8b53-9973656228c3


## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack