### PR TITLE
Display story progress indicator

### DIFF
--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/EndOfYearViewModel.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/EndOfYearViewModel.kt
@@ -10,6 +10,7 @@ import au.com.shiftyjelly.pocketcasts.repositories.endofyear.EndOfYearManager
 import au.com.shiftyjelly.pocketcasts.repositories.endofyear.EndOfYearStats
 import au.com.shiftyjelly.pocketcasts.repositories.endofyear.EndOfYearSync
 import au.com.shiftyjelly.pocketcasts.repositories.subscription.SubscriptionManager
+import au.com.shiftyjelly.pocketcasts.utils.coroutines.CachedAction
 import au.com.shiftyjelly.pocketcasts.utils.extensions.padEnd
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
@@ -17,8 +18,14 @@ import dagger.assisted.AssistedInject
 import dagger.hilt.android.lifecycle.HiltViewModel
 import java.time.Year
 import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
@@ -32,14 +39,23 @@ class EndOfYearViewModel @AssistedInject constructor(
     subscriptionManager: SubscriptionManager,
 ) : ViewModel() {
     private val syncState = MutableStateFlow<SyncState>(SyncState.Syncing)
+    private val progress = MutableStateFlow(0f)
+    private var countDownJob: Job? = null
+    private val eoyStats = CachedAction<Year, Pair<EndOfYearStats, RandomShowIds?>> {
+        val stats = endOfYearManager.getStats(year)
+        stats to getRandomShowIds(stats)
+    }
+    private val _switchStory = MutableSharedFlow<Unit>()
+    internal val switchStory get() = _switchStory.asSharedFlow()
 
     internal val uiState = combine(
         syncState,
         subscriptionManager.subscriptionTier(),
+        progress,
         ::createUiModel,
     ).stateIn(viewModelScope, SharingStarted.Lazily, UiState.Syncing)
 
-    fun syncData() {
+    internal fun syncData() {
         viewModelScope.launch {
             syncState.emit(SyncState.Syncing)
             val isSynced = endOfYearSync.sync(year)
@@ -50,36 +66,30 @@ class EndOfYearViewModel @AssistedInject constructor(
     private suspend fun createUiModel(
         syncState: SyncState,
         subscriptionTier: SubscriptionTier,
+        progress: Float,
     ) = when (syncState) {
         SyncState.Syncing -> UiState.Syncing
         SyncState.Failure -> UiState.Failure
         SyncState.Synced -> {
-            val stats = endOfYearManager.getStats(year)
-            val stories = createStories(stats, subscriptionTier)
-            UiState.Synced(stories)
+            val (stats, randomShowIds) = eoyStats.run(year, viewModelScope).await()
+            val stories = createStories(stats, randomShowIds, subscriptionTier)
+            UiState.Synced(stories, progress)
         }
     }
 
     private fun createStories(
         stats: EndOfYearStats,
+        randomShowIds: RandomShowIds?,
         subscriptionTier: SubscriptionTier,
     ): List<Story> = buildList {
         add(Story.Cover)
-        val showIds = stats.playedPodcastIds.shuffled().take(8)
-        if (showIds.isNotEmpty()) {
-            val showChunks = showIds.chunked(4)
-            val topShowIds = showChunks[0].padEnd(4)
-            val bottomShowIds = showChunks.getOrNull(1)
-                ?.plus(topShowIds)
-                ?.take(4)
-                .orEmpty()
-                .ifEmpty { showChunks[0].padEnd(8).takeLast(4) }
+        if (randomShowIds != null) {
             add(
                 Story.NumberOfShows(
                     showCount = stats.playedPodcastCount,
                     epsiodeCount = stats.playedEpisodeCount,
-                    topShowIds = topShowIds,
-                    bottomShowIds = bottomShowIds,
+                    topShowIds = randomShowIds.topShows,
+                    bottomShowIds = randomShowIds.bottomShows,
                 ),
             )
         }
@@ -114,6 +124,47 @@ class EndOfYearViewModel @AssistedInject constructor(
         add(Story.Ending)
     }
 
+    internal fun onStoryChanged(story: Story) {
+        viewModelScope.launch {
+            countDownJob?.cancelAndJoin()
+            progress.value = 0f
+            val previewDuration = story.previewDuration
+            if (previewDuration != null) {
+                val progressDelay = previewDuration / 100
+                countDownJob = launch {
+                    var currentProgress = 0f
+                    while (currentProgress < 1f) {
+                        currentProgress += 0.01f
+                        progress.value = currentProgress
+                        delay(progressDelay)
+                    }
+                    _switchStory.emit(Unit)
+                }
+            }
+        }
+    }
+
+    private fun getRandomShowIds(stats: EndOfYearStats): RandomShowIds? {
+        val showIds = stats.playedPodcastIds
+        return if (showIds.isNotEmpty()) {
+            val showChunks = showIds.chunked(4)
+            val topShowIds = showChunks[0].padEnd(4)
+            val bottomShowIds = showChunks.getOrNull(1)
+                ?.plus(topShowIds)
+                ?.take(4)
+                .orEmpty()
+                .ifEmpty { showChunks[0].padEnd(8).takeLast(4) }
+            RandomShowIds(topShowIds, bottomShowIds)
+        } else {
+            null
+        }
+    }
+
+    private data class RandomShowIds(
+        val topShows: List<String>,
+        val bottomShows: List<String>,
+    )
+
     @AssistedFactory
     interface Factory {
         fun create(year: Year): EndOfYearViewModel
@@ -122,6 +173,8 @@ class EndOfYearViewModel @AssistedInject constructor(
 
 @Immutable
 internal sealed interface UiState {
+    val storyProgress: Float get() = 0f
+
     data object Syncing : UiState
 
     data object Failure : UiState
@@ -129,11 +182,14 @@ internal sealed interface UiState {
     @Immutable
     data class Synced(
         val stories: List<Story>,
+        override val storyProgress: Float,
     ) : UiState
 }
 
 @Immutable
 internal sealed interface Story {
+    val previewDuration: Duration? get() = 7.seconds
+
     data object Cover : Story
 
     @Immutable
@@ -165,18 +221,21 @@ internal sealed interface Story {
         val episode: LongestEpisodeData,
     ) : Story
 
-    data object PlusInterstitial : Story
+    data object PlusInterstitial : Story {
+        override val previewDuration: Duration? get() = null
+    }
 
     data class YearVsYear(
         val lastYearDuration: Duration,
         val thisYearDuration: Duration,
         val subscriptionTier: SubscriptionTier?,
     ) : Story {
-        val yearOverYearChange get() = when {
-            lastYearDuration == thisYearDuration -> 1.0
-            lastYearDuration == Duration.ZERO -> Double.POSITIVE_INFINITY
-            else -> thisYearDuration / lastYearDuration
-        }
+        val yearOverYearChange
+            get() = when {
+                lastYearDuration == thisYearDuration -> 1.0
+                lastYearDuration == Duration.ZERO -> Double.POSITIVE_INFINITY
+                else -> thisYearDuration / lastYearDuration
+            }
     }
 
     data class CompletionRate(
@@ -184,10 +243,11 @@ internal sealed interface Story {
         val completedCount: Int,
         val subscriptionTier: SubscriptionTier?,
     ) : Story {
-        val completionRate get() = when {
-            listenedCount == 0 -> 1.0
-            else -> completedCount.toDouble() / listenedCount
-        }
+        val completionRate
+            get() = when {
+                listenedCount == 0 -> 1.0
+                else -> completedCount.toDouble() / listenedCount
+            }
     }
 
     data object Ending : Story

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/ui/Common.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/ui/Common.kt
@@ -1,9 +1,11 @@
 package au.com.shiftyjelly.pocketcasts.endofyear.ui
 
+import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.requiredHeight
+import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.material.ButtonDefaults
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
@@ -173,8 +175,10 @@ internal class HumaneTextFactory(
     }
 }
 
+@OptIn(ExperimentalFoundationApi::class)
 @Composable
 internal fun PreviewBox(
+    currentPage: Int,
     content: @Composable (EndOfYearMeasurements) -> Unit,
 ) {
     BoxWithConstraints {
@@ -187,6 +191,10 @@ internal fun PreviewBox(
                 closeButtonBottomEdge = 44.dp,
             ),
         )
-        CloseButton(onClose = {})
+        TopControls(
+            pagerState = rememberPagerState(initialPage = currentPage, pageCount = { 11 }),
+            progress = 0f,
+            onClose = {},
+        )
     }
 }

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/ui/CompletionRateStory.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/ui/CompletionRateStory.kt
@@ -256,7 +256,7 @@ private fun CompletionRateInfo(
 private fun CompletionRatePreview(
     @PreviewParameter(CompletedCountProvider::class) count: Int,
 ) {
-    PreviewBox { measurements ->
+    PreviewBox(currentPage = 9) { measurements ->
         CompletionRateStory(
             story = Story.CompletionRate(
                 listenedCount = 100,

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/ui/CoverStory.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/ui/CoverStory.kt
@@ -80,7 +80,7 @@ internal fun CoverStory(
 @Preview(device = Devices.PortraitRegular)
 @Composable
 private fun CoverStoryPreview() {
-    PreviewBox { measurements ->
+    PreviewBox(currentPage = 0) { measurements ->
         CoverStory(
             story = Story.Cover,
             measurements = measurements,

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/ui/EndingStory.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/ui/EndingStory.kt
@@ -157,7 +157,7 @@ private fun EndingInfo(
 @Preview(device = Devices.PortraitRegular)
 @Composable
 private fun EndingPreview() {
-    PreviewBox { measurements ->
+    PreviewBox(currentPage = 10) { measurements ->
         EndingStory(
             story = Story.Ending,
             measurements = measurements,

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/ui/LongestEpisodeStory.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/ui/LongestEpisodeStory.kt
@@ -251,7 +251,7 @@ private fun TextInfo(
 @Preview(device = Devices.PortraitRegular)
 @Composable
 private fun LongestEpisodePreview() {
-    PreviewBox { measurements ->
+    PreviewBox(currentPage = 6) { measurements ->
         LongestEpisodeStory(
             story = Story.LongestEpisode(
                 episode = LongestEpisode(

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/ui/NumberOfShowsStory.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/ui/NumberOfShowsStory.kt
@@ -140,7 +140,7 @@ private fun PodcastCoverCarousel(
 @Preview(device = Devices.PortraitRegular)
 @Composable
 private fun NumberOfShowsPreview() {
-    PreviewBox { measurements ->
+    PreviewBox(currentPage = 1) { measurements ->
         NumberOfShowsStory(
             story = Story.NumberOfShows(
                 showCount = 20,

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/ui/PlusInterstitialStory.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/ui/PlusInterstitialStory.kt
@@ -165,7 +165,7 @@ private fun PlusInfo(
 @Preview(device = Devices.PortraitRegular)
 @Composable
 private fun PlusInterstitialPreview() {
-    PreviewBox { measurements ->
+    PreviewBox(currentPage = 7) { measurements ->
         PlusInterstitialStory(
             story = Story.PlusInterstitial,
             measurements = measurements,

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/ui/RatingsStory.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/ui/RatingsStory.kt
@@ -391,7 +391,7 @@ private fun NoRatingsInfo(
 @Preview(device = Devices.PortraitRegular)
 @Composable
 private fun RatingsHighPreview() {
-    PreviewBox { measurements ->
+    PreviewBox(currentPage = 4) { measurements ->
         RatingsStory(
             story = Story.Ratings(
                 stats = RatingStats(
@@ -411,7 +411,7 @@ private fun RatingsHighPreview() {
 @Preview(device = Devices.PortraitRegular)
 @Composable
 private fun RatingsLowPreview() {
-    PreviewBox { measurements ->
+    PreviewBox(currentPage = 4) { measurements ->
         RatingsStory(
             story = Story.Ratings(
                 stats = RatingStats(
@@ -431,7 +431,7 @@ private fun RatingsLowPreview() {
 @Preview(device = Devices.PortraitRegular)
 @Composable
 private fun RatingsNonePreview() {
-    PreviewBox { measurements ->
+    PreviewBox(currentPage = 4) { measurements ->
         RatingsStory(
             story = Story.Ratings(
                 stats = RatingStats(

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/ui/StoriesPage.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/ui/StoriesPage.kt
@@ -10,11 +10,14 @@ import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.pager.HorizontalPager
-import androidx.compose.foundation.pager.rememberPagerState
+import androidx.compose.foundation.pager.PagerState
 import androidx.compose.material.LinearProgressIndicator
 import androidx.compose.material.ripple.rememberRipple
 import androidx.compose.runtime.Composable
@@ -37,6 +40,7 @@ import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.coerceAtLeast
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import au.com.shiftyjelly.pocketcasts.compose.components.PagerProgressingIndicator
 import au.com.shiftyjelly.pocketcasts.compose.components.TextH10
 import au.com.shiftyjelly.pocketcasts.endofyear.Story
 import au.com.shiftyjelly.pocketcasts.endofyear.UiState
@@ -45,9 +49,11 @@ import kotlinx.coroutines.launch
 import au.com.shiftyjelly.pocketcasts.images.R as IR
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
+@OptIn(ExperimentalFoundationApi::class)
 @Composable
 internal fun StoriesPage(
     state: UiState,
+    pagerState: PagerState,
     onClose: () -> Unit,
 ) {
     val size = LocalContext.current.sizeLimit?.let(Modifier::size) ?: Modifier.fillMaxSize()
@@ -75,10 +81,11 @@ internal fun StoriesPage(
                     coverFontSize = coverFontSize,
                     coverTextHeight = coverTextHeight,
                 ),
+                pagerState = pagerState,
             )
         }
 
-        CloseButton(onClose)
+        TopControls(pagerState, state.storyProgress, onClose)
 
         // Use an invisible 'PLAYBACK' text to compute an appropriate font size.
         // The font should occupy the whole viewport's width with some padding.
@@ -111,8 +118,8 @@ internal fun StoriesPage(
 private fun Stories(
     stories: List<Story>,
     measurements: EndOfYearMeasurements,
+    pagerState: PagerState,
 ) {
-    val pagerState = rememberPagerState(pageCount = { stories.size })
     val coroutineScope = rememberCoroutineScope()
     val widthPx = LocalDensity.current.run { measurements.width.toPx() }
 
@@ -150,26 +157,42 @@ private fun Stories(
     }
 }
 
+@OptIn(ExperimentalFoundationApi::class)
 @Composable
-internal fun BoxScope.CloseButton(
+internal fun BoxScope.TopControls(
+    pagerState: PagerState,
+    progress: Float,
     onClose: () -> Unit,
 ) {
-    Image(
-        painter = painterResource(IR.drawable.ic_close),
-        contentDescription = stringResource(LR.string.close),
-        colorFilter = ColorFilter.tint(Color.Black),
+    Column(
+        horizontalAlignment = Alignment.End,
         modifier = Modifier
-            .align(Alignment.TopEnd)
-            .padding(top = 20.dp, end = 18.dp)
-            .size(24.dp)
-            .clickable(
-                interactionSource = remember(::MutableInteractionSource),
-                indication = rememberRipple(color = Color.Black, bounded = false),
-                onClickLabel = stringResource(LR.string.close),
-                role = Role.Button,
-                onClick = onClose,
-            ),
-    )
+            .align(Alignment.TopCenter)
+            .padding(top = 8.dp, start = 16.dp, end = 16.dp),
+    ) {
+        PagerProgressingIndicator(
+            state = pagerState,
+            progress = progress,
+            activeColor = Color.Black,
+        )
+        Spacer(
+            modifier = Modifier.height(10.dp),
+        )
+        Image(
+            painter = painterResource(IR.drawable.ic_close),
+            contentDescription = stringResource(LR.string.close),
+            colorFilter = ColorFilter.tint(Color.Black),
+            modifier = Modifier
+                .size(24.dp)
+                .clickable(
+                    interactionSource = remember(::MutableInteractionSource),
+                    indication = rememberRipple(color = Color.Black, bounded = false),
+                    onClickLabel = stringResource(LR.string.close),
+                    role = Role.Button,
+                    onClick = onClose,
+                ),
+        )
+    }
 }
 
 @Composable

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/ui/StoriesPage.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/ui/StoriesPage.kt
@@ -13,6 +13,7 @@ import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -168,6 +169,7 @@ internal fun BoxScope.TopControls(
         horizontalAlignment = Alignment.End,
         modifier = Modifier
             .align(Alignment.TopCenter)
+            .fillMaxWidth()
             .padding(top = 8.dp, start = 16.dp, end = 16.dp),
     ) {
         PagerProgressingIndicator(

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/ui/TopShowStory.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/ui/TopShowStory.kt
@@ -178,7 +178,7 @@ internal fun TopShowStory(
 @Preview(device = Devices.PortraitRegular)
 @Composable
 private fun TopShowPreview() {
-    PreviewBox { measurements ->
+    PreviewBox(currentPage = 2) { measurements ->
         TopShowStory(
             story = Story.TopShow(
                 show = TopPodcast(

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/ui/TopShowsStory.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/ui/TopShowsStory.kt
@@ -264,7 +264,7 @@ private fun Modifier.fadeScrollingEdges(
 @Preview(device = Devices.PortraitRegular)
 @Composable
 private fun TopShowsPreview() {
-    PreviewBox { measurements ->
+    PreviewBox(currentPage = 3) { measurements ->
         TopShowsStory(
             story = Story.TopShows(
                 shows = List(5) { index ->

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/ui/TotalTimeStory.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/ui/TotalTimeStory.kt
@@ -128,7 +128,7 @@ private data class ListeningTimeTexts(
 private fun TotalTimePreview(
     @PreviewParameter(PlaybackTimeProvider::class) duration: Duration,
 ) {
-    PreviewBox { measurements ->
+    PreviewBox(currentPage = 5) { measurements ->
         TotalTimeStory(
             story = Story.TotalTime(
                 duration = duration,

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/ui/YearVsYearStory.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/ui/YearVsYearStory.kt
@@ -381,7 +381,7 @@ private fun TextInfo(
 @Preview(device = Devices.PortraitRegular)
 @Composable
 private fun YearVsYearThisYearPreview() {
-    PreviewBox { measurements ->
+    PreviewBox(currentPage = 8) { measurements ->
         YearVsYearStory(
             story = Story.YearVsYear(
                 lastYearDuration = 2.hours,
@@ -397,7 +397,7 @@ private fun YearVsYearThisYearPreview() {
 @Preview(device = Devices.PortraitRegular)
 @Composable
 private fun YearVsYearThisYearLargePreview() {
-    PreviewBox { measurements ->
+    PreviewBox(currentPage = 8) { measurements ->
         YearVsYearStory(
             story = Story.YearVsYear(
                 lastYearDuration = 0.hours,
@@ -413,7 +413,7 @@ private fun YearVsYearThisYearLargePreview() {
 @Preview(device = Devices.PortraitRegular)
 @Composable
 private fun YearVsYearLastYearPreview() {
-    PreviewBox { measurements ->
+    PreviewBox(currentPage = 8) { measurements ->
         YearVsYearStory(
             story = Story.YearVsYear(
                 lastYearDuration = 3.hours,
@@ -429,7 +429,7 @@ private fun YearVsYearLastYearPreview() {
 @Preview(device = Devices.PortraitRegular)
 @Composable
 private fun YearVsYearEqualPreview() {
-    PreviewBox { measurements ->
+    PreviewBox(currentPage = 8) { measurements ->
         YearVsYearStory(
             story = Story.YearVsYear(
                 lastYearDuration = 100.hours,

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/PagerProgressingIndicator.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/PagerProgressingIndicator.kt
@@ -1,0 +1,100 @@
+package au.com.shiftyjelly.pocketcasts.compose.components
+
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.pager.PagerState
+import androidx.compose.foundation.pager.rememberPagerState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+
+@OptIn(ExperimentalFoundationApi::class)
+@Composable
+fun PagerProgressingIndicator(
+    state: PagerState,
+    progress: Float,
+    modifier: Modifier = Modifier,
+    activeColor: Color = Color.White,
+    inactiveColor: Color = activeColor.copy(alpha = 0.3f),
+) {
+    if (state.pageCount <= 0) {
+        return
+    }
+    val normalizedProgress = progress.coerceIn(0f, 1f)
+    Row(
+        horizontalArrangement = Arrangement.spacedBy(2.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = modifier,
+    ) {
+        repeat(state.pageCount) { index ->
+            val brush = if (index == state.currentPage) {
+                Brush.horizontalGradient(
+                    0.0f to activeColor,
+                    normalizedProgress to activeColor,
+                    normalizedProgress to inactiveColor,
+                    1f to inactiveColor,
+                )
+            } else if (index > state.currentPage) {
+                SolidColor(inactiveColor)
+            } else {
+                SolidColor(activeColor)
+            }
+            Box(
+                modifier
+                    .weight(1f)
+                    .height(2.dp)
+                    .background(brush, CircleShape),
+            )
+        }
+    }
+}
+
+@OptIn(ExperimentalFoundationApi::class)
+@Preview
+@Composable
+private fun PagerProgressingIndicatorPreview() = Column(
+    verticalArrangement = Arrangement.spacedBy(16.dp),
+    horizontalAlignment = Alignment.CenterHorizontally,
+    modifier = Modifier.background(Color.Black).padding(16.dp),
+) {
+    PagerProgressingIndicator(
+        state = rememberPagerState(pageCount = { 0 }),
+        progress = 0f,
+    )
+    PagerProgressingIndicator(
+        state = rememberPagerState(pageCount = { 8 }),
+        progress = 0f,
+    )
+    PagerProgressingIndicator(
+        state = rememberPagerState(pageCount = { 6 }),
+        progress = 0f,
+    )
+    PagerProgressingIndicator(
+        state = rememberPagerState(initialPage = 4, pageCount = { 8 }),
+        progress = 0f,
+    )
+    PagerProgressingIndicator(
+        state = rememberPagerState(pageCount = { 8 }),
+        progress = 0.5f,
+    )
+    PagerProgressingIndicator(
+        state = rememberPagerState(initialPage = 1, pageCount = { 8 }),
+        progress = 1f,
+    )
+    PagerProgressingIndicator(
+        state = rememberPagerState(initialPage = 2, pageCount = { 4 }),
+        progress = 0.75f,
+    )
+}


### PR DESCRIPTION
## Description

This displays story progress indicator and auto pages the stories.

## Testing Instructions

1. Start PB24 flow.
2. Stories should auto page every 7 seconds. 
4. Story progress should reset upon manually changing a story.
5. Plus Interstitial story (only free accounts can see it) should not have auto progress.
6. Ending story should close the flow upon reaching 7 seconds.

## Checklist
- [x] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~