### PR TITLE
Referrals - Update FF

### DIFF
--- a/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
+++ b/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
@@ -1356,7 +1356,7 @@ class MainActivity :
     }
 
     private fun openReferralClaim(code: String) {
-        if (!FeatureFlag.isEnabled(Feature.REFERRALS)) {
+        if (!FeatureFlag.isEnabled(Feature.REFERRALS_CLAIM)) {
             return
         }
         settings.referralClaimCode.set(code, false)

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/ProfileFragment.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/ProfileFragment.kt
@@ -211,7 +211,7 @@ class ProfileFragment : BaseFragment() {
             }
         }
 
-        if (FeatureFlag.isEnabled(Feature.REFERRALS)) {
+        if (FeatureFlag.isEnabled(Feature.REFERRALS_SEND)) {
             binding.btnGift.setContent {
                 AppTheme(theme.activeTheme) {
                     ReferralsIconWithTooltip()

--- a/modules/features/referrals/src/main/kotlin/au/com/shiftyjelly/pocketcasts/referrals/ReferralsViewModel.kt
+++ b/modules/features/referrals/src/main/kotlin/au/com/shiftyjelly/pocketcasts/referrals/ReferralsViewModel.kt
@@ -42,7 +42,7 @@ class ReferralsViewModel @Inject constructor(
                     userManager.getSignInState().asFlow(),
                     settings.playerOrUpNextBottomSheetState,
                 ) { signInState, playerBottomSheetState ->
-                    val eligibleToSendPass = FeatureFlag.isEnabled(Feature.REFERRALS) && signInState.isSignedInAsPlusOrPatron
+                    val eligibleToSendPass = FeatureFlag.isEnabled(Feature.REFERRALS_SEND) && signInState.isSignedInAsPlusOrPatron
                     val eligibleToClaimPass = FeatureFlag.isEnabled(Feature.REFERRALS) &&
                         (!signInState.isSignedIn || signInState.isSignedInAsFree) &&
                         settings.referralClaimCode.value.isNotEmpty()

--- a/modules/features/referrals/src/main/kotlin/au/com/shiftyjelly/pocketcasts/referrals/ReferralsViewModel.kt
+++ b/modules/features/referrals/src/main/kotlin/au/com/shiftyjelly/pocketcasts/referrals/ReferralsViewModel.kt
@@ -43,7 +43,7 @@ class ReferralsViewModel @Inject constructor(
                     settings.playerOrUpNextBottomSheetState,
                 ) { signInState, playerBottomSheetState ->
                     val eligibleToSendPass = FeatureFlag.isEnabled(Feature.REFERRALS_SEND) && signInState.isSignedInAsPlusOrPatron
-                    val eligibleToClaimPass = FeatureFlag.isEnabled(Feature.REFERRALS) &&
+                    val eligibleToClaimPass = FeatureFlag.isEnabled(Feature.REFERRALS_CLAIM) &&
                         (!signInState.isSignedIn || signInState.isSignedInAsFree) &&
                         settings.referralClaimCode.value.isNotEmpty()
                     _state.update {

--- a/modules/features/referrals/src/test/kotlin/au/com/shiftyjelly/pocketcasts/referrals/ReferralsViewModelTest.kt
+++ b/modules/features/referrals/src/test/kotlin/au/com/shiftyjelly/pocketcasts/referrals/ReferralsViewModelTest.kt
@@ -63,7 +63,8 @@ class ReferralsViewModelTest {
 
     @Before
     fun setUp() {
-        FeatureFlag.setEnabled(Feature.REFERRALS, true)
+        FeatureFlag.setEnabled(Feature.REFERRALS_CLAIM, true)
+        FeatureFlag.setEnabled(Feature.REFERRALS_SEND, true)
         whenever(referralOfferInfo.subscriptionWithOffer).thenReturn(mock<Subscription.Trial>())
         whenever(settings.playerOrUpNextBottomSheetState).thenReturn(flowOf(BottomSheetBehavior.STATE_COLLAPSED))
     }
@@ -86,13 +87,14 @@ class ReferralsViewModelTest {
     }
 
     @Test
-    fun `referrals gift icon is not shown if feature flag is disabled`() = runTest {
-        FeatureFlag.setEnabled(Feature.REFERRALS, false)
+    fun `referrals gift icon with tooltip is not shown if referrals send feature flag is disabled`() = runTest {
+        FeatureFlag.setEnabled(Feature.REFERRALS_SEND, false)
 
         initViewModel()
 
         viewModel.state.test {
             assertEquals(false, (awaitItem() as UiState.Loaded).showIcon)
+            assertEquals(false, (awaitItem() as UiState.Loaded).showTooltip)
         }
     }
 

--- a/modules/features/referrals/src/test/kotlin/au/com/shiftyjelly/pocketcasts/referrals/ReferralsViewModelTest.kt
+++ b/modules/features/referrals/src/test/kotlin/au/com/shiftyjelly/pocketcasts/referrals/ReferralsViewModelTest.kt
@@ -87,14 +87,13 @@ class ReferralsViewModelTest {
     }
 
     @Test
-    fun `referrals gift icon with tooltip is not shown if referrals send feature flag is disabled`() = runTest {
+    fun `referrals gift icon hidden if referrals send feature flag is disabled`() = runTest {
         FeatureFlag.setEnabled(Feature.REFERRALS_SEND, false)
 
         initViewModel()
 
         viewModel.state.test {
             assertEquals(false, (awaitItem() as UiState.Loaded).showIcon)
-            assertEquals(false, (awaitItem() as UiState.Loaded).showTooltip)
         }
     }
 
@@ -191,6 +190,17 @@ class ReferralsViewModelTest {
     }
 
     @Test
+    fun `tooltip hidden if referrals send feature flag is disabled`() = runTest {
+        FeatureFlag.setEnabled(Feature.REFERRALS_SEND, false)
+
+        initViewModel()
+
+        viewModel.state.test {
+            assertEquals(false, (awaitItem() as UiState.Loaded).showTooltip)
+        }
+    }
+
+    @Test
     fun `profile banner is hidden if referral code is empty`() = runTest {
         initViewModel(
             referralCode = "",
@@ -244,6 +254,19 @@ class ReferralsViewModelTest {
         )
 
         viewModel.onHideBannerClick()
+
+        viewModel.state.test {
+            assertEquals(false, (awaitItem() as UiState.Loaded).showProfileBanner)
+        }
+    }
+
+    @Test
+    fun `profile banner is hidden if referrals claim feature is disabled`() = runTest {
+        FeatureFlag.setEnabled(Feature.REFERRALS_CLAIM, false)
+        initViewModel(
+            signInState = SignInState.SignedOut,
+            referralCode = referralClaimCode,
+        )
 
         viewModel.state.test {
             assertEquals(false, (awaitItem() as UiState.Loaded).showProfileBanner)

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/type/SubscriptionMapper.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/type/SubscriptionMapper.kt
@@ -28,7 +28,7 @@ class SubscriptionMapper @Inject constructor() {
                 ?.filter { it.offerSubscriptionPricingPhase == null } // Take the first if there are multiple SubscriptionOfferDetails without special offers
         } ?: emptyList()
 
-        val relevantSubscriptionOfferDetails = if (FeatureFlag.isEnabled(Feature.REFERRALS) && referralProductDetails != null) {
+        val relevantSubscriptionOfferDetails = if ((FeatureFlag.isEnabled(Feature.REFERRALS_CLAIM) || FeatureFlag.isEnabled(Feature.REFERRALS_SEND)) && referralProductDetails != null) {
             matchingSubscriptionOfferDetails.find { it.offerId == referralProductDetails.offerId }
         } else {
             val matchingSubscriptionOfferDetailsWithoutReferralOffer = matchingSubscriptionOfferDetails
@@ -80,7 +80,7 @@ class SubscriptionMapper @Inject constructor() {
             it.offerId in buildList {
                 add(Subscription.TRIAL_OFFER_ID)
                 referralProductDetails?.let {
-                    if (FeatureFlag.isEnabled(Feature.REFERRALS)) {
+                    if (FeatureFlag.isEnabled(Feature.REFERRALS_CLAIM) || FeatureFlag.isEnabled(Feature.REFERRALS_SEND)) {
                         add(referralProductDetails.offerId)
                     }
                 }

--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/Feature.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/Feature.kt
@@ -99,9 +99,17 @@ enum class Feature(
         hasFirebaseRemoteFlag = true,
         hasDevToggle = false,
     ),
-    REFERRALS(
-        key = "referrals",
-        title = "Referrals",
+    REFERRALS_CLAIM(
+        key = "referrals_claim",
+        title = "Referrals Claim",
+        defaultValue = BuildConfig.DEBUG,
+        tier = FeatureTier.Free,
+        hasFirebaseRemoteFlag = true,
+        hasDevToggle = true,
+    ),
+    REFERRALS_SEND(
+        key = "referrals_send",
+        title = "Referrals Send",
         defaultValue = BuildConfig.DEBUG,
         tier = FeatureTier.Free,
         hasFirebaseRemoteFlag = true,


### PR DESCRIPTION
## Description
This updates FF as follows: 
- `referrals_send` for send functionality
- `referrals_claim` for claim functionality

Internal Ref: p1729601600841489/1729500204.071419-slack-C07HDV91FBQ

## Testing Instructions
Code review should be sufficient.

Optional:

Test.1 `referrals_claim` disabled, `referrals_send` enabled
1. Disable `referrals_claim` FF, enable `referrals_send` FF 
2. Open the app using a paid account
3.  ✅ Notice that you see the gift icon with tooltip in the toolbar
4. Tap gift icon to open send pass screen
5. Share and save the referral link
6. Sign out
7. Tap on valid referral link generated above
8.  ✅ Notice that the referral screen is not shown and Profile tab referral banner is not shown

Test.2 `referrals_send` disabled, `referrals_claim` enabled
1. Disable `referrals_send` FF, enable `referrals_claim` FF  
2. Open the app using a paid account
3. Go to `Profile` tab
4. ✅ Notice that you do not see the gift icon with tooltip in the toolbar
5. Sign out
7. Tap on valid referral link generated above in Test.1 
8. ✅ Notice that the referral screen is shown and Profile tab referral banner is shown

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack