### PR TITLE
Add missing download icon to shelf in all configurations

### DIFF
--- a/modules/features/player/src/main/res/layout-land/adapter_player_header.xml
+++ b/modules/features/player/src/main/res/layout-land/adapter_player_header.xml
@@ -315,6 +315,13 @@
                 app:tint="?attr/player_contrast_03"
                 style="@style/shelf_item" />
 
+            <ImageButton
+                android:id="@+id/download"
+                android:contentDescription="@string/download"
+                app:srcCompat="@drawable/auto_filter_downloaded"
+                app:tint="?attr/player_contrast_03"
+                style="@style/shelf_item" />
+
             <FrameLayout
                 android:id="@+id/cast"
                 android:layout_width="0dp"

--- a/modules/features/player/src/main/res/layout-sw600dp/adapter_player_header.xml
+++ b/modules/features/player/src/main/res/layout-sw600dp/adapter_player_header.xml
@@ -310,6 +310,13 @@ Player controls and seekbar are centered horizontally on this layout, which make
                 style="@style/shelf_item" />
 
             <ImageButton
+                android:id="@+id/download"
+                android:contentDescription="@string/download"
+                app:srcCompat="@drawable/auto_filter_downloaded"
+                app:tint="?attr/player_contrast_03"
+                style="@style/shelf_item" />
+
+            <ImageButton
                 android:id="@+id/podcast"
                 android:contentDescription="@string/go_to_podcast"
                 app:srcCompat="@drawable/ic_goto_32"


### PR DESCRIPTION
## Description

The download podcast icon was added only to base layout configuration resulting in a missing icon when device was using, for example, the landscape orientation. Initially reported here: p1730362239561269-slack-C02A333D8LQ

Ideally we should rewrite the code so we don't have to maintain 3 different layouts for this but I'm not going to do this in this task.

There's also a separate issue where the "More actions" bottom sheet has accessibility issues in the landscape orientation on most devices and the title doesn't scroll which obstructs the actions and the whole content doesn't fit when scrolled to the bottom.

## Testing Instructions

1. Play something.
2. Open the player.
3. Make the download action one of the shelf actions.
4. Switch your device to the landscape orientation.
5. Notice that the download action is still visible and it works.

## Checklist
- [ ] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] ~I have considered whether it makes sense to add tests for my changes~
- [ ] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [ ] ~Any jetpack compose components I added or changed are covered by compose previews~
- [ ] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~