### PR TITLE
Don't download episode metadata when already downloaded

### DIFF
--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/download/UpdateEpisodeDetailsTask.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/download/UpdateEpisodeDetailsTask.kt
@@ -60,7 +60,7 @@ class UpdateEpisodeDetailsTask @AssistedInject constructor(
         }
 
         /**
-         * Don't bother calling episodes that are downloaded as the download tasks checks the content type.
+         * Don't bother calling episodes that are downloaded as the download task checks the content type.
          */
         private fun ignoreEpisode(episode: PodcastEpisode): Boolean {
             return episode.isQueued || episode.isDownloaded || episode.isDownloading || episode.isArchived

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/download/UpdateEpisodeDetailsTask.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/download/UpdateEpisodeDetailsTask.kt
@@ -59,10 +59,8 @@ class UpdateEpisodeDetailsTask @AssistedInject constructor(
             WorkManager.getInstance(context).beginUniqueWork(TASK_NAME, ExistingWorkPolicy.APPEND, workRequest).enqueue()
         }
 
-        /**
-         * Don't bother calling episodes that are downloaded as the download task checks the content type.
-         */
         private fun ignoreEpisode(episode: PodcastEpisode): Boolean {
+            // Skip metadata check for episodes that are already downloaded, as the download task also checks the content type.
             return episode.isQueued || episode.isDownloaded || episode.isDownloading || episode.isArchived
         }
     }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/download/UpdateEpisodeDetailsTask.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/download/UpdateEpisodeDetailsTask.kt
@@ -43,7 +43,11 @@ class UpdateEpisodeDetailsTask @AssistedInject constructor(
                 return
             }
 
-            val episodeUuids = episodes.map { it.uuid }
+            val episodeUuids = episodes.filterNot { ignoreEpisode(it) }.map { it.uuid }
+            if (episodeUuids.isEmpty()) {
+                LogBuffer.i(LogBuffer.TAG_BACKGROUND_TASKS, "$TASK_NAME - no episodes found to check")
+                return
+            }
             LogBuffer.i(LogBuffer.TAG_BACKGROUND_TASKS, "$TASK_NAME - enqueued ${episodeUuids.joinToString()}")
             val workData = Data.Builder()
                 .putStringArray(INPUT_EPISODE_UUIDS, episodeUuids.toTypedArray())
@@ -53,6 +57,13 @@ class UpdateEpisodeDetailsTask @AssistedInject constructor(
                 .setInputData(workData)
                 .build()
             WorkManager.getInstance(context).beginUniqueWork(TASK_NAME, ExistingWorkPolicy.APPEND, workRequest).enqueue()
+        }
+
+        /**
+         * Don't bother calling episodes that are downloaded as the download tasks checks the content type.
+         */
+        private fun ignoreEpisode(episode: PodcastEpisode): Boolean {
+            return episode.isQueued || episode.isDownloaded || episode.isDownloading || episode.isArchived
         }
     }
 
@@ -75,6 +86,10 @@ class UpdateEpisodeDetailsTask @AssistedInject constructor(
 
             for (episodeUuid in episodeUuids) {
                 val episode = episodeManager.findByUuid(episodeUuid) ?: continue
+                if (ignoreEpisode(episode)) {
+                    info("Ignoring episode ${episode.uuid}")
+                    continue
+                }
                 val downloadUrl = episode.downloadUrl?.toHttpUrlOrNull() ?: continue
                 val request = Request.Builder()
                     .url(downloadUrl)

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManagerImpl.kt
@@ -843,7 +843,7 @@ class EpisodeManagerImpl @Inject constructor(
 
         if (episodes.isNotEmpty()) {
             if (downloadMetaData) {
-                downloadEpisodesFileDetails(episodes)
+                downloadEpisodesFileDetails(addedEpisodes)
             }
         }
 

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManagerImpl.kt
@@ -841,10 +841,8 @@ class EpisodeManagerImpl @Inject constructor(
             }
         }
 
-        if (episodes.isNotEmpty()) {
-            if (downloadMetaData) {
-                downloadEpisodesFileDetails(addedEpisodes)
-            }
+        if (addedEpisodes.isNotEmpty() && downloadMetaData) {
+            downloadEpisodesFileDetails(addedEpisodes)
         }
 
         return addedEpisodes

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/refresh/RefreshPodcastsThread.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/refresh/RefreshPodcastsThread.kt
@@ -315,7 +315,7 @@ class RefreshPodcastsThread(
             }
 
             // only download the meta data for this episode for the first 10 episodes, after that we'd overwhelm the users phone
-            val downloadMetaData = episodes.size + newEpisodeCount < 10
+            val downloadMetaData = !podcast.isAutoDownloadNewEpisodes && (episodes.size + newEpisodeCount < 10)
             val addedDate = Date()
             for (episode in episodes) {
                 episode.addedDate = addedDate


### PR DESCRIPTION
## Description

If episodes are auto downloading there is no need also to download the content type and file size in a separate task.  The content type logic is also [found here](https://github.com/Automattic/pocket-casts-android/blob/main/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/download/task/DownloadEpisodeTask.kt#L590) in the download episode task.

## Testing Instructions

1. Fresh install the app
2. Subscribe to a podcast
3. Cause a new episode by tapping Profile -> Settings cog -> Developer -> Delete first episodes and then Force refresh
4. In Android Studio open the App Inspection tool window and the Background Task Inspector task
5. ✅ Verify that no metadata tasks have run `UpdateEpisodeDetailsTask` 

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack
