### PR TITLE
[Project] Up Next Shuffle - Add Tracks

### DIFF
--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/UpNextAdapter.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/UpNextAdapter.kt
@@ -175,7 +175,11 @@ class UpNextAdapter(
                 shuffle.updateShuffleButton()
 
                 shuffle.setOnClickListener {
-                    settings.upNextShuffle.set(!settings.upNextShuffle.value, updateModifiedAt = false)
+                    val newValue = !settings.upNextShuffle.value
+                    analyticsTracker.track(AnalyticsEvent.UP_NEXT_SHUFFLE_TOGGLED, mapOf("enabled" to newValue))
+
+                    settings.upNextShuffle.set(newValue, updateModifiedAt = false)
+
                     shuffle.updateShuffleButton()
                 }
 

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/UpNextAdapter.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/UpNextAdapter.kt
@@ -176,7 +176,7 @@ class UpNextAdapter(
 
                 shuffle.setOnClickListener {
                     val newValue = !settings.upNextShuffle.value
-                    analyticsTracker.track(AnalyticsEvent.UP_NEXT_SHUFFLE_TOGGLED, mapOf("enabled" to newValue))
+                    analyticsTracker.track(AnalyticsEvent.UP_NEXT_SHUFFLE_ENABLED, mapOf("enabled" to newValue))
 
                     settings.upNextShuffle.set(newValue, updateModifiedAt = false)
 

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/UpNextAdapter.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/UpNextAdapter.kt
@@ -176,7 +176,7 @@ class UpNextAdapter(
 
                 shuffle.setOnClickListener {
                     val newValue = !settings.upNextShuffle.value
-                    analyticsTracker.track(AnalyticsEvent.UP_NEXT_SHUFFLE_ENABLED, mapOf("value" to newValue))
+                    analyticsTracker.track(AnalyticsEvent.UP_NEXT_SHUFFLE_ENABLED, mapOf("value" to newValue, SOURCE_KEY to upNextSource.analyticsValue))
 
                     settings.upNextShuffle.set(newValue, updateModifiedAt = false)
 

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/UpNextAdapter.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/UpNextAdapter.kt
@@ -176,7 +176,7 @@ class UpNextAdapter(
 
                 shuffle.setOnClickListener {
                     val newValue = !settings.upNextShuffle.value
-                    analyticsTracker.track(AnalyticsEvent.UP_NEXT_SHUFFLE_ENABLED, mapOf("enabled" to newValue))
+                    analyticsTracker.track(AnalyticsEvent.UP_NEXT_SHUFFLE_ENABLED, mapOf("value" to newValue))
 
                     settings.upNextShuffle.set(newValue, updateModifiedAt = false)
 

--- a/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
+++ b/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
@@ -315,6 +315,7 @@ enum class AnalyticsEvent(val key: String) {
     UP_NEXT_MULTI_SELECT_EXITED("up_next_multi_select_exited"),
     UP_NEXT_QUEUE_REORDERED("up_next_queue_reordered"),
     UP_NEXT_DISMISSED("up_next_dismissed"),
+    UP_NEXT_SHUFFLE_TOGGLED("up_next_shuffle_toggled"),
 
     /* Player */
     PLAYER_SHOWN("player_shown"),

--- a/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
+++ b/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
@@ -315,7 +315,7 @@ enum class AnalyticsEvent(val key: String) {
     UP_NEXT_MULTI_SELECT_EXITED("up_next_multi_select_exited"),
     UP_NEXT_QUEUE_REORDERED("up_next_queue_reordered"),
     UP_NEXT_DISMISSED("up_next_dismissed"),
-    UP_NEXT_SHUFFLE_TOGGLED("up_next_shuffle_toggled"),
+    UP_NEXT_SHUFFLE_ENABLED("up_next_shuffle_enabled"),
 
     /* Player */
     PLAYER_SHOWN("player_shown"),


### PR DESCRIPTION
## Description
- This add the track event for when we toggle the shuffle on/off
- This event also has the source like the other up next events:
` mini_player, now_playing, player, up_next_shortcut
`

Fixes #3063

## Testing Instructions
1. Have the shuffle feature flag enabled
2. Add some podcast to Up Next
3. Open Up Next
4. Toggle shuffle ON
5. ✅ Ensure  `🔵 Tracked: up_next_shuffle_enabled, Properties: {"value":true,"source":"source"` is tracked
6. Toggle shuffle OFF
7. ✅ Ensure  `🔵 Tracked: up_next_shuffle_enabled, Properties: {"value":false,"source":"source"` is tracked

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.

