### PR TITLE
Navigate to ratings info page

### DIFF
--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/StoriesFragment.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/StoriesFragment.kt
@@ -29,12 +29,14 @@ import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingLauncher
 import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingUpgradeSource
 import au.com.shiftyjelly.pocketcasts.ui.helper.StatusBarColor
 import au.com.shiftyjelly.pocketcasts.utils.Util
+import au.com.shiftyjelly.pocketcasts.views.activity.WebViewActivity
 import au.com.shiftyjelly.pocketcasts.views.fragments.BaseAppCompatDialogFragment
 import dagger.hilt.android.AndroidEntryPoint
 import dagger.hilt.android.lifecycle.withCreationCallback
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import android.R as AndroidR
+import au.com.shiftyjelly.pocketcasts.localization.R as LR
 import au.com.shiftyjelly.pocketcasts.ui.R as UR
 
 @AndroidEntryPoint
@@ -86,6 +88,7 @@ class StoriesFragment : BaseAppCompatDialogFragment() {
                 state = state,
                 pagerState = pagerState,
                 onChangeStory = storyChanger::change,
+                onLearnAboutRatings = ::openRatingsInfo,
                 onClickUpsell = ::startUpsellFlow,
                 onClose = ::dismiss,
             )
@@ -140,11 +143,6 @@ class StoriesFragment : BaseAppCompatDialogFragment() {
         super.onDismiss(dialog)
     }
 
-    private fun startUpsellFlow() {
-        val flow = OnboardingFlow.Upsell(OnboardingUpgradeSource.END_OF_YEAR)
-        OnboardingLauncher.openOnboardingFlow(requireActivity(), flow)
-    }
-
     override fun onResume() {
         super.onResume()
         viewModel.resumeStoryAutoProgress()
@@ -158,6 +156,19 @@ class StoriesFragment : BaseAppCompatDialogFragment() {
         // some other user actions such as a phone call.
         viewModel.pauseStoryAutoProgress()
         super.onPause()
+    }
+
+    private fun startUpsellFlow() {
+        val flow = OnboardingFlow.Upsell(OnboardingUpgradeSource.END_OF_YEAR)
+        OnboardingLauncher.openOnboardingFlow(requireActivity(), flow)
+    }
+
+    private fun openRatingsInfo() {
+        WebViewActivity.show(
+            requireActivity(),
+            getString(LR.string.podcast_ratings_page_title),
+            "https://support.pocketcasts.com/knowledge-base/ratings/",
+        )
     }
 
     enum class StoriesSource(val value: String) {

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/ui/RatingsStory.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/ui/RatingsStory.kt
@@ -66,19 +66,26 @@ import au.com.shiftyjelly.pocketcasts.ui.R as UR
 internal fun RatingsStory(
     story: Story.Ratings,
     measurements: EndOfYearMeasurements,
-) = RatingsStory(story, measurements, showBars = false)
+    onLearnAboutRatings: () -> Unit,
+) = RatingsStory(
+    story = story,
+    measurements = measurements,
+    showBars = false,
+    onLearnAboutRatings = onLearnAboutRatings,
+)
 
 @Composable
 private fun RatingsStory(
     story: Story.Ratings,
     measurements: EndOfYearMeasurements,
     showBars: Boolean,
+    onLearnAboutRatings: () -> Unit,
 ) {
     val maxRatingCount = story.stats.max().second
     if (maxRatingCount != 0) {
         PresentRatings(story, measurements, showBars)
     } else {
-        AbsentRatings(story, measurements)
+        AbsentRatings(story, measurements, onLearnAboutRatings)
     }
 }
 
@@ -276,6 +283,7 @@ private fun RowScope.RatingBar(
 private fun AbsentRatings(
     story: Story.Ratings,
     measurements: EndOfYearMeasurements,
+    onLearnAboutRatings: () -> Unit,
 ) {
     Column(
         modifier = Modifier
@@ -289,6 +297,7 @@ private fun AbsentRatings(
         NoRatingsInfo(
             story = story,
             measurements = measurements,
+            onLearnAboutRatings = onLearnAboutRatings,
         )
     }
 }
@@ -352,6 +361,7 @@ private fun OopsiesText(
 private fun NoRatingsInfo(
     story: Story.Ratings,
     measurements: EndOfYearMeasurements,
+    onLearnAboutRatings: () -> Unit,
 ) {
     Column(
         modifier = Modifier.background(
@@ -383,7 +393,7 @@ private fun NoRatingsInfo(
         )
         OutlinedEoyButton(
             text = stringResource(LR.string.eoy_story_ratings_learn_button_label),
-            onClick = {},
+            onClick = onLearnAboutRatings,
         )
     }
 }
@@ -404,6 +414,7 @@ private fun RatingsHighPreview() {
             ),
             measurements = measurements,
             showBars = true,
+            onLearnAboutRatings = {},
         )
     }
 }
@@ -424,6 +435,7 @@ private fun RatingsLowPreview() {
             ),
             measurements = measurements,
             showBars = true,
+            onLearnAboutRatings = {},
         )
     }
 }
@@ -444,6 +456,7 @@ private fun RatingsNonePreview() {
             ),
             measurements = measurements,
             showBars = true,
+            onLearnAboutRatings = {},
         )
     }
 }

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/ui/StoriesPage.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/ui/StoriesPage.kt
@@ -54,6 +54,7 @@ internal fun StoriesPage(
     state: UiState,
     pagerState: PagerState,
     onChangeStory: (Boolean) -> Unit,
+    onLearnAboutRatings: () -> Unit,
     onClickUpsell: () -> Unit,
     onClose: () -> Unit,
 ) {
@@ -84,6 +85,7 @@ internal fun StoriesPage(
                 ),
                 pagerState = pagerState,
                 onChangeStory = onChangeStory,
+                onLearnAboutRatings = onLearnAboutRatings,
                 onClickUpsell = onClickUpsell,
             )
         }
@@ -123,6 +125,7 @@ private fun Stories(
     measurements: EndOfYearMeasurements,
     pagerState: PagerState,
     onChangeStory: (Boolean) -> Unit,
+    onLearnAboutRatings: () -> Unit,
     onClickUpsell: () -> Unit,
 ) {
     val widthPx = LocalDensity.current.run { measurements.width.toPx() }
@@ -142,7 +145,7 @@ private fun Stories(
             is Story.NumberOfShows -> NumberOfShowsStory(story, measurements)
             is Story.TopShow -> TopShowStory(story, measurements)
             is Story.TopShows -> TopShowsStory(story, measurements)
-            is Story.Ratings -> RatingsStory(story, measurements)
+            is Story.Ratings -> RatingsStory(story, measurements, onLearnAboutRatings)
             is Story.TotalTime -> TotalTimeStory(story, measurements)
             is Story.LongestEpisode -> LongestEpisodeStory(story, measurements)
             is Story.PlusInterstitial -> PlusInterstitialStory(story, measurements, onClickUpsell)

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -645,6 +645,7 @@
     <string name="thank_you_for_rating">Thank you for rating!</string>
     <string name="something_went_wrong_to_rate_this_podcast">Something went wrong. Please try again later</string>
     <string name="podcast_star_rating_content_description">Podcast Star Rating</string>
+    <string name="podcast_ratings_page_title">Ratings</string>
 
     <!-- Episodes -->
 


### PR DESCRIPTION
## Description

This adds navigation to learn about ratings if users gave none.

## Testing Instructions

1. Start PB24 with an account that gave no ratings.
2. Navigating to the Ratings story.
3. Tap on the button.
4. A web view with the ratings support page should open.

## Checklist
- [x] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] ~I have considered whether it makes sense to add tests for my changes~
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] ~Any jetpack compose components I added or changed are covered by compose previews~
- [x] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~