### PR TITLE
Handle upsell flow in the End of Year flow

### DIFF
--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/EndOfYearViewModel.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/EndOfYearViewModel.kt
@@ -233,7 +233,7 @@ internal sealed interface UiState {
 @Immutable
 internal sealed interface Story {
     val previewDuration: Duration? get() = 7.seconds
-    val isFree = true
+    val isFree: Boolean get() = true
 
     data object Cover : Story
 

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/EndOfYearViewModel.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/EndOfYearViewModel.kt
@@ -181,7 +181,7 @@ class EndOfYearViewModel @AssistedInject constructor(
         return if (state.isPaidAccount || previousStory.isFree) {
             currentIndex - 1
         } else {
-            state.stories.take(currentIndex)
+           stories.take(currentIndex)
                 .lastOrNull { it.isFree }
                 ?.let(stories::indexOf)
         }?.takeIf { it != -1 }
@@ -233,7 +233,7 @@ internal sealed interface UiState {
 @Immutable
 internal sealed interface Story {
     val previewDuration: Duration? get() = 7.seconds
-    val isFree: Boolean get() = true
+    val isFree = true
 
     data object Cover : Story
 

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/EndOfYearViewModel.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/EndOfYearViewModel.kt
@@ -27,6 +27,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import au.com.shiftyjelly.pocketcasts.models.to.LongestEpisode as LongestEpisodeData
@@ -47,6 +48,7 @@ class EndOfYearViewModel @AssistedInject constructor(
     }
     private val _switchStory = MutableSharedFlow<Unit>()
     internal val switchStory get() = _switchStory.asSharedFlow()
+    private val isStoryAutoProgressEnabled = MutableStateFlow(false)
 
     internal val uiState = combine(
         syncState,
@@ -138,6 +140,7 @@ class EndOfYearViewModel @AssistedInject constructor(
                 countDownJob = launch {
                     var currentProgress = 0f
                     while (currentProgress < 1f) {
+                        isStoryAutoProgressEnabled.first { it }
                         currentProgress += 0.01f
                         progress.value = currentProgress
                         delay(progressDelay)
@@ -146,6 +149,14 @@ class EndOfYearViewModel @AssistedInject constructor(
                 }
             }
         }
+    }
+
+    internal fun resumeStoryAutoProgress() {
+        isStoryAutoProgressEnabled.value = true
+    }
+
+    internal fun pauseStoryAutoProgress() {
+        isStoryAutoProgressEnabled.value = false
     }
 
     internal fun getNextStoryIndex(currentIndex: Int): Int? {

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/EndOfYearViewModel.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/EndOfYearViewModel.kt
@@ -181,7 +181,7 @@ class EndOfYearViewModel @AssistedInject constructor(
         return if (state.isPaidAccount || previousStory.isFree) {
             currentIndex - 1
         } else {
-           stories.take(currentIndex)
+            stories.take(currentIndex)
                 .lastOrNull { it.isFree }
                 ?.let(stories::indexOf)
         }?.takeIf { it != -1 }

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/StoriesFragment.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/StoriesFragment.kt
@@ -86,7 +86,7 @@ class StoriesFragment : BaseAppCompatDialogFragment() {
                 state = state,
                 pagerState = pagerState,
                 onChangeStory = storyChanger::change,
-                onUpsellClick = ::startUpsellFlow,
+                onClickUpsell = ::startUpsellFlow,
                 onClose = ::dismiss,
             )
 

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/StoriesFragment.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/StoriesFragment.kt
@@ -145,6 +145,21 @@ class StoriesFragment : BaseAppCompatDialogFragment() {
         OnboardingLauncher.openOnboardingFlow(requireActivity(), flow)
     }
 
+    override fun onResume() {
+        super.onResume()
+        viewModel.resumeStoryAutoProgress()
+    }
+
+    override fun onPause() {
+        // Pause auto progress when the fragment is not active.
+        // This makes sure that users see all stories and they
+        // won't auto switch for example when signing up takes
+        // some time or when the EoY flow is interruped by
+        // some other user actions such as a phone call.
+        viewModel.pauseStoryAutoProgress()
+        super.onPause()
+    }
+
     enum class StoriesSource(val value: String) {
         MODAL("modal"),
         PROFILE("profile"),

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/StoriesFragment.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/StoriesFragment.kt
@@ -76,6 +76,7 @@ class StoriesFragment : BaseAppCompatDialogFragment() {
             StoriesPage(
                 state = state,
                 pagerState = pagerState,
+                onUpsellClick = {},
                 onClose = ::dismiss,
             )
 

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/ui/PlusInterstitialStory.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/ui/PlusInterstitialStory.kt
@@ -41,7 +41,7 @@ import au.com.shiftyjelly.pocketcasts.ui.R as UR
 internal fun PlusInterstitialStory(
     story: Story.PlusInterstitial,
     measurements: EndOfYearMeasurements,
-    onUpsellClick: () -> Unit,
+    onClickUpsell: () -> Unit,
 ) {
     Column(
         modifier = Modifier
@@ -55,7 +55,7 @@ internal fun PlusInterstitialStory(
         PlusInfo(
             story = story,
             measurements = measurements,
-            onUpsellClick = onUpsellClick,
+            onClickUpsell = onClickUpsell,
         )
     }
 }
@@ -123,7 +123,7 @@ private fun WaitText(
 private fun PlusInfo(
     story: Story.PlusInterstitial,
     measurements: EndOfYearMeasurements,
-    onUpsellClick: () -> Unit,
+    onClickUpsell: () -> Unit,
 ) {
     Column(
         modifier = Modifier.background(
@@ -160,7 +160,7 @@ private fun PlusInfo(
         )
         OutlinedEoyButton(
             text = stringResource(LR.string.eoy_story_stories_subscribe_to_plus_button_label),
-            onClick = onUpsellClick,
+            onClick = onClickUpsell,
         )
     }
 }
@@ -172,7 +172,7 @@ private fun PlusInterstitialPreview() {
         PlusInterstitialStory(
             story = Story.PlusInterstitial,
             measurements = measurements,
-            onUpsellClick = {},
+            onClickUpsell = {},
         )
     }
 }

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/ui/PlusInterstitialStory.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/ui/PlusInterstitialStory.kt
@@ -41,6 +41,7 @@ import au.com.shiftyjelly.pocketcasts.ui.R as UR
 internal fun PlusInterstitialStory(
     story: Story.PlusInterstitial,
     measurements: EndOfYearMeasurements,
+    onUpsellClick: () -> Unit,
 ) {
     Column(
         modifier = Modifier
@@ -54,6 +55,7 @@ internal fun PlusInterstitialStory(
         PlusInfo(
             story = story,
             measurements = measurements,
+            onUpsellClick = onUpsellClick,
         )
     }
 }
@@ -121,6 +123,7 @@ private fun WaitText(
 private fun PlusInfo(
     story: Story.PlusInterstitial,
     measurements: EndOfYearMeasurements,
+    onUpsellClick: () -> Unit,
 ) {
     Column(
         modifier = Modifier.background(
@@ -157,7 +160,7 @@ private fun PlusInfo(
         )
         OutlinedEoyButton(
             text = stringResource(LR.string.eoy_story_stories_subscribe_to_plus_button_label),
-            onClick = {},
+            onClick = onUpsellClick,
         )
     }
 }
@@ -169,6 +172,7 @@ private fun PlusInterstitialPreview() {
         PlusInterstitialStory(
             story = Story.PlusInterstitial,
             measurements = measurements,
+            onUpsellClick = {},
         )
     }
 }

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/ui/StoriesPage.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/ui/StoriesPage.kt
@@ -55,6 +55,7 @@ import au.com.shiftyjelly.pocketcasts.localization.R as LR
 internal fun StoriesPage(
     state: UiState,
     pagerState: PagerState,
+    onUpsellClick: () -> Unit,
     onClose: () -> Unit,
 ) {
     val size = LocalContext.current.sizeLimit?.let(Modifier::size) ?: Modifier.fillMaxSize()
@@ -83,6 +84,7 @@ internal fun StoriesPage(
                     coverTextHeight = coverTextHeight,
                 ),
                 pagerState = pagerState,
+                onUpsellClick = onUpsellClick,
             )
         }
 
@@ -120,6 +122,7 @@ private fun Stories(
     stories: List<Story>,
     measurements: EndOfYearMeasurements,
     pagerState: PagerState,
+    onUpsellClick: () -> Unit,
 ) {
     val coroutineScope = rememberCoroutineScope()
     val widthPx = LocalDensity.current.run { measurements.width.toPx() }
@@ -150,7 +153,7 @@ private fun Stories(
             is Story.Ratings -> RatingsStory(story, measurements)
             is Story.TotalTime -> TotalTimeStory(story, measurements)
             is Story.LongestEpisode -> LongestEpisodeStory(story, measurements)
-            is Story.PlusInterstitial -> PlusInterstitialStory(story, measurements)
+            is Story.PlusInterstitial -> PlusInterstitialStory(story, measurements, onUpsellClick)
             is Story.YearVsYear -> YearVsYearStory(story, measurements)
             is Story.CompletionRate -> CompletionRateStory(story, measurements)
             is Story.Ending -> EndingStory(story, measurements)

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/ui/StoriesPage.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/ui/StoriesPage.kt
@@ -25,7 +25,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -46,7 +45,6 @@ import au.com.shiftyjelly.pocketcasts.compose.components.TextH10
 import au.com.shiftyjelly.pocketcasts.endofyear.Story
 import au.com.shiftyjelly.pocketcasts.endofyear.UiState
 import au.com.shiftyjelly.pocketcasts.utils.Util
-import kotlinx.coroutines.launch
 import au.com.shiftyjelly.pocketcasts.images.R as IR
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
@@ -55,6 +53,7 @@ import au.com.shiftyjelly.pocketcasts.localization.R as LR
 internal fun StoriesPage(
     state: UiState,
     pagerState: PagerState,
+    onChangeStory: (Boolean) -> Unit,
     onUpsellClick: () -> Unit,
     onClose: () -> Unit,
 ) {
@@ -84,6 +83,7 @@ internal fun StoriesPage(
                     coverTextHeight = coverTextHeight,
                 ),
                 pagerState = pagerState,
+                onChangeStory = onChangeStory,
                 onUpsellClick = onUpsellClick,
             )
         }
@@ -122,9 +122,9 @@ private fun Stories(
     stories: List<Story>,
     measurements: EndOfYearMeasurements,
     pagerState: PagerState,
+    onChangeStory: (Boolean) -> Unit,
     onUpsellClick: () -> Unit,
 ) {
-    val coroutineScope = rememberCoroutineScope()
     val widthPx = LocalDensity.current.run { measurements.width.toPx() }
 
     HorizontalPager(
@@ -132,16 +132,8 @@ private fun Stories(
         userScrollEnabled = false,
         modifier = Modifier.pointerInput(Unit) {
             detectTapGestures { offset ->
-                if (!pagerState.isScrollInProgress) {
-                    coroutineScope.launch {
-                        val nextPage = if (offset.x > widthPx / 2) {
-                            pagerState.currentPage + 1
-                        } else {
-                            pagerState.currentPage - 1
-                        }
-                        pagerState.scrollToPage(nextPage)
-                    }
-                }
+                val moveForward = offset.x > widthPx / 2
+                onChangeStory(moveForward)
             }
         },
     ) { index ->

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/ui/StoriesPage.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/ui/StoriesPage.kt
@@ -54,7 +54,7 @@ internal fun StoriesPage(
     state: UiState,
     pagerState: PagerState,
     onChangeStory: (Boolean) -> Unit,
-    onUpsellClick: () -> Unit,
+    onClickUpsell: () -> Unit,
     onClose: () -> Unit,
 ) {
     val size = LocalContext.current.sizeLimit?.let(Modifier::size) ?: Modifier.fillMaxSize()
@@ -84,7 +84,7 @@ internal fun StoriesPage(
                 ),
                 pagerState = pagerState,
                 onChangeStory = onChangeStory,
-                onUpsellClick = onUpsellClick,
+                onClickUpsell = onClickUpsell,
             )
         }
 
@@ -123,7 +123,7 @@ private fun Stories(
     measurements: EndOfYearMeasurements,
     pagerState: PagerState,
     onChangeStory: (Boolean) -> Unit,
-    onUpsellClick: () -> Unit,
+    onClickUpsell: () -> Unit,
 ) {
     val widthPx = LocalDensity.current.run { measurements.width.toPx() }
 
@@ -145,7 +145,7 @@ private fun Stories(
             is Story.Ratings -> RatingsStory(story, measurements)
             is Story.TotalTime -> TotalTimeStory(story, measurements)
             is Story.LongestEpisode -> LongestEpisodeStory(story, measurements)
-            is Story.PlusInterstitial -> PlusInterstitialStory(story, measurements, onUpsellClick)
+            is Story.PlusInterstitial -> PlusInterstitialStory(story, measurements, onClickUpsell)
             is Story.YearVsYear -> YearVsYearStory(story, measurements)
             is Story.CompletionRate -> CompletionRateStory(story, measurements)
             is Story.Ending -> EndingStory(story, measurements)

--- a/modules/features/endofyear/src/test/kotlin/au/com/shiftyjelly/pocketcasts/endofyear/EndOfYearViewModelTest.kt
+++ b/modules/features/endofyear/src/test/kotlin/au/com/shiftyjelly/pocketcasts/endofyear/EndOfYearViewModelTest.kt
@@ -495,6 +495,92 @@ class EndOfYearViewModelTest {
         }
     }
 
+    @Test
+    fun `get index of next story for paid account`() = runTest {
+        endOfYearSync.isSynced.add(true)
+        endOfYearManager.stats.add(stats)
+        subscriptionTier.emit(SubscriptionTier.PLUS)
+
+        viewModel.syncData()
+        val stories = (viewModel.uiState.first() as UiState.Synced).stories
+
+        assertEquals(1, viewModel.getNextStoryIndex(stories.indexOf<Cover>()))
+        assertEquals(2, viewModel.getNextStoryIndex(stories.indexOf<NumberOfShows>()))
+        assertEquals(3, viewModel.getNextStoryIndex(stories.indexOf<TopShow>()))
+        assertEquals(4, viewModel.getNextStoryIndex(stories.indexOf<TopShows>()))
+        assertEquals(5, viewModel.getNextStoryIndex(stories.indexOf<Ratings>()))
+        assertEquals(6, viewModel.getNextStoryIndex(stories.indexOf<TotalTime>()))
+        assertEquals(7, viewModel.getNextStoryIndex(stories.indexOf<LongestEpisode>()))
+        assertEquals(8, viewModel.getNextStoryIndex(stories.indexOf<YearVsYear>()))
+        assertEquals(9, viewModel.getNextStoryIndex(stories.indexOf<CompletionRate>()))
+        assertEquals(null, viewModel.getNextStoryIndex(stories.indexOf<Ending>()))
+    }
+
+    @Test
+    fun `get index of previous story for paid account`() = runTest {
+        endOfYearSync.isSynced.add(true)
+        endOfYearManager.stats.add(stats)
+        subscriptionTier.emit(SubscriptionTier.PLUS)
+
+        viewModel.syncData()
+        val stories = (viewModel.uiState.first() as UiState.Synced).stories
+
+        assertEquals(null, viewModel.getPreviousStoryIndex(stories.indexOf<Cover>()))
+        assertEquals(0, viewModel.getPreviousStoryIndex(stories.indexOf<NumberOfShows>()))
+        assertEquals(1, viewModel.getPreviousStoryIndex(stories.indexOf<TopShow>()))
+        assertEquals(2, viewModel.getPreviousStoryIndex(stories.indexOf<TopShows>()))
+        assertEquals(3, viewModel.getPreviousStoryIndex(stories.indexOf<Ratings>()))
+        assertEquals(4, viewModel.getPreviousStoryIndex(stories.indexOf<TotalTime>()))
+        assertEquals(5, viewModel.getPreviousStoryIndex(stories.indexOf<LongestEpisode>()))
+        assertEquals(6, viewModel.getPreviousStoryIndex(stories.indexOf<YearVsYear>()))
+        assertEquals(7, viewModel.getPreviousStoryIndex(stories.indexOf<CompletionRate>()))
+        assertEquals(8, viewModel.getPreviousStoryIndex(stories.indexOf<Ending>()))
+    }
+
+    @Test
+    fun `get index of next story for free account`() = runTest {
+        endOfYearSync.isSynced.add(true)
+        endOfYearManager.stats.add(stats)
+        subscriptionTier.emit(SubscriptionTier.NONE)
+
+        viewModel.syncData()
+        val stories = (viewModel.uiState.first() as UiState.Synced).stories
+
+        assertEquals(1, viewModel.getNextStoryIndex(stories.indexOf<Cover>()))
+        assertEquals(2, viewModel.getNextStoryIndex(stories.indexOf<NumberOfShows>()))
+        assertEquals(3, viewModel.getNextStoryIndex(stories.indexOf<TopShow>()))
+        assertEquals(4, viewModel.getNextStoryIndex(stories.indexOf<TopShows>()))
+        assertEquals(5, viewModel.getNextStoryIndex(stories.indexOf<Ratings>()))
+        assertEquals(6, viewModel.getNextStoryIndex(stories.indexOf<TotalTime>()))
+        assertEquals(7, viewModel.getNextStoryIndex(stories.indexOf<LongestEpisode>()))
+        assertEquals(10, viewModel.getNextStoryIndex(stories.indexOf<PlusInterstitial>()))
+        assertEquals(10, viewModel.getNextStoryIndex(stories.indexOf<YearVsYear>()))
+        assertEquals(10, viewModel.getNextStoryIndex(stories.indexOf<CompletionRate>()))
+        assertEquals(null, viewModel.getNextStoryIndex(stories.indexOf<Ending>()))
+    }
+
+    @Test
+    fun `get index of previous story for free account`() = runTest {
+        endOfYearSync.isSynced.add(true)
+        endOfYearManager.stats.add(stats)
+        subscriptionTier.emit(SubscriptionTier.NONE)
+
+        viewModel.syncData()
+        val stories = (viewModel.uiState.first() as UiState.Synced).stories
+
+        assertEquals(null, viewModel.getPreviousStoryIndex(stories.indexOf<Cover>()))
+        assertEquals(0, viewModel.getPreviousStoryIndex(stories.indexOf<NumberOfShows>()))
+        assertEquals(1, viewModel.getPreviousStoryIndex(stories.indexOf<TopShow>()))
+        assertEquals(2, viewModel.getPreviousStoryIndex(stories.indexOf<TopShows>()))
+        assertEquals(3, viewModel.getPreviousStoryIndex(stories.indexOf<Ratings>()))
+        assertEquals(4, viewModel.getPreviousStoryIndex(stories.indexOf<TotalTime>()))
+        assertEquals(5, viewModel.getPreviousStoryIndex(stories.indexOf<LongestEpisode>()))
+        assertEquals(6, viewModel.getPreviousStoryIndex(stories.indexOf<PlusInterstitial>()))
+        assertEquals(7, viewModel.getPreviousStoryIndex(stories.indexOf<YearVsYear>()))
+        assertEquals(7, viewModel.getPreviousStoryIndex(stories.indexOf<CompletionRate>()))
+        assertEquals(7, viewModel.getPreviousStoryIndex(stories.indexOf<Ending>()))
+    }
+
     private suspend fun TurbineTestContext<UiState>.awaitStories(): List<Story> {
         return (awaitItem() as UiState.Synced).stories
     }
@@ -505,6 +591,10 @@ class EndOfYearViewModelTest {
 
     private inline fun <reified T : Story> List<Story>.getStoryOfType(): T {
         return filterIsInstance<T>().single()
+    }
+
+    private inline fun <reified T : Story> List<Story>.indexOf(): Int {
+        return indexOfFirst { it is T }
     }
 
     private inline fun <reified T : Story> assertHasStory(stories: List<Story>) {

--- a/modules/features/endofyear/src/test/kotlin/au/com/shiftyjelly/pocketcasts/endofyear/EndOfYearViewModelTest.kt
+++ b/modules/features/endofyear/src/test/kotlin/au/com/shiftyjelly/pocketcasts/endofyear/EndOfYearViewModelTest.kt
@@ -455,6 +455,7 @@ class EndOfYearViewModelTest {
         subscriptionTier.emit(SubscriptionTier.NONE)
 
         viewModel.syncData()
+        viewModel.resumeStoryAutoProgress()
         val stories = (viewModel.uiState.first() as UiState.Synced).stories
 
         viewModel.switchStory.test {
@@ -492,6 +493,33 @@ class EndOfYearViewModelTest {
 
             viewModel.onStoryChanged(stories.getStoryOfType<Ending>())
             assertEquals(Unit, awaitItem())
+        }
+    }
+
+    @Test
+    fun `resume and pause stories auto switching`() = runTest {
+        endOfYearSync.isSynced.add(true)
+        endOfYearManager.stats.add(stats)
+        subscriptionTier.emit(SubscriptionTier.NONE)
+
+        viewModel.syncData()
+        val stories = (viewModel.uiState.first() as UiState.Synced).stories
+
+        viewModel.switchStory.test {
+            expectNoEvents()
+
+            // Initially switching should be paused
+            viewModel.onStoryChanged(stories.getStoryOfType<Cover>())
+            expectNoEvents()
+
+            // Resume after pause
+            viewModel.resumeStoryAutoProgress()
+            assertEquals(Unit, awaitItem())
+
+            // Pause after resume
+            viewModel.pauseStoryAutoProgress()
+            viewModel.onStoryChanged(stories.getStoryOfType<NumberOfShows>())
+            expectNoEvents()
         }
     }
 

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/type/SubscriptionTier.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/type/SubscriptionTier.kt
@@ -4,10 +4,22 @@ import au.com.shiftyjelly.pocketcasts.utils.featureflag.UserTier
 import com.squareup.moshi.JsonClass
 
 @JsonClass(generateAdapter = false)
-enum class SubscriptionTier(val label: String) {
-    NONE("none"),
-    PLUS("plus"),
-    PATRON("patron"),
+enum class SubscriptionTier(
+    val label: String,
+    val isPaid: Boolean,
+) {
+    NONE(
+        label = "none",
+        isPaid = false,
+    ),
+    PLUS(
+        label = "plus",
+        isPaid = true,
+    ),
+    PATRON(
+        label = "patron",
+        isPaid = true,
+    ),
     ;
     override fun toString() = label
 


### PR DESCRIPTION
## Description

This PR adds handling of the upsell flow and story navigation.

## Testing Instructions

> [!note]
> Test this with the release variant so you can complete a purchase.

1. Apply [this patch](https://github.com/user-attachments/files/17463085/eoy.patch).
2. Sign in with a paid account.
3. Start Playback 2024.
4. Verify that navigation works as expected.
5. Navigate back to the Profile tab.
6. Sign out.
7. Sign up with a new account.
8. Start **Playback 2024**.
9. Confirm that navigation works, but note that navigating forward on the Plus Interstitial story skips two stories and jumps to the Ending story.
10. Navigating backwards on the Ending story should return to the Plus Interstitial story.
11. Tap the upsell button.
12. Verify that the upsell flow starts.
13. Close the upsell flow.
14. Confirm that you are still on the Plus Interstitial story.
15. Start the upsell flow again.
16. Complete the upsell flow.
17. After onboarding completes, you should see the Year vs Year story, and the Plus Interstitial story should no longer appear in the Playback 2024 flow. Navigation should work like in the 4th step.

## Checklist
- [x] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [x] ~Any jetpack compose components I added or changed are covered by compose previews~
- [x] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/~d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.