### PR TITLE
Inject OkHttpClient to episode details task and to status checker

### DIFF
--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/repositories/download/UpdateEpisodeDetailsTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/repositories/download/UpdateEpisodeDetailsTest.kt
@@ -14,6 +14,7 @@ import java.util.Date
 import java.util.UUID
 import java.util.concurrent.TimeUnit
 import kotlinx.coroutines.runBlocking
+import okhttp3.OkHttpClient
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
 import org.junit.Assert.assertNull
@@ -85,7 +86,7 @@ class UpdateEpisodeDetailsTest {
 
     class TestWorkerFactory(private val episodeManager: EpisodeManager) : WorkerFactory() {
         override fun createWorker(context: Context, workerClassName: String, workerParameters: WorkerParameters): ListenableWorker? {
-            return UpdateEpisodeDetailsTask(context, workerParameters, episodeManager)
+            return UpdateEpisodeDetailsTask(context, workerParameters, episodeManager, OkHttpClient())
         }
     }
 }

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/status/ServiceStatusChecker.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/status/ServiceStatusChecker.kt
@@ -3,6 +3,7 @@ package au.com.shiftyjelly.pocketcasts.settings.status
 import android.content.Context
 import android.net.ConnectivityManager
 import android.net.NetworkCapabilities
+import au.com.shiftyjelly.pocketcasts.servers.di.NoCache
 import au.com.shiftyjelly.pocketcasts.utils.extensions.await
 import dagger.hilt.android.qualifiers.ApplicationContext
 import java.util.concurrent.TimeUnit
@@ -11,7 +12,10 @@ import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.Response
 
-class ServiceStatusChecker @Inject constructor(@ApplicationContext val context: Context) {
+class ServiceStatusChecker @Inject constructor(
+    @ApplicationContext private val context: Context,
+    @NoCache private val httpClient: OkHttpClient,
+) {
 
     suspend fun check(check: Check): ServiceStatus {
         return when (check) {
@@ -32,7 +36,8 @@ class ServiceStatusChecker @Inject constructor(@ApplicationContext val context: 
     private suspend fun checkUrl(url: String): ServiceStatus {
         val log = StringBuilder()
 
-        val okHttpClient = OkHttpClient.Builder()
+        val okHttpClient = httpClient
+            .newBuilder()
             .connectTimeout(30, TimeUnit.SECONDS)
             .writeTimeout(30, TimeUnit.SECONDS)
             .readTimeout(30, TimeUnit.SECONDS)

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
@@ -60,8 +60,6 @@ interface Settings {
         const val INFO_CANCEL_URL = "https://support.pocketcasts.com/knowledge-base/how-to-cancel-a-subscription/"
         const val INFO_FAQ_URL = "https://support.pocketcasts.com/android/?device=android"
 
-        const val USER_AGENT_POCKETCASTS_SERVER = "Pocket Casts/Android/" + BuildConfig.VERSION_NAME
-
         const val CHROME_CAST_APP_ID = "2FA4D21B"
 
         const val WHATS_NEW_VERSION_CODE = 9257

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/di/CastsWorkerFactory.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/di/CastsWorkerFactory.kt
@@ -6,7 +6,6 @@ import androidx.work.WorkerFactory
 import androidx.work.WorkerParameters
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.repositories.download.DownloadManager
-import au.com.shiftyjelly.pocketcasts.repositories.download.UpdateEpisodeDetailsTask
 import au.com.shiftyjelly.pocketcasts.repositories.download.task.DownloadEpisodeTask
 import au.com.shiftyjelly.pocketcasts.repositories.download.task.UploadEpisodeTask
 import au.com.shiftyjelly.pocketcasts.repositories.notification.NotificationHelper
@@ -61,9 +60,6 @@ class CastsWorkerFactory @Inject constructor(
                 instance.podcastManager = podcastManager
                 instance.refreshServiceManager = refreshServiceManager
                 instance.notificationHelper = notificationHelper
-            }
-            is UpdateEpisodeDetailsTask -> {
-                instance.episodeManager = episodeManager
             }
         }
 

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/download/UpdateEpisodeDetailsTask.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/download/UpdateEpisodeDetailsTask.kt
@@ -13,6 +13,7 @@ import androidx.work.WorkManager
 import androidx.work.WorkerParameters
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
+import au.com.shiftyjelly.pocketcasts.servers.di.Downloads
 import au.com.shiftyjelly.pocketcasts.servers.di.NoCache
 import au.com.shiftyjelly.pocketcasts.utils.Util
 import au.com.shiftyjelly.pocketcasts.utils.extensions.await
@@ -30,7 +31,7 @@ class UpdateEpisodeDetailsTask @AssistedInject constructor(
     @Assisted context: Context,
     @Assisted params: WorkerParameters,
     private val episodeManager: EpisodeManager,
-    @NoCache private val httpClient: OkHttpClient,
+    @Downloads private val httpClient: OkHttpClient,
 ) : CoroutineWorker(context, params) {
     companion object {
         private const val TASK_NAME = "UpdateEpisodeDetailsTask"

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/download/UpdateEpisodeDetailsTask.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/download/UpdateEpisodeDetailsTask.kt
@@ -14,7 +14,6 @@ import androidx.work.WorkerParameters
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
 import au.com.shiftyjelly.pocketcasts.servers.di.Downloads
-import au.com.shiftyjelly.pocketcasts.servers.di.NoCache
 import au.com.shiftyjelly.pocketcasts.utils.Util
 import au.com.shiftyjelly.pocketcasts.utils.extensions.await
 import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/download/UpdateEpisodeDetailsTask.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/download/UpdateEpisodeDetailsTask.kt
@@ -13,13 +13,13 @@ import androidx.work.WorkManager
 import androidx.work.WorkerParameters
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
+import au.com.shiftyjelly.pocketcasts.servers.di.NoCache
 import au.com.shiftyjelly.pocketcasts.utils.Util
 import au.com.shiftyjelly.pocketcasts.utils.extensions.await
 import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedInject
 import java.io.IOException
-import java.util.concurrent.TimeUnit
 import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
 import okhttp3.OkHttpClient
 import okhttp3.Request
@@ -27,14 +27,14 @@ import timber.log.Timber
 
 @HiltWorker
 class UpdateEpisodeDetailsTask @AssistedInject constructor(
-    @Assisted val context: Context,
-    @Assisted val params: WorkerParameters,
-    var episodeManager: EpisodeManager,
+    @Assisted context: Context,
+    @Assisted params: WorkerParameters,
+    private val episodeManager: EpisodeManager,
+    @NoCache private val httpClient: OkHttpClient,
 ) : CoroutineWorker(context, params) {
     companion object {
         private const val TASK_NAME = "UpdateEpisodeDetailsTask"
         const val INPUT_EPISODE_UUIDS = "episode_uuids"
-        private const val REQUEST_TIMEOUT_SECS = 20L
         private const val MAX_RETRIES = 3
 
         fun enqueue(episodes: List<PodcastEpisode>, context: Context) {
@@ -80,8 +80,6 @@ class UpdateEpisodeDetailsTask @AssistedInject constructor(
         info("Worker started - episodes: ${episodeUuids.joinToString()}}")
 
         try {
-            val client = OkHttpClient.Builder().callTimeout(REQUEST_TIMEOUT_SECS, TimeUnit.SECONDS).build()
-
             for (episodeUuid in episodeUuids) {
                 val episode = episodeManager.findByUuid(episodeUuid) ?: continue
                 if (ignoreEpisode(episode)) {
@@ -91,7 +89,6 @@ class UpdateEpisodeDetailsTask @AssistedInject constructor(
                 val downloadUrl = episode.downloadUrl?.toHttpUrlOrNull() ?: continue
                 val request = Request.Builder()
                     .url(downloadUrl)
-                    .addHeader("User-Agent", "Pocket Casts")
                     .head()
                     .build()
 
@@ -100,7 +97,7 @@ class UpdateEpisodeDetailsTask @AssistedInject constructor(
                 }
 
                 try {
-                    val response = client.newCall(request).await()
+                    val response = httpClient.newCall(request).await()
 
                     val contentType = response.header("Content-Type")
                     if (!contentType.isNullOrBlank()) {

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/ExoPlayerDataSourceFactory.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/ExoPlayerDataSourceFactory.kt
@@ -20,6 +20,7 @@ import androidx.media3.extractor.DefaultExtractorsFactory
 import androidx.media3.extractor.mp3.Mp3Extractor
 import au.com.shiftyjelly.pocketcasts.models.entity.BaseEpisode
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
+import au.com.shiftyjelly.pocketcasts.servers.di.InterceptorModule
 import au.com.shiftyjelly.pocketcasts.servers.di.Player
 import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
 import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
@@ -54,10 +55,9 @@ class ExoPlayerDataSourceFactory @Inject constructor(
 
     private val httpFactory = if (FeatureFlag.isEnabled(Feature.EXO_OKHTTP)) {
         OkHttpDataSource.Factory(client)
-            .setUserAgent(Settings.USER_AGENT_POCKETCASTS_SERVER)
     } else {
         DefaultHttpDataSource.Factory()
-            .setUserAgent(Settings.USER_AGENT_POCKETCASTS_SERVER)
+            .setUserAgent(InterceptorModule.PocketCastsPublicUserAgent)
             .setAllowCrossProtocolRedirects(true)
             .setConnectTimeoutMs(sixtySeconds)
             .setReadTimeoutMs(sixtySeconds)

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/ServiceManager.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/ServiceManager.kt
@@ -225,7 +225,6 @@ open class ServiceManager @Inject constructor(
         val formBody = parameters.toFormBody()
         val request = Request.Builder()
             .url(url)
-            .header("User-Agent", Settings.USER_AGENT_POCKETCASTS_SERVER)
             .post(formBody)
             .build()
 

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/di/InterceptorModule.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/di/InterceptorModule.kt
@@ -1,7 +1,6 @@
 package au.com.shiftyjelly.pocketcasts.servers.di
 
 import au.com.shiftyjelly.pocketcasts.preferences.AccessToken
-import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.servers.BuildConfig
 import au.com.shiftyjelly.pocketcasts.servers.CleanAndRetryInterceptor
 import au.com.shiftyjelly.pocketcasts.servers.OkHttpInterceptor
@@ -25,6 +24,9 @@ import okhttp3.logging.HttpLoggingInterceptor
 @InstallIn(SingletonComponent::class)
 @Module
 object InterceptorModule {
+    const val PocketCastsPublicUserAgent = "Pocket Casts"
+    const val PocketCastsInternalUserAgent = "$PocketCastsPublicUserAgent/Android/${BuildConfig.VERSION_NAME}"
+
     private val fiveMinutes = 5.minutes.inWholeSeconds
     private val cacheControlHeader = "Cache-Control"
 
@@ -35,9 +37,15 @@ object InterceptorModule {
             }
         })
 
-    private val userAgentInterceptor = Interceptor { chain ->
+    private val publicUserAgentInterceptor = Interceptor { chain ->
         val request = chain.request().newBuilder()
-        request.header("User-Agent", Settings.USER_AGENT_POCKETCASTS_SERVER)
+        request.header("User-Agent", PocketCastsPublicUserAgent)
+        chain.proceed(request.build())
+    }
+
+    private val internalUserAgentInterceptor = Interceptor { chain ->
+        val request = chain.request().newBuilder()
+        request.header("User-Agent", PocketCastsInternalUserAgent)
         chain.proceed(request.build())
     }
 
@@ -115,7 +123,7 @@ object InterceptorModule {
     fun provideCachedInterceptors(): List<OkHttpInterceptor> {
         return buildList {
             add(cacheControlInterceptor.toClientInterceptor())
-            add(userAgentInterceptor.toClientInterceptor())
+            add(internalUserAgentInterceptor.toClientInterceptor())
             add(crashLoggingInterceptor.toClientInterceptor())
 
             if (BuildConfig.DEBUG) {
@@ -131,7 +139,7 @@ object InterceptorModule {
     @NoCache
     fun provideNoCacheInterceptors(): List<OkHttpInterceptor> {
         return buildList {
-            add(userAgentInterceptor.toClientInterceptor())
+            add(internalUserAgentInterceptor.toClientInterceptor())
             add(crashLoggingInterceptor.toClientInterceptor())
 
             if (BuildConfig.DEBUG) {
@@ -149,7 +157,7 @@ object InterceptorModule {
         @TokenInterceptor interceptor: Interceptor,
     ): List<OkHttpInterceptor> {
         return buildList {
-            add(userAgentInterceptor.toClientInterceptor())
+            add(internalUserAgentInterceptor.toClientInterceptor())
             add(interceptor.toClientInterceptor())
             add(crashLoggingInterceptor.toClientInterceptor())
 
@@ -166,7 +174,7 @@ object InterceptorModule {
     @Downloads
     fun provideDownloadsInterceptors(): List<OkHttpInterceptor> {
         return buildList {
-            add(userAgentInterceptor.toClientInterceptor())
+            add(publicUserAgentInterceptor.toClientInterceptor())
             add(crashLoggingInterceptor.toClientInterceptor())
             add(cleanAndRetryInterceptor)
 
@@ -183,7 +191,7 @@ object InterceptorModule {
     @Transcripts
     fun provideTranscriptsInterceptors(): List<OkHttpInterceptor> {
         return buildList {
-            add(userAgentInterceptor.toClientInterceptor())
+            add(publicUserAgentInterceptor.toClientInterceptor())
             add(cacheControlTranscriptsInterceptor.toClientInterceptor())
             add(crashLoggingInterceptor.toClientInterceptor())
 
@@ -200,9 +208,9 @@ object InterceptorModule {
 
     @Provides
     @Player
-    fun providePLayerInterceptors(): List<OkHttpInterceptor> {
+    fun providePlayerInterceptors(): List<OkHttpInterceptor> {
         return buildList {
-            add(userAgentInterceptor.toClientInterceptor())
+            add(publicUserAgentInterceptor.toClientInterceptor())
             add(crashLoggingInterceptor.toClientInterceptor())
             add(cleanAndRetryInterceptor)
 


### PR DESCRIPTION
## Description

`UpdateEpisodeDetailsTask` and `ServiceStatusChecker` didn't use DI for `OkHttpClient` which can lead to performance degradation and generally is harder to maintain as we update our network layer.

## Testing Instructions

1. Test if status check still works.
2. Play an episode and check if you can see the episode details.

## Checklist
- [ ] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [ ] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [ ] ~Any jetpack compose components I added or changed are covered by compose previews~
- [ ] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~