### PR TITLE
Retry streaming and downloading with different headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 *   Updates
     *   Renamed the podcast action 'Subscribe' to 'Follow'
         ([#3120](https://github.com/Automattic/pocket-casts-android/pull/3120))
+    *   Improve connection when some podcasts failed to play or download
+        ([#3180](https://github.com/Automattic/pocket-casts-android/pull/3180))
 *   Bug Fixes
     *   Use red color for the notification icons
         ([#3154](https://github.com/Automattic/pocket-casts-android/pull/3154))

--- a/modules/services/servers/build.gradle.kts
+++ b/modules/services/servers/build.gradle.kts
@@ -45,4 +45,5 @@ dependencies {
 
     testImplementation(libs.coroutines.test)
     testImplementation(libs.junit)
+    testImplementation(libs.okHttp.mockwebserver)
 }

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/CleanAndRetryInterceptor.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/CleanAndRetryInterceptor.kt
@@ -1,0 +1,21 @@
+package au.com.shiftyjelly.pocketcasts.servers
+
+import okhttp3.Interceptor
+import okhttp3.Response
+
+internal class CleanAndRetryInterceptor(
+    private val headersToRemove: List<String>,
+) : Interceptor {
+    override fun intercept(chain: Interceptor.Chain): Response {
+        val originalRequest = chain.request()
+        val response = chain.proceed(originalRequest)
+        return if (response.isSuccessful || response.isRedirect) {
+            response
+        } else {
+            val cleanRequest = originalRequest.newBuilder()
+                .let { builder -> headersToRemove.fold(builder) { acc, header -> acc.removeHeader(header) } }
+                .build()
+            chain.proceed(cleanRequest)
+        }
+    }
+}

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/CleanAndRetryInterceptor.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/CleanAndRetryInterceptor.kt
@@ -12,6 +12,7 @@ internal class CleanAndRetryInterceptor(
         return if (response.isSuccessful || response.isRedirect) {
             response
         } else {
+            response.close()
             val cleanRequest = originalRequest.newBuilder()
                 .let { builder -> headersToRemove.fold(builder) { acc, header -> acc.removeHeader(header) } }
                 .build()

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/di/InterceptorModule.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/di/InterceptorModule.kt
@@ -3,6 +3,7 @@ package au.com.shiftyjelly.pocketcasts.servers.di
 import au.com.shiftyjelly.pocketcasts.preferences.AccessToken
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.servers.BuildConfig
+import au.com.shiftyjelly.pocketcasts.servers.CleanAndRetryInterceptor
 import au.com.shiftyjelly.pocketcasts.servers.OkHttpInterceptor
 import au.com.shiftyjelly.pocketcasts.servers.sync.TokenHandler
 import au.com.shiftyjelly.pocketcasts.servers.toClientInterceptor
@@ -61,6 +62,16 @@ object InterceptorModule {
         }
         responseBuilder.build()
     }
+
+    private val cleanAndRetryInterceptor = CleanAndRetryInterceptor(
+        headersToRemove = listOf(
+            // Remove our custom User-Agent. Internal ref: p1730724100345749-slack-C07J5LNP4SF
+            "User-Agent",
+            // Remove Sentry stuff from requests as well to make it more pure.
+            "sentry-trace",
+            "baggage",
+        ),
+    ).toClientInterceptor() // Must be client interceptor. Otherwise calls cannot be retried.
 
     @Provides
     @TokenInterceptor
@@ -157,6 +168,7 @@ object InterceptorModule {
         return buildList {
             add(userAgentInterceptor.toClientInterceptor())
             add(crashLoggingInterceptor.toClientInterceptor())
+            add(cleanAndRetryInterceptor)
 
             if (BuildConfig.DEBUG) {
                 val loggingInterceptor = HttpLoggingInterceptor().apply {
@@ -192,6 +204,7 @@ object InterceptorModule {
         return buildList {
             add(userAgentInterceptor.toClientInterceptor())
             add(crashLoggingInterceptor.toClientInterceptor())
+            add(cleanAndRetryInterceptor)
 
             if (BuildConfig.DEBUG) {
                 val loggingInterceptor = HttpLoggingInterceptor().apply {

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/di/InterceptorModule.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/di/InterceptorModule.kt
@@ -157,6 +157,13 @@ object InterceptorModule {
         return buildList {
             add(userAgentInterceptor.toClientInterceptor())
             add(crashLoggingInterceptor.toClientInterceptor())
+
+            if (BuildConfig.DEBUG) {
+                val loggingInterceptor = HttpLoggingInterceptor().apply {
+                    level = HttpLoggingInterceptor.Level.HEADERS
+                }
+                add(loggingInterceptor.toClientInterceptor())
+            }
         }
     }
 
@@ -185,6 +192,13 @@ object InterceptorModule {
         return buildList {
             add(userAgentInterceptor.toClientInterceptor())
             add(crashLoggingInterceptor.toClientInterceptor())
+
+            if (BuildConfig.DEBUG) {
+                val loggingInterceptor = HttpLoggingInterceptor().apply {
+                    level = HttpLoggingInterceptor.Level.HEADERS
+                }
+                add(loggingInterceptor.toClientInterceptor())
+            }
         }
     }
 }

--- a/modules/services/servers/src/test/kotlin/au/com/shiftyjelly/pocketcasts/servers/CleanAndRetryInterceptorTest.kt
+++ b/modules/services/servers/src/test/kotlin/au/com/shiftyjelly/pocketcasts/servers/CleanAndRetryInterceptorTest.kt
@@ -1,0 +1,95 @@
+package au.com.shiftyjelly.pocketcasts.servers
+
+import junit.framework.TestCase.assertEquals
+import junit.framework.TestCase.assertNull
+import junit.framework.TestCase.assertTrue
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.junit.Rule
+import org.junit.Test
+
+class CleanAndRetryInterceptorTest {
+    @get:Rule
+    val server = MockWebServer()
+    private val url = server.url("/")
+
+    @Test
+    fun `do not remove header from request if response is succssful`() {
+        val client = OkHttpClient.Builder()
+            .addInterceptor(CleanAndRetryInterceptor(headersToRemove = listOf("x-custom")))
+            .build()
+        val request = Request.Builder()
+            .url(url)
+            .header("x-custom", "value")
+            .build()
+
+        server.enqueue(MockResponse())
+        client.newCall(request).execute()
+
+        val serverRequest = server.takeRequest()
+
+        assertEquals("value", serverRequest.getHeader("X-custom"))
+    }
+
+    @Test
+    fun `remove header from request if response is error`() {
+        val client = OkHttpClient.Builder()
+            .addInterceptor(CleanAndRetryInterceptor(headersToRemove = listOf("x-custom")))
+            .build()
+        val request = Request.Builder()
+            .url(url)
+            .header("x-custom", "value")
+            .build()
+
+        server.enqueue(MockResponse().setResponseCode(404))
+        server.enqueue(MockResponse())
+        client.newCall(request).execute()
+
+        server.takeRequest() // Initial request
+        val serverRequest = server.takeRequest()
+
+        assertNull(serverRequest.getHeader("x-custom"))
+    }
+
+    @Test
+    fun `do not remove header that doesn't match filter list`() {
+        val client = OkHttpClient.Builder()
+            .addInterceptor(CleanAndRetryInterceptor(headersToRemove = listOf("x-custom-1")))
+            .build()
+        val request = Request.Builder()
+            .url(url)
+            .header("x-custom-2", "value")
+            .build()
+
+        server.enqueue(MockResponse().setResponseCode(404))
+        server.enqueue(MockResponse())
+        client.newCall(request).execute()
+
+        server.takeRequest() // Initial request
+        val serverRequest = server.takeRequest()
+
+        assertEquals("value", serverRequest.getHeader("x-custom-2"))
+    }
+
+    @Test
+    fun `replace User-Agent header with the default one`() {
+        val client = OkHttpClient.Builder()
+            .addInterceptor(CleanAndRetryInterceptor(headersToRemove = listOf("User-Agent")))
+            .build()
+        val request = Request.Builder()
+            .url(url)
+            .header("User-Agent", "value")
+            .build()
+
+        server.enqueue(MockResponse().setResponseCode(404))
+        server.enqueue(MockResponse())
+        client.newCall(request).execute()
+
+        server.takeRequest() // Initial request
+        val serverRequest = server.takeRequest()
+
+        assertTrue(serverRequest.getHeader("User-Agent")!!.startsWith("okhttp"))
+    }
+}


### PR DESCRIPTION
## Description

This PR adds fallback to non-PC requests when hosts refuse to serve content.

Closes #3164

## Testing Instructions

1. Go to [Questions & Answers](https://pca.st/SxW3) podcast.
2. Episodes should play and download.

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [ ] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [ ] ~Any jetpack compose components I added or changed are covered by compose previews~
- [ ] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~