### PR TITLE
Add end of year analytics

### DIFF
--- a/modules/features/endofyear/src/test/kotlin/au/com/shiftyjelly/pocketcasts/endofyear/EndOfYearViewModelTest.kt
+++ b/modules/features/endofyear/src/test/kotlin/au/com/shiftyjelly/pocketcasts/endofyear/EndOfYearViewModelTest.kt
@@ -3,6 +3,7 @@ package au.com.shiftyjelly.pocketcasts.endofyear
 import app.cash.turbine.Turbine
 import app.cash.turbine.TurbineTestContext
 import app.cash.turbine.test
+import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTracker
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.to.RatingStats
 import au.com.shiftyjelly.pocketcasts.models.to.Story
@@ -93,11 +94,13 @@ class EndOfYearViewModelTest {
         viewModel = EndOfYearViewModel(
             year = Year.of(1000),
             topListTitle = "Top list title",
+            source = StoriesFragment.StoriesSource.UNKNOWN,
             endOfYearSync = endOfYearSync,
             endOfYearManager = endOfYearManager,
             subscriptionManager = mock { on { subscriptionTier() }.doReturn(subscriptionTier) },
             listServiceManager = listServiceManager,
             sharingClient = FakeSharingClient(),
+            analyticsTracker = AnalyticsTracker.test(),
         )
     }
 
@@ -687,11 +690,11 @@ class EndOfYearViewModelTest {
     }
 
     private inline fun <reified T : Story> assertHasStory(stories: List<Story>) {
-        assertTrue(stories.filterIsInstance<PlusInterstitial>().isNotEmpty())
+        assertTrue(stories.filterIsInstance<T>().isNotEmpty())
     }
 
     private inline fun <reified T : Story> assertDoesNotHaveStory(stories: List<Story>) {
-        assertTrue(stories.filterIsInstance<PlusInterstitial>().isEmpty())
+        assertTrue(stories.filterIsInstance<T>().isEmpty())
     }
 
     private class FakeEofYearManager : EndOfYearManager {

--- a/modules/features/referrals/src/test/kotlin/au/com/shiftyjelly/pocketcasts/referrals/ReferralsSendGuestPassViewModelTest.kt
+++ b/modules/features/referrals/src/test/kotlin/au/com/shiftyjelly/pocketcasts/referrals/ReferralsSendGuestPassViewModelTest.kt
@@ -142,7 +142,6 @@ class ReferralsSendGuestPassViewModelTest {
         val capturedRequest = requestCaptor.firstValue
         with(capturedRequest) {
             assertEquals(referralCode, (data as SharingRequest.Data.ReferralLink).referralCode)
-            assertEquals(SourceView.REFERRALS, source)
             assertEquals(SocialPlatform.More, platform)
             assertEquals(AnalyticsEvent.REFERRAL_PASS_SHARED, analyticsEvent)
             assertEquals(

--- a/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
+++ b/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
@@ -422,9 +422,9 @@ enum class AnalyticsEvent(val key: String) {
     END_OF_YEAR_STORY_SHOWN("end_of_year_story_shown"),
     END_OF_YEAR_STORY_SHARE("end_of_year_story_share"),
     END_OF_YEAR_STORY_SHARED("end_of_year_story_shared"),
-    END_OF_YEAR_STORY_RETRY_BUTTON_TAPPED("end_of_year_story_retry_button_tapped"),
     END_OF_YEAR_PROFILE_CARD_TAPPED("end_of_year_profile_card_tapped"),
     END_OF_YEAR_UPSELL_SHOWN("end_of_year_upsell_shown"),
+    END_OF_YEAR_LEARN_RATINGS_SHOWN("end_of_year_learn_ratings_shown"),
 
     /* Welcome */
     WELCOME_SHOWN("welcome_shown"),

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/to/Story.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/to/Story.kt
@@ -9,9 +9,11 @@ sealed interface Story {
     val previewDuration: Duration? get() = 7.seconds
     val isFree: Boolean get() = true
     val isShareble: Boolean get() = true
+    val analyticsValue: String
 
     data object Cover : Story {
         override val isShareble = false
+        override val analyticsValue = "cover"
     }
 
     data class NumberOfShows(
@@ -19,42 +21,55 @@ sealed interface Story {
         val epsiodeCount: Int,
         val topShowIds: List<String>,
         val bottomShowIds: List<String>,
-    ) : Story
+    ) : Story {
+        override val analyticsValue = "number_of_shows"
+    }
 
     data class TopShow(
         val show: TopPodcast,
-    ) : Story
+    ) : Story {
+        override val analyticsValue = "top_1_show"
+    }
 
-    data class TopShows constructor(
+    data class TopShows(
         val shows: List<TopPodcast>,
         val podcastListUrl: String?,
-    ) : Story
+    ) : Story {
+        override val analyticsValue = "top_5_shows"
+    }
 
     data class Ratings(
         val stats: RatingStats,
     ) : Story {
         override val isShareble get() = stats.max().second != 0
+        override val analyticsValue = "ratings"
     }
 
     data class TotalTime(
         val duration: Duration,
-    ) : Story
+    ) : Story {
+        override val analyticsValue = "total_time"
+    }
 
     data class LongestEpisode(
         val episode: LongestEpisodeData,
-    ) : Story
+    ) : Story {
+        override val analyticsValue = "longest_episode"
+    }
 
     data object PlusInterstitial : Story {
         override val previewDuration = null
         override val isShareble = false
+        override val analyticsValue = "plus_interstitial"
     }
 
-    data class YearVsYear constructor(
+    data class YearVsYear(
         val lastYearDuration: Duration,
         val thisYearDuration: Duration,
         val subscriptionTier: SubscriptionTier,
     ) : Story {
         override val isFree = false
+        override val analyticsValue = "year_vs_year"
 
         val yearOverYearChange
             get() = when {
@@ -70,6 +85,7 @@ sealed interface Story {
         val subscriptionTier: SubscriptionTier,
     ) : Story {
         override val isFree = false
+        override val analyticsValue = "completion_rate"
 
         val completionRate
             get() = when {
@@ -80,5 +96,6 @@ sealed interface Story {
 
     data object Ending : Story {
         override val isShareble get() = false
+        override val analyticsValue = "ending"
     }
 }

--- a/modules/services/sharing/src/main/AndroidManifest.xml
+++ b/modules/services/sharing/src/main/AndroidManifest.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <application>
+        <receiver
+            android:name=".ItemSharedReceiver"
+            android:exported="false" />
+    </application>
+</manifest>

--- a/modules/services/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/ItemSharedReceiver.kt
+++ b/modules/services/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/ItemSharedReceiver.kt
@@ -1,0 +1,63 @@
+package au.com.shiftyjelly.pocketcasts.sharing
+
+import android.app.PendingIntent
+import android.content.BroadcastReceiver
+import android.content.ComponentName
+import android.content.Context
+import android.content.Intent
+import android.os.Build
+import androidx.core.content.IntentCompat
+import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
+import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTracker
+import dagger.hilt.android.AndroidEntryPoint
+import javax.inject.Inject
+
+@AndroidEntryPoint
+internal class ItemSharedReceiver : BroadcastReceiver() {
+    @Inject
+    lateinit var analyticsTracker: AnalyticsTracker
+
+    @Suppress("UNCHECKED_CAST")
+    override fun onReceive(context: Context, intent: Intent) {
+        val activity = IntentCompat.getParcelableExtra(intent, Intent.EXTRA_CHOSEN_COMPONENT, ComponentName::class.java)?.className
+        val event = IntentCompat.getSerializableExtra(intent, ANALYTICS_EVENT_KEY, AnalyticsEvent::class.java)
+        val values = IntentCompat.getSerializableExtra(intent, ANALYTICS_VALUES_KEY, HashMap::class.java) as? HashMap<String, Any>
+        if (event != null) {
+            analyticsTracker.track(
+                AnalyticsEvent.END_OF_YEAR_STORY_SHARED,
+                buildMap {
+                    if (activity != null) {
+                        put("activity", activity)
+                    }
+                    if (values != null) {
+                        putAll(values)
+                    }
+                },
+            )
+        }
+    }
+
+    companion object {
+        private const val ANALYTICS_EVENT_KEY = "analytics_event"
+        private const val ANALYTICS_VALUES_KEY = "analytics_values"
+
+        fun intent(
+            context: Context,
+            event: AnalyticsEvent,
+            values: Map<String, Any> = emptyMap(),
+        ): PendingIntent {
+            val serializableMap = HashMap<String, Any>().apply { putAll(values) }
+            return PendingIntent.getBroadcast(
+                context,
+                0, // requestCode
+                Intent(context, ItemSharedReceiver::class.java)
+                    .putExtra(ANALYTICS_EVENT_KEY, event)
+                    .putExtra(ANALYTICS_VALUES_KEY, serializableMap),
+                when {
+                    Build.VERSION.SDK_INT >= 31 -> PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_MUTABLE
+                    else -> PendingIntent.FLAG_UPDATE_CURRENT
+                },
+            )
+        }
+    }
+}

--- a/modules/services/sharing/src/test/kotlin/au/com/shiftyjelly/pocketcasts/sharing/SharingAnalyticsTest.kt
+++ b/modules/services/sharing/src/test/kotlin/au/com/shiftyjelly/pocketcasts/sharing/SharingAnalyticsTest.kt
@@ -6,8 +6,15 @@ import au.com.shiftyjelly.pocketcasts.analytics.SourceView
 import au.com.shiftyjelly.pocketcasts.analytics.Tracker
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
+import au.com.shiftyjelly.pocketcasts.models.to.LongestEpisode
+import au.com.shiftyjelly.pocketcasts.models.to.RatingStats
+import au.com.shiftyjelly.pocketcasts.models.to.Story
+import au.com.shiftyjelly.pocketcasts.models.to.TopPodcast
 import au.com.shiftyjelly.pocketcasts.models.type.ReferralsOfferInfoMock
+import au.com.shiftyjelly.pocketcasts.models.type.SubscriptionTier
+import java.time.Year
 import java.util.Date
+import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
 import org.junit.Assert.assertEquals
 import org.junit.Rule
@@ -456,6 +463,201 @@ class SharingAnalyticsTest {
                 "type" to "referral_link",
                 "action" to "system_sheet",
                 "source" to "referrals",
+            ),
+        )
+    }
+
+    @Test
+    fun `log number of shows story sharing`() {
+        val story = Story.NumberOfShows(
+            showCount = 100,
+            epsiodeCount = 200,
+            topShowIds = emptyList(),
+            bottomShowIds = emptyList(),
+        )
+        val request = SharingRequest.endOfYearStory(story, Year.of(1000)).build()
+
+        analytics.onShare(request)
+        val event = tracker.events.single()
+
+        event.assertType(AnalyticsEvent.END_OF_YEAR_STORY_SHARE)
+        event.assertProperties(
+            mapOf(
+                "type" to "end_of_year_story",
+                "story" to "number_of_shows",
+                "source" to "unknown",
+                "action" to "system_sheet",
+            ),
+        )
+    }
+
+    @Test
+    fun `log top 1 show story sharing`() {
+        val story = Story.TopShow(
+            show = TopPodcast(
+                uuid = "podcast-id",
+                title = "podcast-title",
+                author = "pocast-author",
+                playbackTimeSeconds = 0.0,
+                playedEpisodeCount = 0,
+            ),
+        )
+        val request = SharingRequest.endOfYearStory(story, Year.of(1000)).build()
+
+        analytics.onShare(request)
+        val event = tracker.events.single()
+
+        event.assertType(AnalyticsEvent.END_OF_YEAR_STORY_SHARE)
+        event.assertProperties(
+            mapOf(
+                "type" to "end_of_year_story",
+                "story" to "top_1_show",
+                "source" to "unknown",
+                "action" to "system_sheet",
+            ),
+        )
+    }
+
+    @Test
+    fun `log top 5 shows story sharing`() {
+        val story = Story.TopShows(
+            shows = emptyList(),
+            podcastListUrl = null,
+        )
+        val request = SharingRequest.endOfYearStory(story, Year.of(1000)).build()
+
+        analytics.onShare(request)
+        val event = tracker.events.single()
+
+        event.assertType(AnalyticsEvent.END_OF_YEAR_STORY_SHARE)
+        event.assertProperties(
+            mapOf(
+                "type" to "end_of_year_story",
+                "story" to "top_5_shows",
+                "source" to "unknown",
+                "action" to "system_sheet",
+            ),
+        )
+    }
+
+    @Test
+    fun `log ratings story sharing`() {
+        val story = Story.Ratings(
+            stats = RatingStats(
+                ones = 10,
+                twos = 20,
+                threes = 30,
+                fours = 40,
+                fives = 50,
+            ),
+        )
+        val request = SharingRequest.endOfYearStory(story, Year.of(1000)).build()
+
+        analytics.onShare(request)
+        val event = tracker.events.single()
+
+        event.assertType(AnalyticsEvent.END_OF_YEAR_STORY_SHARE)
+        event.assertProperties(
+            mapOf(
+                "type" to "end_of_year_story",
+                "story" to "ratings",
+                "source" to "unknown",
+                "action" to "system_sheet",
+            ),
+        )
+    }
+
+    @Test
+    fun `log total time story sharing`() {
+        val story = Story.TotalTime(
+            duration = 12345.seconds,
+        )
+        val request = SharingRequest.endOfYearStory(story, Year.of(1000)).build()
+
+        analytics.onShare(request)
+        val event = tracker.events.single()
+
+        event.assertType(AnalyticsEvent.END_OF_YEAR_STORY_SHARE)
+        event.assertProperties(
+            mapOf(
+                "type" to "end_of_year_story",
+                "story" to "total_time",
+                "source" to "unknown",
+                "action" to "system_sheet",
+            ),
+        )
+    }
+
+    @Test
+    fun `log longest episode story sharing`() {
+        val story = Story.LongestEpisode(
+            episode = LongestEpisode(
+                episodeId = "episode-id",
+                episodeTitle = "",
+                podcastId = "",
+                podcastTitle = "",
+                durationSeconds = 0.0,
+                coverUrl = null,
+            ),
+        )
+        val request = SharingRequest.endOfYearStory(story, Year.of(1000)).build()
+
+        analytics.onShare(request)
+        val event = tracker.events.single()
+
+        event.assertType(AnalyticsEvent.END_OF_YEAR_STORY_SHARE)
+        event.assertProperties(
+            mapOf(
+                "type" to "end_of_year_story",
+                "story" to "longest_episode",
+                "source" to "unknown",
+                "action" to "system_sheet",
+            ),
+        )
+    }
+
+    @Test
+    fun `log year vs year story sharing`() {
+        val story = Story.YearVsYear(
+            lastYearDuration = Duration.ZERO,
+            thisYearDuration = Duration.ZERO,
+            subscriptionTier = SubscriptionTier.NONE,
+        )
+        val request = SharingRequest.endOfYearStory(story, Year.of(1000)).build()
+
+        analytics.onShare(request)
+        val event = tracker.events.single()
+
+        event.assertType(AnalyticsEvent.END_OF_YEAR_STORY_SHARE)
+        event.assertProperties(
+            mapOf(
+                "type" to "end_of_year_story",
+                "story" to "year_vs_year",
+                "source" to "unknown",
+                "action" to "system_sheet",
+            ),
+        )
+    }
+
+    @Test
+    fun `log completion rate story sharing`() {
+        val story = Story.CompletionRate(
+            listenedCount = 0,
+            completedCount = 0,
+            subscriptionTier = SubscriptionTier.NONE,
+        )
+        val request = SharingRequest.endOfYearStory(story, Year.of(1000)).build()
+
+        analytics.onShare(request)
+        val event = tracker.events.single()
+
+        event.assertType(AnalyticsEvent.END_OF_YEAR_STORY_SHARE)
+        event.assertProperties(
+            mapOf(
+                "type" to "end_of_year_story",
+                "story" to "completion_rate",
+                "source" to "unknown",
+                "action" to "system_sheet",
             ),
         )
     }


### PR DESCRIPTION
## Description

This adds EoY analytics.

## Testing Instructions

Test analytics events from the "End of Year" section [here](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?gid=0#gid=0&range=506:506).

## Checklist
- [x] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [x] ~Any jetpack compose components I added or changed are covered by compose previews~
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.``