### PR TITLE
Update date added podcast display sort order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
         ([#3120](https://github.com/Automattic/pocket-casts-android/pull/3120))
     *   Improve connection when some podcasts failed to play or download
         ([#3180](https://github.com/Automattic/pocket-casts-android/pull/3180))
+    *   Add new podcast subscriptions to the top instead of bottom for Data Added podcast sort order 
+        ([#3192](https://github.com/Automattic/pocket-casts-android/pull/3192)) 
 *   Bug Fixes
     *   Use red color for the notification icons
         ([#3154](https://github.com/Automattic/pocket-casts-android/pull/3154))

--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/models/db/ExternalDataDaoTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/models/db/ExternalDataDaoTest.kt
@@ -181,7 +181,7 @@ class ExternalDataDaoTest {
         podcastDao.insert(Podcast(uuid = "id-4", title = "title-4", isSubscribed = true, addedDate = Date(1)))
         podcastDao.insert(Podcast(uuid = "id-5", title = "title-5", isSubscribed = true, addedDate = null))
 
-        val podcastIds = externalDataDao.getSubscribedPodcasts(PodcastsSortType.DATE_ADDED_OLDEST_TO_NEWEST, limit = 100).map { it.id }
+        val podcastIds = externalDataDao.getSubscribedPodcasts(PodcastsSortType.DATE_ADDED_NEWEST_TO_OLDEST, limit = 100).map { it.id }
 
         assertEquals(listOf("id-4", "id-3", "id-1", "id-2", "id-5"), podcastIds)
     }

--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/utils/FakeFileGenerator.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/utils/FakeFileGenerator.kt
@@ -13,7 +13,7 @@ object FakeFileGenerator {
         color = 1,
         addedDate = Date(),
         sortPosition = 1,
-        podcastsSortType = PodcastsSortType.DATE_ADDED_OLDEST_TO_NEWEST,
+        podcastsSortType = PodcastsSortType.DATE_ADDED_NEWEST_TO_OLDEST,
         deleted = false,
         syncModified = 1L,
     )

--- a/app/src/test/java/au/com/shiftyjelly/pocketcasts/models/to/PodcastFolderHelperTest.kt
+++ b/app/src/test/java/au/com/shiftyjelly/pocketcasts/models/to/PodcastFolderHelperTest.kt
@@ -20,7 +20,7 @@ class PodcastFolderHelperTest {
         color = 0,
         addedDate = Date(),
         sortPosition = 0,
-        podcastsSortType = PodcastsSortType.DATE_ADDED_OLDEST_TO_NEWEST,
+        podcastsSortType = PodcastsSortType.DATE_ADDED_NEWEST_TO_OLDEST,
         deleted = false,
         syncModified = 0,
     )
@@ -31,7 +31,7 @@ class PodcastFolderHelperTest {
         color = 0,
         addedDate = Date(),
         sortPosition = 0,
-        podcastsSortType = PodcastsSortType.DATE_ADDED_OLDEST_TO_NEWEST,
+        podcastsSortType = PodcastsSortType.DATE_ADDED_NEWEST_TO_OLDEST,
         deleted = false,
         syncModified = 0,
     )
@@ -113,7 +113,7 @@ class PodcastFolderHelperTest {
         }
 
         PodcastFolderHelper.sortForSelectingPodcasts(
-            sortType = PodcastsSortType.DATE_ADDED_OLDEST_TO_NEWEST,
+            sortType = PodcastsSortType.DATE_ADDED_NEWEST_TO_OLDEST,
             podcastsSortedByReleaseDate = list,
             currentFolderUuid = null,
         ).let {

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/folders/FolderEditViewModel.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/folders/FolderEditViewModel.kt
@@ -151,7 +151,7 @@ class FolderEditViewModel
         val podcasts = podcastsSortedByReleaseDate
         return when (settings.podcastsSortType.value) {
             PodcastsSortType.EPISODE_DATE_NEWEST_TO_OLDEST -> podcastsSortedByReleaseDate
-            PodcastsSortType.DATE_ADDED_OLDEST_TO_NEWEST -> podcasts.sortedWith(compareBy { it.addedDate })
+            PodcastsSortType.DATE_ADDED_NEWEST_TO_OLDEST -> podcasts.sortedWith(compareBy { it.addedDate })
             PodcastsSortType.DRAG_DROP -> podcasts.sortedWith(compareBy { it.sortPosition })
             PodcastsSortType.NAME_A_TO_Z -> podcasts.sortedWith(compareBy { PodcastsSortType.cleanStringForSort(it.title) })
         }

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/folders/PodcastFolderHelper.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/folders/PodcastFolderHelper.kt
@@ -41,7 +41,7 @@ object PodcastFolderHelper {
             }
         }
         val podcastComparator: Comparator<PodcastFolder>? = when (sortType) {
-            PodcastsSortType.DATE_ADDED_OLDEST_TO_NEWEST -> addDateComparator
+            PodcastsSortType.DATE_ADDED_NEWEST_TO_OLDEST -> addDateComparator
             PodcastsSortType.EPISODE_DATE_NEWEST_TO_OLDEST -> null
             else -> aToZComparator
         }

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/PodcastsViewModel.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/PodcastsViewModel.kt
@@ -276,7 +276,7 @@ class PodcastsViewModel
     fun trackFolderShown(folderUuid: String) {
         launch {
             val properties = HashMap<String, Any>()
-            properties[SORT_ORDER_KEY] = (folderManager.findByUuid(folderUuid)?.podcastsSortType ?: PodcastsSortType.DATE_ADDED_OLDEST_TO_NEWEST).analyticsValue
+            properties[SORT_ORDER_KEY] = (folderManager.findByUuid(folderUuid)?.podcastsSortType ?: PodcastsSortType.DATE_ADDED_NEWEST_TO_OLDEST).analyticsValue
             properties[NUMBER_OF_PODCASTS_KEY] = folderManager.findFolderPodcastsSorted(folderUuid).size
             analyticsTracker.track(AnalyticsEvent.FOLDER_SHOWN, properties)
         }

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/type/PodcastsSortType.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/type/PodcastsSortType.kt
@@ -22,14 +22,6 @@ enum class PodcastsSortType(
     val folderComparator: Comparator<FolderItem>,
     val analyticsValue: String,
 ) {
-    DATE_ADDED_OLDEST_TO_NEWEST(
-        clientId = 0,
-        serverId = 0,
-        labelId = R.string.podcasts_sort_by_date_added,
-        podcastComparator = compareBy { it.addedDate },
-        folderComparator = compareBy { it.addedDate },
-        analyticsValue = "date_added",
-    ),
     NAME_A_TO_Z(
         clientId = 2,
         serverId = 1,
@@ -46,6 +38,14 @@ enum class PodcastsSortType(
         podcastComparator = Comparator { _, _ -> 0 },
         folderComparator = Comparator { _, _ -> 0 },
         analyticsValue = "episode_release_date",
+    ),
+    DATE_ADDED_OLDEST_TO_NEWEST(
+        clientId = 0,
+        serverId = 0,
+        labelId = R.string.podcasts_sort_by_date_added,
+        podcastComparator = compareBy { it.addedDate },
+        folderComparator = compareBy { it.addedDate },
+        analyticsValue = "date_added",
     ),
     DRAG_DROP(
         clientId = 6,

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/type/PodcastsSortType.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/type/PodcastsSortType.kt
@@ -39,7 +39,7 @@ enum class PodcastsSortType(
         folderComparator = Comparator { _, _ -> 0 },
         analyticsValue = "episode_release_date",
     ),
-    DATE_ADDED_OLDEST_TO_NEWEST(
+    DATE_ADDED_NEWEST_TO_OLDEST(
         clientId = 0,
         serverId = 0,
         labelId = R.string.podcasts_sort_by_date_added,
@@ -58,7 +58,7 @@ enum class PodcastsSortType(
     ;
 
     companion object {
-        val default = DATE_ADDED_OLDEST_TO_NEWEST
+        val default = DATE_ADDED_NEWEST_TO_OLDEST
 
         fun fromServerId(serverId: Int?): PodcastsSortType {
             if (serverId == null) {

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/type/PodcastsSortType.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/type/PodcastsSortType.kt
@@ -43,8 +43,8 @@ enum class PodcastsSortType(
         clientId = 0,
         serverId = 0,
         labelId = R.string.podcasts_sort_by_date_added,
-        podcastComparator = compareBy { it.addedDate },
-        folderComparator = compareBy { it.addedDate },
+        podcastComparator = compareByDescending { it.addedDate },
+        folderComparator = compareByDescending { it.addedDate },
         analyticsValue = "date_added",
     ),
     DRAG_DROP(
@@ -88,7 +88,7 @@ enum class PodcastsSortType(
     }
 
     fun isAsc(): Boolean {
-        return clientId == DATE_ADDED_OLDEST_TO_NEWEST.clientId || clientId == NAME_A_TO_Z.clientId
+        return clientId == NAME_A_TO_Z.clientId
     }
 }
 

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/FolderManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/FolderManagerImpl.kt
@@ -5,7 +5,7 @@ import au.com.shiftyjelly.pocketcasts.models.entity.Folder
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.to.FolderItem
 import au.com.shiftyjelly.pocketcasts.models.type.PodcastsSortType
-import au.com.shiftyjelly.pocketcasts.models.type.PodcastsSortType.DATE_ADDED_OLDEST_TO_NEWEST
+import au.com.shiftyjelly.pocketcasts.models.type.PodcastsSortType.DATE_ADDED_NEWEST_TO_OLDEST
 import au.com.shiftyjelly.pocketcasts.models.type.PodcastsSortType.DRAG_DROP
 import au.com.shiftyjelly.pocketcasts.models.type.PodcastsSortType.EPISODE_DATE_NEWEST_TO_OLDEST
 import au.com.shiftyjelly.pocketcasts.models.type.PodcastsSortType.NAME_A_TO_Z
@@ -250,7 +250,7 @@ class FolderManagerImpl @Inject constructor(
 
             val itemsSorted = when (podcastSortType) {
                 NAME_A_TO_Z -> items.sortedWith(compareBy { PodcastsSortType.cleanStringForSort(it.title) })
-                DATE_ADDED_OLDEST_TO_NEWEST -> items.sortedWith(compareBy { it.addedDate })
+                DATE_ADDED_NEWEST_TO_OLDEST -> items.sortedWith(compareBy { it.addedDate })
                 DRAG_DROP -> items.sortedWith(compareBy { it.sortPosition })
                 else -> items
             }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PodcastManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PodcastManagerImpl.kt
@@ -490,7 +490,7 @@ class PodcastManagerImpl @Inject constructor(
     override fun observePodcastsInFolderOrderByUserChoice(folder: Folder): Flowable<List<Podcast>> {
         val sort = folder.podcastsSortType
         return when (sort) {
-            PodcastsSortType.DATE_ADDED_OLDEST_TO_NEWEST -> podcastDao.observeFolderOrderByAddedDate(folder.uuid, sort.isAsc())
+            PodcastsSortType.DATE_ADDED_NEWEST_TO_OLDEST -> podcastDao.observeFolderOrderByAddedDate(folder.uuid, sort.isAsc())
             PodcastsSortType.EPISODE_DATE_NEWEST_TO_OLDEST -> podcastDao.observeFolderOrderByLatestEpisode(folder.uuid, sort.isAsc())
             PodcastsSortType.DRAG_DROP -> podcastDao.observeFolderOrderByUserSort(folder.uuid)
             else -> podcastDao.observeFolderOrderByName(folder.uuid, sort.isAsc())


### PR DESCRIPTION
## Description
This PR makes the following changes 
1. `Cross-Platform Sorting`: The "Sort by" order on Android matches iOS and Web:
- Name
- Episode Release Date
- Date Added
- Drag and Drop

2. `Date Added Sorting`: New podcast subscriptions are added to the top of the list instead of at the bottom

Internal Ref: p1730854048067249-slack-C06EHRAPW12

## Testing Instructions
1. Login with an account with podcasts and folders
2. Go to the `Podcasts` tab 
3. Open `Sort By` options using more menu in the top bar
4. ✅ Notice that sort options are displayed in the following order
- Name
- Episode Release Date
- Date Added
- Drag and Drop
5. Go to `Discover` tab and follow a podcast
6. Tap on `Podcasts` tab and notice that the podcast is added to the top of the list
7. Go to Discover and follow another podcast
8. Add this podcast to an existing folder with podcasts
9.  ✅ Notice that the podcast is added to the top of the list in the folder
10. Sync data from `Profile` using `Refresh now`
11. Install and open `Automotive` app using the same account
12. Open `Podcasts` tab
13.  ✅ Notice that podcasts are shown in the same order as on phone (make sure that the app is synced with latest data)
14. Install and open Wear app using the same account
15. Open `Podcasts` menu
16.  ✅ Notice that podcasts are shown in the same order as on phone (make sure that the app is synced with latest data)

## Screenshots or Screencast 

[sort_order_date_added.webm](https://github.com/user-attachments/assets/5f638dd8-3679-4f76-825a-f09d52a7e5f4)

Automotive Podcasts | Automotive Inside Folder
---|----
![after_automotive](https://github.com/user-attachments/assets/69f27b81-1a18-4349-8a66-62aa853f1bd7) | ![after_automotive_folder](https://github.com/user-attachments/assets/3d6a03ca-d212-4856-aba8-75ec92c6b462)

Wear Podcasts | Wear Inside Folder
---|----
![after_wear](https://github.com/user-attachments/assets/c8f827ee-e813-4f24-97fb-734d2aee8497) | ![after_wear_folder](https://github.com/user-attachments/assets/b746e177-95d7-4a47-9894-51c969ba0bb8)


## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
