### PR TITLE
Add story sharing

### DIFF
--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/settings/stats/StatsHelperTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/settings/stats/StatsHelperTest.kt
@@ -1,6 +1,7 @@
 package au.com.shiftyjelly.pocketcasts.settings.stats
 
 import androidx.test.platform.app.InstrumentationRegistry
+import au.com.shiftyjelly.pocketcasts.localization.helper.StatsHelper
 import org.junit.Assert.assertEquals
 import org.junit.Test
 

--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/sharing/SharingClientTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/sharing/SharingClientTest.kt
@@ -895,7 +895,7 @@ class SharingClientTest {
     @Test
     fun shareYearVsYearStory() = runTest {
         val text = buildString {
-            append(context.getString(LR.string.end_of_year_stories_year_over_share_text, 999, 1000))
+            append(context.getString(LR.string.end_of_year_stories_year_over_share_text, 1000, 999))
             append(" https://pca.st")
             append(" #pocketcasts #playback1000")
         }

--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/sharing/SharingClientTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/sharing/SharingClientTest.kt
@@ -15,17 +15,24 @@ import android.net.Uri
 import androidx.core.content.IntentCompat
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
+import au.com.shiftyjelly.pocketcasts.localization.helper.StatsHelper
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
+import au.com.shiftyjelly.pocketcasts.models.to.LongestEpisode
+import au.com.shiftyjelly.pocketcasts.models.to.RatingStats
+import au.com.shiftyjelly.pocketcasts.models.to.Story
+import au.com.shiftyjelly.pocketcasts.models.to.TopPodcast
 import au.com.shiftyjelly.pocketcasts.models.type.ReferralsOfferInfoMock
+import au.com.shiftyjelly.pocketcasts.models.type.SubscriptionTier
 import au.com.shiftyjelly.pocketcasts.sharing.BuildConfig.WEB_BASE_HOST
 import au.com.shiftyjelly.pocketcasts.utils.FileUtil
 import java.io.File
+import java.time.Year
 import java.util.Date
 import kotlin.random.Random
+import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -36,7 +43,6 @@ import org.junit.runner.RunWith
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 @RunWith(AndroidJUnit4::class)
-@OptIn(ExperimentalCoroutinesApi::class)
 class SharingClientTest {
     private val context = InstrumentationRegistry.getInstrumentation().targetContext
 
@@ -691,6 +697,307 @@ class SharingClientTest {
         assertEquals("$text\n\nhttps://$WEB_BASE_HOST/redeem/$referralCode", intent.getStringExtra(EXTRA_TEXT))
         assertEquals(subject, intent.getStringExtra(EXTRA_SUBJECT))
         assertEquals(FLAG_GRANT_READ_URI_PERMISSION, intent.flags and FLAG_GRANT_READ_URI_PERMISSION)
+    }
+
+    @Test
+    fun numberOfShowsStory() = runTest {
+        val text = buildString {
+            append(context.getString(LR.string.end_of_year_story_listened_to_numbers_share_text, 100, 200, 1000))
+            append(" https://pca.st")
+            append(" #pocketcasts #playback1000")
+        }
+        val story = Story.NumberOfShows(
+            showCount = 100,
+            epsiodeCount = 200,
+            topShowIds = emptyList(),
+            bottomShowIds = emptyList(),
+        )
+        val request = SharingRequest.endOfYearStory(story, Year.of(1000)).build()
+
+        val response = client.share(request)
+        assertTrue(response.isSuccsessful)
+        assertNull(response.feedbackMessage)
+
+        val intent = shareStarter.requireChooserIntent
+
+        assertEquals(ACTION_SEND, intent.action)
+        assertEquals("text/plain", intent.type)
+        assertEquals(text, intent.getStringExtra(EXTRA_TEXT))
+        assertEquals(FLAG_GRANT_READ_URI_PERMISSION, intent.flags and FLAG_GRANT_READ_URI_PERMISSION)
+    }
+
+    @Test
+    fun shareTopShowStory() = runTest {
+        val text = buildString {
+            append(context.getString(LR.string.end_of_year_story_top_podcast_share_text, 1000, "https://pca.st/podcast/podcast-id"))
+            append(" #pocketcasts #playback1000")
+        }
+        val story = Story.TopShow(
+            show = TopPodcast(
+                uuid = "podcast-id",
+                title = "podcast-title",
+                author = "pocast-author",
+                playbackTimeSeconds = 0.0,
+                playedEpisodeCount = 0,
+            ),
+        )
+        val request = SharingRequest.endOfYearStory(story, Year.of(1000)).build()
+
+        val response = client.share(request)
+        assertTrue(response.isSuccsessful)
+        assertNull(response.feedbackMessage)
+
+        val intent = shareStarter.requireChooserIntent
+
+        assertEquals(ACTION_SEND, intent.action)
+        assertEquals("text/plain", intent.type)
+        assertEquals(text, intent.getStringExtra(EXTRA_TEXT))
+        assertEquals(FLAG_GRANT_READ_URI_PERMISSION, intent.flags and FLAG_GRANT_READ_URI_PERMISSION)
+    }
+
+    @Test
+    fun shareTopShowsStoryWithCustomUrl() = runTest {
+        val text = buildString {
+            append(context.getString(LR.string.end_of_year_story_top_podcasts_share_text, "https://pca.st"))
+            append(" #pocketcasts #playback1000")
+        }
+        val story = Story.TopShows(
+            shows = emptyList(),
+            podcastListUrl = null,
+        )
+        val request = SharingRequest.endOfYearStory(story, Year.of(1000)).build()
+
+        val response = client.share(request)
+        assertTrue(response.isSuccsessful)
+        assertNull(response.feedbackMessage)
+
+        val intent = shareStarter.requireChooserIntent
+
+        assertEquals(ACTION_SEND, intent.action)
+        assertEquals("text/plain", intent.type)
+        assertEquals(text, intent.getStringExtra(EXTRA_TEXT))
+        assertEquals(FLAG_GRANT_READ_URI_PERMISSION, intent.flags and FLAG_GRANT_READ_URI_PERMISSION)
+    }
+
+    @Test
+    fun shareTopShowsStoryWithoutCustomUrl() = runTest {
+        val text = buildString {
+            append(context.getString(LR.string.end_of_year_story_top_podcasts_share_text, "podcast-list-url"))
+            append(" #pocketcasts #playback1000")
+        }
+        val story = Story.TopShows(
+            shows = emptyList(),
+            podcastListUrl = "podcast-list-url",
+        )
+        val request = SharingRequest.endOfYearStory(story, Year.of(1000)).build()
+
+        val response = client.share(request)
+        assertTrue(response.isSuccsessful)
+        assertNull(response.feedbackMessage)
+
+        val intent = shareStarter.requireChooserIntent
+
+        assertEquals(ACTION_SEND, intent.action)
+        assertEquals("text/plain", intent.type)
+        assertEquals(text, intent.getStringExtra(EXTRA_TEXT))
+        assertEquals(FLAG_GRANT_READ_URI_PERMISSION, intent.flags and FLAG_GRANT_READ_URI_PERMISSION)
+    }
+
+    @Test
+    fun shareRatingsStory() = runTest {
+        val text = buildString {
+            append(context.getString(LR.string.end_of_year_story_ratings_share_text, 150, 1000, 5))
+            append(" https://pca.st")
+            append(" #pocketcasts #playback1000")
+        }
+        val story = Story.Ratings(
+            stats = RatingStats(
+                ones = 10,
+                twos = 20,
+                threes = 30,
+                fours = 40,
+                fives = 50,
+            ),
+        )
+        val request = SharingRequest.endOfYearStory(story, Year.of(1000)).build()
+
+        val response = client.share(request)
+        assertTrue(response.isSuccsessful)
+        assertNull(response.feedbackMessage)
+
+        val intent = shareStarter.requireChooserIntent
+
+        assertEquals(ACTION_SEND, intent.action)
+        assertEquals("text/plain", intent.type)
+        assertEquals(text, intent.getStringExtra(EXTRA_TEXT))
+        assertEquals(FLAG_GRANT_READ_URI_PERMISSION, intent.flags and FLAG_GRANT_READ_URI_PERMISSION)
+    }
+
+    @Test
+    fun shareTotalTimeStory() = runTest {
+        val text = buildString {
+            append(
+                context.getString(
+                    LR.string.end_of_year_story_listened_to_share_text,
+                    StatsHelper.secondsToFriendlyString(12345, context.resources),
+                ),
+            )
+            append(" https://pca.st")
+            append(" #pocketcasts #playback1000")
+        }
+        val story = Story.TotalTime(
+            duration = 12345.seconds,
+        )
+        val request = SharingRequest.endOfYearStory(story, Year.of(1000)).build()
+
+        val response = client.share(request)
+        assertTrue(response.isSuccsessful)
+        assertNull(response.feedbackMessage)
+
+        val intent = shareStarter.requireChooserIntent
+
+        assertEquals(ACTION_SEND, intent.action)
+        assertEquals("text/plain", intent.type)
+        assertEquals(text, intent.getStringExtra(EXTRA_TEXT))
+        assertEquals(FLAG_GRANT_READ_URI_PERMISSION, intent.flags and FLAG_GRANT_READ_URI_PERMISSION)
+    }
+
+    @Test
+    fun shareLongestEpisodeStory() = runTest {
+        val text = buildString {
+            append(context.getString(LR.string.end_of_year_story_longest_episode_share_text, 1000, "https://pca.st/episode/episode-id"))
+            append(" #pocketcasts #playback1000")
+        }
+        val story = Story.LongestEpisode(
+            episode = LongestEpisode(
+                episodeId = "episode-id",
+                episodeTitle = "",
+                podcastId = "",
+                podcastTitle = "",
+                durationSeconds = 0.0,
+                coverUrl = null,
+            ),
+        )
+        val request = SharingRequest.endOfYearStory(story, Year.of(1000)).build()
+
+        val response = client.share(request)
+        assertTrue(response.isSuccsessful)
+        assertNull(response.feedbackMessage)
+
+        val intent = shareStarter.requireChooserIntent
+
+        assertEquals(ACTION_SEND, intent.action)
+        assertEquals("text/plain", intent.type)
+        assertEquals(text, intent.getStringExtra(EXTRA_TEXT))
+        assertEquals(FLAG_GRANT_READ_URI_PERMISSION, intent.flags and FLAG_GRANT_READ_URI_PERMISSION)
+    }
+
+    @Test
+    fun shareYearVsYearStory() = runTest {
+        val text = buildString {
+            append(context.getString(LR.string.end_of_year_stories_year_over_share_text, 999, 1000))
+            append(" https://pca.st")
+            append(" #pocketcasts #playback1000")
+        }
+        val story = Story.YearVsYear(
+            lastYearDuration = Duration.ZERO,
+            thisYearDuration = Duration.ZERO,
+            subscriptionTier = SubscriptionTier.NONE,
+        )
+        val request = SharingRequest.endOfYearStory(story, Year.of(1000)).build()
+
+        val response = client.share(request)
+        assertTrue(response.isSuccsessful)
+        assertNull(response.feedbackMessage)
+
+        val intent = shareStarter.requireChooserIntent
+
+        assertEquals(ACTION_SEND, intent.action)
+        assertEquals("text/plain", intent.type)
+        assertEquals(text, intent.getStringExtra(EXTRA_TEXT))
+        assertEquals(FLAG_GRANT_READ_URI_PERMISSION, intent.flags and FLAG_GRANT_READ_URI_PERMISSION)
+    }
+
+    @Test
+    fun shareCompletionRateStory() = runTest {
+        val text = buildString {
+            append(context.getString(LR.string.end_of_year_stories_completion_rate_share_text, 1000))
+            append(" https://pca.st")
+            append(" #pocketcasts #playback1000")
+        }
+        val story = Story.CompletionRate(
+            listenedCount = 0,
+            completedCount = 0,
+            subscriptionTier = SubscriptionTier.NONE,
+        )
+        val request = SharingRequest.endOfYearStory(story, Year.of(1000)).build()
+
+        val response = client.share(request)
+        assertTrue(response.isSuccsessful)
+        assertNull(response.feedbackMessage)
+
+        val intent = shareStarter.requireChooserIntent
+
+        assertEquals(ACTION_SEND, intent.action)
+        assertEquals("text/plain", intent.type)
+        assertEquals(text, intent.getStringExtra(EXTRA_TEXT))
+        assertEquals(FLAG_GRANT_READ_URI_PERMISSION, intent.flags and FLAG_GRANT_READ_URI_PERMISSION)
+    }
+
+    @Test
+    fun shareCoverStory() = runTest {
+        val story = Story.Cover
+        val request = SharingRequest.endOfYearStory(story, Year.of(1000)).build()
+
+        val response = client.share(request)
+        assertFalse(response.isSuccsessful)
+        assertEquals(context.getString(LR.string.end_of_year_cant_share_message), response.feedbackMessage)
+
+        assertNull(shareStarter.chooserIntent)
+    }
+
+    @Test
+    fun sharePlusInterstitialStory() = runTest {
+        val story = Story.PlusInterstitial
+        val request = SharingRequest.endOfYearStory(story, Year.of(1000)).build()
+
+        val response = client.share(request)
+        assertFalse(response.isSuccsessful)
+        assertEquals(context.getString(LR.string.end_of_year_cant_share_message), response.feedbackMessage)
+
+        assertNull(shareStarter.chooserIntent)
+    }
+
+    @Test
+    fun shareEndingStory() = runTest {
+        val story = Story.Ending
+        val request = SharingRequest.endOfYearStory(story, Year.of(1000)).build()
+
+        val response = client.share(request)
+        assertFalse(response.isSuccsessful)
+        assertEquals(context.getString(LR.string.end_of_year_cant_share_message), response.feedbackMessage)
+
+        assertNull(shareStarter.chooserIntent)
+    }
+
+    @Test
+    fun shareRatingsStoryWithoutAnyRatings() = runTest {
+        val story = Story.Ratings(
+            stats = RatingStats(
+                ones = 0,
+                twos = 0,
+                threes = 0,
+                fours = 0,
+                fives = 0,
+            ),
+        )
+        val request = SharingRequest.endOfYearStory(story, Year.of(1000)).build()
+
+        val response = client.share(request)
+        assertFalse(response.isSuccsessful)
+        assertEquals(context.getString(LR.string.end_of_year_cant_share_message), response.feedbackMessage)
+
+        assertNull(shareStarter.chooserIntent)
     }
 
     private fun createClient(

--- a/modules/features/endofyear/build.gradle.kts
+++ b/modules/features/endofyear/build.gradle.kts
@@ -29,6 +29,7 @@ dependencies {
     api(projects.modules.services.preferences)
     api(projects.modules.services.repositories)
     api(projects.modules.services.servers)
+    api(projects.modules.services.sharing)
     api(projects.modules.services.ui)
     api(projects.modules.services.utils)
     api(projects.modules.services.views)

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/EndOfYearViewModel.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/EndOfYearViewModel.kt
@@ -12,6 +12,7 @@ import au.com.shiftyjelly.pocketcasts.repositories.endofyear.EndOfYearStats
 import au.com.shiftyjelly.pocketcasts.repositories.endofyear.EndOfYearSync
 import au.com.shiftyjelly.pocketcasts.repositories.subscription.SubscriptionManager
 import au.com.shiftyjelly.pocketcasts.servers.list.ListServiceManager
+import au.com.shiftyjelly.pocketcasts.sharing.SharingRequest
 import au.com.shiftyjelly.pocketcasts.utils.coroutines.CachedAction
 import au.com.shiftyjelly.pocketcasts.utils.extensions.padEnd
 import dagger.assisted.Assisted
@@ -39,6 +40,7 @@ class EndOfYearViewModel @AssistedInject constructor(
     private val endOfYearManager: EndOfYearManager,
     subscriptionManager: SubscriptionManager,
     private val listServiceManager: ListServiceManager,
+    private val sharingClient: StorySharingClient,
 ) : ViewModel() {
     private val syncState = MutableStateFlow<SyncState>(SyncState.Syncing)
 
@@ -208,6 +210,11 @@ class EndOfYearViewModel @AssistedInject constructor(
                 .lastOrNull { it.isFree }
                 ?.let(stories::indexOf)
         }?.takeIf { it != -1 }
+    }
+
+    internal fun share(story: Story) {
+        val request = SharingRequest.endOfYearStory(story, year).build()
+        viewModelScope.launch { sharingClient.shareStory(request) }
     }
 
     private fun getRandomShowIds(stats: EndOfYearStats): RandomShowIds? {

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/StoriesFragment.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/StoriesFragment.kt
@@ -41,7 +41,6 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
-import timber.log.Timber
 import android.R as AndroidR
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 import au.com.shiftyjelly.pocketcasts.ui.R as UR

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/StoriesFragment.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/StoriesFragment.kt
@@ -58,9 +58,10 @@ class StoriesFragment : BaseAppCompatDialogFragment() {
     private val viewModel by viewModels<EndOfYearViewModel>(
         extrasProducer = {
             defaultViewModelCreationExtras.withCreationCallback<EndOfYearViewModel.Factory> { factory ->
+                val year = EndOfYearManager.YEAR_TO_SYNC
                 factory.create(
-                    year = EndOfYearManager.YEAR_TO_SYNC,
-                    topListTitle = getString(LR.string.end_of_year_story_top_podcasts_share_text, "")
+                    year = year,
+                    topListTitle = getString(LR.string.end_of_year_story_top_podcasts_list_title, year.value),
                 )
             }
         },

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/StoriesFragment.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/StoriesFragment.kt
@@ -58,7 +58,10 @@ class StoriesFragment : BaseAppCompatDialogFragment() {
     private val viewModel by viewModels<EndOfYearViewModel>(
         extrasProducer = {
             defaultViewModelCreationExtras.withCreationCallback<EndOfYearViewModel.Factory> { factory ->
-                factory.create(EndOfYearManager.YEAR_TO_SYNC)
+                factory.create(
+                    year = EndOfYearManager.YEAR_TO_SYNC,
+                    topListTitle = getString(LR.string.end_of_year_story_top_podcasts_share_text, "")
+                )
             }
         },
     )

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/StorySharingClient.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/StorySharingClient.kt
@@ -1,0 +1,15 @@
+package au.com.shiftyjelly.pocketcasts.endofyear
+
+import au.com.shiftyjelly.pocketcasts.sharing.SharingClient
+import au.com.shiftyjelly.pocketcasts.sharing.SharingRequest
+import au.com.shiftyjelly.pocketcasts.sharing.SharingResponse
+
+interface StorySharingClient {
+    suspend fun shareStory(request: SharingRequest): SharingResponse
+}
+
+internal fun SharingClient.asStoryClient() = object : StorySharingClient {
+    override suspend fun shareStory(request: SharingRequest): SharingResponse {
+        return this@asStoryClient.share(request)
+    }
+}

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/di/EoyModule.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/di/EoyModule.kt
@@ -1,0 +1,16 @@
+package au.com.shiftyjelly.pocketcasts.endofyear.di
+
+import au.com.shiftyjelly.pocketcasts.endofyear.StorySharingClient
+import au.com.shiftyjelly.pocketcasts.endofyear.asStoryClient
+import au.com.shiftyjelly.pocketcasts.sharing.SharingClient
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+
+@Module
+@InstallIn(SingletonComponent::class)
+object EoyModule {
+    @Provides
+    fun storySharingClient(client: SharingClient): StorySharingClient = client.asStoryClient()
+}

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/ui/CompletionRateStory.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/ui/CompletionRateStory.kt
@@ -210,7 +210,7 @@ private fun CompletionRateInfo(
         val badgeId = when (story.subscriptionTier) {
             SubscriptionTier.PLUS -> IR.drawable.end_of_year_2024_completion_rate_plus_badge
             SubscriptionTier.PATRON -> IR.drawable.end_of_year_2024_completion_rate_patron_badge
-            SubscriptionTier.NONE, null -> null
+            SubscriptionTier.NONE -> null
         }
 
         if (badgeId != null) {

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/ui/CompletionRateStory.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/ui/CompletionRateStory.kt
@@ -52,13 +52,20 @@ import au.com.shiftyjelly.pocketcasts.ui.R as UR
 internal fun CompletionRateStory(
     story: Story.CompletionRate,
     measurements: EndOfYearMeasurements,
-) = CompletionRateStory(story, measurements, showBars = false)
+    onShareStory: () -> Unit,
+) = CompletionRateStory(
+    story = story,
+    measurements = measurements,
+    onShareStory = onShareStory,
+    showBars = false,
+)
 
 @Composable
 private fun CompletionRateStory(
     story: Story.CompletionRate,
     measurements: EndOfYearMeasurements,
     showBars: Boolean,
+    onShareStory: () -> Unit,
 ) {
     Column(
         modifier = Modifier
@@ -80,6 +87,7 @@ private fun CompletionRateStory(
         CompletionRateInfo(
             story = story,
             measurements = measurements,
+            onShareStory,
         )
     }
 }
@@ -128,7 +136,7 @@ private fun BarsSection(
                     index++
                 }
                 if (bars.isNotEmpty()) {
-                    bars.removeLast()
+                    bars.removeAt(bars.size - 1)
                 }
                 val spaceHeightPx = LocalDensity.run { SpaceHeight.roundToPx() }
                 val barsHeightPx = (bars.sumOf { it.height } - spaceHeightPx).coerceAtLeast(0)
@@ -202,6 +210,7 @@ private fun BarsSection(
 private fun CompletionRateInfo(
     story: Story.CompletionRate,
     measurements: EndOfYearMeasurements,
+    onShareStory: () -> Unit,
 ) {
     Column {
         Spacer(
@@ -247,7 +256,7 @@ private fun CompletionRateInfo(
             color = colorResource(UR.color.coolgrey_90),
             modifier = Modifier.padding(horizontal = 24.dp),
         )
-        ShareStoryButton(onClick = {})
+        ShareStoryButton(onClick = onShareStory)
     }
 }
 
@@ -265,6 +274,7 @@ private fun CompletionRatePreview(
             ),
             measurements = measurements,
             showBars = true,
+            onShareStory = {},
         )
     }
 }

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/ui/LongestEpisodeStory.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/ui/LongestEpisodeStory.kt
@@ -54,13 +54,20 @@ import au.com.shiftyjelly.pocketcasts.ui.R as UR
 internal fun LongestEpisodeStory(
     story: Story.LongestEpisode,
     measurements: EndOfYearMeasurements,
-) = LongestEpisodeStory(story, measurements, showCovers = false)
+    onShareStory: () -> Unit,
+) = LongestEpisodeStory(
+    story = story,
+    measurements = measurements,
+    onShareStory = onShareStory,
+    showCovers = false,
+)
 
 @Composable
 private fun LongestEpisodeStory(
     story: Story.LongestEpisode,
     measurements: EndOfYearMeasurements,
     showCovers: Boolean,
+    onShareStory: () -> Unit,
 ) {
     Column(
         modifier = Modifier
@@ -77,6 +84,7 @@ private fun LongestEpisodeStory(
         TextInfo(
             story = story,
             measurements = measurements,
+            onShareStory = onShareStory,
         )
     }
 }
@@ -208,6 +216,7 @@ private fun PodcastCover(
 private fun TextInfo(
     story: Story.LongestEpisode,
     measurements: EndOfYearMeasurements,
+    onShareStory: () -> Unit,
 ) {
     Column(
         modifier = Modifier.background(
@@ -244,7 +253,7 @@ private fun TextInfo(
             color = colorResource(UR.color.coolgrey_90),
             modifier = Modifier.padding(horizontal = 24.dp),
         )
-        ShareStoryButton(onClick = {})
+        ShareStoryButton(onClick = onShareStory)
     }
 }
 
@@ -265,6 +274,7 @@ private fun LongestEpisodePreview() {
             ),
             measurements = measurements,
             showCovers = true,
+            onShareStory = {},
         )
     }
 }

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/ui/LongestEpisodeStory.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/ui/LongestEpisodeStory.kt
@@ -42,9 +42,9 @@ import au.com.shiftyjelly.pocketcasts.compose.Devices
 import au.com.shiftyjelly.pocketcasts.compose.components.PodcastImage
 import au.com.shiftyjelly.pocketcasts.compose.components.TextH10
 import au.com.shiftyjelly.pocketcasts.compose.components.TextP40
+import au.com.shiftyjelly.pocketcasts.localization.helper.StatsHelper
 import au.com.shiftyjelly.pocketcasts.models.to.LongestEpisode
 import au.com.shiftyjelly.pocketcasts.models.to.Story
-import au.com.shiftyjelly.pocketcasts.settings.stats.StatsHelper
 import kotlinx.coroutines.delay
 import au.com.shiftyjelly.pocketcasts.images.R as IR
 import au.com.shiftyjelly.pocketcasts.localization.R as LR

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/ui/NumberOfShowsStory.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/ui/NumberOfShowsStory.kt
@@ -39,6 +39,7 @@ import au.com.shiftyjelly.pocketcasts.ui.R as UR
 internal fun NumberOfShowsStory(
     story: Story.NumberOfShows,
     measurements: EndOfYearMeasurements,
+    onShareStory: () -> Unit,
 ) {
     val smallCoverSize = 160.dp * measurements.scale
     val smallSpacingSize = smallCoverSize / 10
@@ -106,7 +107,7 @@ internal fun NumberOfShowsStory(
                 color = colorResource(UR.color.coolgrey_90),
                 modifier = Modifier.padding(horizontal = 24.dp),
             )
-            ShareStoryButton(onClick = {})
+            ShareStoryButton(onClick = onShareStory)
         }
     }
 }
@@ -149,6 +150,7 @@ private fun NumberOfShowsPreview() {
                 bottomShowIds = List(4) { "id-$it" },
             ),
             measurements = measurements,
+            onShareStory = {},
         )
     }
 }

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/ui/RatingsStory.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/ui/RatingsStory.kt
@@ -66,11 +66,13 @@ import au.com.shiftyjelly.pocketcasts.ui.R as UR
 internal fun RatingsStory(
     story: Story.Ratings,
     measurements: EndOfYearMeasurements,
+    onShareStory: () -> Unit,
     onLearnAboutRatings: () -> Unit,
 ) = RatingsStory(
     story = story,
     measurements = measurements,
     showBars = false,
+    onShareStory = onShareStory,
     onLearnAboutRatings = onLearnAboutRatings,
 )
 
@@ -79,11 +81,12 @@ private fun RatingsStory(
     story: Story.Ratings,
     measurements: EndOfYearMeasurements,
     showBars: Boolean,
+    onShareStory: () -> Unit,
     onLearnAboutRatings: () -> Unit,
 ) {
     val maxRatingCount = story.stats.max().second
     if (maxRatingCount != 0) {
-        PresentRatings(story, measurements, showBars)
+        PresentRatings(story, measurements, showBars, onShareStory)
     } else {
         AbsentRatings(story, measurements, onLearnAboutRatings)
     }
@@ -94,6 +97,7 @@ private fun PresentRatings(
     story: Story.Ratings,
     measurements: EndOfYearMeasurements,
     showBars: Boolean,
+    onShareStory: () -> Unit,
 ) {
     Column(
         modifier = Modifier
@@ -139,7 +143,7 @@ private fun PresentRatings(
                 color = colorResource(UR.color.coolgrey_90),
                 modifier = Modifier.padding(horizontal = 24.dp),
             )
-            ShareStoryButton(onClick = {})
+            ShareStoryButton(onClick = onShareStory)
         }
     }
 }
@@ -414,6 +418,7 @@ private fun RatingsHighPreview() {
             ),
             measurements = measurements,
             showBars = true,
+            onShareStory = {},
             onLearnAboutRatings = {},
         )
     }
@@ -435,6 +440,7 @@ private fun RatingsLowPreview() {
             ),
             measurements = measurements,
             showBars = true,
+            onShareStory = {},
             onLearnAboutRatings = {},
         )
     }
@@ -456,6 +462,7 @@ private fun RatingsNonePreview() {
             ),
             measurements = measurements,
             showBars = true,
+            onShareStory = {},
             onLearnAboutRatings = {},
         )
     }

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/ui/StoriesPage.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/ui/StoriesPage.kt
@@ -1,7 +1,6 @@
 package au.com.shiftyjelly.pocketcasts.endofyear.ui
 
 import android.content.Context
-import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
@@ -60,12 +59,12 @@ import kotlin.time.TimeSource
 import au.com.shiftyjelly.pocketcasts.images.R as IR
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
-@OptIn(ExperimentalFoundationApi::class)
 @Composable
 internal fun StoriesPage(
     state: UiState,
     pagerState: PagerState,
     onChangeStory: (Boolean) -> Unit,
+    onShareStory: (Story) -> Unit,
     onHoldStory: () -> Unit,
     onReleaseStory: () -> Unit,
     onLearnAboutRatings: () -> Unit,
@@ -101,6 +100,7 @@ internal fun StoriesPage(
                 ),
                 pagerState = pagerState,
                 onChangeStory = onChangeStory,
+                onShareStory = onShareStory,
                 onHoldStory = onHoldStory,
                 onReleaseStory = onReleaseStory,
                 onLearnAboutRatings = onLearnAboutRatings,
@@ -137,13 +137,13 @@ internal fun StoriesPage(
     }
 }
 
-@OptIn(ExperimentalFoundationApi::class)
 @Composable
 private fun Stories(
     stories: List<Story>,
     measurements: EndOfYearMeasurements,
     pagerState: PagerState,
     onChangeStory: (Boolean) -> Unit,
+    onShareStory: (Story) -> Unit,
     onHoldStory: () -> Unit,
     onReleaseStory: () -> Unit,
     onLearnAboutRatings: () -> Unit,
@@ -170,22 +170,65 @@ private fun Stories(
         },
     ) { index ->
         when (val story = stories[index]) {
-            is Story.Cover -> CoverStory(story, measurements)
-            is Story.NumberOfShows -> NumberOfShowsStory(story, measurements)
-            is Story.TopShow -> TopShowStory(story, measurements)
-            is Story.TopShows -> TopShowsStory(story, measurements)
-            is Story.Ratings -> RatingsStory(story, measurements, onLearnAboutRatings)
-            is Story.TotalTime -> TotalTimeStory(story, measurements)
-            is Story.LongestEpisode -> LongestEpisodeStory(story, measurements)
-            is Story.PlusInterstitial -> PlusInterstitialStory(story, measurements, onClickUpsell)
-            is Story.YearVsYear -> YearVsYearStory(story, measurements)
-            is Story.CompletionRate -> CompletionRateStory(story, measurements)
-            is Story.Ending -> EndingStory(story, measurements, onRestartPlayback)
+            is Story.Cover -> CoverStory(
+                story = story,
+                measurements = measurements,
+            )
+            is Story.NumberOfShows -> NumberOfShowsStory(
+                story = story,
+                measurements = measurements,
+                onShareStory = { onShareStory(story) },
+            )
+            is Story.TopShow -> TopShowStory(
+                story = story,
+                measurements = measurements,
+                onShareStory = { onShareStory(story) },
+            )
+            is Story.TopShows -> TopShowsStory(
+                story = story,
+                measurements = measurements,
+                onShareStory = { onShareStory(story) },
+            )
+            is Story.Ratings -> RatingsStory(
+                story = story,
+                measurements = measurements,
+                onShareStory = { onShareStory(story) },
+                onLearnAboutRatings = onLearnAboutRatings,
+            )
+            is Story.TotalTime -> TotalTimeStory(
+                story = story,
+                measurements = measurements,
+                onShareStory = { onShareStory(story) },
+            )
+            is Story.LongestEpisode -> LongestEpisodeStory(
+                story = story,
+                measurements = measurements,
+                onShareStory = { onShareStory(story) },
+            )
+            is Story.PlusInterstitial -> PlusInterstitialStory(
+                story = story,
+                measurements = measurements,
+                onClickUpsell = onClickUpsell,
+            )
+            is Story.YearVsYear -> YearVsYearStory(
+                story = story,
+                measurements = measurements,
+                onShareStory = { onShareStory(story) },
+            )
+            is Story.CompletionRate -> CompletionRateStory(
+                story = story,
+                measurements = measurements,
+                onShareStory = { onShareStory(story) },
+            )
+            is Story.Ending -> EndingStory(
+                story = story,
+                measurements = measurements,
+                onRestartPlayback = onRestartPlayback,
+            )
         }
     }
 }
 
-@OptIn(ExperimentalFoundationApi::class)
 @Composable
 internal fun BoxScope.TopControls(
     pagerState: PagerState,

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/ui/TopShowStory.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/ui/TopShowStory.kt
@@ -40,9 +40,9 @@ import au.com.shiftyjelly.pocketcasts.compose.components.PodcastImage
 import au.com.shiftyjelly.pocketcasts.compose.components.TextH10
 import au.com.shiftyjelly.pocketcasts.compose.components.TextP40
 import au.com.shiftyjelly.pocketcasts.localization.R
+import au.com.shiftyjelly.pocketcasts.localization.helper.StatsHelper
 import au.com.shiftyjelly.pocketcasts.models.to.Story
 import au.com.shiftyjelly.pocketcasts.models.to.TopPodcast
-import au.com.shiftyjelly.pocketcasts.settings.stats.StatsHelper
 import kotlin.math.sqrt
 import au.com.shiftyjelly.pocketcasts.ui.R as UR
 

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/ui/TopShowStory.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/ui/TopShowStory.kt
@@ -50,6 +50,7 @@ import au.com.shiftyjelly.pocketcasts.ui.R as UR
 internal fun TopShowStory(
     story: Story.TopShow,
     measurements: EndOfYearMeasurements,
+    onShareStory: () -> Unit,
 ) {
     Box {
         val shapeSize = measurements.width * 1.12f
@@ -147,7 +148,7 @@ internal fun TopShowStory(
                 color = colorResource(UR.color.coolgrey_90),
                 modifier = Modifier.padding(horizontal = 24.dp),
             )
-            ShareStoryButton(onClick = {})
+            ShareStoryButton(onClick = onShareStory)
         }
 
         // Clip the rotating shape at top
@@ -190,6 +191,7 @@ private fun TopShowPreview() {
                 ),
             ),
             measurements = measurements,
+            onShareStory = {},
         )
     }
 }

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/ui/TopShowsStory.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/ui/TopShowsStory.kt
@@ -60,13 +60,20 @@ import au.com.shiftyjelly.pocketcasts.ui.R as UR
 internal fun TopShowsStory(
     story: Story.TopShows,
     measurements: EndOfYearMeasurements,
-) = TopShowsStory(story, measurements, initialAnimationProgress = 0f)
+    onShareStory: () -> Unit,
+) = TopShowsStory(
+    story = story,
+    measurements = measurements,
+    onShareStory = onShareStory,
+    initialAnimationProgress = 0f,
+)
 
 @Composable
 private fun TopShowsStory(
     story: Story.TopShows,
     measurements: EndOfYearMeasurements,
     initialAnimationProgress: Float,
+    onShareStory: () -> Unit,
 ) {
     Column(
         modifier = Modifier
@@ -126,7 +133,7 @@ private fun TopShowsStory(
                 disableAutoScale = true,
                 modifier = Modifier.padding(horizontal = 24.dp),
             )
-            ShareStoryButton(onClick = {})
+            ShareStoryButton(onClick = onShareStory)
         }
     }
 }
@@ -288,6 +295,7 @@ private fun TopShowsPreview() {
             ),
             measurements = measurements,
             initialAnimationProgress = 1f,
+            onShareStory = {},
         )
     }
 }

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/ui/TopShowsStory.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/ui/TopShowsStory.kt
@@ -284,6 +284,7 @@ private fun TopShowsPreview() {
                         playedEpisodeCount = Random.nextInt(60, 100),
                     )
                 },
+                podcastListUrl = null,
             ),
             measurements = measurements,
             initialAnimationProgress = 1f,

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/ui/TotalTimeStory.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/ui/TotalTimeStory.kt
@@ -22,8 +22,8 @@ import androidx.compose.ui.unit.dp
 import au.com.shiftyjelly.pocketcasts.compose.Devices
 import au.com.shiftyjelly.pocketcasts.compose.components.AutoResizeText
 import au.com.shiftyjelly.pocketcasts.compose.components.TextH10
+import au.com.shiftyjelly.pocketcasts.localization.helper.StatsHelper
 import au.com.shiftyjelly.pocketcasts.models.to.Story
-import au.com.shiftyjelly.pocketcasts.settings.stats.StatsHelper
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.days
 import kotlin.time.Duration.Companion.hours

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/ui/TotalTimeStory.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/ui/TotalTimeStory.kt
@@ -37,6 +37,7 @@ import au.com.shiftyjelly.pocketcasts.ui.R as UR
 internal fun TotalTimeStory(
     story: Story.TotalTime,
     measurements: EndOfYearMeasurements,
+    onShareStory: () -> Unit,
 ) {
     Box(
         modifier = Modifier
@@ -57,7 +58,7 @@ internal fun TotalTimeStory(
             }[0].measure(constraints)
 
             val shareButton = subcompose("share-button") {
-                ShareStoryButton(onClick = {})
+                ShareStoryButton(onClick = onShareStory)
             }[0].measure(constraints)
 
             val titleConstraints = constraints.copy(
@@ -134,6 +135,7 @@ private fun TotalTimePreview(
                 duration = duration,
             ),
             measurements = measurements,
+            onShareStory = {},
         )
     }
 }

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/ui/YearVsYearStory.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/ui/YearVsYearStory.kt
@@ -57,13 +57,20 @@ import au.com.shiftyjelly.pocketcasts.ui.R as UR
 internal fun YearVsYearStory(
     story: Story.YearVsYear,
     measurements: EndOfYearMeasurements,
-) = YearVsYearStory(story, measurements, showCircles = false)
+    onShareStory: () -> Unit,
+) = YearVsYearStory(
+    story = story,
+    measurements = measurements,
+    showCircles = false,
+    onShareStory = onShareStory,
+)
 
 @Composable
 private fun YearVsYearStory(
     story: Story.YearVsYear,
     measurements: EndOfYearMeasurements,
     showCircles: Boolean,
+    onShareStory: () -> Unit,
 ) {
     Column(
         modifier = Modifier
@@ -79,6 +86,7 @@ private fun YearVsYearStory(
         TextInfo(
             story = story,
             measurements = measurements,
+            onShareStory = onShareStory,
         )
     }
 }
@@ -307,6 +315,7 @@ private class YearVsYearConfiguration(
 private fun TextInfo(
     story: Story.YearVsYear,
     measurements: EndOfYearMeasurements,
+    onShareStory: () -> Unit,
 ) {
     Column(
         modifier = Modifier.background(
@@ -374,7 +383,7 @@ private fun TextInfo(
             color = colorResource(UR.color.coolgrey_90),
             modifier = Modifier.padding(horizontal = 24.dp),
         )
-        ShareStoryButton(onClick = {})
+        ShareStoryButton(onClick = onShareStory)
     }
 }
 
@@ -390,6 +399,7 @@ private fun YearVsYearThisYearPreview() {
             ),
             measurements = measurements,
             showCircles = true,
+            onShareStory = {},
         )
     }
 }
@@ -406,6 +416,7 @@ private fun YearVsYearThisYearLargePreview() {
             ),
             measurements = measurements,
             showCircles = true,
+            onShareStory = {},
         )
     }
 }
@@ -422,6 +433,7 @@ private fun YearVsYearLastYearPreview() {
             ),
             measurements = measurements,
             showCircles = true,
+            onShareStory = {},
         )
     }
 }
@@ -438,6 +450,7 @@ private fun YearVsYearEqualPreview() {
             ),
             measurements = measurements,
             showCircles = true,
+            onShareStory = {},
         )
     }
 }

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/ui/YearVsYearStory.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/ui/YearVsYearStory.kt
@@ -319,7 +319,7 @@ private fun TextInfo(
         val badgeId = when (story.subscriptionTier) {
             SubscriptionTier.PLUS -> IR.drawable.end_of_year_2024_year_vs_year_plus_badge
             SubscriptionTier.PATRON -> IR.drawable.end_of_year_2024_year_vs_year_patron_badge
-            SubscriptionTier.NONE, null -> null
+            SubscriptionTier.NONE -> null
         }
         if (badgeId != null) {
             Image(

--- a/modules/features/endofyear/src/test/kotlin/au/com/shiftyjelly/pocketcasts/endofyear/EndOfYearViewModelTest.kt
+++ b/modules/features/endofyear/src/test/kotlin/au/com/shiftyjelly/pocketcasts/endofyear/EndOfYearViewModelTest.kt
@@ -721,7 +721,7 @@ class EndOfYearViewModelTest {
             description: String,
             podcasts: List<Podcast>,
             date: Date,
-            serverSecret: String
+            serverSecret: String,
         ) = podcastListUrl.await()
 
         override suspend fun openPodcastList(listId: String) = PodcastList(

--- a/modules/features/endofyear/src/test/kotlin/au/com/shiftyjelly/pocketcasts/endofyear/EndOfYearViewModelTest.kt
+++ b/modules/features/endofyear/src/test/kotlin/au/com/shiftyjelly/pocketcasts/endofyear/EndOfYearViewModelTest.kt
@@ -25,6 +25,8 @@ import au.com.shiftyjelly.pocketcasts.repositories.endofyear.EndOfYearSync
 import au.com.shiftyjelly.pocketcasts.servers.list.ListServiceManager
 import au.com.shiftyjelly.pocketcasts.servers.list.PodcastList
 import au.com.shiftyjelly.pocketcasts.sharedtest.MainCoroutineRule
+import au.com.shiftyjelly.pocketcasts.sharing.SharingRequest
+import au.com.shiftyjelly.pocketcasts.sharing.SharingResponse
 import java.time.Year
 import java.util.Date
 import junit.framework.TestCase.assertEquals
@@ -95,6 +97,7 @@ class EndOfYearViewModelTest {
             endOfYearManager = endOfYearManager,
             subscriptionManager = mock { on { subscriptionTier() }.doReturn(subscriptionTier) },
             listServiceManager = listServiceManager,
+            sharingClient = FakeSharingClient(),
         )
     }
 
@@ -733,5 +736,15 @@ class EndOfYearViewModelTest {
         )
 
         override fun extractShareListIdFromWebUrl(webUrl: String) = ""
+    }
+
+    private class FakeSharingClient : StorySharingClient {
+        override suspend fun shareStory(request: SharingRequest): SharingResponse {
+            return SharingResponse(
+                isSuccsessful = true,
+                feedbackMessage = null,
+                error = null,
+            )
+        }
     }
 }

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/stats/StatsFragment.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/stats/StatsFragment.kt
@@ -55,6 +55,7 @@ import au.com.shiftyjelly.pocketcasts.compose.components.TextH40
 import au.com.shiftyjelly.pocketcasts.compose.components.TextP40
 import au.com.shiftyjelly.pocketcasts.compose.preview.ThemePreviewParameterProvider
 import au.com.shiftyjelly.pocketcasts.compose.theme
+import au.com.shiftyjelly.pocketcasts.localization.helper.StatsHelper
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.settings.R
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme

--- a/modules/services/localization/src/main/java/au/com/shiftyjelly/pocketcasts/localization/helper/StatsHelper.kt
+++ b/modules/services/localization/src/main/java/au/com/shiftyjelly/pocketcasts/localization/helper/StatsHelper.kt
@@ -1,4 +1,4 @@
-package au.com.shiftyjelly.pocketcasts.settings.stats
+package au.com.shiftyjelly.pocketcasts.localization.helper
 
 import android.content.res.Resources
 import au.com.shiftyjelly.pocketcasts.localization.extensions.getStringPluralDays

--- a/modules/services/localization/src/main/res/values-ar/strings.xml
+++ b/modules/services/localization/src/main/res/values-ar/strings.xml
@@ -284,7 +284,6 @@ Language: ar
     <string name="log_in">تسجيل الدخول</string>
     <string name="end_of_year_story_top_podcast_subtitle">لقد استمعتَ إلى ⁦%1$d⁩ من الحلقات بإجمالي ⁦%2$s⁩</string>
     <string name="end_of_year_story_top_podcasts_share_text">أهم حلقات البودكاست الخاصة بي في العام! %1$s</string>
-    <string name="end_of_year_story_top_podcasts_list_title">أهم حلقات البودكاست الخاصة بي في 2022</string>
     <string name="end_of_year_story_epilogue_subtitle">لا تنسَ المشاركة مع أصدقائك والتعبير عن مبدعي الحلقات الصوتية الذين تفضلهم</string>
     <string name="end_of_year_story_top_categories">أهم تصنيفاتك</string>
     <string name="end_of_year_story_top_categories_share_text">الأكثر استماعًا إلى تصنيفات الحلقات الصوتية</string>

--- a/modules/services/localization/src/main/res/values-ca/strings.xml
+++ b/modules/services/localization/src/main/res/values-ca/strings.xml
@@ -259,12 +259,10 @@ Language: ca
     <string name="bookmark_not_found">No s\'ha trobat el marcador</string>
     <string name="settings_use_dark_up_next_details">Quan està activat, \'Tot seguit\' sempre utilitzarà el tema fosc, o coincidirà amb el tema actual quan estigui desactivat</string>
     <string name="settings_use_dark_up_next">Emprar el tema fosc a la llista \'Tot seguit\'</string>
-    <string name="end_of_year_stories_completion_rate_share_text">El meu percentatge de finalització del 2023</string>
     <string name="end_of_year_stories_theres_more">Encara hi ha més!</string>
     <string name="end_of_year_stories_year_completion_rate">taxa de finalització</string>
     <string name="end_of_year_stories_year_completion_rate_subtitle">Dels %1$d episodis que has començat, n\'has escoltat completament un total de %2$d</string>
     <string name="end_of_year_stories_year_completion_rate_title">La teva taxa de finalització enguany ha estat del %1$d%%</string>
-    <string name="end_of_year_stories_year_over_share_text">El temps escoltat al 20223 comparat amb 2022</string>
     <string name="eoy_year_over_year_title_skyrocketed">Comparat amb el 2022, el teu temps d\'escolta ha pujat com un coet!</string>
     <string name="end_of_year_stories_year_over_year_subtitle_went_down">Aaaah… la vida s\'ha de viure, no?</string>
     <string name="end_of_year_stories_year_over_year_title_went_down">Comparat amb %1$s, el teu que has escoltat ha baixat una mica.</string>
@@ -590,12 +588,8 @@ Language: ca
     <string name="end_of_year_story_top_categories_share_text">Les meves categories de pòdcasts més escoltades</string>
     <string name="end_of_year_story_top_categories">Les teves principals categories</string>
     <string name="end_of_year_story_epilogue_subtitle">No t\'oblidis de compartir-ho amb els teus amics i fer un reconeixement als teus creadors de pòdcast favorits</string>
-    <string name="end_of_year_story_longest_episode_share_text">L\'episodi més llarg que vaig escoltar el 2023 %1$s</string>
-    <string name="end_of_year_story_top_podcasts_list_title">Els meus pòdcasts principals de 2022</string>
     <string name="end_of_year_story_top_podcasts_share_text">Els meus pòdcasts preferits de l\'any! %1$s</string>
-    <string name="end_of_year_story_top_podcast_share_text">El meu pòdcast favorit de 2023! %1$s</string>
     <string name="end_of_year_story_top_podcast_subtitle">Has escoltat %1$d episodis d\'un total de %2$s</string>
-    <string name="end_of_year_story_listened_to_numbers_share_text">He escoltat %1$d pòdcasts diferents i %2$d episodis el 2023</string>
     <string name="end_of_year_story_listened_to_numbers_subtitle">Però n\'hi havia un al que tornaves…</string>
     <string name="end_of_year_story_listened_to_numbers">Has escoltat %1$d programes diferents i %2$d episodis en total</string>
     <string name="end_of_year_story_listened_to_categories_share_text">He escoltat %1$d categories diferents el 2023</string>

--- a/modules/services/localization/src/main/res/values-de/strings.xml
+++ b/modules/services/localization/src/main/res/values-de/strings.xml
@@ -251,12 +251,10 @@ Language: de
     <string name="bookmark_not_found">Lesezeichen nicht gefunden</string>
     <string name="settings_use_dark_up_next_details">Wenn das dunkle Theme aktiviert ist, wird es in „Up Next“ immer verwendet. Wenn es deaktiviert ist, wird „Up Next“ an das aktuelle Theme angepasst</string>
     <string name="settings_use_dark_up_next">Dunkles „Up Next“-Theme verwenden</string>
-    <string name="end_of_year_stories_completion_rate_share_text">Meine Abschlussquote 2023</string>
     <string name="end_of_year_stories_theres_more">Es gibt noch mehr!</string>
     <string name="end_of_year_stories_year_completion_rate">Abschlussquote</string>
     <string name="end_of_year_stories_year_completion_rate_subtitle">Von deinen %1$d angefangenen Episoden, hast du insgesamt %2$d vollständig angehört</string>
     <string name="end_of_year_stories_year_completion_rate_title">Deine Abschlussquote lag dieses Jahr bei %1$d %%</string>
-    <string name="end_of_year_stories_year_over_share_text">Meine Audiozeit in 2023 im Vergleich zu 2022</string>
     <string name="eoy_year_over_year_title_skyrocketed">Im Vergleich zu 2022 ist deine Audiozeit in die Höhe geschnellt!</string>
     <string name="end_of_year_stories_year_over_year_subtitle_went_down">Man muss das Leben genießen, nicht wahr?</string>
     <string name="end_of_year_stories_year_over_year_subtitle_flat">Man sagt, Beständigkeit ist der Schlüssel zum Erfolg … oder so ähnlich!</string>
@@ -579,12 +577,8 @@ Language: de
     <string name="end_of_year_story_top_categories_share_text">Meine am häufigsten gehörten Podcast-Kategorien</string>
     <string name="end_of_year_story_top_categories">Deine Top-Kategorien</string>
     <string name="end_of_year_story_epilogue_subtitle">Vergiss nicht, sie mit deinen Freunden zu teilen und deine bevorzugten Podcast-Ersteller dankend zu erwähnen</string>
-    <string name="end_of_year_story_longest_episode_share_text">Die längste Folge, die ich mir im Jahr 2023 angehört habe (%1$s)</string>
-    <string name="end_of_year_story_top_podcasts_list_title">Meine Top-Podcasts 2022</string>
     <string name="end_of_year_story_top_podcasts_share_text">Meine Top-Podcasts des Jahres! %1$s</string>
-    <string name="end_of_year_story_top_podcast_share_text">Mein Lieblings-Podcast 2023! %1$s</string>
     <string name="end_of_year_story_top_podcast_subtitle">Du hast dir %1$d Folgen mit einer Gesamtdauer von %2$s angehört</string>
-    <string name="end_of_year_story_listened_to_numbers_share_text">Ich habe mir im Jahr 2023 %1$d verschiedene Podcasts und %2$d Folgen angehört</string>
     <string name="end_of_year_story_listened_to_numbers_subtitle">Aber es gab eine, die dir besonders gut gefallen hat …</string>
     <string name="end_of_year_story_listened_to_numbers">Du hast dir insgesamt %1$d verschiedene Shows und %2$d Folgen angehört</string>
     <string name="end_of_year_story_listened_to_categories_share_text">Ich habe mir im Jahr 2023 %1$d unterschiedliche Kategorien angehört</string>

--- a/modules/services/localization/src/main/res/values-en-rGB/strings.xml
+++ b/modules/services/localization/src/main/res/values-en-rGB/strings.xml
@@ -297,7 +297,6 @@ Language: en_GB
     <string name="end_of_year_story_top_categories_share_text">My most listened to podcast categories</string>
     <string name="end_of_year_story_top_categories">Your Top Categories</string>
     <string name="end_of_year_story_epilogue_subtitle">Don’t forget to share with your friends and give a shout out to your favourite podcast creators</string>
-    <string name="end_of_year_story_top_podcasts_list_title">My top podcasts of 2022</string>
     <string name="end_of_year_story_listened_to_categories_subtitle">Let’s take a look at some of your favourites…</string>
     <string name="end_of_year_story_listened_to_categories">You listened to %1$d different categories this year</string>
     <string name="end_of_year_story_intro_title">Let’s celebrate your year of listening!</string>

--- a/modules/services/localization/src/main/res/values-es-rMX/strings.xml
+++ b/modules/services/localization/src/main/res/values-es-rMX/strings.xml
@@ -251,12 +251,10 @@ Language: es
     <string name="bookmark_not_found">No se ha encontrado el marcador.</string>
     <string name="settings_use_dark_up_next_details">Si está activado, Up Next utilizará siempre el tema oscuro, o coincidirá con el tema actual si está desactivado</string>
     <string name="settings_use_dark_up_next">Utilizar tema Up Next oscuro</string>
-    <string name="end_of_year_stories_completion_rate_share_text">Mi tasa de finalización de 2023</string>
     <string name="end_of_year_stories_theres_more">¡Y hay más!</string>
     <string name="end_of_year_stories_year_completion_rate">tasa de finalización</string>
     <string name="end_of_year_stories_year_completion_rate_subtitle">De los %1$d episodios que has comenzado, has escuchado por completo un total de %2$d.</string>
     <string name="end_of_year_stories_year_completion_rate_title">Tu tasa de finalización de este año es de %1$d%%.</string>
-    <string name="end_of_year_stories_year_over_share_text">Mis escuchas de 2023, en comparación con las de 2022.</string>
     <string name="eoy_year_over_year_title_skyrocketed">En comparación con 2022, ¡tu tiempo de escucha se ha disparado!</string>
     <string name="end_of_year_stories_year_over_year_subtitle_went_down">La vida hay que vivirla, ¿no?</string>
     <string name="end_of_year_stories_year_over_year_subtitle_flat">Dicen que la constancia es la clave del éxito, ¡o algo así!</string>
@@ -579,12 +577,8 @@ Language: es
     <string name="end_of_year_story_top_categories_share_text">Mis categorías de pódcast más escuchadas</string>
     <string name="end_of_year_story_top_categories">Tus categorías principales</string>
     <string name="end_of_year_story_epilogue_subtitle">No olvides compartirlos con tus amigos y mandar un saludo a tus creadores de pódcast favoritos</string>
-    <string name="end_of_year_story_longest_episode_share_text">El episodio más largo que escuché en 2023 %1$s.</string>
-    <string name="end_of_year_story_top_podcasts_list_title">Mis pódcast favoritos de 2022</string>
     <string name="end_of_year_story_top_podcasts_share_text">¡Mis pódcast favoritos del año! %1$s</string>
-    <string name="end_of_year_story_top_podcast_share_text">¡Mi pódcast favorito de 2023! %1$s</string>
     <string name="end_of_year_story_top_podcast_subtitle">Escuchaste %1$d episodios de un total de %2$s.</string>
-    <string name="end_of_year_story_listened_to_numbers_share_text">Escuché %1$d pódcast diferentes y %2$d episodios en 2023.</string>
     <string name="end_of_year_story_listened_to_numbers_subtitle">Pero había uno al que siempre venías…</string>
     <string name="end_of_year_story_listened_to_numbers">Has escuchado %1$d programas diferentes y %2$d episodios en total</string>
     <string name="end_of_year_story_listened_to_categories_share_text">Escuché %1$d categorías diferentes en 2023.</string>

--- a/modules/services/localization/src/main/res/values-es/strings.xml
+++ b/modules/services/localization/src/main/res/values-es/strings.xml
@@ -251,12 +251,10 @@ Language: es
     <string name="bookmark_not_found">No se ha encontrado el marcador.</string>
     <string name="settings_use_dark_up_next_details">Si está activado, Up Next utilizará siempre el tema oscuro, o coincidirá con el tema actual si está desactivado</string>
     <string name="settings_use_dark_up_next">Utilizar tema Up Next oscuro</string>
-    <string name="end_of_year_stories_completion_rate_share_text">Mi tasa de finalización de 2023</string>
     <string name="end_of_year_stories_theres_more">¡Y hay más!</string>
     <string name="end_of_year_stories_year_completion_rate">tasa de finalización</string>
     <string name="end_of_year_stories_year_completion_rate_subtitle">De los %1$d episodios que has comenzado, has escuchado por completo un total de %2$d.</string>
     <string name="end_of_year_stories_year_completion_rate_title">Tu tasa de finalización de este año es de %1$d%%.</string>
-    <string name="end_of_year_stories_year_over_share_text">Mis escuchas de 2023, en comparación con las de 2022.</string>
     <string name="eoy_year_over_year_title_skyrocketed">En comparación con 2022, ¡tu tiempo de escucha se ha disparado!</string>
     <string name="end_of_year_stories_year_over_year_subtitle_went_down">La vida hay que vivirla, ¿no?</string>
     <string name="end_of_year_stories_year_over_year_subtitle_flat">Dicen que la constancia es la clave del éxito, ¡o algo así!</string>
@@ -579,12 +577,8 @@ Language: es
     <string name="end_of_year_story_top_categories_share_text">Mis categorías de pódcast más escuchadas</string>
     <string name="end_of_year_story_top_categories">Tus categorías principales</string>
     <string name="end_of_year_story_epilogue_subtitle">No olvides compartirlos con tus amigos y mandar un saludo a tus creadores de pódcast favoritos</string>
-    <string name="end_of_year_story_longest_episode_share_text">El episodio más largo que escuché en 2023 %1$s.</string>
-    <string name="end_of_year_story_top_podcasts_list_title">Mis pódcast favoritos de 2022</string>
     <string name="end_of_year_story_top_podcasts_share_text">¡Mis pódcast favoritos del año! %1$s</string>
-    <string name="end_of_year_story_top_podcast_share_text">¡Mi pódcast favorito de 2023! %1$s</string>
     <string name="end_of_year_story_top_podcast_subtitle">Escuchaste %1$d episodios de un total de %2$s.</string>
-    <string name="end_of_year_story_listened_to_numbers_share_text">Escuché %1$d pódcast diferentes y %2$d episodios en 2023.</string>
     <string name="end_of_year_story_listened_to_numbers_subtitle">Pero había uno al que siempre venías…</string>
     <string name="end_of_year_story_listened_to_numbers">Has escuchado %1$d programas diferentes y %2$d episodios en total</string>
     <string name="end_of_year_story_listened_to_categories_share_text">Escuché %1$d categorías diferentes en 2023.</string>

--- a/modules/services/localization/src/main/res/values-fr-rCA/strings.xml
+++ b/modules/services/localization/src/main/res/values-fr-rCA/strings.xml
@@ -251,12 +251,10 @@ Language: fr
     <string name="bookmark_not_found">Impossible de trouver le favori</string>
     <string name="settings_use_dark_up_next_details">Quand l’option est activée, la File d’attente affichera toujours le thème sombre ou alors elle correspondra au thème actuel si l’option est désactivée</string>
     <string name="settings_use_dark_up_next">Utiliser le thème File d’attente sombre</string>
-    <string name="end_of_year_stories_completion_rate_share_text">Mon taux d’achèvement en 2023</string>
     <string name="end_of_year_stories_theres_more">Ce n’est pas tout !</string>
     <string name="end_of_year_stories_year_completion_rate">taux d’achèvement</string>
     <string name="end_of_year_stories_year_completion_rate_subtitle">Sur les %1$d épisode(s) que vous avez commencé(s), vous en avez écouté %2$d en totalité</string>
     <string name="end_of_year_stories_year_completion_rate_title">Cette année, votre taux d’achèvement s’élève à %1$d %%</string>
-    <string name="end_of_year_stories_year_over_share_text">Mon temps d’écoute en 2023 par rapport à 2022</string>
     <string name="eoy_year_over_year_title_skyrocketed">Par rapport à 2022, votre temps d’écoute a explosé !</string>
     <string name="end_of_year_stories_year_over_year_subtitle_went_down">Aaaah… il faut vivre sa vie à fond, n’est-ce pas ?</string>
     <string name="end_of_year_stories_year_over_year_subtitle_flat">On dit que la constance est la clé du succès… ou un truc du genre !</string>
@@ -579,12 +577,8 @@ Language: fr
     <string name="end_of_year_story_top_categories_share_text">Mes catégories de podcasts les plus écoutés</string>
     <string name="end_of_year_story_top_categories">Vos meilleures catégories</string>
     <string name="end_of_year_story_epilogue_subtitle">N’oubliez pas de montrer votre soutien à vos créateurs de podcasts préférés et à partager ces podcasts avec vos amis</string>
-    <string name="end_of_year_story_longest_episode_share_text">L’épisode le plus long que j’ai écouté en 2023 %1$s</string>
-    <string name="end_of_year_story_top_podcasts_list_title">Mes meilleurs podcasts de 2022</string>
     <string name="end_of_year_story_top_podcasts_share_text">Mes meilleurs podcasts de l\'année ! %1$s</string>
-    <string name="end_of_year_story_top_podcast_share_text">Mon podcast préféré de 2023 ! %1$s</string>
     <string name="end_of_year_story_top_podcast_subtitle">Vous avez écouté %1$d épisodes pour une durée totale de %2$s</string>
-    <string name="end_of_year_story_listened_to_numbers_share_text">J’ai écouté %1$d podcasts différents et %2$d épisodes en 2023</string>
     <string name="end_of_year_story_listened_to_numbers_subtitle">Vous avez écouté plusieurs fois une même émission…</string>
     <string name="end_of_year_story_listened_to_numbers">Vous avez écouté %1$d émissions différentes et %2$d épisodes au total</string>
     <string name="end_of_year_story_listened_to_categories_share_text">J’ai écouté %1$d catégories différentes en 2023</string>

--- a/modules/services/localization/src/main/res/values-fr/strings.xml
+++ b/modules/services/localization/src/main/res/values-fr/strings.xml
@@ -251,12 +251,10 @@ Language: fr
     <string name="bookmark_not_found">Impossible de trouver le favori</string>
     <string name="settings_use_dark_up_next_details">Quand l’option est activée, la File d’attente affichera toujours le thème sombre ou alors elle correspondra au thème actuel si l’option est désactivée</string>
     <string name="settings_use_dark_up_next">Utiliser le thème File d’attente sombre</string>
-    <string name="end_of_year_stories_completion_rate_share_text">Mon taux d’achèvement en 2023</string>
     <string name="end_of_year_stories_theres_more">Ce n’est pas tout !</string>
     <string name="end_of_year_stories_year_completion_rate">taux d’achèvement</string>
     <string name="end_of_year_stories_year_completion_rate_subtitle">Sur les %1$d épisode(s) que vous avez commencé(s), vous en avez écouté %2$d en totalité</string>
     <string name="end_of_year_stories_year_completion_rate_title">Cette année, votre taux d’achèvement s’élève à %1$d %%</string>
-    <string name="end_of_year_stories_year_over_share_text">Mon temps d’écoute en 2023 par rapport à 2022</string>
     <string name="eoy_year_over_year_title_skyrocketed">Par rapport à 2022, votre temps d’écoute a explosé !</string>
     <string name="end_of_year_stories_year_over_year_subtitle_went_down">Aaaah… il faut vivre sa vie à fond, n’est-ce pas ?</string>
     <string name="end_of_year_stories_year_over_year_subtitle_flat">On dit que la constance est la clé du succès… ou un truc du genre !</string>
@@ -579,12 +577,8 @@ Language: fr
     <string name="end_of_year_story_top_categories_share_text">Mes catégories de podcasts les plus écoutés</string>
     <string name="end_of_year_story_top_categories">Vos meilleures catégories</string>
     <string name="end_of_year_story_epilogue_subtitle">N’oubliez pas de montrer votre soutien à vos créateurs de podcasts préférés et à partager ces podcasts avec vos amis</string>
-    <string name="end_of_year_story_longest_episode_share_text">L’épisode le plus long que j’ai écouté en 2023 %1$s</string>
-    <string name="end_of_year_story_top_podcasts_list_title">Mes meilleurs podcasts de 2022</string>
     <string name="end_of_year_story_top_podcasts_share_text">Mes meilleurs podcasts de l\'année ! %1$s</string>
-    <string name="end_of_year_story_top_podcast_share_text">Mon podcast préféré de 2023 ! %1$s</string>
     <string name="end_of_year_story_top_podcast_subtitle">Vous avez écouté %1$d épisodes pour une durée totale de %2$s</string>
-    <string name="end_of_year_story_listened_to_numbers_share_text">J’ai écouté %1$d podcasts différents et %2$d épisodes en 2023</string>
     <string name="end_of_year_story_listened_to_numbers_subtitle">Vous avez écouté plusieurs fois une même émission…</string>
     <string name="end_of_year_story_listened_to_numbers">Vous avez écouté %1$d émissions différentes et %2$d épisodes au total</string>
     <string name="end_of_year_story_listened_to_categories_share_text">J’ai écouté %1$d catégories différentes en 2023</string>

--- a/modules/services/localization/src/main/res/values-it/strings.xml
+++ b/modules/services/localization/src/main/res/values-it/strings.xml
@@ -251,12 +251,10 @@ Language: it
     <string name="bookmark_not_found">Segnalibro non trovato</string>
     <string name="settings_use_dark_up_next_details">Se attivato, il Successivo utilizzerà sempre il tema scuro, oppure sarà applicato il tema corrente se disattivato</string>
     <string name="settings_use_dark_up_next">Usa il tema scuro per Successivo</string>
-    <string name="end_of_year_stories_completion_rate_share_text">Il mio tasso di completamento del 2023</string>
     <string name="end_of_year_stories_theres_more">E c\'è di più.</string>
     <string name="end_of_year_stories_year_completion_rate">tasso di completamento</string>
     <string name="end_of_year_stories_year_completion_rate_subtitle">Dei %1$d episodi iniziati, ne hai ascoltati integralmente un totale pari a: %2$d</string>
     <string name="end_of_year_stories_year_completion_rate_title">Il tuo tasso di completamento quest\'anno è stato: %1$d%%</string>
-    <string name="end_of_year_stories_year_over_share_text">Il mio tempo di ascolto nel 2023 rispetto al 2022</string>
     <string name="eoy_year_over_year_title_skyrocketed">Rispetto al 2022, il tuo tempo di ascolto è salito alle stelle.</string>
     <string name="end_of_year_stories_year_over_year_subtitle_went_down">Ma hai ancora tutta la vita davanti, giusto?</string>
     <string name="end_of_year_stories_year_over_year_subtitle_flat">Dicono che la costanza sia la chiave per il successo. O qualcosa del genere.</string>
@@ -579,12 +577,8 @@ Language: it
     <string name="end_of_year_story_top_categories_share_text">I più ascoltati nelle categorie podcast</string>
     <string name="end_of_year_story_top_categories">Categorie migliori</string>
     <string name="end_of_year_story_epilogue_subtitle">Non dimenticare di condividere con i tuoi amici e ringrazia i creatori dei tuoi podcast preferiti</string>
-    <string name="end_of_year_story_longest_episode_share_text">L\'episodio più lungo ascoltato nel 2023: %1$s</string>
-    <string name="end_of_year_story_top_podcasts_list_title">I miei podcast preferiti del 2022</string>
     <string name="end_of_year_story_top_podcasts_share_text">I miei podcast preferiti dell\'anno! %1$s</string>
-    <string name="end_of_year_story_top_podcast_share_text">Il mio podcast preferito del 2023. %1$s</string>
     <string name="end_of_year_story_top_podcast_subtitle">Hai ascoltato %1$d episodi per un totale di %2$s</string>
-    <string name="end_of_year_story_listened_to_numbers_share_text">Nel 2023 ho ascoltato %1$d podcast differenti e %2$d episodi</string>
     <string name="end_of_year_story_listened_to_numbers_subtitle">C\'è stato però uno su cui continuavi ad andare…</string>
     <string name="end_of_year_story_listened_to_numbers">Hai ascoltato %1$d podcast diversi e %2$d episodi in totale</string>
     <string name="end_of_year_story_listened_to_categories_share_text">Ho ascoltato %1$d categorie diverse nel 2023</string>

--- a/modules/services/localization/src/main/res/values-ja/strings.xml
+++ b/modules/services/localization/src/main/res/values-ja/strings.xml
@@ -251,12 +251,10 @@ Language: ja_JP
     <string name="bookmark_not_found">ブックマークが見つかりません</string>
     <string name="settings_use_dark_up_next_details">有効にすると、「次のエピソード待機リスト」では常にダークテーマを使用し、無効にすると現在のテーマと一致します</string>
     <string name="settings_use_dark_up_next">次のエピソード待機リストのダークテーマを使用</string>
-    <string name="end_of_year_stories_completion_rate_share_text">My 2023完了率</string>
     <string name="end_of_year_stories_theres_more">その他にもございます !</string>
     <string name="end_of_year_stories_year_completion_rate">完了率</string>
     <string name="end_of_year_stories_year_completion_rate_subtitle">開始した%1$d件のエピソードから合計%2$d件を最後まで聴きました</string>
     <string name="end_of_year_stories_year_completion_rate_title">今年の完了率は%1$d%% です</string>
-    <string name="end_of_year_stories_year_over_share_text">2023年と2022年の聴取時間の比較</string>
     <string name="eoy_year_over_year_title_skyrocketed">2022年と比較して、聴取時間が急増しました !</string>
     <string name="end_of_year_stories_year_over_year_subtitle_went_down">生きてこその人生ですね。</string>
     <string name="end_of_year_stories_year_over_year_subtitle_flat">一貫性が成功の鍵であるとかなんとか言われています。</string>
@@ -579,12 +577,8 @@ Language: ja_JP
     <string name="end_of_year_story_top_categories_share_text">一番聴いたポッドキャストのカテゴリー</string>
     <string name="end_of_year_story_top_categories">トップカテゴリー</string>
     <string name="end_of_year_story_epilogue_subtitle">友達と共有したりお気に入りのポッドキャストクリエイターにエールを送ったりしましょう</string>
-    <string name="end_of_year_story_longest_episode_share_text">2023年に聴いた最長のエピソード: %1$s</string>
-    <string name="end_of_year_story_top_podcasts_list_title">2022年に再生数が多かったポッドキャスト</string>
     <string name="end_of_year_story_top_podcasts_share_text">今年再生数が多かったポッドキャストはこちら ! %1$s</string>
-    <string name="end_of_year_story_top_podcast_share_text">2023年のお気に入りのポッドキャストはこちら ! %1$s</string>
     <string name="end_of_year_story_top_podcast_subtitle">%1$d話のエピソードで合計%2$s聴きました</string>
-    <string name="end_of_year_story_listened_to_numbers_share_text">2023年は%1$d個のポッドキャストで%2$d話のエピソードを聴きました</string>
     <string name="end_of_year_story_listened_to_numbers_subtitle">何度も聴いたエピソードもありました…</string>
     <string name="end_of_year_story_listened_to_numbers">%1$d個のショーで合計%2$d話のエピソードを聴きました</string>
     <string name="end_of_year_story_listened_to_categories_share_text">2023年は%1$d個のカテゴリーを聴きました</string>

--- a/modules/services/localization/src/main/res/values-ko/strings.xml
+++ b/modules/services/localization/src/main/res/values-ko/strings.xml
@@ -251,12 +251,10 @@ Language: ko_KR
     <string name="bookmark_not_found">북마크를 찾을 수 없음</string>
     <string name="settings_use_dark_up_next_details">활성화되면 다음 에피소드에 항상 어두운 테마를 사용하고 비활성화되면 현재와 일치하는 테마를 사용합니다.</string>
     <string name="settings_use_dark_up_next">다음 에피소드에 어두운 테마 사용</string>
-    <string name="end_of_year_stories_completion_rate_share_text">나의 2023년 완료율</string>
     <string name="end_of_year_stories_theres_more">더 있습니다!</string>
     <string name="end_of_year_stories_year_completion_rate">완료율</string>
     <string name="end_of_year_stories_year_completion_rate_subtitle">시작하신 %1$d개 에피소드 중에서 총 %2$d개 완전히 청취</string>
     <string name="end_of_year_stories_year_completion_rate_title">올해 완료율은 %1$d%%이었습니다.</string>
-    <string name="end_of_year_stories_year_over_share_text">2022년 대비 내 2023년 청취 시간</string>
     <string name="eoy_year_over_year_title_skyrocketed">2022년 대비 청취 시간이 급증했습니다!</string>
     <string name="end_of_year_stories_year_over_year_subtitle_went_down">일상생활도 중요하겠죠?</string>
     <string name="end_of_year_stories_year_over_year_subtitle_flat">일관성이 성공의 열쇠라는 말도 있습니다!</string>
@@ -579,12 +577,8 @@ Language: ko_KR
     <string name="end_of_year_story_top_categories_share_text">내가 가장 많이 청취하는 팟캐스트 카테고리</string>
     <string name="end_of_year_story_top_categories">회원님의 상위 카테고리</string>
     <string name="end_of_year_story_epilogue_subtitle">잊지 말고 친구와 공유하고 즐겨 찾는 팟캐스트 창작자에게 감사 인사 보내기</string>
-    <string name="end_of_year_story_longest_episode_share_text">2023년에 내가 청취한 가장 긴 에피소드 %1$s</string>
-    <string name="end_of_year_story_top_podcasts_list_title">나의 2022년 상위 팟캐스트</string>
     <string name="end_of_year_story_top_podcasts_share_text">나의 올해 상위 팟캐스트입니다! %1$s</string>
-    <string name="end_of_year_story_top_podcast_share_text">내가 즐겨찾는 2023년 팟캐스트입니다! %1$s</string>
     <string name="end_of_year_story_top_podcast_subtitle">총 %2$s 동안 %1$d개 에피소드를 청취하셨습니다.</string>
-    <string name="end_of_year_story_listened_to_numbers_share_text">내가 2023년에 청취한 팟캐스트는 %1$d가지, 에피소드는 %2$d개</string>
     <string name="end_of_year_story_listened_to_numbers_subtitle">그러나 반복 청취한 것이 있었습니다…</string>
     <string name="end_of_year_story_listened_to_numbers">청취하신 총 프로그램 %1$d개, 에피소드 %2$d개</string>
     <string name="end_of_year_story_listened_to_categories_share_text">내가 2023년에 청취한 카테고리는 %1$d가지</string>

--- a/modules/services/localization/src/main/res/values-nb/strings.xml
+++ b/modules/services/localization/src/main/res/values-nb/strings.xml
@@ -280,7 +280,6 @@ Language: nb_NO
     <string name="log_in">Logg på</string>
     <string name="end_of_year_story_top_podcast_subtitle">Du lyttet til %1$d episoder av totalt %2$s</string>
     <string name="end_of_year_story_top_podcasts_share_text">Mine favorittpodcaster for året! %1$s</string>
-    <string name="end_of_year_story_top_podcasts_list_title">Mine favorittpodcaster for 2022</string>
     <string name="end_of_year_story_epilogue_subtitle">Ikke glem å dele med vennene dine og fremheve favorittene blant podcastskaperne</string>
     <string name="end_of_year_story_top_categories">Favorittkategoriene dine</string>
     <string name="end_of_year_story_top_categories_share_text">Podcastkategoriene jeg lyttet mest til</string>

--- a/modules/services/localization/src/main/res/values-nl/strings.xml
+++ b/modules/services/localization/src/main/res/values-nl/strings.xml
@@ -251,12 +251,10 @@ Language: nl
     <string name="bookmark_not_found">Bladwijzer niet gevonden</string>
     <string name="settings_use_dark_up_next_details">Indien ingeschakeld gebruikt Hierna altijd het donkere thema en indien uitgeschakeld gebruikt het het huidige thema</string>
     <string name="settings_use_dark_up_next">Donker thema voor Hierna gebruiken</string>
-    <string name="end_of_year_stories_completion_rate_share_text">Mijn afrondingspercentage 2023</string>
     <string name="end_of_year_stories_theres_more">Dat is niet alles!</string>
     <string name="end_of_year_stories_year_completion_rate">afrondingspercentage</string>
     <string name="end_of_year_stories_year_completion_rate_subtitle">Van de %1$d afleveringen waar je aan bent begonnen, heb je dit aantal helemaal afgekeken %2$d</string>
     <string name="end_of_year_stories_year_completion_rate_title">Je afrondingspercentage dit jaar was %1$d%%</string>
-    <string name="end_of_year_stories_year_over_share_text">Mijn luistertijd in 2023, ten opzichte van 2022</string>
     <string name="eoy_year_over_year_title_skyrocketed">Ten opzichte van 2022 is je luistertijd veel hoger!</string>
     <string name="end_of_year_stories_year_over_year_subtitle_went_down">Aaaah… er moet worden geleefd, toch?</string>
     <string name="end_of_year_stories_year_over_year_subtitle_flat">Consistentie is de sleutel tot succes… of zoiets!</string>
@@ -579,12 +577,8 @@ Language: nl
     <string name="end_of_year_story_top_categories_share_text">Mijn meest beluisterde podcastcategorieën</string>
     <string name="end_of_year_story_top_categories">Je beste categorieën</string>
     <string name="end_of_year_story_epilogue_subtitle">Vergeet niet om te delen met je vrienden en een shoutout te geven naar je favoriete podcastmakers</string>
-    <string name="end_of_year_story_longest_episode_share_text">De langste aflevering waarnaar ik heb geluisterd in 2023 %1$s</string>
-    <string name="end_of_year_story_top_podcasts_list_title">Mijn beste podcasts van 2022</string>
     <string name="end_of_year_story_top_podcasts_share_text">Mijn beste podcasts van het jaar! %1$s</string>
-    <string name="end_of_year_story_top_podcast_share_text">Mijn favoriete podcast van 2023! %1$s</string>
     <string name="end_of_year_story_top_podcast_subtitle">Je hebt in totaal %2$s geluisterd naar %1$d afleveringen</string>
-    <string name="end_of_year_story_listened_to_numbers_share_text">Ik heb in 2023 naar %1$d verschillende podcasts en %2$d afleveringen geluisterd</string>
     <string name="end_of_year_story_listened_to_numbers_subtitle">Maar er was er één waar je steeds maar weer naar terugkeerde …</string>
     <string name="end_of_year_story_listened_to_numbers">Je hebt naar %1$d verschillende shows en %2$d afleveringen geluisterd</string>
     <string name="end_of_year_story_listened_to_categories_share_text">Ik heb in 2023 naar %1$d verschillende categorieën geluisterd</string>

--- a/modules/services/localization/src/main/res/values-pt-rBR/strings.xml
+++ b/modules/services/localization/src/main/res/values-pt-rBR/strings.xml
@@ -251,12 +251,10 @@ Language: pt_BR
     <string name="bookmark_not_found">Favorito não encontrado</string>
     <string name="settings_use_dark_up_next_details">Com essa opção ativada, a lista Próximos sempre usará o tema escuro. Quando desativada, a lista usará o tema atual.</string>
     <string name="settings_use_dark_up_next">Usar tema escuro na fila Próximos</string>
-    <string name="end_of_year_stories_completion_rate_share_text">Minha taxa de conclusão em 2023</string>
     <string name="end_of_year_stories_theres_more">E tem mais!</string>
     <string name="end_of_year_stories_year_completion_rate">taxa de conclusão</string>
     <string name="end_of_year_stories_year_completion_rate_subtitle">Dos %1$d episódios que você começou, você concluiu um total de %2$d</string>
     <string name="end_of_year_stories_year_completion_rate_title">Sua taxa de conclusão este ano foi de %1$d%%</string>
-    <string name="end_of_year_stories_year_over_share_text">Meu tempo de streaming em 2023 em comparação com 2022</string>
     <string name="eoy_year_over_year_title_skyrocketed">Em comparação com 2022, seu tempo de streaming disparou!</string>
     <string name="end_of_year_stories_year_over_year_subtitle_went_down">Poxa… tem sempre algo para se viver, né?</string>
     <string name="end_of_year_stories_year_over_year_subtitle_flat">E dizem que continuidade é a chave do sucesso… ou algo parecido.</string>
@@ -579,12 +577,8 @@ Language: pt_BR
     <string name="end_of_year_story_top_categories_share_text">Categorias dos podcasts que mais ouvi</string>
     <string name="end_of_year_story_top_categories">Suas principais categorias</string>
     <string name="end_of_year_story_epilogue_subtitle">Não esqueça de compartilhar com seus amigos e agradecer a seus criadores favoritos</string>
-    <string name="end_of_year_story_longest_episode_share_text">O episódio mais longo que eu ouvi em 2023 %1$s</string>
-    <string name="end_of_year_story_top_podcasts_list_title">Meus principais podcasts de 2022</string>
     <string name="end_of_year_story_top_podcasts_share_text">Meus principais podcasts do ano! %1$s</string>
-    <string name="end_of_year_story_top_podcast_share_text">Meu podcast favorito de 2023! %1$s</string>
     <string name="end_of_year_story_top_podcast_subtitle">Você ouviu %1$d episódios em um total de %2$s</string>
-    <string name="end_of_year_story_listened_to_numbers_share_text">Eu ouvi %1$d podcasts diferentes e %2$d episódios em 2023</string>
     <string name="end_of_year_story_listened_to_numbers_subtitle">Mas tinha um que sempre fazia você pedir bis…</string>
     <string name="end_of_year_story_listened_to_numbers">Você ouviu %1$d programas diferentes e %2$d episódios no total</string>
     <string name="end_of_year_story_listened_to_categories_share_text">Eu ouvi %1$d categorias diferentes em 2023</string>

--- a/modules/services/localization/src/main/res/values-ru/strings.xml
+++ b/modules/services/localization/src/main/res/values-ru/strings.xml
@@ -251,12 +251,10 @@ Language: ru
     <string name="bookmark_not_found">Закладка не найдена</string>
     <string name="settings_use_dark_up_next_details">При включённом параметре Up Next будет всегда использовать тёмную тему, а при выключенном — соответствовать текущей теме</string>
     <string name="settings_use_dark_up_next">Использовать тёмную тему Up Next</string>
-    <string name="end_of_year_stories_completion_rate_share_text">Мои итоги 2023 года</string>
     <string name="end_of_year_stories_theres_more">Есть и многое другое!</string>
     <string name="end_of_year_stories_year_completion_rate">процент завершения</string>
     <string name="end_of_year_stories_year_completion_rate_subtitle">Из %1$d запущенных эпизодов всего вы дослушали до конца %2$d</string>
     <string name="end_of_year_stories_year_completion_rate_title">Ваш процент завершения в этом году равен %1$d%%</string>
-    <string name="end_of_year_stories_year_over_share_text">Время прослушивания в 2023 г. по сравнению с 2022 г.</string>
     <string name="eoy_year_over_year_title_skyrocketed">По сравнению с 2022 г. вы посвятили прослушиванию намного больше времени!</string>
     <string name="end_of_year_stories_year_over_year_subtitle_went_down">И… как, вам хватает времени на всё остальное?</string>
     <string name="end_of_year_stories_year_over_year_subtitle_flat">Говорят, постоянство — ключ к успеху… или что-то в этом роде.</string>
@@ -579,12 +577,8 @@ Language: ru
     <string name="end_of_year_story_top_categories_share_text">Рубрики подкастов, которые я слушаю чаще всего</string>
     <string name="end_of_year_story_top_categories">Ваши любимые рубрики</string>
     <string name="end_of_year_story_epilogue_subtitle">Не забудьте поделиться с друзьями и рассказать о любимых подкастерах</string>
-    <string name="end_of_year_story_longest_episode_share_text">Самый продолжительный выпуск, прослушанный мною в 2023 году: %1$s</string>
-    <string name="end_of_year_story_top_podcasts_list_title">Мои любимые подкасты в 2022 году</string>
     <string name="end_of_year_story_top_podcasts_share_text">Мои любимые подкасты этого года! %1$s</string>
-    <string name="end_of_year_story_top_podcast_share_text">Мой любимый подкаст в 2023 году! %1$s</string>
     <string name="end_of_year_story_top_podcast_subtitle">Вы прослушали %1$d выпусков (-а) общей продолжительностью %2$s</string>
-    <string name="end_of_year_story_listened_to_numbers_share_text">Я прослушал(а) %1$d подкастов(а) и %2$d выпусков(а) в 2023 году</string>
     <string name="end_of_year_story_listened_to_numbers_subtitle">Но было одно шоу, которое вы слушали снова и снова…</string>
     <string name="end_of_year_story_listened_to_numbers">Вы прослушали %1$d шоу и %2$d выпусков</string>
     <string name="end_of_year_story_listened_to_categories_share_text">Я выбрал(а) %1$d рубрик(и) в 2023 году</string>

--- a/modules/services/localization/src/main/res/values-sv/strings.xml
+++ b/modules/services/localization/src/main/res/values-sv/strings.xml
@@ -251,12 +251,10 @@ Language: sv_SE
     <string name="bookmark_not_found">Bokmärke hittades inte</string>
     <string name="settings_use_dark_up_next_details">När det är aktiverat kommer Up Next alltid att använda mörkt tema, eller matcha det aktuella temat när det är inaktiverat</string>
     <string name="settings_use_dark_up_next">Använd mörkt Up Next-tema</string>
-    <string name="end_of_year_stories_completion_rate_share_text">Min slutförandegrad för 2023</string>
     <string name="end_of_year_stories_theres_more">Och det finns mer!</string>
     <string name="end_of_year_stories_year_completion_rate">slutförandegrad</string>
     <string name="end_of_year_stories_year_completion_rate_subtitle">Av de %1$d avsnitt du började lyssna på lyssnade du sammanlagt på %2$d</string>
     <string name="end_of_year_stories_year_completion_rate_title">Din slutförandegrad i år var %1$d%%</string>
-    <string name="end_of_year_stories_year_over_share_text">Min lyssningstid för 2023 jämfört med 2022</string>
     <string name="eoy_year_over_year_title_skyrocketed">Jämfört med 2022 har din lyssningstid skjutit i höjden!</string>
     <string name="end_of_year_stories_year_over_year_subtitle_went_down">Ack ja … det finns ett liv att leva, eller hur?</string>
     <string name="end_of_year_stories_year_over_year_subtitle_flat">Och det sägs att kontinuitet är nyckeln till framgång … eller något i den stilen!</string>
@@ -579,12 +577,8 @@ Language: sv_SE
     <string name="end_of_year_story_top_categories_share_text">Mina mest lyssnade podcastkategorier</string>
     <string name="end_of_year_story_top_categories">Dina favoritkategorier</string>
     <string name="end_of_year_story_epilogue_subtitle">Glöm inte att dela med dina vänner och att berätta om dina favoritpodcastkreatörer</string>
-    <string name="end_of_year_story_longest_episode_share_text">Det längsta avsnittet jag lyssnade på under 2023 %1$s</string>
-    <string name="end_of_year_story_top_podcasts_list_title">Mina favoritpodcasts 2022</string>
     <string name="end_of_year_story_top_podcasts_share_text">Mina favoritpodcasts för året. %1$s</string>
-    <string name="end_of_year_story_top_podcast_share_text">Min favoritpodcast 2023! %1$s</string>
     <string name="end_of_year_story_top_podcast_subtitle">Du lyssnade på %1$d avsnitt i sammanlagt %2$s</string>
-    <string name="end_of_year_story_listened_to_numbers_share_text">Jag lyssnade på %1$d olika podcasts och %2$d avsnitt under 2023</string>
     <string name="end_of_year_story_listened_to_numbers_subtitle">Det fanns dock ett avsnitt som du fortsatte att komma tillbaka till …</string>
     <string name="end_of_year_story_listened_to_numbers">Du lyssnade sammanlagt på %1$d olika podcasts och %2$d avsnitt</string>
     <string name="end_of_year_story_listened_to_categories_share_text">Jag lyssnade på %1$d olika kategorier under 2023</string>

--- a/modules/services/localization/src/main/res/values-zh-rTW/strings.xml
+++ b/modules/services/localization/src/main/res/values-zh-rTW/strings.xml
@@ -251,12 +251,10 @@ Language: zh_TW
     <string name="bookmark_not_found">找不到書籤</string>
     <string name="settings_use_dark_up_next_details">啟用後，「接下來播放」將永遠使用深色系佈景主題；若停用，系統則將採用與屆時設定相符的主題</string>
     <string name="settings_use_dark_up_next">使用暗色系「接下來播放」佈景主題</string>
-    <string name="end_of_year_stories_completion_rate_share_text">我的 2023 年完成率</string>
     <string name="end_of_year_stories_theres_more">還有更多有趣內容！</string>
     <string name="end_of_year_stories_year_completion_rate">完成率</string>
     <string name="end_of_year_stories_year_completion_rate_subtitle">從你開始收聽的 %1$d 集起，你完整收聽了 %2$d 集</string>
     <string name="end_of_year_stories_year_completion_rate_title">你今年的完成率為 %1$d%%</string>
-    <string name="end_of_year_stories_year_over_share_text">我在 2023 年與 2022 年的收聽時間比較</string>
     <string name="eoy_year_over_year_title_skyrocketed">比起 2022 年，你的收聽時間可說是一飛沖天！</string>
     <string name="end_of_year_stories_year_over_year_subtitle_went_down">啊啊啊…人就是要享受生活，對吧？</string>
     <string name="end_of_year_stories_year_over_year_subtitle_flat">大家都說，成功的關鍵在於持之以恆…大概是這樣吧！</string>
@@ -579,12 +577,8 @@ Language: zh_TW
     <string name="end_of_year_story_top_categories_share_text">我最常收聽的 Podcast 分類</string>
     <string name="end_of_year_story_top_categories">你最愛的分類</string>
     <string name="end_of_year_story_epilogue_subtitle">別忘了與朋友分享，並向你最喜愛的 Podcast 創作者致意</string>
-    <string name="end_of_year_story_longest_episode_share_text">我在 2023 年收聽時間最長的一集%1$s</string>
-    <string name="end_of_year_story_top_podcasts_list_title">2022 年我最愛的 Podcast</string>
     <string name="end_of_year_story_top_podcasts_share_text">本年度我最愛的 Podcast！ %1$s</string>
-    <string name="end_of_year_story_top_podcast_share_text">2023 年我最愛的 Podcast！ %1$s</string>
     <string name="end_of_year_story_top_podcast_subtitle">你收聽了 %1$d 集，總共 %2$s</string>
-    <string name="end_of_year_story_listened_to_numbers_share_text">我在 2023 年收聽了 %1$d 個不同的 Podcast，總共 %2$d 集</string>
     <string name="end_of_year_story_listened_to_numbers_subtitle">但有個節目你已成為忠實聽眾了…</string>
     <string name="end_of_year_story_listened_to_numbers">你一共收聽了 %1$d 個不同節目和 %2$d 集內容</string>
     <string name="end_of_year_story_listened_to_categories_share_text">我在 2023 年收聽了 %1$d 個不同的分類</string>

--- a/modules/services/localization/src/main/res/values-zh/strings.xml
+++ b/modules/services/localization/src/main/res/values-zh/strings.xml
@@ -251,12 +251,10 @@ Language: zh_CN
     <string name="bookmark_not_found">未找到书签</string>
     <string name="settings_use_dark_up_next_details">启用后，“下一个”将始终使用深色主题；禁用后，将与当前主题匹配</string>
     <string name="settings_use_dark_up_next">使用深色的“下一个”主题</string>
-    <string name="end_of_year_stories_completion_rate_share_text">我在 2023 年的完成率</string>
     <string name="end_of_year_stories_theres_more">更多精彩有待进一步探索！</string>
     <string name="end_of_year_stories_year_completion_rate">完成率</string>
     <string name="end_of_year_stories_year_completion_rate_subtitle">从最初收听的 %1$d 集开始，您总共完整收听的时长为 %2$d</string>
     <string name="end_of_year_stories_year_completion_rate_title">您今年的完成率为 %1$d%%</string>
-    <string name="end_of_year_stories_year_over_share_text">我的 2023 年收听时长与 2022 年的比较情况</string>
     <string name="eoy_year_over_year_title_skyrocketed">相比于 2022 年，您的收听时长飙升！</string>
     <string name="end_of_year_stories_year_over_year_subtitle_went_down">啊哈…生活还得继续，不是吗？</string>
     <string name="end_of_year_stories_year_over_year_subtitle_flat">人们常说，一致性是成功的关键…或诸如此类的话！</string>
@@ -579,12 +577,8 @@ Language: zh_CN
     <string name="end_of_year_story_top_categories_share_text">我收听最多的播客分类</string>
     <string name="end_of_year_story_top_categories">您的热门分类</string>
     <string name="end_of_year_story_epilogue_subtitle">不要忘记共享给朋友，告诉他们您最喜欢的播客创作者</string>
-    <string name="end_of_year_story_longest_episode_share_text">2023 年我收听时间最长的剧集 %1$s</string>
-    <string name="end_of_year_story_top_podcasts_list_title">我的 2022 年热门播客</string>
     <string name="end_of_year_story_top_podcasts_share_text">我的年度热门播客！ %1$s</string>
-    <string name="end_of_year_story_top_podcast_share_text">2023 年我最喜欢的播客！ %1$s</string>
     <string name="end_of_year_story_top_podcast_subtitle">您收听了 %1$d 部剧集，共 %2$s 部</string>
-    <string name="end_of_year_story_listened_to_numbers_share_text">我在 2023 年收听了 %1$d 个不同的播客和 %2$d 部剧集</string>
     <string name="end_of_year_story_listened_to_numbers_subtitle">但还有一个您经常收听的播客…</string>
     <string name="end_of_year_story_listened_to_numbers">您总共收听了 %1$d 个不同的节目和 %2$d 部剧集</string>
     <string name="end_of_year_story_listened_to_categories_share_text">我在 2023 年收听了 %1$d 种不同的分类</string>

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -1780,14 +1780,14 @@
     <string name="end_of_year_stories_year_over_year_subtitle_went_down">Aaaah… there’s a life to be lived, right?</string>
     <!-- Title of the story when this year's listening time is way bigger than previous year. -->
     <string name="eoy_year_over_year_title_skyrocketed">Compared to 2022, your listening time skyrocketed!</string>
-    <!-- Text for when a user shares the story comparing the previous year (%1$d) and this year (%2$d) listening time. -->
+    <!-- Text for when a user shares the story comparing the this year (%1$d) and previous year (%2$d) listening time. -->
     <string name="end_of_year_stories_year_over_share_text">My %1$d listening time compared to %2$d</string>
     <!-- Title for the completion rate. %1$d is the percentage.-->
     <string name="end_of_year_stories_year_completion_rate_title">Your completion rate this year was %1$d%%</string>
     <!-- Title for the completion rate. %1$d is the total of episodes listened this year, %2$d is the total of episodes fully listened to. -->
     <string name="end_of_year_stories_year_completion_rate_subtitle">From the %1$d episodes you started you listened fully to a total of %2$d</string>
-    <!-- Title for when sharing the completion rate story to social media. %1$d is the year -->
-    <string name="end_of_year_stories_completion_rate_share_text">My %1$d completion rate</string>
+    <!-- Title for when sharing the completion rate story to social media. %1$d is percentage -->
+    <string name="end_of_year_stories_completion_rate_share_text">My completion rate this year was %1$d</string>
     <string name="end_of_year_stories_year_completion_rate">completion rate</string>
     <!-- Title of the story paywall. Telling the users that there are more stories to check. -->
     <string name="end_of_year_stories_theres_more">There\’s more!</string>>

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -1725,28 +1725,28 @@
     <string name="end_of_year_story_listened_to_numbers_english_only" translatable="false">You listened to\n%1$d different shows\nand %2$d episodes in total</string>
     <!-- Subtitle for the story containing number of podcasts and episodes played this year. Segway for the next story. -->
     <string name="end_of_year_story_listened_to_numbers_subtitle">But there was one that you kept coming to…</string>
-    <!-- Text that appear when someone share the listened numbers story to Twitter. %1$d is a placeholder for the number of podcasts listened and %2$d for the number of episodes. -->
-    <string name="end_of_year_story_listened_to_numbers_share_text">I listened to %1$d different podcasts and %2$d episodes in 2023</string>
+    <!-- Text that appear when someone share the listened numbers story to Twitter. %1$d is a placeholder for the number of podcasts listened and %2$d for the number of episodes. %3$d is the year. -->
+    <string name="end_of_year_story_listened_to_numbers_share_text">I listened to %1$d different podcasts and %2$d episodes in %3$d</string>
     <!-- Title for the story that display the most listened podcast by the user this year. %1$s is a placeholder for the podcast title. -->
     <string name="end_of_year_story_top_podcast_title">Your top podcast in 2024 was %1$s</string>
     <!-- Subtitle for the story that display the most listened podcast by the user this year. %1$d is a placeholder for the number of episodes and %2$s is a placeholder for the listened time. -->
     <string name="end_of_year_story_top_podcast_subtitle">You listened to %1$d episodes for a total of %2$s</string>
-    <!-- Text that appear when someone share the top podcast of the year story to Twitter. %1$s is the URL to the podcast. -->
-    <string name="end_of_year_story_top_podcast_share_text">My favorite podcast of 2023! %1$s</string>
+    <!-- Text that appear when someone share the top podcast of the year story to Twitter. %1$d is the year and %2$s is the URL to the podcast. -->
+    <string name="end_of_year_story_top_podcast_share_text">My favorite podcast of %1$d! %2$s</string>
     <!-- Title for the story showing the top podcasts for the user in the current year. -->
     <string name="eoy_story_top_podcasts_title">And you were big on these shows too!</string>
     <!-- Subtitle for the story showing the top podcasts for the user in the current year. -->
     <string name="eoy_story_top_podcasts_subtitle">This is your top 5 most listened to in 2023"</string>
     <!-- Text that appear when someone share the top 5 podcasts of the year story to Twitter. %1$s is a link to the list of the top podcasts. -->
     <string name="end_of_year_story_top_podcasts_share_text">My top podcasts of the year! %1$s</string>
-    <!-- Title of a list of podcasts created containing the user's top 5 podcasts of 2022. -->
-    <string name="end_of_year_story_top_podcasts_list_title">My top podcasts of 2022</string>
+    <!-- Title of a list of podcasts created containing the user's top 5 podcasts of the year. %1$d is the year. -->
+    <string name="end_of_year_story_top_podcasts_list_title">My top podcasts of %1$d</string>
     <!-- Title for the story showing the longest episode listened for the user in the current year. %1$s is a placeholder for the episode length. -->
     <string name="end_of_year_story_longest_episode_title">The longest episode you listened to was %1$s</string>
     <!-- Subtitle for the story showing the longest episode listened for the user in the current year. %1$s is a placeholder for the episode title and %2$s is a placeholder for the podcast title. -->
     <string name="end_of_year_story_longest_episode_subtitle">It was \"%1$s\" from \"%2$s\"</string>
-    <!-- Text that appear when someone share the longest episode they listened to story to Twitter. %1$s is the URL to the episode. -->
-    <string name="end_of_year_story_longest_episode_share_text">The longest episode I listened to in 2023 %1$s</string>
+    <!-- Text that appear when someone share the longest episode they listened to story to Twitter. %1$d is the year and %2$s is the URL to the episode. -->
+    <string name="end_of_year_story_longest_episode_share_text">The longest episode I listened to in %1$d %2$s</string>
     <!-- Title for the epilogue story. %1$d is the yer. -->
     <string name="end_of_year_story_epilogue_title">Thank you for listening with us this year.\nSee you in %1$d!</string>
     <!-- Subtitle for the epilogue story -->
@@ -1780,14 +1780,14 @@
     <string name="end_of_year_stories_year_over_year_subtitle_went_down">Aaaah… there’s a life to be lived, right?</string>
     <!-- Title of the story when this year's listening time is way bigger than previous year. -->
     <string name="eoy_year_over_year_title_skyrocketed">Compared to 2022, your listening time skyrocketed!</string>
-    <!-- Text for when a user shares the story comparing the 2022 and 2023 listening time. -->
-    <string name="end_of_year_stories_year_over_share_text">My 2023 listening time compared to 2022</string>
+    <!-- Text for when a user shares the story comparing the previous year (%1$d) and this year (%2$d) listening time. -->
+    <string name="end_of_year_stories_year_over_share_text">My %1$d listening time compared to %2$d</string>
     <!-- Title for the completion rate. %1$d is the percentage.-->
     <string name="end_of_year_stories_year_completion_rate_title">Your completion rate this year was %1$d%%</string>
     <!-- Title for the completion rate. %1$d is the total of episodes listened this year, %2$d is the total of episodes fully listened to. -->
     <string name="end_of_year_stories_year_completion_rate_subtitle">From the %1$d episodes you started you listened fully to a total of %2$d</string>
-    <!-- Title for when sharing the completion rate story to social media. -->
-    <string name="end_of_year_stories_completion_rate_share_text">My 2023 completion rate</string>
+    <!-- Title for when sharing the completion rate story to social media. %1$d is the year -->
+    <string name="end_of_year_stories_completion_rate_share_text">My %1$d completion rate</string>
     <string name="end_of_year_stories_year_completion_rate">completion rate</string>
     <!-- Title of the story paywall. Telling the users that there are more stories to check. -->
     <string name="end_of_year_stories_theres_more">There\’s more!</string>>
@@ -1811,6 +1811,9 @@
     <string name="end_of_year_share_dialog_title">Share this story?</string>
     <!-- Message of a dialog when a user takes a screenshot of a story. -->
     <string name="end_of_year_share_dialog_message">Paste this image to your socials and give a shout out to your favourite shows and creators</string>
+    <!-- Text that appear when someone share the ratings story to Twitter. %1$d is a number of rated shows, %2$d is the year, and %3$d is the most used rating (from 1 to 5) -->
+    <string name="end_of_year_story_ratings_share_text">I rated %1$d different podcasts in %2$d, with %3$d as my most used rating</string>
+    <string name="end_of_year_cant_share_message">This story can\'t be shared</string>
 
     <!-- Onboarding -->
 

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/to/RatingStats.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/to/RatingStats.kt
@@ -9,6 +9,8 @@ data class RatingStats(
 ) {
     private val max = maxOf(ones, twos, threes, fours, fives)
 
+    fun count() = ones + twos + threes + fours + fives
+
     fun count(rating: Rating) = when (rating) {
         Rating.One -> ones
         Rating.Two -> twos

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/to/Story.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/to/Story.kt
@@ -49,10 +49,10 @@ sealed interface Story {
         override val isShareble = false
     }
 
-    data class YearVsYear(
+    data class YearVsYear constructor(
         val lastYearDuration: Duration,
         val thisYearDuration: Duration,
-        val subscriptionTier: SubscriptionTier?,
+        val subscriptionTier: SubscriptionTier,
     ) : Story {
         override val isFree = false
 
@@ -67,7 +67,7 @@ sealed interface Story {
     data class CompletionRate(
         val listenedCount: Int,
         val completedCount: Int,
-        val subscriptionTier: SubscriptionTier?,
+        val subscriptionTier: SubscriptionTier,
     ) : Story {
         override val isFree = false
 

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/to/Story.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/to/Story.kt
@@ -25,8 +25,9 @@ sealed interface Story {
         val show: TopPodcast,
     ) : Story
 
-    data class TopShows(
+    data class TopShows constructor(
         val shows: List<TopPodcast>,
+        val podcastListUrl: String?,
     ) : Story
 
     data class Ratings(

--- a/modules/services/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/SharingClient.kt
+++ b/modules/services/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/SharingClient.kt
@@ -631,8 +631,8 @@ data class SharingRequest internal constructor(
                     append(
                         context.getString(
                             LR.string.end_of_year_stories_year_over_share_text,
-                            year.value - 1,
                             year.value,
+                            year.value - 1,
                         ),
                     )
                     append(' ')


### PR DESCRIPTION
## Description

This adds basic implementation of story sharing. I'll do image capturing in a separate task.

## Testing Instructions

Verify that shared stories satisfy these requirements. Stories should be also sharable from [the screenshot detection dialog](https://github.com/Automattic/pocket-casts-android/pull/3080).

![Screenshot 2024-10-24 at 14 20 31](https://github.com/user-attachments/assets/60ad8b83-4f5f-47e9-9a65-6fa6ed058dbf)

## Checklist
- [x] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] ~Any jetpack compose components I added or changed are covered by compose previews~
- [x] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~