### PR TITLE
Referrals - Enable remote FF

### DIFF
--- a/modules/features/referrals/src/main/kotlin/au/com/shiftyjelly/pocketcasts/referrals/ReferralsClaimGuestPassViewModel.kt
+++ b/modules/features/referrals/src/main/kotlin/au/com/shiftyjelly/pocketcasts/referrals/ReferralsClaimGuestPassViewModel.kt
@@ -167,6 +167,7 @@ class ReferralsClaimGuestPassViewModel @Inject constructor(
                 (_state.value as? UiState.Loaded)
                     ?.let { loadedState -> _state.update { loadedState.copy(flowComplete = true) } }
                 _navigationEvent.emit(NavigationEvent.Close)
+                job?.cancel()
             }
 
             is ReferralResult.EmptyResult -> {

--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/Feature.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/Feature.kt
@@ -104,7 +104,7 @@ enum class Feature(
         title = "Referrals",
         defaultValue = BuildConfig.DEBUG,
         tier = FeatureTier.Free,
-        hasFirebaseRemoteFlag = false,
+        hasFirebaseRemoteFlag = true,
         hasDevToggle = true,
     ),
     EXO_OKHTTP(


### PR DESCRIPTION
## Description
This enables remote FF flag for `Referrals`. 

Firebase remote config for `referrals` is currently set to false. 

I'm targeting 7.75 for releasing the feature but not sure if the feature will be enabled for 7.75, so I haven't yet added a changelog for it. 

## Testing Instructions
Code review should be sufficient. 


## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
