### PR TITLE
[Auto Downloading] Exclude Auto Downloads After Importing Podcasts

### DIFF
--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/opml/OpmlImportTask.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/opml/OpmlImportTask.kt
@@ -334,7 +334,7 @@ class OpmlImportTask @AssistedInject constructor(
 private fun Flow<ImportOpmlResponse>.subscribeToPodcasts(podcastManager: PodcastManager): Flow<ImportOpmlResponse> {
     return onEach {
         // add podcast uuid to subscribe queue
-        it.uuids.forEach { uuid -> podcastManager.subscribeToPodcast(uuid, true) }
+        it.uuids.forEach { uuid -> podcastManager.subscribeToPodcast(uuid, sync = true, shouldAutoDownload = false) }
     }
 }
 

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/HistoryManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/HistoryManager.kt
@@ -52,7 +52,7 @@ class HistoryManager @Inject constructor(
             .observeOn(Schedulers.io())
             .flatMap(
                 { podcastUuid ->
-                    podcastManager.addPodcast(podcastUuid = podcastUuid, sync = false, subscribed = false)
+                    podcastManager.addPodcast(podcastUuid = podcastUuid, sync = false, subscribed = false, shouldAutoDownload = false)
                         .doOnError { throwable -> LogBuffer.e(LogBuffer.TAG_BACKGROUND_TASKS, throwable, "History manager could not add podcast") }
                         .onErrorReturn { Podcast(uuid = podcastUuid) }
                         .toObservable()

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PodcastManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PodcastManager.kt
@@ -59,15 +59,15 @@ interface PodcastManager {
     fun observeEpisodeCountByPodcatUuid(uuid: String): Flow<Int>
 
     /** Add methods  */
-    fun subscribeToPodcast(podcastUuid: String, sync: Boolean)
+    fun subscribeToPodcast(podcastUuid: String, sync: Boolean, shouldAutoDownload: Boolean = true)
 
     suspend fun subscribeToPodcastSuspend(podcastUuid: String, sync: Boolean = false): Podcast
-    fun subscribeToPodcastRx(podcastUuid: String, sync: Boolean = false): Single<Podcast>
+    fun subscribeToPodcastRx(podcastUuid: String, sync: Boolean = false, shouldAutoDownload: Boolean = true): Single<Podcast>
     fun findOrDownloadPodcastRx(podcastUuid: String): Single<Podcast>
     fun isSubscribingToPodcasts(): Boolean
     fun getSubscribedPodcastUuids(): Single<List<String>>
     fun isSubscribingToPodcast(podcastUuid: String): Boolean
-    fun addPodcast(podcastUuid: String, sync: Boolean, subscribed: Boolean): Single<Podcast>
+    fun addPodcast(podcastUuid: String, sync: Boolean, subscribed: Boolean, shouldAutoDownload: Boolean): Single<Podcast>
 
     fun addFolderPodcast(podcast: Podcast)
 

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PodcastManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PodcastManagerImpl.kt
@@ -121,8 +121,8 @@ class PodcastManagerImpl @Inject constructor(
     /**
      * Download and add podcast to the database. Or if it exists already just mark is as subscribed.
      */
-    override fun subscribeToPodcast(podcastUuid: String, sync: Boolean) {
-        subscribeManager.subscribeOnQueue(podcastUuid, sync)
+    override fun subscribeToPodcast(podcastUuid: String, sync: Boolean, shouldAutoDownload: Boolean) {
+        subscribeManager.subscribeOnQueue(podcastUuid, sync, shouldAutoDownload)
     }
 
     override suspend fun subscribeToPodcastSuspend(podcastUuid: String, sync: Boolean): Podcast =
@@ -132,8 +132,8 @@ class PodcastManagerImpl @Inject constructor(
      * Download and add podcast to the database. Or if it exists already just mark is as subscribed.
      * Do this now rather than adding it to a queue.
      */
-    override fun subscribeToPodcastRx(podcastUuid: String, sync: Boolean): Single<Podcast> {
-        return addPodcast(podcastUuid = podcastUuid, sync = sync, subscribed = true)
+    override fun subscribeToPodcastRx(podcastUuid: String, sync: Boolean, shouldAutoDownload: Boolean): Single<Podcast> {
+        return addPodcast(podcastUuid = podcastUuid, sync = sync, subscribed = true, shouldAutoDownload = shouldAutoDownload)
     }
 
     /**
@@ -145,8 +145,8 @@ class PodcastManagerImpl @Inject constructor(
             .toSingle()
     }
 
-    override fun addPodcast(podcastUuid: String, sync: Boolean, subscribed: Boolean): Single<Podcast> {
-        return subscribeManager.addPodcast(podcastUuid = podcastUuid, sync = sync, subscribed = subscribed, shouldAutoDownload = false)
+    override fun addPodcast(podcastUuid: String, sync: Boolean, subscribed: Boolean, shouldAutoDownload: Boolean): Single<Podcast> {
+        return subscribeManager.addPodcast(podcastUuid = podcastUuid, sync = sync, subscribed = subscribed, shouldAutoDownload = shouldAutoDownload)
     }
 
     override fun isSubscribingToPodcast(podcastUuid: String): Boolean {

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/SubscribeManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/SubscribeManager.kt
@@ -62,7 +62,7 @@ class SubscribeManager @Inject constructor(
     private val episodeDao = appDatabase.episodeDao()
     private val imageRequestFactory = PocketCastsImageRequestFactory(context, isDarkTheme = true)
 
-    data class PodcastSubscribe(val podcastUuid: String, val sync: Boolean)
+    data class PodcastSubscribe(val podcastUuid: String, val sync: Boolean, val shouldAutoDownload: Boolean)
 
     @SuppressLint("CheckResult")
     private fun setupSubscribeRelay(): PublishRelay<PodcastSubscribe> {
@@ -73,7 +73,7 @@ class SubscribeManager @Inject constructor(
             .flatMap({ info ->
                 // shouldAutoDownload = true because the user manually subscribed to the podcast,
                 // so we want to automatically download episodes at this moment.
-                addPodcast(info.podcastUuid, sync = info.sync, subscribed = true, shouldAutoDownload = true).toObservable()
+                addPodcast(info.podcastUuid, sync = info.sync, subscribed = true, shouldAutoDownload = info.shouldAutoDownload).toObservable()
             }, true, 5)
             .doOnError { throwable -> LogBuffer.e(LogBuffer.TAG_BACKGROUND_TASKS, throwable, "Could not subscribe to podcast") }
             .subscribeBy(
@@ -89,12 +89,12 @@ class SubscribeManager @Inject constructor(
     /**
      * Subscribe to a podcast on a background queue.
      */
-    fun subscribeOnQueue(podcastUuid: String, sync: Boolean = false) {
+    fun subscribeOnQueue(podcastUuid: String, sync: Boolean = false, shouldAutoDownload: Boolean) {
         if (uuidsInQueue.contains(podcastUuid)) {
             return
         }
         uuidsInQueue.add(podcastUuid)
-        subscribeRelay.accept(PodcastSubscribe(podcastUuid, sync))
+        subscribeRelay.accept(PodcastSubscribe(podcastUuid, sync, shouldAutoDownload))
     }
 
     /**

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/PodcastSyncProcess.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/PodcastSyncProcess.kt
@@ -262,7 +262,7 @@ class PodcastSyncProcess(
 
     private fun importPodcast(podcastResponse: UserPodcastResponse?): Maybe<Podcast> {
         val podcastUuid = podcastResponse?.uuid ?: return Maybe.empty()
-        return podcastManager.subscribeToPodcastRx(podcastUuid = podcastUuid, sync = false)
+        return podcastManager.subscribeToPodcastRx(podcastUuid = podcastUuid, sync = false, shouldAutoDownload = false)
             .flatMap { podcast -> updatePodcastSyncValues(podcast, podcastResponse).toSingleDefault(podcast) }
             .toMaybe()
             .doOnError { LogBuffer.e(LogBuffer.TAG_BACKGROUND_TASKS, it, "Could not import server podcast %s", podcastUuid) }
@@ -788,7 +788,7 @@ class PodcastSyncProcess(
         val isSubscribed = podcastSync.subscribed
         val podcastUuid = podcastSync.uuid
         if (podcastSync.subscribed && isSubscribed && podcastUuid != null) {
-            return podcastManager.subscribeToPodcastRx(podcastUuid, sync = false)
+            return podcastManager.subscribeToPodcastRx(podcastUuid, sync = false, shouldAutoDownload = false)
                 .doOnSuccess { podcast ->
                     applyPodcastSyncUpdatesToPodcast(podcast, podcastSync)
                     podcastManager.updatePodcast(podcast)


### PR DESCRIPTION
## Description
- This PR excludes auto download from OPML files import

> [!NOTE]  
> The global disabling will be handled in another PR

> [!NOTE]  
>Auto Clean feature is not implemented yet

Fixes #2998

## Testing Instructions
- For the tests, I recommend to try different combinations of Log in, Import OPML files and regular podcast subscribing
- The episodes should only be downloaded when the user manually subscribes to a podcast

Here are some scenarios you can try:

### Test 1
1. Fresh install 
2. Log in with an account that already has podcasts subscribed
3. ✅ Ensure that does not download episodes from the podcasts when syncing account after logging
4. Subscribe to a podcast
5. ✅ Ensure that downloads the latest 2 episodes of this podcast
6. Import OPML file
7.  ✅ Ensure that does not download episodes from the podcasts imported 

### Test 2
1. Fresh install 
2. Import OPML file
3. ✅ Ensure that does not download episodes from the podcasts imported 
4. Subscribe to a podcast
5. ✅ Ensure that downloads the latest 2 episodes of this podcast
6. Log in with an account that already has podcasts subscribed
7. ✅ Ensure that does not download episodes from the podcasts when syncing account after logging


### Test 3
1. Fresh install
2. Subscribe to a podcast
3. ✅ Ensure that downloads the latest 2 episodes of this podcast
4. Log in with an account that already has podcasts subscribed
5. ✅ Ensure that does not download episodes from the podcasts when syncing account after logging
6. Import OPML file
7. ✅ Ensure that does not download episodes from the podcasts imported


## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
