### PR TITLE
Migrate `VersionMigrationsJob` to worker

### DIFF
--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/repositories/jobs/VersionMigrationsWorkerTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/repositories/jobs/VersionMigrationsWorkerTest.kt
@@ -10,7 +10,7 @@ import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 
 @RunWith(AndroidJUnit4::class)
-class VersionMigrationsJobTest {
+class VersionMigrationsWorkerTest {
 
     @Test
     fun testUpgradeMultiSelectItems() {
@@ -20,7 +20,7 @@ class VersionMigrationsJobTest {
         val settings = mock<Settings>()
         whenever(settings.getMultiSelectItems()).thenReturn(resourceIds)
 
-        VersionMigrationsJob.upgradeMultiSelectItems(settings)
+        VersionMigrationsWorker.upgradeMultiSelectItems(settings)
 
         verify(settings).setMultiSelectItems(expectedItems)
     }
@@ -32,7 +32,7 @@ class VersionMigrationsJobTest {
         val settings = mock<Settings>()
         whenever(settings.getMultiSelectItems()).thenReturn(items)
 
-        VersionMigrationsJob.upgradeMultiSelectItems(settings)
+        VersionMigrationsWorker.upgradeMultiSelectItems(settings)
 
         verify(settings, never()).setMultiSelectItems(items)
     }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -538,7 +538,7 @@
         <service android:name="au.com.shiftyjelly.pocketcasts.repositories.refresh.RefreshPodcastsJob"
                  android:permission="android.permission.BIND_JOB_SERVICE"
                  android:exported="true"/>
-        <service android:name="au.com.shiftyjelly.pocketcasts.repositories.jobs.VersionMigrationsJob"
+        <service android:name="au.com.shiftyjelly.pocketcasts.repositories.jobs.VersionMigrationsWorker"
                  android:permission="android.permission.BIND_JOB_SERVICE"
                  android:exported="true"/>
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -538,9 +538,6 @@
         <service android:name="au.com.shiftyjelly.pocketcasts.repositories.refresh.RefreshPodcastsJob"
                  android:permission="android.permission.BIND_JOB_SERVICE"
                  android:exported="true"/>
-        <service android:name="au.com.shiftyjelly.pocketcasts.repositories.jobs.VersionMigrationsWorker"
-                 android:permission="android.permission.BIND_JOB_SERVICE"
-                 android:exported="true"/>
 
         <receiver android:name="au.com.shiftyjelly.pocketcasts.repositories.playback.SleepTimerReceiver" />
 

--- a/app/src/main/java/au/com/shiftyjelly/pocketcasts/PocketCastsApplication.kt
+++ b/app/src/main/java/au/com/shiftyjelly/pocketcasts/PocketCastsApplication.kt
@@ -19,7 +19,7 @@ import au.com.shiftyjelly.pocketcasts.repositories.download.DownloadManager
 import au.com.shiftyjelly.pocketcasts.repositories.endofyear.EndOfYearSync
 import au.com.shiftyjelly.pocketcasts.repositories.file.FileStorage
 import au.com.shiftyjelly.pocketcasts.repositories.file.StorageOptions
-import au.com.shiftyjelly.pocketcasts.repositories.jobs.VersionMigrationsJob
+import au.com.shiftyjelly.pocketcasts.repositories.jobs.VersionMigrationsWorker
 import au.com.shiftyjelly.pocketcasts.repositories.notification.NotificationHelper
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
 import au.com.shiftyjelly.pocketcasts.repositories.playback.SleepTimerRestartWhenShakingDevice
@@ -244,7 +244,7 @@ class PocketCastsApplication : Application(), Configuration.Provider {
                     Timber.e(e, "Unable to create opml folder.")
                 }
 
-                VersionMigrationsJob.run(
+                VersionMigrationsWorker.run(
                     podcastManager = podcastManager,
                     settings = settings,
                     syncManager = syncManager,

--- a/app/src/main/java/au/com/shiftyjelly/pocketcasts/PocketCastsApplication.kt
+++ b/app/src/main/java/au/com/shiftyjelly/pocketcasts/PocketCastsApplication.kt
@@ -244,7 +244,7 @@ class PocketCastsApplication : Application(), Configuration.Provider {
                     Timber.e(e, "Unable to create opml folder.")
                 }
 
-                VersionMigrationsWorker.run(
+                VersionMigrationsWorker.performMigrations(
                     podcastManager = podcastManager,
                     settings = settings,
                     syncManager = syncManager,

--- a/automotive/src/main/AndroidManifest.xml
+++ b/automotive/src/main/AndroidManifest.xml
@@ -58,7 +58,7 @@
         <service android:name=".repositories.refresh.RefreshPodcastsJob"
             android:permission="android.permission.BIND_JOB_SERVICE"
             android:exported="true"/>
-        <service android:name=".repositories.jobs.VersionMigrationsJob"
+        <service android:name=".repositories.jobs.VersionMigrationsWorker"
             android:permission="android.permission.BIND_JOB_SERVICE"
             android:exported="true"/>
 

--- a/automotive/src/main/AndroidManifest.xml
+++ b/automotive/src/main/AndroidManifest.xml
@@ -58,9 +58,6 @@
         <service android:name=".repositories.refresh.RefreshPodcastsJob"
             android:permission="android.permission.BIND_JOB_SERVICE"
             android:exported="true"/>
-        <service android:name=".repositories.jobs.VersionMigrationsWorker"
-            android:permission="android.permission.BIND_JOB_SERVICE"
-            android:exported="true"/>
 
         <!-- Work Manager -->
         <provider

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/jobs/JobIds.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/jobs/JobIds.kt
@@ -2,6 +2,4 @@ package au.com.shiftyjelly.pocketcasts.repositories.jobs
 
 object JobIds {
     const val REFRESH_PODCASTS_JOB_ID = 51111
-    const val EPISODE_METADATA_JOB_ID = 62222
-    const val VERSION_MIGRATION_JOB_ID = 70000
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/jobs/JobIds.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/jobs/JobIds.kt
@@ -1,5 +1,0 @@
-package au.com.shiftyjelly.pocketcasts.repositories.jobs
-
-object JobIds {
-    const val REFRESH_PODCASTS_JOB_ID = 51111
-}

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/jobs/VersionMigrationsWorker.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/jobs/VersionMigrationsWorker.kt
@@ -139,7 +139,7 @@ class VersionMigrationsWorker @AssistedInject constructor(
         }
     }
 
-    private fun performMigrationsAsync() {
+    private suspend fun performMigrationsAsync() {
         val previousVersionCode = settings.getMigratedVersionCode()
         val versionCode = settings.getVersionCode()
 
@@ -195,9 +195,9 @@ class VersionMigrationsWorker @AssistedInject constructor(
         }
     }
 
-    private fun removeCustomEpisodes() {
+    private suspend fun removeCustomEpisodes() {
         val customPodcastUuid = "customFolderPodcast"
-        val podcast: Podcast = podcastManager.findPodcastByUuid(customPodcastUuid) ?: return
+        val podcast: Podcast = podcastManager.findPodcastByUuidSuspend(customPodcastUuid) ?: return
         val episodes: List<PodcastEpisode> = episodeManager.findEpisodesByPodcastOrderedByPublishDate(podcast)
         episodes.forEach { episode ->
             playbackManager.removeEpisode(
@@ -245,7 +245,7 @@ class VersionMigrationsWorker @AssistedInject constructor(
         }
     }
 
-    private fun upgradeTrimSilenceMode() {
+    private suspend fun upgradeTrimSilenceMode() {
         try {
             val podcasts = podcastManager.findSubscribed()
             podcasts.forEach { podcast ->

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/jobs/VersionMigrationsWorker.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/jobs/VersionMigrationsWorker.kt
@@ -88,7 +88,7 @@ class VersionMigrationsWorker @AssistedInject constructor(
 
             LogBuffer.i(LogBuffer.TAG_BACKGROUND_TASKS, "Running VersionMigrationsWorker")
             val workRequest = OneTimeWorkRequestBuilder<VersionMigrationsWorker>().build()
-            WorkManager.getInstance(context).enqueueUniqueWork(VERSION_MIGRATIONS_WORKER_NAME, ExistingWorkPolicy.REPLACE, workRequest)
+            WorkManager.getInstance(context).enqueueUniqueWork(VERSION_MIGRATIONS_WORKER_NAME, ExistingWorkPolicy.KEEP, workRequest)
         }
 
         /**

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/jobs/VersionMigrationsWorker.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/jobs/VersionMigrationsWorker.kt
@@ -166,7 +166,6 @@ class VersionMigrationsWorker @AssistedInject constructor(
         removeCustomEpisodes()
         removeOldTempPodcastDirectory()
         unscheduleEpisodeDetailsJob(applicationContext)
-        unscheduleRefreshJob(applicationContext)
 
         if (previousVersionCode < 6362) {
             upgradeTrimSilenceMode()
@@ -244,11 +243,6 @@ class VersionMigrationsWorker @AssistedInject constructor(
                 LogBuffer.i(LogBuffer.TAG_BACKGROUND_TASKS, "Unscheduling UpdateEpisodeDetailsJob ${jobInfo.id}")
             }
         }
-    }
-
-    private fun unscheduleRefreshJob(context: Context) {
-        val jobScheduler = context.getSystemService(Context.JOB_SCHEDULER_SERVICE) as? JobScheduler ?: return
-        jobScheduler.cancel(JobIds.REFRESH_PODCASTS_JOB_ID)
     }
 
     private fun upgradeTrimSilenceMode() {

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/jobs/VersionMigrationsWorker.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/jobs/VersionMigrationsWorker.kt
@@ -29,7 +29,7 @@ import timber.log.Timber
 
 @AndroidEntryPoint
 @SuppressLint("SpecifyJobSchedulerIdRange")
-class VersionMigrationsJob : JobService() {
+class VersionMigrationsWorker : JobService() {
 
     companion object {
         fun run(podcastManager: PodcastManager, settings: Settings, syncManager: SyncManager, context: Context) {
@@ -78,7 +78,7 @@ class VersionMigrationsJob : JobService() {
             val jobScheduler = context.getSystemService(Context.JOB_SCHEDULER_SERVICE) as JobScheduler
             jobScheduler.cancel(JobIds.VERSION_MIGRATION_JOB_ID)
             jobScheduler.schedule(
-                JobInfo.Builder(JobIds.VERSION_MIGRATION_JOB_ID, ComponentName(context, VersionMigrationsJob::class.java))
+                JobInfo.Builder(JobIds.VERSION_MIGRATION_JOB_ID, ComponentName(context, VersionMigrationsWorker::class.java))
                     .setOverrideDeadline(500) // don't let Android wait for more than 500ms before kicking this off
                     .build(),
             )

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PodcastManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PodcastManager.kt
@@ -83,7 +83,7 @@ interface PodcastManager {
     suspend fun updateAutoAddToUpNextsIf(podcastUuids: List<String>, newValue: Podcast.AutoAddUpNext, onlyIfValue: Podcast.AutoAddUpNext)
     fun updateExcludeFromAutoArchive(podcast: Podcast, excludeFromAutoArchive: Boolean)
     fun updateOverrideGlobalEffects(podcast: Podcast, override: Boolean)
-    fun updateTrimMode(podcast: Podcast, trimMode: TrimMode)
+    suspend fun updateTrimMode(podcast: Podcast, trimMode: TrimMode)
     fun updateVolumeBoosted(podcast: Podcast, override: Boolean)
     fun updatePlaybackSpeed(podcast: Podcast, speed: Double)
     fun updateEffects(podcast: Podcast, effects: PlaybackEffects)

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PodcastManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PodcastManagerImpl.kt
@@ -662,7 +662,7 @@ class PodcastManagerImpl @Inject constructor(
         podcastDao.updateOverrideGlobalEffects(override, podcast.uuid)
     }
 
-    override fun updateTrimMode(podcast: Podcast, trimMode: TrimMode) {
+    override suspend fun updateTrimMode(podcast: Podcast, trimMode: TrimMode) {
         podcast.trimMode = trimMode
         podcastDao.updateTrimSilenceMode(trimMode, podcast.uuid)
     }
@@ -679,7 +679,9 @@ class PodcastManagerImpl @Inject constructor(
 
     override fun updateEffects(podcast: Podcast, effects: PlaybackEffects) {
         podcastDao.updateEffects(effects.playbackSpeed, effects.isVolumeBoosted, effects.trimMode, podcast.uuid)
-        updateTrimMode(podcast, effects.trimMode)
+        launch {
+            updateTrimMode(podcast, effects.trimMode)
+        }
     }
 
     override fun updateEpisodesSortType(podcast: Podcast, episodesSortType: EpisodesSortType) {

--- a/wear/src/main/AndroidManifest.xml
+++ b/wear/src/main/AndroidManifest.xml
@@ -81,7 +81,7 @@
         <service android:name="au.com.shiftyjelly.pocketcasts.repositories.refresh.RefreshPodcastsJob"
             android:permission="android.permission.BIND_JOB_SERVICE"
             android:exported="true"/>
-        <service android:name="au.com.shiftyjelly.pocketcasts.repositories.jobs.VersionMigrationsJob"
+        <service android:name="au.com.shiftyjelly.pocketcasts.repositories.jobs.VersionMigrationsWorker"
             android:permission="android.permission.BIND_JOB_SERVICE"
             android:exported="true"/>
 

--- a/wear/src/main/AndroidManifest.xml
+++ b/wear/src/main/AndroidManifest.xml
@@ -81,9 +81,6 @@
         <service android:name="au.com.shiftyjelly.pocketcasts.repositories.refresh.RefreshPodcastsJob"
             android:permission="android.permission.BIND_JOB_SERVICE"
             android:exported="true"/>
-        <service android:name="au.com.shiftyjelly.pocketcasts.repositories.jobs.VersionMigrationsWorker"
-            android:permission="android.permission.BIND_JOB_SERVICE"
-            android:exported="true"/>
 
         <!-- File sharing / Opml export -->
         <provider

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/PocketCastsWearApplication.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/PocketCastsWearApplication.kt
@@ -107,7 +107,7 @@ class PocketCastsWearApplication : Application(), Configuration.Provider {
                 }
             }
 
-            VersionMigrationsWorker.run(
+            VersionMigrationsWorker.performMigrations(
                 podcastManager = podcastManager,
                 settings = settings,
                 syncManager = syncManager,

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/PocketCastsWearApplication.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/PocketCastsWearApplication.kt
@@ -9,7 +9,7 @@ import au.com.shiftyjelly.pocketcasts.crashlogging.InitializeRemoteLogging
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.repositories.download.DownloadManager
 import au.com.shiftyjelly.pocketcasts.repositories.file.StorageOptions
-import au.com.shiftyjelly.pocketcasts.repositories.jobs.VersionMigrationsJob
+import au.com.shiftyjelly.pocketcasts.repositories.jobs.VersionMigrationsWorker
 import au.com.shiftyjelly.pocketcasts.repositories.notification.NotificationHelper
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
@@ -107,7 +107,7 @@ class PocketCastsWearApplication : Application(), Configuration.Provider {
                 }
             }
 
-            VersionMigrationsJob.run(
+            VersionMigrationsWorker.run(
                 podcastManager = podcastManager,
                 settings = settings,
                 syncManager = syncManager,


### PR DESCRIPTION
## Description
This migrates `VersionMigrationsJob` to worker.

Fixes #3009

## Testing Instructions
Code review should be sufficient. 

`Optional`
1. Change version code to `375` in `version.properties`
2. Fresh install the app
3. Change version code to `376` in `version.properties`
4. Reinstall the app 
5. Notice  `VersionMigrationsWorker - finished` in `Help & feedback` -> `Logs`


## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
