### PR TITLE
Display Number Of Shows story

### DIFF
--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/ui/StoriesPage.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/ui/StoriesPage.kt
@@ -338,7 +338,7 @@ private fun NumberOfShowsStory(
                 modifier = Modifier.padding(horizontal = 24.dp),
             )
             RowOutlinedButton(
-                "Share this story",
+                text = stringResource(LR.string.end_of_year_share_story),
                 colors = ButtonDefaults.outlinedButtonColors(
                     backgroundColor = Color.Transparent,
                     contentColor = Color.Black,

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/ui/StoriesPage.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/ui/StoriesPage.kt
@@ -8,17 +8,24 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.gestures.scrollBy
 import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.requiredWidth
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.sizeIn
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.ButtonDefaults
 import androidx.compose.material.LinearProgressIndicator
 import androidx.compose.material.ripple.rememberRipple
 import androidx.compose.runtime.Composable
@@ -30,8 +37,11 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.rotate
+import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
@@ -46,12 +56,19 @@ import androidx.compose.ui.unit.coerceAtLeast
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import au.com.shiftyjelly.pocketcasts.compose.Devices
+import au.com.shiftyjelly.pocketcasts.compose.buttons.RowOutlinedButton
+import au.com.shiftyjelly.pocketcasts.compose.components.PodcastImage
+import au.com.shiftyjelly.pocketcasts.compose.components.ScrollDirection
+import au.com.shiftyjelly.pocketcasts.compose.components.ScrollingRow
 import au.com.shiftyjelly.pocketcasts.compose.components.TextH10
+import au.com.shiftyjelly.pocketcasts.compose.components.TextP40
 import au.com.shiftyjelly.pocketcasts.compose.components.TextP50
+import au.com.shiftyjelly.pocketcasts.compose.extensions.nonScaledSp
 import au.com.shiftyjelly.pocketcasts.endofyear.Story
 import au.com.shiftyjelly.pocketcasts.endofyear.UiState
 import au.com.shiftyjelly.pocketcasts.utils.Util
 import kotlin.math.roundToLong
+import kotlin.math.tan
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
@@ -84,7 +101,7 @@ internal fun StoriesPage(
                 sizes = EndOfYearSizes(
                     width = this@BoxWithConstraints.maxWidth,
                     height = this@BoxWithConstraints.maxHeight,
-                    closeButtonBottomEdge = 36.dp,
+                    closeButtonBottomEdge = 44.dp,
                     coverFontSize = coverFontSize,
                     coverTextHeight = coverTextHeight,
                 ),
@@ -97,7 +114,7 @@ internal fun StoriesPage(
             colorFilter = ColorFilter.tint(Color.Black),
             modifier = Modifier
                 .align(Alignment.TopEnd)
-                .padding(top = 12.dp, end = 18.dp)
+                .padding(top = 20.dp, end = 18.dp)
                 .size(24.dp)
                 .clickable(
                     interactionSource = remember(::MutableInteractionSource),
@@ -164,7 +181,7 @@ private fun Stories(
     ) { index ->
         when (val story = stories[index]) {
             is Story.Cover -> CoverStory(story, sizes)
-            is Story.NumberOfShows -> StoryPlaceholder(story)
+            is Story.NumberOfShows -> NumberOfShowsStory(story, sizes)
             is Story.TopShow -> StoryPlaceholder(story)
             is Story.TopShows -> StoryPlaceholder(story)
             is Story.Ratings -> StoryPlaceholder(story)
@@ -241,6 +258,122 @@ private fun CoverStory(
     }
 }
 
+private val rotationDegrees = -15f
+private val rotationAngle = (rotationDegrees * Math.PI / 180).toFloat()
+
+@Composable
+private fun NumberOfShowsStory(
+    story: Story.NumberOfShows,
+    sizes: EndOfYearSizes,
+) {
+    val coverSize = sizes.width * 0.4f
+    val spacingSize = coverSize / 10
+    val carouselHeight = coverSize * 2 + spacingSize
+    val carouselRotationOffset = (sizes.width / 2) * tan(rotationAngle)
+
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(story.backgroundColor),
+    ) {
+        Column(
+            modifier = Modifier
+                .align(Alignment.TopCenter)
+                .rotate(rotationDegrees)
+                .offset(y = sizes.closeButtonBottomEdge + 8.dp - carouselRotationOffset)
+                .requiredWidth(sizes.width * 1.5f), // Increase the size to account for rotation
+        ) {
+            PodcastCoverCarousel(
+                podcastIds = story.topShowIds,
+                scrollDirection = ScrollDirection.Right,
+                coverSize = coverSize,
+                spacingSize = spacingSize,
+            )
+            Spacer(
+                modifier = Modifier.height(spacingSize),
+            )
+            PodcastCoverCarousel(
+                podcastIds = story.bottomShowIds,
+                scrollDirection = ScrollDirection.Left,
+                coverSize = coverSize,
+                spacingSize = spacingSize,
+            )
+        }
+
+        // Fake sticker: lH66LwxxgG8btQ8NrM0ldx-fi-3070_28391#986464596
+        val stickerWidth = 214.dp * (sizes.width / 393.dp)
+        val stickerHeight = 112.dp * (sizes.width / 393.dp)
+        Box(
+            modifier = Modifier
+                .align(Alignment.TopCenter)
+                .offset(
+                    x = stickerWidth / 3,
+                    y = sizes.closeButtonBottomEdge + 8.dp + carouselHeight,
+                )
+                .size(stickerWidth, stickerHeight)
+                .background(Color.Black, shape = CircleShape),
+        )
+
+        Column(
+            modifier = Modifier
+                .align(Alignment.BottomCenter)
+                .background(
+                    brush = Brush.verticalGradient(
+                        0f to Color.Transparent,
+                        0.1f to story.backgroundColor,
+                    ),
+                ),
+        ) {
+            TextH10(
+                text = stringResource(LR.string.end_of_year_story_listened_to_numbers, story.showCount, story.epsiodeCount),
+                fontSize = 31.nonScaledSp,
+                modifier = Modifier.padding(horizontal = 24.dp),
+            )
+            Spacer(
+                modifier = Modifier.height(16.dp),
+            )
+            TextP40(
+                text = stringResource(LR.string.end_of_year_story_listened_to_numbers_subtitle),
+                fontSize = 15.nonScaledSp,
+                modifier = Modifier.padding(horizontal = 24.dp),
+            )
+            RowOutlinedButton(
+                "Share this story",
+                colors = ButtonDefaults.outlinedButtonColors(
+                    backgroundColor = Color.Transparent,
+                    contentColor = Color.Black,
+                ),
+                border = ButtonDefaults.outlinedBorder.copy(
+                    brush = SolidColor(Color.Black),
+                ),
+                onClick = {},
+            )
+        }
+    }
+}
+
+@Composable
+private fun PodcastCoverCarousel(
+    podcastIds: List<String>,
+    scrollDirection: ScrollDirection,
+    coverSize: Dp,
+    spacingSize: Dp,
+) {
+    ScrollingRow(
+        items = podcastIds,
+        scrollDirection = scrollDirection,
+        scrollByPixels = 2f,
+        horizontalArrangement = Arrangement.spacedBy(spacingSize),
+    ) { podcastId ->
+        PodcastImage(
+            uuid = podcastId,
+            elevation = 0.dp,
+            cornerSize = 4.dp,
+            modifier = Modifier.size(coverSize),
+        )
+    }
+}
+
 private data class EndOfYearSizes(
     val width: Dp = Dp.Unspecified,
     val height: Dp = Dp.Unspecified,
@@ -249,19 +382,20 @@ private data class EndOfYearSizes(
     val closeButtonBottomEdge: Dp = Dp.Unspecified,
 )
 
-private val Story.backgroundColor get() = when (this) {
-    is Story.Cover -> Color(0xFFEE661C)
-    is Story.NumberOfShows -> Color(0xFFEFECAD)
-    is Story.TopShow -> Color(0xFFEDB0F3)
-    is Story.TopShows -> Color(0xFFE0EFAD)
-    is Story.Ratings -> Color(0xFFEFECAD)
-    is Story.TotalTime -> Color(0xFFEDB0F3)
-    is Story.LongestEpisode -> Color(0xFFE0EFAD)
-    is Story.PlusInterstitial -> Color(0xFFEFECAD)
-    is Story.YearVsYear -> Color(0xFFEEB1F4)
-    is Story.CompletionRate -> Color(0xFFE0EFAD)
-    is Story.Ending -> Color(0xFFEE661C)
-}
+private val Story.backgroundColor
+    get() = when (this) {
+        is Story.Cover -> Color(0xFFEE661C)
+        is Story.NumberOfShows -> Color(0xFFEFECAD)
+        is Story.TopShow -> Color(0xFFEDB0F3)
+        is Story.TopShows -> Color(0xFFE0EFAD)
+        is Story.Ratings -> Color(0xFFEFECAD)
+        is Story.TotalTime -> Color(0xFFEDB0F3)
+        is Story.LongestEpisode -> Color(0xFFE0EFAD)
+        is Story.PlusInterstitial -> Color(0xFFEFECAD)
+        is Story.YearVsYear -> Color(0xFFEEB1F4)
+        is Story.CompletionRate -> Color(0xFFE0EFAD)
+        is Story.Ending -> Color(0xFFEE661C)
+    }
 
 private fun getSizeLimit(context: Context): DpSize? {
     return if (Util.isTablet(context)) {
@@ -311,4 +445,24 @@ fun CoverStoryPreview() {
             coverTextHeight = 210.dp,
         ),
     )
+}
+
+@Preview(device = Devices.PortraitRegular)
+@Composable
+fun NumberOfShowsPreview() {
+    BoxWithConstraints {
+        NumberOfShowsStory(
+            story = Story.NumberOfShows(
+                showCount = 20,
+                epsiodeCount = 125,
+                topShowIds = List(4) { "id-$it" },
+                bottomShowIds = List(4) { "id-$it" },
+            ),
+            sizes = EndOfYearSizes(
+                width = maxWidth,
+                height = maxHeight,
+                closeButtonBottomEdge = 44.dp,
+            ),
+        )
+    }
 }

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/ui/StoriesPage.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/ui/StoriesPage.kt
@@ -285,7 +285,7 @@ private fun NumberOfShowsStory(
         ) {
             PodcastCoverCarousel(
                 podcastIds = story.topShowIds,
-                scrollDirection = ScrollDirection.Right,
+                scrollDirection = ScrollDirection.Left,
                 coverSize = coverSize,
                 spacingSize = spacingSize,
             )
@@ -294,7 +294,7 @@ private fun NumberOfShowsStory(
             )
             PodcastCoverCarousel(
                 podcastIds = story.bottomShowIds,
-                scrollDirection = ScrollDirection.Left,
+                scrollDirection = ScrollDirection.Right,
                 coverSize = coverSize,
                 spacingSize = spacingSize,
             )

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/ScrollingRow.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/ScrollingRow.kt
@@ -38,8 +38,8 @@ fun <T> ScrollingRow(
     val state = remember {
         LazyListState(
             firstVisibleItemIndex = when (scrollDirection) {
-                ScrollDirection.Left -> Int.MAX_VALUE - 1
-                ScrollDirection.Right -> 0
+                ScrollDirection.Left -> 0
+                ScrollDirection.Right -> Int.MAX_VALUE - 1
             },
         )
     }
@@ -47,8 +47,8 @@ fun <T> ScrollingRow(
     LaunchedEffect(Unit) {
         while (isActive) {
             val scrollValue = when (scrollDirection) {
-                ScrollDirection.Left -> -scrollByPixels
-                ScrollDirection.Right -> scrollByPixels
+                ScrollDirection.Left -> scrollByPixels
+                ScrollDirection.Right -> -scrollByPixels
             }
             state.scrollBy(scrollValue)
             delay(scrollDelay(density))

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/ScrollingRow.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/ScrollingRow.kt
@@ -2,112 +2,74 @@ package au.com.shiftyjelly.pocketcasts.compose.components
 
 import androidx.compose.foundation.gestures.scrollBy
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.IntrinsicSize
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.lazy.LazyItemScope
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalConfiguration
-import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.dp
-import java.lang.Long.max
+import kotlin.math.roundToLong
 import kotlinx.coroutines.delay
-
-private const val MAX_ITEMS = 500
+import kotlinx.coroutines.isActive
 
 @Composable
-fun ScrollingRow(
-    scrollDirection: ScrollDirection = ScrollDirection.RIGHT,
-    scrollAutomatically: Boolean = true,
-    spacedBy: Dp = 16.dp,
-    paused: Boolean = false,
-    rowItems: @Composable () -> Unit,
+fun <T> ScrollingRow(
+    items: List<T>,
+    modifier: Modifier = Modifier,
+    scrollDirection: ScrollDirection = ScrollDirection.Right,
+    scrollByPixels: Float = 1f,
+    scrollDelay: (Density) -> Long = { (100 / it.density).roundToLong().coerceAtLeast(4L) },
+    contentPadding: PaddingValues = PaddingValues(0.dp),
+    reverseLayout: Boolean = false,
+    horizontalArrangement: Arrangement.Horizontal = if (!reverseLayout) Arrangement.Start else Arrangement.End,
+    verticalAlignment: Alignment.Vertical = Alignment.Top,
+    content: @Composable LazyItemScope.(T) -> Unit,
 ) {
     // Not using rememberLazyListState() because we want to reset
     // the scroll state on orientation changes so that the hardcoded column
     // is redisplayed, which insures the height is correctly calculated. For that
     // reason, we want to use remember, not rememberSaveable.
-    val state = remember { LazyListState() }
-    var initialScrollCompleted by remember { mutableStateOf(false) }
-    val localConfiguration = LocalConfiguration.current
-    LaunchedEffect(scrollAutomatically && paused) {
-        if (scrollAutomatically) {
-            // This seems to get a good scroll speed across multiple devices
-            val scrollDelay = max(1L, (1000L - localConfiguration.densityDpi) / 90)
-            if (!initialScrollCompleted) {
-                if (scrollDirection == ScrollDirection.LEFT) {
-                    state.scrollToItem(MAX_ITEMS - 1)
-                }
-                initialScrollCompleted = true
+    val state = remember {
+        LazyListState(
+            firstVisibleItemIndex = when (scrollDirection) {
+                ScrollDirection.Left -> Int.MAX_VALUE - 1
+                ScrollDirection.Right -> 0
+            },
+        )
+    }
+    val density = LocalDensity.current
+    LaunchedEffect(Unit) {
+        while (isActive) {
+            val scrollValue = when (scrollDirection) {
+                ScrollDirection.Left -> -scrollByPixels
+                ScrollDirection.Right -> scrollByPixels
             }
-            autoScroll(scrollDirection, scrollDelay, state, paused)
+            state.scrollBy(scrollValue)
+            delay(scrollDelay(density))
         }
     }
     LazyRow(
+        modifier = modifier,
         state = state,
-        horizontalArrangement = Arrangement.spacedBy(spacedBy),
-        userScrollEnabled = !scrollAutomatically,
+        contentPadding = contentPadding,
+        reverseLayout = reverseLayout,
+        horizontalArrangement = horizontalArrangement,
+        verticalAlignment = verticalAlignment,
+        userScrollEnabled = false,
     ) {
-        if (scrollAutomatically) {
-            items(MAX_ITEMS) { // arbitrary large number that users will probably never hit
-                // Nesting a Row of items inside the LazyRow because a Row can use IntrinsidSize.Max
-                // to determine the height of the tallest list item and keep a consistent
-                // height, regardless of which items are visible. This ensures that the
-                // LazyRow as a whole always has a single, consistent height that does not
-                // change as items scroll into/out-of view. If IntrinsicSize.Max could work
-                // with LazyRows, we wouldn't need to nest Rows in the LazyRow.
-                NestedRow(rowItems, spacedBy)
-            }
-        } else {
-            item {
-                NestedRow(rowItems, spacedBy)
-            }
+        items(Int.MAX_VALUE) { index ->
+            content(this, items[index % items.size])
         }
-    }
-}
-
-@Composable
-fun NestedRow(
-    rowItems: @Composable () -> Unit,
-    spacedBy: Dp,
-) {
-    Row(
-        horizontalArrangement = Arrangement.spacedBy(spacedBy),
-        modifier = Modifier
-            .height(IntrinsicSize.Max),
-    ) {
-        rowItems()
-    }
-}
-
-// Based on https://stackoverflow.com/a/71344813/1910286
-private tailrec suspend fun autoScroll(
-    scrollDirection: ScrollDirection,
-    scrollDelay: Long,
-    lazyListState: LazyListState,
-    paused: Boolean = false,
-) {
-    val scrollAmount = lazyListState.scrollBy(if (scrollDirection == ScrollDirection.RIGHT) 1f else -1f)
-    if (scrollAmount == 0f) {
-        // If we can't scroll, we're at one end, so jump to the other end.
-        // This will be an abrupt jump, but users shouldn't really ever be
-        // getting to the end of the list, so it should be very rare.
-        lazyListState.scrollToItem(if (scrollDirection == ScrollDirection.RIGHT) 0 else MAX_ITEMS - 1)
-    }
-    if (!paused) {
-        delay(scrollDelay)
-        autoScroll(scrollDirection, scrollDelay, lazyListState)
     }
 }
 
 enum class ScrollDirection {
-    LEFT,
-    RIGHT,
+    Left,
+    Right,
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/subscription/SubscriptionManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/subscription/SubscriptionManagerImpl.kt
@@ -51,6 +51,7 @@ import javax.inject.Singleton
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.transformLatest
 import kotlinx.coroutines.launch
@@ -113,7 +114,7 @@ class SubscriptionManagerImpl @Inject constructor(
     override fun subscriptionTier(): Flow<SubscriptionTier> {
         return observeSubscriptionStatus().asFlow().map { status ->
             (status.get() as? SubscriptionStatus.Paid)?.tier ?: SubscriptionTier.NONE
-        }
+        }.distinctUntilChanged()
     }
 
     override fun getSubscriptionStatus(allowCache: Boolean): Single<SubscriptionStatus> {

--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/extensions/List.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/extensions/List.kt
@@ -1,0 +1,18 @@
+package au.com.shiftyjelly.pocketcasts.utils.extensions
+
+fun <T> List<T>.padEnd(
+    length: Int,
+    padItem: (List<T>, Int) -> T = { list, newIndex -> list[newIndex % list.size] },
+): List<T> {
+    return if (size < length) {
+        buildList(length) {
+            addAll(this@padEnd)
+            repeat(length - this@padEnd.size) { index ->
+                val newIndex = index + this@padEnd.size
+                add(padItem(this@padEnd, newIndex))
+            }
+        }
+    } else {
+        this
+    }
+}

--- a/modules/services/utils/src/test/java/au/com/shiftyjelly/pocketcasts/utils/extensions/ListTest.kt
+++ b/modules/services/utils/src/test/java/au/com/shiftyjelly/pocketcasts/utils/extensions/ListTest.kt
@@ -1,0 +1,42 @@
+package au.com.shiftyjelly.pocketcasts.utils.extensions
+
+import junit.framework.TestCase.assertEquals
+import org.junit.Test
+
+class ListTest {
+    @Test
+    fun `do not pad end if length is smaller than list`() {
+        val list = listOf(1, 2, 3)
+
+        val paddedList = list.padEnd(1)
+
+        assertEquals(list, paddedList)
+    }
+
+    @Test
+    fun `do not pad end if length is equal to list`() {
+        val list = listOf(1, 2, 3)
+
+        val paddedList = list.padEnd(3)
+
+        assertEquals(list, paddedList)
+    }
+
+    @Test
+    fun `pad end cyclically`() {
+        val list = listOf(1, 2, 3)
+
+        val paddedList = list.padEnd(7)
+
+        assertEquals(listOf(1, 2, 3, 1, 2, 3, 1), paddedList)
+    }
+
+    @Test
+    fun `use custom pad function`() {
+        val list = listOf(1, 2, 3)
+
+        val paddedList = list.padEnd(5, padItem = { _, _ -> 0 })
+
+        assertEquals(listOf(1, 2, 3, 0, 0), paddedList)
+    }
+}


### PR DESCRIPTION
## Description

This adds number of shows story.

Figma: lH66LwxxgG8btQ8NrM0ldx-fi-3054_3820

As I commented on Figma I'm missing sticker asset so right now I'm mocking it with rounded rectangle shape. There's also an issue on small devices with an overlapping sticker and the text, which I also asked about.

> [!note]
> Edge to edge is not supported ATM due to the legacy code. Enabling it would break the UI in the whole app. I'll work on supporting it as a separate task.

## Testing Instructions

1. Sign in with an account that listened to at least 5 minutes of episodes this year.
2. Sync your profile data.
3. Close the app.
4. Reopen the app.
5. Open Playback 2024.
6. You might see a loading progress bar and it might take some time to sync your data.
7. Once data is synced go to the number of shows story and verify it.

## Screenshots or Screencast 

### Preview

| Regular | Small |
| - | - |
| ![reg](https://github.com/user-attachments/assets/f24b16ff-3b5c-4f0e-916e-de896cc183ee) | ![small](https://github.com/user-attachments/assets/f15d92c8-f9ae-4d0d-9377-ebd01c43b96b) |

### Animation

https://github.com/user-attachments/assets/a966b8a0-0edd-4fbb-9640-035b2d5f1601

## Checklist
- [x] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] ~I have considered whether it makes sense to add tests for my changes~
- [x] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] ~for accessibility with TalkBack~