### PR TITLE
Revert paywall title

### DIFF
--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -1811,7 +1811,7 @@
     <string name="onboarding_recommendations_make_pocket_casts_yours">Make Pocket Casts yours by selecting your favorite podcasts or import them from another podcast player. You can always do this later.</string>
     <string name="onboarding_recommendations_import">Import</string>
     <string name="onboarding_recommendations_more">More %s</string>
-    <string name="onboarding_upgrade_everything_you_love_about_pocket_casts_plus">Unlock exclusive features with Pocket&#160;Casts&#160;Plus</string>
+    <string name="onboarding_upgrade_everything_you_love_about_pocket_casts_plus">Everything you love about Pocket&#160;Casts, plus more</string>
     <string name="onboarding_upgrade_no_subscriptions_found">No subscriptions found.</string>
     <string name="onboarding_patron_features_title">Believe in what we\’re doing and want to show your support?</string>
     <string name="onboarding_patron_feature_everything_in_plus_title">Everything in Plus</string>


### PR DESCRIPTION
## Description
This PR reverts the Paywall title to `Everything you love about Pocket Casts, plus more`

This matches the iOS change https://github.com/Automattic/pocket-casts-ios/pull/2273

## Testing Instructions
1. Use an account without Pocket Casts Plus
2. Go to Profile -> Settings -> Pocket Casts Plus
3. ✅ Verify the text is updated
4. Change [the following line](https://github.com/Automattic/pocket-casts-android/blob/main/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/OnboardingUpgradeFeaturesViewModel.kt#L112) to `UpgradeLayout.Features`
5. Go to Profile -> Settings -> Pocket Casts Plus
6. ✅ Verify the text is updated

## Screenshots 

| Default | Feature Variant |
| -------- | ------- |
| ![Screenshot_20241015_215354](https://github.com/user-attachments/assets/04352be5-821e-44b0-8121-0c14848db446) | ![Screenshot_20241015_215957](https://github.com/user-attachments/assets/a4091fa2-9468-4651-b271-34db53ce6e6a) |

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack
