### PR TITLE
Referrals  - Update error message + screen style 

### DIFF
--- a/modules/features/referrals/src/main/kotlin/au/com/shiftyjelly/pocketcasts/referrals/ReferralsClaimGuestPassPage.kt
+++ b/modules/features/referrals/src/main/kotlin/au/com/shiftyjelly/pocketcasts/referrals/ReferralsClaimGuestPassPage.kt
@@ -211,7 +211,7 @@ private fun ReferralsClaimGuestPassContent(
 
                 is UiState.Error -> {
                     val errorMessage = when (state.error) {
-                        ReferralsClaimGuestPassError.FailedToLoadOffer -> stringResource(LR.string.error_generic_message)
+                        ReferralsClaimGuestPassError.FailedToLoadOffer -> stringResource(LR.string.referrals_failed_to_load_offer)
                     }
                     ReferralsGuestPassError(errorMessage, onRetry, onDismiss)
                 }

--- a/modules/features/referrals/src/main/kotlin/au/com/shiftyjelly/pocketcasts/referrals/ReferralsGuestPassError.kt
+++ b/modules/features/referrals/src/main/kotlin/au/com/shiftyjelly/pocketcasts/referrals/ReferralsGuestPassError.kt
@@ -22,6 +22,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import au.com.shiftyjelly.pocketcasts.compose.AppTheme
 import au.com.shiftyjelly.pocketcasts.compose.buttons.CloseButton
+import au.com.shiftyjelly.pocketcasts.compose.components.TextH40
 import au.com.shiftyjelly.pocketcasts.compose.components.TextP40
 import au.com.shiftyjelly.pocketcasts.images.R
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
@@ -51,7 +52,7 @@ fun ReferralsGuestPassError(
             tint = Color.White.copy(alpha = 0.5f),
         )
         Spacer(modifier = Modifier.height(16.dp))
-        TextP40(
+        TextH40(
             text = errorMessage,
             textAlign = TextAlign.Center,
         )
@@ -60,7 +61,7 @@ fun ReferralsGuestPassError(
             onClick = onRetry,
             shape = RoundedCornerShape(40.dp),
             colors = ButtonDefaults.buttonColors(
-                backgroundColor = Color.White.copy(alpha = 0.5f),
+                backgroundColor = Color.White.copy(alpha = 0.2f),
             ),
         ) {
             TextP40(

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -2158,6 +2158,7 @@
     <string name="referrals_claim_guest_pass_title">Claim your %1$s Guest Pass</string>
     <!-- Referrals guest pass card title, `%1$s' is a placeholder for the offer duration on the Plus subscription -->
     <string name="referrals_guest_pass_card_title">%1$s Guest Pass</string>
+    <string name="referrals_failed_to_load_offer">Sorry, but something went wrong fetching your referral link.</string>
     <string name="referrals_invalid_offer_description">This guest pass can only be redeemed once and is available for those without an active Plus or Patron subscription. Thanks for listening!</string>
     <string name="referrals_invalid_offer_title">This offer isn\'t available</string>
     <!-- Referrals send guest pass title, `%1$s' is a placeholder for the offer duration on the Plus subscription -->


### PR DESCRIPTION
## Description
This updates failed to load offer message and updates error screen to match with the Figma design (FVJPaWlRMlosEpsRhqxnSD-fi-2189_9583)


## Testing Instructions
1. Append a random string to `REFERRAL_OFFER_ID` in `ReferralOfferInfoProvider`
2. Open a referral link
3. ✅ Notice that an error screen is loaded with an updated error message 
4. ✅ Notice that the error screen design matches Figma design (FVJPaWlRMlosEpsRhqxnSD-fi-2189_9583)

## Screenshots or Screencast 
<img width=200 src="https://github.com/user-attachments/assets/7fa7cf02-6a4f-4829-9f2a-afb99f176b97"/>

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack