### PR TITLE
Add configurable duartion formatting

### DIFF
--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/localization/helper/DurationUtilTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/localization/helper/DurationUtilTest.kt
@@ -1,6 +1,7 @@
 package au.com.shiftyjelly.pocketcasts.localization.helper
 
 import androidx.test.platform.app.InstrumentationRegistry
+import kotlin.time.Duration
 import kotlin.time.Duration.Companion.days
 import kotlin.time.Duration.Companion.hours
 import kotlin.time.Duration.Companion.minutes
@@ -192,5 +193,41 @@ class DurationUtilTest {
         val text = duration.toFriendlyString(resources)
 
         assertEquals("1 day 3 minutes", text)
+    }
+
+    @Test
+    fun neagtiveDuration() {
+        val duration = -1.days - 2.hours - 3.minutes - 5.seconds
+
+        val text = duration.toFriendlyString(resources)
+
+        assertEquals("0 seconds", text)
+    }
+
+    @Test
+    fun zeroDuration() {
+        val duration = Duration.ZERO
+
+        val text = duration.toFriendlyString(resources)
+
+        assertEquals("0 seconds", text)
+    }
+
+    @Test
+    fun mismatchedMinAndMaxUnits() {
+        val duration = 1.days + 2.hours + 3.minutes + 4.seconds
+
+        val text = duration.toFriendlyString(resources, minUnit = FriendlyDurationUnit.Hour, maxUnit = FriendlyDurationUnit.Minute)
+
+        assertEquals("26 hours", text)
+    }
+
+    @Test
+    fun largeDuration() {
+        val duration = 100.days + 2.hours + 3.minutes + 4.seconds
+
+        val text = duration.toFriendlyString(resources)
+
+        assertEquals("100 days 2 hours", text)
     }
 }

--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/localization/helper/DurationUtilTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/localization/helper/DurationUtilTest.kt
@@ -16,7 +16,7 @@ class DurationUtilTest {
     fun daysSingular() {
         val duration = 1.days
 
-        val text = duration.toFriendlyStirng(resources)
+        val text = duration.toFriendlyString(resources)
 
         assertEquals("1 day", text)
     }
@@ -25,7 +25,7 @@ class DurationUtilTest {
     fun daysPlural() {
         val duration = 2.days
 
-        val text = duration.toFriendlyStirng(resources)
+        val text = duration.toFriendlyString(resources)
 
         assertEquals("2 days", text)
     }
@@ -34,7 +34,7 @@ class DurationUtilTest {
     fun hoursSingular() {
         val duration = 1.hours
 
-        val text = duration.toFriendlyStirng(resources)
+        val text = duration.toFriendlyString(resources)
 
         assertEquals("1 hour", text)
     }
@@ -43,7 +43,7 @@ class DurationUtilTest {
     fun hoursPlural() {
         val duration = 2.hours
 
-        val text = duration.toFriendlyStirng(resources)
+        val text = duration.toFriendlyString(resources)
 
         assertEquals("2 hours", text)
     }
@@ -52,7 +52,7 @@ class DurationUtilTest {
     fun minutesSingular() {
         val duration = 1.minutes
 
-        val text = duration.toFriendlyStirng(resources)
+        val text = duration.toFriendlyString(resources)
 
         assertEquals("1 minute", text)
     }
@@ -61,7 +61,7 @@ class DurationUtilTest {
     fun minutesPlural() {
         val duration = 2.minutes
 
-        val text = duration.toFriendlyStirng(resources)
+        val text = duration.toFriendlyString(resources)
 
         assertEquals("2 minutes", text)
     }
@@ -70,7 +70,7 @@ class DurationUtilTest {
     fun secondsSingular() {
         val duration = 1.seconds
 
-        val text = duration.toFriendlyStirng(resources)
+        val text = duration.toFriendlyString(resources)
 
         assertEquals("1 second", text)
     }
@@ -79,7 +79,7 @@ class DurationUtilTest {
     fun secondsPlural() {
         val duration = 2.seconds
 
-        val text = duration.toFriendlyStirng(resources)
+        val text = duration.toFriendlyString(resources)
 
         assertEquals("2 seconds", text)
     }
@@ -88,7 +88,7 @@ class DurationUtilTest {
     fun subSecondDurationIsZeroSeconds() {
         val duration = 1.seconds - 1.nanoseconds
 
-        val text = duration.toFriendlyStirng(resources)
+        val text = duration.toFriendlyString(resources)
 
         assertEquals("0 seconds", text)
     }
@@ -97,7 +97,7 @@ class DurationUtilTest {
     fun maxLimitDurationToDays() {
         val duration = 1.days + 2.hours + 3.minutes + 4.seconds
 
-        val text = duration.toFriendlyStirng(resources, maxUnit = FriendlyDurationUnit.Day)
+        val text = duration.toFriendlyString(resources, maxUnit = FriendlyDurationUnit.Day)
 
         assertEquals("1 day 2 hours", text)
     }
@@ -106,7 +106,7 @@ class DurationUtilTest {
     fun maxLimitDurationToHours() {
         val duration = 1.days + 2.hours + 3.minutes + 4.seconds
 
-        val text = duration.toFriendlyStirng(resources, maxUnit = FriendlyDurationUnit.Hours)
+        val text = duration.toFriendlyString(resources, maxUnit = FriendlyDurationUnit.Hour)
 
         assertEquals("26 hours 3 minutes", text)
     }
@@ -115,7 +115,7 @@ class DurationUtilTest {
     fun maxLimitDurationToMinutes() {
         val duration = 1.days + 2.hours + 3.minutes + 4.seconds
 
-        val text = duration.toFriendlyStirng(resources, maxUnit = FriendlyDurationUnit.Minute)
+        val text = duration.toFriendlyString(resources, maxUnit = FriendlyDurationUnit.Minute)
 
         assertEquals("1563 minutes 4 seconds", text)
     }
@@ -124,7 +124,7 @@ class DurationUtilTest {
     fun maxLimitDurationToSeconds() {
         val duration = 1.days + 2.hours + 3.minutes + 4.seconds
 
-        val text = duration.toFriendlyStirng(resources, maxUnit = FriendlyDurationUnit.Second)
+        val text = duration.toFriendlyString(resources, maxUnit = FriendlyDurationUnit.Second)
 
         assertEquals("93784 seconds", text)
     }
@@ -133,7 +133,7 @@ class DurationUtilTest {
     fun minLimitDurationToDays() {
         val duration = 1.days + 2.hours + 3.minutes + 4.seconds
 
-        val text = duration.toFriendlyStirng(resources, minUnit = FriendlyDurationUnit.Day, maxPartCount = 4)
+        val text = duration.toFriendlyString(resources, minUnit = FriendlyDurationUnit.Day, maxPartCount = 4)
 
         assertEquals("1 day", text)
     }
@@ -142,7 +142,7 @@ class DurationUtilTest {
     fun minLimitDurationToHours() {
         val duration = 1.days + 2.hours + 3.minutes + 4.seconds
 
-        val text = duration.toFriendlyStirng(resources, minUnit = FriendlyDurationUnit.Hours, maxPartCount = 4)
+        val text = duration.toFriendlyString(resources, minUnit = FriendlyDurationUnit.Hour, maxPartCount = 4)
 
         assertEquals("1 day 2 hours", text)
     }
@@ -151,7 +151,7 @@ class DurationUtilTest {
     fun minLimitDurationToMinutes() {
         val duration = 1.days + 2.hours + 3.minutes + 4.seconds
 
-        val text = duration.toFriendlyStirng(resources, minUnit = FriendlyDurationUnit.Minute, maxPartCount = 4)
+        val text = duration.toFriendlyString(resources, minUnit = FriendlyDurationUnit.Minute, maxPartCount = 4)
 
         assertEquals("1 day 2 hours 3 minutes", text)
     }
@@ -160,7 +160,7 @@ class DurationUtilTest {
     fun minLimitDurationToSeconds() {
         val duration = 1.days + 2.hours + 3.minutes + 4.seconds
 
-        val text = duration.toFriendlyStirng(resources, minUnit = FriendlyDurationUnit.Second, maxPartCount = 4)
+        val text = duration.toFriendlyString(resources, minUnit = FriendlyDurationUnit.Second, maxPartCount = 4)
 
         assertEquals("1 day 2 hours 3 minutes 4 seconds", text)
     }
@@ -169,27 +169,27 @@ class DurationUtilTest {
     fun limitPartsToMaxPartCount() {
         val duration = 1.days + 2.hours + 3.minutes + 4.seconds
 
-        assertEquals("1 day 2 hours 3 minutes 4 seconds", duration.toFriendlyStirng(resources, maxPartCount = 4))
-        assertEquals("1 day 2 hours 3 minutes", duration.toFriendlyStirng(resources, maxPartCount = 3))
-        assertEquals("1 day 2 hours", duration.toFriendlyStirng(resources, maxPartCount = 2))
-        assertEquals("1 day", duration.toFriendlyStirng(resources, maxPartCount = 1))
+        assertEquals("1 day 2 hours 3 minutes 4 seconds", duration.toFriendlyString(resources, maxPartCount = 4))
+        assertEquals("1 day 2 hours 3 minutes", duration.toFriendlyString(resources, maxPartCount = 3))
+        assertEquals("1 day 2 hours", duration.toFriendlyString(resources, maxPartCount = 2))
+        assertEquals("1 day", duration.toFriendlyString(resources, maxPartCount = 1))
     }
 
     @Test
     fun useMinUnitIfMaxPartCountIsTooLow() {
         val duration = 1.days + 2.hours + 3.minutes + 4.seconds
 
-        assertEquals("1 day", duration.toFriendlyStirng(resources, minUnit = FriendlyDurationUnit.Day, maxPartCount = 0))
-        assertEquals("26 hours", duration.toFriendlyStirng(resources, minUnit = FriendlyDurationUnit.Hours, maxPartCount = 0))
-        assertEquals("1563 minutes", duration.toFriendlyStirng(resources, minUnit = FriendlyDurationUnit.Minute, maxPartCount = 0))
-        assertEquals("93784 seconds", duration.toFriendlyStirng(resources, minUnit = FriendlyDurationUnit.Second, maxPartCount = 0))
+        assertEquals("1 day", duration.toFriendlyString(resources, minUnit = FriendlyDurationUnit.Day, maxPartCount = 0))
+        assertEquals("26 hours", duration.toFriendlyString(resources, minUnit = FriendlyDurationUnit.Hour, maxPartCount = 0))
+        assertEquals("1563 minutes", duration.toFriendlyString(resources, minUnit = FriendlyDurationUnit.Minute, maxPartCount = 0))
+        assertEquals("93784 seconds", duration.toFriendlyString(resources, minUnit = FriendlyDurationUnit.Second, maxPartCount = 0))
     }
 
     @Test
     fun skipZeroParts() {
         val duration = 1.days + 3.minutes // no hours
 
-        val text = duration.toFriendlyStirng(resources)
+        val text = duration.toFriendlyString(resources)
 
         assertEquals("1 day 3 minutes", text)
     }

--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/localization/helper/DurationUtilTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/localization/helper/DurationUtilTest.kt
@@ -1,0 +1,196 @@
+package au.com.shiftyjelly.pocketcasts.localization.helper
+
+import androidx.test.platform.app.InstrumentationRegistry
+import kotlin.time.Duration.Companion.days
+import kotlin.time.Duration.Companion.hours
+import kotlin.time.Duration.Companion.minutes
+import kotlin.time.Duration.Companion.nanoseconds
+import kotlin.time.Duration.Companion.seconds
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class DurationUtilTest {
+    private val resources = InstrumentationRegistry.getInstrumentation().targetContext.resources
+
+    @Test
+    fun daysSingular() {
+        val duration = 1.days
+
+        val text = duration.toFriendlyStirng(resources)
+
+        assertEquals("1 day", text)
+    }
+
+    @Test
+    fun daysPlural() {
+        val duration = 2.days
+
+        val text = duration.toFriendlyStirng(resources)
+
+        assertEquals("2 days", text)
+    }
+
+    @Test
+    fun hoursSingular() {
+        val duration = 1.hours
+
+        val text = duration.toFriendlyStirng(resources)
+
+        assertEquals("1 hour", text)
+    }
+
+    @Test
+    fun hoursPlural() {
+        val duration = 2.hours
+
+        val text = duration.toFriendlyStirng(resources)
+
+        assertEquals("2 hours", text)
+    }
+
+    @Test
+    fun minutesSingular() {
+        val duration = 1.minutes
+
+        val text = duration.toFriendlyStirng(resources)
+
+        assertEquals("1 minute", text)
+    }
+
+    @Test
+    fun minutesPlural() {
+        val duration = 2.minutes
+
+        val text = duration.toFriendlyStirng(resources)
+
+        assertEquals("2 minutes", text)
+    }
+
+    @Test
+    fun secondsSingular() {
+        val duration = 1.seconds
+
+        val text = duration.toFriendlyStirng(resources)
+
+        assertEquals("1 second", text)
+    }
+
+    @Test
+    fun secondsPlural() {
+        val duration = 2.seconds
+
+        val text = duration.toFriendlyStirng(resources)
+
+        assertEquals("2 seconds", text)
+    }
+
+    @Test
+    fun subSecondDurationIsZeroSeconds() {
+        val duration = 1.seconds - 1.nanoseconds
+
+        val text = duration.toFriendlyStirng(resources)
+
+        assertEquals("0 seconds", text)
+    }
+
+    @Test
+    fun maxLimitDurationToDays() {
+        val duration = 1.days + 2.hours + 3.minutes + 4.seconds
+
+        val text = duration.toFriendlyStirng(resources, maxUnit = FriendlyDurationUnit.Day)
+
+        assertEquals("1 day 2 hours", text)
+    }
+
+    @Test
+    fun maxLimitDurationToHours() {
+        val duration = 1.days + 2.hours + 3.minutes + 4.seconds
+
+        val text = duration.toFriendlyStirng(resources, maxUnit = FriendlyDurationUnit.Hours)
+
+        assertEquals("26 hours 3 minutes", text)
+    }
+
+    @Test
+    fun maxLimitDurationToMinutes() {
+        val duration = 1.days + 2.hours + 3.minutes + 4.seconds
+
+        val text = duration.toFriendlyStirng(resources, maxUnit = FriendlyDurationUnit.Minute)
+
+        assertEquals("1563 minutes 4 seconds", text)
+    }
+
+    @Test
+    fun maxLimitDurationToSeconds() {
+        val duration = 1.days + 2.hours + 3.minutes + 4.seconds
+
+        val text = duration.toFriendlyStirng(resources, maxUnit = FriendlyDurationUnit.Second)
+
+        assertEquals("93784 seconds", text)
+    }
+
+    @Test
+    fun minLimitDurationToDays() {
+        val duration = 1.days + 2.hours + 3.minutes + 4.seconds
+
+        val text = duration.toFriendlyStirng(resources, minUnit = FriendlyDurationUnit.Day, maxPartCount = 4)
+
+        assertEquals("1 day", text)
+    }
+
+    @Test
+    fun minLimitDurationToHours() {
+        val duration = 1.days + 2.hours + 3.minutes + 4.seconds
+
+        val text = duration.toFriendlyStirng(resources, minUnit = FriendlyDurationUnit.Hours, maxPartCount = 4)
+
+        assertEquals("1 day 2 hours", text)
+    }
+
+    @Test
+    fun minLimitDurationToMinutes() {
+        val duration = 1.days + 2.hours + 3.minutes + 4.seconds
+
+        val text = duration.toFriendlyStirng(resources, minUnit = FriendlyDurationUnit.Minute, maxPartCount = 4)
+
+        assertEquals("1 day 2 hours 3 minutes", text)
+    }
+
+    @Test
+    fun minLimitDurationToSeconds() {
+        val duration = 1.days + 2.hours + 3.minutes + 4.seconds
+
+        val text = duration.toFriendlyStirng(resources, minUnit = FriendlyDurationUnit.Second, maxPartCount = 4)
+
+        assertEquals("1 day 2 hours 3 minutes 4 seconds", text)
+    }
+
+    @Test
+    fun limitPartsToMaxPartCount() {
+        val duration = 1.days + 2.hours + 3.minutes + 4.seconds
+
+        assertEquals("1 day 2 hours 3 minutes 4 seconds", duration.toFriendlyStirng(resources, maxPartCount = 4))
+        assertEquals("1 day 2 hours 3 minutes", duration.toFriendlyStirng(resources, maxPartCount = 3))
+        assertEquals("1 day 2 hours", duration.toFriendlyStirng(resources, maxPartCount = 2))
+        assertEquals("1 day", duration.toFriendlyStirng(resources, maxPartCount = 1))
+    }
+
+    @Test
+    fun useMinUnitIfMaxPartCountIsTooLow() {
+        val duration = 1.days + 2.hours + 3.minutes + 4.seconds
+
+        assertEquals("1 day", duration.toFriendlyStirng(resources, minUnit = FriendlyDurationUnit.Day, maxPartCount = 0))
+        assertEquals("26 hours", duration.toFriendlyStirng(resources, minUnit = FriendlyDurationUnit.Hours, maxPartCount = 0))
+        assertEquals("1563 minutes", duration.toFriendlyStirng(resources, minUnit = FriendlyDurationUnit.Minute, maxPartCount = 0))
+        assertEquals("93784 seconds", duration.toFriendlyStirng(resources, minUnit = FriendlyDurationUnit.Second, maxPartCount = 0))
+    }
+
+    @Test
+    fun skipZeroParts() {
+        val duration = 1.days + 3.minutes // no hours
+
+        val text = duration.toFriendlyStirng(resources)
+
+        assertEquals("1 day 3 minutes", text)
+    }
+}

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/ui/LongestEpisodeStory.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/ui/LongestEpisodeStory.kt
@@ -45,7 +45,7 @@ import au.com.shiftyjelly.pocketcasts.compose.components.TextH10
 import au.com.shiftyjelly.pocketcasts.compose.components.TextP40
 import au.com.shiftyjelly.pocketcasts.endofyear.StoryCaptureController
 import au.com.shiftyjelly.pocketcasts.localization.helper.FriendlyDurationUnit
-import au.com.shiftyjelly.pocketcasts.localization.helper.toFriendlyStirng
+import au.com.shiftyjelly.pocketcasts.localization.helper.toFriendlyString
 import au.com.shiftyjelly.pocketcasts.models.to.LongestEpisode
 import au.com.shiftyjelly.pocketcasts.models.to.Story
 import dev.shreyaspatil.capturable.capturable
@@ -248,7 +248,7 @@ private fun TextInfo(
             text = stringResource(
                 LR.string.end_of_year_story_longest_episode_title,
                 remember(story.episode.duration, context) {
-                    story.episode.duration.toFriendlyStirng(
+                    story.episode.duration.toFriendlyString(
                         resources = context.resources,
                         minUnit = FriendlyDurationUnit.Minute,
                     )

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/ui/LongestEpisodeStory.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/ui/LongestEpisodeStory.kt
@@ -44,7 +44,8 @@ import au.com.shiftyjelly.pocketcasts.compose.components.PodcastImage
 import au.com.shiftyjelly.pocketcasts.compose.components.TextH10
 import au.com.shiftyjelly.pocketcasts.compose.components.TextP40
 import au.com.shiftyjelly.pocketcasts.endofyear.StoryCaptureController
-import au.com.shiftyjelly.pocketcasts.localization.helper.StatsHelper
+import au.com.shiftyjelly.pocketcasts.localization.helper.FriendlyDurationUnit
+import au.com.shiftyjelly.pocketcasts.localization.helper.toFriendlyStirng
 import au.com.shiftyjelly.pocketcasts.models.to.LongestEpisode
 import au.com.shiftyjelly.pocketcasts.models.to.Story
 import dev.shreyaspatil.capturable.capturable
@@ -242,10 +243,16 @@ private fun TextInfo(
         Spacer(
             modifier = Modifier.height(16.dp),
         )
+        val context = LocalContext.current
         TextH10(
             text = stringResource(
                 LR.string.end_of_year_story_longest_episode_title,
-                StatsHelper.secondsToFriendlyString(story.episode.duration.inWholeSeconds, LocalContext.current.resources),
+                remember(story.episode.duration, context) {
+                    story.episode.duration.toFriendlyStirng(
+                        resources = context.resources,
+                        minUnit = FriendlyDurationUnit.Minute,
+                    )
+                },
             ),
             fontScale = measurements.smallDeviceFactor,
             disableAutoScale = true,

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/ui/TopShowStory.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/ui/TopShowStory.kt
@@ -19,6 +19,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.requiredSize
 import androidx.compose.foundation.layout.size
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
@@ -44,7 +45,8 @@ import au.com.shiftyjelly.pocketcasts.compose.components.TextH10
 import au.com.shiftyjelly.pocketcasts.compose.components.TextP40
 import au.com.shiftyjelly.pocketcasts.endofyear.StoryCaptureController
 import au.com.shiftyjelly.pocketcasts.localization.R
-import au.com.shiftyjelly.pocketcasts.localization.helper.StatsHelper
+import au.com.shiftyjelly.pocketcasts.localization.helper.FriendlyDurationUnit
+import au.com.shiftyjelly.pocketcasts.localization.helper.toFriendlyStirng
 import au.com.shiftyjelly.pocketcasts.models.to.Story
 import au.com.shiftyjelly.pocketcasts.models.to.TopPodcast
 import dev.shreyaspatil.capturable.capturable
@@ -203,14 +205,18 @@ private fun TopShowInfo(
         Spacer(
             modifier = Modifier.height(16.dp),
         )
+        val context = LocalContext.current
         TextP40(
             text = stringResource(
                 R.string.end_of_year_story_top_podcast_subtitle,
                 story.show.playedEpisodeCount,
-                StatsHelper.secondsToFriendlyString(
-                    story.show.playbackTime.inWholeSeconds,
-                    LocalContext.current.resources,
-                ),
+                remember(story.show.playbackTime, context) {
+                    story.show.playbackTime.toFriendlyStirng(
+                        resources = context.resources,
+                        maxPartCount = 3,
+                        minUnit = FriendlyDurationUnit.Minute,
+                    )
+                },
             ),
             fontSize = 15.sp,
             disableAutoScale = true,

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/ui/TopShowStory.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/ui/TopShowStory.kt
@@ -46,7 +46,7 @@ import au.com.shiftyjelly.pocketcasts.compose.components.TextP40
 import au.com.shiftyjelly.pocketcasts.endofyear.StoryCaptureController
 import au.com.shiftyjelly.pocketcasts.localization.R
 import au.com.shiftyjelly.pocketcasts.localization.helper.FriendlyDurationUnit
-import au.com.shiftyjelly.pocketcasts.localization.helper.toFriendlyStirng
+import au.com.shiftyjelly.pocketcasts.localization.helper.toFriendlyString
 import au.com.shiftyjelly.pocketcasts.models.to.Story
 import au.com.shiftyjelly.pocketcasts.models.to.TopPodcast
 import dev.shreyaspatil.capturable.capturable
@@ -211,7 +211,7 @@ private fun TopShowInfo(
                 R.string.end_of_year_story_top_podcast_subtitle,
                 story.show.playedEpisodeCount,
                 remember(story.show.playbackTime, context) {
-                    story.show.playbackTime.toFriendlyStirng(
+                    story.show.playbackTime.toFriendlyString(
                         resources = context.resources,
                         maxPartCount = 3,
                         minUnit = FriendlyDurationUnit.Minute,

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/ui/TotalTimeStory.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/ui/TotalTimeStory.kt
@@ -26,7 +26,7 @@ import au.com.shiftyjelly.pocketcasts.compose.components.AutoResizeText
 import au.com.shiftyjelly.pocketcasts.compose.components.TextH10
 import au.com.shiftyjelly.pocketcasts.endofyear.StoryCaptureController
 import au.com.shiftyjelly.pocketcasts.localization.helper.FriendlyDurationUnit
-import au.com.shiftyjelly.pocketcasts.localization.helper.toFriendlyStirng
+import au.com.shiftyjelly.pocketcasts.localization.helper.toFriendlyString
 import au.com.shiftyjelly.pocketcasts.models.to.Story
 import dev.shreyaspatil.capturable.capturable
 import java.io.File
@@ -126,11 +126,11 @@ private fun getListeningTimeTexts(
     duration: Duration,
 ): ListeningTimeTexts {
     val (mainNumber, subtitle) = remember(duration, context) {
-        val timeText = duration.toFriendlyStirng(
+        val timeText = duration.toFriendlyString(
             resources = context.resources,
             maxPartCount = 3,
             minUnit = FriendlyDurationUnit.Minute,
-            maxUnit = if (duration < 100.hours) FriendlyDurationUnit.Hours else FriendlyDurationUnit.Day,
+            maxUnit = if (duration < 100.hours) FriendlyDurationUnit.Hour else FriendlyDurationUnit.Day,
         )
         val timeTextStrings = timeText.split(" ")
         val mainNumber = timeTextStrings.firstOrNull() ?: ""

--- a/modules/services/localization/src/main/java/au/com/shiftyjelly/pocketcasts/localization/helper/DurationUtil.kt
+++ b/modules/services/localization/src/main/java/au/com/shiftyjelly/pocketcasts/localization/helper/DurationUtil.kt
@@ -31,7 +31,7 @@ import au.com.shiftyjelly.pocketcasts.localization.R as LR
  * @return A formatted string representing the duration, with units and values up to the specified
  * constraints.
  */
-fun Duration.toFriendlyStirng(
+fun Duration.toFriendlyString(
     resources: Resources,
     maxPartCount: Int = 2,
     minUnit: FriendlyDurationUnit = FriendlyDurationUnit.Second,
@@ -41,7 +41,7 @@ fun Duration.toFriendlyStirng(
     var usedParts = 0
     var timeLeft = this
 
-    val units = FriendlyDurationUnit.entries.reversed().filter { it in minUnit..maxUnit }
+    val units = FriendlyDurationUnit.reversedEntries.filter { it in minUnit..maxUnit }
     for (unit in units) {
         val wholeUnitDuration = unit.inWholeUnits(timeLeft)
         if (usedParts < maxPartCount && wholeUnitDuration > Duration.ZERO) {
@@ -68,7 +68,7 @@ enum class FriendlyDurationUnit(
         durationUnit = DurationUnit.MINUTES,
         resourceId = LR.plurals.minute,
     ),
-    Hours(
+    Hour(
         durationUnit = DurationUnit.HOURS,
         resourceId = LR.plurals.hour,
     ),
@@ -94,4 +94,8 @@ enum class FriendlyDurationUnit(
     internal fun inWholeUnits(duration: Duration) = toUnitCount(duration).toDuration(durationUnit)
 
     private fun toUnitCount(duration: Duration) = duration.toInt(durationUnit)
+
+    internal companion object {
+        val reversedEntries = FriendlyDurationUnit.entries.reversed()
+    }
 }

--- a/modules/services/localization/src/main/java/au/com/shiftyjelly/pocketcasts/localization/helper/DurationUtil.kt
+++ b/modules/services/localization/src/main/java/au/com/shiftyjelly/pocketcasts/localization/helper/DurationUtil.kt
@@ -1,0 +1,97 @@
+package au.com.shiftyjelly.pocketcasts.localization.helper
+
+import android.content.res.Resources
+import androidx.annotation.PluralsRes
+import kotlin.time.Duration
+import kotlin.time.DurationUnit
+import kotlin.time.toDuration
+import au.com.shiftyjelly.pocketcasts.localization.R as LR
+
+/**
+ * Converts the duration to a readable, user-friendly string.
+ *
+ * Examples of formatted output include:
+ * - "34 seconds"
+ * - "1 minute 37 seconds"
+ * - "10 hours"
+ * - "10 days 14 hours 50 minutes 10 seconds"
+ *
+ * If the resulting string would be empty, the duration will be displayed in [minUnit].
+ *
+ * @param resources the [Resources] instance used to fetch pluralized strings.
+ * @param maxPartCount the maximum number of consecutive time parts to include in the result.
+ * For example, with `maxPartsCount = 2`, "1 day 3 hours 45 minutes" would be shortened to "1 day 3 hours".
+ * A time part is defined as a unit of time with a value, such as "1 day" or "3 hours".
+ * @param minUnit the smallest unit of time allowed in the formatted output.
+ * Units smaller than this value are converted to the next allowed unit.
+ * For example, with `minUnit = FriendlyDurationUnit.Minute`, "1 minute 36 seconds" would become "1 minute".
+ * @param maxUnit the largest unit of time allowed in the formatted output.
+ * Units larger than this value are converted to the next allowed unit.
+ * For example, with `maxUnit = FriendlyDurationUnit.Minute`, "2 hours" would become "120 minutes".
+ * @return A formatted string representing the duration, with units and values up to the specified
+ * constraints.
+ */
+fun Duration.toFriendlyStirng(
+    resources: Resources,
+    maxPartCount: Int = 2,
+    minUnit: FriendlyDurationUnit = FriendlyDurationUnit.Second,
+    maxUnit: FriendlyDurationUnit = FriendlyDurationUnit.Day,
+): String {
+    val builder = StringBuilder()
+    var usedParts = 0
+    var timeLeft = this
+
+    val units = FriendlyDurationUnit.entries.reversed().filter { it in minUnit..maxUnit }
+    for (unit in units) {
+        val wholeUnitDuration = unit.inWholeUnits(timeLeft)
+        if (usedParts < maxPartCount && wholeUnitDuration > Duration.ZERO) {
+            unit.append(builder, resources, timeLeft)
+            timeLeft -= wholeUnitDuration
+            usedParts++
+        }
+    }
+    if (builder.isEmpty()) {
+        minUnit.append(builder, resources, this)
+    }
+    return builder.toString().trimEnd()
+}
+
+enum class FriendlyDurationUnit(
+    private val durationUnit: DurationUnit,
+    @PluralsRes private val resourceId: Int,
+) {
+    Second(
+        durationUnit = DurationUnit.SECONDS,
+        resourceId = LR.plurals.second,
+    ),
+    Minute(
+        durationUnit = DurationUnit.MINUTES,
+        resourceId = LR.plurals.minute,
+    ),
+    Hours(
+        durationUnit = DurationUnit.HOURS,
+        resourceId = LR.plurals.hour,
+    ),
+    Day(
+        durationUnit = DurationUnit.DAYS,
+        resourceId = LR.plurals.day,
+    ),
+    ;
+
+    internal fun append(
+        builder: StringBuilder,
+        resources: Resources,
+        duration: Duration,
+    ) {
+        val unitCount = toUnitCount(duration)
+        builder
+            .append(unitCount)
+            .append(' ')
+            .append(resources.getQuantityString(resourceId, unitCount))
+            .append(' ')
+    }
+
+    internal fun inWholeUnits(duration: Duration) = toUnitCount(duration).toDuration(durationUnit)
+
+    private fun toUnitCount(duration: Duration) = duration.toInt(durationUnit)
+}

--- a/modules/services/localization/src/main/java/au/com/shiftyjelly/pocketcasts/localization/helper/DurationUtil.kt
+++ b/modules/services/localization/src/main/java/au/com/shiftyjelly/pocketcasts/localization/helper/DurationUtil.kt
@@ -16,7 +16,7 @@ import au.com.shiftyjelly.pocketcasts.localization.R as LR
  * - "10 hours"
  * - "10 days 14 hours 50 minutes 10 seconds"
  *
- * If the resulting string would be empty, the duration will be displayed in [minUnit].
+ * If the duration is negative or resulting string would be empty, the duration will be displayed in [minUnit].
  *
  * @param resources the [Resources] instance used to fetch pluralized strings.
  * @param maxPartCount the maximum number of consecutive time parts to include in the result.
@@ -39,7 +39,7 @@ fun Duration.toFriendlyString(
 ): String {
     val builder = StringBuilder()
     var usedParts = 0
-    var timeLeft = this
+    var timeLeft = coerceAtLeast(Duration.ZERO)
 
     val units = FriendlyDurationUnit.reversedEntries.filter { it in minUnit..maxUnit }
     for (unit in units) {
@@ -51,7 +51,7 @@ fun Duration.toFriendlyString(
         }
     }
     if (builder.isEmpty()) {
-        minUnit.append(builder, resources, this)
+        minUnit.append(builder, resources, coerceAtLeast(Duration.ZERO))
     }
     return builder.toString().trimEnd()
 }

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -635,6 +635,22 @@
     <string name="podcast_refresh_artwork">Refresh artwork</string>
     <string name="podcast_rate">Rate %s</string>
     <string name="podcast_cover_description">Cover of %s podcast</string>
+    <plurals name="day">
+        <item quantity="one">day</item>
+        <item quantity="other">days</item>
+    </plurals>
+    <plurals name="hour">
+        <item quantity="one">hour</item>
+        <item quantity="other">hours</item>
+    </plurals>
+    <plurals name="minute">
+        <item quantity="one">minute</item>
+        <item quantity="other">minutes</item>
+    </plurals>
+    <plurals name="second">
+        <item quantity="one">second</item>
+        <item quantity="other">seconds</item>
+    </plurals>
 
     <!-- Give Rating -->
 


### PR DESCRIPTION
## Description

Part of feedback from #3169

> In this screen, I'm realising that values like these (which should be common) look a bit dumb. To make it better, I'm suggesting we change the logic to show anything that's below 100 hours in hours (for example, this would be "41 hours") and anything greater in days/hours. Can we add the number of minutes too?

It updates all displayed duration texts as requested here: p1730808072188289/1730808008.565789-slack-C041BGTFQ5R

## Testing Instructions

1. Start PB24.
2. Have less than 100 hours listened or fake this data in `EndOfYearViewModel`.
3. Navigate to the Total Time story.
4. Time should be displayed in hours and not in days.

## Screenshots or Screencast 

| Before | After |
| - | - |
| ![Screenshot 2024-11-05 at 14 37 42](https://github.com/user-attachments/assets/78a79f8c-1a23-4c8a-b834-0326a5a1e851) | ![aftr](https://github.com/user-attachments/assets/c14435ca-9c95-44ad-a2ba-c6ce2bd85699) |

## Checklist
- [ ] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] ~I have considered whether it makes sense to add tests for my changes~
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [ ] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~