### PR TITLE
Pause and resume story auto progress with the hold gesture

### DIFF
--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/StoriesFragment.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/StoriesFragment.kt
@@ -89,6 +89,8 @@ class StoriesFragment : BaseAppCompatDialogFragment() {
                 state = state,
                 pagerState = pagerState,
                 onChangeStory = storyChanger::change,
+                onHoldStory = { viewModel.pauseStoryAutoProgress(StoryProgressPauseReason.UserHoldingStory) },
+                onReleaseStory = { viewModel.resumeStoryAutoProgress(StoryProgressPauseReason.UserHoldingStory) },
                 onLearnAboutRatings = ::openRatingsInfo,
                 onClickUpsell = ::startUpsellFlow,
                 onClose = ::dismiss,

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/StoriesFragment.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/StoriesFragment.kt
@@ -146,7 +146,7 @@ class StoriesFragment : BaseAppCompatDialogFragment() {
 
     override fun onResume() {
         super.onResume()
-        viewModel.resumeStoryAutoProgress()
+        viewModel.resumeStoryAutoProgress(StoryProgressPauseReason.ScreenInBackground)
     }
 
     override fun onPause() {
@@ -155,7 +155,7 @@ class StoriesFragment : BaseAppCompatDialogFragment() {
         // won't auto switch for example when signing up takes
         // some time or when the EoY flow is interruped by
         // some other user actions such as a phone call.
-        viewModel.pauseStoryAutoProgress()
+        viewModel.pauseStoryAutoProgress(StoryProgressPauseReason.ScreenInBackground)
         super.onPause()
     }
 


### PR DESCRIPTION
## Description

This pauses auto progress of stories when users hold their finger on the screen.

## Testing Instructions

1. Start PB24.
2. Check that the navigation by tapping on the screen still works.
3. Hold a finger on a story. The auto progress should pause.
4. Release the finger. The auto progress should resume.
5. Check that the navigation still works.

## Checklist
- [x] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [x] ~Any jetpack compose components I added or changed are covered by compose previews~
- [x] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~