### PR TITLE
[Paywall Experiment] - Run Experiment only from onboarding and profile

### DIFF
--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/OnboardingUpgradeFeaturesViewModel.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/OnboardingUpgradeFeaturesViewModel.kt
@@ -104,8 +104,11 @@ class OnboardingUpgradeFeaturesViewModel @Inject constructor(
 
         val showNotNow = source == OnboardingUpgradeSource.RECOMMENDATIONS
 
+        val isEligibleForExperiment = source == OnboardingUpgradeSource.PROFILE || source == OnboardingUpgradeSource.RECOMMENDATIONS
+
         val upgradeLayout = when {
             showPatronOnly -> UpgradeLayout.Original
+            !isEligibleForExperiment -> UpgradeLayout.Original
             FeatureFlag.isEnabled(Feature.EXPLAT_EXPERIMENT) -> {
                 when (val variation = experiments.getVariation(Experiment.PaywallUpgradeAATest)) {
                     is Variation.Control -> {


### PR DESCRIPTION
## Description
- We decided to run the experiment only from onBoarding and Profile source. The others source will always open the original paywall layout
- See: p1730319424980979/1730077568.183099-slack-C07T08CTND9

Fixes #3143

## Testing Instructions
1. Apply [updated.patch](https://github.com/user-attachments/files/17647669/updated.patch) to mock the experiment to run Reviews Layout
2. Run the app
4. Start the account creation flow
5. ✅ After tap on `Not now` from recommendation screen, you should see the Reviews Layout Paywall Experiment
6. Go to Profile
7. Scroll down and tap on the learn more banner about plus
8.  ✅ You should see the Reviews Layout Paywall Experiment
9. Try to open the paywall from others sources such as folders, bookmark, etc
10. ✅ You should see the original paywall layout


## Screenshots or Screencast 
[Screen_recording_20241104_160125.webm](https://github.com/user-attachments/assets/cd27becd-62c2-4e27-a005-0f9d64624a84)


## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.