### PR TITLE
[Auto Downloading] - Disable all podcasts auto download status when disabling the Global Auto Download

### DIFF
--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/models/db/PodcastManagerTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/models/db/PodcastManagerTest.kt
@@ -57,7 +57,7 @@ class PodcastManagerTest {
         val settings = mock<Settings> {
             on { podcastGroupingDefault } doReturn UserSetting.Mock(PodcastGrouping.None, mock())
             on { showArchivedDefault } doReturn UserSetting.Mock(false, mock())
-            on { autoDownloadNewEpisodes } doReturn UserSetting.Mock(true, mock())
+            on { autoDownloadNewEpisodes } doReturn UserSetting.Mock(Podcast.AUTO_DOWNLOAD_NEW_EPISODES, mock())
             on { autoDownloadLimit } doReturn UserSetting.Mock(AutoDownloadLimitSetting.TWO_LATEST_EPISODE, mock())
         }
 

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/AutoDownloadSettingsFragment.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/AutoDownloadSettingsFragment.kt
@@ -239,7 +239,7 @@ class AutoDownloadSettingsFragment :
     private fun handleNewEpisodesToggle(isEnabled: Boolean) {
         lifecycleScope.launch {
             if (!isEnabled) {
-                async(Dispatchers.IO) { podcastManager.updateAllAutoDownloadStatus(Podcast.AUTO_DOWNLOAD_OFF) }.await()
+                podcastManager.updateAllAutoDownloadStatus(Podcast.AUTO_DOWNLOAD_OFF)
             }
             updateNewEpisodesSwitch(isEnabled)
             updatePodcastsSummary()

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/AutoDownloadSettingsFragment.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/AutoDownloadSettingsFragment.kt
@@ -391,7 +391,6 @@ class AutoDownloadSettingsFragment :
             )
     }
 
-    @SuppressLint("CheckResult")
     private fun setupNewEpisodesToggle() {
         val value = viewModel.getAutoDownloadNewEpisodes()
         when (value) {

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/AutoDownloadSettingsFragment.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/AutoDownloadSettingsFragment.kt
@@ -238,6 +238,9 @@ class AutoDownloadSettingsFragment :
 
     private fun handleNewEpisodesToggle(isEnabled: Boolean) {
         lifecycleScope.launch {
+            if (!isEnabled) {
+                async(Dispatchers.IO) { podcastManager.updateAllAutoDownloadStatus(Podcast.AUTO_DOWNLOAD_OFF) }.await()
+            }
             updateNewEpisodesSwitch(isEnabled)
             updatePodcastsSummary()
         }

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/AutoDownloadSettingsFragment.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/AutoDownloadSettingsFragment.kt
@@ -139,6 +139,10 @@ class AutoDownloadSettingsFragment :
                 settings.bottomInset.collect {
                     view.updatePadding(bottom = it)
                 }
+                viewModel.hasEpisodesWithAutoDownloadEnabled.collect {
+                    setupNewEpisodesToggleStatusCheck()
+                    onNewEpisodesToggleChange(viewModel.getAutoDownloadNewEpisodes())
+                }
             }
         }
     }
@@ -159,7 +163,7 @@ class AutoDownloadSettingsFragment :
                 setOnPreferenceChangeListener { _, newValue ->
                     if (newValue is Boolean) {
                         viewModel.onNewEpisodesChange(newValue)
-                        handleNewEpisodesToggle(newValue.toAutoDownloadStatus())
+                        onNewEpisodesToggleChange(newValue.toAutoDownloadStatus())
                     }
                     true
                 }
@@ -238,17 +242,17 @@ class AutoDownloadSettingsFragment :
         updateView()
     }
 
-    private fun handleNewEpisodesToggle(status: Int) {
+    private fun onNewEpisodesToggleChange(status: Int) {
         lifecycleScope.launch {
             if (status == Podcast.AUTO_DOWNLOAD_OFF) {
                 viewModel.updateAllAutoDownloadStatus(Podcast.AUTO_DOWNLOAD_OFF)
             }
-            updateNewEpisodesSwitch(status)
+            updateNewEpisodesPreferencesVisibility(status)
             updatePodcastsSummary()
         }
     }
 
-    private fun updateNewEpisodesSwitch(status: Int) {
+    private fun updateNewEpisodesPreferencesVisibility(status: Int) {
         val podcastsPreference = podcastsPreference ?: return
         val podcastsLimitPreference = podcastsAutoDownloadLimitPreference ?: return
         val podcastsCategory = podcastsCategory ?: return
@@ -352,13 +356,13 @@ class AutoDownloadSettingsFragment :
         updateFiltersSelectedSummary()
 
         upNextPreference.isChecked = viewModel.getAutoDownloadUpNext()
-        setupNewEpisodesToggle()
+        setupNewEpisodesToggleStatusCheck()
         autoDownloadOnlyDownloadOnWifi.isChecked = viewModel.getAutoDownloadUnmeteredOnly()
         autoDownloadOnlyWhenCharging.isChecked = viewModel.getAutoDownloadOnlyWhenCharging()
         if (FeatureFlag.isEnabled(Feature.AUTO_DOWNLOAD)) {
             newEpisodesPreference?.summary = getString(LR.string.settings_auto_download_new_episodes_description)
         }
-        handleNewEpisodesToggle(viewModel.getAutoDownloadNewEpisodes())
+        onNewEpisodesToggleChange(viewModel.getAutoDownloadNewEpisodes())
     }
 
     private fun countPodcastsAutoDownloading(): Single<Int> {
@@ -391,7 +395,7 @@ class AutoDownloadSettingsFragment :
             )
     }
 
-    private fun setupNewEpisodesToggle() {
+    private fun setupNewEpisodesToggleStatusCheck() {
         val value = viewModel.getAutoDownloadNewEpisodes()
         when (value) {
             Podcast.AUTO_DOWNLOAD_OFF -> {

--- a/modules/features/shared/src/main/java/au/com/shiftyjelly/pocketcasts/shared/AppLifecycleObserver.kt
+++ b/modules/features/shared/src/main/java/au/com/shiftyjelly/pocketcasts/shared/AppLifecycleObserver.kt
@@ -6,6 +6,7 @@ import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.ProcessLifecycleOwner
 import au.com.shiftyjelly.pocketcasts.analytics.AppLifecycleAnalytics
+import au.com.shiftyjelly.pocketcasts.models.entity.Podcast.Companion.AUTO_DOWNLOAD_NEW_EPISODES
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.repositories.di.ApplicationScope
 import au.com.shiftyjelly.pocketcasts.utils.AppPlatform
@@ -115,7 +116,7 @@ class AppLifecycleObserver constructor(
                     settings.autoPlayNextEpisodeOnEmpty.set(true, updateModifiedAt = false)
 
                     // For new users we want to auto download new episodes by default
-                    settings.autoDownloadNewEpisodes.set(true, updateModifiedAt = false)
+                    settings.autoDownloadNewEpisodes.set(AUTO_DOWNLOAD_NEW_EPISODES, updateModifiedAt = false)
                 }
             }
         } else if (previousVersionCode < versionCode) {

--- a/modules/features/shared/src/test/java/au/com/shiftyjelly/pocketcasts/shared/AppLifecycleObserverTest.kt
+++ b/modules/features/shared/src/test/java/au/com/shiftyjelly/pocketcasts/shared/AppLifecycleObserverTest.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleOwner
 import au.com.shiftyjelly.pocketcasts.analytics.AppLifecycleAnalytics
+import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.preferences.UserSetting
 import au.com.shiftyjelly.pocketcasts.utils.AppPlatform
@@ -39,7 +40,7 @@ class AppLifecycleObserverTest {
 
     @Mock private lateinit var autoPlayNextEpisodeSetting: UserSetting<Boolean>
 
-    @Mock private lateinit var autoDownloadNewEpisodesSetting: UserSetting<Boolean>
+    @Mock private lateinit var autoDownloadNewEpisodesSetting: UserSetting<Int>
 
     @Mock private lateinit var useUpNextDarkThemeSetting: UserSetting<Boolean>
 
@@ -94,7 +95,7 @@ class AppLifecycleObserverTest {
 
         verify(appLifecycleAnalytics).onNewApplicationInstall()
         verify(autoPlayNextEpisodeSetting).set(true, updateModifiedAt = false)
-        verify(autoDownloadNewEpisodesSetting).set(true, updateModifiedAt = false)
+        verify(autoDownloadNewEpisodesSetting).set(Podcast.AUTO_DOWNLOAD_NEW_EPISODES, updateModifiedAt = false)
         verify(useUpNextDarkThemeSetting).set(false, updateModifiedAt = false)
 
         verify(appLifecycleAnalytics, never()).onApplicationUpgrade(any())

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/PodcastDao.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/PodcastDao.kt
@@ -343,7 +343,7 @@ abstract class PodcastDao {
     }
 
     @Query("UPDATE podcasts SET auto_download_status = :autoDownloadStatus")
-    abstract fun updateAllAutoDownloadStatus(autoDownloadStatus: Int)
+    abstract suspend fun updateAllAutoDownloadStatus(autoDownloadStatus: Int)
 
     @Query("UPDATE podcasts SET show_notifications = :showNotifications, show_notifications_modified = :modified, sync_status = 0")
     abstract suspend fun updateAllShowNotifications(showNotifications: Boolean, modified: Date = Date())

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/PodcastDao.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/PodcastDao.kt
@@ -240,6 +240,9 @@ abstract class PodcastDao {
     @Query("SELECT COUNT(*) FROM podcasts WHERE subscribed = 1 AND auto_download_status = :downloadStatus")
     abstract fun countDownloadStatus(downloadStatus: Int): Int
 
+    @Query("SELECT COUNT(*) > 0 FROM podcasts WHERE subscribed = 1 AND auto_download_status = :downloadStatus")
+    abstract suspend fun hasEpisodesWithAutoDownloadStatus(downloadStatus: Int): Boolean
+
     fun exists(uuid: String): Boolean {
         return countByUuid(uuid) != 0
     }

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
@@ -93,6 +93,8 @@ interface Settings {
 
         const val STORAGE_ON_CUSTOM_FOLDER = "custom_folder"
 
+        const val GLOBAL_AUTO_DOWNLOAD_NONE = -1
+
         const val PREFERENCE_BOOKMARKS_SORT_TYPE_FOR_EPISODE = "bookmarksSortTypeForEpisode"
         const val PREFERENCE_BOOKMARKS_SORT_TYPE_FOR_PLAYER = "bookmarksSortTypeForPlayer"
         const val PREFERENCE_BOOKMARKS_SORT_TYPE_FOR_PODCAST = "bookmarksSortTypeForPodcast"
@@ -332,7 +334,7 @@ interface Settings {
     val autoDownloadUnmeteredOnly: UserSetting<Boolean>
     val autoDownloadOnlyWhenCharging: UserSetting<Boolean>
     val autoDownloadUpNext: UserSetting<Boolean>
-    val autoDownloadNewEpisodes: UserSetting<Boolean>
+    val autoDownloadNewEpisodes: UserSetting<Int>
 
     val artworkConfiguration: UserSetting<ArtworkConfiguration>
 

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
@@ -19,6 +19,7 @@ import au.com.shiftyjelly.pocketcasts.models.type.Subscription
 import au.com.shiftyjelly.pocketcasts.models.type.SubscriptionFrequency
 import au.com.shiftyjelly.pocketcasts.models.type.TrimMode
 import au.com.shiftyjelly.pocketcasts.preferences.Settings.Companion.DEFAULT_MAX_AUTO_ADD_LIMIT
+import au.com.shiftyjelly.pocketcasts.preferences.Settings.Companion.GLOBAL_AUTO_DOWNLOAD_NONE
 import au.com.shiftyjelly.pocketcasts.preferences.Settings.Companion.NOTIFICATIONS_DISABLED_MESSAGE_SHOWN
 import au.com.shiftyjelly.pocketcasts.preferences.Settings.Companion.SETTINGS_ENCRYPT_SECRET
 import au.com.shiftyjelly.pocketcasts.preferences.Settings.MediaNotificationControls
@@ -550,9 +551,9 @@ class SettingsImpl @Inject constructor(
         sharedPrefs = sharedPreferences,
     )
 
-    override val autoDownloadNewEpisodes = UserSetting.BoolPref(
+    override val autoDownloadNewEpisodes = UserSetting.IntPref(
         sharedPrefKey = "autoDownloadNewEpisodes",
-        defaultValue = false,
+        defaultValue = GLOBAL_AUTO_DOWNLOAD_NONE,
         sharedPrefs = sharedPreferences,
     )
 

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
@@ -552,7 +552,7 @@ class SettingsImpl @Inject constructor(
     )
 
     override val autoDownloadNewEpisodes = UserSetting.IntPref(
-        sharedPrefKey = "autoDownloadNewEpisodes",
+        sharedPrefKey = "globalAutoDownloadNewEpisodes",
         defaultValue = GLOBAL_AUTO_DOWNLOAD_NONE,
         sharedPrefs = sharedPreferences,
     )

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PodcastManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PodcastManager.kt
@@ -75,7 +75,7 @@ interface PodcastManager {
     /** Update methods  */
     fun updatePodcast(podcast: Podcast)
 
-    fun updateAllAutoDownloadStatus(autoDownloadStatus: Int)
+    suspend fun updateAllAutoDownloadStatus(autoDownloadStatus: Int)
     suspend fun updateAllShowNotifications(showNotifications: Boolean)
     fun updateAutoDownloadStatus(podcast: Podcast, autoDownloadStatus: Int)
     suspend fun updateAutoAddToUpNext(podcast: Podcast, autoAddToUpNext: Podcast.AutoAddUpNext)

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PodcastManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PodcastManager.kt
@@ -126,6 +126,7 @@ interface PodcastManager {
     fun countSubscribedRx(): Single<Int>
     fun observeCountSubscribed(): Flowable<Int>
     fun countDownloadStatus(downloadStatus: Int): Int
+    suspend fun hasEpisodesWithAutoDownloadStatus(downloadStatus: Int): Boolean
     fun countDownloadStatusRx(downloadStatus: Int): Single<Int>
     fun countNotificationsOn(): Int
     fun countNotificationsOnRx(): Single<Int>

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PodcastManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PodcastManagerImpl.kt
@@ -620,7 +620,7 @@ class PodcastManagerImpl @Inject constructor(
         podcastDao.update(podcast)
     }
 
-    override fun updateAllAutoDownloadStatus(autoDownloadStatus: Int) {
+    override suspend fun updateAllAutoDownloadStatus(autoDownloadStatus: Int) {
         podcastDao.updateAllAutoDownloadStatus(autoDownloadStatus)
     }
 

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PodcastManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PodcastManagerImpl.kt
@@ -587,6 +587,10 @@ class PodcastManagerImpl @Inject constructor(
         return podcastDao.countDownloadStatus(downloadStatus)
     }
 
+    override suspend fun hasEpisodesWithAutoDownloadStatus(downloadStatus: Int): Boolean {
+        return podcastDao.hasEpisodesWithAutoDownloadStatus(downloadStatus)
+    }
+
     override fun countDownloadStatusRx(downloadStatus: Int): Single<Int> {
         return Single.fromCallable { countDownloadStatus(downloadStatus) }
     }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/support/Support.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/support/Support.kt
@@ -13,6 +13,7 @@ import androidx.lifecycle.toPublisher
 import androidx.work.WorkManager
 import au.com.shiftyjelly.pocketcasts.localization.R
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
+import au.com.shiftyjelly.pocketcasts.models.entity.Podcast.Companion.AUTO_DOWNLOAD_NEW_EPISODES
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.models.to.SubscriptionStatus
 import au.com.shiftyjelly.pocketcasts.models.type.SubscriptionTier
@@ -317,7 +318,7 @@ class Support @Inject constructor(
             output.append(eol)
             output.append("Auto downloads").append(eol)
             output.append("  Any podcast? ").append(yesNoString(autoDownloadOn[0])).append(eol)
-            output.append("  New Episodes? ").append(yesNoString(settings.autoDownloadNewEpisodes.value)).append(eol)
+            output.append("  New Episodes? ").append(yesNoString(settings.autoDownloadNewEpisodes.value == AUTO_DOWNLOAD_NEW_EPISODES)).append(eol)
             output.append("  Limit Downloads ").append(settings.autoDownloadLimit.value).append(eol)
             output.append("  Up Next? ").append(yesNoString(settings.autoDownloadUpNext.value)).append(eol)
             output.append("  Only on unmetered WiFi? ").append(yesNoString(settings.autoDownloadUnmeteredOnly.value)).append(eol)


### PR DESCRIPTION
## Description
- This PR adds the ability back to disable all auto download podcast status after disabling the global Auto download flag
- Put back the code that was removed here: https://github.com/Automattic/pocket-casts-android/pull/3020/files
- To handle cases where users have already configured global auto-download, I refactored `autoDownloadNewEpisodes` to be a `UserSetting<Int>` instead of a `UserSetting<Boolean>`. This change allows me to determine whether the user manually disabled the `New Episodes` toggle or if it was simply unset due to using an app version prior to `7.76`, which does not yet include the autoDownloadNewEpisodes toggle
- This issue was reported here: pdeCcb-7pt-p2#comment-5894 in our Beta Testing

## Testing Instructions

### Disable all podcasts auto download
1. Fresh install
2. Subscribe to a podcast
3. ✅ Verify the episodes are auto downloading
4. ✅ Verify the podcast has auto download enabled
5. Go to the Profile tab -> Settings cog -> Auto Download
6. Toggle off “New Episodes”
7. Go to a podcast settings page
8. ✅ Verify the auto download has been turned off for the podcast too

### App Update
1. Install the app from 946dda11c757ac87c7b4ca29dd3d8725482933b5
2. Subscribe to some podcasts and enable their auto download toggle
3. Open Profile -> Settings -> Auto Download
4. ✅ Ensure you have New Episodes toggle ON
5. Install the app from this branch
6. Open Profile -> Settings -> Auto Download
7. ✅ Ensure you have New Episodes toggle ON

## Screenshots or Screencast 
[Screen_recording_20241104_103007.webm](https://github.com/user-attachments/assets/a2e3ffa6-ac5f-45b5-975f-8c6c57128182)


## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack