### PR TITLE
[Auto Downloading] - Enable New Episodes toggle by default for New Users Only

### DIFF
--- a/modules/features/shared/src/main/java/au/com/shiftyjelly/pocketcasts/shared/AppLifecycleObserver.kt
+++ b/modules/features/shared/src/main/java/au/com/shiftyjelly/pocketcasts/shared/AppLifecycleObserver.kt
@@ -110,8 +110,13 @@ class AppLifecycleObserver constructor(
                 // do nothing because feature has not been enabled on Wear OS yet
                 AppPlatform.WearOs -> {}
 
-                // For new users we want to auto play when the queue is empty by default
-                AppPlatform.Phone -> settings.autoPlayNextEpisodeOnEmpty.set(true, updateModifiedAt = false)
+                AppPlatform.Phone -> {
+                    // For new users we want to auto play when the queue is empty by default
+                    settings.autoPlayNextEpisodeOnEmpty.set(true, updateModifiedAt = false)
+
+                    // For new users we want to auto download new episodes by default
+                    settings.autoDownloadNewEpisodes.set(true, updateModifiedAt = false)
+                }
             }
         } else if (previousVersionCode < versionCode) {
             appLifecycleAnalytics.onApplicationUpgrade(previousVersionCode)

--- a/modules/features/shared/src/test/java/au/com/shiftyjelly/pocketcasts/shared/AppLifecycleObserverTest.kt
+++ b/modules/features/shared/src/test/java/au/com/shiftyjelly/pocketcasts/shared/AppLifecycleObserverTest.kt
@@ -39,6 +39,8 @@ class AppLifecycleObserverTest {
 
     @Mock private lateinit var autoPlayNextEpisodeSetting: UserSetting<Boolean>
 
+    @Mock private lateinit var autoDownloadNewEpisodesSetting: UserSetting<Boolean>
+
     @Mock private lateinit var useUpNextDarkThemeSetting: UserSetting<Boolean>
 
     @Mock private lateinit var appLifecycleAnalytics: AppLifecycleAnalytics
@@ -60,6 +62,7 @@ class AppLifecycleObserverTest {
     @Before
     fun setUp() {
         whenever(settings.autoPlayNextEpisodeOnEmpty).thenReturn(autoPlayNextEpisodeSetting)
+        whenever(settings.autoDownloadNewEpisodes).thenReturn(autoDownloadNewEpisodesSetting)
         whenever(settings.useDarkUpNextTheme).thenReturn(useUpNextDarkThemeSetting)
 
         whenever(appLifecycleOwner.lifecycle).thenReturn(appLifecycle)
@@ -91,6 +94,7 @@ class AppLifecycleObserverTest {
 
         verify(appLifecycleAnalytics).onNewApplicationInstall()
         verify(autoPlayNextEpisodeSetting).set(true, updateModifiedAt = false)
+        verify(autoDownloadNewEpisodesSetting).set(true, updateModifiedAt = false)
         verify(useUpNextDarkThemeSetting).set(false, updateModifiedAt = false)
 
         verify(appLifecycleAnalytics, never()).onApplicationUpgrade(any())
@@ -108,6 +112,7 @@ class AppLifecycleObserverTest {
         verify(appLifecycleAnalytics).onNewApplicationInstall()
 
         verify(autoPlayNextEpisodeSetting, never()).set(any(), any(), any(), any())
+        verify(autoDownloadNewEpisodesSetting, never()).set(any(), any(), any(), any())
         verify(useUpNextDarkThemeSetting).set(false, updateModifiedAt = false)
         verify(appLifecycleAnalytics, never()).onApplicationUpgrade(any())
     }
@@ -124,6 +129,7 @@ class AppLifecycleObserverTest {
         verify(appLifecycleAnalytics).onNewApplicationInstall()
 
         verify(autoPlayNextEpisodeSetting, never()).set(any(), any(), any(), any())
+        verify(autoDownloadNewEpisodesSetting, never()).set(any(), any(), any(), any())
         verify(useUpNextDarkThemeSetting).set(false, updateModifiedAt = false)
         verify(appLifecycleAnalytics, never()).onApplicationUpgrade(any())
     }
@@ -140,6 +146,7 @@ class AppLifecycleObserverTest {
 
         verify(appLifecycleAnalytics, never()).onNewApplicationInstall()
         verify(autoPlayNextEpisodeSetting, never()).set(any(), any(), any(), any())
+        verify(autoDownloadNewEpisodesSetting, never()).set(any(), any(), any(), any())
         verify(useUpNextDarkThemeSetting, never()).set(any(), any(), any(), any())
     }
 }

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
@@ -546,7 +546,7 @@ class SettingsImpl @Inject constructor(
 
     override val autoDownloadNewEpisodes = UserSetting.BoolPref(
         sharedPrefKey = "autoDownloadNewEpisodes",
-        defaultValue = true,
+        defaultValue = false,
         sharedPrefs = sharedPreferences,
     )
 


### PR DESCRIPTION
## Description
- We want to enable the `New Episodes` toggle by default for New Users Only
- See the context here: p1729146760964459/1729083057.704669-slack-C07QMC2GB1B

Fixes #3034

## Testing Instructions

### Fresh Install and creating new Account
1. Fresh install the app
2. Don't Log in
3. Go to Profile -> Settings -> Auto Download
4. ✅ Ensure `New Episodes` toggle is **ON**
5. Go to Profile -> Account -> Create a new account
6. ✅ Ensure `New Episodes` toggle is **ON**

### Fresh Install & using existing account
1. Fresh install the app
2. Don't Log in
3. Go to Profile -> Settings -> Auto Download
4. ✅ Ensure `New Episodes` toggle is **ON**
5. Go to Profile -> Account -> Log in with existing account
6. ✅ Ensure `New Episodes` toggle is **ON**

### Existing user upgrading the app
1. Checkout to d76d68717ca94253a12b4ee9cadb99b5e3e8e7de
2. Install the app
3. Log in
4. Go to Profile -> Settings -> Auto Download -> Disable  `New Episodes`
5. Checkout to this branch
6. Install the app again
7. Run the app and check the `New Episodes`
8. ✅ Ensure `New Episodes` toggle is **OFF**

## Screenshots or Screencast 
<img width="300" alt="image" src="https://github.com/user-attachments/assets/4ba7855b-ee8f-4a71-ba07-880117cf4a66">


## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.