### PR TITLE
[Tooling] Automate the download of the signed APK from Google Play into the GitHub Release during beta/final builds

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -534,6 +534,7 @@ platform :android do
       version: version,
       release_notes_file_path: nil,
       prerelease: prerelease,
+      is_draft: !prerelease,
       release_assets: release_assets.join(',')
     )
   end

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -335,8 +335,16 @@ platform :android do
         skip_upload_screenshots: true,
         json_key: UPLOAD_TO_PLAY_STORE_JSON_KEY
       )
-
       release_assets << aab_artifact_path
+
+      signed_apk_artifact_path = signed_apk_artifact_path(app, version)
+      download_universal_apk_from_google_play(
+        package_name: APP_PACKAGE_NAME,
+        version_code: version_code_for_app(build_code, app),
+        destination: signed_apk_artifact_path,
+        json_key: UPLOAD_TO_PLAY_STORE_JSON_KEY
+      )
+      release_assets << signed_apk_artifact_path
     end
 
     create_gh_release(version: version, prerelease: is_beta, release_assets: release_assets.compact) if options[:create_gh_release]
@@ -520,11 +528,7 @@ platform :android do
   # @param [Hash<String>] version The version to create. Expects keys "name" and "code"
   # @param [Bool] prerelease If true, the GitHub Release will have the prerelease flag
   #
-  private_lane :create_gh_release do |options|
-    version = options[:version]
-    prerelease = options[:prerelease] || false
-    release_assets = options[:release_assets]
-
+  private_lane :create_gh_release do |version:, prerelease: false, release_assets: []|
     create_github_release(
       repository: GH_REPOSITORY,
       version: version,
@@ -539,6 +543,10 @@ platform :android do
   #####################################################################################
   def aab_artifact_path(app, version)
     File.join(PROJECT_ROOT_FOLDER, 'artifacts', "#{app}-#{version}.aab")
+  end
+
+  def signed_apk_artifact_path(app, version)
+    File.join(PROJECT_ROOT_FOLDER, 'artifacts', "#{app}-#{version}.apk")
   end
 
   def bundle_output_path(app)
@@ -651,5 +659,20 @@ platform :android do
     build_code_next = BUILD_CODE_CALCULATOR.next_build_code(build_code: build_code_current)
     # Return the formatted build code
     BUILD_CODE_FORMATTER.build_code(build_code: build_code_next)
+  end
+
+  # Returns the versionCode for a given app, adjusting for offset depending if it's the mobile, automotive or wear app
+  #
+  # See also `dependencies.gradle.kts` and its `versionCodeDifferenceBetweenAppAnd*` constants where those offsets are defined
+  #
+  def version_code_for_app(build_code, app)
+    case app
+    when APPS_AUTOMOTIVE
+      (build_code.to_i + 50_000).to_s
+    when APPS_WEAR
+      (build_code.to_i + 100_000).to_s
+    else
+      build_code
+    end
   end
 end


### PR DESCRIPTION
## Description

Currently the Release Scenario instructs to download the universal, signed APK from Google Play Console (under `App bundle explorer > Downloads`) manually, and also rename and attach those `.apk` to the GitHub Release manually.

But we now have an action to automate that in our `release-toolkit`, so we can automate all those!

 - This PR automates the download of the universal, signed APKs from GPC for all 3 apps (mobile, wear, automotive), then attaching them to the GitHub Release that gets created (alongside the `.aab` files that were already attached)
 - This also means that we'll be able to remove a lot of tedious manual tasks from the Release Scenario in Release V2 🎉 

**Companion diff** updating the MC Release Scenario template: D164732-code

## Testing Instructions

To avoid waiting for a new beta build to be done by running the whole `build_and_upload_to_play_store` lane just to test this, we can copy/paste just the lines of code that downloading the latest APKs to extract them in a dedicated temp lane and test just that part:

```ruby
  lane :test_apk_dl do
    version = version_name_current
    build_code = build_code_current

    APPS.each do |app|
      signed_apk_artifact_path = signed_apk_artifact_path(app, version)
      download_universal_apk_from_google_play(
        package_name: APP_PACKAGE_NAME,
        version_code: version_code_for_app(build_code, app),
        destination: signed_apk_artifact_path,
        json_key: UPLOAD_TO_PLAY_STORE_JSON_KEY
      )
      puts "> #{signed_apk_artifact_path}"
    end
  end
```

Running this via `bundle exec test_apk_dl` should result in the latest APKs (`7.75-rc-2`) for all 3 apps (`app`, `automotive`, `wear`) to be downloaded in `./artifacts/` folder on your Mac.

You can then optionally use a command like the below to validate the downloaded APKs are the expected ones:
```bash
# Note: aapt2 and apksigner are typically installed in `$ANDROID_SDK_ROOT/build-tools/{version}`, in case you don't have this in your $PATH
$ for apk in artifacts/*.apk; do echo --$apk; aapt2 dump badging "$apk" | head -n1; apksigner verify --print-certs "$apk"; done
```
<details><summary>Expected result</summary>

```bash
--artifacts/app-7.75-rc-2.apk
package: name='au.com.shiftyjelly.pocketcasts' versionCode='9278' versionName='7.75-rc-2' platformBuildVersionName='14' platformBuildVersionCode='34' compileSdkVersion='34' compileSdkVersionCodename='14'
Signer #1 certificate DN: CN=Shifty Jelly, OU=Shifty Jelly, O=Shifty Jelly, L=Adelaide, ST=South Australia, C=AU
Signer #1 certificate SHA-256 digest: ce0825f4ca785676d90d3af60f54fe43b8427afe9e1bb677add758dac1291820
Signer #1 certificate SHA-1 digest: 265bfda6992d75d455bc74dd43f9ace83efae7e5
Signer #1 certificate MD5 digest: c2fe0da38fcd86839b85da0837e63c08
Source Stamp Signer certificate DN: CN=Android, OU=Android, O=Google Inc., L=Mountain View, ST=California, C=US
Source Stamp Signer certificate SHA-256 digest: 3257d599a49d2c961a471ca9843f59d341a405884583fc087df4237b733bbd6d
Source Stamp Signer certificate SHA-1 digest: b1af3a0bf998aeede1a8716a539e5a59da1d86d6
Source Stamp Signer certificate MD5 digest: 577b8a9fbc7e308321aec6411169d2fb
--artifacts/automotive-7.75-rc-2.apk
package: name='au.com.shiftyjelly.pocketcasts' versionCode='59278' versionName='7.75-rc-2a' platformBuildVersionName='14' platformBuildVersionCode='34' compileSdkVersion='34' compileSdkVersionCodename='14'
Signer #1 certificate DN: CN=Shifty Jelly, OU=Shifty Jelly, O=Shifty Jelly, L=Adelaide, ST=South Australia, C=AU
Signer #1 certificate SHA-256 digest: ce0825f4ca785676d90d3af60f54fe43b8427afe9e1bb677add758dac1291820
Signer #1 certificate SHA-1 digest: 265bfda6992d75d455bc74dd43f9ace83efae7e5
Signer #1 certificate MD5 digest: c2fe0da38fcd86839b85da0837e63c08
Source Stamp Signer certificate DN: CN=Android, OU=Android, O=Google Inc., L=Mountain View, ST=California, C=US
Source Stamp Signer certificate SHA-256 digest: 3257d599a49d2c961a471ca9843f59d341a405884583fc087df4237b733bbd6d
Source Stamp Signer certificate SHA-1 digest: b1af3a0bf998aeede1a8716a539e5a59da1d86d6
Source Stamp Signer certificate MD5 digest: 577b8a9fbc7e308321aec6411169d2fb
--artifacts/wear-7.75-rc-2.apk
package: name='au.com.shiftyjelly.pocketcasts' versionCode='109278' versionName='7.75-rc-2w' platformBuildVersionName='14' platformBuildVersionCode='34' compileSdkVersion='34' compileSdkVersionCodename='14'
Signer #1 certificate DN: CN=Shifty Jelly, OU=Shifty Jelly, O=Shifty Jelly, L=Adelaide, ST=South Australia, C=AU
Signer #1 certificate SHA-256 digest: ce0825f4ca785676d90d3af60f54fe43b8427afe9e1bb677add758dac1291820
Signer #1 certificate SHA-1 digest: 265bfda6992d75d455bc74dd43f9ace83efae7e5
Signer #1 certificate MD5 digest: c2fe0da38fcd86839b85da0837e63c08
Source Stamp Signer certificate DN: CN=Android, OU=Android, O=Google Inc., L=Mountain View, ST=California, C=US
Source Stamp Signer certificate SHA-256 digest: 3257d599a49d2c961a471ca9843f59d341a405884583fc087df4237b733bbd6d
Source Stamp Signer certificate SHA-1 digest: b1af3a0bf998aeede1a8716a539e5a59da1d86d6
Source Stamp Signer certificate MD5 digest: 577b8a9fbc7e308321aec6411169d2fb
```
</details>

## Checklist
- [ ] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~ N/A
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] ~I have considered whether it makes sense to add tests for my changes~ N/A
- [ ] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~ N/A
- [ ] ~Any jetpack compose components I added or changed are covered by compose previews~ N/A
- [ ] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~ N/A