### PR TITLE
Add close button to EoY stories

### DIFF
--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/StoriesFragment.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/StoriesFragment.kt
@@ -66,7 +66,10 @@ class StoriesFragment : BaseAppCompatDialogFragment() {
                 viewModel.syncData()
             }
             val state by viewModel.uiState.collectAsState()
-            StoriesPage(state)
+            StoriesPage(
+                state = state,
+                onClose = ::dismiss,
+            )
         }
     }
 


### PR DESCRIPTION
## Description

Add close button to EoY stories.

## Testing Instructions

1. Open Playback 2024.
2. Notice that there is close button in the top right corner.
3. Tapping on it should close the stories.

## Screenshots or Screencast 

![Screenshot_20241015-123229](https://github.com/user-attachments/assets/6b72402b-34dd-4b1a-a495-277de8653471)

## Checklist
- [x] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] ~I have considered whether it makes sense to add tests for my changes~
- [x] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [x] ~Any jetpack compose components I added or changed are covered by compose previews~
- [x] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~