### PR TITLE
[Project] Manage Downloaded Episodes - Add banner to downloads screen to manager downloads

### DIFF
--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/ProfileEpisodeListFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/ProfileEpisodeListFragment.kt
@@ -49,6 +49,7 @@ import au.com.shiftyjelly.pocketcasts.ui.helper.FragmentHostListener
 import au.com.shiftyjelly.pocketcasts.utils.extensions.dpToPx
 import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
 import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
+import au.com.shiftyjelly.pocketcasts.utils.isDeviceRunningOnLowStorage
 import au.com.shiftyjelly.pocketcasts.views.dialog.ConfirmationDialog
 import au.com.shiftyjelly.pocketcasts.views.dialog.OptionsDialog
 import au.com.shiftyjelly.pocketcasts.views.extensions.setup
@@ -414,9 +415,9 @@ class ProfileEpisodeListFragment : BaseFragment(), Toolbar.OnMenuItemClickListen
         toolbar.setOnMenuItemClickListener(this)
     }
 
-    private fun updateManageDownloadsCard(downloadedEpisodesSize: Long) {
+    private suspend fun updateManageDownloadsCard(downloadedEpisodesSize: Long) {
         binding?.manageDownloadsCard?.apply {
-            isVisible = downloadedEpisodesSize != 0L
+            isVisible = downloadedEpisodesSize != 0L && isDeviceRunningOnLowStorage()
             if (isVisible) {
                 setContent {
                     AppTheme(theme.activeTheme) {

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/ProfileEpisodeListFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/ProfileEpisodeListFragment.kt
@@ -47,6 +47,8 @@ import au.com.shiftyjelly.pocketcasts.settings.viewmodel.ManualCleanupViewModel
 import au.com.shiftyjelly.pocketcasts.ui.extensions.themed
 import au.com.shiftyjelly.pocketcasts.ui.helper.FragmentHostListener
 import au.com.shiftyjelly.pocketcasts.utils.extensions.dpToPx
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
 import au.com.shiftyjelly.pocketcasts.views.dialog.ConfirmationDialog
 import au.com.shiftyjelly.pocketcasts.views.dialog.OptionsDialog
 import au.com.shiftyjelly.pocketcasts.views.extensions.setup
@@ -250,7 +252,7 @@ class ProfileEpisodeListFragment : BaseFragment(), Toolbar.OnMenuItemClickListen
             )
         }
 
-        if (mode is Mode.Downloaded) {
+        if (mode is Mode.Downloaded && FeatureFlag.isEnabled(Feature.MANAGE_DOWNLOADED_EPISODES)) {
             viewLifecycleOwner.lifecycleScope.launch {
                 viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
                     cleanUpViewModel.state.collect { state ->

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/ProfileEpisodeListFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/ProfileEpisodeListFragment.kt
@@ -253,7 +253,7 @@ class ProfileEpisodeListFragment : BaseFragment(), Toolbar.OnMenuItemClickListen
             binding?.manageDownloadsCard?.setContent {
                 ManageDownloadsCard(
                     totalDownloadSize = 10,
-                    onManageDownloadsClick = {},
+                    onManageDownloadsClick = { showCleanupSettings() },
                 )
             }
         } else {

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/ProfileEpisodeListFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/ProfileEpisodeListFragment.kt
@@ -247,12 +247,26 @@ class ProfileEpisodeListFragment : BaseFragment(), Toolbar.OnMenuItemClickListen
             )
         }
 
+        if (mode is Mode.Downloaded) {
+            binding?.manageDownloadsCard?.isVisible = true
+
+            binding?.manageDownloadsCard?.setContent {
+                ManageDownloadsCard(
+                    totalDownloadSize = 10,
+                    onManageDownloadsClick = {},
+                )
+            }
+        } else {
+            binding?.manageDownloadsCard?.isVisible = false
+        }
+
         viewLifecycleOwner.lifecycleScope.launch {
             viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
                 viewModel.state.collect { state ->
                     when (state) {
                         is State.Empty -> {
                             binding?.recyclerView?.isVisible = false
+                            binding?.manageDownloadsCard?.isVisible = false
                             binding?.emptyLayout?.isVisible = true
                             binding?.lblEmptyTitle?.setText(state.titleRes)
                             binding?.lblEmptySummary?.setText(state.summaryRes)

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/ProfileEpisodeListFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/ProfileEpisodeListFragment.kt
@@ -256,9 +256,7 @@ class ProfileEpisodeListFragment : BaseFragment(), Toolbar.OnMenuItemClickListen
             viewLifecycleOwner.lifecycleScope.launch {
                 viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
                     cleanUpViewModel.state.collect { state ->
-                        state.playedDiskSpaceView?.let {
-                            updateManageDownloadsCard(it.episodesBytesSize)
-                        }
+                        updateManageDownloadsCard(state.diskSpaceViews.sumOf { it.episodesBytesSize })
                     }
                 }
             }
@@ -416,14 +414,14 @@ class ProfileEpisodeListFragment : BaseFragment(), Toolbar.OnMenuItemClickListen
         toolbar.setOnMenuItemClickListener(this)
     }
 
-    private fun updateManageDownloadsCard(downloadedPlayedEpisodesSize: Long) {
+    private fun updateManageDownloadsCard(downloadedEpisodesSize: Long) {
         binding?.manageDownloadsCard?.apply {
-            isVisible = downloadedPlayedEpisodesSize != 0L
+            isVisible = downloadedEpisodesSize != 0L
             if (isVisible) {
                 setContent {
                     AppTheme(theme.activeTheme) {
                         ManageDownloadsCard(
-                            totalDownloadSize = downloadedPlayedEpisodesSize,
+                            totalDownloadSize = downloadedEpisodesSize,
                             onManageDownloadsClick = { showCleanupSettings() },
                         )
                     }

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/ProfileEpisodeListFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/ProfileEpisodeListFragment.kt
@@ -21,6 +21,7 @@ import androidx.recyclerview.widget.SimpleItemAnimator
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTracker
 import au.com.shiftyjelly.pocketcasts.analytics.SourceView
+import au.com.shiftyjelly.pocketcasts.compose.AppTheme
 import au.com.shiftyjelly.pocketcasts.models.entity.BaseEpisode
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.models.type.EpisodeViewSource
@@ -418,10 +419,12 @@ class ProfileEpisodeListFragment : BaseFragment(), Toolbar.OnMenuItemClickListen
             isVisible = downloadedPlayedEpisodesSize != 0L
             if (isVisible) {
                 setContent {
-                    ManageDownloadsCard(
-                        totalDownloadSize = downloadedPlayedEpisodesSize,
-                        onManageDownloadsClick = { showCleanupSettings() },
-                    )
+                    AppTheme(theme.activeTheme) {
+                        ManageDownloadsCard(
+                            totalDownloadSize = downloadedPlayedEpisodesSize,
+                            onManageDownloadsClick = { showCleanupSettings() },
+                        )
+                    }
                 }
             }
         }

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/ProfileManageDownloadsCard.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/ProfileManageDownloadsCard.kt
@@ -21,11 +21,15 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.dp
+import au.com.shiftyjelly.pocketcasts.compose.AppThemeWithBackground
 import au.com.shiftyjelly.pocketcasts.compose.components.TextH40
 import au.com.shiftyjelly.pocketcasts.compose.components.TextH50
 import au.com.shiftyjelly.pocketcasts.compose.components.TextP50
+import au.com.shiftyjelly.pocketcasts.compose.preview.ThemePreviewParameterProvider
 import au.com.shiftyjelly.pocketcasts.compose.theme
+import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import au.com.shiftyjelly.pocketcasts.utils.Util
 import au.com.shiftyjelly.pocketcasts.images.R as IR
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
@@ -40,7 +44,7 @@ fun ManageDownloadsCard(
 
     Row(
         modifier = modifier
-            .background(color = MaterialTheme.theme.colors.primaryUi01, RoundedCornerShape(8.dp))
+            .background(color = MaterialTheme.theme.colors.primaryUi06, RoundedCornerShape(8.dp))
             .border(
                 width = 0.5.dp,
                 color = MaterialTheme.theme.colors.primaryField03,
@@ -64,18 +68,18 @@ fun ManageDownloadsCard(
             TextH40(
                 text = stringResource(LR.string.you_are_running_low_on_storage),
                 fontWeight = FontWeight.Bold,
-                color = Color.Black,
+                color = MaterialTheme.theme.colors.primaryText01,
             )
 
             Spacer(modifier = Modifier.height(2.dp))
 
             TextP50(
                 text = stringResource(LR.string.save_x_by_removing_played_episodes, formattedTotalDownloadSize),
-                color = Color.Gray,
+                color = MaterialTheme.theme.colors.primaryText02,
             )
 
             TextButton(onClick = { onManageDownloadsClick.invoke() }, contentPadding = PaddingValues()) {
-                TextH50(text = stringResource(LR.string.manage_downloads), color = MaterialTheme.theme.colors.primaryInteractive01)
+                TextH50(text = stringResource(LR.string.manage_downloads), color = MaterialTheme.theme.colors.primaryIcon01)
             }
         }
     }
@@ -83,6 +87,10 @@ fun ManageDownloadsCard(
 
 @Preview
 @Composable
-fun ManageDownloadsCardPreview() {
-    ManageDownloadsCard(totalDownloadSize = 10, onManageDownloadsClick = {})
+fun ManageDownloadsCardPreview(
+    @PreviewParameter(ThemePreviewParameterProvider::class) themeType: Theme.ThemeType,
+) {
+    AppThemeWithBackground(themeType) {
+        ManageDownloadsCard(totalDownloadSize = 15023232, onManageDownloadsClick = {})
+    }
 }

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/ProfileManageDownloadsCard.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/ProfileManageDownloadsCard.kt
@@ -74,7 +74,7 @@ fun ManageDownloadsCard(
             Spacer(modifier = Modifier.height(2.dp))
 
             TextP50(
-                text = stringResource(LR.string.save_x_by_removing_played_episodes, formattedTotalDownloadSize),
+                text = stringResource(LR.string.save_space_by_managing_downloaded_episodes, formattedTotalDownloadSize),
                 color = MaterialTheme.theme.colors.primaryText02,
             )
 

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/ProfileManageDownloadsCard.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/ProfileManageDownloadsCard.kt
@@ -1,0 +1,84 @@
+package au.com.shiftyjelly.pocketcasts.podcasts.view
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.Icon
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import au.com.shiftyjelly.pocketcasts.compose.components.TextH40
+import au.com.shiftyjelly.pocketcasts.compose.components.TextH50
+import au.com.shiftyjelly.pocketcasts.compose.components.TextP50
+import au.com.shiftyjelly.pocketcasts.compose.theme
+import au.com.shiftyjelly.pocketcasts.images.R as IR
+import au.com.shiftyjelly.pocketcasts.localization.R as LR
+
+@Composable
+fun ManageDownloadsCard(
+    totalDownloadSize: Int,
+    onManageDownloadsClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Row(
+        modifier = modifier
+            .background(color = MaterialTheme.theme.colors.primaryUi01, RoundedCornerShape(8.dp))
+            .border(
+                width = 0.5.dp,
+                color = MaterialTheme.theme.colors.primaryField03,
+                shape = RoundedCornerShape(8.dp),
+            )
+            .padding(16.dp),
+
+    ) {
+        Icon(
+            painter = painterResource(id = IR.drawable.pencil_cleanup),
+            contentDescription = stringResource(LR.string.pencil_clean_up_icon_content_description),
+            modifier = Modifier
+                .padding(end = 12.dp)
+                .size(24.dp),
+            tint = Color.Black,
+        )
+
+        Column(
+            modifier = Modifier.padding(end = 16.dp),
+        ) {
+            TextH40(
+                text = stringResource(LR.string.you_are_running_low_on_storage),
+                fontWeight = FontWeight.Bold,
+                color = Color.Black,
+            )
+
+            Spacer(modifier = Modifier.height(2.dp))
+
+            TextP50(
+                text = stringResource(LR.string.save_x_gb_by_removing_played_episodes, totalDownloadSize),
+                color = Color.Gray,
+            )
+
+            TextButton(onClick = { onManageDownloadsClick.invoke() }, contentPadding = PaddingValues()) {
+                TextH50(text = stringResource(LR.string.manage_downloads), color = MaterialTheme.theme.colors.primaryInteractive01)
+            }
+        }
+    }
+}
+
+@Preview
+@Composable
+fun ManageDownloadsCardPreview() {
+    ManageDownloadsCard(totalDownloadSize = 10, onManageDownloadsClick = {})
+}

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/ProfileManageDownloadsCard.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/ProfileManageDownloadsCard.kt
@@ -16,6 +16,7 @@ import androidx.compose.material.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
@@ -25,15 +26,18 @@ import au.com.shiftyjelly.pocketcasts.compose.components.TextH40
 import au.com.shiftyjelly.pocketcasts.compose.components.TextH50
 import au.com.shiftyjelly.pocketcasts.compose.components.TextP50
 import au.com.shiftyjelly.pocketcasts.compose.theme
+import au.com.shiftyjelly.pocketcasts.utils.Util
 import au.com.shiftyjelly.pocketcasts.images.R as IR
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 @Composable
 fun ManageDownloadsCard(
-    totalDownloadSize: Int,
+    totalDownloadSize: Long,
     onManageDownloadsClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
+    val formattedTotalDownloadSize = Util.formattedBytes(bytes = totalDownloadSize, context = LocalContext.current)
+
     Row(
         modifier = modifier
             .background(color = MaterialTheme.theme.colors.primaryUi01, RoundedCornerShape(8.dp))
@@ -66,7 +70,7 @@ fun ManageDownloadsCard(
             Spacer(modifier = Modifier.height(2.dp))
 
             TextP50(
-                text = stringResource(LR.string.save_x_gb_by_removing_played_episodes, totalDownloadSize),
+                text = stringResource(LR.string.save_x_by_removing_played_episodes, formattedTotalDownloadSize),
                 color = Color.Gray,
             )
 

--- a/modules/features/podcasts/src/main/res/layout/fragment_profile_episode_list.xml
+++ b/modules/features/podcasts/src/main/res/layout/fragment_profile_episode_list.xml
@@ -1,5 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
-<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     xmlns:app="http://schemas.android.com/apk/res-auto"
@@ -7,7 +6,9 @@
 
     <com.google.android.material.appbar.AppBarLayout
         android:layout_width="match_parent"
-        android:layout_height="wrap_content">
+        android:id="@+id/appBar"
+        android:layout_height="wrap_content"
+        app:layout_constraintTop_toTopOf="parent">
 
         <com.google.android.material.appbar.CollapsingToolbarLayout
             android:id="@+id/collapsingToolbar"
@@ -44,14 +45,26 @@
 
     </com.google.android.material.appbar.AppBarLayout>
 
+    <androidx.compose.ui.platform.ComposeView
+        android:id="@+id/manageDownloadsCard"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:layout_constraintTop_toBottomOf="@id/appBar"
+        android:visibility="gone"
+        android:layout_marginHorizontal="16dp"
+        android:layout_marginTop="16dp"
+        />
+
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/recyclerView"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
+        android:layout_height="0dp"
         android:clipToPadding="false"
         android:background="?attr/primary_ui_02"
         android:paddingTop="16dp"
         android:paddingBottom="16dp"
+        app:layout_constraintTop_toBottomOf="@id/manageDownloadsCard"
+        app:layout_constraintBottom_toBottomOf="parent"
         app:layout_behavior="@string/appbar_scrolling_view_behavior"/>
 
     <LinearLayout
@@ -59,7 +72,8 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:orientation="vertical"
-        android:layout_gravity="center"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"
         android:layout_marginStart="24dp"
         android:layout_marginEnd="24dp"
         android:visibility="gone">
@@ -81,4 +95,4 @@
             android:gravity="center" />
     </LinearLayout>
 
-</androidx.coordinatorlayout.widget.CoordinatorLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/viewmodel/ManualCleanupViewModel.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/viewmodel/ManualCleanupViewModel.kt
@@ -52,9 +52,6 @@ class ManualCleanupViewModel
         data class DeleteButton(
             val isEnabled: Boolean = false,
         )
-
-        val playedDiskSpaceView: DiskSpaceView?
-            get() = diskSpaceViews.find { it.title == LR.string.played }
     }
 
     private var isFragmentChangingConfigurations: Boolean = false

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/viewmodel/ManualCleanupViewModel.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/viewmodel/ManualCleanupViewModel.kt
@@ -52,6 +52,9 @@ class ManualCleanupViewModel
         data class DeleteButton(
             val isEnabled: Boolean = false,
         )
+
+        val playedDiskSpaceView: DiskSpaceView?
+            get() = diskSpaceViews.find { it.title == LR.string.played }
     }
 
     private var isFragmentChangingConfigurations: Boolean = false

--- a/modules/services/images/src/main/res/drawable/pencil_cleanup.xml
+++ b/modules/services/images/src/main/res/drawable/pencil_cleanup.xml
@@ -1,0 +1,28 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="25dp"
+    android:height="24dp"
+    android:viewportWidth="25"
+    android:viewportHeight="24">
+  <path
+      android:pathData="M21.06,12C21.06,11.448 20.612,11 20.06,11L15.06,11C14.508,11 14.06,11.448 14.06,12C14.06,12.552 14.508,13 15.06,13L20.06,13C20.612,13 21.06,12.552 21.06,12Z"
+      android:strokeAlpha="0.5"
+      android:fillColor="#000000"
+      android:fillType="evenOdd"
+      android:fillAlpha="0.5"/>
+  <path
+      android:pathData="M22.06,16C22.06,15.448 21.612,15 21.06,15L15.06,15C14.508,15 14.06,15.448 14.06,16C14.06,16.552 14.508,17 15.06,17H21.06C21.612,17 22.06,16.552 22.06,16Z"
+      android:strokeAlpha="0.5"
+      android:fillColor="#000000"
+      android:fillType="evenOdd"
+      android:fillAlpha="0.5"/>
+  <path
+      android:pathData="M23.06,20C23.06,19.448 22.612,19 22.06,19H15.06C14.508,19 14.06,19.448 14.06,20C14.06,20.552 14.508,21 15.06,21H22.06C22.612,21 23.06,20.552 23.06,20Z"
+      android:strokeAlpha="0.5"
+      android:fillColor="#000000"
+      android:fillType="evenOdd"
+      android:fillAlpha="0.5"/>
+  <path
+      android:pathData="M13.166,2.553C13.413,2.059 14.013,1.859 14.507,2.106C15.001,2.353 15.202,2.953 14.955,3.447L11.205,10.947C11.697,11.422 12.06,12.103 12.06,13V21H4.06C2.441,21 0.971,19.657 1.176,17.886C1.51,15.005 2.548,13.003 4.005,11.727C5.455,10.457 7.211,10 8.81,10C8.993,10 9.198,10.018 9.413,10.058L13.166,2.553ZM3.163,18.117C3.453,15.607 4.322,14.108 5.323,13.231C6.33,12.349 7.582,12 8.81,12C9.026,12 9.389,12.08 9.669,12.268C9.907,12.428 10.06,12.639 10.06,13V19H4.06C3.47,19 3.114,18.54 3.163,18.117Z"
+      android:fillColor="#000000"
+      android:fillType="evenOdd"/>
+</vector>

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -2193,7 +2193,7 @@
     <!-- Manage Downloaded Episodes -->
     <string name="pencil_clean_up_icon_content_description">Pencil Clean Up</string>
     <string name="you_are_running_low_on_storage">You\'re running low on storage</string>
-    <string name="save_x_by_removing_played_episodes">Save %1$s – by removing played episodes.</string>
+    <string name="save_space_by_managing_downloaded_episodes">Save %1$s – by managing downloaded episodes.</string>
     <string name="manage_downloads">Manage Downloads</string>
 
 </resources>

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -2190,4 +2190,10 @@
     <string name="referrals_create_subscription_failed">Could not create subscription. Please try again later.</string>
     <string name="referrals_redeem_code_failed">Could not redeem code. Please try again later.</string>
 
+    <!-- Manage Downloaded Episodes -->
+    <string name="pencil_clean_up_icon_content_description">Pencil Clean Up</string>
+    <string name="you_are_running_low_on_storage">You\'re running low on storage</string>
+    <string name="save_x_gb_by_removing_played_episodes">Save %1$d GB – by removing played episodes.</string>
+    <string name="manage_downloads">Manage Downloads</string>
+
 </resources>

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -2193,7 +2193,7 @@
     <!-- Manage Downloaded Episodes -->
     <string name="pencil_clean_up_icon_content_description">Pencil Clean Up</string>
     <string name="you_are_running_low_on_storage">You\'re running low on storage</string>
-    <string name="save_x_gb_by_removing_played_episodes">Save %1$d GB – by removing played episodes.</string>
+    <string name="save_x_by_removing_played_episodes">Save %1$s – by removing played episodes.</string>
     <string name="manage_downloads">Manage Downloads</string>
 
 </resources>

--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/StorageUtil.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/StorageUtil.kt
@@ -1,0 +1,21 @@
+package au.com.shiftyjelly.pocketcasts.utils
+
+import android.os.Environment
+import android.os.StatFs
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import timber.log.Timber
+
+private const val lowStorageThreshold = 0.10
+
+suspend fun isDeviceRunningOnLowStorage(statFs: StatFs = StatFs(Environment.getExternalStorageDirectory().path)): Boolean = withContext(Dispatchers.IO) {
+    try {
+        val totalStorage = statFs.blockCountLong * statFs.blockSizeLong
+        val availableStorage = statFs.availableBlocksLong * statFs.blockSizeLong
+
+        availableStorage < totalStorage * lowStorageThreshold
+    } catch (e: Exception) {
+        Timber.e(e, "Error checking if device is running low on storage")
+        false
+    }
+}

--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/Feature.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/Feature.kt
@@ -163,6 +163,14 @@ enum class Feature(
         hasFirebaseRemoteFlag = false,
         hasDevToggle = true,
     ),
+    MANAGE_DOWNLOADED_EPISODES(
+        key = "manage_downloaded_episodes",
+        title = "Manage Downloaded Episodes",
+        defaultValue = BuildConfig.DEBUG,
+        tier = FeatureTier.Free,
+        hasFirebaseRemoteFlag = false,
+        hasDevToggle = true,
+    ),
     ;
 
     companion object {

--- a/modules/services/utils/src/test/java/au/com/shiftyjelly/pocketcasts/utils/StorageUtilTest.kt
+++ b/modules/services/utils/src/test/java/au/com/shiftyjelly/pocketcasts/utils/StorageUtilTest.kt
@@ -1,0 +1,42 @@
+package au.com.shiftyjelly.pocketcasts.utils
+
+import android.os.StatFs
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.mockito.Mockito.mock
+import org.mockito.kotlin.whenever
+
+class StorageUtilTest {
+
+    private lateinit var statFs: StatFs
+
+    @Before
+    fun setUp() {
+        statFs = mock(StatFs::class.java)
+    }
+
+    @Test
+    fun `test storage is low when available space is less than 10 percent`() = runBlocking {
+        whenever(statFs.blockCountLong).thenReturn(100L)
+        whenever(statFs.blockSizeLong).thenReturn(1024L)
+        whenever(statFs.availableBlocksLong).thenReturn(5L) // 5% available
+
+        val result = isDeviceRunningOnLowStorage(statFs)
+
+        assertTrue(result)
+    }
+
+    @Test
+    fun `test storage is not low when available space is more than 10 percent`() = runBlocking {
+        whenever(statFs.blockCountLong).thenReturn(100L)
+        whenever(statFs.blockSizeLong).thenReturn(1024L)
+        whenever(statFs.availableBlocksLong).thenReturn(20L) // 20% available
+
+        val result = isDeviceRunningOnLowStorage(statFs)
+
+        assertFalse(result)
+    }
+}


### PR DESCRIPTION
## Description
- This PR adds the banner to downloads screen
- For this PR, the banner will always show when there is episode downloaded. In a later PR I will update the logic to handle the visibility
- Also the background color is different the one we have in figma. I am proposing these colors and asked p1729890721860929-slack-C07TL9YK9V1
- See VvERCFIopLjFL8Fnczsf8r-fi-119_1272

Fixes #3100

## Testing Instructions
1. Have downloaded episodes
2. Have the Manage Downloaded Episodes feature flag enabled
3. Go to Profile -> Downloads
4. ✅ Ensure you see the banner
5. Tap on Manage Downloads
6. ✅ Ensure Downloaded files screen opens 
7. Select the Played option and Clean Up
8. Back to Downloads screen
9. ✅ Ensure you don't see the banner
10. Go to Profile -> Starred
11.  ✅ Ensure you don't see the banner
12. Go to Profile -> Listening History
13. ✅ Ensure you don't see the banner

## Screenshots or Screencast 

[Screen_recording_20241025_173848.webm](https://github.com/user-attachments/assets/0a5b09b5-4ecf-4244-98b7-eed2781ec78b)


<img width="1288" alt="image" src="https://github.com/user-attachments/assets/f237d2a3-84b2-42b5-95eb-ebd5ede41eae">



<img src="https://github.com/user-attachments/assets/ffa25576-2284-498e-af9b-08c238da7407" alt="Screenshot_20241025_173637" width="400">




## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack