### PR TITLE
[Project] Up Next Shuffle - Display Paywall for free users

### DIFF
--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/OnboardingFlowComposable.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/OnboardingFlowComposable.kt
@@ -235,6 +235,7 @@ private fun Content(
                 OnboardingUpgradeSource.SETTINGS,
                 OnboardingUpgradeSource.SLUMBER_STUDIOS,
                 OnboardingUpgradeSource.WHATS_NEW_SKIP_CHAPTERS,
+                OnboardingUpgradeSource.UP_NEXT_SHUFFLE,
                 OnboardingUpgradeSource.UNKNOWN,
                 -> false
 

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/UpgradeFeatureCard.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/UpgradeFeatureCard.kt
@@ -45,6 +45,10 @@ sealed class UpgradeFeatureCard(
                 )
             -> LR.string.skip_chapters_plus_prompt
 
+            source == OnboardingUpgradeSource.UP_NEXT_SHUFFLE &&
+                SubscriptionTier.fromFeatureTier(Feature.UP_NEXT_SHUFFLE) == SubscriptionTier.PLUS
+            -> LR.string.up_next_shuffle_plus_prompt
+
             else -> LR.string.onboarding_plus_features_title
         }
     }

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/UpNextAdapter.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/UpNextAdapter.kt
@@ -33,10 +33,14 @@ import au.com.shiftyjelly.pocketcasts.repositories.images.loadInto
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
 import au.com.shiftyjelly.pocketcasts.repositories.playback.UpNextSource
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
+import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingFlow
+import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingLauncher
+import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingUpgradeSource
 import au.com.shiftyjelly.pocketcasts.ui.extensions.themed
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import au.com.shiftyjelly.pocketcasts.ui.theme.ThemeColor
 import au.com.shiftyjelly.pocketcasts.utils.extensions.dpToPx
+import au.com.shiftyjelly.pocketcasts.utils.extensions.getActivity
 import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
 import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
 import au.com.shiftyjelly.pocketcasts.views.helper.SwipeButtonLayoutFactory
@@ -185,10 +189,14 @@ class UpNextAdapter(
                 shuffle.updateShuffleButton()
 
                 shuffle.setOnClickListener {
-                    val newValue = !settings.upNextShuffle.value
-                    analyticsTracker.track(AnalyticsEvent.UP_NEXT_SHUFFLE_ENABLED, mapOf("value" to newValue, SOURCE_KEY to upNextSource.analyticsValue))
+                    if (isSignedInAsPaidUser) {
+                        val newValue = !settings.upNextShuffle.value
+                        analyticsTracker.track(AnalyticsEvent.UP_NEXT_SHUFFLE_ENABLED, mapOf("value" to newValue, SOURCE_KEY to upNextSource.analyticsValue))
 
-                    settings.upNextShuffle.set(newValue, updateModifiedAt = false)
+                        settings.upNextShuffle.set(newValue, updateModifiedAt = false)
+                    } else {
+                        OnboardingLauncher.openOnboardingFlow(root.context.getActivity(), OnboardingFlow.Upsell(OnboardingUpgradeSource.UP_NEXT_SHUFFLE))
+                    }
 
                     shuffle.updateShuffleButton()
                 }

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/onboarding/OnboardingUpgradeSource.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/onboarding/OnboardingUpgradeSource.kt
@@ -20,5 +20,6 @@ enum class OnboardingUpgradeSource(val analyticsValue: String) {
     SETTINGS("settings"),
     SLUMBER_STUDIOS("slumber_studios"),
     WHATS_NEW_SKIP_CHAPTERS("what_new_skip_chapters"),
+    UP_NEXT_SHUFFLE("up_next_shuffle"),
     UNKNOWN("unknown"),
 }

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -2000,8 +2000,6 @@
     <string name="clear_before_adding">Clear Before Adding</string>
     <string name="dont_clear">Don\'t Clear</string>
     <string name="clear_up_next">Clear Up Next</string>
-    <string name="up_next_shuffle_button_content_description">Up next shuffle</string>
-    <string name="up_next_shuffle_disable_button_content_description">Up next shuffle disable</string>
     <string name="clear_all">Clear All</string>
     <string name="clear_search">Clear Search</string>
     <string name="add_mode">Add Mode</string>
@@ -2195,5 +2193,10 @@
     <string name="you_are_running_low_on_storage">You\'re running low on storage</string>
     <string name="save_space_by_managing_downloaded_episodes">Save %1$s – by managing downloaded episodes.</string>
     <string name="manage_downloads">Manage Downloads</string>
+
+    <!-- Up Next Shuffle -->
+    <string name="up_next_shuffle_button_content_description">Up next shuffle</string>
+    <string name="up_next_shuffle_disable_button_content_description">Up next shuffle disable</string>
+    <string name="up_next_shuffle_plus_prompt">Shuffle your episodes with Pocket Casts Plus, and more</string>
 
 </resources>

--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/Feature.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/Feature.kt
@@ -151,7 +151,7 @@ enum class Feature(
         key = "up_next_shuffle",
         title = "Up Next Shuffle",
         defaultValue = BuildConfig.DEBUG,
-        tier = FeatureTier.Free,
+        tier = FeatureTier.Plus(patronExclusiveAccessRelease = null),
         hasFirebaseRemoteFlag = false,
         hasDevToggle = true,
     ),


### PR DESCRIPTION
## Description
- This PR opens the paywall with shuffle copy updated for plus card when a free user taps on shuffle button
- Figma: KjyDLK1DPPg3snPBMVGWHw-fi-148_3551
- Context: p1730305046943719/1730077568.183099-slack-C07T08CTND9

Fixes #3128

## Testing Instructions
1. Play an episode
2. Add episodes to Up Next
3. Have a free user logged in
4. Go to Up Next
5. Tap on Shuffle Button
6. ✅ Ensure you see the paywall with the `Shuffle your episodes with Pocket Casts Plus, and more` copy for plus card
7. ✅  `plus_promotion_shown` event is tracked with `source = up_next_shuffle`
8. Swipe to Patron
9. ✅ Ensure you see the original Patron copy
10. Go to Bookmarks and open the paywall from there
11. ✅ Ensure you don't see the shuffle copy for plus card

## Screenshots or Screencast 
[Screen_recording_20241030_141146.webm](https://github.com/user-attachments/assets/66aa23ea-0953-4ee2-8b61-48e487f76062)


## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack