### PR TITLE
[Paywall Experiment] Set AB Experiment

### DIFF
--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/OnboardingUpgradeFeaturesViewModel.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/OnboardingUpgradeFeaturesViewModel.kt
@@ -107,7 +107,7 @@ class OnboardingUpgradeFeaturesViewModel @Inject constructor(
         val upgradeLayout = when {
             showPatronOnly -> UpgradeLayout.Original
             FeatureFlag.isEnabled(Feature.EXPLAT_EXPERIMENT) -> {
-                when (val variation = experiments.getVariation(Experiment.PaywallUpgradeAATest)) {
+                when (val variation = experiments.getVariation(Experiment.PaywallUpgradeABTest)) {
                     is Variation.Control -> {
                         UpgradeLayout.Original
                     }

--- a/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/experiments/Experiment.kt
+++ b/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/experiments/Experiment.kt
@@ -5,7 +5,7 @@ interface ExperimentType {
 }
 
 enum class Experiment(override val identifier: String) : ExperimentType {
-    PaywallUpgradeAATest("pocketcasts_paywall_android_aa_test"),
+    PaywallUpgradeABTest("pocketcasts_paywall_upgrade_android_ab_test"),
     ;
 
     companion object {


### PR DESCRIPTION
## Description
- This PR just sets the AB experiment for release `7.76`
- Context: p1729790811044969/1729729858.793479-slack-C046HLX37K2
- Note: The AA experiment was set to release `7.75` -> https://github.com/Automattic/pocket-casts-android/pull/3092

## Testing Instructions
Code review should be fine

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.