### PR TITLE
Coerce remaining time to display at least 0 seconds

### DIFF
--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/PlayerSeekBar.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/PlayerSeekBar.kt
@@ -137,7 +137,13 @@ class PlayerSeekBar @JvmOverloads constructor(context: Context, attrs: Attribute
             val elapsedTime = currentTime.toHhMmSs()
             elapsedTimeText.text = currentTime.toHhMmSs()
             elapsedTimeText.contentDescription = resources.getString(LR.string.player_played_up_to, elapsedTime)
-            val remaingingTime = (-remainingDuration()).toHhMmSs()
+            val timeLeft = remainingDuration()
+            val remaingingTime = buildString {
+                if (timeLeft > Duration.ZERO) {
+                    append('-')
+                }
+                append(timeLeft.toHhMmSs())
+            }
             remainingTimeText.text = remaingingTime
             remainingTimeText.contentDescription = resources.getString(LR.string.player_time_remaining, remaingingTime.removePrefix("-"))
         }
@@ -148,7 +154,7 @@ class PlayerSeekBar @JvmOverloads constructor(context: Context, attrs: Attribute
             (duration - currentTime - chapters.skippedChaptersDuration(currentTime)) / playbackSpeed
         } else {
             duration - currentTime
-        }
+        }.coerceAtLeast(Duration.ZERO)
     }
 
     interface OnUserSeekListener {


### PR DESCRIPTION
## Description

@geekygecko  reported:

> I have just noticed that the time remaining can go to a positive value if the duration is incorrect which it seems to be with the podcast I’m testing with.
> The old code used to stop this happening by limiting it to 0.
> 
> It was https://pca.st/podcast/4010e110-45d0-0131-8293-723c91aeae46 while I was testing Chromecast
> I was testing it loaded the next episode in the Up Next

I can't replicate the issue but the fix is simple.

I'm targetting `7.75` since it was introduced there and the change is very harmless.

## Testing Instructions

Not sure. Smoke the remaining time. But code review should be enough.

## Checklist
- [x] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] ~I have considered whether it makes sense to add tests for my changes~
- [x] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [x] ~Any jetpack compose components I added or changed are covered by compose previews~
- [x] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~