### PR TITLE
[Project] Up Next Shuffle - Hide shuffle button when there is no current playing episode

### DIFF
--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/UpNextAdapter.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/UpNextAdapter.kt
@@ -164,14 +164,14 @@ class UpNextAdapter(
             with(binding) {
                 emptyUpNextContainer.isVisible = header.episodeCount == 0
                 val time = TimeHelper.getTimeDurationShortString(timeMs = (header.totalTimeSecs * 1000).toLong(), context = root.context)
-                lblUpNextTime.isVisible = playbackManager.getCurrentEpisode() != null
+                lblUpNextTime.isVisible = hasEpisodeInProgress()
                 lblUpNextTime.text = if (header.episodeCount == 0) {
                     root.resources.getString(LR.string.player_up_next_time_left, time)
                 } else {
                     root.resources.getQuantityString(LR.plurals.player_up_next_header_title, header.episodeCount, header.episodeCount, time)
                 }
 
-                shuffle.isVisible = FeatureFlag.isEnabled(Feature.UP_NEXT_SHUFFLE)
+                shuffle.isVisible = hasEpisodeInProgress() && FeatureFlag.isEnabled(Feature.UP_NEXT_SHUFFLE)
                 shuffle.updateShuffleButton()
 
                 shuffle.setOnClickListener {
@@ -205,6 +205,8 @@ class UpNextAdapter(
                 context.getString(LR.string.up_next_shuffle_button_content_description),
             )
         }
+
+        private fun hasEpisodeInProgress() = playbackManager.getCurrentEpisode() != null
     }
 
     inner class PlayingViewHolder(val binding: AdapterUpNextPlayingBinding) : RecyclerView.ViewHolder(binding.root) {


### PR DESCRIPTION
## Description
- The shuffle button should be hidden when there is no episode in progress

Fixes #3089

## Testing Instructions
1. Have the shuffle feature flag on
2. Remove all in progress episode
3. Tap on Up next tap
4. ✅ Ensure you don't see the shuffle button
5. Play an episode
6. Open Up next
7. ✅ Ensure you see the shuffle button

## Screenshots or Screencast 

| Before | After |
|-------------|--------------|
| ![Before](https://github.com/user-attachments/assets/546f6dcd-11d9-4f5f-a115-19b26b0d1eab) | ![After](https://github.com/user-attachments/assets/0fd534f4-3f76-4490-a2e6-bb061d40416f) |




## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack
