### PR TITLE
Extend story preview duration to 10 seconds

### DIFF
--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/to/Story.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/to/Story.kt
@@ -6,7 +6,7 @@ import kotlin.time.Duration.Companion.seconds
 import au.com.shiftyjelly.pocketcasts.models.to.LongestEpisode as LongestEpisodeData
 
 sealed interface Story {
-    val previewDuration: Duration? get() = 7.seconds
+    val previewDuration: Duration? get() = 10.seconds
     val isFree: Boolean get() = true
     val isShareble: Boolean get() = true
     val analyticsValue: String


### PR DESCRIPTION
## Description

Part of feedback from #3169

> Like I suggested for iOS, let's add 3s to the amount of time each story persists before jumping to the next one.

## Testing Instructions

1. Start PB24.
2. Notice that stories auto-progress every 10 seconds instead o 7.

## Checklist
- [ ] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] ~I have considered whether it makes sense to add tests for my changes~
- [ ] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [ ] ~Any jetpack compose components I added or changed are covered by compose previews~
- [ ] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~