### PR TITLE
Display End of Year stories skeleton UI

### DIFF
--- a/modules/features/endofyear/build.gradle.kts
+++ b/modules/features/endofyear/build.gradle.kts
@@ -54,6 +54,7 @@ dependencies {
     testImplementation(libs.junit)
     testImplementation(libs.mockito.core)
     testImplementation(libs.mockito.kotlin)
+    testImplementation(libs.turbine)
 
     testImplementation(projects.modules.services.sharedtest)
 }

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/EndOfYearViewModel.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/EndOfYearViewModel.kt
@@ -1,0 +1,174 @@
+package au.com.shiftyjelly.pocketcasts.endofyear
+
+import androidx.compose.runtime.Immutable
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import au.com.shiftyjelly.pocketcasts.models.to.RatingStats
+import au.com.shiftyjelly.pocketcasts.models.to.TopPodcast
+import au.com.shiftyjelly.pocketcasts.models.type.SubscriptionTier
+import au.com.shiftyjelly.pocketcasts.repositories.endofyear.EndOfYearManager
+import au.com.shiftyjelly.pocketcasts.repositories.endofyear.EndOfYearStats
+import au.com.shiftyjelly.pocketcasts.repositories.endofyear.EndOfYearSync
+import au.com.shiftyjelly.pocketcasts.repositories.subscription.SubscriptionManager
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedFactory
+import dagger.assisted.AssistedInject
+import dagger.hilt.android.lifecycle.HiltViewModel
+import java.time.Year
+import kotlin.time.Duration
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+import au.com.shiftyjelly.pocketcasts.models.to.LongestEpisode as LongestEpisodeData
+
+@HiltViewModel(assistedFactory = EndOfYearViewModel.Factory::class)
+class EndOfYearViewModel @AssistedInject constructor(
+    @Assisted private val year: Year,
+    private val endOfYearSync: EndOfYearSync,
+    private val endOfYearManager: EndOfYearManager,
+    subscriptionManager: SubscriptionManager,
+) : ViewModel() {
+    private val syncState = MutableStateFlow<SyncState>(SyncState.Syncing)
+
+    internal val uiState = combine(
+        syncState,
+        subscriptionManager.subscriptionTier(),
+        ::createUiModel,
+    ).stateIn(viewModelScope, SharingStarted.Lazily, UiState.Syncing)
+
+    fun syncData() {
+        viewModelScope.launch {
+            syncState.emit(SyncState.Syncing)
+            val isSynced = endOfYearSync.sync(year)
+            syncState.emit(if (isSynced) SyncState.Synced else SyncState.Failure)
+        }
+    }
+
+    private suspend fun createUiModel(
+        syncState: SyncState,
+        subscriptionTier: SubscriptionTier,
+    ) = when (syncState) {
+        SyncState.Syncing -> UiState.Syncing
+        SyncState.Failure -> UiState.Failure
+        SyncState.Synced -> {
+            val stats = endOfYearManager.getStats(year)
+            val stories = createStories(stats, subscriptionTier)
+            UiState.Synced(stories)
+        }
+    }
+
+    private fun createStories(
+        stats: EndOfYearStats,
+        subscriptionTier: SubscriptionTier,
+    ): List<Story> = buildList {
+        add(Story.Cover)
+        add(
+            Story.NumberOfShows(
+                showCount = stats.playedPodcastCount,
+                epsiodeCount = stats.playedEpisodeCount,
+                showIds = stats.playedPodcastIds.shuffled().take(8),
+            ),
+        )
+        val topPodcast = stats.topPodcasts.firstOrNull()
+        if (topPodcast != null) {
+            add(Story.TopShow(topPodcast))
+            add(Story.TopShows(stats.topPodcasts))
+        }
+        add(Story.Ratings(stats.ratingStats))
+        add(Story.TotalTime(stats.playbackTime))
+        val longestEpisode = stats.longestEpisode
+        if (longestEpisode != null) {
+            add(Story.LongestEpisode(longestEpisode))
+        }
+        if (subscriptionTier == SubscriptionTier.NONE) {
+            add(Story.PlusInterstitial)
+        }
+        add(
+            Story.YearVsYear(
+                lastYearDuration = stats.lastYearPlaybackTime,
+                thisYearDuration = stats.playbackTime,
+                subscriptionTier = subscriptionTier,
+            ),
+        )
+        add(
+            Story.CompletionRate(
+                listenedCount = stats.playedEpisodeCount,
+                completedCount = stats.completedEpisodeCount,
+                subscriptionTier = subscriptionTier,
+            ),
+        )
+        add(Story.Ending)
+    }
+
+    @AssistedFactory
+    interface Factory {
+        fun create(year: Year): EndOfYearViewModel
+    }
+}
+
+internal sealed interface UiState {
+    data object Syncing : UiState
+
+    data object Failure : UiState
+
+    @Immutable
+    data class Synced(
+        val stories: List<Story>,
+    ) : UiState
+}
+
+internal sealed interface Story {
+    data object Cover : Story
+
+    @Immutable
+    data class NumberOfShows(
+        val showCount: Int,
+        val epsiodeCount: Int,
+        val showIds: List<String>,
+    ) : Story
+
+    data class TopShow(
+        val show: TopPodcast,
+    ) : Story
+
+    @Immutable
+    data class TopShows(
+        val shows: List<TopPodcast>,
+    ) : Story
+
+    data class Ratings(
+        val stats: RatingStats,
+    ) : Story
+
+    data class TotalTime(
+        val duration: Duration,
+    ) : Story
+
+    data class LongestEpisode(
+        val episode: LongestEpisodeData,
+    ) : Story
+
+    data object PlusInterstitial : Story
+
+    data class YearVsYear(
+        val lastYearDuration: Duration,
+        val thisYearDuration: Duration,
+        val subscriptionTier: SubscriptionTier?,
+    ) : Story
+
+    data class CompletionRate(
+        val listenedCount: Int,
+        val completedCount: Int,
+        val subscriptionTier: SubscriptionTier?,
+    ) : Story
+
+    data object Ending : Story
+}
+
+private sealed interface SyncState {
+    data object Syncing : SyncState
+    data object Failure : SyncState
+    data object Synced : SyncState
+}

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/EndOfYearViewModel.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/EndOfYearViewModel.kt
@@ -108,6 +108,7 @@ class EndOfYearViewModel @AssistedInject constructor(
     }
 }
 
+@Immutable
 internal sealed interface UiState {
     data object Syncing : UiState
 
@@ -119,6 +120,7 @@ internal sealed interface UiState {
     ) : UiState
 }
 
+@Immutable
 internal sealed interface Story {
     data object Cover : Story
 

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/StoriesFragment.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/StoriesFragment.kt
@@ -11,11 +11,14 @@ import android.view.ViewGroup
 import androidx.compose.ui.platform.ComposeView
 import androidx.core.os.BundleCompat
 import androidx.core.os.bundleOf
+import androidx.fragment.app.viewModels
 import au.com.shiftyjelly.pocketcasts.endofyear.ui.StoriesPage
+import au.com.shiftyjelly.pocketcasts.repositories.endofyear.EndOfYearManager
 import au.com.shiftyjelly.pocketcasts.ui.helper.StatusBarColor
 import au.com.shiftyjelly.pocketcasts.utils.Util
 import au.com.shiftyjelly.pocketcasts.views.fragments.BaseAppCompatDialogFragment
 import dagger.hilt.android.AndroidEntryPoint
+import dagger.hilt.android.lifecycle.withCreationCallback
 import android.R as AndroidR
 import au.com.shiftyjelly.pocketcasts.ui.R as UR
 
@@ -25,6 +28,14 @@ class StoriesFragment : BaseAppCompatDialogFragment() {
         get() = StatusBarColor.Custom(Color.BLACK, true)
     private val source: StoriesSource
         get() = requireNotNull(BundleCompat.getSerializable(requireArguments(), ARG_SOURCE, StoriesSource::class.java))
+
+    private val viewModel by viewModels<EndOfYearViewModel>(
+        extrasProducer = {
+            defaultViewModelCreationExtras.withCreationCallback<EndOfYearViewModel.Factory> { factory ->
+                factory.create(EndOfYearManager.YEAR_TO_SYNC)
+            }
+        },
+    )
 
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
         val dialog = super.onCreateDialog(savedInstanceState)

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/StoriesFragment.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/StoriesFragment.kt
@@ -8,6 +8,9 @@ import android.graphics.Color
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.ViewGroup
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.platform.ComposeView
 import androidx.core.os.BundleCompat
 import androidx.core.os.bundleOf
@@ -59,7 +62,11 @@ class StoriesFragment : BaseAppCompatDialogFragment() {
         savedInstanceState: Bundle?,
     ) = ComposeView(requireContext()).apply {
         setContent {
-            StoriesPage()
+            LaunchedEffect(Unit) {
+                viewModel.syncData()
+            }
+            val state by viewModel.uiState.collectAsState()
+            StoriesPage(state)
         }
     }
 

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/ui/StoriesPage.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/ui/StoriesPage.kt
@@ -1,12 +1,15 @@
 package au.com.shiftyjelly.pocketcasts.endofyear.ui
 
+import android.content.Context
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.BoxWithConstraintsScope
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.material.LinearProgressIndicator
@@ -16,68 +19,72 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
 import au.com.shiftyjelly.pocketcasts.compose.components.TextH10
 import au.com.shiftyjelly.pocketcasts.compose.components.TextP50
 import au.com.shiftyjelly.pocketcasts.endofyear.Story
 import au.com.shiftyjelly.pocketcasts.endofyear.UiState
+import au.com.shiftyjelly.pocketcasts.utils.Util
 import kotlinx.coroutines.launch
 
 @Composable
 internal fun StoriesPage(
     state: UiState,
 ) {
-    when (state) {
-        is UiState.Synced -> Stories(state.stories)
-        is UiState.Syncing -> LoadingIndicator()
-        is UiState.Failure -> ErrorMessage()
+    val size = getSizeLimit(LocalContext.current)?.let(Modifier::size) ?: Modifier.fillMaxSize()
+    BoxWithConstraints(
+        modifier = Modifier.then(size),
+    ) {
+        when (state) {
+            is UiState.Synced -> Stories(state.stories)
+            is UiState.Syncing -> LoadingIndicator()
+            is UiState.Failure -> ErrorMessage()
+        }
     }
 }
 
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
-private fun Stories(
+private fun BoxWithConstraintsScope.Stories(
     stories: List<Story>,
 ) {
-    BoxWithConstraints(
-        modifier = Modifier.fillMaxSize(),
-    ) {
-        val pagerState = rememberPagerState(pageCount = { stories.size })
-        val coroutineScope = rememberCoroutineScope()
-        val widthPx = LocalDensity.current.run { maxWidth.toPx() }
+    val pagerState = rememberPagerState(pageCount = { stories.size })
+    val coroutineScope = rememberCoroutineScope()
+    val widthPx = LocalDensity.current.run { maxWidth.toPx() }
 
-        HorizontalPager(
-            state = pagerState,
-            userScrollEnabled = false,
-            modifier = Modifier.pointerInput(Unit) {
-                detectTapGestures { offset ->
-                    if (!pagerState.isScrollInProgress) {
-                        coroutineScope.launch {
-                            val nextPage = if (offset.x > widthPx / 2) {
-                                pagerState.currentPage + 1
-                            } else {
-                                pagerState.currentPage - 1
-                            }
-                            pagerState.scrollToPage(nextPage)
+    HorizontalPager(
+        state = pagerState,
+        userScrollEnabled = false,
+        modifier = Modifier.pointerInput(Unit) {
+            detectTapGestures { offset ->
+                if (!pagerState.isScrollInProgress) {
+                    coroutineScope.launch {
+                        val nextPage = if (offset.x > widthPx / 2) {
+                            pagerState.currentPage + 1
+                        } else {
+                            pagerState.currentPage - 1
                         }
+                        pagerState.scrollToPage(nextPage)
                     }
                 }
-            },
-        ) { index ->
-            when (val story = stories[index]) {
-                is Story.Cover -> StoryPlaceholder(story)
-                is Story.NumberOfShows -> StoryPlaceholder(story)
-                is Story.TopShow -> StoryPlaceholder(story)
-                is Story.TopShows -> StoryPlaceholder(story)
-                is Story.Ratings -> StoryPlaceholder(story)
-                is Story.TotalTime -> StoryPlaceholder(story)
-                is Story.LongestEpisode -> StoryPlaceholder(story)
-                is Story.PlusInterstitial -> StoryPlaceholder(story)
-                is Story.YearVsYear -> StoryPlaceholder(story)
-                is Story.CompletionRate -> StoryPlaceholder(story)
-                is Story.Ending -> StoryPlaceholder(story)
             }
+        },
+    ) { index ->
+        when (val story = stories[index]) {
+            is Story.Cover -> StoryPlaceholder(story)
+            is Story.NumberOfShows -> StoryPlaceholder(story)
+            is Story.TopShow -> StoryPlaceholder(story)
+            is Story.TopShows -> StoryPlaceholder(story)
+            is Story.Ratings -> StoryPlaceholder(story)
+            is Story.TotalTime -> StoryPlaceholder(story)
+            is Story.LongestEpisode -> StoryPlaceholder(story)
+            is Story.PlusInterstitial -> StoryPlaceholder(story)
+            is Story.YearVsYear -> StoryPlaceholder(story)
+            is Story.CompletionRate -> StoryPlaceholder(story)
+            is Story.Ending -> StoryPlaceholder(story)
         }
     }
 }
@@ -106,6 +113,18 @@ private val Story.backgroundColor get() = when (this) {
     is Story.YearVsYear -> Color(0xFFEEB1F4)
     is Story.CompletionRate -> Color(0xFFE0EFAD)
     is Story.Ending -> Color(0xFFEE661C)
+}
+
+private fun getSizeLimit(context: Context): DpSize? {
+    return if (Util.isTablet(context)) {
+        val configuration = context.resources.configuration
+        val screenHeightInDp = configuration.screenHeightDp
+        val dialogHeight = (screenHeightInDp * 0.9f).coerceAtMost(700.dp.value)
+        val dialogWidth = dialogHeight / 2f
+        DpSize(dialogWidth.dp, dialogHeight.dp)
+    } else {
+        null
+    }
 }
 
 @Composable

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/ui/StoriesPage.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/ui/StoriesPage.kt
@@ -1,13 +1,135 @@
 package au.com.shiftyjelly.pocketcasts.endofyear.ui
 
+import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
+import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.pager.HorizontalPager
+import androidx.compose.foundation.pager.rememberPagerState
+import androidx.compose.material.LinearProgressIndicator
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.dp
+import au.com.shiftyjelly.pocketcasts.compose.components.TextH10
+import au.com.shiftyjelly.pocketcasts.compose.components.TextP50
+import au.com.shiftyjelly.pocketcasts.endofyear.Story
+import au.com.shiftyjelly.pocketcasts.endofyear.UiState
+import kotlinx.coroutines.launch
 
 @Composable
-fun StoriesPage() {
-    Box(modifier = Modifier.fillMaxSize().background(Color.White))
+internal fun StoriesPage(
+    state: UiState,
+) {
+    when (state) {
+        is UiState.Synced -> Stories(state.stories)
+        is UiState.Syncing -> LoadingIndicator()
+        is UiState.Failure -> ErrorMessage()
+    }
+}
+
+@OptIn(ExperimentalFoundationApi::class)
+@Composable
+private fun Stories(
+    stories: List<Story>,
+) {
+    BoxWithConstraints(
+        modifier = Modifier.fillMaxSize(),
+    ) {
+        val pagerState = rememberPagerState(pageCount = { stories.size })
+        val coroutineScope = rememberCoroutineScope()
+        val widthPx = LocalDensity.current.run { maxWidth.toPx() }
+
+        HorizontalPager(
+            state = pagerState,
+            userScrollEnabled = false,
+            modifier = Modifier.pointerInput(Unit) {
+                detectTapGestures { offset ->
+                    if (!pagerState.isScrollInProgress) {
+                        coroutineScope.launch {
+                            val nextPage = if (offset.x > widthPx / 2) {
+                                pagerState.currentPage + 1
+                            } else {
+                                pagerState.currentPage - 1
+                            }
+                            pagerState.scrollToPage(nextPage)
+                        }
+                    }
+                }
+            },
+        ) { index ->
+            when (val story = stories[index]) {
+                is Story.Cover -> StoryPlaceholder(story)
+                is Story.NumberOfShows -> StoryPlaceholder(story)
+                is Story.TopShow -> StoryPlaceholder(story)
+                is Story.TopShows -> StoryPlaceholder(story)
+                is Story.Ratings -> StoryPlaceholder(story)
+                is Story.TotalTime -> StoryPlaceholder(story)
+                is Story.LongestEpisode -> StoryPlaceholder(story)
+                is Story.PlusInterstitial -> StoryPlaceholder(story)
+                is Story.YearVsYear -> StoryPlaceholder(story)
+                is Story.CompletionRate -> StoryPlaceholder(story)
+                is Story.Ending -> StoryPlaceholder(story)
+            }
+        }
+    }
+}
+
+@Composable
+private fun StoryPlaceholder(story: Story) {
+    Box(
+        contentAlignment = Alignment.Center,
+        modifier = Modifier
+            .fillMaxSize()
+            .background(story.backgroundColor),
+    ) {
+        TextP50("$story", color = Color.Black)
+    }
+}
+
+private val Story.backgroundColor get() = when (this) {
+    is Story.Cover -> Color(0xFFEE661C)
+    is Story.NumberOfShows -> Color(0xFFEFECAD)
+    is Story.TopShow -> Color(0xFFEDB0F3)
+    is Story.TopShows -> Color(0xFFE0EFAD)
+    is Story.Ratings -> Color(0xFFEFECAD)
+    is Story.TotalTime -> Color(0xFFEDB0F3)
+    is Story.LongestEpisode -> Color(0xFFE0EFAD)
+    is Story.PlusInterstitial -> Color(0xFFEFECAD)
+    is Story.YearVsYear -> Color(0xFFEEB1F4)
+    is Story.CompletionRate -> Color(0xFFE0EFAD)
+    is Story.Ending -> Color(0xFFEE661C)
+}
+
+@Composable
+private fun LoadingIndicator() {
+    Box(
+        contentAlignment = Alignment.Center,
+        modifier = Modifier
+            .fillMaxSize()
+            .background(Story.Cover.backgroundColor)
+            .padding(16.dp),
+    ) {
+        LinearProgressIndicator(color = Color.Black)
+    }
+}
+
+@Composable
+private fun ErrorMessage() {
+    Box(
+        contentAlignment = Alignment.Center,
+        modifier = Modifier
+            .fillMaxSize()
+            .background(Story.Cover.backgroundColor)
+            .padding(16.dp),
+    ) {
+        TextH10(text = "Whoops!")
+    }
 }

--- a/modules/features/endofyear/src/test/kotlin/au/com/shiftyjelly/pocketcasts/endofyear/EndOfYearViewModelTest.kt
+++ b/modules/features/endofyear/src/test/kotlin/au/com/shiftyjelly/pocketcasts/endofyear/EndOfYearViewModelTest.kt
@@ -1,0 +1,432 @@
+package au.com.shiftyjelly.pocketcasts.endofyear
+
+import app.cash.turbine.Turbine
+import app.cash.turbine.TurbineTestContext
+import app.cash.turbine.test
+import au.com.shiftyjelly.pocketcasts.endofyear.Story.CompletionRate
+import au.com.shiftyjelly.pocketcasts.endofyear.Story.Cover
+import au.com.shiftyjelly.pocketcasts.endofyear.Story.Ending
+import au.com.shiftyjelly.pocketcasts.endofyear.Story.LongestEpisode
+import au.com.shiftyjelly.pocketcasts.endofyear.Story.NumberOfShows
+import au.com.shiftyjelly.pocketcasts.endofyear.Story.PlusInterstitial
+import au.com.shiftyjelly.pocketcasts.endofyear.Story.Ratings
+import au.com.shiftyjelly.pocketcasts.endofyear.Story.TopShow
+import au.com.shiftyjelly.pocketcasts.endofyear.Story.TopShows
+import au.com.shiftyjelly.pocketcasts.endofyear.Story.TotalTime
+import au.com.shiftyjelly.pocketcasts.endofyear.Story.YearVsYear
+import au.com.shiftyjelly.pocketcasts.models.to.RatingStats
+import au.com.shiftyjelly.pocketcasts.models.to.TopPodcast
+import au.com.shiftyjelly.pocketcasts.models.type.SubscriptionTier
+import au.com.shiftyjelly.pocketcasts.repositories.endofyear.EndOfYearManager
+import au.com.shiftyjelly.pocketcasts.repositories.endofyear.EndOfYearStats
+import au.com.shiftyjelly.pocketcasts.repositories.endofyear.EndOfYearSync
+import au.com.shiftyjelly.pocketcasts.sharedtest.MainCoroutineRule
+import java.time.Year
+import junit.framework.TestCase.assertEquals
+import junit.framework.TestCase.assertTrue
+import kotlin.time.Duration.Companion.minutes
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import au.com.shiftyjelly.pocketcasts.models.to.LongestEpisode as LongestEpisodeData
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class EndOfYearViewModelTest {
+    @get:Rule
+    val coroutineRule = MainCoroutineRule()
+
+    private lateinit var viewModel: EndOfYearViewModel
+
+    private val endOfYearSync = FakeEndOfYearSync()
+    private val endOfYearManager = FakeEofYearManager()
+    private val subscriptionTier = MutableStateFlow(SubscriptionTier.PLUS)
+
+    private val stats = EndOfYearStats(
+        playedEpisodeCount = 100,
+        completedEpisodeCount = 50,
+        playedPodcastIds = List(13) { "id-$it" },
+        playbackTime = 200.minutes,
+        lastYearPlaybackTime = 20.minutes,
+        topPodcasts = List(5) {
+            TopPodcast(
+                uuid = "top-id-$it",
+                title = "top-title-$it",
+                author = "author-$it",
+                playbackTimeSeconds = 100.0 * it,
+                playedEpisodeCount = it,
+            )
+        },
+        longestEpisode = LongestEpisodeData(
+            episodeId = "longest-id",
+            episodeTitle = "longest-title",
+            podcastId = "longest-podcas-id",
+            podcastTitle = "longest-podcast-title",
+            durationSeconds = 420.0,
+            coverUrl = "longest-cover-url",
+        ),
+        ratingStats = RatingStats(
+            ones = 0,
+            twos = 35,
+            threes = 66,
+            fours = 17,
+            fives = 89,
+        ),
+    )
+
+    @Before
+    fun setUp() {
+        viewModel = EndOfYearViewModel(
+            year = Year.of(1000),
+            endOfYearSync = endOfYearSync,
+            endOfYearManager = endOfYearManager,
+            subscriptionManager = mock { on { subscriptionTier() }.doReturn(subscriptionTier) },
+        )
+    }
+
+    @Test
+    fun `initialize in syncing state`() = runTest {
+        viewModel.uiState.test {
+            assertEquals(UiState.Syncing, awaitItem())
+        }
+    }
+
+    @Test
+    fun `failure when data not synced`() = runTest {
+        endOfYearSync.isSynced.add(false)
+
+        viewModel.syncData()
+        viewModel.uiState.test {
+            assertEquals(UiState.Failure, awaitItem())
+        }
+    }
+
+    @Test
+    fun `success when data is synced`() = runTest {
+        endOfYearSync.isSynced.add(true)
+        endOfYearManager.stats.add(stats)
+
+        viewModel.syncData()
+        viewModel.uiState.test {
+            assertTrue(awaitItem() is UiState.Synced)
+        }
+    }
+
+    @Test
+    fun `stories are in correct order`() = runTest {
+        endOfYearSync.isSynced.add(true)
+        endOfYearManager.stats.add(stats)
+        subscriptionTier.emit(SubscriptionTier.NONE)
+
+        viewModel.syncData()
+        viewModel.uiState.test {
+            val stories = awaitStories()
+
+            assertEquals(11, stories.size)
+            assertTrue(stories[0] is Cover)
+            assertTrue(stories[1] is NumberOfShows)
+            assertTrue(stories[2] is TopShow)
+            assertTrue(stories[3] is TopShows)
+            assertTrue(stories[4] is Ratings)
+            assertTrue(stories[5] is TotalTime)
+            assertTrue(stories[6] is LongestEpisode)
+            assertTrue(stories[7] is PlusInterstitial)
+            assertTrue(stories[8] is YearVsYear)
+            assertTrue(stories[9] is CompletionRate)
+            assertTrue(stories[10] is Ending)
+        }
+    }
+
+    @Test
+    fun `number of shows`() = runTest {
+        endOfYearSync.isSynced.add(true)
+        endOfYearManager.stats.add(stats)
+
+        viewModel.syncData()
+        viewModel.uiState.test {
+            val story = awaitStory<NumberOfShows>()
+
+            assertEquals(stats.playedPodcastCount, story.showCount)
+            assertEquals(stats.playedEpisodeCount, story.epsiodeCount)
+            // We select 8 random episodes to display in the UI
+            assertEquals(8, story.showIds.distinct().size)
+            assertTrue(stats.playedPodcastIds.containsAll(story.showIds))
+        }
+    }
+
+    @Test
+    fun `number of shows for no podcast ids`() = runTest {
+        endOfYearSync.isSynced.add(true)
+        endOfYearManager.stats.add(stats.copy(playedPodcastIds = emptyList()))
+
+        viewModel.syncData()
+        viewModel.uiState.test {
+            val story = awaitStory<NumberOfShows>()
+
+            assertEquals(0, story.showIds.size)
+        }
+    }
+
+    @Test
+    fun `top show`() = runTest {
+        endOfYearSync.isSynced.add(true)
+        endOfYearManager.stats.add(stats)
+
+        viewModel.syncData()
+        viewModel.uiState.test {
+            val story = awaitStory<TopShow>()
+
+            assertEquals(
+                TopShow(stats.topPodcasts.first()),
+                story,
+            )
+        }
+    }
+
+    @Test
+    fun `top show for no top podcasts`() = runTest {
+        endOfYearSync.isSynced.add(true)
+        endOfYearManager.stats.add(stats.copy(topPodcasts = emptyList()))
+
+        viewModel.syncData()
+        viewModel.uiState.test {
+            val stories = awaitStories()
+
+            assertDoesNotHaveStory<TopShow>(stories)
+        }
+    }
+
+    @Test
+    fun `top shows`() = runTest {
+        endOfYearSync.isSynced.add(true)
+        endOfYearManager.stats.add(stats)
+
+        viewModel.syncData()
+        viewModel.uiState.test {
+            val story = awaitStory<TopShows>()
+
+            assertEquals(
+                TopShows(stats.topPodcasts),
+                story,
+            )
+        }
+    }
+
+    @Test
+    fun `top shows for no top podcasts`() = runTest {
+        endOfYearSync.isSynced.add(true)
+        endOfYearManager.stats.add(stats.copy(topPodcasts = emptyList()))
+
+        viewModel.syncData()
+        viewModel.uiState.test {
+            val stories = awaitStories()
+
+            assertDoesNotHaveStory<TopShows>(stories)
+        }
+    }
+
+    @Test
+    fun `ratings`() = runTest {
+        endOfYearSync.isSynced.add(true)
+        endOfYearManager.stats.add(stats)
+
+        viewModel.syncData()
+        viewModel.uiState.test {
+            val story = awaitStory<Ratings>()
+
+            assertEquals(
+                Ratings(stats.ratingStats),
+                story,
+            )
+        }
+    }
+
+    @Test
+    fun `total time`() = runTest {
+        endOfYearSync.isSynced.add(true)
+        endOfYearManager.stats.add(stats)
+
+        viewModel.syncData()
+        viewModel.uiState.test {
+            val story = awaitStory<TotalTime>()
+
+            assertEquals(
+                TotalTime(stats.playbackTime),
+                story,
+            )
+        }
+    }
+
+    @Test
+    fun `longest episode`() = runTest {
+        endOfYearSync.isSynced.add(true)
+        endOfYearManager.stats.add(stats)
+
+        viewModel.syncData()
+        viewModel.uiState.test {
+            val story = awaitStory<LongestEpisode>()
+
+            assertEquals(
+                LongestEpisode(stats.longestEpisode!!),
+                story,
+            )
+        }
+    }
+
+    @Test
+    fun `longest episode for no episode`() = runTest {
+        endOfYearSync.isSynced.add(true)
+        endOfYearManager.stats.add(stats.copy(longestEpisode = null))
+
+        viewModel.syncData()
+        viewModel.uiState.test {
+            val stories = awaitStories()
+
+            assertDoesNotHaveStory<LongestEpisode>(stories)
+        }
+    }
+
+    @Test
+    fun `plus interstitial for regular user`() = runTest {
+        endOfYearSync.isSynced.add(true)
+        endOfYearManager.stats.add(stats)
+        subscriptionTier.emit(SubscriptionTier.NONE)
+
+        viewModel.syncData()
+        viewModel.uiState.test {
+            val stories = awaitStories()
+
+            assertHasStory<PlusInterstitial>(stories)
+        }
+    }
+
+    @Test
+    fun `plus interstitial for Plus user`() = runTest {
+        endOfYearSync.isSynced.add(true)
+        endOfYearManager.stats.add(stats)
+        subscriptionTier.emit(SubscriptionTier.PLUS)
+
+        viewModel.syncData()
+        viewModel.uiState.test {
+            val stories = awaitStories()
+
+            assertDoesNotHaveStory<PlusInterstitial>(stories)
+        }
+    }
+
+    @Test
+    fun `plus interstitial for Patron user`() = runTest {
+        endOfYearSync.isSynced.add(true)
+        endOfYearManager.stats.add(stats)
+        subscriptionTier.emit(SubscriptionTier.PATRON)
+
+        viewModel.syncData()
+        viewModel.uiState.test {
+            val stories = awaitStories()
+
+            assertDoesNotHaveStory<PlusInterstitial>(stories)
+        }
+    }
+
+    @Test
+    fun `year vs year`() = runTest {
+        endOfYearSync.isSynced.add(true)
+        endOfYearManager.stats.add(stats)
+
+        viewModel.syncData()
+        viewModel.uiState.test {
+            val story = awaitStory<YearVsYear>()
+
+            assertEquals(
+                YearVsYear(
+                    lastYearDuration = stats.lastYearPlaybackTime,
+                    thisYearDuration = stats.playbackTime,
+                    subscriptionTier = SubscriptionTier.PLUS,
+                ),
+                story,
+            )
+        }
+    }
+
+    @Test
+    fun `completion rate`() = runTest {
+        endOfYearSync.isSynced.add(true)
+        endOfYearManager.stats.add(stats)
+
+        viewModel.syncData()
+        viewModel.uiState.test {
+            val story = awaitStory<CompletionRate>()
+
+            assertEquals(
+                CompletionRate(
+                    listenedCount = stats.playedEpisodeCount,
+                    completedCount = stats.completedEpisodeCount,
+                    subscriptionTier = SubscriptionTier.PLUS,
+                ),
+                story,
+            )
+        }
+    }
+
+    @Test
+    fun `update stories with subscription tier`() = runTest {
+        endOfYearSync.isSynced.add(true)
+        endOfYearManager.stats.add(stats)
+        subscriptionTier.emit(SubscriptionTier.NONE)
+
+        viewModel.syncData()
+        viewModel.uiState.test {
+            assertHasStory<PlusInterstitial>(awaitStories())
+
+            subscriptionTier.emit(SubscriptionTier.PLUS)
+            endOfYearManager.stats.add(stats)
+            assertDoesNotHaveStory<PlusInterstitial>(awaitStories())
+
+            subscriptionTier.emit(SubscriptionTier.NONE)
+            endOfYearManager.stats.add(stats)
+            assertHasStory<PlusInterstitial>(awaitStories())
+        }
+    }
+
+    private suspend fun TurbineTestContext<UiState>.awaitStories(): List<Story> {
+        return (awaitItem() as UiState.Synced).stories
+    }
+
+    private suspend inline fun <reified T : Story> TurbineTestContext<UiState>.awaitStory(): T {
+        return awaitStories().filterIsInstance<T>().single()
+    }
+
+    private inline fun <reified T : Story> assertHasStory(stories: List<Story>) {
+        assertTrue(stories.filterIsInstance<PlusInterstitial>().isNotEmpty())
+    }
+
+    private inline fun <reified T : Story> assertDoesNotHaveStory(stories: List<Story>) {
+        assertTrue(stories.filterIsInstance<PlusInterstitial>().isEmpty())
+    }
+
+    private class FakeEofYearManager : EndOfYearManager {
+        val stats = Turbine<EndOfYearStats>()
+
+        override suspend fun getStats(year: Year): EndOfYearStats {
+            return stats.awaitItem()
+        }
+
+        override suspend fun isEligibleForEndOfYear(year: Year) = true
+
+        override suspend fun getPlayedEpisodeCount(year: Year) = -1
+    }
+
+    private class FakeEndOfYearSync : EndOfYearSync {
+        val isSynced = Turbine<Boolean>()
+
+        override suspend fun sync(year: Year): Boolean {
+            return isSynced.awaitItem()
+        }
+
+        override suspend fun reset() = Unit
+    }
+}

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/di/RepositoryModule.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/di/RepositoryModule.kt
@@ -14,6 +14,8 @@ import au.com.shiftyjelly.pocketcasts.repositories.download.DownloadManager
 import au.com.shiftyjelly.pocketcasts.repositories.download.DownloadManagerImpl
 import au.com.shiftyjelly.pocketcasts.repositories.endofyear.EndOfYearManager
 import au.com.shiftyjelly.pocketcasts.repositories.endofyear.EndOfYearManagerImpl
+import au.com.shiftyjelly.pocketcasts.repositories.endofyear.EndOfYearSync
+import au.com.shiftyjelly.pocketcasts.repositories.endofyear.EndOfYearSyncImpl
 import au.com.shiftyjelly.pocketcasts.repositories.notification.NotificationDrawer
 import au.com.shiftyjelly.pocketcasts.repositories.notification.NotificationDrawerImpl
 import au.com.shiftyjelly.pocketcasts.repositories.notification.NotificationHelper
@@ -182,4 +184,7 @@ abstract class RepositoryModule {
 
     @Binds
     abstract fun provideReferralManager(referralManagerImpl: ReferralManagerImpl): ReferralManager
+
+    @Binds
+    abstract fun provideEndOfYearSync(endOfYearSyncImpl: EndOfYearSyncImpl): EndOfYearSync
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/subscription/SubscriptionManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/subscription/SubscriptionManager.kt
@@ -5,6 +5,7 @@ import android.content.Context
 import au.com.shiftyjelly.pocketcasts.models.to.SubscriptionStatus
 import au.com.shiftyjelly.pocketcasts.models.type.Subscription
 import au.com.shiftyjelly.pocketcasts.models.type.SubscriptionFrequency
+import au.com.shiftyjelly.pocketcasts.models.type.SubscriptionTier
 import au.com.shiftyjelly.pocketcasts.utils.Optional
 import com.android.billingclient.api.BillingResult
 import com.android.billingclient.api.ProductDetails
@@ -21,6 +22,7 @@ interface SubscriptionManager {
     fun observeProductDetails(): Flowable<ProductDetailsState>
     fun observePurchaseEvents(): Flowable<PurchaseEvent>
     fun observeSubscriptionStatus(): Flowable<Optional<SubscriptionStatus>>
+    fun subscriptionTier(): Flow<SubscriptionTier>
     fun getSubscriptionStatus(allowCache: Boolean = true): Single<SubscriptionStatus>
     fun connectToGooglePlay(context: Context)
     fun loadProducts()

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/subscription/SubscriptionManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/subscription/SubscriptionManagerImpl.kt
@@ -50,6 +50,8 @@ import javax.inject.Inject
 import javax.inject.Singleton
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.transformLatest
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.reactive.asFlow
@@ -106,6 +108,12 @@ class SubscriptionManagerImpl @Inject constructor(
 
     override fun observeSubscriptionStatus(): Flowable<Optional<SubscriptionStatus>> {
         return subscriptionStatus.toFlowable(BackpressureStrategy.LATEST)
+    }
+
+    override fun subscriptionTier(): Flow<SubscriptionTier> {
+        return observeSubscriptionStatus().asFlow().map { status ->
+            (status.get() as? SubscriptionStatus.Paid)?.tier ?: SubscriptionTier.NONE
+        }
     }
 
     override fun getSubscriptionStatus(allowCache: Boolean): Single<SubscriptionStatus> {


### PR DESCRIPTION
## Description

This PR maps EoY stats to stories and pushes them to a basic UI.

Figma with all stories listed: lH66LwxxgG8btQ8NrM0ldx-fi-3070_28391

## Testing Instructions

1. Sign in with a paid account that listened to at least 5 minutes of episodes this year.
2. Sync your profile data.
3. Close the app.
4. Reopen the app.
5. Open Playback 2024 either by using the bottom sheet or the banner in the profile.
6. You might see a loading progress bar and it might take some time to sync your data.
7. Once data is synced tapping on the right edge side of a story should move you forward and tapping on a left edge of a story should move you backwards.
8. Verify that you can see all stories except for the `PlusInterstitial`.
9. Sign out.
10. Sign in with a non-paid account.
11. Verify that you can see the `PlusInterstitial` story.

## Checklist
- [x] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [x] ~Any jetpack compose components I added or changed are covered by compose previews~
- [x] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~