### PR TITLE
Fix episodes stuck on the downloads page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
         ([#2979](https://github.com/Automattic/pocket-casts-android/pull/2979))
     *   Fix search podcast results scroll back to the start after subscribing
         ([#2923](https://github.com/Automattic/pocket-casts-android/pull/2923))
+    *   Fix episodes stuck on the downloads page
+        ([#3006](https://github.com/Automattic/pocket-casts-android/pull/3006))
     *   Display web-page based HTML transcripts in web view
         ([#2910](https://github.com/Automattic/pocket-casts-android/pull/2910))
 *   New Features


### PR DESCRIPTION
## Description

There is a user on the forums that says they have [Episodes are stuck in downloads](https://forums.pocketcasts.com/forums/topic/episodes-are-stuck-in-downloads/?view=all#post-6103). This fix is a bit of a guess, but it's possible to see how it would happen. If the episode was in the middle of a download, the app was killed, and the Work Manager download tasks were cleared, then the episodes could be left with a `download_task_id` value. The clean up method wouldn't be able to find the task, so it wouldn't be removed from the downloads page. 

## Testing Instructions
1. Open the Android Studio window App Inspection
2. Connect to the running app
3. Tap the "Open New Query Tab"
4. Run the following SQL to set the download_task_id to one that doesn't exist
```SQL
UPDATE podcast_episodes SET download_task_id = 'f26a743a-3463-42d3-80b6-9ebecdb6c242' WHERE uuid IN (SELECT uuid FROM podcast_episodes WHERE episode_status = 0 LIMIT 10);
```
5. In the app tap the Profile tab
6. Tap Downloads
7. ✅ Verify there are episodes listed that aren't downloaded
8. Archive a couple of the episodes
9. Quit and reopen the app
10. Go back to the Downloads page
11. ✅ Verify the episodes have been removed

## Screenshots

<img  width="300" src="https://github.com/user-attachments/assets/7b9c4d65-788f-48b0-b9b6-f46e56ac79fb" /> 

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack
