### PR TITLE
[Auto Downloading] -  Add Remote Feature Flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 7.76
 -----
-
+*   New Features
+    *   Add the ability to auto download episodes after subscribing to a podcast
+        ([#3048](https://github.com/Automattic/pocket-casts-android/pull/3048))
 
 7.75
 -----

--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/Feature.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/Feature.kt
@@ -125,10 +125,10 @@ enum class Feature(
     ),
     AUTO_DOWNLOAD(
         key = "auto_download",
-        title = "Auto download episodes",
+        title = "Auto download episodes after subscribing to a podcast",
         defaultValue = BuildConfig.DEBUG,
         tier = FeatureTier.Free,
-        hasFirebaseRemoteFlag = false,
+        hasFirebaseRemoteFlag = true,
         hasDevToggle = true,
     ),
     ;


### PR DESCRIPTION
## Description
- Adds the remote feature flag
- See: p1729260716519079-slack-C07QMC2GB1B
- I am also updating the changelog here since it's enabling the feature in `7.76`

## Testing Instructions
- Code review should be fine
- You can also check if the name of the feature flag matches with the name in Firebase

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.