### PR TITLE
[Project] Up Next Shuffle - Update Shuffle Button Visibility

### DIFF
--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/UpNextAdapter.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/UpNextAdapter.kt
@@ -82,6 +82,7 @@ class UpNextAdapter(
         }
 
     private var isSignedInAsPaidUser: Boolean = false
+    private var isUpNextNotEmpty: Boolean = false
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): RecyclerView.ViewHolder {
         val inflater = LayoutInflater.from(parent.context)
@@ -163,6 +164,10 @@ class UpNextAdapter(
         this.isSignedInAsPaidUser = isSignedInAsPaidUser
     }
 
+    fun updateUpNextEmptyState(isUpNextNotEmpty: Boolean) {
+        this.isUpNextNotEmpty = isUpNextNotEmpty
+    }
+
     inner class HeaderViewHolder(val binding: AdapterUpNextFooterBinding) : RecyclerView.ViewHolder(binding.root) {
 
         fun bind(header: PlayerViewModel.UpNextSummary) {
@@ -176,7 +181,7 @@ class UpNextAdapter(
                     root.resources.getQuantityString(LR.plurals.player_up_next_header_title, header.episodeCount, header.episodeCount, time)
                 }
 
-                shuffle.isVisible = hasEpisodeInProgress() && FeatureFlag.isEnabled(Feature.UP_NEXT_SHUFFLE)
+                shuffle.isVisible = isUpNextNotEmpty && FeatureFlag.isEnabled(Feature.UP_NEXT_SHUFFLE)
                 shuffle.updateShuffleButton()
 
                 shuffle.setOnClickListener {

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/UpNextFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/UpNextFragment.kt
@@ -308,6 +308,7 @@ class UpNextFragment : BaseFragment(), UpNextListener, UpNextTouchCallback.ItemT
 
         playerViewModel.listDataLive.observe(viewLifecycleOwner) {
             adapter.isPlaying = it.podcastHeader.isPlaying
+            adapter.updateUpNextEmptyState(it.upNextEpisodes.isNotEmpty())
             toolbar.menu.findItem(R.id.menu_select)?.isVisible = it.upNextEpisodes.isNotEmpty()
             toolbar.menu.findItem(R.id.clear_up_next)?.isVisible = it.upNextEpisodes.isNotEmpty()
         }


### PR DESCRIPTION
## Description
- Update the shuffle button visibility. It will be visible only when the up next is not empty
- Context: p1730257991386309/1730230283.156089-slack-C07T08CTND9

Fixes #3089

## Testing Instructions

1. Have the shuffle feature flag on
2. Play an episode and have up next empty
3. Tap on Up next tap
4. ✅ Ensure you don't see the shuffle button
5. Add episodes to up next
6. Open Up next
7. ✅ Ensure you see the shuffle button

## Screenshots or Screencast 

#### Free User
[Screen_recording_20241030_085326.webm](https://github.com/user-attachments/assets/02d2ae5d-f750-4643-ac38-1b65ccedfe75)

#### Plus User
[Screen_recording_20241030_085412.webm](https://github.com/user-attachments/assets/1c8a5be1-d117-4666-b7d4-71d3cd5d002f)



## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.