### PR TITLE
Add End of Year failure state

### DIFF
--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/StoriesFragment.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/StoriesFragment.kt
@@ -91,6 +91,7 @@ class StoriesFragment : BaseAppCompatDialogFragment() {
                 onChangeStory = storyChanger::change,
                 onLearnAboutRatings = ::openRatingsInfo,
                 onClickUpsell = ::startUpsellFlow,
+                onRetry = viewModel::syncData,
                 onClose = ::dismiss,
             )
 

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/ui/StoriesPage.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/ui/StoriesPage.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.foundation.layout.BoxWithConstraints
@@ -19,6 +20,9 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.PagerState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.Button
+import androidx.compose.material.ButtonDefaults
 import androidx.compose.material.LinearProgressIndicator
 import androidx.compose.material.ripple.rememberRipple
 import androidx.compose.runtime.Composable
@@ -36,12 +40,16 @@ import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.coerceAtLeast
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import au.com.shiftyjelly.pocketcasts.compose.Devices
 import au.com.shiftyjelly.pocketcasts.compose.components.PagerProgressingIndicator
-import au.com.shiftyjelly.pocketcasts.compose.components.TextH10
+import au.com.shiftyjelly.pocketcasts.compose.components.TextH30
+import au.com.shiftyjelly.pocketcasts.compose.components.TextP40
 import au.com.shiftyjelly.pocketcasts.endofyear.UiState
 import au.com.shiftyjelly.pocketcasts.models.to.Story
 import au.com.shiftyjelly.pocketcasts.utils.Util
@@ -56,6 +64,7 @@ internal fun StoriesPage(
     onChangeStory: (Boolean) -> Unit,
     onLearnAboutRatings: () -> Unit,
     onClickUpsell: () -> Unit,
+    onRetry: () -> Unit,
     onClose: () -> Unit,
 ) {
     val size = LocalContext.current.sizeLimit?.let(Modifier::size) ?: Modifier.fillMaxSize()
@@ -70,7 +79,7 @@ internal fun StoriesPage(
         var coverTextHeight by remember { mutableStateOf(0.dp) }
 
         if (state is UiState.Failure) {
-            ErrorMessage()
+            ErrorMessage(onRetry)
         } else if (state is UiState.Syncing || !isTextSizeComputed) {
             LoadingIndicator()
         } else if (state is UiState.Synced) {
@@ -209,15 +218,33 @@ private fun LoadingIndicator() {
 }
 
 @Composable
-private fun ErrorMessage() {
-    Box(
-        contentAlignment = Alignment.Center,
+private fun ErrorMessage(
+    onRetry: () -> Unit,
+) {
+    Column(
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally,
         modifier = Modifier
             .fillMaxSize()
-            .background(Story.Cover.backgroundColor)
-            .padding(16.dp),
+            .background(Story.Cover.backgroundColor),
     ) {
-        TextH10(text = "Whoops!")
+        TextH30(
+            text = stringResource(id = LR.string.end_of_year_stories_failed),
+            textAlign = TextAlign.Center,
+            color = Color.Black,
+            modifier = Modifier.padding(horizontal = 40.dp),
+        )
+        Button(
+            onClick = onRetry,
+            shape = RoundedCornerShape(20.dp),
+            colors = ButtonDefaults.buttonColors(backgroundColor = Color(0xFFEEB1F4)),
+            modifier = Modifier.padding(top = 20.dp),
+        ) {
+            TextP40(
+                text = stringResource(id = LR.string.retry),
+                color = Color.Black,
+            )
+        }
     }
 }
 
@@ -233,3 +260,11 @@ private val Context.sizeLimit: DpSize?
             null
         }
     }
+
+@Preview(device = Devices.PortraitRegular)
+@Composable
+private fun ErrorMessagePreview() {
+    ErrorMessage(
+        onRetry = {},
+    )
+}


### PR DESCRIPTION
## Description

This adds error state to the End of Year.

## Testing Instructions

1. Apply [this patch](https://github.com/user-attachments/files/17486631/eoy-err.patch).
2. Start the app and sync your account so you can start PB24.
3. Turn off the Internet connection.
4. Start PB24.
5. You should see the error screen.
6. Tap on "Retry".
7. It should still fail to load the data.
8. Turn on the Internet connection.
9. Tap on "Retry".
10. You should see the loading screen.
11. After a while you should see the stories.

## Screenshots or Screencast 

### Error screen

![Screenshot_20241023-090711](https://github.com/user-attachments/assets/c2e0bbcf-057e-44fd-9b77-7d5987385069)

### Demo

https://github.com/user-attachments/assets/0a4ce365-15f1-430d-aa32-ae54546154a4

## Checklist
- [x] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] ~I have considered whether it makes sense to add tests for my changes~
- [x] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] ~with different themes~
- [x] ~with a landscape orientation~
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack
