### PR TITLE
Apply correct sort order in ExternalDataDao

### DIFF
--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/models/db/ExternalDataDaoTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/models/db/ExternalDataDaoTest.kt
@@ -183,7 +183,7 @@ class ExternalDataDaoTest {
 
         val podcastIds = externalDataDao.getSubscribedPodcasts(PodcastsSortType.DATE_ADDED_NEWEST_TO_OLDEST, limit = 100).map { it.id }
 
-        assertEquals(listOf("id-4", "id-3", "id-1", "id-2", "id-5"), podcastIds)
+        assertEquals(listOf("id-2", "id-1", "id-3", "id-4", "id-5"), podcastIds)
     }
 
     @Test

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/ExternalDataDao.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/ExternalDataDao.kt
@@ -31,7 +31,7 @@ abstract class ExternalDataDao {
         WHERE 
           podcasts.subscribed IS NOT 0
         ORDER BY
-          -- Order by oldest to newest date added
+          -- Order by newest to oldest date added
           CASE WHEN :sortOrder IS 0 THEN IFNULL(podcasts.added_date, 0) END DESC,
           -- Order by A-Z podcast title
           CASE WHEN :sortOrder IS 1 THEN (CASE

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/ExternalDataDao.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/ExternalDataDao.kt
@@ -31,8 +31,8 @@ abstract class ExternalDataDao {
         WHERE 
           podcasts.subscribed IS NOT 0
         ORDER BY
-          -- Order by oldest to newest date added, '9223372036854775807' is the max possible value putting things at the bottom
-          CASE WHEN :sortOrder IS 0 THEN IFNULL(podcasts.added_date, 9223372036854775807) END ASC,
+          -- Order by oldest to newest date added
+          CASE WHEN :sortOrder IS 0 THEN IFNULL(podcasts.added_date, 0) END DESC,
           -- Order by A-Z podcast title
           CASE WHEN :sortOrder IS 1 THEN (CASE
             WHEN UPPER(podcasts.title) LIKE 'THE %' THEN SUBSTR(UPPER(podcasts.title), 5)


### PR DESCRIPTION
## Description

Follow up to #3192. Since the sort order changed its meaning it should be updated in the query as well.

## Testing Instructions

Code review should be enough since the data access is covered by tests.

## Checklist
- [ ] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [ ] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [ ] ~Any jetpack compose components I added or changed are covered by compose previews~
- [ ] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~