### PR TITLE
Referrals - Improve claim display from referrals deep link

### DIFF
--- a/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
+++ b/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
@@ -1360,13 +1360,9 @@ class MainActivity :
             return
         }
         settings.referralClaimCode.set(code, false)
-        launch {
-            delay(1000) // To allow loading tabs and prevent race condition in updating activity's status bar color
-            withContext(Dispatchers.Main) {
-                val fragment = ReferralsGuestPassFragment.newInstance(ReferralsGuestPassFragment.ReferralsPageType.Claim)
-                showBottomSheet(fragment)
-            }
-        }
+        openTab(VR.id.navigation_profile)
+        val fragment = ReferralsGuestPassFragment.newInstance(ReferralsGuestPassFragment.ReferralsPageType.Claim)
+        showBottomSheet(fragment)
     }
 
     override fun onConfigurationChanged(newConfig: Configuration) {

--- a/modules/features/referrals/src/main/kotlin/au/com/shiftyjelly/pocketcasts/referrals/ReferralsGuestPassFragment.kt
+++ b/modules/features/referrals/src/main/kotlin/au/com/shiftyjelly/pocketcasts/referrals/ReferralsGuestPassFragment.kt
@@ -25,6 +25,7 @@ import au.com.shiftyjelly.pocketcasts.utils.extensions.getActivity
 import au.com.shiftyjelly.pocketcasts.views.fragments.BaseFragment
 import au.com.shiftyjelly.pocketcasts.views.helper.UiUtil.setBackgroundColor
 import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.parcelize.Parcelize
 import androidx.compose.ui.graphics.Color as ComposeColor
@@ -71,6 +72,7 @@ class ReferralsGuestPassFragment : BaseFragment() {
                     if (windowSize.widthSizeClass == WindowWidthSizeClass.Compact ||
                         windowSize.heightSizeClass == WindowHeightSizeClass.Compact
                     ) {
+                        delay(200) // To prevent race condition in updating activity's status bar color from tab fragments on fresh install
                         updateStatusAndNavColors()
                     }
                 }


### PR DESCRIPTION
## Description
This displays `Profile` tab before opening `Referrals` claim screen from `Referrals` deep link so that if another bottom sheet dismisses `Referrals` bottom sheet (e.g. pdeCcb-7f3-p2#comment-5708), user can still see the `Referrals` banner and open `Referrals` claim screen.

## Testing Instructions
Prerequisites: Save a valid referral link

1. Apply [this patch](https://github.com/user-attachments/files/17488090/force_refresh_on_resume.patch)
2. Login with a paid account
3. Switch to any tab other than Profile
4. Force stop the app 
5. Changed this account to Free using Users Admin console
6. Tap on the valid referral link
7. Wait for the app to open
8. ✅  Notice that `Referrals` screen is shown
9. ✅ Notice that when refresh completes, trial finished screen is shown
10. ✅ After dismissing the screen you see the Profile tab where referrals claim banner is displayed

## Screenshots or Screencast 

https://github.com/user-attachments/assets/c0b3e5df-29d7-434d-967a-a8f3f4b69d39



## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack