### PR TITLE
Logging Refresh call times

### DIFF
--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/SyncSettingsTask.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/SyncSettingsTask.kt
@@ -23,8 +23,6 @@ class SyncSettingsTask(context: Context, parameters: WorkerParameters) : Corouti
                 return Result.failure()
             }
 
-            LogBuffer.i(LogBuffer.TAG_BACKGROUND_TASKS, "Settings synced")
-
             return Result.success()
         }
 


### PR DESCRIPTION
## Description

This is a simple change to fix the Up Next timing, clean up the repeating logging statement a little, and remove a log we don't need. I'm making this change as I'm working on tracking down what's slow in a refresh, I have another change but I'm splitting it into another PR as it's bigger. 

```
BgTask: Refresh - podcasts response - 1917 ms
BgTask: Refresh - sync complete - 48 ms
BgTask: Refresh - sync up next - 2917 ms
BgTask: Refresh - sync settings - 359 ms
BgTask: Refresh - sync play history - 6 ms
BgTask: Refresh - checkForEpisodesToAutoArchive - 17 ms
BgTask: Refresh - checkForUnusedPodcasts - 5 ms
BgTask: Refresh - playlist checkForEpisodesToDownload - 1 ms
BgTask: Refresh - podcast checkForEpisodesToDownload - 17 ms
BgTask: Refresh - updateNotifications - 1 ms
```

## Testing Instructions

There isn't much to test here. Maybe run a sync and filter by "BgTask".

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
