### PR TITLE
Referrals - Show welcome screen after user signed up and referral flow is complete

### DIFF
--- a/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
+++ b/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
@@ -281,6 +281,9 @@ class MainActivity :
                 settings.setHasDoneInitialOnboarding()
                 OnboardingLauncher.openOnboardingFlow(this, OnboardingFlow.Upsell(OnboardingUpgradeSource.LOGIN_PLUS_PROMOTION))
             }
+            OnboardingFinish.DoneShowWelcomeInReferralFlow -> {
+                settings.showReferralWelcome.set(true, updateModifiedAt = false)
+            }
             null -> {
                 Timber.e("Unexpected null result from onboarding activity")
             }

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/OnboardingActivityContract.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/OnboardingActivityContract.kt
@@ -21,6 +21,7 @@ class OnboardingActivityContract : ActivityResultContract<Intent, OnboardingActi
         Done,
         DoneGoToDiscover,
         DoneShowPlusPromotion,
+        DoneShowWelcomeInReferralFlow,
     }
 
     companion object {

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/OnboardingFlowComposable.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/OnboardingFlowComposable.kt
@@ -80,6 +80,9 @@ private fun Content(
         is OnboardingFlow.PlusAccountUpgrade,
         is OnboardingFlow.PlusFlow,
         -> OnboardingNavRoute.PlusUpgrade.route
+
+        is OnboardingFlow.Welcome,
+        -> OnboardingNavRoute.welcome
     }
 
     val onAccountCreated = {
@@ -124,6 +127,7 @@ private fun Content(
                         // This should never happen. If the user isn't logged in they should be in the AccountUpgradeNeedsLogin flow
                         is OnboardingFlow.PlusAccountUpgrade,
                         is OnboardingFlow.PatronAccountUpgrade,
+                        is OnboardingFlow.Welcome,
                         -> throw IllegalStateException("Account upgrade flow tried to present LoginOrSignupPage")
 
                         OnboardingFlow.PlusAccountUpgradeNeedsLogin,
@@ -293,6 +297,7 @@ private fun onLoginToExistingAccount(
         -> exitOnboarding(OnboardingExitInfo(showPlusPromotionForFreeUser = true))
         OnboardingFlow.ReferralLoginOrSignUp,
         -> exitOnboarding(OnboardingExitInfo(showPlusPromotionForFreeUser = false))
+        OnboardingFlow.Welcome -> Unit // this should never happens, login is not initiated from welcome screen
         is OnboardingFlow.PlusAccountUpgrade,
         is OnboardingFlow.PatronAccountUpgrade,
         OnboardingFlow.PlusAccountUpgradeNeedsLogin,

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/OnboardingFlowComposable.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/OnboardingFlowComposable.kt
@@ -87,7 +87,7 @@ private fun Content(
 
     val onAccountCreated = {
         if (flow is OnboardingFlow.ReferralLoginOrSignUp) {
-            exitOnboarding(OnboardingExitInfo())
+            exitOnboarding(OnboardingExitInfo(showWelcomeInReferralFlow = true))
         } else {
             navController.navigate(OnboardingRecommendationsFlow.route) {
                 // clear backstack after account is created

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/OnboardingActivityViewModel.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/OnboardingActivityViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.viewModelScope
 import au.com.shiftyjelly.pocketcasts.account.onboarding.OnboardingActivityContract.OnboardingFinish
 import au.com.shiftyjelly.pocketcasts.models.to.SignInState
 import au.com.shiftyjelly.pocketcasts.models.to.SubscriptionStatus
+import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.repositories.user.UserManager
 import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingExitInfo
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -20,6 +21,7 @@ import kotlinx.coroutines.reactive.asFlow
 @HiltViewModel
 class OnboardingActivityViewModel @Inject constructor(
     private val userManager: UserManager,
+    private val settings: Settings,
 ) : ViewModel() {
 
     private var showPlusPromotionForFreeUserFlow = MutableStateFlow(false)
@@ -50,10 +52,13 @@ class OnboardingActivityViewModel @Inject constructor(
     }
 
     fun onExitOnboarding(exitInfo: OnboardingExitInfo) {
-        if (exitInfo.showPlusPromotionForFreeUser) {
-            showPlusPromotionForFreeUserFlow.value = true
-        } else {
-            viewModelScope.launch {
+        when {
+            exitInfo.showPlusPromotionForFreeUser -> showPlusPromotionForFreeUserFlow.value = true
+            exitInfo.showWelcomeInReferralFlow -> viewModelScope.launch {
+                settings.showReferralWelcome.set(true, updateModifiedAt = false)
+            }
+
+            else -> viewModelScope.launch {
                 _finishState.emit(OnboardingFinish.Done)
             }
         }

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/OnboardingActivityViewModel.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/OnboardingActivityViewModel.kt
@@ -5,7 +5,6 @@ import androidx.lifecycle.viewModelScope
 import au.com.shiftyjelly.pocketcasts.account.onboarding.OnboardingActivityContract.OnboardingFinish
 import au.com.shiftyjelly.pocketcasts.models.to.SignInState
 import au.com.shiftyjelly.pocketcasts.models.to.SubscriptionStatus
-import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.repositories.user.UserManager
 import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingExitInfo
 import dagger.hilt.android.lifecycle.HiltViewModel

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/OnboardingActivityViewModel.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/OnboardingActivityViewModel.kt
@@ -21,7 +21,6 @@ import kotlinx.coroutines.reactive.asFlow
 @HiltViewModel
 class OnboardingActivityViewModel @Inject constructor(
     private val userManager: UserManager,
-    private val settings: Settings,
 ) : ViewModel() {
 
     private var showPlusPromotionForFreeUserFlow = MutableStateFlow(false)
@@ -55,7 +54,7 @@ class OnboardingActivityViewModel @Inject constructor(
         when {
             exitInfo.showPlusPromotionForFreeUser -> showPlusPromotionForFreeUserFlow.value = true
             exitInfo.showWelcomeInReferralFlow -> viewModelScope.launch {
-                settings.showReferralWelcome.set(true, updateModifiedAt = false)
+                _finishState.emit(OnboardingFinish.DoneShowWelcomeInReferralFlow)
             }
 
             else -> viewModelScope.launch {

--- a/modules/features/account/src/test/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/OnboardingActivityViewModelTest.kt
+++ b/modules/features/account/src/test/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/OnboardingActivityViewModelTest.kt
@@ -7,6 +7,7 @@ import au.com.shiftyjelly.pocketcasts.models.to.SubscriptionStatus
 import au.com.shiftyjelly.pocketcasts.models.type.SubscriptionPlatform
 import au.com.shiftyjelly.pocketcasts.models.type.SubscriptionTier
 import au.com.shiftyjelly.pocketcasts.models.type.SubscriptionType
+import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.repositories.user.UserManager
 import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingExitInfo
 import au.com.shiftyjelly.pocketcasts.sharedtest.MainCoroutineRule
@@ -29,6 +30,9 @@ class OnboardingActivityViewModelTest {
 
     @Mock
     private lateinit var userManager: UserManager
+
+    @Mock
+    private lateinit var settings: Settings
 
     private lateinit var viewModel: OnboardingActivityViewModel
 
@@ -73,6 +77,16 @@ class OnboardingActivityViewModelTest {
         }
     }
 
+    @Test
+    fun `given showWelcomeInReferralFlow is true, when exit onboarding, then finish with DoneShowWelcomeInReferralFlow`() = runTest {
+        initViewModel(freeSubscriptionStatus)
+
+        viewModel.finishState.test {
+            viewModel.onExitOnboarding(OnboardingExitInfo(showWelcomeInReferralFlow = true))
+            assert(awaitItem() == OnboardingFinish.DoneShowWelcomeInReferralFlow)
+        }
+    }
+
     private fun initViewModel(subscriptionStatus: SubscriptionStatus) {
         whenever(userManager.getSignInState()).thenReturn(
             Flowable.just(
@@ -81,6 +95,7 @@ class OnboardingActivityViewModelTest {
         )
         viewModel = OnboardingActivityViewModel(
             userManager = userManager,
+            settings = settings,
         )
     }
 }

--- a/modules/features/account/src/test/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/OnboardingActivityViewModelTest.kt
+++ b/modules/features/account/src/test/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/OnboardingActivityViewModelTest.kt
@@ -7,7 +7,6 @@ import au.com.shiftyjelly.pocketcasts.models.to.SubscriptionStatus
 import au.com.shiftyjelly.pocketcasts.models.type.SubscriptionPlatform
 import au.com.shiftyjelly.pocketcasts.models.type.SubscriptionTier
 import au.com.shiftyjelly.pocketcasts.models.type.SubscriptionType
-import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.repositories.user.UserManager
 import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingExitInfo
 import au.com.shiftyjelly.pocketcasts.sharedtest.MainCoroutineRule
@@ -30,9 +29,6 @@ class OnboardingActivityViewModelTest {
 
     @Mock
     private lateinit var userManager: UserManager
-
-    @Mock
-    private lateinit var settings: Settings
 
     private lateinit var viewModel: OnboardingActivityViewModel
 
@@ -95,7 +91,6 @@ class OnboardingActivityViewModelTest {
         )
         viewModel = OnboardingActivityViewModel(
             userManager = userManager,
-            settings = settings,
         )
     }
 }

--- a/modules/features/referrals/src/main/kotlin/au/com/shiftyjelly/pocketcasts/referrals/ReferralsClaimGuestPassPage.kt
+++ b/modules/features/referrals/src/main/kotlin/au/com/shiftyjelly/pocketcasts/referrals/ReferralsClaimGuestPassPage.kt
@@ -122,6 +122,10 @@ fun ReferralsClaimGuestPassPage(
                     }
 
                     NavigationEvent.Close -> { onDismiss() }
+                    NavigationEvent.Welcome -> openOnboardingFlow(
+                        activity = activity,
+                        onboardingFlow = OnboardingFlow.Welcome,
+                    )
                 }
             }
         }

--- a/modules/features/referrals/src/main/kotlin/au/com/shiftyjelly/pocketcasts/referrals/ReferralsClaimGuestPassViewModel.kt
+++ b/modules/features/referrals/src/main/kotlin/au/com/shiftyjelly/pocketcasts/referrals/ReferralsClaimGuestPassViewModel.kt
@@ -108,6 +108,7 @@ class ReferralsClaimGuestPassViewModel @Inject constructor(
                             }
                         }
                     } else {
+                        settings.showReferralWelcome.set(false, updateModifiedAt = false)
                         _navigationEvent.emit(NavigationEvent.LoginOrSignup)
                     }
                 }
@@ -167,6 +168,11 @@ class ReferralsClaimGuestPassViewModel @Inject constructor(
                 (_state.value as? UiState.Loaded)
                     ?.let { loadedState -> _state.update { loadedState.copy(flowComplete = true) } }
                 _navigationEvent.emit(NavigationEvent.Close)
+                if (settings.showReferralWelcome.value) {
+                    settings.showReferralWelcome.set(false, updateModifiedAt = false)
+                    _navigationEvent.emit(NavigationEvent.Welcome)
+                }
+                job?.cancel()
             }
 
             is ReferralResult.EmptyResult -> {
@@ -216,6 +222,7 @@ class ReferralsClaimGuestPassViewModel @Inject constructor(
         data object InValidOffer : NavigationEvent()
         data class LaunchBillingFlow(val subscriptionWithOffer: Subscription.WithOffer) : NavigationEvent()
         data object Close : NavigationEvent()
+        data object Welcome : NavigationEvent()
     }
 
     sealed class SnackbarEvent {

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/onboarding/OnboardingExitInfo.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/onboarding/OnboardingExitInfo.kt
@@ -2,4 +2,5 @@ package au.com.shiftyjelly.pocketcasts.settings.onboarding
 
 data class OnboardingExitInfo(
     val showPlusPromotionForFreeUser: Boolean = false,
+    val showWelcomeInReferralFlow: Boolean = false,
 )

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/onboarding/OnboardingFlow.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/onboarding/OnboardingFlow.kt
@@ -27,4 +27,6 @@ sealed class OnboardingFlow(val analyticsValue: String) : Parcelable {
     sealed interface PlusFlow {
         val source: OnboardingUpgradeSource
     }
+
+    @Parcelize data object Welcome : OnboardingFlow("welcome")
 }

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
@@ -549,4 +549,5 @@ interface Settings {
     fun updatePlayerOrUpNextBottomSheetState(state: Int)
 
     val referralClaimCode: UserSetting<String>
+    val showReferralWelcome: UserSetting<Boolean>
 }

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
@@ -1490,6 +1490,12 @@ class SettingsImpl @Inject constructor(
         sharedPrefs = sharedPreferences,
     )
 
+    override val showReferralWelcome = UserSetting.BoolPref(
+        sharedPrefKey = "showReferralWelcome",
+        defaultValue = false,
+        sharedPrefs = sharedPreferences,
+    )
+
     private val _playerOrUpNextBottomSheetState = MutableSharedFlow<Int>(onBufferOverflow = BufferOverflow.DROP_OLDEST, replay = 1)
     override val playerOrUpNextBottomSheetState: Flow<Int>
         get() = _playerOrUpNextBottomSheetState.asSharedFlow().distinctUntilChanged()


### PR DESCRIPTION
## Description
This displays welcome screen after user signed up and referral flow is complete

## Testing Instructions

Prerequisites: 
- Release build
- Referrals FF enabled for release build
- License testing account
- Valid referral link

1. Install release build after enabling `Referrals` FF for release build
2. Open referral link
3. Notice that claim referral pass screen is shown
4. Tap `Activate my pass`
5. Sign up and complete purchase flow
6. Wait until the referral flow completes
7. ✅ Notice that the welcome screen is shown


## Screenshots or Screencast 

https://github.com/user-attachments/assets/c9ec7540-eda4-433e-b052-e8e5b3f89244


https://github.com/user-attachments/assets/c17270f7-95b7-454e-8b9c-5675e58e2a42


## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
