### PR TITLE
Custom Playback Settings - Analytics

### DIFF
--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/EffectsFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/EffectsFragment.kt
@@ -84,7 +84,9 @@ class EffectsFragment : BaseDialogFragment(), CompoundButton.OnCheckedChangeList
         super.onCreate(savedInstanceState)
 
         if (savedInstanceState == null) {
-            viewModel.trackPlaybackEffectsEvent(AnalyticsEvent.PLAYBACK_EFFECT_SETTINGS_VIEW_APPEARED)
+            if (FeatureFlag.isEnabled(Feature.CUSTOM_PLAYBACK_SETTINGS)) {
+                viewModel.trackPlaybackEffectsEvent(AnalyticsEvent.PLAYBACK_EFFECT_SETTINGS_VIEW_APPEARED)
+            }
         }
     }
 

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/EffectsFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/EffectsFragment.kt
@@ -274,7 +274,12 @@ class EffectsFragment : BaseDialogFragment(), CompoundButton.OnCheckedChangeList
     private fun FragmentEffectsBinding.setupEffectsSettingsSegmentedTabBar() {
         effectsSettingsSegmentedTabBar.setContent {
             val podcastEffectsData by viewModel.effectsLive.asFlow()
-                .distinctUntilChanged { t1, t2 -> t1.podcast.uuid == t2.podcast.uuid && t1.podcast.playbackEffects.toData() == t2.podcast.playbackEffects.toData() }
+                .distinctUntilChanged { t1, t2 ->
+                    t1.podcast.uuid == t2.podcast.uuid &&
+                        t1.podcast.playbackEffects.toData() == t2.podcast.playbackEffects.toData() &&
+                        t1.podcast.overrideGlobalEffects == t2.podcast.overrideGlobalEffects &&
+                        t1.podcast.overrideGlobalEffectsModified == t2.podcast.overrideGlobalEffectsModified
+                }
                 .collectAsStateWithLifecycle(null)
             val podcast = podcastEffectsData?.podcast ?: return@setContent
 

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastEffectsFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastEffectsFragment.kt
@@ -164,9 +164,4 @@ class PodcastEffectsFragment : PreferenceFragmentCompat() {
         preferenceTrimSilence?.icon = context.getTintedDrawable(R.drawable.ic_silence, tintColor)
         preferenceBoostVolume?.icon = context.getTintedDrawable(R.drawable.ic_volumeboost, tintColor)
     }
-
-    override fun onDestroyView() {
-        super.onDestroyView()
-        viewModel.trackSpeedChangeIfNeeded()
-    }
 }

--- a/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
+++ b/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
@@ -334,6 +334,8 @@ enum class AnalyticsEvent(val key: String) {
     PLAYER_SLEEP_TIMER_SETTINGS_TAPPED("player_sleep_timer_settings_tapped"),
 
     /* Player - Playback effects */
+    PLAYBACK_EFFECT_SETTINGS_VIEW_APPEARED("playback_effect_settings_view_appeared"),
+    PLAYBACK_EFFECT_SETTINGS_CHANGED("playback_effect_settings_changed"),
     PLAYBACK_EFFECT_SPEED_CHANGED("playback_effect_speed_changed"),
     PLAYBACK_EFFECT_TRIM_SILENCE_TOGGLED("playback_effect_trim_silence_toggled"),
     PLAYBACK_EFFECT_TRIM_SILENCE_AMOUNT_CHANGED("playback_effect_trim_silence_amount_changed"),

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
@@ -2547,10 +2547,15 @@ open class PlaybackManager @Inject constructor(
         props: Map<String, Any> = emptyMap(),
         sourceView: SourceView,
     ) {
-        val properties = HashMap<String, Any>()
-        properties[SOURCE_KEY] = sourceView.analyticsValue
-        properties.putAll(props)
-        analyticsTracker.track(event, properties)
+        val contentType = if (getCurrentEpisode()?.isVideo == true) ContentType.VIDEO else ContentType.AUDIO
+        analyticsTracker.track(
+            event = event,
+            properties = buildMap {
+                put(SOURCE_KEY, sourceView.analyticsValue)
+                put(CONTENT_TYPE_KEY, contentType.analyticsValue)
+                putAll(props)
+            },
+        )
     }
 
     fun setNotificationPermissionChecker(notificationPermissionChecker: NotificationPermissionChecker) {
@@ -2587,7 +2592,7 @@ open class PlaybackManager @Inject constructor(
         this["chapterUuid"] = value
     }
 
-    private enum class ContentType(val analyticsValue: String) {
+    enum class ContentType(val analyticsValue: String) {
         AUDIO("audio"),
         VIDEO("video"),
     }

--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/Debouncer.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/Debouncer.kt
@@ -1,0 +1,31 @@
+package au.com.shiftyjelly.pocketcasts.utils
+
+import kotlin.time.Duration
+import kotlin.time.DurationUnit
+import kotlin.time.toDuration
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.FlowPreview
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.debounce
+import kotlinx.coroutines.launch
+
+@OptIn(FlowPreview::class)
+class Debouncer(
+    coroutineScope: CoroutineScope = CoroutineScope(Dispatchers.Default),
+    private val waitDuration: Duration = (1).toDuration(DurationUnit.SECONDS),
+) {
+    class Work(val work: suspend () -> Unit)
+    private val stateFlow = MutableStateFlow<Work?>(null)
+    init {
+        coroutineScope.launch {
+            stateFlow.debounce(waitDuration).collect {
+                it?.let { it.work() }
+            }
+        }
+    }
+
+    suspend fun debounce(work: suspend () -> Unit) {
+        stateFlow.emit(Work(work))
+    }
+}


### PR DESCRIPTION
## Description
This updates analytics for playback effects settings.

Part of: #3042 

## Testing Instructions

### Events with FF Off

- Run the app and make sure the `custom_playback_settings` FF is off
- Open the player full screen and tap the Effects to prompt the sheet
- Enable/Disable the trim silence
- Event `🔵 Tracked: playback_effect_trim_silence_toggled ["enabled": SELECTED_VALUE, "source": "player_playback_effects", "content_type": "audio"]`
- Change the value of the Trim Silence
- Event `🔵 Tracked: playback_effect_trim_silence_amount_changed ["content_type": "audio", "source": "player_playback_effects", "amount": SELECTED_VALUE]`
- Enable/Disable the Volume Boost
- Event `🔵 Tracked: playback_effect_volume_boost_toggled ["enabled": SELECTED_VALUE, "content_type": "audio", "source": "player_playback_effects"]`
- Change the playback speed and dismiss the screen
- Event `🔵 Tracked: playback_effect_speed_changed ["content_type": "audio", "source": "player_playback_effects", "speed": SELECTED_VALUE]`

### Events with FF On
**Note: with the FF on, the new property `settings` could be `global` or `local`**
- Run the app and make sure the FF is on
- Open the player full screen and tap the Effects to prompt the sheet
- Event `🔵 Tracked: playback_effect_settings_view_appeared ["source": "player_playback_effects", "content_type": "audio", "settings": YOUR_VALUE]`
- Change tapping the segmented to apply the global or local settings
- Event `🔵 Tracked: playback_effect_settings_changed ["source": "player_playback_effects", "settings": YOUR_VALUE, "content_type": "audio"]`
- Event `🔵 Tracked: playback_effect_trim_silence_toggled ["enabled": SELECTED_VALUE, "source": "player_playback_effects", "content_type": "audio", "settings": YOUR_VALUE]`
- Change the value of the Trim Silence
- Event `🔵 Tracked: playback_effect_trim_silence_amount_changed ["content_type": "audio", "source": "player_playback_effects", "amount": SELECTED_VALUE, "settings": YOUR_VALUE]`
- Enable/Disable the Volume Boost
- Event `🔵 Tracked: playback_effect_volume_boost_toggled ["enabled": SELECTED_VALUE, "content_type": "audio", "source": "player_playback_effects", "settings": YOUR_VALUE]`
- Change the playback speed: with the FF on we use a debouncer to track the event
- Event: `🔵 Tracked: playback_effect_speed_changed ["speed": 1.5, "settings": "local", "content_type": "audio", "source": "player_playback_effects", "settings": YOUR_VALUE]`

### Podcast Settings
- Navigate to the `podcast settings -> Playback Effects -> Enable Custom for this podcast`. 
- Do the same test with the FF on/off when `Enable Custom for this podcast` is on
- If the FF is on the event contains the property `settings`
- Events are the same as above

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
