### PR TITLE
Make profile app bar icons part of the scrollable content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@
 *   Bug Fixes
     *   Keep the playing service in the foreground when casting
         ([#3094](https://github.com/Automattic/pocket-casts-android/pull/3094))
+    *   Scroll profile tab app bar icons with the content in the landscape orientation
+        ([#3138](https://github.com/Automattic/pocket-casts-android/pull/3138))
 *   Updates
     *   Move Up Next clear queue button to app bar
         ([#3068](https://github.com/Automattic/pocket-casts-android/pull/3068))

--- a/modules/features/profile/src/main/res/layout-land/fragment_profile.xml
+++ b/modules/features/profile/src/main/res/layout-land/fragment_profile.xml
@@ -171,39 +171,32 @@
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toBottomOf="@+id/btnRefresh"
                 app:layout_constraintBottom_toBottomOf="parent"/>
+
+            <androidx.compose.ui.platform.ComposeView
+                android:id="@+id/btnGift"
+                android:layout_width="44dp"
+                android:layout_height="44dp"
+                android:layout_gravity="end"
+                android:layout_marginTop="8dp"
+                android:layout_marginEnd="8dp"
+                app:layout_constraintEnd_toStartOf="@id/btnSettings"
+                app:layout_constraintTop_toTopOf="parent" />
+
+            <ImageButton
+                android:id="@+id/btnSettings"
+                android:layout_width="44dp"
+                android:layout_height="44dp"
+                android:layout_marginTop="8dp"
+                android:layout_marginEnd="8dp"
+                android:background="?android:attr/actionBarItemBackground"
+                android:contentDescription="@string/settings"
+                android:src="@drawable/ic_profile_settings"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintTop_toTopOf="parent"
+                app:tint="?attr/primary_icon_01" />
+
         </androidx.constraintlayout.widget.ConstraintLayout>
 
     </androidx.core.widget.NestedScrollView>
-
-    <androidx.constraintlayout.widget.ConstraintLayout
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_gravity="end"
-        android:layout_marginTop="7dp"
-        android:layout_marginEnd="6dp"
-        android:layout_marginBottom="10dp">
-
-        <androidx.compose.ui.platform.ComposeView
-            android:id="@+id/btnGift"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_gravity="end"
-            android:layout_marginEnd="8dp"
-            app:layout_constraintEnd_toStartOf="@id/btnSettings"
-            app:layout_constraintTop_toTopOf="parent"/>
-
-        <ImageButton
-            android:id="@+id/btnSettings"
-            android:layout_width="44dp"
-            android:layout_height="44dp"
-            android:layout_marginBottom="10dp"
-            android:background="?android:attr/actionBarItemBackground"
-            android:contentDescription="@string/settings"
-            android:src="@drawable/ic_profile_settings"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintTop_toTopOf="parent"
-            app:tint="?attr/primary_icon_01" />
-
-    </androidx.constraintlayout.widget.ConstraintLayout>
 
 </FrameLayout>

--- a/modules/features/profile/src/main/res/layout/fragment_profile.xml
+++ b/modules/features/profile/src/main/res/layout/fragment_profile.xml
@@ -172,19 +172,19 @@
 
             <androidx.compose.ui.platform.ComposeView
                 android:id="@+id/btnGift"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="7dp"
-                android:layout_marginStart="7dp"
+                android:layout_width="44dp"
+                android:layout_height="44dp"
+                android:layout_marginStart="8dp"
+                android:layout_marginTop="8dp"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toTopOf="parent"/>
+                app:layout_constraintTop_toTopOf="parent" />
 
             <ImageButton
                 android:id="@+id/btnSettings"
                 android:layout_width="44dp"
                 android:layout_height="44dp"
-                android:layout_marginTop="7dp"
-                android:layout_marginEnd="7dp"
+                android:layout_marginTop="8dp"
+                android:layout_marginEnd="8dp"
                 android:background="?android:attr/actionBarItemBackground"
                 android:contentDescription="@string/settings"
                 android:src="@drawable/ic_profile_settings"


### PR DESCRIPTION
## Description

Fixes an issue where settings were not scrolling with the content in the landscape mode. Initially reported here: p1730362239561269-slack-C02A333D8LQ

I took the liberty of resizing the gift icon to match it size-wise with the cog icon so they align a bit better.

## Testing Instructions

1. Sign in with a paid account.
2. Go to the Profile tab.
3. Switch orientation to the landscape mode.
4. Notice that the app bar icons scroll with the content.

## Screenshots or Screencast 

| Before | After |
| - | - |
| <video src="https://github.com/user-attachments/assets/dc2ee699-69f5-41f0-8501-47a6b39f3b44"> | <video src="https://github.com/user-attachments/assets/6ad1f596-b4fa-47fd-9216-6468d34eeb77"> |

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] ~I have considered whether it makes sense to add tests for my changes~
- [ ] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [ ] ~Any jetpack compose components I added or changed are covered by compose previews~
- [ ] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~