### PR TITLE
Start Android 15 upgrade

### DIFF
--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/auto/PackageValidator.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/auto/PackageValidator.kt
@@ -165,14 +165,14 @@ class PackageValidator(context: Context, @XmlRes xmlResId: Int) {
     private fun buildCallerInfo(callingPackage: String): CallerPackageInfo? {
         val packageInfo = getPackageInfo(callingPackage) ?: return null
 
-        val appName = packageInfo.applicationInfo.loadLabel(packageManager).toString()
-        val uid = packageInfo.applicationInfo.uid
+        val appName = packageInfo.applicationInfo?.loadLabel(packageManager)?.toString() ?: return null
+        val uid = packageInfo.applicationInfo?.uid ?: return null
         val signature = getSignature(packageInfo)
 
-        val requestedPermissions = packageInfo.requestedPermissions
-        val permissionFlags = packageInfo.requestedPermissionsFlags
+        val requestedPermissions = packageInfo.requestedPermissions ?: emptyArray()
+        val permissionFlags = packageInfo.requestedPermissionsFlags ?: IntArray(requestedPermissions.size)
         val activePermissions = mutableSetOf<String>()
-        requestedPermissions?.forEachIndexed { index, permission ->
+        requestedPermissions.forEachIndexed { index, permission ->
             if (permissionFlags[index] and REQUESTED_PERMISSION_GRANTED != 0) {
                 activePermissions += permission
             }
@@ -206,15 +206,17 @@ class PackageValidator(context: Context, @XmlRes xmlResId: Int) {
      * returns `null` as the signature.
      */
     @Suppress("DEPRECATION")
-    private fun getSignature(packageInfo: PackageInfo): String? =
-        if (packageInfo.signatures == null || packageInfo.signatures.size != 1) {
+    private fun getSignature(packageInfo: PackageInfo): String? {
+        val signatures = packageInfo.signatures
+        return if (signatures == null || signatures.size != 1) {
             // Security best practices dictate that an app should be signed with exactly one (1)
             // signature. Because of this, if there are multiple signatures, reject it.
             null
         } else {
-            val certificate = packageInfo.signatures[0].toByteArray()
+            val certificate = signatures[0].toByteArray()
             getSignatureSha256(certificate)
         }
+    }
 
     private fun buildCertificateAllowList(parser: XmlResourceParser): Map<String, KnownCallerInfo> {
         val certificateAllowList = LinkedHashMap<String, KnownCallerInfo>()

--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/images/RoundedCornersTransformation.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/images/RoundedCornersTransformation.kt
@@ -53,7 +53,7 @@ class RoundedCornersTransformation(
         // https://github.com/coil-kt/coil/issues/421#issuecomment-640133205
         val (outputWidth, outputHeight) = input.width to input.height
 
-        val output = createBitmap(outputWidth, outputHeight, input.config)
+        val output = createBitmap(outputWidth, outputHeight, input.config ?: Bitmap.Config.ARGB_8888)
         output.applyCanvas {
             drawColor(Color.TRANSPARENT, PorterDuff.Mode.CLEAR)
 


### PR DESCRIPTION
## Description

We need to make a few upgrades before changing the `targetSdkVersion` and `compileSdkVersion` to 35. The main change is upgrading to edge to edge and I will try to do this in another PR. The changes in this PR are caused by errors while trying to build using 35.

## Testing Instructions

These changes are strange to test while we aren't targeting SDK 35. The round corner change is because the method changed from @NotNull to @Nullable. And I'm not sure it's possible to test the PackageValidator.kt change as it's related to Automotive.

- Open the mobile app
- ✅ Check the podcast image corners are rounded
- Open the Automotive app
- ✅ Check you can play an episode

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack
