### PR TITLE
Change order of profile banners

### DIFF
--- a/modules/features/profile/src/main/res/layout/fragment_profile.xml
+++ b/modules/features/profile/src/main/res/layout/fragment_profile.xml
@@ -97,23 +97,23 @@
                 app:layout_constraintTop_toBottomOf="@+id/lblDaysSaved" />
 
             <androidx.compose.ui.platform.ComposeView
-                android:id="@+id/referralsClaimGuestPassBannerCard"
+                android:id="@+id/endOfYearPromptCard"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
-                android:background="?attr/primary_ui_02"
+                android:layout_marginHorizontal="16dp"
+                android:layout_marginTop="16dp"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toBottomOf="@+id/lblPodcastCountLabel" />
 
             <androidx.compose.ui.platform.ComposeView
-                android:id="@+id/endOfYearPromptCard"
+                android:id="@+id/referralsClaimGuestPassBannerCard"
                 android:layout_width="0dp"
+                android:layout_marginTop="8dp"
                 android:layout_height="wrap_content"
-                android:layout_marginHorizontal="16dp"
-                android:background="?attr/primary_ui_02"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/referralsClaimGuestPassBannerCard" />
+                app:layout_constraintTop_toBottomOf="@+id/endOfYearPromptCard" />
 
             <androidx.recyclerview.widget.RecyclerView
                 android:id="@+id/recyclerView"
@@ -121,10 +121,10 @@
                 android:layout_height="wrap_content"
                 android:background="?attr/primary_ui_02"
                 android:clipToPadding="false"
-                android:layout_marginTop="16dp"
+                android:layout_marginTop="8dp"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/endOfYearPromptCard" />
+                app:layout_constraintTop_toBottomOf="@+id/referralsClaimGuestPassBannerCard" />
 
             <TextView
                 android:id="@+id/lblRefreshStatus"


### PR DESCRIPTION
## Description

This PR moves EoY banner to the top.

## Testing Instructions

You can play around with different banner configurations but reviewing the screenshots should be enough.

## Screenshots or Screencast 

| Both | EoY | Referrals | None |
| - | - | - | - |
| ![both](https://github.com/user-attachments/assets/f3d2e1f1-325d-4959-b857-fb56e6767c88) | ![eoy](https://github.com/user-attachments/assets/25d7855d-c449-4fdb-96d9-70c7579ea87a) | ![ref](https://github.com/user-attachments/assets/c367e2bf-60dc-42f7-8f46-7b294adb9a0d) | ![none](https://github.com/user-attachments/assets/18dd37c5-ab3b-4606-be78-2b8f5fd6f079) |

## Checklist
- [x] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] ~I have considered whether it makes sense to add tests for my changes~
- [x] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [x] ~Any jetpack compose components I added or changed are covered by compose previews~
- [x] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~