### PR TITLE
Control syncing End of Year data with a separate flag

### DIFF
--- a/app/src/main/java/au/com/shiftyjelly/pocketcasts/PocketCastsApplication.kt
+++ b/app/src/main/java/au/com/shiftyjelly/pocketcasts/PocketCastsApplication.kt
@@ -37,6 +37,8 @@ import au.com.shiftyjelly.pocketcasts.shared.AppLifecycleObserver
 import au.com.shiftyjelly.pocketcasts.shared.DownloadStatisticsReporter
 import au.com.shiftyjelly.pocketcasts.ui.helper.AppIcon
 import au.com.shiftyjelly.pocketcasts.utils.TimberDebugTree
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
 import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
 import au.com.shiftyjelly.pocketcasts.utils.log.LogBufferUncaughtExceptionHandler
 import au.com.shiftyjelly.pocketcasts.utils.log.RxJavaUncaughtExceptionHandling
@@ -280,7 +282,9 @@ class PocketCastsApplication : Application(), Configuration.Provider {
             .launchIn(applicationScope)
         keepPlayerWidgetsUpdated()
 
-        applicationScope.launch { endOfYearSync.sync() }
+        if (FeatureFlag.isEnabled(Feature.SYNC_EOY_DATA_ON_STARTUP)) {
+            applicationScope.launch { endOfYearSync.sync() }
+        }
 
         Timber.i("Launched ${BuildConfig.APPLICATION_ID}")
     }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/endofyear/EndOfYearSyncImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/endofyear/EndOfYearSyncImpl.kt
@@ -8,8 +8,6 @@ import au.com.shiftyjelly.pocketcasts.repositories.sync.SyncManager
 import au.com.shiftyjelly.pocketcasts.servers.extensions.toDate
 import au.com.shiftyjelly.pocketcasts.utils.coroutines.CachedAction
 import au.com.shiftyjelly.pocketcasts.utils.coroutines.run
-import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
-import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
 import java.time.Clock
 import java.time.Duration
 import java.time.Instant
@@ -65,11 +63,11 @@ class EndOfYearSyncImpl @Inject constructor(
     }
 
     private fun isDataSynced(): Boolean {
-        return Duration.between(timestampSetting.value, clock.instant()) < Duration.ofHours(6)
+        return Duration.between(timestampSetting.value, clock.instant()) < Duration.ofDays(1)
     }
 
     private fun canSyncData(): Boolean {
-        return FeatureFlag.isEnabled(Feature.END_OF_YEAR_2024) && syncManager.isLoggedIn()
+        return syncManager.isLoggedIn()
     }
 
     private suspend fun syncRatings() {

--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/Feature.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/Feature.kt
@@ -11,6 +11,14 @@ enum class Feature(
     val hasFirebaseRemoteFlag: Boolean,
     val hasDevToggle: Boolean,
 ) {
+    SYNC_EOY_DATA_ON_STARTUP(
+        key = "sync_eoy_data_on_startup",
+        title = "Whether the End of Year data should be synced on startup",
+        defaultValue = BuildConfig.DEBUG,
+        tier = FeatureTier.Free,
+        hasFirebaseRemoteFlag = true,
+        hasDevToggle = false,
+    ),
     END_OF_YEAR_2024(
         key = "end_of_year_2024",
         title = "End of Year 2024",


### PR DESCRIPTION
## Description

Two small improvements to the syncing process:
* Add a separate feature flag. This will allow me to enable syncing before enabling End of Year feature to let users sync data earlier and have better UX.
* Assume that data is in sync when it was synced at most a 1 day ago instead of 6 hours. This only affects users with multiple devices and from testing 6 hours period seems too small to me.

## Testing Instructions

Code review is enough.

## Checklist
- [x] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] ~I have considered whether it makes sense to add tests for my changes~
- [x] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [x] ~Any jetpack compose components I added or changed are covered by compose previews~
- [x] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~