### PR TITLE
Display Ratings story

### DIFF
--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/ui/Common.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/ui/Common.kt
@@ -60,8 +60,23 @@ internal fun ShareStoryButton(
     modifier: Modifier = Modifier,
     includePadding: Boolean = true,
 ) {
-    RowOutlinedButton(
+    OutlinedEoyButton(
         text = stringResource(LR.string.end_of_year_share_story),
+        onClick = onClick,
+        includePadding = includePadding,
+        modifier = modifier,
+    )
+}
+
+@Composable
+internal fun OutlinedEoyButton(
+    text: String,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    includePadding: Boolean = true,
+) {
+    RowOutlinedButton(
+        text = text,
         fontSize = 18.nonScaledSp,
         colors = ButtonDefaults.outlinedButtonColors(
             backgroundColor = Color.Transparent,

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/ui/CoverStory.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/ui/CoverStory.kt
@@ -79,7 +79,7 @@ internal fun CoverStory(
 
 @Preview(device = Devices.PortraitRegular)
 @Composable
-fun CoverStoryPreview() {
+private fun CoverStoryPreview() {
     PreviewBox { measurements ->
         CoverStory(
             story = Story.Cover,

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/ui/NumberOfShowsStory.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/ui/NumberOfShowsStory.kt
@@ -23,13 +23,13 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import au.com.shiftyjelly.pocketcasts.compose.Devices
 import au.com.shiftyjelly.pocketcasts.compose.components.PodcastImage
 import au.com.shiftyjelly.pocketcasts.compose.components.ScrollDirection
 import au.com.shiftyjelly.pocketcasts.compose.components.ScrollingRow
 import au.com.shiftyjelly.pocketcasts.compose.components.TextH10
 import au.com.shiftyjelly.pocketcasts.compose.components.TextP40
-import au.com.shiftyjelly.pocketcasts.compose.extensions.nonScaledSp
 import au.com.shiftyjelly.pocketcasts.endofyear.Story
 import au.com.shiftyjelly.pocketcasts.localization.R
 import kotlin.math.tan
@@ -104,7 +104,7 @@ internal fun NumberOfShowsStory(
                     story.showCount,
                     story.epsiodeCount,
                 ),
-                fontSize = 31.nonScaledSp,
+                disableScale = true,
                 color = colorResource(UR.color.coolgrey_90),
                 modifier = Modifier.padding(horizontal = 24.dp),
             )
@@ -113,7 +113,8 @@ internal fun NumberOfShowsStory(
             )
             TextP40(
                 text = stringResource(R.string.end_of_year_story_listened_to_numbers_subtitle),
-                fontSize = 15.nonScaledSp,
+                fontSize = 15.sp,
+                disableScale = true,
                 color = colorResource(UR.color.coolgrey_90),
                 modifier = Modifier.padding(horizontal = 24.dp),
             )

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/ui/NumberOfShowsStory.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/ui/NumberOfShowsStory.kt
@@ -146,7 +146,7 @@ private fun PodcastCoverCarousel(
 
 @Preview(device = Devices.PortraitRegular)
 @Composable
-fun NumberOfShowsPreview() {
+private fun NumberOfShowsPreview() {
     PreviewBox { measurements ->
         NumberOfShowsStory(
             story = Story.NumberOfShows(

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/ui/RatingsStory.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/ui/RatingsStory.kt
@@ -188,9 +188,7 @@ private fun AbsentRatings(
             .background(story.backgroundColor)
             .padding(top = measurements.closeButtonBottomEdge),
     ) {
-        SubcomposeLayout(
-            modifier = Modifier,
-        ) { constraints ->
+        SubcomposeLayout { constraints ->
             val noRatingsInfo = subcompose("noRatingsInfo") {
                 NoRatingsInfo(
                     story = story,

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/ui/RatingsStory.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/ui/RatingsStory.kt
@@ -86,7 +86,7 @@ private fun PresentRatings(
         Column {
             TextH10(
                 text = stringResource(LR.string.eoy_story_ratings_title_1),
-                fontSize = 31.nonScaledSp,
+                disableScale = true,
                 color = colorResource(UR.color.coolgrey_90),
                 modifier = Modifier.padding(horizontal = 24.dp),
             )
@@ -98,7 +98,8 @@ private fun PresentRatings(
                     Rating.One, Rating.Two, Rating.Three -> stringResource(LR.string.eoy_story_ratings_subtitle_2)
                     Rating.Four, Rating.Five -> stringResource(LR.string.eoy_story_ratings_subtitle_1, rating.numericalValue)
                 },
-                fontSize = 15.nonScaledSp,
+                fontSize = 15.sp,
+                disableScale = true,
                 color = colorResource(UR.color.coolgrey_90),
                 modifier = Modifier.padding(horizontal = 24.dp),
             )
@@ -155,7 +156,7 @@ private fun RowScope.RatingBar(
     ) {
         TextH20(
             text = "$rating",
-            fontSize = 22.nonScaledSp,
+            disableScale = true,
             color = colorResource(UR.color.coolgrey_90),
         )
         Spacer(
@@ -283,7 +284,7 @@ private fun NoRatingsInfo(
         )
         TextH10(
             text = stringResource(LR.string.eoy_story_ratings_title_2),
-            fontSize = 31.nonScaledSp,
+            disableScale = true,
             color = colorResource(UR.color.coolgrey_90),
             modifier = Modifier.padding(horizontal = 24.dp),
         )
@@ -292,7 +293,8 @@ private fun NoRatingsInfo(
         )
         TextP40(
             text = stringResource(LR.string.eoy_story_ratings_subtitle_3),
-            fontSize = 15.nonScaledSp,
+            fontSize = 15.sp,
+            disableScale = true,
             color = colorResource(UR.color.coolgrey_90),
             modifier = Modifier.padding(horizontal = 24.dp),
         )

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/ui/RatingsStory.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/ui/RatingsStory.kt
@@ -30,6 +30,7 @@ import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.TextLayoutResult
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.rememberTextMeasurer
@@ -216,50 +217,60 @@ private fun AbsentRatings(
 private fun OopsiesSection(
     measurements: EndOfYearMeasurements,
 ) {
-    Column(
-        modifier = Modifier.requiredWidth(measurements.width * 2),
-    ) {
-        OopsiesText(
-            modifier = Modifier.offset(x = measurements.width / 5),
-        )
-        OopsiesText(
-            modifier = Modifier.offset(x = -measurements.width / 5),
-        )
-    }
-}
-
-@Composable
-private fun OopsiesText(
-    modifier: Modifier = Modifier,
-) {
     // Measure text to postion things better
     val textMeasurer = rememberTextMeasurer()
     val fontSize = 227.nonScaledSp
     val textMeasurement = remember {
         textMeasurer.measure(
-            text = "OOPSIES",
+            text = "OOOOPSIES",
             style = TextStyle(
                 fontFamily = humaneFontFamily,
                 fontSize = fontSize,
             ),
         )
     }
+    val topOffset = LocalDensity.current.run { textMeasurement.size.width.toDp() } * 2.8f / 9
+    val bottomOffset = LocalDensity.current.run { textMeasurement.size.width.toDp() } * 6.5f / 9
+
+    Column(
+        modifier = Modifier
+            .offset(x = measurements.width / 2)
+            .requiredWidth(measurements.width * 2),
+    ) {
+        OopsiesText(
+            textMeasurement = textMeasurement,
+            modifier = Modifier.offset(x = -topOffset),
+        )
+        OopsiesText(
+            textMeasurement = textMeasurement,
+            modifier = Modifier.offset(x = -bottomOffset),
+        )
+    }
+}
+
+@Composable
+private fun OopsiesText(
+    textMeasurement: TextLayoutResult,
+    modifier: Modifier = Modifier,
+) {
     val textHeight = LocalDensity.current.run { textMeasurement.firstBaseline.toDp() } + 12.dp
     Row(
         verticalAlignment = Alignment.CenterVertically,
         modifier = modifier,
     ) {
-        repeat(3) {
-            Image(
-                painter = painterResource(au.com.shiftyjelly.pocketcasts.images.R.drawable.eoy_star_text_stop),
-                contentDescription = null,
-                colorFilter = ColorFilter.tint(colorResource(UR.color.coolgrey_90)),
-                modifier = Modifier.padding(horizontal = 8.dp),
-            )
+        repeat(3) { index ->
+            if (index != 0) {
+                Image(
+                    painter = painterResource(au.com.shiftyjelly.pocketcasts.images.R.drawable.eoy_star_text_stop),
+                    contentDescription = null,
+                    colorFilter = ColorFilter.tint(colorResource(UR.color.coolgrey_90)),
+                    modifier = Modifier.padding(horizontal = 8.dp),
+                )
+            }
             Text(
-                text = "OOPSIES",
+                text = "OOOOPSIES",
                 fontFamily = humaneFontFamily,
-                fontSize = fontSize,
+                fontSize = 227.nonScaledSp,
                 maxLines = 1,
                 modifier = Modifier.requiredHeight(textHeight),
             )
@@ -343,7 +354,7 @@ private fun RatingsLowPreview() {
     }
 }
 
-@Preview(device = Devices.PortraitSmall)
+@Preview(device = Devices.PortraitRegular)
 @Composable
 private fun RatingsNonePreview() {
     PreviewBox { measurements ->

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/ui/RatingsStory.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/ui/RatingsStory.kt
@@ -38,6 +38,8 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import au.com.shiftyjelly.pocketcasts.compose.Devices
+import au.com.shiftyjelly.pocketcasts.compose.components.ScrollDirection
+import au.com.shiftyjelly.pocketcasts.compose.components.ScrollingRow
 import au.com.shiftyjelly.pocketcasts.compose.components.TextH10
 import au.com.shiftyjelly.pocketcasts.compose.components.TextH20
 import au.com.shiftyjelly.pocketcasts.compose.components.TextP40
@@ -45,6 +47,7 @@ import au.com.shiftyjelly.pocketcasts.compose.extensions.nonScaledSp
 import au.com.shiftyjelly.pocketcasts.endofyear.Story
 import au.com.shiftyjelly.pocketcasts.models.to.Rating
 import au.com.shiftyjelly.pocketcasts.models.to.RatingStats
+import kotlin.math.roundToLong
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 import au.com.shiftyjelly.pocketcasts.ui.R as UR
 
@@ -236,41 +239,42 @@ private fun OopsiesSection(
             .requiredWidth(measurements.width * 2),
     ) {
         OopsiesText(
+            scrollDirection = ScrollDirection.Left,
             textMeasurement = textMeasurement,
-            modifier = Modifier.offset(x = -topOffset),
         )
         OopsiesText(
+            scrollDirection = ScrollDirection.Right,
             textMeasurement = textMeasurement,
-            modifier = Modifier.offset(x = -bottomOffset),
         )
     }
 }
 
 @Composable
 private fun OopsiesText(
+    scrollDirection: ScrollDirection,
     textMeasurement: TextLayoutResult,
-    modifier: Modifier = Modifier,
 ) {
     val textHeight = LocalDensity.current.run { textMeasurement.firstBaseline.toDp() } + 12.dp
-    Row(
-        verticalAlignment = Alignment.CenterVertically,
-        modifier = modifier,
+    ScrollingRow(
+        scrollDelay = { (20 / it.density).roundToLong().coerceAtLeast(4L) },
+        items = listOf("OOOOPSIES"),
+        scrollDirection = scrollDirection,
     ) {
-        repeat(3) { index ->
-            if (index != 0) {
-                Image(
-                    painter = painterResource(au.com.shiftyjelly.pocketcasts.images.R.drawable.eoy_star_text_stop),
-                    contentDescription = null,
-                    colorFilter = ColorFilter.tint(colorResource(UR.color.coolgrey_90)),
-                    modifier = Modifier.padding(horizontal = 8.dp),
-                )
-            }
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
             Text(
                 text = "OOOOPSIES",
                 fontFamily = humaneFontFamily,
                 fontSize = 227.nonScaledSp,
                 maxLines = 1,
                 modifier = Modifier.requiredHeight(textHeight),
+            )
+            Image(
+                painter = painterResource(au.com.shiftyjelly.pocketcasts.images.R.drawable.eoy_star_text_stop),
+                contentDescription = null,
+                colorFilter = ColorFilter.tint(colorResource(UR.color.coolgrey_90)),
+                modifier = Modifier.padding(horizontal = 8.dp),
             )
         }
     }

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/ui/RatingsStory.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/ui/RatingsStory.kt
@@ -117,7 +117,7 @@ private val SectionHeight = BarHeight + SpaceHeight
 private fun BoxWithConstraintsScope.RatingBars(
     stats: RatingStats,
 ) {
-    // Measure text heigh to account for available space for rating lines
+    // Measure text height to account for available space for rating lines
     val textMeasurer = rememberTextMeasurer()
     val fontSize = 22.nonScaledSp
     val ratingTextHeight = remember(maxHeight) {

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/ui/RatingsStory.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/ui/RatingsStory.kt
@@ -1,0 +1,361 @@
+package au.com.shiftyjelly.pocketcasts.endofyear.ui
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.BoxWithConstraintsScope
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.RowScope
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.requiredHeight
+import androidx.compose.foundation.layout.requiredWidth
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.layout.SubcomposeLayout
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.res.colorResource
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.rememberTextMeasurer
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import au.com.shiftyjelly.pocketcasts.compose.Devices
+import au.com.shiftyjelly.pocketcasts.compose.components.TextH10
+import au.com.shiftyjelly.pocketcasts.compose.components.TextH20
+import au.com.shiftyjelly.pocketcasts.compose.components.TextP40
+import au.com.shiftyjelly.pocketcasts.compose.extensions.nonScaledSp
+import au.com.shiftyjelly.pocketcasts.endofyear.Story
+import au.com.shiftyjelly.pocketcasts.models.to.Rating
+import au.com.shiftyjelly.pocketcasts.models.to.RatingStats
+import au.com.shiftyjelly.pocketcasts.localization.R as LR
+import au.com.shiftyjelly.pocketcasts.ui.R as UR
+
+@Composable
+internal fun RatingsStory(
+    story: Story.Ratings,
+    measurements: EndOfYearMeasurements,
+) {
+    val maxRatingCount = story.stats.max().second
+    if (maxRatingCount != 0) {
+        PresentRatings(story, measurements)
+    } else {
+        AbsentRatings(story, measurements)
+    }
+}
+
+@Composable
+private fun PresentRatings(
+    story: Story.Ratings,
+    measurements: EndOfYearMeasurements,
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(story.backgroundColor)
+            .padding(top = measurements.closeButtonBottomEdge + 100.dp),
+    ) {
+        BoxWithConstraints(
+            contentAlignment = Alignment.BottomCenter,
+            modifier = Modifier
+                .fillMaxWidth()
+                .weight(1f)
+                .padding(horizontal = 24.dp),
+        ) {
+            RatingBars(story.stats)
+        }
+        Spacer(
+            modifier = Modifier.height(32.dp),
+        )
+        Column {
+            TextH10(
+                text = stringResource(LR.string.eoy_story_ratings_title_1),
+                fontSize = 31.nonScaledSp,
+                color = colorResource(UR.color.coolgrey_90),
+                modifier = Modifier.padding(horizontal = 24.dp),
+            )
+            Spacer(
+                modifier = Modifier.height(16.dp),
+            )
+            TextP40(
+                text = when (val rating = story.stats.max().first) {
+                    Rating.One, Rating.Two, Rating.Three -> stringResource(LR.string.eoy_story_ratings_subtitle_2)
+                    Rating.Four, Rating.Five -> stringResource(LR.string.eoy_story_ratings_subtitle_1, rating.numericalValue)
+                },
+                fontSize = 15.nonScaledSp,
+                color = colorResource(UR.color.coolgrey_90),
+                modifier = Modifier.padding(horizontal = 24.dp),
+            )
+            ShareStoryButton(onClick = {})
+        }
+    }
+}
+
+private val BarHeight = 1.5.dp
+private val SpaceHeight = 4.dp
+private val SectionHeight = BarHeight + SpaceHeight
+
+@Composable
+private fun BoxWithConstraintsScope.RatingBars(
+    stats: RatingStats,
+) {
+    // Measure text heigh to account for available space for rating lines
+    val textMeasurer = rememberTextMeasurer()
+    val fontSize = 22.nonScaledSp
+    val ratingTextHeight = remember(maxHeight) {
+        textMeasurer.measure(
+            text = "1",
+            style = TextStyle(
+                fontSize = fontSize,
+                lineHeight = 30.sp,
+                fontWeight = FontWeight.W700,
+            ),
+        ).size.height.dp + 8.dp // Plus padding
+    }
+    val maxLineCount = ((maxHeight - ratingTextHeight) / SectionHeight)
+
+    Row(
+        verticalAlignment = Alignment.Bottom,
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+        modifier = Modifier.fillMaxSize(),
+    ) {
+        Rating.entries.forEach { rating ->
+            RatingBar(
+                rating = rating.numericalValue,
+                lineCount = (maxLineCount * stats.relativeToMax(rating)).toInt(),
+            )
+        }
+    }
+}
+
+@Composable
+private fun RowScope.RatingBar(
+    rating: Int,
+    lineCount: Int,
+) {
+    Column(
+        horizontalAlignment = Alignment.CenterHorizontally,
+        modifier = Modifier.weight(1f),
+    ) {
+        TextH20(
+            text = "$rating",
+            fontSize = 22.nonScaledSp,
+            color = colorResource(UR.color.coolgrey_90),
+        )
+        Spacer(
+            modifier = Modifier.height(8.dp),
+        )
+        repeat(lineCount.coerceAtLeast(1)) {
+            Spacer(
+                modifier = Modifier.height(SpaceHeight),
+            )
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(BarHeight)
+                    .background(Color.Black),
+            )
+        }
+    }
+}
+
+@Composable
+private fun AbsentRatings(
+    story: Story.Ratings,
+    measurements: EndOfYearMeasurements,
+) {
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(story.backgroundColor)
+            .padding(top = measurements.closeButtonBottomEdge),
+    ) {
+        SubcomposeLayout(
+            modifier = Modifier,
+        ) { constraints ->
+            val noRatingsInfo = subcompose("noRatingsInfo") {
+                NoRatingsInfo(
+                    story = story,
+                )
+            }[0].measure(constraints)
+            val oopsiesSection = subcompose("oopsiesSection") {
+                OopsiesSection(
+                    measurements = measurements,
+                )
+            }[0].measure(constraints)
+
+            val emptySpaceHeight = constraints.maxHeight - noRatingsInfo.height
+            val oopsiesPosition = (emptySpaceHeight - oopsiesSection.height).coerceAtLeast(0) / 2
+
+            layout(constraints.maxWidth, constraints.maxHeight) {
+                oopsiesSection.place(0, oopsiesPosition)
+                noRatingsInfo.place(0, emptySpaceHeight)
+            }
+        }
+    }
+}
+
+@Composable
+private fun OopsiesSection(
+    measurements: EndOfYearMeasurements,
+) {
+    Column(
+        modifier = Modifier.requiredWidth(measurements.width * 2),
+    ) {
+        OopsiesText(
+            modifier = Modifier.offset(x = measurements.width / 5),
+        )
+        OopsiesText(
+            modifier = Modifier.offset(x = -measurements.width / 5),
+        )
+    }
+}
+
+@Composable
+private fun OopsiesText(
+    modifier: Modifier = Modifier,
+) {
+    // Measure text to postion things better
+    val textMeasurer = rememberTextMeasurer()
+    val fontSize = 227.nonScaledSp
+    val textMeasurement = remember {
+        textMeasurer.measure(
+            text = "OOPSIES",
+            style = TextStyle(
+                fontFamily = humaneFontFamily,
+                fontSize = fontSize,
+            ),
+        )
+    }
+    val textHeight = LocalDensity.current.run { textMeasurement.firstBaseline.toDp() } + 12.dp
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = modifier,
+    ) {
+        repeat(3) {
+            Image(
+                painter = painterResource(au.com.shiftyjelly.pocketcasts.images.R.drawable.eoy_star_text_stop),
+                contentDescription = null,
+                colorFilter = ColorFilter.tint(colorResource(UR.color.coolgrey_90)),
+                modifier = Modifier.padding(horizontal = 8.dp),
+            )
+            Text(
+                text = "OOPSIES",
+                fontFamily = humaneFontFamily,
+                fontSize = fontSize,
+                maxLines = 1,
+                modifier = Modifier.requiredHeight(textHeight),
+            )
+        }
+    }
+}
+
+@Composable
+private fun NoRatingsInfo(
+    story: Story.Ratings,
+) {
+    Column(
+        modifier = Modifier.background(
+            brush = Brush.verticalGradient(
+                0f to Color.Transparent,
+                0.1f to story.backgroundColor,
+            ),
+        ),
+    ) {
+        Spacer(
+            modifier = Modifier.height(16.dp),
+        )
+        TextH10(
+            text = stringResource(LR.string.eoy_story_ratings_title_2),
+            fontSize = 31.nonScaledSp,
+            color = colorResource(UR.color.coolgrey_90),
+            modifier = Modifier.padding(horizontal = 24.dp),
+        )
+        Spacer(
+            modifier = Modifier.height(16.dp),
+        )
+        TextP40(
+            text = stringResource(LR.string.eoy_story_ratings_subtitle_3),
+            fontSize = 15.nonScaledSp,
+            color = colorResource(UR.color.coolgrey_90),
+            modifier = Modifier.padding(horizontal = 24.dp),
+        )
+        OutlinedEoyButton(
+            text = stringResource(LR.string.eoy_story_ratings_learn_button_label),
+            onClick = {},
+        )
+    }
+}
+
+@Preview(device = Devices.PortraitRegular)
+@Composable
+private fun RatingsHighPreview() {
+    PreviewBox { measurements ->
+        RatingsStory(
+            story = Story.Ratings(
+                stats = RatingStats(
+                    ones = 20,
+                    twos = 30,
+                    threes = 0,
+                    fours = 25,
+                    fives = 130,
+                ),
+            ),
+            measurements = measurements,
+        )
+    }
+}
+
+@Preview(device = Devices.PortraitRegular)
+@Composable
+private fun RatingsLowPreview() {
+    PreviewBox { measurements ->
+        RatingsStory(
+            story = Story.Ratings(
+                stats = RatingStats(
+                    ones = 20,
+                    twos = 50,
+                    threes = 0,
+                    fours = 25,
+                    fives = 0,
+                ),
+            ),
+            measurements = measurements,
+        )
+    }
+}
+
+@Preview(device = Devices.PortraitSmall)
+@Composable
+private fun RatingsNonePreview() {
+    PreviewBox { measurements ->
+        RatingsStory(
+            story = Story.Ratings(
+                stats = RatingStats(
+                    ones = 0,
+                    twos = 0,
+                    threes = 0,
+                    fours = 0,
+                    fives = 0,
+                ),
+            ),
+            measurements = measurements,
+        )
+    }
+}

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/ui/StoriesPage.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/ui/StoriesPage.kt
@@ -140,7 +140,7 @@ private fun Stories(
             is Story.NumberOfShows -> NumberOfShowsStory(story, sizes)
             is Story.TopShow -> TopShowStory(story, sizes)
             is Story.TopShows -> TopShowsStory(story, sizes)
-            is Story.Ratings -> StoryPlaceholder(story)
+            is Story.Ratings -> RatingsStory(story, sizes)
             is Story.TotalTime -> StoryPlaceholder(story)
             is Story.LongestEpisode -> StoryPlaceholder(story)
             is Story.PlusInterstitial -> StoryPlaceholder(story)

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/ui/TopShowStory.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/ui/TopShowStory.kt
@@ -34,11 +34,11 @@ import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import au.com.shiftyjelly.pocketcasts.compose.Devices
 import au.com.shiftyjelly.pocketcasts.compose.components.PodcastImage
 import au.com.shiftyjelly.pocketcasts.compose.components.TextH10
 import au.com.shiftyjelly.pocketcasts.compose.components.TextP40
-import au.com.shiftyjelly.pocketcasts.compose.extensions.nonScaledSp
 import au.com.shiftyjelly.pocketcasts.endofyear.Story
 import au.com.shiftyjelly.pocketcasts.localization.R
 import au.com.shiftyjelly.pocketcasts.models.to.TopPodcast
@@ -125,7 +125,7 @@ internal fun TopShowStory(
                     R.string.end_of_year_story_top_podcast_title,
                     story.show.title,
                 ),
-                fontSize = 31.nonScaledSp,
+                disableScale = true,
                 color = colorResource(UR.color.coolgrey_90),
                 modifier = Modifier.padding(horizontal = 24.dp),
             )
@@ -141,7 +141,8 @@ internal fun TopShowStory(
                         LocalContext.current.resources,
                     ),
                 ),
-                fontSize = 15.nonScaledSp,
+                fontSize = 15.sp,
+                disableScale = true,
                 color = colorResource(UR.color.coolgrey_90),
                 modifier = Modifier.padding(horizontal = 24.dp),
             )

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/ui/TopShowStory.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/ui/TopShowStory.kt
@@ -175,7 +175,7 @@ internal fun TopShowStory(
 
 @Preview(device = Devices.PortraitRegular)
 @Composable
-fun TopShowPreview() {
+private fun TopShowPreview() {
     PreviewBox { measurements ->
         TopShowStory(
             story = Story.TopShow(

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/ui/TopShowsStory.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/ui/TopShowsStory.kt
@@ -259,7 +259,7 @@ private fun Modifier.fadeScrollingEdges(
 
 @Preview(device = Devices.PortraitRegular)
 @Composable
-fun TopShowsPreview() {
+private fun TopShowsPreview() {
     PreviewBox { measurements ->
         TopShowsStory(
             story = Story.TopShows(

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/ui/TopShowsStory.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/ui/TopShowsStory.kt
@@ -39,12 +39,12 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import au.com.shiftyjelly.pocketcasts.compose.Devices
 import au.com.shiftyjelly.pocketcasts.compose.components.PodcastImage
 import au.com.shiftyjelly.pocketcasts.compose.components.TextH10
 import au.com.shiftyjelly.pocketcasts.compose.components.TextH20
 import au.com.shiftyjelly.pocketcasts.compose.components.TextP40
-import au.com.shiftyjelly.pocketcasts.compose.extensions.nonScaledSp
 import au.com.shiftyjelly.pocketcasts.endofyear.Story
 import au.com.shiftyjelly.pocketcasts.models.to.TopPodcast
 import kotlin.random.Random
@@ -122,7 +122,7 @@ private fun TopShowsStory(
         Column {
             TextH10(
                 text = stringResource(LR.string.eoy_story_top_podcasts_title),
-                fontSize = 31.nonScaledSp,
+                disableScale = true,
                 modifier = Modifier.padding(horizontal = 24.dp),
             )
             ShareStoryButton(onClick = {})
@@ -145,7 +145,7 @@ private fun PodcastItem(
     ) {
         TextH20(
             text = "#${index + 1}",
-            fontSize = 22.nonScaledSp,
+            disableScale = true,
             color = colorResource(UR.color.coolgrey_90),
             modifier = Modifier
                 .offset { IntOffset(x = (50.dp * (1f - animationProgress)).roundToPx(), y = 0) }
@@ -184,13 +184,14 @@ private fun PodcastItem(
         ) {
             TextP40(
                 text = podcast.author,
-                fontSize = 15.nonScaledSp,
+                fontSize = 15.sp,
+                disableScale = true,
                 color = colorResource(UR.color.coolgrey_90),
                 maxLines = 1,
             )
             TextH20(
                 text = podcast.title,
-                fontSize = 22.nonScaledSp,
+                disableScale = true,
                 color = colorResource(UR.color.coolgrey_90),
                 maxLines = 2,
             )

--- a/modules/services/images/src/main/res/drawable/eoy_star_text_stop.xml
+++ b/modules/services/images/src/main/res/drawable/eoy_star_text_stop.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="30dp"
+    android:height="28dp"
+    android:viewportWidth="30"
+    android:viewportHeight="28">
+    <path
+        android:fillColor="#161718"
+        android:pathData="M8.926,27.595C7.152,28.527 5.447,27.279 5.785,25.313L7.032,18.038L1.747,12.887C0.313,11.488 0.972,9.481 2.947,9.194L10.251,8.133L13.517,1.515C14.404,-0.282 16.517,-0.275 17.4,1.515L20.666,8.133L27.97,9.194C29.952,9.482 30.598,11.494 29.17,12.887L23.885,18.038L25.132,25.313C25.471,27.287 23.757,28.523 21.991,27.595L15.458,24.16L8.926,27.595Z" />
+</vector>

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -1783,6 +1783,18 @@
     <string name="end_of_year_stories_theres_more">There\’s more!</string>>
     <!-- Subtitle explaining the user why they should susbcribe to Plus in the context of the end of year stories. -->
     <string name="end_of_year_stories_subscribe_to_plus">Subscribe to Plus and find out how your listening compares to 2022, other fun stats, and Premium features like bookmarks and folders.</string>
+    <!-- Title for the story showing the podcast ratings given by the user. -->
+    <string name="eoy_story_ratings_title_1">Let\'s see your ratings!</string>
+    <!-- Title for the story showing the podcast ratings given by the user when they gave no ratings. -->
+    <string name="eoy_story_ratings_title_2">Oh-oh! No podcast ratings to show you yet</string>
+    <!-- Subtitle for the story showing the podcast ratings given by the user when they gave high ratings. -->
+    <string name="eoy_story_ratings_subtitle_1">Wow, so many %1$d star ratings! Thanks for sharing the love with your favorite creators!</string>
+    <!-- Subtitle for the story showing the podcast ratings given by the user when they gave low ratings. -->
+    <string name="eoy_story_ratings_subtitle_2">Thanks for sharing your feedback with the creator community</string>
+    <!-- Subtitle for the story showing the podcast ratings given by the user when they gave no ratings. -->
+    <string name="eoy_story_ratings_subtitle_3">Did you know that you can rate shows now? Share the love for your favorite creators and help them get noticed!</string>
+    <!-- Label of a button for the story showing podcast ratings given by the user when they gave no ratings. -->
+    <string name="eoy_story_ratings_learn_button_label">Learn about ratings</string>
 
     <!-- Onboarding -->
 

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/to/RatingStats.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/to/RatingStats.kt
@@ -6,4 +6,14 @@ data class RatingStats(
     val threes: Int,
     val fours: Int,
     val fives: Int,
-)
+) {
+    val onesRelative get() = relativeToMax(ones)
+    val twosRelative get() = relativeToMax(twos)
+    val threesRelative get() = relativeToMax(threes)
+    val foursRelative get() = relativeToMax(fours)
+    val fivesRelative get() = relativeToMax(fives)
+
+    private val max = maxOf(ones, twos, threes, fours, fives)
+
+    private fun relativeToMax(value: Int) = if (max == 0) 0f else (value.toFloat() / max)
+}

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/to/RatingStats.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/to/RatingStats.kt
@@ -1,19 +1,48 @@
 package au.com.shiftyjelly.pocketcasts.models.to
 
 data class RatingStats(
-    val ones: Int,
-    val twos: Int,
-    val threes: Int,
-    val fours: Int,
-    val fives: Int,
+    private val ones: Int,
+    private val twos: Int,
+    private val threes: Int,
+    private val fours: Int,
+    private val fives: Int,
 ) {
-    val onesRelative get() = relativeToMax(ones)
-    val twosRelative get() = relativeToMax(twos)
-    val threesRelative get() = relativeToMax(threes)
-    val foursRelative get() = relativeToMax(fours)
-    val fivesRelative get() = relativeToMax(fives)
-
     private val max = maxOf(ones, twos, threes, fours, fives)
 
+    fun count(rating: Rating) = when (rating) {
+        Rating.One -> ones
+        Rating.Two -> twos
+        Rating.Three -> threes
+        Rating.Four -> fours
+        Rating.Five -> fives
+    }
+
+    fun max() = when (max) {
+        fives -> Rating.Five
+        fours -> Rating.Four
+        threes -> Rating.Three
+        twos -> Rating.Two
+        ones -> Rating.One
+        else -> error("Unexpected max value: $max")
+    } to max
+
+    fun relativeToMax(rating: Rating) = when (rating) {
+        Rating.One -> relativeToMax(ones)
+        Rating.Two -> relativeToMax(twos)
+        Rating.Three -> relativeToMax(threes)
+        Rating.Four -> relativeToMax(fours)
+        Rating.Five -> relativeToMax(fives)
+    }
+
     private fun relativeToMax(value: Int) = if (max == 0) 0f else (value.toFloat() / max)
+}
+
+enum class Rating(
+    val numericalValue: Int,
+) {
+    One(1),
+    Two(2),
+    Three(3),
+    Four(4),
+    Five(5),
 }

--- a/modules/services/model/src/test/java/au/com/shiftyjelly/pocketcasts/models/to/RatingStatsTest.kt
+++ b/modules/services/model/src/test/java/au/com/shiftyjelly/pocketcasts/models/to/RatingStatsTest.kt
@@ -5,41 +5,7 @@ import org.junit.Test
 
 class RatingStatsTest {
     @Test
-    fun `relateive sats for no ratings`() {
-        val stats = RatingStats(
-            ones = 0,
-            twos = 0,
-            threes = 0,
-            fours = 0,
-            fives = 0,
-        )
-
-        assertEquals(stats.onesRelative, 0f)
-        assertEquals(stats.twosRelative, 0f)
-        assertEquals(stats.threesRelative, 0f)
-        assertEquals(stats.foursRelative, 0f)
-        assertEquals(stats.fivesRelative, 0f)
-    }
-
-    @Test
-    fun `relative stats for equal ratings`() {
-        val stats = RatingStats(
-            ones = 10,
-            twos = 10,
-            threes = 10,
-            fours = 10,
-            fives = 10,
-        )
-
-        assertEquals(stats.onesRelative, 1f, 0.001f)
-        assertEquals(stats.twosRelative, 1f, 0.001f)
-        assertEquals(stats.threesRelative, 1f, 0.001f)
-        assertEquals(stats.foursRelative, 1f, 0.001f)
-        assertEquals(stats.fivesRelative, 1f, 0.001f)
-    }
-
-    @Test
-    fun `relative stats for ratings`() {
+    fun `rating count`() {
         val stats = RatingStats(
             ones = 0,
             twos = 76,
@@ -48,10 +14,104 @@ class RatingStatsTest {
             fives = 100,
         )
 
-        assertEquals(stats.onesRelative, 0f, 0.001f)
-        assertEquals(stats.twosRelative, 0.76f, 0.001f)
-        assertEquals(stats.threesRelative, 0.25f, 0.001f)
-        assertEquals(stats.foursRelative, 0.11f, 0.001f)
-        assertEquals(stats.fivesRelative, 1f, 0.001f)
+        assertEquals(stats.count(Rating.One), 0)
+        assertEquals(stats.count(Rating.Two), 76)
+        assertEquals(stats.count(Rating.Three), 25)
+        assertEquals(stats.count(Rating.Four), 11)
+        assertEquals(stats.count(Rating.Five), 100)
+    }
+
+    @Test
+    fun `all ratings`() {
+        val stats = RatingStats(
+            ones = 0,
+            twos = 76,
+            threes = 25,
+            fours = 11,
+            fives = 100,
+        )
+
+        assertEquals(stats.count(Rating.One), 0)
+        assertEquals(stats.count(Rating.Two), 76)
+        assertEquals(stats.count(Rating.Three), 25)
+        assertEquals(stats.count(Rating.Four), 11)
+        assertEquals(stats.count(Rating.Five), 100)
+    }
+
+    @Test
+    fun `max rating`() {
+        val stats = RatingStats(
+            ones = 110,
+            twos = 234,
+            threes = 17,
+            fours = 0,
+            fives = 55,
+        )
+
+        assertEquals(stats.max(), Rating.Two to 234)
+    }
+
+    @Test
+    fun `max rating prioritizes higher rating`() {
+        val stats = RatingStats(
+            ones = 110,
+            twos = 234,
+            threes = 17,
+            fours = 0,
+            fives = 234,
+        )
+
+        assertEquals(stats.max(), Rating.Five to 234)
+    }
+
+    @Test
+    fun `relative for no ratings`() {
+        val stats = RatingStats(
+            ones = 0,
+            twos = 0,
+            threes = 0,
+            fours = 0,
+            fives = 0,
+        )
+
+        assertEquals(stats.relativeToMax(Rating.One), 0f)
+        assertEquals(stats.relativeToMax(Rating.Two), 0f)
+        assertEquals(stats.relativeToMax(Rating.Three), 0f)
+        assertEquals(stats.relativeToMax(Rating.Four), 0f)
+        assertEquals(stats.relativeToMax(Rating.Five), 0f)
+    }
+
+    @Test
+    fun `relative for equal ratings`() {
+        val stats = RatingStats(
+            ones = 10,
+            twos = 10,
+            threes = 10,
+            fours = 10,
+            fives = 10,
+        )
+
+        assertEquals(stats.relativeToMax(Rating.One), 1f, 0.001f)
+        assertEquals(stats.relativeToMax(Rating.Two), 1f, 0.001f)
+        assertEquals(stats.relativeToMax(Rating.Three), 1f, 0.001f)
+        assertEquals(stats.relativeToMax(Rating.Four), 1f, 0.001f)
+        assertEquals(stats.relativeToMax(Rating.Five), 1f, 0.001f)
+    }
+
+    @Test
+    fun `relative for ratings`() {
+        val stats = RatingStats(
+            ones = 0,
+            twos = 76,
+            threes = 25,
+            fours = 11,
+            fives = 100,
+        )
+
+        assertEquals(stats.relativeToMax(Rating.One), 0f, 0.001f)
+        assertEquals(stats.relativeToMax(Rating.Two), 0.76f, 0.001f)
+        assertEquals(stats.relativeToMax(Rating.Three), 0.25f, 0.001f)
+        assertEquals(stats.relativeToMax(Rating.Four), 0.11f, 0.001f)
+        assertEquals(stats.relativeToMax(Rating.Five), 1f, 0.001f)
     }
 }

--- a/modules/services/model/src/test/java/au/com/shiftyjelly/pocketcasts/models/to/RatingStatsTest.kt
+++ b/modules/services/model/src/test/java/au/com/shiftyjelly/pocketcasts/models/to/RatingStatsTest.kt
@@ -1,0 +1,57 @@
+package au.com.shiftyjelly.pocketcasts.models.to
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class RatingStatsTest {
+    @Test
+    fun `relateive sats for no ratings`() {
+        val stats = RatingStats(
+            ones = 0,
+            twos = 0,
+            threes = 0,
+            fours = 0,
+            fives = 0,
+        )
+
+        assertEquals(stats.onesRelative, 0f)
+        assertEquals(stats.twosRelative, 0f)
+        assertEquals(stats.threesRelative, 0f)
+        assertEquals(stats.foursRelative, 0f)
+        assertEquals(stats.fivesRelative, 0f)
+    }
+
+    @Test
+    fun `relative stats for equal ratings`() {
+        val stats = RatingStats(
+            ones = 10,
+            twos = 10,
+            threes = 10,
+            fours = 10,
+            fives = 10,
+        )
+
+        assertEquals(stats.onesRelative, 1f, 0.001f)
+        assertEquals(stats.twosRelative, 1f, 0.001f)
+        assertEquals(stats.threesRelative, 1f, 0.001f)
+        assertEquals(stats.foursRelative, 1f, 0.001f)
+        assertEquals(stats.fivesRelative, 1f, 0.001f)
+    }
+
+    @Test
+    fun `relative stats for ratings`() {
+        val stats = RatingStats(
+            ones = 0,
+            twos = 76,
+            threes = 25,
+            fours = 11,
+            fives = 100,
+        )
+
+        assertEquals(stats.onesRelative, 0f, 0.001f)
+        assertEquals(stats.twosRelative, 0.76f, 0.001f)
+        assertEquals(stats.threesRelative, 0.25f, 0.001f)
+        assertEquals(stats.foursRelative, 0.11f, 0.001f)
+        assertEquals(stats.fivesRelative, 1f, 0.001f)
+    }
+}


### PR DESCRIPTION
## Description

This adds ratings story UI.

Figma: lH66LwxxgG8btQ8NrM0ldx-fi-3070_21275

## Testing Instructions

1. Sign in with an account that listened to at least 5 minutes of episodes this year.
2. Sync your profile data.
3. Close the app.
4. Reopen the app.
5. Open Playback 2024.
6. You might see a loading progress bar and it might take some time to sync your data.
7. Once data is synced go to the ratings story and verify it.

## Screenshots or Screencast 

### Preview

| High ratings | Low ratings | No ratings | No ratings small device |
| - | - | - | - |
| ![high](https://github.com/user-attachments/assets/55c88835-edf3-4f99-94a2-86d27ce78508) | ![low](https://github.com/user-attachments/assets/642ae455-35e1-4055-b36f-6719eb462adf) | ![Screenshot_20241016-172428](https://github.com/user-attachments/assets/51840efa-c9c3-400a-923b-f8d1c23cef30) | ![Screenshot 2024-10-16 at 17 25 31](https://github.com/user-attachments/assets/8a6c603d-4e10-40f5-b2e8-a2fed033be52) |

### Ratings animation

https://github.com/user-attachments/assets/38b86b62-05b2-4532-bec8-ca33dc7e816c

### No ratings animation

https://github.com/user-attachments/assets/9c756c8f-fd70-4e17-9b11-3159d4e92c55

## Checklist
- [x] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] ~I have considered whether it makes sense to add tests for my changes~
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] ~for accessibility with TalkBack~