### PR TITLE
[Paywall Experiment] - Use the same UUID for both Tracks and Explat

### DIFF
--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/OnboardingCreateAccountViewModel.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/OnboardingCreateAccountViewModel.kt
@@ -84,8 +84,8 @@ class OnboardingCreateAccountViewModel @Inject constructor(
             when (result) {
                 is LoginResult.Success -> {
                     podcastManager.refreshPodcastsAfterSignIn()
-                    experimentProvider.refreshExperiments()
                     analyticsTracker.refreshMetadata()
+                    experimentProvider.refreshExperiments()
                     onAccountCreated()
                 }
 

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/OnboardingLogInViewModel.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/OnboardingLogInViewModel.kt
@@ -79,7 +79,7 @@ class OnboardingLogInViewModel @Inject constructor(
             when (result) {
                 is LoginResult.Success -> {
                     podcastManager.refreshPodcastsAfterSignIn()
-                    experiments.initialize()
+                    experiments.refreshExperiments()
                     onSuccessfulLogin()
                 }
 

--- a/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/IdentifyingTracker.kt
+++ b/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/IdentifyingTracker.kt
@@ -29,7 +29,7 @@ abstract class IdentifyingTracker(
         }
     }
 
-    protected val anonID: String?
+    val anonID: String?
         get() {
             if (anonymousID == null) {
                 anonymousID = preferences.getString(anonIdPrefKey, null)
@@ -37,7 +37,7 @@ abstract class IdentifyingTracker(
             return anonymousID
         }
 
-    protected fun generateNewAnonID(): String {
+    internal fun generateNewAnonID(): String {
         val uuid = UUID.randomUUID().toString().replace("-", "")
         Timber.d("\uD83D\uDD35 New anonID generated in " + this.javaClass.simpleName + ": " + uuid)
         preferences.edit {

--- a/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/di/ExperimentModule.kt
+++ b/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/di/ExperimentModule.kt
@@ -3,6 +3,7 @@ package au.com.shiftyjelly.pocketcasts.analytics.di
 import android.content.Context
 import au.com.shiftyjelly.pocketcasts.analytics.AccountStatusInfo
 import au.com.shiftyjelly.pocketcasts.analytics.BuildConfig
+import au.com.shiftyjelly.pocketcasts.analytics.TracksAnalyticsTracker
 import au.com.shiftyjelly.pocketcasts.analytics.experiments.Experiment
 import au.com.shiftyjelly.pocketcasts.analytics.experiments.ExperimentProvider
 import au.com.shiftyjelly.pocketcasts.servers.di.Cached
@@ -28,9 +29,10 @@ object ExperimentModule {
     @Provides
     @Singleton
     fun provideExperimentProvider(
-        accountStatusInfo: AccountStatusInfo,
+        tracksAnalyticsTracker: TracksAnalyticsTracker,
         repository: VariationsRepository,
-    ): ExperimentProvider = ExperimentProvider(accountStatusInfo, repository)
+        accountStatusInfo: AccountStatusInfo,
+    ): ExperimentProvider = ExperimentProvider(tracksAnalyticsTracker, repository, accountStatusInfo)
 
     @Provides
     @Singleton

--- a/modules/services/analytics/src/test/kotlin/au/com/shiftyjelly/pocketcasts/analytics/experiments/ExperimentProviderTest.kt
+++ b/modules/services/analytics/src/test/kotlin/au/com/shiftyjelly/pocketcasts/analytics/experiments/ExperimentProviderTest.kt
@@ -1,6 +1,7 @@
 package au.com.shiftyjelly.pocketcasts.analytics.experiments
 
 import au.com.shiftyjelly.pocketcasts.analytics.AccountStatusInfo
+import au.com.shiftyjelly.pocketcasts.analytics.TracksAnalyticsTracker
 import au.com.shiftyjelly.pocketcasts.analytics.experiments.Variation.Control
 import au.com.shiftyjelly.pocketcasts.analytics.experiments.Variation.Treatment
 import au.com.shiftyjelly.pocketcasts.sharedtest.InMemoryFeatureFlagRule
@@ -28,9 +29,10 @@ import org.mockito.kotlin.verify
 @OptIn(ExperimentalCoroutinesApi::class)
 class ExperimentProviderTest {
 
-    private lateinit var accountStatusInfo: AccountStatusInfo
     private lateinit var repository: VariationsRepository
     private lateinit var experimentProvider: ExperimentProvider
+    private lateinit var tracksAnalyticsTracker: TracksAnalyticsTracker
+    private lateinit var accountStatusInfo: AccountStatusInfo
 
     @get:Rule
     val featureFlagRule = InMemoryFeatureFlagRule()
@@ -40,13 +42,14 @@ class ExperimentProviderTest {
 
     @Before
     fun setUp() {
-        accountStatusInfo = mock(AccountStatusInfo::class.java)
         repository = mock(VariationsRepository::class.java)
-        experimentProvider = ExperimentProvider(accountStatusInfo, repository, coroutineRule.testDispatcher)
+        tracksAnalyticsTracker = mock(TracksAnalyticsTracker::class.java)
+        accountStatusInfo = mock(AccountStatusInfo::class.java)
+        experimentProvider = ExperimentProvider(tracksAnalyticsTracker, repository, accountStatusInfo, coroutineRule.testDispatcher)
     }
 
     @Test
-    fun `initialize should call repository initialize with correct uuid`() {
+    fun `should initialize with uuid`() {
         FeatureFlag.setEnabled(Feature.EXPLAT_EXPERIMENT, true)
 
         val uuid = "test-uuid"
@@ -59,27 +62,45 @@ class ExperimentProviderTest {
     }
 
     @Test
-    fun `initialize should generate uuid if accountStatusInfo getUuid is null`() {
+    fun `should initialize with anonID`() {
         FeatureFlag.setEnabled(Feature.EXPLAT_EXPERIMENT, true)
 
+        val uuid = "test-anonID"
+
         `when`(accountStatusInfo.getUuid()).thenReturn(null)
+        `when`(tracksAnalyticsTracker.anonID).thenReturn(uuid)
 
         experimentProvider.initialize()
 
-        verify(repository).initialize(anyString(), eq(null))
+        verify(repository).initialize(uuid)
         verify(accountStatusInfo).getUuid()
+        verify(tracksAnalyticsTracker).anonID
     }
 
     @Test
-    fun `should not initialize with empty uuid`() {
+    fun `should initialize with non null uuid`() {
         FeatureFlag.setEnabled(Feature.EXPLAT_EXPERIMENT, true)
 
-        `when`(accountStatusInfo.getUuid()).thenReturn("")
+        val uuid = "non-null-uuid"
+
+        `when`(accountStatusInfo.getUuid()).thenReturn(null)
+        `when`(tracksAnalyticsTracker.anonID).thenReturn(null)
+        `when`(tracksAnalyticsTracker.generateNewAnonID()).thenReturn(uuid)
 
         experimentProvider.initialize()
 
-        verify(repository, never()).initialize(eq(""), eq(null))
-        verify(accountStatusInfo).getUuid()
+        verify(repository).initialize(uuid)
+    }
+
+    @Test
+    fun `should initialize with provided uuid`() {
+        FeatureFlag.setEnabled(Feature.EXPLAT_EXPERIMENT, true)
+
+        val uuid = "uuid"
+
+        experimentProvider.initialize(uuid)
+
+        verify(repository).initialize(uuid)
     }
 
     @Test

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/user/UserManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/user/UserManager.kt
@@ -6,6 +6,7 @@ import android.content.Context
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTracker
 import au.com.shiftyjelly.pocketcasts.analytics.SourceView
+import au.com.shiftyjelly.pocketcasts.analytics.TracksAnalyticsTracker
 import au.com.shiftyjelly.pocketcasts.analytics.experiments.ExperimentProvider
 import au.com.shiftyjelly.pocketcasts.models.to.SignInState
 import au.com.shiftyjelly.pocketcasts.models.to.SubscriptionStatus
@@ -21,7 +22,6 @@ import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.UserEpisodeManager
 import au.com.shiftyjelly.pocketcasts.repositories.searchhistory.SearchHistoryManager
 import au.com.shiftyjelly.pocketcasts.repositories.subscription.SubscriptionManager
-import au.com.shiftyjelly.pocketcasts.repositories.sync.AccountManagerStatusInfo
 import au.com.shiftyjelly.pocketcasts.repositories.sync.SyncManager
 import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
 import com.automattic.android.tracks.crashlogging.CrashLogging
@@ -52,10 +52,10 @@ class UserManagerImpl @Inject constructor(
     val podcastManager: PodcastManager,
     val userEpisodeManager: UserEpisodeManager,
     private val analyticsTracker: AnalyticsTracker,
+    private val tracker: TracksAnalyticsTracker,
     @ApplicationScope private val applicationScope: CoroutineScope,
     private val crashLogging: CrashLogging,
     private val experimentProvider: ExperimentProvider,
-    private val accountManager: AccountManagerStatusInfo,
     private val endOfYearSync: EndOfYearSync,
 ) : UserManager, CoroutineScope {
 
@@ -130,7 +130,8 @@ class UserManagerImpl @Inject constructor(
                     analyticsTracker.clearAllData()
                     analyticsTracker.refreshMetadata()
 
-                    experimentProvider.refreshExperiments()
+                    // Force experiments to refresh after signing out with an anonymous UUID
+                    experimentProvider.refreshExperiments(tracker.anonID)
 
                     settings.setEndOfYearShowModal(true)
                     endOfYearSync.reset()


### PR DESCRIPTION
## Description
- We encountered an issue where data from the AA experiment was not being collected. After investigation, the data team identified the problem: we were using different UUIDs for Tracks and Explat when we should have been using the same one. So this PR make sure we use the same uuid for both cases.
- See: p1730936149575659/1729729858.793479-slack-C046HLX37K2

Fixes #3193

## Testing Instructions
1. Apply [log-track.patch](https://github.com/user-attachments/files/17670975/log-track.patch) to log the uuid every time an event is tracked
2. Fresh install the app
3. Look for `ExperimentsProvider` in logcat
4. See what uuid the explat was initialized: ExperimentsProvider: Initializing experiments with uuid: {uuid}
5. Navigate to some screen to track event
6. ✅ Ensure the event tracked has the same uuid you saw in step 4
7. Log in with a new account
8.  ✅ See the Experiment was refreshed with another uuid
9. Track some events
10. ✅ Ensure the event tracked has the same uuid you saw in step 8
11. Log out
12. ✅ See the Experiment was refreshed with another uuid
13. Track some events
14. ✅ Ensure the event tracked has the same uuid you saw in step 12


## Screenshots or Screencast 

https://github.com/user-attachments/assets/cb0b8838-3c51-43e2-bdbc-7aeff9fdb6d4



## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.