### PR TITLE
Rename 'Subscribe' to 'Follow'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 7.77
 -----
-
+*   Updates
+    *   Renamed the podcast action 'Subscribe' to 'Follow'
+        ([#3120](https://github.com/Automattic/pocket-casts-android/pull/3120))
 
 7.76
 -----

--- a/modules/features/podcasts/src/main/res/layout-land/view_podcast_header_top.xml
+++ b/modules/features/podcasts/src/main/res/layout-land/view_podcast_header_top.xml
@@ -146,7 +146,7 @@
         android:visibility="gone"
         app:layout_constraintStart_toStartOf="@+id/animationSubscribedButton"
         app:layout_constraintEnd_toEndOf="@+id/animationSubscribedButton"
-        app:layout_constraintTop_toBottomOf="@+id/header" />
+        app:layout_constraintBottom_toBottomOf="parent" />
 
     <ImageView
         android:id="@+id/subscribedButton"

--- a/modules/features/podcasts/src/main/res/layout-land/view_podcast_header_top.xml
+++ b/modules/features/podcasts/src/main/res/layout-land/view_podcast_header_top.xml
@@ -136,7 +136,7 @@
 
     <TextView
         android:id="@+id/animationSubscribeText"
-        android:layout_width="wrap_content"
+        android:layout_width="0dp"
         android:layout_height="32dp"
         android:text="@string/podcast_subscribed"
         android:textColor="?attr/primary_interactive_02"
@@ -144,11 +144,9 @@
         android:fontFamily="sans-serif-medium"
         android:gravity="center"
         android:visibility="gone"
-        android:layout_marginEnd="16dp"
-        android:paddingEnd="48dp"
-        android:paddingStart="48dp"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintBottom_toBottomOf="parent" />
+        app:layout_constraintStart_toStartOf="@+id/animationSubscribedButton"
+        app:layout_constraintEnd_toEndOf="@+id/animationSubscribedButton"
+        app:layout_constraintTop_toBottomOf="@+id/header" />
 
     <ImageView
         android:id="@+id/subscribedButton"

--- a/modules/features/podcasts/src/main/res/layout/view_podcast_header_top.xml
+++ b/modules/features/podcasts/src/main/res/layout/view_podcast_header_top.xml
@@ -148,19 +148,17 @@
 
     <TextView
         android:id="@+id/animationSubscribeText"
-        android:layout_width="wrap_content"
+        android:layout_width="0dp"
         android:layout_height="32dp"
         android:layout_marginTop="8dp"
-        android:layout_marginEnd="16dp"
         android:fontFamily="sans-serif-medium"
         android:gravity="center"
-        android:paddingStart="48dp"
-        android:paddingEnd="48dp"
         android:text="@string/podcast_subscribed"
         android:textColor="?attr/primary_interactive_02"
         android:textSize="15sp"
         android:visibility="gone"
-        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="@+id/animationSubscribedButton"
+        app:layout_constraintEnd_toEndOf="@+id/animationSubscribedButton"
         app:layout_constraintTop_toBottomOf="@+id/header" />
 
     <ImageView

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -114,13 +114,13 @@
     <string name="starred">Starred</string>
     <string name="stop_downloading">Stop downloading</string>
     <string name="stream">Stream</string>
-    <string name="subscribe">Subscribe</string>
+    <string name="subscribe">Follow</string>
     <string name="subscribe_to">Subscribe to %s</string>
     <string name="upgrade_to">Upgrade to %s</string>
     <string name="unarchive_all">Unarchive all</string>
     <string name="get_pocket_casts_plus">Get Pocket Casts Plus</string>
     <string name="unplayed">Unplayed</string>
-    <string name="unsubscribe">Unsubscribe</string>
+    <string name="unsubscribe">Unfollow</string>
     <string name="up_next">Up Next</string>
     <string name="learn_more">Learn more.</string>
     <string name="today">Today</string>
@@ -603,8 +603,8 @@
     </plurals>
     <string name="podcast_show_archived" translatable="false">@string/show_archived</string>
     <string name="podcast_sort_episodes">Sort episodes</string>
-    <string name="podcast_subscribed">Subscribed</string>
-    <string name="podcast_not_subscribed">Not Subscribed</string>
+    <string name="podcast_subscribed">Following</string>
+    <string name="podcast_not_subscribed">Not Following</string>
     <string name="podcast_support_this_podcast">Support This Show</string>
     <string name="podcast_supporter">SUPPORTER</string>
     <string name="podcast_supporter_cancelled">Support cancelled</string>
@@ -620,7 +620,7 @@
     <string name="podcast_share_open_fail">Unable to load details about shared podcast. If this problem persists, why not reach out to the person who shared with you, and ask them what\'s up.</string>
     <string name="podcast_unsubscribe_downloaded_file_singular">1 Downloaded File</string>
     <string name="podcast_unsubscribe_downloaded_file_plural">%d Downloaded Files</string>
-    <string name="podcast_unsubscribe_warning">Unsubscribing will delete all downloaded files.</string>
+    <string name="podcast_unsubscribe_warning">Unfollowing will delete all downloaded files.</string>
     <string name="podcast_not_in_filters">Not included in any filters</string>
     <string name="podcast_included_in_filters">Included in %s</string>
     <string name="podcast_effects_summary_speed">Speed %s×</string>

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -445,7 +445,7 @@
     <string name="podcasts_menu_search_podcasts">Search podcasts</string>
     <string name="podcasts_menu_share_podcasts">Share podcasts</string>
     <string name="podcasts_menu_sort_by">Sort by</string>
-    <string name="podcasts_no_subscriptions">No subscribed podcasts</string>
+    <string name="podcasts_no_subscriptions">No podcasts found</string>
     <string name="podcasts_plural">%d Podcasts</string>
     <string name="podcasts_share">Share podcasts</string>
     <string name="podcasts_share_0_selected">0 selected</string>
@@ -459,7 +459,7 @@
     <string name="podcasts_share_failed_description">Something went wrong creating your share page.</string>
     <string name="podcasts_share_select_all">Select all</string>
     <string name="podcasts_share_selected_podcasts">Share selected podcasts</string>
-    <string name="podcasts_share_subscribe_to_all">SUBSCRIBE TO ALL</string>
+    <string name="podcasts_share_subscribe_to_all">FOLLOW ALL</string>
     <string name="podcasts_share_title">Title</string>
     <string name="podcasts_share_create_error">Oops unable to share</string>
     <string name="podcasts_share_missing_title">Please enter a title for your list.</string>
@@ -477,7 +477,7 @@
     <string name="podcasts_sort_by_release_date">Episode release date</string>
     <string name="podcasts_sort_by_title">"Title (A - Z)"</string>
     <string name="podcasts_sort_order">Sort order</string>
-    <string name="podcasts_subscribe_on_phone">Subscribe to podcasts on your phone and they\'ll appear here.</string>
+    <string name="podcasts_subscribe_on_phone">Follow podcasts on your phone and they\'ll appear here.</string>
     <string name="podcasts_time_to_add_some_podcasts">Time to add some Podcasts!</string>
     <string name="podcasts_time_to_add_some_podcasts_summary">You can add podcasts by searching above or if you are looking for some inspiration try the Discover tab.</string>
     <string name="podcasts_empty_folder">Your folder is empty</string>

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -1275,8 +1275,8 @@
     <string name="settings_podcast_artwork">Podcast Artwork</string>
     <string name="settings_podcast_custom">Custom for this podcast</string>
     <string name="settings_podcast_episode_grouping">Podcast episode grouping</string>
-    <string name="settings_podcast_episode_grouping_summary">New podcasts you subscribe to will have their episodes grouped by %s.</string>
-    <string name="settings_podcast_episode_grouping_summary_none">New podcasts you subscribe to won\'t have their episodes grouped.</string>
+    <string name="settings_podcast_episode_grouping_summary">New podcasts you follow will have their episodes grouped by %s.</string>
+    <string name="settings_podcast_episode_grouping_summary_none">New podcasts you follow won\'t have their episodes grouped.</string>
     <string name="settings_podcast_episode_grouping_title_downloaded" translatable="false">@string/downloaded</string>
     <string name="settings_podcast_episode_grouping_title_none">None</string>
     <string name="settings_podcast_episode_grouping_title_season">Season</string>
@@ -1297,8 +1297,8 @@
     <string name="settings_show_archived" translatable="false">@string/show_archived</string>
     <string name="settings_show_archived_action_hide">Hide</string>
     <string name="settings_show_archived_action_show">Show</string>
-    <string name="settings_show_archived_summary_hide">New podcasts you subscribe to won\'t show archived episodes.</string>
-    <string name="settings_show_archived_summary_show">New podcasts you subscribe to will show archived episodes.</string>
+    <string name="settings_show_archived_summary_hide">New podcasts you follow won\'t show archived episodes.</string>
+    <string name="settings_show_archived_summary_show">New podcasts you follow will show archived episodes.</string>
     <string name="settings_show_artwork">Show artwork on lock screen</string>
     <string name="settings_show_artwork_details">This will also show artwork on connected Bluetooth devices, watches, etc.</string>
     <string name="settings_skip_back_time">Skip back time</string>
@@ -1338,7 +1338,7 @@
     <string name="settings_storage_store_on">Store podcasts on</string>
     <string name="settings_storage_fix_downloads">Fix downloads</string>
     <string name="settings_storage_fix_downloads_description">Attempt to restore any downloaded files if they are missing in the Pocket Casts app.</string>
-    <string name="settings_subscribe_to_played">Subscribe to played podcasts</string>
+    <string name="settings_subscribe_to_played">Follow played podcasts</string>
     <string name="settings_show_played">Show played episodes</string>
     <string name="settings_show_played_summary">Episodes that you have finished playing will still be displayed</string>
     <string name="settings_theme">Theme</string>

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -1186,8 +1186,8 @@
     <string name="settings_export_save_file">Save file</string>
     <string name="settings_export_save_file_summary">Export the OPML file to your storage.</string>
     <string name="settings_export_send_email">Send email</string>
-    <string name="settings_export_send_email_summary">Export your subscriptions in the super geeky (but widely supported) OPML format.</string>
-    <string name="settings_export_subscriptions">Export subscriptions</string>
+    <string name="settings_export_send_email_summary">Export your podcasts in the super geeky (but widely supported) OPML format.</string>
+    <string name="settings_export_subscriptions">Export podcasts</string>
     <string name="settings_general_defaults">Defaults</string>
     <string name="settings_general_player">Player</string>
     <string name="settings_general_sleep_timer">Sleep Timer</string>
@@ -1212,7 +1212,7 @@
     <string name="settings_help_phone_unavailable_message">Please try again when your phone is connected to your watch.</string>
     <string name="settings_import_choose_file">Choose an OPML file.</string>
     <string name="settings_import_file">Select file</string>
-    <string name="settings_import_file_summary">If you have podcast subscriptions in another app or service, Pocket Casts can import them from an OPML file.</string>
+    <string name="settings_import_file_summary">If you have podcasts in another app or service, Pocket Casts can import them from an OPML file.</string>
     <string name="settings_import_url">By URL</string>
     <string name="settings_import_url_summary">Import your podcasts from an OPML file using a URL.</string>
     <string name="settings_import_opml_progress">%1$d of %2$d podcasts</string>
@@ -1472,7 +1472,7 @@
     <string name="settings_opml_export_failed">Unable to save the OPML file.</string>
     <string name="settings_subscribe_to_played_summary">Podcasts you listen to will be automatically added to the Podcasts tab</string>
     <string name="settings_notification_default_sound">Default sound</string>
-    <string name="settings_import_title">Import subscriptions</string>
+    <string name="settings_import_title">Import podcasts</string>
     <string name="settings_export_database">Export database</string>
     <string name="settings_export_database_failed">Database export failed</string>
     <string name="settings_status_page">Status Page</string>
@@ -1488,7 +1488,7 @@
     <string name="settings_status_service_refresh">Refresh Service</string>
     <string name="settings_status_service_refresh_summary">The service used to find new episodes.</string>
     <string name="settings_status_service_account">Account Service</string>
-    <string name="settings_status_service_account_summary">The service used to store episode progress, subscriptions, filters, etc.</string>
+    <string name="settings_status_service_account_summary">The service used to store episode progress, podcasts you follow, filters, etc.</string>
     <string name="settings_status_service_discover"><![CDATA[Discover & Search]]></string>
     <string name="settings_status_service_discover_summary">The discover section of the app, including podcast search.</string>
     <string name="settings_status_service_ad_blocker_help_singular">The most common cause is that you have an ad-blocker configured on your phone or network. You’ll need to unblock the domain %s</string>


### PR DESCRIPTION
## Description

We want to rename the subscribe button to follow. See discussion pdeCcb-7cS-p2

I considered renaming the strings key but thought it would be best to keep the old translations until they were converted, as they are an important string label in the app.

## Testing Instructions

Checking the strings file and screenshots is probably enough but if you want to find them on a device these are the steps.

1. Tap the Discover tab
2. Open a podcast you aren't subscribed to
3. ✅ Verify the label says follow
4. Tap the follow button
5. ✅ Verify the label says following while animating to a tick
6. Tap the green tick button
7. ✅ Verify the dialog uses unfollow 
8. Try steps 1 to 7 in landscape
9. Go to the Podcasts tab, tap the three dots, tap Share podcasts
10. Create a list and copy the URL
11. Unsubscribe from the podcasts
12. Open the share URL in Chrome and tap "Open List in Pocket Casts"
13. ✅ Verify is says "Follow all"
14. Go to Profile -> Settings -> General 
15. ✅ Verify the "Podcast episode grouping" and "Show archived" description uses follow instead of subscribe.
16. Open the app on Automotive
17. Tap the settings cog
18. ✅ Verify it says "Follow played podcasts"
19. Open the app on Wear OS
20. Logging to an account with no podcasts
21. ✅ Verify it uses follow

## Screenshots

| Before | After |
| --- | --- |
| ![Screenshot_20241029_143750](https://github.com/user-attachments/assets/98a7bd49-c2fa-4f2f-8ba7-be631accda6f) | ![Screenshot_20241029_151951](https://github.com/user-attachments/assets/bc046a4c-efc1-48c9-887d-1c566ad88f76) | 
| ![Screenshot_20241029_143804](https://github.com/user-attachments/assets/2435230f-011d-4b9c-b8de-c0dee4da4bdb) | ![Screenshot_20241029_163900](https://github.com/user-attachments/assets/83c4c02c-83a2-4645-ad80-c3336983354c) | 
| ![Screenshot_20241029_143823](https://github.com/user-attachments/assets/96f0d481-bd2b-4376-ba14-758a64659d68) | ![Screenshot_20241029_151925](https://github.com/user-attachments/assets/95c71464-9728-48d0-ab55-2e2f2b86f128) |
| ![Screenshot_20241031_143411](https://github.com/user-attachments/assets/1889ab23-8d23-4c4d-9409-9f84b2d1eca2) | ![Screenshot_20241031_145050](https://github.com/user-attachments/assets/986638ad-e9ad-483b-90a5-6c799988fd9c) |
| ![Screenshot_20241031_144332](https://github.com/user-attachments/assets/eee17e17-3e7d-4834-b910-ba15566ace25) | ![Screenshot_20241031_144827](https://github.com/user-attachments/assets/c20a0491-c8d2-4560-99da-5a39b6c022ef) |
| ![Screenshot_20241031_154745](https://github.com/user-attachments/assets/9ba8f421-bc68-4245-906b-6f41206fa167) | ![Screenshot_20241031_160122](https://github.com/user-attachments/assets/d03ab4f6-7724-4ed5-aebb-16cf7fa43bad) |
| ![Screenshot_20241031_161441](https://github.com/user-attachments/assets/86c57228-2bee-4b3e-b250-e93b727eb3c8) | ![Screenshot_20241031_161546](https://github.com/user-attachments/assets/635f6e84-f92b-432a-952b-1ce0847be09b) |

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack