### PR TITLE
[Auto Downloading] Add auto download toggles to support file

### DIFF
--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/support/Support.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/support/Support.kt
@@ -317,6 +317,8 @@ class Support @Inject constructor(
             output.append(eol)
             output.append("Auto downloads").append(eol)
             output.append("  Any podcast? ").append(yesNoString(autoDownloadOn[0])).append(eol)
+            output.append("  New Episodes? ").append(yesNoString(settings.autoDownloadNewEpisodes.value)).append(eol)
+            output.append("  Limit Downloads ").append(settings.autoDownloadLimit.value).append(eol)
             output.append("  Up Next? ").append(yesNoString(settings.autoDownloadUpNext.value)).append(eol)
             output.append("  Only on unmetered WiFi? ").append(yesNoString(settings.autoDownloadUnmeteredOnly.value)).append(eol)
             output.append("  Only when charging? ").append(yesNoString(settings.autoDownloadOnlyWhenCharging.value)).append(eol)


### PR DESCRIPTION
## Description
- This will help us to know when the user reaches us on support if they have `New Episodes` enabled and the value set for `Limit downloads`

Fixes #3028

## Testing Instructions
1. Go to Profile -> Settings -> Auto Download
2. See the value of `New Episodes` and `Limit downloads`
3. Go to Profile -> Help & feedback
4. Export the debug file
5. ✅ Ensure the value of the flags matches with the ones you saw

## Screenshots or Screencast 
[Screen_recording_20241016_103502.webm](https://github.com/user-attachments/assets/fdeb7a61-f96a-48aa-9d7f-d72e2e0793b1)


## Checklist
- [ ] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] ~I have considered whether it makes sense to add tests for my changes~
- [ ] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [ ] ~Any jetpack compose components I added or changed are covered by compose previews~
- [ ] ~I have updated (or requested that someone edit) [the spreadsheet]~(https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
