### PR TITLE
[Project] Manage Downloaded Episodes - Add Tracks

### DIFF
--- a/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
+++ b/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
@@ -762,6 +762,7 @@ class MainActivity :
                                 analyticsTracker.track(AnalyticsEvent.FREE_UP_SPACE_MODAL_SHOWN, mapOf("source" to sourceView.analyticsValue))
                             },
                             onMaybeLaterClick = {
+                                analyticsTracker.track(AnalyticsEvent.FREE_UP_SPACE_MAYBE_LATER_TAPPED, mapOf("source" to sourceView.analyticsValue))
                                 settings.setDismissLowStorageModalTime(System.currentTimeMillis())
                             },
                             totalDownloadSize = downloadedEpisodesState.downloadedEpisodes,

--- a/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
+++ b/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
@@ -95,8 +95,6 @@ import au.com.shiftyjelly.pocketcasts.player.view.bookmark.BookmarksContainerFra
 import au.com.shiftyjelly.pocketcasts.player.view.dialog.MiniPlayerDialog
 import au.com.shiftyjelly.pocketcasts.player.view.video.VideoActivity
 import au.com.shiftyjelly.pocketcasts.podcasts.view.ProfileEpisodeListFragment
-import au.com.shiftyjelly.pocketcasts.podcasts.view.ProfileEpisodeListFragment.Companion.CLEAN_UP
-import au.com.shiftyjelly.pocketcasts.podcasts.view.ProfileEpisodeListFragment.Companion.OPTION_KEY
 import au.com.shiftyjelly.pocketcasts.podcasts.view.episode.EpisodeContainerFragment
 import au.com.shiftyjelly.pocketcasts.podcasts.view.podcast.PodcastFragment
 import au.com.shiftyjelly.pocketcasts.podcasts.view.podcasts.PodcastsFragment
@@ -757,7 +755,7 @@ class MainActivity :
                             parent = viewGroup,
                             shouldShow = shouldShow,
                             onManageDownloadsClick = {
-                                analyticsTracker.track(AnalyticsEvent.DOWNLOADS_OPTIONS_MODAL_OPTION_TAPPED, mapOf(OPTION_KEY to CLEAN_UP))
+                                analyticsTracker.track(AnalyticsEvent.FREE_UP_SPACE_MANAGE_DOWNLOADS_TAPPED, mapOf("source" to sourceView.analyticsValue))
                                 addFragment(ManualCleanupFragment.newInstance())
                             },
                             onExpanded = {

--- a/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
+++ b/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
@@ -740,7 +740,7 @@ class MainActivity :
         )
     }
 
-    private fun setupLowStorageLaunchBottomSheet() {
+    private fun setupLowStorageLaunchBottomSheet(sourceView: SourceView) {
         val viewGroup = binding.modalBottomSheet
         viewGroup.removeAllViews()
         viewGroup.addView(
@@ -761,6 +761,7 @@ class MainActivity :
                                 addFragment(ManualCleanupFragment.newInstance())
                             },
                             onExpanded = {
+                                analyticsTracker.track(AnalyticsEvent.FREE_UP_SPACE_MODAL_SHOWN, mapOf("source" to sourceView.analyticsValue))
                             },
                             onMaybeLaterClick = {
                                 settings.setDismissLowStorageModalTime(System.currentTimeMillis())
@@ -1667,9 +1668,9 @@ class MainActivity :
             .show()
     }
 
-    override fun showModal() {
+    override fun showModal(sourceView: SourceView) {
         launch(Dispatchers.Main) {
-            setupLowStorageLaunchBottomSheet()
+            setupLowStorageLaunchBottomSheet(sourceView)
         }
     }
 }

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/ProfileEpisodeListFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/ProfileEpisodeListFragment.kt
@@ -427,7 +427,10 @@ class ProfileEpisodeListFragment : BaseFragment(), Toolbar.OnMenuItemClickListen
                         }
                         ManageDownloadsCard(
                             totalDownloadSize = downloadedEpisodesSize,
-                            onManageDownloadsClick = { showCleanupSettings() },
+                            onManageDownloadsClick = {
+                                analyticsTracker.track(AnalyticsEvent.FREE_UP_SPACE_MANAGE_DOWNLOADS_TAPPED, mapOf("source" to SourceView.DOWNLOADS.analyticsValue))
+                                showFragment(ManualCleanupFragment.newInstance())
+                            },
                         )
                     }
                 }

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/ProfileEpisodeListFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/ProfileEpisodeListFragment.kt
@@ -22,6 +22,7 @@ import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTracker
 import au.com.shiftyjelly.pocketcasts.analytics.SourceView
 import au.com.shiftyjelly.pocketcasts.compose.AppTheme
+import au.com.shiftyjelly.pocketcasts.compose.CallOnce
 import au.com.shiftyjelly.pocketcasts.models.entity.BaseEpisode
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.models.type.EpisodeViewSource
@@ -421,6 +422,9 @@ class ProfileEpisodeListFragment : BaseFragment(), Toolbar.OnMenuItemClickListen
             if (isVisible) {
                 setContent {
                     AppTheme(theme.activeTheme) {
+                        CallOnce {
+                            analyticsTracker.track(AnalyticsEvent.FREE_UP_SPACE_BANNER_SHOWN)
+                        }
                         ManageDownloadsCard(
                             totalDownloadSize = downloadedEpisodesSize,
                             onManageDownloadsClick = { showCleanupSettings() },

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/AutoDownloadSettingsFragment.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/AutoDownloadSettingsFragment.kt
@@ -20,6 +20,7 @@ import androidx.preference.Preference
 import androidx.preference.PreferenceCategory
 import androidx.preference.PreferenceFragmentCompat
 import androidx.preference.SwitchPreference
+import au.com.shiftyjelly.pocketcasts.analytics.SourceView
 import au.com.shiftyjelly.pocketcasts.localization.extensions.getStringPlural
 import au.com.shiftyjelly.pocketcasts.localization.extensions.getStringPluralPodcastsSelected
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
@@ -165,7 +166,7 @@ class AutoDownloadSettingsFragment :
                         handleNewEpisodesToggle(newValue)
 
                         viewLifecycleOwner.lifecycleScope.launch {
-                            if (newValue && isDeviceRunningOnLowStorage()) lowStorageListener?.showModal()
+                            if (newValue && isDeviceRunningOnLowStorage()) lowStorageListener?.showModal(SourceView.AUTO_DOWNLOAD)
                         }
                     }
                     true

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/StorageSettingsFragment.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/StorageSettingsFragment.kt
@@ -17,6 +17,7 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
+import au.com.shiftyjelly.pocketcasts.analytics.SourceView
 import au.com.shiftyjelly.pocketcasts.compose.AppThemeWithBackground
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.repositories.file.StorageOptions
@@ -79,7 +80,7 @@ class StorageSettingsFragment : BaseFragment() {
         viewLifecycleOwner.lifecycleScope.launch {
             viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
                 if (isDeviceRunningOnLowStorage()) {
-                    lowStorageListener?.showModal()
+                    lowStorageListener?.showModal(SourceView.STORAGE_AND_DATA_USAGE)
                 }
                 viewModel.permissionRequest.collect { permissionRequest ->
                     if (permissionRequest == Manifest.permission.WRITE_EXTERNAL_STORAGE) {

--- a/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
+++ b/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
@@ -667,4 +667,5 @@ enum class AnalyticsEvent(val key: String) {
     FREE_UP_SPACE_BANNER_SHOWN("free_up_space_banner_shown"),
     FREE_UP_SPACE_MODAL_SHOWN("free_up_space_modal_shown"),
     FREE_UP_SPACE_MANAGE_DOWNLOADS_TAPPED("free_up_space_manage_downloads_tapped"),
+    FREE_UP_SPACE_MAYBE_LATER_TAPPED("free_up_space_maybe_later_tapped"),
 }

--- a/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
+++ b/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
@@ -665,4 +665,5 @@ enum class AnalyticsEvent(val key: String) {
 
     /* Free Up Space */
     FREE_UP_SPACE_BANNER_SHOWN("free_up_space_banner_shown"),
+    FREE_UP_SPACE_MODAL_SHOWN("free_up_space_modal_shown"),
 }

--- a/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
+++ b/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
@@ -662,4 +662,7 @@ enum class AnalyticsEvent(val key: String) {
     REFERRAL_PASS_BANNER_HIDE_TAPPED("referral_pass_banner_hide_tapped"),
     REFERRAL_PURCHASE_SHOWN("referral_purchase_shown"),
     REFERRAL_PURCHASE_SUCCESS("referral_purchase_success"),
+
+    /* Free Up Space */
+    FREE_UP_SPACE_BANNER_SHOWN("free_up_space_banner_shown"),
 }

--- a/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
+++ b/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
@@ -666,4 +666,5 @@ enum class AnalyticsEvent(val key: String) {
     /* Free Up Space */
     FREE_UP_SPACE_BANNER_SHOWN("free_up_space_banner_shown"),
     FREE_UP_SPACE_MODAL_SHOWN("free_up_space_modal_shown"),
+    FREE_UP_SPACE_MANAGE_DOWNLOADS_TAPPED("free_up_space_manage_downloads_tapped"),
 }

--- a/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/SourceView.kt
+++ b/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/SourceView.kt
@@ -3,6 +3,7 @@ package au.com.shiftyjelly.pocketcasts.analytics
 enum class SourceView(val analyticsValue: String) {
     AUTO_PAUSE("auto_pause"),
     AUTO_PLAY("auto_play"),
+    AUTO_DOWNLOAD("auto_download"),
     BOTTOM_SHELF("bottom_shelf"),
     CLIP_SHARING("clip_sharing"),
     CHROMECAST("chromecast"),
@@ -50,6 +51,7 @@ enum class SourceView(val analyticsValue: String) {
     UNKNOWN("unknown"),
     UP_NEXT("up_next"),
     WHATS_NEW("whats_new"),
+    STORAGE_AND_DATA_USAGE("storage_and_data_usage"),
     WIDGET_PLAYER_LARGE("widget_player_large"),
     WIDGET_PLAYER_MEDIUM("widget_player_medium"),
     WIDGET_PLAYER_OLD("widget_player_old"),

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
@@ -541,6 +541,7 @@ open class PlaybackManager @Inject constructor(
         when (sourceView) {
             SourceView.AUTO_PAUSE,
             SourceView.AUTO_PLAY,
+            SourceView.AUTO_DOWNLOAD,
             SourceView.CLIP_SHARING,
             SourceView.CHROMECAST,
             SourceView.DISCOVER,
@@ -568,6 +569,7 @@ open class PlaybackManager @Inject constructor(
             SourceView.UP_NEXT,
             SourceView.STATS,
             SourceView.WHATS_NEW,
+            SourceView.STORAGE_AND_DATA_USAGE,
             SourceView.NOTIFICATION_BOOKMARK,
             SourceView.METERED_NETWORK_CHANGE,
             SourceView.WIDGET_PLAYER_SMALL,

--- a/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/lowstorage/LowStorageDialog.kt
+++ b/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/lowstorage/LowStorageDialog.kt
@@ -23,6 +23,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.dp
+import au.com.shiftyjelly.pocketcasts.analytics.SourceView
 import au.com.shiftyjelly.pocketcasts.compose.AppThemeWithBackground
 import au.com.shiftyjelly.pocketcasts.compose.bottomsheet.ModalBottomSheet
 import au.com.shiftyjelly.pocketcasts.compose.buttons.RowButton
@@ -158,5 +159,5 @@ fun PreviewLowStorageDialog(@PreviewParameter(ThemePreviewParameterProvider::cla
 }
 
 interface LowStorageBottomSheetListener {
-    fun showModal()
+    fun showModal(sourceView: SourceView)
 }


### PR DESCRIPTION
## Description
- This add tracks for managing downloads
- See: pdeCcb-7pb-p2

Fixes #3102

## Testing Instructions
1. Apply this [track-mock.patch](https://github.com/user-attachments/files/17621355/track-mock.patch)
2. Download an episode
3. Go to Profile -> Downloads
4. ✅ Ensure you see the free up space banner and `free_up_space_banner_shown` event is tracked
5. Tap on Manage Downloads
6. ✅ Ensure `free_up_space_manage_downloads_tapped, Properties: {"source":"downloads"` is tracked
7. Go to Profile -> Storage & data usage
8. See the free up space modal
9. ✅ Ensure you see the free up space modal and `free_up_space_modal_shown, Properties: {"source":"storage_and_data_usage"` event is tracked
10. Tap on Manage Downloads
11. ✅ Ensure `free_up_space_manage_downloads_tapped, Properties: {"source":"storage_and_data_usage"` event is tracked
12. Open the modal again
13. Tap on Maybe Later
14. ✅ Ensure `free_up_space_maybe_later_tapped, Properties: {"source":"storage_and_data_usage"` event is tracked
15. Go to Profile -> Auto Download
16. Turn on `New Episodes` toggle
17. ✅ Ensure `free_up_space_modal_shown, Properties: {"source":"auto_download"` is tracked
18. Tap on Manage Downloads
11. ✅ Ensure `free_up_space_manage_downloads_tapped, Properties: {"source":"auto_download"` event is tracked
12. Open the modal again
13. Tap on Maybe Later
14. ✅ Ensure `free_up_space_maybe_later_tapped, Properties: {"source":"auto_download"` event is tracked

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.