### PR TITLE
Update EoY progress bar

### DIFF
--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/EndOfYearViewModel.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/EndOfYearViewModel.kt
@@ -182,6 +182,8 @@ class EndOfYearViewModel @AssistedInject constructor(
                     }
                     _switchStory.emit(Unit)
                 }
+            } else {
+                progress.value = 1f
             }
         }
     }

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/ui/Common.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/ui/Common.kt
@@ -196,6 +196,7 @@ internal class HumaneTextFactory(
 @Composable
 internal fun PreviewBox(
     currentPage: Int,
+    progress: Float = 0.5f,
     content: @Composable (EndOfYearMeasurements) -> Unit,
 ) {
     BoxWithConstraints {
@@ -210,7 +211,7 @@ internal fun PreviewBox(
         content(measurements)
         TopControls(
             pagerState = rememberPagerState(initialPage = currentPage, pageCount = { 11 }),
-            progress = 0f,
+            progress = progress,
             measurements = measurements,
             onClose = {},
         )

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/ui/PlusInterstitialStory.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/ui/PlusInterstitialStory.kt
@@ -166,7 +166,7 @@ private fun PlusInfo(
 @Preview(device = Devices.PortraitRegular)
 @Composable
 private fun PlusInterstitialPreview() {
-    PreviewBox(currentPage = 7) { measurements ->
+    PreviewBox(currentPage = 7, progress = 1f) { measurements ->
         PlusInterstitialStory(
             story = Story.PlusInterstitial,
             measurements = measurements,

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/ui/StoriesPage.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/ui/StoriesPage.kt
@@ -274,6 +274,7 @@ internal fun BoxScope.TopControls(
             state = pagerState,
             progress = progress,
             activeColor = Color.Black,
+            isProgressedActive = false,
         )
         Spacer(
             modifier = Modifier.height(10.dp),

--- a/modules/features/endofyear/src/test/kotlin/au/com/shiftyjelly/pocketcasts/endofyear/EndOfYearViewModelTest.kt
+++ b/modules/features/endofyear/src/test/kotlin/au/com/shiftyjelly/pocketcasts/endofyear/EndOfYearViewModelTest.kt
@@ -673,6 +673,21 @@ class EndOfYearViewModelTest {
         assertEquals(7, viewModel.getPreviousStoryIndex(stories.indexOf<Ending>()))
     }
 
+    @Test
+    fun `plus interstitial has max progress`() = runTest {
+        endOfYearSync.isSynced.add(true)
+        endOfYearManager.stats.add(stats)
+        subscriptionTier.emit(SubscriptionTier.NONE)
+
+        viewModel.syncData()
+        viewModel.uiState.test {
+            val stories = awaitStories()
+
+            viewModel.onStoryChanged(stories.getStoryOfType<PlusInterstitial>())
+            assertEquals(1f, awaitItem().storyProgress)
+        }
+    }
+
     private suspend fun TurbineTestContext<UiState>.awaitStories(): List<Story> {
         return (awaitItem() as UiState.Synced).stories
     }

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/PagerProgressingIndicator.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/PagerProgressingIndicator.kt
@@ -28,6 +28,7 @@ fun PagerProgressingIndicator(
     modifier: Modifier = Modifier,
     activeColor: Color = Color.White,
     inactiveColor: Color = activeColor.copy(alpha = 0.3f),
+    isProgressedActive: Boolean = true,
 ) {
     if (state.pageCount <= 0) {
         return
@@ -49,7 +50,7 @@ fun PagerProgressingIndicator(
             } else if (index > state.currentPage) {
                 SolidColor(inactiveColor)
             } else {
-                SolidColor(activeColor)
+                SolidColor(if (isProgressedActive) activeColor else inactiveColor)
             }
             Box(
                 modifier
@@ -96,5 +97,10 @@ private fun PagerProgressingIndicatorPreview() = Column(
     PagerProgressingIndicator(
         state = rememberPagerState(initialPage = 2, pageCount = { 4 }),
         progress = 0.75f,
+    )
+    PagerProgressingIndicator(
+        state = rememberPagerState(initialPage = 2, pageCount = { 4 }),
+        progress = 0.75f,
+        isProgressedActive = false,
     )
 }


### PR DESCRIPTION
## Description

This update aligns the PB24 progress bar with the design specifications. Previously, seen stories were displayed as active segments, but now they are shown as inactive, consistent with the intended design.

Additionally, if a story does not auto-progress, it will now appear as an active segment on the progress bar, providing a clearer visual cue for the user.

## Testing Instructions

1. Start PB24 as a free user.
2. Navigate forward to some story.
3. Notice that the progress bar doesn't show previous segments as active.
4. Navigate to the Plus Interstitial story.
5. It should be shown as active in the progress bar.

## Screenshots or Screencast 

| Before | After |
| - | - |
| ![Screenshot 2024-11-06 at 10 52 58](https://github.com/user-attachments/assets/1da34290-48d5-4173-85c2-c40efd85293d) | ![Screenshot 2024-11-06 at 10 52 24](https://github.com/user-attachments/assets/7bb0722f-7b50-4be7-990d-a3327aee9b2c) |
| ![bef](https://github.com/user-attachments/assets/ef4f7d11-6362-420e-9d6f-b841279263ca) | ![aft](https://github.com/user-attachments/assets/1dec7cd2-e845-48de-a060-e388f230cd69) |

## Checklist
- [ ] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [ ] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [ ] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~