### PR TITLE
[Paywall Experiment] - Update anon uuid 

### DIFF
--- a/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/experiments/ExperimentProvider.kt
+++ b/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/experiments/ExperimentProvider.kt
@@ -26,7 +26,7 @@ class ExperimentProvider @Inject constructor(
 
     fun initialize() {
         if (FeatureFlag.isEnabled(Feature.EXPLAT_EXPERIMENT)) {
-            val uuid = accountStatusInfo.getUuid().takeIf { !it.isNullOrBlank() } ?: UUID.randomUUID().toString().replace("-", "")
+            val uuid = accountStatusInfo.getUuid().takeIf { !it.isNullOrBlank() } ?: UUID.randomUUID().toString()
 
             LogBuffer.i(TAG, "Initializing experiments with uuid: $uuid")
 


### PR DESCRIPTION
## Description
- This removes the dash from the anon uuid in order to avoid this issue reported by data team: p1730400542921179/1730118881.270029-slack-C07DLM97HRQ


## Testing Instructions
Code review is fine

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.