### PR TITLE
Add click action to EoY sheet's image

### DIFF
--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/ui/EndOfYearLaunchBottomSheet.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/ui/EndOfYearLaunchBottomSheet.kt
@@ -7,6 +7,7 @@ import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.PaddingValues
@@ -19,10 +20,13 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.pager.VerticalPager
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.ModalBottomSheetValue
+import androidx.compose.material.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -35,6 +39,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import au.com.shiftyjelly.pocketcasts.compose.bottomsheet.BottomSheetContentState
 import au.com.shiftyjelly.pocketcasts.compose.bottomsheet.ModalBottomSheet
+import kotlinx.coroutines.launch
 import au.com.shiftyjelly.pocketcasts.images.R as IR
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
@@ -46,16 +51,29 @@ fun EndOfYearLaunchBottomSheet(
     onClick: () -> Unit,
     onExpanded: () -> Unit,
 ) {
+    val sheetState = rememberModalBottomSheetState(
+        initialValue = ModalBottomSheetValue.Hidden,
+        skipHalfExpanded = true,
+    )
+    val scope = rememberCoroutineScope()
     ModalBottomSheet(
         parent = parent,
+        sheetState = sheetState,
         shouldShow = shouldShow,
         onExpanded = onExpanded,
         content = BottomSheetContentState.Content(
-            imageContent = { ImageContent(modifier) },
+            imageContent = {
+                ImageContent(
+                    modifier = modifier.clickable {
+                        onClick()
+                        scope.launch { sheetState.hide() }
+                    },
+                )
+            },
             summaryText = stringResource(LR.string.end_of_year_launch_modal_summary),
             primaryButton = BottomSheetContentState.Content.Button.Primary(
                 label = stringResource(LR.string.end_of_year_launch_modal_primary_button_title),
-                onClick = { onClick.invoke() },
+                onClick = onClick,
             ),
         ),
     )

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/bottomsheet/ModalBottomSheet.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/bottomsheet/ModalBottomSheet.kt
@@ -26,11 +26,11 @@ fun ModalBottomSheet(
     onExpanded: () -> Unit,
     shouldShow: Boolean,
     content: BottomSheetContentState.Content,
-) {
-    val sheetState = rememberModalBottomSheetState(
+    sheetState: ModalBottomSheetState = rememberModalBottomSheetState(
         initialValue = ModalBottomSheetValue.Hidden,
         skipHalfExpanded = true,
-    )
+    ),
+) {
     val coroutineScope = rememberCoroutineScope()
     var isSheetShown by remember { mutableStateOf(false) }
 
@@ -132,7 +132,7 @@ private fun hideBottomSheet(coroutineScope: CoroutineScope, sheetState: ModalBot
     }
 }
 
-fun displayBottomSheet(coroutineScope: CoroutineScope, sheetState: ModalBottomSheetState) {
+private fun displayBottomSheet(coroutineScope: CoroutineScope, sheetState: ModalBottomSheetState) {
     coroutineScope.launch {
         sheetState.show()
     }


### PR DESCRIPTION
## Description

Part of feedback from #3169

> In the [what's new sheet](https://www.figma.com/design/lH66LwxxgG8btQ8NrM0ldx/Playback?node-id=3089-20982&t=fglMq3JryXUDJ2jk-1) that announces the feature let's add a link to the image and not just the CTA

## Testing Instructions

1. Sign in.
2. Close the app.
3. Open the app.
4. PB24 bottom sheet should appear.
5. Tap on the image.
6. PB24 should start.

## Checklist
- [ ] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] ~I have considered whether it makes sense to add tests for my changes~
- [ ] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [ ] ~Any jetpack compose components I added or changed are covered by compose previews~
- [ ] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~