### PR TITLE
Fix FlowOperatorInvokedInComposition Lint issue

### DIFF
--- a/lint.xml
+++ b/lint.xml
@@ -22,7 +22,5 @@
 
     <!-- This issue causes nondeterministic results when generating baseline files -->
     <issue id="ConvertToWebp" severity="ignore"/>
-    <!-- https://issuetracker.google.com/issues/220326924 -->
-    <issue id="FlowOperatorInvokedInComposition" severity="ignore"/>
 
 </lint>

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/EffectsFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/EffectsFragment.kt
@@ -12,6 +12,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.material.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
@@ -291,19 +292,21 @@ class EffectsFragment : BaseDialogFragment(), CompoundButton.OnCheckedChangeList
 
     private fun FragmentEffectsBinding.setupEffectsSettingsSegmentedTabBar() {
         effectsSettingsSegmentedTabBar.setContent {
-            val podcastHeaderBackgroundColor by viewModel.playingEpisodeLive.asFlow()
-                .map { it.second }
-                .distinctUntilChangedBy { it }
-                .collectAsStateWithLifecycle(null)
+            val podcastHeaderBackgroundColor by remember {
+                viewModel.playingEpisodeLive.asFlow()
+                    .map { it.second }
+                    .distinctUntilChangedBy { it }
+            }.collectAsStateWithLifecycle(null)
 
-            val podcastEffectsData by viewModel.effectsLive.asFlow()
-                .distinctUntilChanged { t1, t2 ->
-                    t1.podcast.uuid == t2.podcast.uuid &&
-                        t1.podcast.playbackEffects.toData() == t2.podcast.playbackEffects.toData() &&
-                        t1.podcast.overrideGlobalEffects == t2.podcast.overrideGlobalEffects &&
-                        t1.podcast.overrideGlobalEffectsModified == t2.podcast.overrideGlobalEffectsModified
-                }
-                .collectAsStateWithLifecycle(null)
+            val podcastEffectsData by remember {
+                viewModel.effectsLive.asFlow()
+                    .distinctUntilChanged { t1, t2 ->
+                        t1.podcast.uuid == t2.podcast.uuid &&
+                            t1.podcast.playbackEffects.toData() == t2.podcast.playbackEffects.toData() &&
+                            t1.podcast.overrideGlobalEffects == t2.podcast.overrideGlobalEffects &&
+                            t1.podcast.overrideGlobalEffectsModified == t2.podcast.overrideGlobalEffectsModified
+                    }
+            }.collectAsStateWithLifecycle(null)
             val podcast = podcastEffectsData?.podcast ?: return@setContent
 
             if (podcastEffectsData?.showCustomEffectsSettings == true) {

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/bookmark/BookmarksFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/bookmark/BookmarksFragment.kt
@@ -8,6 +8,8 @@ import androidx.compose.material.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.State
 import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.nestedscroll.nestedScroll
@@ -104,13 +106,14 @@ class BookmarksFragment : BaseFragment() {
             // Hack to allow nested scrolling inside bottom sheet viewpager
             // https://stackoverflow.com/a/70195667/193545
             Surface(modifier = Modifier.nestedScroll(rememberNestedScrollInteropConnection())) {
-                val listData = playerViewModel.listDataLive.asFlow()
-                    // ignore the episode progress
-                    .distinctUntilChanged { t1, t2 ->
-                        t1.podcastHeader.episodeUuid == t2.podcastHeader.episodeUuid &&
-                            t1.podcastHeader.isPlaying == t2.podcastHeader.isPlaying
-                    }
-                    .collectAsState(initial = null)
+                val listData = remember {
+                    playerViewModel.listDataLive.asFlow()
+                        // ignore the episode progress
+                        .distinctUntilChanged { t1, t2 ->
+                            t1.podcastHeader.episodeUuid == t2.podcastHeader.episodeUuid &&
+                                t1.podcastHeader.isPlaying == t2.podcastHeader.isPlaying
+                        }
+                }.collectAsState(initial = null)
 
                 val episodeUuid = episodeUuid(listData)
                 val bottomInset = settings.bottomInset.collectAsStateWithLifecycle(initialValue = 0)


### PR DESCRIPTION
## Description

This re-enables the `FlowOperatorInvokedInComposition` check. [This issue](https://issuetracker.google.com/issues/220326924) is still open but we no longer seem to be affected by it.

## Testing Instructions

Smoke test playback effects and bookmarks page.

## Checklist
- [ ] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] ~I have considered whether it makes sense to add tests for my changes~
- [ ] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [ ] ~Any jetpack compose components I added or changed are covered by compose previews~
- [ ] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~