### PR TITLE
Fix notification color

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 *   Updates
     *   Renamed the podcast action 'Subscribe' to 'Follow'
         ([#3120](https://github.com/Automattic/pocket-casts-android/pull/3120))
+*   Bug Fixes
+    *   Use red color for the notification icons
+        ([#3154](https://github.com/Automattic/pocket-casts-android/pull/3154))
 
 7.76
 -----

--- a/modules/services/repositories/src/main/res/values/colors.xml
+++ b/modules/services/repositories/src/main/res/values/colors.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <color name="notification_color">#03a9f4</color>
+    <color name="notification_color">#F43E37</color>
 </resources>


### PR DESCRIPTION
## Description

The bug got introduced back in 2017 when the accent color got changed and it propagated forwards. [Here](https://github.com/Automattic/pocket-casts-android-private/commit/8528bb6336c94ebaeb560141b22f80613ac3d2de#diff-3406701c069879a69173ef9a1d12baf2a71b85b5881a36a21255fe0efb521d42L28) is the change that introduced it.

## Testing Instructions

1. Trigger new episode notification from the developer options menu.
2. Notice that the icon uses red color as its background.

## Screenshots or Screencast 

| Before | After |
| - | - |
| ![share_6998091212107933246](https://github.com/user-attachments/assets/e34de4de-ddc2-4e61-9f74-a264ab68a896) | ![share_2330159640879517981](https://github.com/user-attachments/assets/43df17c4-30e7-402a-9ae6-d990a91bd8eb) |

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] ~I have considered whether it makes sense to add tests for my changes~
- [ ] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [ ] ~Any jetpack compose components I added or changed are covered by compose previews~
- [ ] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~