### PR TITLE
Change the prototype domain

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -11,7 +11,7 @@ UI.user_error!('Please run fastlane via `bundle exec`') unless FastlaneCore::Hel
 ENV_FILE_NAME = '.pocketcastsandroid-env.default'
 USER_ENV_FILE_PATH = File.join(Dir.home, ENV_FILE_NAME)
 PROJECT_ROOT_FOLDER = File.dirname(File.expand_path(__dir__))
-PROTOTYPE_BUILD_DOMAIN = 'https://d2twmm2nzpx3bg.cloudfront.net'
+PROTOTYPE_BUILD_DOMAIN = 'https://cdn.a8c-ci.services'
 APP_PACKAGE_NAME = 'au.com.shiftyjelly.pocketcasts'
 GOOGLE_FIREBASE_SECRETS_PATH = File.join(PROJECT_ROOT_FOLDER, '.configure-files', 'firebase.secrets.json')
 ORIGINALS_METADATA_DIR_PATH = File.join(PROJECT_ROOT_FOLDER, 'metadata')


### PR DESCRIPTION
## Description

The prototype APKs show a browser warning when clicked, not using the CloudFront domain fixes this for now.

Slack discussion: p1729710669676249/1729685360.539729-slack-CC7L49W13 

## Testing Instructions

Check the prototype links don't show the warning when clicked.

## Screenshots 

<img width="960" alt="Screenshot 2024-10-24 at 9 58 10 am" src="https://github.com/user-attachments/assets/428920fb-a1ec-40f2-9455-2e9fbccb5d76">

