### PR TITLE
Keep the playing service in the foreground when casting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
         ([#3048](https://github.com/Automattic/pocket-casts-android/pull/3048))
     *   Add support for the Catalan laguage
         ([#3072](https://github.com/Automattic/pocket-casts-android/pull/3072))
+*   Bug Fixes
+    *   Keep the playing service in the foreground when casting
+        ([#3094](https://github.com/Automattic/pocket-casts-android/pull/3094))
 *   Updates
     *   Move Up Next clear queue button to app bar
         ([#3068](https://github.com/Automattic/pocket-casts-android/pull/3068))

--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/ui/PlaybackServiceTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/ui/PlaybackServiceTest.kt
@@ -38,7 +38,6 @@ import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.timeout
 import org.mockito.kotlin.verify
-import org.mockito.kotlin.verifyNoMoreInteractions
 
 @RunWith(AndroidJUnit4::class)
 class PlaybackServiceTest {
@@ -184,6 +183,6 @@ class PlaybackServiceTest {
             .build()
         service.testPlaybackStateChange(metaData, stopped)
         testScheduler.triggerActions()
-        verifyNoMoreInteractions(testNotificationManager)
+        verify(testNotificationManager, timeout(5000).times(1)).cancel(eq(NotificationId.PLAYING.value))
     }
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -565,6 +565,11 @@
             </intent-filter>
         </receiver>
 
+        <receiver
+            android:name="androidx.mediarouter.media.MediaTransferReceiver"
+            android:exported="true">
+        </receiver>
+
         <service
                 android:name="au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackService"
                 android:exported="true"

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackService.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackService.kt
@@ -243,12 +243,6 @@ open class PlaybackService : MediaBrowserServiceCompat(), CoroutineScope {
             val isForegroundService = isForegroundService()
             val state = playbackState.state
 
-            // If we have switched to casting we need to remove the notification
-            if (isForegroundService && notification == null && playbackManager.isPlaybackRemote()) {
-                stopForeground(STOP_FOREGROUND_REMOVE)
-                LogBuffer.i(LogBuffer.TAG_PLAYBACK, "stopForeground as player is remote")
-            }
-
             // If we are already showing a notification, update it no matter the state.
             if (notification != null && notificationHelper.isShowing(Settings.NotificationId.PLAYING.value)) {
                 Timber.d("Updating playback notification")
@@ -303,8 +297,11 @@ open class PlaybackService : MediaBrowserServiceCompat(), CoroutineScope {
                             LogBuffer.i(LogBuffer.TAG_PLAYBACK, "stopForeground state: $state removing notification: $removeNotification")
                         }
 
-                        @Suppress("DEPRECATION")
-                        stopForeground(removeNotification)
+                        // When paused keep the notification otherwise remove it
+                        stopForeground(if (removeNotification) STOP_FOREGROUND_REMOVE else STOP_FOREGROUND_DETACH)
+                        if (removeNotification) {
+                            notificationManager.cancel(Settings.NotificationId.PLAYING.value)
+                        }
                     }
 
                     if (state == PlaybackStateCompat.STATE_ERROR) {
@@ -330,10 +327,6 @@ open class PlaybackService : MediaBrowserServiceCompat(), CoroutineScope {
             useEpisodeArtwork: Boolean,
         ): Notification? {
             if (Util.isAutomotive(this@PlaybackService)) {
-                return null
-            }
-
-            if (playbackManager.isPlaybackRemote()) {
                 return null
             }
 

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlayerNotificationManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlayerNotificationManager.kt
@@ -8,6 +8,7 @@ import androidx.core.app.NotificationManagerCompat
 interface PlayerNotificationManager {
     fun enteredForeground(notification: Notification)
     fun notify(notificationId: Int, notification: Notification)
+    fun cancel(notificationId: Int)
 }
 
 class PlayerNotificationManagerImpl(context: Context) : PlayerNotificationManager {
@@ -22,5 +23,9 @@ class PlayerNotificationManagerImpl(context: Context) : PlayerNotificationManage
     @SuppressLint("MissingPermission")
     override fun notify(notificationId: Int, notification: Notification) {
         notificationManager.notify(notificationId, notification)
+    }
+
+    override fun cancel(notificationId: Int) {
+        notificationManager.cancel(notificationId)
     }
 }


### PR DESCRIPTION
## Description

Chromecasting from Pocket Casts has an issue that the Pocket Casts PlaybackService doesn’t run in the foreground, so the system kills off the service while it's still needed. This means that the episode progress would not be tracked, and when the episode ends, the next episode in the Up Next would not start. For the service to run in the foreground, we need to create a notification. We didn't create a notification as the Chromecast library creates a separate playback notification causing  two playback notifications but it seems recent versions of Android only show one notification. 

## Testing Instructions

1. Play an episode
2. ✅ Verify there is a playback notification
3. Cast the episode 
4. ✅ Verify there is only a casting playback notification
5. ✅ Verify logcat doesn't contain the following message "can't startForeground as the notification is null"

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack