### PR TITLE
Improve general settings

### DIFF
--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/PlaybackSettingsFragment.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/PlaybackSettingsFragment.kt
@@ -48,7 +48,7 @@ import au.com.shiftyjelly.pocketcasts.compose.components.DialogFrame
 import au.com.shiftyjelly.pocketcasts.compose.components.SettingRadioDialogRow
 import au.com.shiftyjelly.pocketcasts.compose.components.SettingRow
 import au.com.shiftyjelly.pocketcasts.compose.components.SettingRowToggle
-import au.com.shiftyjelly.pocketcasts.compose.components.SettingSection
+import au.com.shiftyjelly.pocketcasts.compose.components.SettingSectionHeader
 import au.com.shiftyjelly.pocketcasts.compose.theme
 import au.com.shiftyjelly.pocketcasts.images.R
 import au.com.shiftyjelly.pocketcasts.models.to.PodcastGrouping
@@ -118,7 +118,7 @@ class PlaybackSettingsFragment : BaseFragment() {
         val listState = rememberLazyListState()
         val settingsItemsKey = SettingsItems.entries
 
-        val sleepTimerIndex = settingsItemsKey.indexOf(SettingsItems.SETTINGS_GENERAL_SLEEP_TIMER)
+        val sleepTimerIndex = settingsItemsKey.indexOf(SettingsItems.SETTINGS_HEADER_SLEEP_TIMER)
         LaunchedEffect(scrollToSleepTimer) {
             if (scrollToSleepTimer) {
                 listState.animateScrollToItem(index = sleepTimerIndex)
@@ -143,27 +143,32 @@ class PlaybackSettingsFragment : BaseFragment() {
             ) {
                 items(settingsItemsKey.size) { item ->
                     when (settingsItemsKey[item]) {
-                        SettingsItems.SETTINGS_GENERAL_DEFAULTS -> {
-                            SettingSection(heading = stringResource(LR.string.settings_general_defaults)) {
-                                RowAction(
-                                    saved = settings.streamingMode.flow.collectAsState().value,
-                                    onSave = {
-                                        analyticsTracker.track(
-                                            AnalyticsEvent.SETTINGS_GENERAL_ROW_ACTION_CHANGED,
-                                            mapOf(
-                                                "value" to when (it) {
-                                                    true -> "play"
-                                                    false -> "download"
-                                                },
-                                            ),
-                                        )
-                                        settings.streamingMode.set(it, updateModifiedAt = true)
-                                    },
-                                )
-                            }
+                        SettingsItems.SETTINGS_HEADER_DEFAULTS -> {
+                            SettingSectionHeader(
+                                text = stringResource(LR.string.settings_general_defaults),
+                                indent = false,
+                            )
                         }
 
-                        SettingsItems.SETTINGS_GENERAL_UP_NEXT -> {
+                        SettingsItems.SETTINGS_ROW_ACTION -> {
+                            RowAction(
+                                saved = settings.streamingMode.flow.collectAsState().value,
+                                onSave = {
+                                    analyticsTracker.track(
+                                        AnalyticsEvent.SETTINGS_GENERAL_ROW_ACTION_CHANGED,
+                                        mapOf(
+                                            "value" to when (it) {
+                                                true -> "play"
+                                                false -> "download"
+                                            },
+                                        ),
+                                    )
+                                    settings.streamingMode.set(it, updateModifiedAt = true)
+                                },
+                            )
+                        }
+
+                        SettingsItems.SETTINGS_UP_NEXT_SWIPE -> {
                             UpNextSwipe(
                                 saved = settings.upNextSwipe.flow.collectAsState().value,
                                 onSave = {
@@ -181,7 +186,7 @@ class PlaybackSettingsFragment : BaseFragment() {
                             )
                         }
 
-                        SettingsItems.SETTINGS_GENERAL_EPISODE -> {
+                        SettingsItems.SETTINGS_EPISODE_GROUPING -> {
                             PodcastEpisodeGrouping(
                                 saved = settings.podcastGroupingDefault.flow.collectAsState().value,
                                 onSave = {
@@ -203,7 +208,7 @@ class PlaybackSettingsFragment : BaseFragment() {
                             )
                         }
 
-                        SettingsItems.SETTINGS_GENERAL_ARCHIVED_EPISODES -> {
+                        SettingsItems.SETTINGS_ARCHIVED_EPISODES -> {
                             ShowArchived(
                                 saved = settings.showArchivedDefault.flow.collectAsState().value,
                                 onSave = {
@@ -229,25 +234,31 @@ class PlaybackSettingsFragment : BaseFragment() {
                                 modifier = Modifier.clickable {
                                     (activity as? FragmentHostListener)?.addFragment(MediaActionsFragment())
                                 },
+                                indent = false,
                             )
                         }
 
-                        SettingsItems.SETTINGS_GENERAL_PLAYER -> {
-                            SettingSection(heading = stringResource(LR.string.settings_general_player)) {
-                                SkipTime(
-                                    primaryText = stringResource(LR.string.settings_skip_forward_time),
-                                    saved = settings.skipForwardInSecs.flow
-                                        .collectAsState()
-                                        .value,
-                                    onSave = {
-                                        analyticsTracker.track(
-                                            AnalyticsEvent.SETTINGS_GENERAL_SKIP_FORWARD_CHANGED,
-                                            mapOf("value" to it),
-                                        )
-                                        settings.skipForwardInSecs.set(it, updateModifiedAt = true)
-                                    },
-                                )
-                            }
+                        SettingsItems.SETTINGS_HEADER_PLAYER -> {
+                            SettingSectionHeader(
+                                text = stringResource(LR.string.settings_general_player),
+                                indent = false,
+                            )
+                        }
+
+                        SettingsItems.SETTINGS_SKIP_FORWARD_TIME -> {
+                            SkipTime(
+                                primaryText = stringResource(LR.string.settings_skip_forward_time),
+                                saved = settings.skipForwardInSecs.flow
+                                    .collectAsState()
+                                    .value,
+                                onSave = {
+                                    analyticsTracker.track(
+                                        AnalyticsEvent.SETTINGS_GENERAL_SKIP_FORWARD_CHANGED,
+                                        mapOf("value" to it),
+                                    )
+                                    settings.skipForwardInSecs.set(it, updateModifiedAt = true)
+                                },
+                            )
                         }
 
                         SettingsItems.SETTINGS_SKIP_BACK_TIME -> {
@@ -264,7 +275,7 @@ class PlaybackSettingsFragment : BaseFragment() {
                             )
                         }
 
-                        SettingsItems.SETTINGS_GENERAL_KEEP_SCREEN_AWAKE -> {
+                        SettingsItems.SETTINGS_KEEP_SCREEN_AWAKE -> {
                             KeepScreenAwake(
                                 saved = settings.keepScreenAwake.flow.collectAsState().value,
                                 onSave = {
@@ -277,7 +288,7 @@ class PlaybackSettingsFragment : BaseFragment() {
                             )
                         }
 
-                        SettingsItems.SETTINGS_GENERAL_OPEN_PLAYER_AUTOMATICALLY -> {
+                        SettingsItems.SETTINGS_OPEN_PLAYER_AUTOMATICALLY -> {
                             OpenPlayerAutomatically(
                                 saved = settings.openPlayerAutomatically.flow.collectAsState().value,
                                 onSave = {
@@ -290,7 +301,7 @@ class PlaybackSettingsFragment : BaseFragment() {
                             )
                         }
 
-                        SettingsItems.SETTINGS_GENERAL_INTELLIGENT_PLAYBACK -> {
+                        SettingsItems.SETTINGS_INTELLIGENT_PLAYBACK -> {
                             IntelligentPlaybackResumption(
                                 saved = settings.intelligentPlaybackResumption.flow.collectAsState().value,
                                 onSave = {
@@ -303,7 +314,7 @@ class PlaybackSettingsFragment : BaseFragment() {
                             )
                         }
 
-                        SettingsItems.SETTINGS_GENERAL_PLAY_UP_NEXT -> {
+                        SettingsItems.SETTINGS_PLAY_UP_NEXT_EPISODE -> {
                             PlayUpNextOnTap(
                                 saved = settings.tapOnUpNextShouldPlay.flow.collectAsState().value,
                                 onSave = {
@@ -316,8 +327,8 @@ class PlaybackSettingsFragment : BaseFragment() {
                             )
                         }
 
-                        SettingsItems.SETTINGS_USE_REAL_TIME_FOR_PLAYBACK_REMAINING_TIME -> {
-                            UseRealTimeForPlaybackRemaingingTime(
+                        SettingsItems.SETTINGS_ADJUST_REMAINING_TIME -> {
+                            UseRealTimeForPlaybackRemainingTime(
                                 saved = settings.useRealTimeForPlaybackRemaingTime.flow.collectAsState().value,
                                 onSave = {
                                     analyticsTracker.track(
@@ -329,30 +340,37 @@ class PlaybackSettingsFragment : BaseFragment() {
                             )
                         }
 
-                        SettingsItems.SETTINGS_GENERAL_SLEEP_TIMER -> {
-                            SettingSection(heading = stringResource(LR.string.settings_general_sleep_timer)) {
-                                AutoSleepTimerRestart(
-                                    saved = settings.autoSleepTimerRestart.flow.collectAsState().value,
-                                    onSave = {
-                                        analyticsTracker.track(
-                                            AnalyticsEvent.SETTINGS_GENERAL_AUTO_SLEEP_TIMER_RESTART_TOGGLED,
-                                            mapOf("enabled" to it),
-                                        )
-                                        settings.autoSleepTimerRestart.set(it, updateModifiedAt = true)
-                                    },
-                                )
+                        SettingsItems.SETTINGS_HEADER_SLEEP_TIMER -> {
+                            SettingSectionHeader(
+                                text = stringResource(LR.string.settings_general_sleep_timer),
+                                indent = false,
+                            )
+                        }
 
-                                ShakeToResetSleepTimer(
-                                    saved = settings.shakeToResetSleepTimer.flow.collectAsState().value,
-                                    onSave = {
-                                        analyticsTracker.track(
-                                            AnalyticsEvent.SETTINGS_GENERAL_SHAKE_TO_RESET_SLEEP_TIMER_TOGGLED,
-                                            mapOf("enabled" to it),
-                                        )
-                                        settings.shakeToResetSleepTimer.set(it, updateModifiedAt = true)
-                                    },
-                                )
-                            }
+                        SettingsItems.SETTINGS_SLEEP_TIMER_RESTART -> {
+                            AutoSleepTimerRestart(
+                                saved = settings.autoSleepTimerRestart.flow.collectAsState().value,
+                                onSave = {
+                                    analyticsTracker.track(
+                                        AnalyticsEvent.SETTINGS_GENERAL_AUTO_SLEEP_TIMER_RESTART_TOGGLED,
+                                        mapOf("enabled" to it),
+                                    )
+                                    settings.autoSleepTimerRestart.set(it, updateModifiedAt = true)
+                                },
+                            )
+                        }
+
+                        SettingsItems.SETTINGS_SLEEP_TIMER_SHAKE -> {
+                            ShakeToResetSleepTimer(
+                                saved = settings.shakeToResetSleepTimer.flow.collectAsState().value,
+                                onSave = {
+                                    analyticsTracker.track(
+                                        AnalyticsEvent.SETTINGS_GENERAL_SHAKE_TO_RESET_SLEEP_TIMER_TOGGLED,
+                                        mapOf("enabled" to it),
+                                    )
+                                    settings.shakeToResetSleepTimer.set(it, updateModifiedAt = true)
+                                },
+                            )
                         }
 
                         SettingsItems.SETTINGS_GENERAL_AUTOPLAY -> {
@@ -387,6 +405,7 @@ class PlaybackSettingsFragment : BaseFragment() {
             savedOption = saved,
             onSave = onSave,
             optionToLocalisedString = { getString(rowActionToStringRes(it)) },
+            indent = false,
         )
     }
 
@@ -411,6 +430,7 @@ class PlaybackSettingsFragment : BaseFragment() {
             savedOption = saved,
             optionToLocalisedString = { getString(upNextActionToStringRes(it)) },
             onSave = onSave,
+            indent = false,
         )
     }
 
@@ -438,6 +458,7 @@ class PlaybackSettingsFragment : BaseFragment() {
             savedOption = saved,
             optionToLocalisedString = { getString(podcastGroupingToStringRes(it)) },
             onSave = onSave,
+            indent = false,
         )
     }
 
@@ -469,6 +490,7 @@ class PlaybackSettingsFragment : BaseFragment() {
                 false -> getString(LR.string.settings_show_archived_action_hide)
             }
         },
+        indent = false,
     )
 
     @Composable
@@ -483,6 +505,7 @@ class PlaybackSettingsFragment : BaseFragment() {
             primaryText = primaryText,
             secondaryText = stringResource(LR.string.seconds_plural, saved),
             modifier = Modifier.clickable { showDialog = true },
+            indent = false,
         ) {
             if (showDialog) {
                 val focusRequester = remember { FocusRequester() }
@@ -571,6 +594,7 @@ class PlaybackSettingsFragment : BaseFragment() {
             secondaryText = stringResource(LR.string.settings_keep_screen_awake_summary),
             toggle = SettingRowToggle.Switch(checked = saved),
             modifier = Modifier.toggleable(value = saved, role = Role.Switch) { onSave(!saved) },
+            indent = false,
         )
 
     @Composable
@@ -580,6 +604,7 @@ class PlaybackSettingsFragment : BaseFragment() {
             secondaryText = stringResource(id = LR.string.settings_open_player_automatically_summary),
             toggle = SettingRowToggle.Switch(checked = saved),
             modifier = Modifier.toggleable(value = saved, role = Role.Switch) { onSave(!saved) },
+            indent = false,
         )
 
     @Composable
@@ -589,6 +614,7 @@ class PlaybackSettingsFragment : BaseFragment() {
             secondaryText = stringResource(LR.string.settings_playback_resumption_summary),
             toggle = SettingRowToggle.Switch(checked = saved),
             modifier = Modifier.toggleable(value = saved, role = Role.Switch) { onSave(!saved) },
+            indent = false,
         )
 
     @Composable
@@ -598,6 +624,7 @@ class PlaybackSettingsFragment : BaseFragment() {
             secondaryText = stringResource(LR.string.settings_up_next_tap_summary),
             toggle = SettingRowToggle.Switch(checked = saved),
             modifier = Modifier.toggleable(value = saved, role = Role.Switch) { onSave(!saved) },
+            indent = false,
         )
 
     @Composable
@@ -607,6 +634,7 @@ class PlaybackSettingsFragment : BaseFragment() {
             secondaryText = stringResource(LR.string.settings_sleep_timer_shake_to_reset_summary),
             toggle = SettingRowToggle.Switch(checked = saved),
             modifier = Modifier.toggleable(value = saved, role = Role.Switch) { onSave(!saved) },
+            indent = false,
         )
 
     @Composable
@@ -616,6 +644,7 @@ class PlaybackSettingsFragment : BaseFragment() {
             secondaryText = stringResource(LR.string.settings_sleep_timer_auto_restart_summary),
             toggle = SettingRowToggle.Switch(checked = saved),
             modifier = Modifier.toggleable(value = saved, role = Role.Switch) { onSave(!saved) },
+            indent = false,
         )
 
     @Composable
@@ -627,10 +656,11 @@ class PlaybackSettingsFragment : BaseFragment() {
         secondaryText = stringResource(LR.string.settings_continuous_playback_summary),
         toggle = SettingRowToggle.Switch(checked = saved),
         modifier = Modifier.toggleable(value = saved, role = Role.Switch) { onSave(!saved) },
+        indent = false,
     )
 
     @Composable
-    private fun UseRealTimeForPlaybackRemaingingTime(
+    private fun UseRealTimeForPlaybackRemainingTime(
         saved: Boolean,
         onSave: (Boolean) -> Unit,
     ) = SettingRow(
@@ -638,6 +668,7 @@ class PlaybackSettingsFragment : BaseFragment() {
         secondaryText = stringResource(LR.string.settings_real_time_playback_summary),
         toggle = SettingRowToggle.Switch(checked = saved),
         modifier = Modifier.toggleable(value = saved, role = Role.Switch) { onSave(!saved) },
+        indent = false,
     )
 
     private fun showSetAllGroupingDialog(grouping: PodcastGrouping) {
@@ -677,19 +708,23 @@ class PlaybackSettingsFragment : BaseFragment() {
 }
 
 private enum class SettingsItems {
-    SETTINGS_GENERAL_DEFAULTS,
-    SETTINGS_GENERAL_UP_NEXT,
-    SETTINGS_GENERAL_EPISODE,
-    SETTINGS_GENERAL_ARCHIVED_EPISODES,
+    SETTINGS_HEADER_DEFAULTS,
+    SETTINGS_ROW_ACTION,
+    SETTINGS_UP_NEXT_SWIPE,
+    SETTINGS_EPISODE_GROUPING,
+    SETTINGS_ARCHIVED_EPISODES,
     SETTINGS_MEDIA_NOTIFICATION_CONTROLS,
-    SETTINGS_GENERAL_PLAYER,
+    SETTINGS_HEADER_PLAYER,
+    SETTINGS_SKIP_FORWARD_TIME,
     SETTINGS_SKIP_BACK_TIME,
-    SETTINGS_GENERAL_KEEP_SCREEN_AWAKE,
-    SETTINGS_GENERAL_OPEN_PLAYER_AUTOMATICALLY,
-    SETTINGS_GENERAL_INTELLIGENT_PLAYBACK,
-    SETTINGS_GENERAL_PLAY_UP_NEXT,
-    SETTINGS_USE_REAL_TIME_FOR_PLAYBACK_REMAINING_TIME,
-    SETTINGS_GENERAL_SLEEP_TIMER,
+    SETTINGS_KEEP_SCREEN_AWAKE,
+    SETTINGS_OPEN_PLAYER_AUTOMATICALLY,
+    SETTINGS_INTELLIGENT_PLAYBACK,
+    SETTINGS_PLAY_UP_NEXT_EPISODE,
+    SETTINGS_ADJUST_REMAINING_TIME,
+    SETTINGS_HEADER_SLEEP_TIMER,
+    SETTINGS_SLEEP_TIMER_RESTART,
+    SETTINGS_SLEEP_TIMER_SHAKE,
 
     // The [scrollToAutoPlay] fragment argument handling depends on this item being last
     // in the list. If it's position is changed, make sure you update the handling when

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/PlaybackSettingsFragment.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/PlaybackSettingsFragment.kt
@@ -9,6 +9,8 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.rememberLazyListState
@@ -49,6 +51,7 @@ import au.com.shiftyjelly.pocketcasts.compose.components.SettingRadioDialogRow
 import au.com.shiftyjelly.pocketcasts.compose.components.SettingRow
 import au.com.shiftyjelly.pocketcasts.compose.components.SettingRowToggle
 import au.com.shiftyjelly.pocketcasts.compose.components.SettingSectionHeader
+import au.com.shiftyjelly.pocketcasts.compose.components.SettingsSection
 import au.com.shiftyjelly.pocketcasts.compose.theme
 import au.com.shiftyjelly.pocketcasts.images.R
 import au.com.shiftyjelly.pocketcasts.models.to.PodcastGrouping
@@ -144,10 +147,13 @@ class PlaybackSettingsFragment : BaseFragment() {
                 items(settingsItemsKey.size) { item ->
                     when (settingsItemsKey[item]) {
                         SettingsItems.SETTINGS_HEADER_DEFAULTS -> {
-                            SettingSectionHeader(
-                                text = stringResource(LR.string.settings_general_defaults),
-                                indent = false,
-                            )
+                            Column {
+                                Spacer(modifier = Modifier.height(SettingsSection.verticalPadding))
+                                SettingSectionHeader(
+                                    text = stringResource(LR.string.settings_general_defaults),
+                                    indent = false,
+                                )
+                            }
                         }
 
                         SettingsItems.SETTINGS_ROW_ACTION -> {
@@ -239,10 +245,13 @@ class PlaybackSettingsFragment : BaseFragment() {
                         }
 
                         SettingsItems.SETTINGS_HEADER_PLAYER -> {
-                            SettingSectionHeader(
-                                text = stringResource(LR.string.settings_general_player),
-                                indent = false,
-                            )
+                            Column {
+                                Spacer(modifier = Modifier.height(SettingsSection.verticalPadding))
+                                SettingSectionHeader(
+                                    text = stringResource(LR.string.settings_general_player),
+                                    indent = false,
+                                )
+                            }
                         }
 
                         SettingsItems.SETTINGS_SKIP_FORWARD_TIME -> {
@@ -341,10 +350,13 @@ class PlaybackSettingsFragment : BaseFragment() {
                         }
 
                         SettingsItems.SETTINGS_HEADER_SLEEP_TIMER -> {
-                            SettingSectionHeader(
-                                text = stringResource(LR.string.settings_general_sleep_timer),
-                                indent = false,
-                            )
+                            Column {
+                                Spacer(modifier = Modifier.height(SettingsSection.verticalPadding))
+                                SettingSectionHeader(
+                                    text = stringResource(LR.string.settings_general_sleep_timer),
+                                    indent = false,
+                                )
+                            }
                         }
 
                         SettingsItems.SETTINGS_SLEEP_TIMER_RESTART -> {

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/Settings.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/Settings.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.height
@@ -76,15 +77,9 @@ fun SettingSection(
             modifier = Modifier.padding(vertical = verticalPadding),
         ) {
             if (heading != null) {
-                TextH40(
+                SettingSectionHeader(
                     text = heading,
-                    color = MaterialTheme.theme.colors.primaryInteractive01,
-                    modifier = Modifier.padding(
-                        start = if (indent) indentedStartPadding else horizontalPadding,
-                        end = horizontalPadding,
-                        top = verticalPadding,
-                        bottom = verticalPadding,
-                    ),
+                    indent = indent,
                 )
             }
             if (subHeading != null) {
@@ -109,6 +104,24 @@ fun SettingSection(
 }
 
 @Composable
+fun SettingSectionHeader(
+    text: String,
+    indent: Boolean = true,
+    paddingValues: PaddingValues = PaddingValues(
+        start = if (indent) indentedStartPadding else horizontalPadding,
+        end = horizontalPadding,
+        top = verticalPadding * 2,
+        bottom = verticalPadding,
+    ),
+) {
+    TextH40(
+        text = text,
+        color = MaterialTheme.theme.colors.primaryInteractive01,
+        modifier = Modifier.padding(paddingValues),
+    )
+}
+
+@Composable
 fun <T> SettingRadioDialogRow(
     primaryText: String,
     modifier: Modifier = Modifier,
@@ -116,6 +129,7 @@ fun <T> SettingRadioDialogRow(
     icon: Painter? = null,
     iconGradientColors: List<Color>? = null,
     options: List<T>,
+    indent: Boolean = true,
     savedOption: T,
     optionToLocalisedString: (T) -> String,
     onSave: (T) -> Unit,
@@ -127,6 +141,7 @@ fun <T> SettingRadioDialogRow(
         icon = icon,
         iconGradientColors = iconGradientColors,
         modifier = modifier.clickable { showDialog = true },
+        indent = indent,
     ) {
         if (showDialog) {
             RadioDialog(

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/Settings.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/Settings.kt
@@ -110,7 +110,7 @@ fun SettingSectionHeader(
     paddingValues: PaddingValues = PaddingValues(
         start = if (indent) indentedStartPadding else horizontalPadding,
         end = horizontalPadding,
-        top = verticalPadding * 2,
+        top = verticalPadding,
         bottom = verticalPadding,
     ),
 ) {


### PR DESCRIPTION
## Description

This change improves the General settings page by removing the separators that were in the wrong place. Also, it removes the indent so the descriptions don't wrap over so many lines.

There is a `SettingSection` component, but the way the page is laid out it can't be used. In future commits I would like to improve the other settings pages to match this page.

Slack discussion p1730421542295429/1730421438.913309-slack-C05RR9P9RAT

## Testing Instructions
1. Tap the Profile tab
2. Tap the settings cog
3. Tap General
4. ✅ Verify the page looks right 

## Screenshots
| Before | After |
| --- | --- |
| ![Old Settings](https://github.com/user-attachments/assets/b301c7d0-ec8f-4bfb-8e8c-076fd256281b) | ![New Settings](https://github.com/user-attachments/assets/dff0d213-9294-492b-a2db-7e6dc1fb66c3) | 

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack