### PR TITLE
[Project] Up Next Shuffle - Implement Shuffle Action

### DIFF
--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/models/db/UpNextQueueTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/models/db/UpNextQueueTest.kt
@@ -250,4 +250,30 @@ class UpNextQueueTest {
         assertTrue("Current episode should still be first", currentEpisode?.uuid == uuids.first())
         assertTrue("Queue should be empty", upNextQueue.queueEpisodes.isEmpty())
     }
+
+    @Test
+    fun testRemoveAndShuffle() {
+        val uuids = mutableListOf<String>()
+        val episodes = mutableListOf<PodcastEpisode>()
+
+        runBlocking {
+            for (i in 0..5) {
+                val uuid = UUID.randomUUID().toString()
+                val episode = PodcastEpisode(uuid = uuid, publishedDate = Date())
+                uuids.add(uuid)
+                episodes.add(episode)
+                appDatabase.episodeDao().insert(episode)
+                upNextQueue.playLast(episode, downloadManager, null)
+            }
+
+            val initialEpisode = upNextQueue.currentEpisode
+            assertTrue("Initial current episode should be the first uuid", initialEpisode?.uuid == uuids.first())
+
+            upNextQueue.removeEpisode(initialEpisode!!, shouldShuffleUpNext = true)
+        }
+
+        val newCurrentEpisode = upNextQueue.currentEpisode
+        assertTrue("New current episode should not be the removed episode", newCurrentEpisode?.uuid != uuids.first())
+        assertTrue("New current episode should be one of the remaining episodes", uuids.contains(newCurrentEpisode?.uuid))
+    }
 }

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/UpNextAdapter.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/UpNextAdapter.kt
@@ -173,30 +173,43 @@ class UpNextAdapter(
                 }
 
                 shuffle.isVisible = FeatureFlag.isEnabled(Feature.UP_NEXT_SHUFFLE)
-                shuffle.setShuffleDisabledButton()
+                shuffle.updateShuffleButton()
 
                 shuffle.setOnClickListener {
-                    shuffle.setShuffleEnabledButton()
+                    settings.upNextShuffle.set(!settings.upNextShuffle.value, updateModifiedAt = false)
+                    shuffle.updateShuffleButton()
                 }
 
                 root.layoutParams.height = ViewGroup.LayoutParams.WRAP_CONTENT
             }
         }
 
-        private fun ImageButton.setShuffleDisabledButton() {
-            this.setImageDrawable(ContextCompat.getDrawable(context, IR.drawable.shuffle))
-            this.contentDescription = context.getString(LR.string.up_next_shuffle_button_content_description)
-            this.setImageTintList(ColorStateList.valueOf(ThemeColor.primaryIcon02(theme)))
+        private fun ImageButton.updateShuffleButton() {
+            if (!FeatureFlag.isEnabled(Feature.UP_NEXT_SHUFFLE)) return
 
-            TooltipCompat.setTooltipText(this, context.getString(LR.string.up_next_shuffle_button_content_description))
-        }
+            val isEnabled = settings.upNextShuffle.value
 
-        private fun ImageButton.setShuffleEnabledButton() {
-            this.setImageDrawable(ContextCompat.getDrawable(context, IR.drawable.shuffle_enabled))
-            this.contentDescription = context.getString(LR.string.up_next_shuffle_disable_button_content_description)
-            this.setImageTintList(ColorStateList.valueOf(ThemeColor.primaryIcon01(theme)))
+            this.setImageDrawable(
+                ContextCompat.getDrawable(
+                    context,
+                    if (isEnabled) IR.drawable.shuffle_enabled else IR.drawable.shuffle,
+                ),
+            )
 
-            TooltipCompat.setTooltipText(this, context.getString(LR.string.up_next_shuffle_button_content_description))
+            this.contentDescription = context.getString(
+                if (isEnabled) LR.string.up_next_shuffle_disable_button_content_description else LR.string.up_next_shuffle_button_content_description,
+            )
+
+            this.setImageTintList(
+                ColorStateList.valueOf(
+                    if (isEnabled) ThemeColor.primaryIcon01(theme) else ThemeColor.primaryIcon02(theme),
+                ),
+            )
+
+            TooltipCompat.setTooltipText(
+                this,
+                context.getString(LR.string.up_next_shuffle_button_content_description),
+            )
         }
     }
 

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
@@ -261,6 +261,8 @@ interface Settings {
 
     val shelfItems: UserSetting<List<ShelfItem>>
 
+    val upNextShuffle: UserSetting<Boolean>
+
     fun getVersion(): String
     fun getVersionCode(): Int
 

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
@@ -114,6 +114,12 @@ class SettingsImpl @Inject constructor(
         },
     )
 
+    override val upNextShuffle: UserSetting<Boolean> = UserSetting.BoolPref(
+        sharedPrefKey = "upNextShuffle",
+        defaultValue = false,
+        sharedPrefs = sharedPreferences,
+    )
+
     override val refreshStateObservable = BehaviorRelay.create<RefreshState>().apply {
         val lastError = getLastRefreshError()
         val refreshDate = getLastRefreshDate()

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
@@ -1295,7 +1295,7 @@ open class PlaybackManager @Inject constructor(
             }
 
             // remove from Up Next
-            upNextQueue.removeEpisode(episode)
+            upNextQueue.removeEpisode(episode, shouldShuffleUpNext = settings.upNextShuffle.value)
 
             // stop the downloads
             episodeManager.updateAutoDownloadStatus(episode, PodcastEpisode.AUTO_DOWNLOAD_STATUS_IGNORE)

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/UpNextQueue.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/UpNextQueue.kt
@@ -36,7 +36,7 @@ interface UpNextQueue {
     suspend fun playLast(episode: BaseEpisode, downloadManager: DownloadManager, onAdd: (() -> Unit)?)
     suspend fun playAllNext(episodes: List<BaseEpisode>, downloadManager: DownloadManager)
     suspend fun playAllLast(episodes: List<BaseEpisode>, downloadManager: DownloadManager)
-    suspend fun removeEpisode(episode: BaseEpisode)
+    suspend fun removeEpisode(episode: BaseEpisode, shouldShuffleUpNext: Boolean = false)
     suspend fun clearAndPlayAll(episodes: List<BaseEpisode>, downloadManager: DownloadManager)
     fun moveEpisode(from: Int, to: Int)
     fun changeList(episodes: List<BaseEpisode>)


### PR DESCRIPTION
## Description
- This PR add the action to shuffle when tapping on up next shuffle button

> [!NOTE]  
> In another PR I will handle the shuffle state sync

Fixes #3064

## Testing Instructions
Have the shuffle feature flag enabled

### Shuffle Feature

1. Add some episodes to Up Next
2. Play an episode
3. Have the shuffle disabled
4. Seek the current playing episode to almost the end
5. Wait for the episode ends
6. ✅ Ensure the first episode from up next starts playing
7. Enable shuffle
8. Seek the current playing episode to almost the end
9. Wait for the episode ends
10. ✅ Ensure a random episode from up next starts playing _(Since we are using a random way to get the next episode, we can also pick the first one from up next, so I recommend to test this a couple of times to ensure that is taking random episodes from up next)_
11. ✅ Ensure the random episode that started playing was removed from the up next queue

### Regression tests

#### Play Next / Play Last
1. Have some episodes in Up next and shuffle enabled
2. Open an podcast
3. Swipe to add episode to Up next
4. ✅ Ensure you can add episodes to both end of the queue and top of the queue

<img width="356" alt="image" src="https://github.com/user-attachments/assets/fc243577-62b8-4b96-8091-5effb7b75ac0">

#### Play Up Next episode on Tap
1. Have some episodes in Up next and shuffle enabled
2. Go to Profile -> Settings -> General -> Enable `Play Up Next episode on Tap`
3. Go to Up next
4. Tap on some episode from Up next on queue
5. ✅ Ensure the episode you tapped starts playing
6. ✅ Ensure the up next kept the episode sort (only changed the episode you tapped and the current playing episode)

#### Sync Up next Queue
1. Have two devices logged with the same account
2. Have some populated Up Next
3. Tap on Refresh now in both of them to ensure they are synced
4. Ensure the two devices have the same up next queue
5. On device A, enable shuffle, wait for the current episode finishes
6. ✅ Ensure a random episode was picked
7. Observe the current Up Next
8. Go to Profile and Refresh Now
9. On device B, go to Profile and Refresh Now
10. Check the Up Next
11. ✅ Ensure the Up Next is the same you checked on step 7




## Screenshots or Screencast 
[Screen_recording_20241022_161358.webm](https://github.com/user-attachments/assets/5e93b8af-c9f0-4cf9-a6d3-ed2c792ed091)


## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [ ] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
