### PR TITLE
Fix effects being lost when paused

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
         ([#3048](https://github.com/Automattic/pocket-casts-android/pull/3048))
     *   Add support for the Catalan laguage
         ([#3072](https://github.com/Automattic/pocket-casts-android/pull/3072))
+*   Bug Fixes
+    *   Fix effects being lost when paused
+        ([#3084](https://github.com/Automattic/pocket-casts-android/pull/3084))
 *   Updates
     *   Move Up Next clear queue button to app bar
         ([#3068](https://github.com/Automattic/pocket-casts-android/pull/3068))

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/PlayerSeekBar.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/PlayerSeekBar.kt
@@ -137,9 +137,9 @@ class PlayerSeekBar @JvmOverloads constructor(context: Context, attrs: Attribute
             val elapsedTime = currentTime.toHhMmSs()
             elapsedTimeText.text = currentTime.toHhMmSs()
             elapsedTimeText.contentDescription = resources.getString(LR.string.player_played_up_to, elapsedTime)
-            val remaingingTime = (-remainingDuration()).toHhMmSs()
-            remainingTimeText.text = remaingingTime
-            remainingTimeText.contentDescription = resources.getString(LR.string.player_time_remaining, remaingingTime.removePrefix("-"))
+            val remainingTime = (-remainingDuration()).toHhMmSs()
+            remainingTimeText.text = remainingTime
+            remainingTimeText.contentDescription = resources.getString(LR.string.player_time_remaining, remainingTime.removePrefix("-"))
         }
     }
 

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
@@ -1809,18 +1809,14 @@ open class PlaybackManager @Inject constructor(
             ) {
                 sendDataWarningNotification(episode)
                 val previousPlaybackState = playbackStateRelay.blockingFirst()
-                val playbackState = PlaybackState(
+                val playbackState = PlaybackState.buildInitialState(
                     state = PlaybackState.State.EMPTY, // Make sure an existing playback notification goes away
-                    isBuffering = false,
-                    isPrepared = true,
-                    isSleepTimerRunning = previousPlaybackState?.isSleepTimerRunning ?: false,
-                    title = episode.title,
-                    durationMs = episode.durationMs,
-                    positionMs = episode.playedUpToMs,
-                    episodeUuid = episode.uuid,
+                    episode = episode,
                     podcast = podcast,
-                    chapters = if (sameEpisode) (previousPlaybackState?.chapters ?: Chapters()) else Chapters(),
-                    lastChangeFrom = LastChangeFrom.OnLoadCurrentEpisodeDataWarning.value,
+                    isPrepared = true,
+                    previousPlaybackState = previousPlaybackState,
+                    lastChangeFrom = LastChangeFrom.OnLoadCurrentEpisodeDataWarning,
+                    settings = settings,
                 )
                 withContext(Dispatchers.Main) {
                     playbackStateRelay.accept(playbackState)

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackState.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackState.kt
@@ -56,10 +56,10 @@ data class PlaybackState(
             podcast: Podcast?,
             isPrepared: Boolean,
             previousPlaybackState: PlaybackState?,
-            sameEpisode: Boolean = previousPlaybackState != null && episode.uuid == previousPlaybackState.episodeUuid,
             lastChangeFrom: LastChangeFrom,
             settings: Settings,
         ): PlaybackState {
+            val sameEpisode: Boolean = previousPlaybackState != null && episode.uuid == previousPlaybackState.episodeUuid
             val playbackEffects = if (podcast != null && podcast.overrideGlobalEffects) {
                 podcast.playbackEffects
             } else {


### PR DESCRIPTION
## Description

When the app is first open or playback is paused, the player doesn't show that the playback effects are enabled. The reason is that a new PlaybackState is created without the effects. 

I have tried to group the initialisation logic and put it in the PlaybackState object. I'm not sure if it should just in the PlaybackManager. 🤔 

Fixes https://github.com/Automattic/pocket-casts-android/issues/3057

## Testing Instructions

1. Go to Profile tab -> Settings -> General
2. Turn on "Adjust remaining time"
3. Play an episode
4. Open the full screen player
5. Take note of the time remaining
6. Tap on the effects icon
7. Increase the playback speed to 2
8. Close the effect dialog
9. ✅ Verify the time remaining has decreased
10. Pause the episode
11. Move the seekbar to a different position in the episode 
12. ✅ Verify the playback effect icon stays highlight and the remaining time stays decreased
13. Restart the app
14. Open the full screen player
15. ✅ Verify the playback effect icon is highlight and the remaining time is still decreased 

## Video


https://github.com/user-attachments/assets/4638d62d-c280-41a2-ad32-82b0d40fee33

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack
