### PR TITLE
Do not reset Top Show animation for screenshots

### DIFF
--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/ui/TopShowStory.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/ui/TopShowStory.kt
@@ -145,7 +145,7 @@ private fun ColumnScope.TopShowCover(
                         drawContent()
 
                         rotate(
-                            degrees = if (controller.isSharing) 0f else rotation.value,
+                            degrees = rotation.value,
                             pivot = Offset(widthPx / 2, heightPx / 2),
                         ) {
                             translate(


### PR DESCRIPTION
## Description

This PR changes screenshot capturing logic in the Top Show story. Previously the animation was being reset to the initial state but it doesn't make much sense for this animations since it is an infinite loop and screenshots are more interesting and varied this way.

## Testing Instructions

1. Start PB24.
2. Go to the Top Show story.
3. Share the story at different points of the animation.
4. Each time the cutout shape should be in the correct position.

## Screenshots or Screencast 

<table>
  <tr>
    <td><img src="https://github.com/user-attachments/assets/4878380e-4a19-4c7b-87e4-8a472bd9e8a5"></td>
    <td><img src="https://github.com/user-attachments/assets/75634f08-2326-4f31-807e-0b441fbdb94d"></td>
    <td><img src="https://github.com/user-attachments/assets/5ce972f7-f962-4b3b-bb75-0a9f6ae1a53f"></td>
  </tr>
</table>

## Checklist
- [ ] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] ~I have considered whether it makes sense to add tests for my changes~
- [ ] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [ ] ~Any jetpack compose components I added or changed are covered by compose previews~
- [ ] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~