### PR TITLE
Referrals - Hide tooltip on tooltip click

### DIFF
--- a/modules/features/referrals/src/main/kotlin/au/com/shiftyjelly/pocketcasts/referrals/ReferralsIconWithTooltip.kt
+++ b/modules/features/referrals/src/main/kotlin/au/com/shiftyjelly/pocketcasts/referrals/ReferralsIconWithTooltip.kt
@@ -1,5 +1,6 @@
 package au.com.shiftyjelly.pocketcasts.referrals
 
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.padding
@@ -54,6 +55,7 @@ fun ReferralsIconWithTooltip(
                     val fragment = ReferralsGuestPassFragment.newInstance(ReferralsPageType.Send)
                     (activity as FragmentHostListener).showBottomSheet(fragment)
                 },
+                onTooltipClick = viewModel::onTooltipClick,
             )
         }
     }
@@ -63,6 +65,7 @@ fun ReferralsIconWithTooltip(
 private fun ReferralsIconWithTooltip(
     state: UiState.Loaded,
     onIconClick: () -> Unit,
+    onTooltipClick: () -> Unit,
 ) {
     if (state.showIcon) {
         Icon(
@@ -76,6 +79,7 @@ private fun ReferralsIconWithTooltip(
             state.referralsOfferInfo?.let {
                 TooltipContent(
                     referralsOfferInfo = it,
+                    onClick = onTooltipClick,
                 )
             }
         }
@@ -85,11 +89,15 @@ private fun ReferralsIconWithTooltip(
 @Composable
 private fun TooltipContent(
     referralsOfferInfo: ReferralsOfferInfo,
+    onClick: () -> Unit,
 ) {
     Column(
         modifier = Modifier
             .padding(horizontal = 16.dp)
-            .padding(top = 24.dp, bottom = 16.dp),
+            .padding(top = 24.dp, bottom = 16.dp)
+            .clickable {
+                onClick()
+            },
     ) {
         TextH40(
             text = stringResource(LR.string.referrals_tooltip_message, referralsOfferInfo.localizedOfferDurationNoun.lowercase()),
@@ -134,6 +142,7 @@ fun TooltipContentPreview(
     AppThemeWithBackground(themeType) {
         TooltipContent(
             referralsOfferInfo = ReferralsOfferInfoMock,
+            onClick = {},
         )
     }
 }

--- a/modules/features/referrals/src/main/kotlin/au/com/shiftyjelly/pocketcasts/referrals/ReferralsViewModel.kt
+++ b/modules/features/referrals/src/main/kotlin/au/com/shiftyjelly/pocketcasts/referrals/ReferralsViewModel.kt
@@ -75,16 +75,20 @@ class ReferralsViewModel @Inject constructor(
     }
 
     fun onIconClick() {
+        hideTooltip()
+    }
+
+    fun onTooltipClick() {
+        hideTooltip()
+        analyticsTracker.track(AnalyticsEvent.REFERRAL_TOOLTIP_TAPPED)
+    }
+
+    private fun hideTooltip() {
         if (settings.showReferralsTooltip.value) {
             settings.showReferralsTooltip.set(false, updateModifiedAt = false)
-            analyticsTracker.track(AnalyticsEvent.REFERRAL_TOOLTIP_TAPPED)
         }
         (_state.value as? UiState.Loaded)?.let { loadedState ->
-            _state.update {
-                loadedState.copy(
-                    showTooltip = false,
-                )
-            }
+            _state.update { loadedState.copy(showTooltip = false) }
         }
     }
 

--- a/modules/features/referrals/src/test/kotlin/au/com/shiftyjelly/pocketcasts/referrals/ReferralsViewModelTest.kt
+++ b/modules/features/referrals/src/test/kotlin/au/com/shiftyjelly/pocketcasts/referrals/ReferralsViewModelTest.kt
@@ -65,7 +65,6 @@ class ReferralsViewModelTest {
     fun setUp() {
         FeatureFlag.setEnabled(Feature.REFERRALS, true)
         whenever(referralOfferInfo.subscriptionWithOffer).thenReturn(mock<Subscription.Trial>())
-        whenever(settings.showReferralsTooltip).thenReturn(UserSetting.Mock(true, mock()))
         whenever(settings.playerOrUpNextBottomSheetState).thenReturn(flowOf(BottomSheetBehavior.STATE_COLLAPSED))
     }
 
@@ -169,10 +168,20 @@ class ReferralsViewModelTest {
 
     @Test
     fun `tooltip is hidden on icon click`() = runTest {
-        whenever(referralOfferInfoProvider.referralOfferInfo()).thenReturn(null)
         initViewModel()
 
         viewModel.onIconClick()
+
+        viewModel.state.test {
+            assertEquals(false, (awaitItem() as UiState.Loaded).showTooltip)
+        }
+    }
+
+    @Test
+    fun `tooltip is hidden on tooltip click`() = runTest {
+        initViewModel()
+
+        viewModel.onTooltipClick()
 
         viewModel.state.test {
             assertEquals(false, (awaitItem() as UiState.Loaded).showTooltip)
@@ -243,7 +252,9 @@ class ReferralsViewModelTest {
         signInState: SignInState = SignInState.SignedIn(email, statusAndroidPaidSubscription),
         offerInfo: ReferralsOfferInfo = referralOfferInfo,
         referralCode: String = referralClaimCode,
+        showReferralsTooltipUserSetting: UserSetting<Boolean> = UserSetting.Mock(true, mock()),
     ) {
+        whenever(settings.showReferralsTooltip).thenReturn(showReferralsTooltipUserSetting)
         whenever(referralOfferInfoProvider.referralOfferInfo()).thenReturn(offerInfo)
         whenever(userManager.getSignInState()).thenReturn(Flowable.just(signInState))
         whenever(settings.referralClaimCode).thenReturn(UserSetting.Mock(referralCode, mock()))


### PR DESCRIPTION
## Description
This 
- hides tooltip on tooltip click
- moves tooltip tap tracking from gift icon click to tooltip click. Both actions dismiss the tooltip but the description for `referral_tooltip_tapped` says to track it only on tooltip tap.

`referral_tooltip_tapped – User taps the tooltip to dismiss it`

## Testing Instructions
1. Fresh install the app and login as a paid user
2. Go to Profile screen
3. Notice that you see referral tooltip 
4. Tap on the tooltip
5. ✅ Notice that tooltip is dismissed
6.  ✅ Notice that `referral_tooltip_tapped` is shown in logs
7. Clear app storage
8. Go to Profile screen
9. Notice that you see referral tooltip 
10. Tap on gift icon
11. ✅ Notice that tooltip is dismissed
12. ✅ Notice that `referral_tooltip_tapped` is not shown in logs
13. ✅ Notice that referral send pass screen is shown

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
