### PR TITLE
[Auto Downloading] Download episodes after subscribing to a podcast

### DIFF
--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/models/db/PodcastManagerTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/models/db/PodcastManagerTest.kt
@@ -8,8 +8,10 @@ import au.com.shiftyjelly.pocketcasts.models.di.ModelModule
 import au.com.shiftyjelly.pocketcasts.models.di.addTypeConverters
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.to.PodcastGrouping
+import au.com.shiftyjelly.pocketcasts.models.type.AutoDownloadLimitSetting
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.preferences.UserSetting
+import au.com.shiftyjelly.pocketcasts.repositories.download.DownloadManager
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.PlaylistManager
@@ -50,10 +52,12 @@ class PodcastManagerTest {
 
         val episodeManager = mock<EpisodeManager>()
         val playlistManager = mock<PlaylistManager>()
+        val downloadManager = mock<DownloadManager>()
 
         val settings = mock<Settings> {
             on { podcastGroupingDefault } doReturn UserSetting.Mock(PodcastGrouping.None, mock())
             on { showArchivedDefault } doReturn UserSetting.Mock(false, mock())
+            on { autoDownloadLimit } doReturn UserSetting.Mock(AutoDownloadLimitSetting.TWO_LATEST_EPISODE, mock())
         }
 
         val syncManagerSignedOut = mock<SyncManager> {
@@ -76,7 +80,7 @@ class PodcastManagerTest {
             .build()
 
         val refreshServiceManager = mock<RefreshServiceManager> {}
-        val subscribeManager = SubscribeManager(appDatabase, podcastCacheService, staticServiceManager, syncManagerSignedOut, application, settings)
+        val subscribeManager = SubscribeManager(appDatabase, podcastCacheService, staticServiceManager, syncManagerSignedOut, episodeManager, downloadManager, application, settings)
         podcastDao = appDatabase.podcastDao()
         podcastManagerSignedOut = PodcastManagerImpl(
             episodeManager = episodeManager,

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastSettingsFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastSettingsFragment.kt
@@ -519,13 +519,24 @@ class PodcastSettingsFragment : BasePreferenceFragment(), FilterSelectFragment.L
 
     private fun updateAutoDownloadLimit(podcast: Podcast) {
         val options = AutoDownloadLimitSetting.entries
-        val podcastAutoDownloadLimit = podcast.autoDownloadLimit ?: AutoDownloadLimitSetting.TWO_LATEST_EPISODE
+
+        // If there is no auto download limit set,
+        // we try to copy the global auto download limit value,
+        // otherwise we set the default value
+        val podcastAutoDownloadLimit = podcast.autoDownloadLimit
+            ?: if (podcast.isAutoDownloadNewEpisodes) {
+                settings.autoDownloadLimit.value
+            } else {
+                AutoDownloadLimitSetting.TWO_LATEST_EPISODE
+            }
 
         autoDownloadPodcastsLimit?.let { autoDownloadLimit ->
-            autoDownloadLimit.entries = options.map { getString(it.titleRes) }.toTypedArray()
-            autoDownloadLimit.entryValues = options.map { it.id.toString() }.toTypedArray()
-            autoDownloadLimit.value = podcastAutoDownloadLimit.id.toString()
-            autoDownloadLimit.summary = getString(podcastAutoDownloadLimit.titleRes)
+            with(autoDownloadLimit) {
+                entries = options.map { getString(it.titleRes) }.toTypedArray()
+                entryValues = options.map { it.id.toString() }.toTypedArray()
+                value = podcastAutoDownloadLimit.id.toString()
+                summary = getString(podcastAutoDownloadLimit.titleRes)
+            }
         }
     }
 

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/AutoDownloadSettingsFragment.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/AutoDownloadSettingsFragment.kt
@@ -178,7 +178,7 @@ class AutoDownloadSettingsFragment :
 
                     viewModel.onLimitDownloadsChange(autoDownloadLimitSetting)
 
-                    changeAutoDownloadLimitSummary()
+                    updateLimitDownloadsSummary()
                     true
                 }
             }
@@ -256,6 +256,10 @@ class AutoDownloadSettingsFragment :
         } else {
             podcastsCategory.removePreference(podcastsPreference)
             podcastsCategory.removePreference(podcastsLimitPreference)
+
+            // Reset Limit Downloads to default value after disabling auto download toggle
+            viewModel.setLimitDownloads(AutoDownloadLimitSetting.TWO_LATEST_EPISODE)
+            updateLimitDownloadsSummary()
         }
     }
 
@@ -420,10 +424,10 @@ class AutoDownloadSettingsFragment :
             entryValues = options.map { it.id.toString() }.toTypedArray()
             value = settings.autoDownloadLimit.value.id.toString()
         }
-        changeAutoDownloadLimitSummary()
+        updateLimitDownloadsSummary()
     }
 
-    private fun changeAutoDownloadLimitSummary() {
+    private fun updateLimitDownloadsSummary() {
         podcastsAutoDownloadLimitPreference?.summary = getString(settings.autoDownloadLimit.value.titleRes)
     }
 }

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/viewmodel/AutoDownloadSettingsViewModel.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/viewmodel/AutoDownloadSettingsViewModel.kt
@@ -51,12 +51,16 @@ class AutoDownloadSettingsViewModel @Inject constructor(
         )
     }
 
-    fun onLimitDownloadsChange(autoDownloadLimitSetting: AutoDownloadLimitSetting) {
-        settings.autoDownloadLimit.set(autoDownloadLimitSetting, updateModifiedAt = true)
+    fun setLimitDownloads(value: AutoDownloadLimitSetting) {
+        settings.autoDownloadLimit.set(value, updateModifiedAt = true)
+    }
+
+    fun onLimitDownloadsChange(value: AutoDownloadLimitSetting) {
+        setLimitDownloads(value)
 
         analyticsTracker.track(
             AnalyticsEvent.SETTINGS_AUTO_DOWNLOAD_LIMIT_DOWNLOADS_TOGGLED,
-            mapOf("value" to autoDownloadLimitSetting.analyticsString),
+            mapOf("value" to value.analyticsString),
         )
     }
 

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/type/AutoDownloadLimitSetting.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/type/AutoDownloadLimitSetting.kt
@@ -57,5 +57,15 @@ enum class AutoDownloadLimitSetting(
         }
 
         fun fromInt(id: Int) = (AutoDownloadLimitSetting.entries.firstOrNull { it.id == id })
+
+        fun getNumberOfEpisodes(setting: AutoDownloadLimitSetting): Int = when (setting) {
+            OFF -> 0
+            LATEST_EPISODE -> 1
+            TWO_LATEST_EPISODE -> 2
+            THREE_LATEST_EPISODE -> 3
+            FIVE_LATEST_EPISODE -> 5
+            TEN_LATEST_EPISODE -> 10
+            ALL_LATEST_EPISODES -> 1 // todo - confirm what does all latest episodes mean
+        }
     }
 }

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/type/AutoDownloadLimitSetting.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/type/AutoDownloadLimitSetting.kt
@@ -8,11 +8,6 @@ enum class AutoDownloadLimitSetting(
     @StringRes val titleRes: Int,
     val analyticsString: String,
 ) {
-    OFF(
-        id = 0,
-        titleRes = LR.string.settings_auto_download_limit_off,
-        analyticsString = "off",
-    ),
     LATEST_EPISODE(
         id = 1,
         titleRes = LR.string.settings_auto_download_limit_latest_episode,
@@ -59,7 +54,6 @@ enum class AutoDownloadLimitSetting(
         fun fromInt(id: Int) = (AutoDownloadLimitSetting.entries.firstOrNull { it.id == id })
 
         fun getNumberOfEpisodes(setting: AutoDownloadLimitSetting): Int = when (setting) {
-            OFF -> 0
             LATEST_EPISODE -> 1
             TWO_LATEST_EPISODE -> 2
             THREE_LATEST_EPISODE -> 3

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
@@ -387,7 +387,7 @@ class SettingsImpl @Inject constructor(
         toString = { it.preferenceInt.toString() },
     )
 
-    override val autoDownloadLimit: UserSetting<AutoDownloadLimitSetting> = UserSetting.PrefFromString(
+    override val autoDownloadLimit = UserSetting.PrefFromString(
         sharedPrefKey = "autoDownloadLimit",
         defaultValue = AutoDownloadLimitSetting.TWO_LATEST_EPISODE,
         sharedPrefs = sharedPreferences,

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/SubscribeManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/SubscribeManager.kt
@@ -107,7 +107,7 @@ class SubscribeManager @Inject constructor(
 
                 if (subscribed && FeatureFlag.isEnabled(Feature.AUTO_DOWNLOAD)) {
                     podcastDao.findByUuid(podcastUuid)?.let { podcast ->
-                        val episodes = episodeManager.findEpisodesByPodcastOrdered(podcast)
+                        val episodes = episodeManager.findEpisodesByPodcastOrderedByPublishDate(podcast)
                         val autoDownloadLimit = podcast.autoDownloadLimit ?: settings.autoDownloadLimit.value
 
                         episodes.take(AutoDownloadLimitSetting.getNumberOfEpisodes(autoDownloadLimit)).forEach { episode ->

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/SubscribeManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/SubscribeManager.kt
@@ -1,6 +1,7 @@
 package au.com.shiftyjelly.pocketcasts.repositories.podcast
 
 import android.content.Context
+import au.com.shiftyjelly.pocketcasts.analytics.SourceView
 import au.com.shiftyjelly.pocketcasts.models.db.AppDatabase
 import au.com.shiftyjelly.pocketcasts.models.entity.ChapterIndices
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
@@ -11,6 +12,8 @@ import au.com.shiftyjelly.pocketcasts.models.type.EpisodePlayingStatus
 import au.com.shiftyjelly.pocketcasts.models.type.EpisodeStatusEnum
 import au.com.shiftyjelly.pocketcasts.models.type.EpisodesSortType
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
+import au.com.shiftyjelly.pocketcasts.repositories.download.DownloadHelper
+import au.com.shiftyjelly.pocketcasts.repositories.download.DownloadManager
 import au.com.shiftyjelly.pocketcasts.repositories.images.PocketCastsImageRequestFactory
 import au.com.shiftyjelly.pocketcasts.repositories.sync.SyncManager
 import au.com.shiftyjelly.pocketcasts.servers.cdn.ArtworkColors
@@ -18,6 +21,8 @@ import au.com.shiftyjelly.pocketcasts.servers.cdn.StaticServiceManager
 import au.com.shiftyjelly.pocketcasts.servers.podcast.PodcastCacheServiceManager
 import au.com.shiftyjelly.pocketcasts.servers.sync.PodcastEpisodesResponse
 import au.com.shiftyjelly.pocketcasts.utils.Optional
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
 import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
 import coil.executeBlocking
 import coil.imageLoader
@@ -42,6 +47,8 @@ class SubscribeManager @Inject constructor(
     val podcastCacheServiceManager: PodcastCacheServiceManager,
     private val staticServiceManager: StaticServiceManager,
     private val syncManager: SyncManager,
+    private val episodeManager: EpisodeManager,
+    private val downloadManager: DownloadManager,
     @ApplicationContext val context: Context,
     val settings: Settings,
 ) {
@@ -97,6 +104,27 @@ class SubscribeManager @Inject constructor(
                 LogBuffer.i(LogBuffer.TAG_BACKGROUND_TASKS, "Added podcast $podcastUuid to database")
                 // update the notification time as any podcasts added after this date will be ignored
                 settings.setNotificationLastSeenToNow()
+
+                if (subscribed && FeatureFlag.isEnabled(Feature.AUTO_DOWNLOAD)) {
+                    podcastDao.findByUuid(podcastUuid)?.let { podcast ->
+                        val episodes = episodeManager.findEpisodesByPodcastOrdered(podcast)
+                        val autoDownloadLimit = podcast.autoDownloadLimit ?: settings.autoDownloadLimit.value
+
+                        episodes.take(AutoDownloadLimitSetting.getNumberOfEpisodes(autoDownloadLimit)).forEach { episode ->
+                            if (episode.isQueued || episode.isDownloaded || episode.isDownloading || episode.isExemptFromAutoDownload) {
+                                return@forEach
+                            }
+
+                            DownloadHelper.addAutoDownloadedEpisodeToQueue(
+                                episode,
+                                "Auto Download after subscribing to $podcastUuid",
+                                downloadManager,
+                                episodeManager,
+                                source = SourceView.DOWNLOADS,
+                            )
+                        }
+                    }
+                }
             }
     }
 
@@ -151,9 +179,9 @@ class SubscribeManager @Inject constructor(
                 podcast.isSubscribed = subscribed
                 podcast.grouping = settings.podcastGroupingDefault.value
                 podcast.showArchived = settings.showArchivedDefault.value
-                if (subscribed) {
+                if (subscribed && FeatureFlag.isEnabled(Feature.AUTO_DOWNLOAD)) {
                     podcast.autoDownloadStatus = AUTO_DOWNLOAD_NEW_EPISODES
-                    podcast.autoDownloadLimit = AutoDownloadLimitSetting.TWO_LATEST_EPISODE
+                    podcast.autoDownloadLimit = settings.autoDownloadLimit.value
                 }
             }
         // add the podcast

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/SubscribeManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/SubscribeManager.kt
@@ -4,7 +4,9 @@ import android.content.Context
 import au.com.shiftyjelly.pocketcasts.models.db.AppDatabase
 import au.com.shiftyjelly.pocketcasts.models.entity.ChapterIndices
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
+import au.com.shiftyjelly.pocketcasts.models.entity.Podcast.Companion.AUTO_DOWNLOAD_NEW_EPISODES
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
+import au.com.shiftyjelly.pocketcasts.models.type.AutoDownloadLimitSetting
 import au.com.shiftyjelly.pocketcasts.models.type.EpisodePlayingStatus
 import au.com.shiftyjelly.pocketcasts.models.type.EpisodeStatusEnum
 import au.com.shiftyjelly.pocketcasts.models.type.EpisodesSortType
@@ -149,6 +151,10 @@ class SubscribeManager @Inject constructor(
                 podcast.isSubscribed = subscribed
                 podcast.grouping = settings.podcastGroupingDefault.value
                 podcast.showArchived = settings.showArchivedDefault.value
+                if (subscribed) {
+                    podcast.autoDownloadStatus = AUTO_DOWNLOAD_NEW_EPISODES
+                    podcast.autoDownloadLimit = AutoDownloadLimitSetting.TWO_LATEST_EPISODE
+                }
             }
         // add the podcast
         val insertPodcastObservable = podcastObservable.flatMap { podcast ->


### PR DESCRIPTION
## Description
- This PR, introduces the auto download after subscribing to a podcast.
- I've deleted the OFF option for the auto download limit option since I don't think we will need. After getting back from the designs I will update in another PR in case it's necessary
- There are some pending questions questions that I did not get back any update, but since we are putting this behind a feature flag, I can safety merge this PR. p1728497690817009/1728311298.538509-slack-C07QMC2GB1B
- The global disabling will be handled in another PR
- Auto Clean feature is not implemented yet

Fixes #2972

## Testing Instructions
1. Have auto download feature flag enabled
2. Fresh install
3. Subscribe to some podcast
4. ✅ Ensure the latest 2 episodes sorted by publish date start downloading
5. Open this podcast setting
6. ✅ Ensure the Auto Download toggle is enabled with limit downloads sets to 2 latest episodes
7. Go to Profile -> Settings -> Auto Download
8. Change the global limit downloads to another number
9. Subscribe to anther podcast
10. ✅ Ensure the first X episodes started downloading

## Screenshots or Screencast 
[Screen_recording_20241010_172551.webm](https://github.com/user-attachments/assets/06f16794-9e3f-4313-9c50-dd934536650f)


## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack