### PR TITLE
Add year property to End of Year analytics

### DIFF
--- a/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
+++ b/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
@@ -112,6 +112,7 @@ import au.com.shiftyjelly.pocketcasts.referrals.ReferralsGuestPassFragment
 import au.com.shiftyjelly.pocketcasts.repositories.bumpstats.BumpStatsTask
 import au.com.shiftyjelly.pocketcasts.repositories.di.ApplicationScope
 import au.com.shiftyjelly.pocketcasts.repositories.di.NotificationPermissionChecker
+import au.com.shiftyjelly.pocketcasts.repositories.endofyear.EndOfYearManager
 import au.com.shiftyjelly.pocketcasts.repositories.notification.NotificationHelper
 import au.com.shiftyjelly.pocketcasts.repositories.opml.OpmlImportTask
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
@@ -725,7 +726,10 @@ class MainActivity :
                                 showStoriesOrAccount(StoriesSource.MODAL.value)
                             },
                             onExpanded = {
-                                analyticsTracker.track(AnalyticsEvent.END_OF_YEAR_MODAL_SHOWN)
+                                analyticsTracker.track(
+                                    AnalyticsEvent.END_OF_YEAR_MODAL_SHOWN,
+                                    mapOf("year" to EndOfYearManager.YEAR_TO_SYNC.value),
+                                )
                                 settings.setEndOfYearShowModal(false)
                                 viewModel.updateStoriesModalShowState(false)
                             },

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/EndOfYearViewModel.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/EndOfYearViewModel.kt
@@ -230,47 +230,60 @@ class EndOfYearViewModel @AssistedInject constructor(
     }
 
     internal fun trackFailedToLoad() {
-        analyticsTracker.track(AnalyticsEvent.END_OF_YEAR_STORIES_FAILED_TO_LOAD)
+        trackEvent(AnalyticsEvent.END_OF_YEAR_STORIES_FAILED_TO_LOAD)
     }
 
     internal fun trackStoriesShown() {
-        analyticsTracker.track(
+        trackEvent(
             AnalyticsEvent.END_OF_YEAR_STORIES_SHOWN,
             mapOf("source" to source.value),
         )
     }
 
     internal fun trackStoriesClosed(source: String) {
-        analyticsTracker.track(
+        trackEvent(
             AnalyticsEvent.END_OF_YEAR_STORIES_DISMISSED,
             mapOf("source" to source),
         )
     }
 
     internal fun trackStoriesAutoFinished() {
-        analyticsTracker.track(
+        trackEvent(
             AnalyticsEvent.END_OF_YEAR_STORIES_DISMISSED,
             mapOf("source" to "auto_progress"),
         )
     }
 
     internal fun trackStoryShown(story: Story) {
-        analyticsTracker.track(
+        trackEvent(
             AnalyticsEvent.END_OF_YEAR_STORY_SHOWN,
             mapOf("story" to story.analyticsValue),
         )
     }
 
     internal fun trackReplayStoriesTapped() {
-        analyticsTracker.track(AnalyticsEvent.END_OF_YEAR_STORY_REPLAY_BUTTON_TAPPED)
+        trackEvent(AnalyticsEvent.END_OF_YEAR_STORY_REPLAY_BUTTON_TAPPED)
     }
 
     internal fun trackUpsellShown() {
-        analyticsTracker.track(AnalyticsEvent.END_OF_YEAR_UPSELL_SHOWN)
+        trackEvent(AnalyticsEvent.END_OF_YEAR_UPSELL_SHOWN)
     }
 
     internal fun trackLearnRatingsShown() {
-        analyticsTracker.track(AnalyticsEvent.END_OF_YEAR_LEARN_RATINGS_SHOWN)
+        trackEvent(AnalyticsEvent.END_OF_YEAR_LEARN_RATINGS_SHOWN)
+    }
+
+    private fun trackEvent(
+        event: AnalyticsEvent,
+        properties: Map<String, Any> = emptyMap(),
+    ) {
+        analyticsTracker.track(
+            event,
+            buildMap {
+                putAll(properties)
+                put("year", year.value)
+            },
+        )
     }
 
     private fun getRandomShowIds(stats: EndOfYearStats): RandomShowIds? {

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/ProfileFragment.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/ProfileFragment.kt
@@ -38,6 +38,7 @@ import au.com.shiftyjelly.pocketcasts.profile.cloud.CloudFilesFragment
 import au.com.shiftyjelly.pocketcasts.profile.databinding.FragmentProfileBinding
 import au.com.shiftyjelly.pocketcasts.referrals.ReferralsClaimGuestPassBannerCard
 import au.com.shiftyjelly.pocketcasts.referrals.ReferralsIconWithTooltip
+import au.com.shiftyjelly.pocketcasts.repositories.endofyear.EndOfYearManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
 import au.com.shiftyjelly.pocketcasts.repositories.user.UserManager
 import au.com.shiftyjelly.pocketcasts.settings.HelpFragment
@@ -277,7 +278,10 @@ class ProfileFragment : BaseFragment() {
             AppTheme(theme.activeTheme) {
                 EndOfYearPromptCard(
                     onClick = {
-                        analyticsTracker.track(AnalyticsEvent.END_OF_YEAR_PROFILE_CARD_TAPPED)
+                        analyticsTracker.track(
+                            AnalyticsEvent.END_OF_YEAR_PROFILE_CARD_TAPPED,
+                            mapOf("year" to EndOfYearManager.YEAR_TO_SYNC.value),
+                        )
                         // once stories prompt card is tapped, we don't want to show stories launch modal if not already shown
                         if (settings.getEndOfYearShowModal()) {
                             settings.setEndOfYearShowModal(false)

--- a/modules/services/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/SharingClient.kt
+++ b/modules/services/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/SharingClient.kt
@@ -246,7 +246,10 @@ class SharingClient(
                 val pendingIntent = ItemSharedReceiver.intent(
                     context = context,
                     event = AnalyticsEvent.END_OF_YEAR_STORY_SHARED,
-                    values = mapOf("story" to data.story.analyticsValue),
+                    values = mapOf(
+                        "story" to data.story.analyticsValue,
+                        "year" to data.year.value,
+                    ),
                 )
                 Intent()
                     .setAction(Intent.ACTION_SEND)
@@ -393,6 +396,7 @@ data class SharingRequest internal constructor(
         ) = Builder(Data.EndOfYearStory(story, year, screenshot))
             .setAnalyticsEvent(AnalyticsEvent.END_OF_YEAR_STORY_SHARE)
             .addAnalyticsProperty("story", story.analyticsValue)
+            .addAnalyticsProperty("year", year.value)
     }
 
     class Builder internal constructor(

--- a/modules/services/sharing/src/test/kotlin/au/com/shiftyjelly/pocketcasts/sharing/SharingAnalyticsTest.kt
+++ b/modules/services/sharing/src/test/kotlin/au/com/shiftyjelly/pocketcasts/sharing/SharingAnalyticsTest.kt
@@ -487,6 +487,7 @@ class SharingAnalyticsTest {
                 "story" to "number_of_shows",
                 "source" to "unknown",
                 "action" to "system_sheet",
+                "year" to 1000,
             ),
         )
     }
@@ -514,6 +515,7 @@ class SharingAnalyticsTest {
                 "story" to "top_1_show",
                 "source" to "unknown",
                 "action" to "system_sheet",
+                "year" to 1000,
             ),
         )
     }
@@ -536,6 +538,7 @@ class SharingAnalyticsTest {
                 "story" to "top_5_shows",
                 "source" to "unknown",
                 "action" to "system_sheet",
+                "year" to 1000,
             ),
         )
     }
@@ -563,6 +566,7 @@ class SharingAnalyticsTest {
                 "story" to "ratings",
                 "source" to "unknown",
                 "action" to "system_sheet",
+                "year" to 1000,
             ),
         )
     }
@@ -584,6 +588,7 @@ class SharingAnalyticsTest {
                 "story" to "total_time",
                 "source" to "unknown",
                 "action" to "system_sheet",
+                "year" to 1000,
             ),
         )
     }
@@ -612,6 +617,7 @@ class SharingAnalyticsTest {
                 "story" to "longest_episode",
                 "source" to "unknown",
                 "action" to "system_sheet",
+                "year" to 1000,
             ),
         )
     }
@@ -635,6 +641,7 @@ class SharingAnalyticsTest {
                 "story" to "year_vs_year",
                 "source" to "unknown",
                 "action" to "system_sheet",
+                "year" to 1000,
             ),
         )
     }
@@ -658,6 +665,7 @@ class SharingAnalyticsTest {
                 "story" to "completion_rate",
                 "source" to "unknown",
                 "action" to "system_sheet",
+                "year" to 1000,
             ),
         )
     }


### PR DESCRIPTION
## Description

This PR adds `year` property to all End of Year analytics events.

## Testing Instructions

Code review should be enough.

## Checklist
- [ ] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [ ] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [ ] ~Any jetpack compose components I added or changed are covered by compose previews~
- [ ] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~