### PR TITLE
Custom Playback Settings: Update distinctUntilChanged condition for selecting effects tabs

### DIFF
--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/EffectsFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/EffectsFragment.kt
@@ -274,7 +274,12 @@ class EffectsFragment : BaseDialogFragment(), CompoundButton.OnCheckedChangeList
     private fun FragmentEffectsBinding.setupEffectsSettingsSegmentedTabBar() {
         effectsSettingsSegmentedTabBar.setContent {
             val podcastEffectsData by viewModel.effectsLive.asFlow()
-                .distinctUntilChanged { t1, t2 -> t1.podcast.uuid == t2.podcast.uuid && t1.podcast.playbackEffects.toData() == t2.podcast.playbackEffects.toData() }
+                .distinctUntilChanged { t1, t2 ->
+                    t1.podcast.uuid == t2.podcast.uuid &&
+                        t1.podcast.playbackEffects.toData() == t2.podcast.playbackEffects.toData() &&
+                        t1.podcast.overrideGlobalEffects == t2.podcast.overrideGlobalEffects &&
+                        t1.podcast.overrideGlobalEffectsModified == t2.podcast.overrideGlobalEffectsModified
+                }
                 .collectAsStateWithLifecycle(null)
             val podcast = podcastEffectsData?.podcast ?: return@setContent
 


### PR DESCRIPTION
## Description
This updates `distinctUntilChanged` condition for `effectsSettingsSegmentedTabBar` to include global effects override state. 

## Testing Instructions
1. Play an episode
2. Open full-screen player
3. Tap on effects view
4. Change playback speed in "All podcasts" view
5. Tap on "This podcast"
6. ✅ Notice that "This podcast" tab is selected and displays playback effects for the selected podcast. If podcast playback effects were never changed, it should display `1x, off, off` (p1730208229140779-slack-C07QMR40VV3)

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack