### PR TITLE
Custom Playback Effects - Update trim mode component and segmented bar

### DIFF
--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/EffectsFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/EffectsFragment.kt
@@ -16,7 +16,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import androidx.core.view.isVisible
 import androidx.core.view.updatePadding
 import androidx.fragment.app.activityViewModels
@@ -325,13 +324,10 @@ class EffectsFragment : BaseDialogFragment(), CompoundButton.OnCheckedChangeList
             items = PlaybackEffectsSettingsTab.entries.map { stringResource(it.labelResId) },
             selectedIndex = PlaybackEffectsSettingsTab.entries.indexOf(selectedItem),
             colors = SegmentedTabBarDefaults.colors.copy(
-                selectedTabBackgroundColor = MaterialTheme.theme.colors.playerContrast06.copy(alpha = .1f),
-                borderColor = MaterialTheme.theme.colors.playerContrast03.copy(alpha = .4f),
+                selectedTabBackgroundColor = MaterialTheme.theme.colors.playerContrast01,
+                borderColor = MaterialTheme.theme.colors.playerContrast03,
             ),
             cornerRadius = 120.dp,
-            textStyle = SegmentedTabBarDefaults.textStyle.copy(
-                fontSize = 13.sp,
-            ),
             modifier = modifier.fillMaxWidth(),
             onItemSelected = onItemSelected,
         )

--- a/modules/features/player/src/main/res/color/trim_mode_background.xml
+++ b/modules/features/player/src/main/res/color/trim_mode_background.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <selector xmlns:android="http://schemas.android.com/apk/res/android">
     <item android:state_checked="true" android:color="?attr/player_contrast_01" />
-    <item android:color="@color/transparent" />
+    <item android:color="?attr/player_contrast_06" />
 </selector>

--- a/modules/features/player/src/main/res/color/trim_stroke_color.xml
+++ b/modules/features/player/src/main/res/color/trim_stroke_color.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <selector xmlns:android="http://schemas.android.com/apk/res/android">
     <item android:state_checked="true" android:color="?attr/player_contrast_01" />
-    <item android:color="?attr/player_contrast_02" />
+    <item android:color="?attr/player_contrast_03"/>
 </selector>

--- a/modules/features/player/src/main/res/layout/fragment_effects.xml
+++ b/modules/features/player/src/main/res/layout/fragment_effects.xml
@@ -172,7 +172,7 @@
                     app:strokeColor="@color/trim_stroke_color"
                     android:textAllCaps="false"
                     android:text="@string/player_effects_trim_mild"
-                    style="?attr/materialButtonOutlinedStyle"
+                    style="@style/TrimMode.Button.Left"
                     />
                 <com.google.android.material.button.MaterialButton
                     android:id="@+id/trimMedium"
@@ -194,7 +194,7 @@
                     app:strokeColor="@color/trim_stroke_color"
                     android:textAllCaps="false"
                     android:text="@string/player_effects_trim_mad_max"
-                    style="?attr/materialButtonOutlinedStyle"
+                    style="@style/TrimMode.Button.Right"
                     />
             </com.google.android.material.button.MaterialButtonToggleGroup>
             <TextView

--- a/modules/features/player/src/main/res/layout/fragment_effects.xml
+++ b/modules/features/player/src/main/res/layout/fragment_effects.xml
@@ -203,7 +203,7 @@
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="4dp"
-                android:textColor="?attr/player_contrast_01"
+                android:textColor="?attr/player_contrast_02"
                 android:text="@string/player_trim_silence_detail"
                 app:layout_constraintLeft_toLeftOf="@id/trimSilenceLabel"
                 app:layout_constraintRight_toLeftOf="@id/switchTrim"
@@ -257,7 +257,7 @@
                 android:layout_height="wrap_content"
                 android:layout_marginTop="4dp"
                 android:text="@string/player_effects_voices_sound_louder"
-                android:textColor="?attr/player_contrast_01"
+                android:textColor="?attr/player_contrast_02"
                 app:layout_constraintLeft_toLeftOf="@id/trimSilenceLabel"
                 app:layout_constraintTop_toBottomOf="@id/volumeLabel" />
 

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/SegmentedTabBar.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/SegmentedTabBar.kt
@@ -1,12 +1,10 @@
 package au.com.shiftyjelly.pocketcasts.compose.components
 
 import androidx.compose.foundation.BorderStroke
-import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.RowScope
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
@@ -14,13 +12,11 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.ButtonDefaults
 import androidx.compose.material.ExperimentalMaterialApi
-import androidx.compose.material.Icon
 import androidx.compose.material.LocalMinimumInteractiveComponentEnforcement
+import androidx.compose.material.MaterialTheme
 import androidx.compose.material.OutlinedButton
 import androidx.compose.material.Surface
 import androidx.compose.material.Text
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Check
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.Modifier
@@ -31,7 +27,6 @@ import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.role
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.TextStyle
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
@@ -77,9 +72,6 @@ fun SegmentedTabBar(
                             onItemSelected(index)
                         },
                     )
-                    if (index < items.size - 1) {
-                        Divider(colors.borderColor)
-                    }
                 }
             }
         }
@@ -107,37 +99,15 @@ private fun RowScope.SegmentedTab(
             .defaultMinSize(minWidth = SegmentedTabBarDefaults.tabMinSize)
             .semantics { role = Role.Tab },
     ) {
-        if (isSelected) {
-            Icon(
-                imageVector = Icons.Filled.Check,
-                contentDescription = null,
-                tint = colors.selectedTabIconColor,
-            )
-            Spacer(modifier = Modifier.width(8.dp))
-        }
         Text(
             text = text,
             color = if (isSelected) colors.selectedTabTextColor else colors.unSelectedTabTextColor,
+            style = MaterialTheme.typography.button,
             fontSize = textStyle.fontSize,
-            letterSpacing = textStyle.letterSpacing,
-            lineHeight = 18.sp,
             maxLines = 1,
             overflow = TextOverflow.Ellipsis,
-            fontWeight = FontWeight.W500,
         )
     }
-}
-
-@Composable
-private fun Divider(
-    color: Color,
-) {
-    Spacer(
-        modifier = Modifier
-            .background(color)
-            .width(SegmentedTabBarDefaults.borderThickness)
-            .height(SegmentedTabBarDefaults.height),
-    )
 }
 
 object SegmentedTabBarDefaults {
@@ -146,15 +116,14 @@ object SegmentedTabBarDefaults {
     val borderThickness = 1.0.dp
     val textStyle = TextStyle(
         fontSize = 15.sp,
-        letterSpacing = -(0.08).sp,
     )
-    val height: Dp = 40.dp
+    val height: Dp = 43.dp
     val tabMinSize: Dp = 150.dp
 }
 
 data class SegmentedTabBarColors(
-    val selectedTabBackgroundColor: Color = Color.White.copy(alpha = .1f),
-    val selectedTabTextColor: Color = Color.White,
+    val selectedTabBackgroundColor: Color = Color.White,
+    val selectedTabTextColor: Color = Color.Black,
     val selectedTabIconColor: Color = Color.White,
     val unSelectedTabBackgroundColor: Color = Color.Transparent,
     val unSelectedTabTextColor: Color = Color.White,

--- a/modules/services/ui/src/main/res/values/dimens.xml
+++ b/modules/services/ui/src/main/res/values/dimens.xml
@@ -5,4 +5,5 @@
     <dimen name="bottom_sheet_top_padding">10dp</dimen>
     <dimen name="divider_height">1dp</dimen>
     <dimen name="mini_player_height">68dp</dimen>
+    <dimen name="trim_mode_button_corner_radius">18dp</dimen>
 </resources>

--- a/modules/services/ui/src/main/res/values/styles.xml
+++ b/modules/services/ui/src/main/res/values/styles.xml
@@ -179,4 +179,29 @@
     <style name="TextAppearanceCarHint">
         <item name="android:textSize">20sp</item>
     </style>
+
+    <style name="TrimMode.Button.Left" parent="Widget.MaterialComponents.Button.OutlinedButton">
+        <item name="shapeAppearanceOverlay">@style/TrimMode.ShapeAppearance.Corner.Left</item>
+    </style>
+
+    <style name="TrimMode.Button.Right" parent="Widget.MaterialComponents.Button.OutlinedButton">
+        <item name="shapeAppearanceOverlay">@style/TrimMode.ShapeAppearance.Corner.Right</item>
+    </style>
+
+    <style name="TrimMode.ShapeAppearance.Corner.Left" parent="">
+        <item name="cornerFamily">rounded</item>
+        <item name="cornerSizeTopRight">0dp</item>
+        <item name="cornerSizeBottomRight">0dp</item>
+        <item name="cornerSizeTopLeft">@dimen/trim_mode_button_corner_radius</item>
+        <item name="cornerSizeBottomLeft">@dimen/trim_mode_button_corner_radius</item>
+    </style>
+
+    <style name="TrimMode.ShapeAppearance.Corner.Right" parent="">
+        <item name="cornerFamily">rounded</item>
+        <item name="cornerSizeTopLeft">0dp</item>
+        <item name="cornerSizeBottomLeft">0dp</item>
+        <item name="cornerSizeTopRight">@dimen/trim_mode_button_corner_radius</item>
+        <item name="cornerSizeBottomRight">@dimen/trim_mode_button_corner_radius</item>
+    </style>
+
 </resources>


### PR DESCRIPTION
## Description
This updates trim mode component and segmented bar

Internal Ref: pdeCcb-7bh#comment-5868

Part of #3042 

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Tap on the Filters tab -->
<!-- 2. Tap on a filter -->
<!-- 3. etc. -->

## Screenshots or Screencast 

Normal Font | Large Font| Plans
---|---|----
![normal](https://github.com/user-attachments/assets/b8fc5bb7-2d00-4b13-8cc2-099eaf300eaa) | ![large](https://github.com/user-attachments/assets/0a6a3089-8166-416a-8f69-4d671e561c57) | ![plans](https://github.com/user-attachments/assets/b7213673-4b3e-4731-8545-73dbe1f58646)

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [ ] with a landscape orientation
- [x] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
