### PR TITLE
Don't update episode metadata on Wear OS or Automotive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 *   Updates
     *   Renamed the podcast action 'Subscribe' to 'Follow'
         ([#3120](https://github.com/Automattic/pocket-casts-android/pull/3120))
+    *   Improve the performance of the refresh on Wear OS and Android Automotive
+        ([#3171](https://github.com/Automattic/pocket-casts-android/pull/3171))
     *   Improve connection when some podcasts failed to play or download
         ([#3180](https://github.com/Automattic/pocket-casts-android/pull/3180))
 *   Bug Fixes

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/download/UpdateEpisodeDetailsTask.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/download/UpdateEpisodeDetailsTask.kt
@@ -35,7 +35,7 @@ class UpdateEpisodeDetailsTask @AssistedInject constructor(
         private const val TASK_NAME = "UpdateEpisodeDetailsTask"
         const val INPUT_EPISODE_UUIDS = "episode_uuids"
         private const val REQUEST_TIMEOUT_SECS = 20L
-        private const val RETRY_ATTEMPT_LIMIT = 3
+        private const val ATTEMPT_LIMIT = 3
 
         fun enqueue(episodes: List<PodcastEpisode>, context: Context) {
             // As Wear OS or Automotive are both have limited resources and they won't play audio don't check the episode content type and file size
@@ -127,14 +127,16 @@ class UpdateEpisodeDetailsTask @AssistedInject constructor(
         }
     }
 
-    private fun retryWithLimit(): Result =
-        if (runAttemptCount < RETRY_ATTEMPT_LIMIT) {
+    private fun retryWithLimit(): Result {
+        val attempt = runAttemptCount + 1
+        return if (attempt < ATTEMPT_LIMIT) {
             Result.retry()
         } else {
-            info("Worker stopped after $runAttemptCount retries.")
+            info("Worker stopped after $attempt attempts.")
             // mark the worker as a success or it will won't process all the chain tasks
             Result.success()
         }
+    }
 
     /**
      * Log a message to the log buffer for support and to the console for debugging.

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/download/UpdateEpisodeDetailsTask.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/download/UpdateEpisodeDetailsTask.kt
@@ -35,7 +35,7 @@ class UpdateEpisodeDetailsTask @AssistedInject constructor(
         private const val TASK_NAME = "UpdateEpisodeDetailsTask"
         const val INPUT_EPISODE_UUIDS = "episode_uuids"
         private const val REQUEST_TIMEOUT_SECS = 20L
-        private const val ATTEMPT_LIMIT = 3
+        private const val MAX_RETRIES = 3
 
         fun enqueue(episodes: List<PodcastEpisode>, context: Context) {
             // As Wear OS or Automotive are both have limited resources and they won't play audio don't check the episode content type and file size
@@ -129,7 +129,7 @@ class UpdateEpisodeDetailsTask @AssistedInject constructor(
 
     private fun retryWithLimit(): Result {
         val attempt = runAttemptCount + 1
-        return if (attempt < ATTEMPT_LIMIT) {
+        return if (attempt < MAX_RETRIES) {
             Result.retry()
         } else {
             info("Worker stopped after $attempt attempts.")

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManagerImpl.kt
@@ -841,10 +841,8 @@ class EpisodeManagerImpl @Inject constructor(
             }
         }
 
-        if (episodes.isNotEmpty()) {
-            if (downloadMetaData) {
-                downloadEpisodesFileDetails(episodes)
-            }
+        if (addedEpisodes.isNotEmpty() && downloadMetaData) {
+            downloadEpisodesFileDetails(addedEpisodes)
         }
 
         return addedEpisodes

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/refresh/RefreshPodcastsThread.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/refresh/RefreshPodcastsThread.kt
@@ -315,7 +315,7 @@ class RefreshPodcastsThread(
             }
 
             // only download the meta data for this episode for the first 10 episodes, after that we'd overwhelm the users phone
-            val downloadMetaData = episodes.size + newEpisodeCount < 10
+            val downloadMetaData = !podcast.isAutoDownloadNewEpisodes && (episodes.size + newEpisodeCount < 10)
             val addedDate = Date()
             for (episode in episodes) {
                 episode.addedDate = addedDate


### PR DESCRIPTION
## Description

This contains two changes:
- On Wear OS and Android Automotive, it disables the background job that checks the episode content type and file size. As these both have limited resources and neither play video I think it would be good not to add this processing when the app finds new episodes.
- There could be the case that these jobs would retry forever. To stop this happening I have added a retry limit for three.

## Testing Instructions
1. Apply this patch to make it easier to test [testing.patch](https://github.com/user-attachments/files/17674050/testing.patch)
2. Deploy the app to an Automotive emulator
3. In the app play an episode to subscribe to the podcast
4. Tap the settings cog and refresh
5. ✅ Verify no tasks have been created by filtering logcat for `UpdateEpisodeDetailsTask` 
6. Deploy the app to a Wear OS emulator
7. Make sure you are subscribed to a podcast
8. In the app tap the Settings -> Refresh now
9. ✅ Verify no tasks have been created by filtering logcat for `UpdateEpisodeDetailsTask` 
10. Fresh install the app to an phone emulator
11. Subscribe to a podcast
12. Cause a new episode by tapping Profile -> Settings cog -> Developer -> Delete first episodes and then Force refresh
13. Open the logcat window and filter by "Worker"
14. ✅ Verify there is three retries 
```
Worker result RETRY for Work [ id=bb598988-7f66-4bac-82ed-ffe4cd14ab96, tags={ au.com.shiftyjelly.pocketcasts.repositories.download.UpdateEpisodeDetailsTask } ]
Worker result RETRY for Work [ id=bb598988-7f66-4bac-82ed-ffe4cd14ab96, tags={ au.com.shiftyjelly.pocketcasts.repositories.download.UpdateEpisodeDetailsTask } ]
BgTask: UpdateEpisodeDetailsTask (Worker ID: bb598988-7f66-4bac-82ed-ffe4cd14ab96) - Worker stopped after 3 attempts.
```

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack
