### PR TITLE
Navigate to the End of Year Cover story

### DIFF
--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/StoriesFragment.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/StoriesFragment.kt
@@ -91,6 +91,7 @@ class StoriesFragment : BaseAppCompatDialogFragment() {
                 onChangeStory = storyChanger::change,
                 onLearnAboutRatings = ::openRatingsInfo,
                 onClickUpsell = ::startUpsellFlow,
+                onRestartPlayback = storyChanger::reset,
                 onRetry = viewModel::syncData,
                 onClose = ::dismiss,
             )
@@ -224,5 +225,9 @@ private class StoryChanger(
                 scope.launch { pagerState.scrollToPage(nextIndex) }
             }
         }
+    }
+
+    fun reset() {
+        scope.launch { pagerState.scrollToPage(0) }
     }
 }

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/ui/EndingStory.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/ui/EndingStory.kt
@@ -39,6 +39,7 @@ import au.com.shiftyjelly.pocketcasts.ui.R as UR
 internal fun EndingStory(
     story: Story.Ending,
     measurements: EndOfYearMeasurements,
+    onRestartPlayback: () -> Unit,
 ) {
     Column(
         modifier = Modifier
@@ -52,6 +53,7 @@ internal fun EndingStory(
         EndingInfo(
             story = story,
             measurements = measurements,
+            onRestartPlayback = onRestartPlayback,
         )
     }
 }
@@ -118,6 +120,7 @@ private fun ByeByeText(
 private fun EndingInfo(
     story: Story.Ending,
     measurements: EndOfYearMeasurements,
+    onRestartPlayback: () -> Unit,
 ) {
     Column(
         modifier = Modifier.background(
@@ -149,7 +152,7 @@ private fun EndingInfo(
         )
         OutlinedEoyButton(
             text = stringResource(LR.string.end_of_year_replay),
-            onClick = {},
+            onClick = onRestartPlayback,
         )
     }
 }
@@ -161,6 +164,7 @@ private fun EndingPreview() {
         EndingStory(
             story = Story.Ending,
             measurements = measurements,
+            onRestartPlayback = {},
         )
     }
 }

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/ui/StoriesPage.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/ui/StoriesPage.kt
@@ -64,6 +64,7 @@ internal fun StoriesPage(
     onChangeStory: (Boolean) -> Unit,
     onLearnAboutRatings: () -> Unit,
     onClickUpsell: () -> Unit,
+    onRestartPlayback: () -> Unit,
     onRetry: () -> Unit,
     onClose: () -> Unit,
 ) {
@@ -96,6 +97,7 @@ internal fun StoriesPage(
                 onChangeStory = onChangeStory,
                 onLearnAboutRatings = onLearnAboutRatings,
                 onClickUpsell = onClickUpsell,
+                onRestartPlayback = onRestartPlayback,
             )
         }
 
@@ -136,6 +138,7 @@ private fun Stories(
     onChangeStory: (Boolean) -> Unit,
     onLearnAboutRatings: () -> Unit,
     onClickUpsell: () -> Unit,
+    onRestartPlayback: () -> Unit,
 ) {
     val widthPx = LocalDensity.current.run { measurements.width.toPx() }
 
@@ -160,7 +163,7 @@ private fun Stories(
             is Story.PlusInterstitial -> PlusInterstitialStory(story, measurements, onClickUpsell)
             is Story.YearVsYear -> YearVsYearStory(story, measurements)
             is Story.CompletionRate -> CompletionRateStory(story, measurements)
-            is Story.Ending -> EndingStory(story, measurements)
+            is Story.Ending -> EndingStory(story, measurements, onRestartPlayback)
         }
     }
 }


### PR DESCRIPTION
## Description

This adds navigation back to the beginning of the Plabyack flow.

## Testing Instructions

1. Start PB24.
2. Go to the Ending story.
3. Tap on "Play again".
4. PB24 should jump back to the Cover story.

## Checklist
- [x] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] ~I have considered whether it makes sense to add tests for my changes~
- [x] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [x] ~Any jetpack compose components I added or changed are covered by compose previews~
- [x] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~