### PR TITLE
[Project] Up Next Shuffle - Update Up Next Clear 

### DIFF
--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/UpNextAdapter.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/UpNextAdapter.kt
@@ -154,16 +154,11 @@ class UpNextAdapter(
     }
 
     inner class HeaderViewHolder(val binding: AdapterUpNextFooterBinding) : RecyclerView.ViewHolder(binding.root) {
-        init {
-            binding.btnClear.setOnClickListener { listener.onClearUpNext() }
-        }
 
         fun bind(header: PlayerViewModel.UpNextSummary) {
             with(binding) {
-                btnClear.isEnabled = header.episodeCount > 0
                 emptyUpNextContainer.isVisible = header.episodeCount == 0
                 val time = TimeHelper.getTimeDurationShortString(timeMs = (header.totalTimeSecs * 1000).toLong(), context = root.context)
-                btnClear.isVisible = playbackManager.getCurrentEpisode() != null
                 lblUpNextTime.isVisible = playbackManager.getCurrentEpisode() != null
                 lblUpNextTime.text = if (header.episodeCount == 0) {
                     root.resources.getString(LR.string.player_up_next_time_left, time)

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/UpNextFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/UpNextFragment.kt
@@ -394,7 +394,7 @@ class UpNextFragment : BaseFragment(), UpNextListener, UpNextTouchCallback.ItemT
 
     override fun onClearUpNext() {
         playerViewModel.clearUpNext(context = requireContext(), upNextSource = upNextSource)
-            .showOrClear(parentFragmentManager)
+            .showClearUpNextConfirmationDialog(parentFragmentManager, tag = "up_next_clear_dialog")
     }
 
     override fun onUpNextEpisodeStartDrag(viewHolder: RecyclerView.ViewHolder) {

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/UpNextFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/UpNextFragment.kt
@@ -302,6 +302,7 @@ class UpNextFragment : BaseFragment(), UpNextListener, UpNextTouchCallback.ItemT
         playerViewModel.listDataLive.observe(viewLifecycleOwner) {
             adapter.isPlaying = it.podcastHeader.isPlaying
             toolbar.menu.findItem(R.id.menu_select)?.isVisible = it.upNextEpisodes.isNotEmpty()
+            toolbar.menu.findItem(R.id.clear_up_next)?.isVisible = it.upNextEpisodes.isNotEmpty()
         }
 
         view.isClickable = true

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/UpNextFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/UpNextFragment.kt
@@ -286,6 +286,10 @@ class UpNextFragment : BaseFragment(), UpNextListener, UpNextTouchCallback.ItemT
                     multiSelectHelper.isMultiSelecting = true
                     true
                 }
+                R.id.clear_up_next -> {
+                    onClearUpNext()
+                    true
+                }
                 else -> false
             }
         }

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/dialog/ClearUpNextDialog.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/dialog/ClearUpNextDialog.kt
@@ -41,14 +41,16 @@ class ClearUpNextDialog(
         }
     }
 
-    fun showOrClear(fragmentManager: FragmentManager) {
+    fun showOrClear(fragmentManager: FragmentManager, tag: String) {
         val episodeCount = playbackManager.upNextQueue.queueEpisodes.size
         return if (episodeCount >= 3) {
-            show(fragmentManager, "mini_player_clear_dialog")
+            showClearUpNextConfirmationDialog(fragmentManager, tag)
         } else {
             clear()
         }
     }
+
+    fun showClearUpNextConfirmationDialog(fragmentManager: FragmentManager, tag: String) = show(fragmentManager, tag)
 
     companion object {
         private const val SOURCE_KEY = "source"

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/dialog/MiniPlayerDialog.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/dialog/MiniPlayerDialog.kt
@@ -68,7 +68,7 @@ class MiniPlayerDialog(
             analyticsTracker = analyticsTracker,
             context = context,
         )
-        dialog.showOrClear(fragmentManager)
+        dialog.showOrClear(fragmentManager, tag = "mini_player_clear_dialog")
     }
 
     private fun markAsPlayed() {

--- a/modules/features/player/src/main/res/layout/adapter_up_next_footer.xml
+++ b/modules/features/player/src/main/res/layout/adapter_up_next_footer.xml
@@ -7,44 +7,17 @@
     android:layout_height="wrap_content"
     android:orientation="vertical">
 
-    <androidx.constraintlayout.widget.ConstraintLayout
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
+    <TextView
+        android:id="@+id/lblUpNextTime"
+        style="@style/P60"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center_vertical"
         android:layout_marginStart="16dp"
-        android:layout_marginTop="4dp"
-        android:layout_marginEnd="16dp">
-
-        <androidx.constraintlayout.helper.widget.Flow
-            android:layout_width="match_parent"
-            android:orientation="horizontal"
-            android:layout_height="wrap_content"
-            app:constraint_referenced_ids="lblUpNextTime,btnClear"
-            app:flow_wrapMode="chain"
-            app:flow_horizontalStyle="spread_inside"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent" />
-
-        <TextView
-            android:id="@+id/lblUpNextTime"
-            style="@style/P60"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_gravity="center_vertical"
-            android:textColor="?attr/primary_text_02"
-            tools:text="2 episodes - 23 min." />
-
-
-        <com.google.android.material.button.MaterialButton
-            android:id="@+id/btnClear"
-            style="@style/Widget.MaterialComponents.Button.TextButton"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_gravity="center_vertical"
-            android:text="@string/player_up_next_clear_queue"
-            android:textColor="@color/player_button_text_color" />
-
-    </androidx.constraintlayout.widget.ConstraintLayout>
+        android:layout_marginTop="16dp"
+        android:layout_marginBottom="16dp"
+        android:textColor="?attr/primary_text_02"
+        tools:text="2 episodes - 23 min." />
 
     <LinearLayout
         android:id="@+id/emptyUpNextContainer"

--- a/modules/features/player/src/main/res/layout/adapter_up_next_footer.xml
+++ b/modules/features/player/src/main/res/layout/adapter_up_next_footer.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/upNextFooter"
     android:layout_width="match_parent"
@@ -9,7 +8,7 @@
 
     <TextView
         android:id="@+id/lblUpNextTime"
-        style="@style/P60"
+        style="@style/P50"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_gravity="center_vertical"

--- a/modules/features/player/src/main/res/menu/upnext.xml
+++ b/modules/features/player/src/main/res/menu/upnext.xml
@@ -1,15 +1,22 @@
 <?xml version="1.0" encoding="utf-8"?>
 <menu xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <item
+        android:id="@+id/clear_up_next"
+        android:title="@string/player_up_next_clear_queue"
+        android:icon="@drawable/ic_delete"
+        app:showAsAction="ifRoom" />
+
     <item
         android:id="@+id/media_route_menu_item"
         android:title="@string/play_on"
         android:visible="false"
         app:actionProviderClass="androidx.mediarouter.app.MediaRouteActionProvider"
-        app:showAsAction="always" />
+        app:showAsAction="ifRoom" />
 
     <item android:id="@+id/menu_select"
         android:title="@string/player_up_next_select"
         android:icon="@drawable/ic_multiselect"
-        app:showAsAction="always" />
+        app:showAsAction="ifRoom" />
 </menu>


### PR DESCRIPTION
## Description
- This PR moves the `Clear Queue` button to toolbar
- Display Up Next clear confirmation dialog regardless of the number of episodes in Up Next 5d9cf76b78c40386facf0183bfff21a71bd91f75
- I also fixed the font size for the remaining up next time to match with figma bbb19fc447a8ae5b873e7c6473b5c71836869f1b
- See this post for context: pdeCcb-7bN-p2
- See design: KjyDLK1DPPg3snPBMVGWHw-fi-0_1492

Fixes #[3059](https://github.com/Automattic/pocket-casts-android/issues/3059)

## Testing Instructions
1. Have an empty Up Next
2. Play an episode
3. Open Up next
4. ✅ Ensure you don't see the trash can icon since the Up Next is empty
5. Add one episode to Up Next
6. ✅ Ensure you see the trash can icon in Up Next
7. Tap on the trash can icon
8. ✅ Ensure the up next clear confirmation dialog opens



## Screenshots or Screencast 


[Screen_recording_20241021_114434.webm](https://github.com/user-attachments/assets/142a84db-09bf-48e3-8823-32951118ca11)




| Before | Small devices | Regular Devices |
|--------|---------------|-----------------|
| <img src="https://github.com/user-attachments/assets/1a867c24-8244-49b1-8112-987fa49e768d" alt="before" width="400"/> | <img src="https://github.com/user-attachments/assets/6221e88c-bb5f-4805-9250-494dd486bb89" alt="small device" width="400"/> | <img src="https://github.com/user-attachments/assets/7914a357-fd4d-4ae1-b619-afe45a00042a" alt="regular device" width="400"/> |









## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [ ] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack