### PR TITLE
Add empty space to artwork settings to account for mini player

### DIFF
--- a/modules/features/player/src/main/res/layout/view_player_bottom_sheet.xml
+++ b/modules/features/player/src/main/res/layout/view_player_bottom_sheet.xml
@@ -7,7 +7,7 @@
     <au.com.shiftyjelly.pocketcasts.player.view.MiniPlayer
         android:id="@+id/miniPlayer"
         android:layout_width="match_parent"
-        android:layout_height="68dp" />
+        android:layout_height="@dimen/mini_player_height" />
 
     <FrameLayout
         android:id="@+id/player"

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/EpisodeArtworkConfigurationFragment.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/EpisodeArtworkConfigurationFragment.kt
@@ -6,6 +6,8 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.selection.toggleable
 import androidx.compose.foundation.verticalScroll
@@ -15,6 +17,7 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.ComposeView
+import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
 import au.com.shiftyjelly.pocketcasts.compose.AppThemeWithBackground
@@ -29,6 +32,7 @@ import au.com.shiftyjelly.pocketcasts.views.fragments.BaseFragment
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
+import au.com.shiftyjelly.pocketcasts.ui.R as UR
 
 @AndroidEntryPoint
 class EpisodeArtworkConfigurationFragment : BaseFragment() {
@@ -88,6 +92,9 @@ class EpisodeArtworkConfigurationFragment : BaseFragment() {
                     ArtworkElement(artworkConfiguration, element, onUpdateConfiguration)
                 }
             }
+            Spacer(
+                modifier = Modifier.height(dimensionResource(UR.dimen.mini_player_height)),
+            )
         }
     }
 

--- a/modules/services/ui/src/main/res/values/dimens.xml
+++ b/modules/services/ui/src/main/res/values/dimens.xml
@@ -4,4 +4,5 @@
     <dimen name="bottom_sheet_corner_radius">8dp</dimen>
     <dimen name="bottom_sheet_top_padding">10dp</dimen>
     <dimen name="divider_height">1dp</dimen>
+    <dimen name="mini_player_height">68dp</dimen>
 </resources>


### PR DESCRIPTION
## Description

When mini player was visible it could obstruct advanced artwork settings making them unusable. This PR adds an empty space to account for the player.

I'm not adding it to the changelog because the changes is so small and we don't have any reports about it.

## Testing Instructions

1. Install the app on a small device.
2. Play something.
3. Go to the advanced artwork settings.
4. Notice that you can scroll the screen and see all entries.

## Screenshots or Screencast 

| Before | After |
| - | - |
| ![before](https://github.com/user-attachments/assets/6ed86d79-98d0-4720-a82b-dab31f66a46d) | ![after](https://github.com/user-attachments/assets/a635d2dd-47c7-43ed-a3e7-cc7dba243f67) |

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] ~I have considered whether it makes sense to add tests for my changes~
- [x] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml``
- [x] ~Any jetpack compose components I added or changed are covered by compose previews~
- [x] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] ~for accessibility with TalkBack~
