### PR TITLE
[Project] Manage Downloaded Episodes - Show the banner only if it has downloaded episodes and the device has low storage

### DIFF
--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/ProfileEpisodeListFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/ProfileEpisodeListFragment.kt
@@ -415,7 +415,7 @@ class ProfileEpisodeListFragment : BaseFragment(), Toolbar.OnMenuItemClickListen
         toolbar.setOnMenuItemClickListener(this)
     }
 
-    private fun updateManageDownloadsCard(downloadedEpisodesSize: Long) {
+    private suspend fun updateManageDownloadsCard(downloadedEpisodesSize: Long) {
         binding?.manageDownloadsCard?.apply {
             isVisible = downloadedEpisodesSize != 0L && isDeviceRunningOnLowStorage()
             if (isVisible) {

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/ProfileEpisodeListFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/ProfileEpisodeListFragment.kt
@@ -49,6 +49,7 @@ import au.com.shiftyjelly.pocketcasts.ui.helper.FragmentHostListener
 import au.com.shiftyjelly.pocketcasts.utils.extensions.dpToPx
 import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
 import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
+import au.com.shiftyjelly.pocketcasts.utils.isDeviceRunningOnLowStorage
 import au.com.shiftyjelly.pocketcasts.views.dialog.ConfirmationDialog
 import au.com.shiftyjelly.pocketcasts.views.dialog.OptionsDialog
 import au.com.shiftyjelly.pocketcasts.views.extensions.setup
@@ -416,7 +417,7 @@ class ProfileEpisodeListFragment : BaseFragment(), Toolbar.OnMenuItemClickListen
 
     private fun updateManageDownloadsCard(downloadedEpisodesSize: Long) {
         binding?.manageDownloadsCard?.apply {
-            isVisible = downloadedEpisodesSize != 0L
+            isVisible = downloadedEpisodesSize != 0L && isDeviceRunningOnLowStorage()
             if (isVisible) {
                 setContent {
                     AppTheme(theme.activeTheme) {

--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/StorageUtil.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/StorageUtil.kt
@@ -1,0 +1,14 @@
+package au.com.shiftyjelly.pocketcasts.utils
+
+import android.os.Environment
+import android.os.StatFs
+
+private const val lowStorageThreshold = 0.10
+
+fun isDeviceRunningOnLowStorage(): Boolean {
+    val statFs = StatFs(Environment.getExternalStorageDirectory().path)
+    val totalStorage = statFs.blockCountLong * statFs.blockSizeLong
+    val availableStorage = statFs.availableBlocksLong * statFs.blockSizeLong
+
+    return availableStorage < totalStorage * lowStorageThreshold
+}

--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/StorageUtil.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/StorageUtil.kt
@@ -2,13 +2,20 @@ package au.com.shiftyjelly.pocketcasts.utils
 
 import android.os.Environment
 import android.os.StatFs
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import timber.log.Timber
 
 private const val lowStorageThreshold = 0.10
 
-fun isDeviceRunningOnLowStorage(): Boolean {
-    val statFs = StatFs(Environment.getExternalStorageDirectory().path)
-    val totalStorage = statFs.blockCountLong * statFs.blockSizeLong
-    val availableStorage = statFs.availableBlocksLong * statFs.blockSizeLong
+suspend fun isDeviceRunningOnLowStorage(statFs: StatFs = StatFs(Environment.getExternalStorageDirectory().path)): Boolean = withContext(Dispatchers.IO) {
+    try {
+        val totalStorage = statFs.blockCountLong * statFs.blockSizeLong
+        val availableStorage = statFs.availableBlocksLong * statFs.blockSizeLong
 
-    return availableStorage < totalStorage * lowStorageThreshold
+        availableStorage < totalStorage * lowStorageThreshold
+    } catch (e: Exception) {
+        Timber.e(e, "Error checking if device is running low on storage")
+        false
+    }
 }

--- a/modules/services/utils/src/test/java/au/com/shiftyjelly/pocketcasts/utils/StorageUtilTest.kt
+++ b/modules/services/utils/src/test/java/au/com/shiftyjelly/pocketcasts/utils/StorageUtilTest.kt
@@ -1,0 +1,48 @@
+package au.com.shiftyjelly.pocketcasts.utils
+
+import android.os.StatFs
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.mockito.Mockito.mock
+import org.mockito.kotlin.whenever
+
+class StorageUtilTest {
+
+    private lateinit var statFs: StatFs
+
+    @Before
+    fun setUp() {
+        statFs = mock(StatFs::class.java)
+    }
+
+    @Test
+    fun `test storage is low when available space is less than 10 percent`() {
+        whenever(statFs.blockCountLong).thenReturn(100L)
+        whenever(statFs.blockSizeLong).thenReturn(1024L)
+        whenever(statFs.availableBlocksLong).thenReturn(5L) // 5% available
+
+        val result = isDeviceLowOnFreeSpace(statFs)
+
+        assertTrue(result)
+    }
+
+    @Test
+    fun `test storage is not low when available space is more than 10 percent`() {
+        whenever(statFs.blockCountLong).thenReturn(100L)
+        whenever(statFs.blockSizeLong).thenReturn(1024L)
+        whenever(statFs.availableBlocksLong).thenReturn(20L) // 20% available
+
+        val result = isDeviceLowOnFreeSpace(statFs)
+
+        assertFalse(result)
+    }
+
+    private fun isDeviceLowOnFreeSpace(statFs: StatFs): Boolean {
+        val totalStorage = statFs.blockCountLong * statFs.blockSizeLong
+        val availableStorage = statFs.availableBlocksLong * statFs.blockSizeLong
+
+        return availableStorage < totalStorage * 0.10
+    }
+}

--- a/modules/services/utils/src/test/java/au/com/shiftyjelly/pocketcasts/utils/StorageUtilTest.kt
+++ b/modules/services/utils/src/test/java/au/com/shiftyjelly/pocketcasts/utils/StorageUtilTest.kt
@@ -1,6 +1,7 @@
 package au.com.shiftyjelly.pocketcasts.utils
 
 import android.os.StatFs
+import kotlinx.coroutines.runBlocking
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Before
@@ -18,31 +19,24 @@ class StorageUtilTest {
     }
 
     @Test
-    fun `test storage is low when available space is less than 10 percent`() {
+    fun `test storage is low when available space is less than 10 percent`() = runBlocking {
         whenever(statFs.blockCountLong).thenReturn(100L)
         whenever(statFs.blockSizeLong).thenReturn(1024L)
         whenever(statFs.availableBlocksLong).thenReturn(5L) // 5% available
 
-        val result = isDeviceLowOnFreeSpace(statFs)
+        val result = isDeviceRunningOnLowStorage(statFs)
 
         assertTrue(result)
     }
 
     @Test
-    fun `test storage is not low when available space is more than 10 percent`() {
+    fun `test storage is not low when available space is more than 10 percent`() = runBlocking {
         whenever(statFs.blockCountLong).thenReturn(100L)
         whenever(statFs.blockSizeLong).thenReturn(1024L)
         whenever(statFs.availableBlocksLong).thenReturn(20L) // 20% available
 
-        val result = isDeviceLowOnFreeSpace(statFs)
+        val result = isDeviceRunningOnLowStorage(statFs)
 
         assertFalse(result)
-    }
-
-    private fun isDeviceLowOnFreeSpace(statFs: StatFs): Boolean {
-        val totalStorage = statFs.blockCountLong * statFs.blockSizeLong
-        val availableStorage = statFs.availableBlocksLong * statFs.blockSizeLong
-
-        return availableStorage < totalStorage * 0.10
     }
 }


### PR DESCRIPTION
## Description

- This PR adds a requirement to display the banner on the Downloads screen.
- The banner displays when the user has downloaded episodes and the device has low storage.
- Low storage is defined as less than 10% of total storage available
- See: p1729915373575909/1729892350.532779-slack-C07TL9YK9V1

The `lowStorageThreshold` from  `modules/services/utils/src/test/java/au/com/shiftyjelly/pocketcasts/utils/StorageUtilTest.kt`  represents the percentage of available space on user's device that we are going to consider low. Currently is set to `10%`

Fixes #3101 

## Testing Instructions

1. Ensure the device has less than 10% storage available (or adjust lowStorageThreshold in StorageUtilTest.kt to simplify testing; it’s currently set to 10%).
2. Enable the Manage Downloaded Episodes feature flag.
3. Download a few episodes.
4. Navigate to Profile > Downloads.
5. ✅ Verify that the banner appears.
6. Delete some downloaded episodes to increase available storage, ensuring it exceeds the lowStorageThreshold
7. Navigate to Profile > Downloads.
8. ✅ Verify that the banner does not appear.

## Screenshots or Screencast 

[Screen_recording_20241027_103553.webm](https://github.com/user-attachments/assets/95afe258-f632-4403-b49d-54281f469464)


## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.