### PR TITLE
[Paywall Experiment] - Tweaks for Explat

### DIFF
--- a/automotive/src/main/java/au/com/shiftyjelly/pocketcasts/AutomotiveApplication.kt
+++ b/automotive/src/main/java/au/com/shiftyjelly/pocketcasts/AutomotiveApplication.kt
@@ -8,6 +8,7 @@ import androidx.core.content.getSystemService
 import androidx.hilt.work.HiltWorkerFactory
 import androidx.work.Configuration
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTracker
+import au.com.shiftyjelly.pocketcasts.analytics.experiments.ExperimentProvider
 import au.com.shiftyjelly.pocketcasts.crashlogging.InitializeRemoteLogging
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.repositories.di.ApplicationScope
@@ -59,6 +60,8 @@ class AutomotiveApplication : Application(), Configuration.Provider {
     @Inject lateinit var initializeRemoteLogging: InitializeRemoteLogging
 
     @Inject lateinit var analyticsTracker: AnalyticsTracker
+
+    @Inject lateinit var experimentProvider: ExperimentProvider
 
     @Inject @ApplicationScope
     lateinit var applicationScope: CoroutineScope
@@ -120,5 +123,6 @@ class AutomotiveApplication : Application(), Configuration.Provider {
 
     private fun setupAnalytics() {
         analyticsTracker.clearAllData()
+        experimentProvider.initialize()
     }
 }

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/OnboardingCreateAccountViewModel.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/OnboardingCreateAccountViewModel.kt
@@ -6,6 +6,7 @@ import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTracker
+import au.com.shiftyjelly.pocketcasts.analytics.experiments.ExperimentProvider
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
 import au.com.shiftyjelly.pocketcasts.repositories.subscription.SubscriptionManager
 import au.com.shiftyjelly.pocketcasts.repositories.sync.LoginResult
@@ -29,6 +30,7 @@ class OnboardingCreateAccountViewModel @Inject constructor(
     private val analyticsTracker: AnalyticsTracker,
     private val subscriptionManager: SubscriptionManager,
     private val podcastManager: PodcastManager,
+    private val experimentProvider: ExperimentProvider,
     @ApplicationContext context: Context,
 ) : AndroidViewModel(context as Application), CoroutineScope {
     override val coroutineContext: CoroutineContext
@@ -82,6 +84,7 @@ class OnboardingCreateAccountViewModel @Inject constructor(
             when (result) {
                 is LoginResult.Success -> {
                     podcastManager.refreshPodcastsAfterSignIn()
+                    experimentProvider.refreshExperiments()
                     analyticsTracker.refreshMetadata()
                     onAccountCreated()
                 }

--- a/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/experiments/ExperimentProvider.kt
+++ b/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/experiments/ExperimentProvider.kt
@@ -26,7 +26,7 @@ class ExperimentProvider @Inject constructor(
 
     fun initialize() {
         if (FeatureFlag.isEnabled(Feature.EXPLAT_EXPERIMENT)) {
-            val uuid = accountStatusInfo.getUuid() ?: UUID.randomUUID().toString().replace("-", "")
+            val uuid = accountStatusInfo.getUuid().takeIf { !it.isNullOrBlank() } ?: UUID.randomUUID().toString().replace("-", "")
 
             LogBuffer.i(TAG, "Initializing experiments with uuid: $uuid")
 

--- a/modules/services/analytics/src/test/kotlin/au/com/shiftyjelly/pocketcasts/analytics/experiments/ExperimentProviderTest.kt
+++ b/modules/services/analytics/src/test/kotlin/au/com/shiftyjelly/pocketcasts/analytics/experiments/ExperimentProviderTest.kt
@@ -71,6 +71,18 @@ class ExperimentProviderTest {
     }
 
     @Test
+    fun `should not initialize with empty uuid`() {
+        FeatureFlag.setEnabled(Feature.EXPLAT_EXPERIMENT, true)
+
+        `when`(accountStatusInfo.getUuid()).thenReturn("")
+
+        experimentProvider.initialize()
+
+        verify(repository, never()).initialize(eq(""), eq(null))
+        verify(accountStatusInfo).getUuid()
+    }
+
+    @Test
     fun `getVariation should return Control when repository returns Control`() {
         FeatureFlag.setEnabled(Feature.EXPLAT_EXPERIMENT, true)
 

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/PocketCastsWearApplication.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/PocketCastsWearApplication.kt
@@ -5,6 +5,7 @@ import androidx.hilt.work.HiltWorkerFactory
 import androidx.work.Configuration
 import au.com.shiftyjelly.pocketcasts.BuildConfig
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTracker
+import au.com.shiftyjelly.pocketcasts.analytics.experiments.ExperimentProvider
 import au.com.shiftyjelly.pocketcasts.crashlogging.InitializeRemoteLogging
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.repositories.download.DownloadManager
@@ -58,6 +59,8 @@ class PocketCastsWearApplication : Application(), Configuration.Provider {
     @Inject lateinit var workerFactory: HiltWorkerFactory
 
     @Inject lateinit var analyticsTracker: AnalyticsTracker
+
+    @Inject lateinit var experimentProvider: ExperimentProvider
 
     @Inject lateinit var downloadStatisticsReporter: DownloadStatisticsReporter
 
@@ -122,6 +125,7 @@ class PocketCastsWearApplication : Application(), Configuration.Provider {
     private fun setupAnalytics() {
         analyticsTracker.clearAllData()
         analyticsTracker.refreshMetadata()
+        experimentProvider.initialize()
         downloadStatisticsReporter.setup()
     }
 


### PR DESCRIPTION
## Description
We saw this error in an user logs and we are trying to put a fix for this, but we are not sure what could be causing this issue. So this PR is just an attempt by adding some improvements

> E 24/10 09:52:19 ExPlat: anonymousId is null or empty, cannot fetch assignments. Make sure ExPlat was initialized.
java.lang.IllegalStateException: ExPlat: anonymousId is null or empty, cannot fetch assignments. Make sure ExPlat was initialized.
	at ab.c1.f(SourceFile:1967)
	at vu.v1.b(SourceFile:165)
	at vu.d1.b(SourceFile:5)
	at ab.b2.invokeSuspend(SourceFile:72)
	at bu.a.resumeWith(SourceFile:9)
	at su.j0.run(SourceFile:107)
	at su.u0.Y(SourceFile:24)
	at xu.a.j(SourceFile:141)
	at su.a.m0(SourceFile:103)
	at su.b0.y(SourceFile:24)
	at su.b0.z(SourceFile:13)
	at au.com.shiftyjelly.pocketcasts.account.viewmodel.OnboardingUpgradeFeaturesViewModel.<init>(SourceFile:82)

This issue appears when we try to get the experiments without having initialized. We have two hypothesis here:

1. We are initializing the SDK with empty uuid provided by `accountStatusInfo.getUuid()`. For this we are not checking if the uuid is empty: f236a52a7041bfb024e762bc583e761530eb82af
2. We are missing the `initialize` explat call in some place over the app. Currently we initialize the sdk when on App application start, when log in and sign out. So here, we are also initializing when creating a new account, Automotive application and wear application.



- Context: p1730333694743159-slack-C07DLM97HRQ

## Testing Instructions

### App

Look for `ExperimentsProvider` in the logs

1. Open the app
2. Ensure you see the experiment logs
3. Log in
4. Ensure you see the experiment logs

### Automotive

Look for `ExperimentsProvider` in the logs
1. Open the automotive app
2. Ensure you see the experiment in the logs

### Wear

Look for `ExperimentsProvider` in the logs
1. Open the wear app
2. Ensure you see the experiment in the logs


## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
