### PR TITLE
[Tooling] Make the created GitHub Releases use the extracted `metadata/release_notes.txt` file for their description body

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -532,7 +532,7 @@ platform :android do
     create_github_release(
       repository: GH_REPOSITORY,
       version: version,
-      release_notes_file_path: nil,
+      release_notes_file_path: EXTRACTED_RELEASE_NOTES_PATH,
       prerelease: prerelease,
       is_draft: !prerelease,
       release_assets: release_assets.join(',')


### PR DESCRIPTION
## Description

Internal Ref: p1730124628114649/1730120910.298079-slack-C028JAG44VD

As discussed in Slack, the GitHub Release that gets created every time we do a new build had an empty description body.

This PR simply uses the content of `metadata/release_notes.txt` file—already extracted from the CHANGELOG during code-freeze—as the body when creating the GitHub Release.

> [!NOTE]
> This PR targets the `release/7.76` so that the tooling fix could already be beneficial to the current code-frozen `7.76` version and so that any potential betas and the future final build of `7.76` that will be made from `release/7.76`.

## Testing Instructions

I'm not sure this is really worth it given how small and straightforward the change is, but if you want to test the change before it lands, you could:
 - Change the `private_lane :create_gh_release` to a non-private `lane`
 - Run `bundle exec fastlane create_gh_release version:7.76-test`
 - Check the created GitHub Release Draft contains the expected release notes
 - Delete the GitHub Release Draft to clean up after yourself.
