### PR TITLE
[Auto Downloading] - Use new episodes global toggle to download episodes

### DIFF
--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/models/db/PodcastManagerTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/models/db/PodcastManagerTest.kt
@@ -57,6 +57,7 @@ class PodcastManagerTest {
         val settings = mock<Settings> {
             on { podcastGroupingDefault } doReturn UserSetting.Mock(PodcastGrouping.None, mock())
             on { showArchivedDefault } doReturn UserSetting.Mock(false, mock())
+            on { autoDownloadNewEpisodes } doReturn UserSetting.Mock(true, mock())
             on { autoDownloadLimit } doReturn UserSetting.Mock(AutoDownloadLimitSetting.TWO_LATEST_EPISODE, mock())
         }
 

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/AutoDownloadSettingsFragment.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/AutoDownloadSettingsFragment.kt
@@ -157,7 +157,7 @@ class AutoDownloadSettingsFragment :
                 setOnPreferenceChangeListener { _, newValue ->
                     if (newValue is Boolean) {
                         viewModel.onNewEpisodesChange(newValue)
-                        onChangeNewEpisodes(newValue)
+                        handleNewEpisodesToggle(newValue)
                     }
                     true
                 }
@@ -236,9 +236,9 @@ class AutoDownloadSettingsFragment :
         updateView()
     }
 
-    private fun onChangeNewEpisodes(on: Boolean) {
+    private fun handleNewEpisodesToggle(isEnabled: Boolean) {
         lifecycleScope.launch {
-            updateNewEpisodesSwitch(on)
+            updateNewEpisodesSwitch(isEnabled)
             updatePodcastsSummary()
         }
     }
@@ -346,6 +346,7 @@ class AutoDownloadSettingsFragment :
         if (FeatureFlag.isEnabled(Feature.AUTO_DOWNLOAD)) {
             newEpisodesPreference?.summary = getString(LR.string.settings_auto_download_new_episodes_description)
         }
+        handleNewEpisodesToggle(viewModel.getAutoDownloadNewEpisodes())
     }
 
     private fun countPodcastsAutoDownloading(): Single<Int> {

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/AutoDownloadSettingsFragment.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/AutoDownloadSettingsFragment.kt
@@ -345,9 +345,9 @@ class AutoDownloadSettingsFragment :
     private fun updateView() {
         updatePodcastsSummary()
         updateFiltersSelectedSummary()
-        updateNewEpisodesSwitch()
 
         upNextPreference.isChecked = viewModel.getAutoDownloadUpNext()
+        newEpisodesPreference?.isChecked = viewModel.getAutoDownloadNewEpisodes()
         autoDownloadOnlyDownloadOnWifi.isChecked = viewModel.getAutoDownloadUnmeteredOnly()
         autoDownloadOnlyWhenCharging.isChecked = viewModel.getAutoDownloadOnlyWhenCharging()
         if (FeatureFlag.isEnabled(Feature.AUTO_DOWNLOAD)) {
@@ -381,19 +381,6 @@ class AutoDownloadSettingsFragment :
                         else -> resources.getString(LR.string.settings_podcasts_selected_x, autoDownloadingCount)
                     }
                     podcastsPreference?.summary = summary
-                },
-            )
-    }
-
-    @SuppressLint("CheckResult")
-    private fun updateNewEpisodesSwitch() {
-        countPodcastsAutoDownloading()
-            .map { it > 0 }
-            .subscribeBy(
-                onError = { Timber.e(it) },
-                onSuccess = { on ->
-                    updateNewEpisodesSwitch(on)
-                    newEpisodesPreference?.isChecked = on
                 },
             )
     }

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/AutoDownloadSettingsFragment.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/AutoDownloadSettingsFragment.kt
@@ -156,8 +156,8 @@ class AutoDownloadSettingsFragment :
             ?.apply {
                 setOnPreferenceChangeListener { _, newValue ->
                     if (newValue is Boolean) {
-                        onChangeNewEpisodes(newValue)
                         viewModel.onNewEpisodesChange(newValue)
+                        onChangeNewEpisodes(newValue)
                     }
                     true
                 }
@@ -238,9 +238,6 @@ class AutoDownloadSettingsFragment :
 
     private fun onChangeNewEpisodes(on: Boolean) {
         lifecycleScope.launch {
-            if (!on) {
-                async(Dispatchers.Default) { podcastManager.updateAllAutoDownloadStatus(Podcast.AUTO_DOWNLOAD_OFF) }.await()
-            }
             updateNewEpisodesSwitch(on)
             updatePodcastsSummary()
         }
@@ -256,10 +253,6 @@ class AutoDownloadSettingsFragment :
         } else {
             podcastsCategory.removePreference(podcastsPreference)
             podcastsCategory.removePreference(podcastsLimitPreference)
-
-            // Reset Limit Downloads to default value after disabling auto download toggle
-            viewModel.setLimitDownloads(AutoDownloadLimitSetting.TWO_LATEST_EPISODE)
-            updateLimitDownloadsSummary()
         }
     }
 

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/viewmodel/AutoDownloadSettingsViewModel.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/viewmodel/AutoDownloadSettingsViewModel.kt
@@ -44,7 +44,11 @@ class AutoDownloadSettingsViewModel @Inject constructor(
 
     fun getAutoDownloadUpNext() = settings.autoDownloadUpNext.value
 
+    fun getAutoDownloadNewEpisodes() = settings.autoDownloadNewEpisodes.value
+
     fun onNewEpisodesChange(newValue: Boolean) {
+        settings.autoDownloadNewEpisodes.set(newValue, updateModifiedAt = true)
+
         analyticsTracker.track(
             AnalyticsEvent.SETTINGS_AUTO_DOWNLOAD_NEW_EPISODES_TOGGLED,
             mapOf("enabled" to newValue),

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
@@ -330,6 +330,7 @@ interface Settings {
     val autoDownloadUnmeteredOnly: UserSetting<Boolean>
     val autoDownloadOnlyWhenCharging: UserSetting<Boolean>
     val autoDownloadUpNext: UserSetting<Boolean>
+    val autoDownloadNewEpisodes: UserSetting<Boolean>
 
     val artworkConfiguration: UserSetting<ArtworkConfiguration>
 

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
@@ -544,6 +544,12 @@ class SettingsImpl @Inject constructor(
         sharedPrefs = sharedPreferences,
     )
 
+    override val autoDownloadNewEpisodes = UserSetting.BoolPref(
+        sharedPrefKey = "autoDownloadNewEpisodes",
+        defaultValue = true,
+        sharedPrefs = sharedPreferences,
+    )
+
     override val autoDownloadOnlyWhenCharging = UserSetting.BoolPref(
         sharedPrefKey = "autoDownloadOnlyDownloadWhenCharging",
         defaultValue = false,

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/support/Support.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/support/Support.kt
@@ -317,6 +317,8 @@ class Support @Inject constructor(
             output.append(eol)
             output.append("Auto downloads").append(eol)
             output.append("  Any podcast? ").append(yesNoString(autoDownloadOn[0])).append(eol)
+            output.append("  New Episodes? ").append(yesNoString(settings.autoDownloadNewEpisodes.value)).append(eol)
+            output.append("  Limit Downloads ").append(settings.autoDownloadLimit.value).append(eol)
             output.append("  Up Next? ").append(yesNoString(settings.autoDownloadUpNext.value)).append(eol)
             output.append("  Only on unmetered WiFi? ").append(yesNoString(settings.autoDownloadUnmeteredOnly.value)).append(eol)
             output.append("  Only when charging? ").append(yesNoString(settings.autoDownloadOnlyWhenCharging.value)).append(eol)


### PR DESCRIPTION
## Description
- Uses the global `New Episodes` toggle to control if we will download the latest episodes after the user subscribes to a podcast e90f3c84b46cb4e319bc603f51ca56b8bc2c1f52
- Changed the behavior of the `New Episodes` toggle. Before this PR, turning the `New Episodes` toggle OFF would reset the auto-download limit value and remove the podcasts selected in the `Choose Podcast` list. We have now removed this behavior to align with iOS 571a3f8bd0b75554047902c2283bafcb4e62a9c3. Context here: p1728920687960259/1728629479.247849-slack-C07QMC2GB1B
- Keeps the `New Episodes` toggle ON even if we don't have any podcast selected. Also to align with iOS

Fixes #2999

## Testing Instructions

### Logged out

1. Install the app
2. Go to Profile -> Auto Download
3. ✅ Ensure you have `New Episodes` ON and `Limit Downloads` with `2 Latest Episodes` set
4. Subscribe to a podcast
5. ✅ Ensure the latest 2 episodes of this podcast was downloaded
6.  Go to Profile -> Auto Download
7. ✅ Ensure you see this podcast in `Choose podcasts` list
8. Turn `New Episodes` OFF
9. Turn `New Episodes` ON
10. ✅ Ensure you see this podcast in `Choose podcasts` list
11. Turn `New Episodes` OFF
12. Subscribe to another podcast
13. ✅ Ensure that no episode has been downloaded

### Existing account
1. Install the app
2. Log in with an account that is already subscribed to some podcasts
3. Go to Profile -> Auto Download
4. ✅ Ensure that `New Episodes` is ON as default
5. Turn `New Episodes` OFF
6. Subscribe to another podcast
7. ✅ Ensure that no episode has been downloaded



## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.