### PR TITLE
[Project] Manage Downloaded Episodes - Reduce bottom padding under “Manage downloads”

### DIFF
--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/ProfileManageDownloadsCard.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/ProfileManageDownloadsCard.kt
@@ -50,7 +50,7 @@ fun ManageDownloadsCard(
                 color = MaterialTheme.theme.colors.primaryField03,
                 shape = RoundedCornerShape(8.dp),
             )
-            .padding(16.dp),
+            .padding(horizontal = 16.dp).padding(top = 16.dp),
 
     ) {
         Icon(


### PR DESCRIPTION
## Description
- The Manage Downloads had extra bottom padding. I am removing this padding due this feedback: p1730045912253859/1729890721.860929-slack-C07TL9YK9V1
- The TextButton already has padding, that's why I don't need extra padding for this button coming from parent

Fixes #3117

## Testing Instructions

1. Ensure the device has less than 10% storage available (or adjust lowStorageThreshold in StorageUtilTest.kt to simplify testing; it’s currently set to 10%).
2. Enable the Manage Downloaded Episodes feature flag.
3. Download a few episodes.
4. Navigate to Profile > Downloads.
5. ✅ Verify that Mange downloads from the banner has bottom padding reduced

## Screenshots or Screencast 
![image](https://github.com/user-attachments/assets/6cdea35b-987a-4529-a9d6-730a10c189ea)


## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack