### PR TITLE
[Auto Downloading] Exclude auto download after login

### DIFF
--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PodcastManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PodcastManagerImpl.kt
@@ -142,12 +142,12 @@ class PodcastManagerImpl @Inject constructor(
      */
     override fun findOrDownloadPodcastRx(podcastUuid: String): Single<Podcast> {
         return findPodcastByUuidRx(podcastUuid)
-            .switchIfEmpty(subscribeManager.addPodcast(podcastUuid, sync = false, subscribed = false).toMaybe())
+            .switchIfEmpty(subscribeManager.addPodcast(podcastUuid, sync = false, subscribed = false, shouldAutoDownload = false).toMaybe())
             .toSingle()
     }
 
     override fun addPodcast(podcastUuid: String, sync: Boolean, subscribed: Boolean): Single<Podcast> {
-        return subscribeManager.addPodcast(podcastUuid = podcastUuid, sync = sync, subscribed = subscribed)
+        return subscribeManager.addPodcast(podcastUuid = podcastUuid, sync = sync, subscribed = subscribed, shouldAutoDownload = false)
     }
 
     override fun isSubscribingToPodcast(podcastUuid: String): Boolean {


### PR DESCRIPTION
## Description
- This PR disables auto-download after the user logs in because, during login, we refresh the podcasts, which was triggering a batch download of the first episodes of the podcasts the user is subscribed to

> [!NOTE]  
>  There are some pending questions questions that I did not get back any update, but since we are putting this behind a feature flag, I can safety merge this PR. p1728497690817009/1728311298.538509-slack-C07QMC2GB1B

> [!NOTE]  
> The global disabling will be handled in another PR

> [!NOTE]  
>Auto Clean feature is not implemented yet

Fixes #3000

## Testing Instructions

### Existing account

1. Have an account with existing podcast subscribed
2. Fresh install the app
3. Log in
4. ✅ Ensure that does not trigger any auto download
5. Subscribe to a new podcast
6. ✅ Ensure you get the latest two episodes from this podcast downloaded 
7. Go to Profile -> Settings -> Auto Download
8. Change the global limit downloads to another number
9. Subscribe to anther podcast
10. ✅ Ensure the first X episodes started downloading 

### Regression test for Logged out flow

1. Fresh install the app
2. Subscribe to some podcast
3. ✅ Ensure the latest 2 episodes sorted by publish date start downloading
4. Open this podcast setting
5. ✅ Ensure the Auto Download toggle is enabled with limit downloads sets to 2 latest episodes
6. Go to Profile -> Settings -> Auto Download
7. Change the global limit downloads to another number
8. Subscribe to anther podcast
9. ✅ Ensure the first X episodes started downloading 

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
