### PR TITLE
Warn about transitive dependencies

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -69,7 +69,7 @@ dependencyAnalysis {
     issues {
         all {
             onUsedTransitiveDependencies {
-                severity("ignore")
+                severity("warn")
             }
 
             onRuntimeOnly {


### PR DESCRIPTION
## Description

This is a followup to the discussion about transitive dependencies. To sum up it is useful for others and it doesn't hinder us in any meaningful way. For more context see here: pdnsEh-1QL-p2#comment-4100

## Testing Instructions

1. Run `./gradlew buildHealth`.
2. Verify that the report contains transitive dependencies warnings.