### PR TITLE
Shelf Row Item - Update ripple configuration

### DIFF
--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/shelf/MenuShelfItems.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/shelf/MenuShelfItems.kt
@@ -66,7 +66,7 @@ private fun Content(
                         ReorderableItem(reorderableLazyListState, key = listItem.id) { isDragging ->
                             val elevation by animateDpAsState(if (isDragging) 4.dp else 0.dp)
                             val color = if (isDragging) selectedBackgroundColor else normalBackgroundColor
-                            val rowDraggableModifier = if (state.isEditable) Modifier.draggableHandle() else Modifier
+                            val rowDraggableModifier = if (state.isEditable) Modifier.longPressDraggableHandle() else Modifier
                             Surface(elevation = elevation, color = color) {
                                 ShelfItemRow(
                                     episode = state.episode,

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/shelf/ShelfItemRow.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/shelf/ShelfItemRow.kt
@@ -7,12 +7,18 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.material.Icon
+import androidx.compose.material.LocalRippleConfiguration
 import androidx.compose.material.MaterialTheme
+import androidx.compose.material.RippleConfiguration
+import androidx.compose.material.RippleDefaults
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
@@ -32,6 +38,7 @@ import java.util.Date
 import au.com.shiftyjelly.pocketcasts.images.R as IR
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
+@OptIn(ExperimentalMaterialApi::class)
 @Composable
 fun ShelfItemRow(
     episode: BaseEpisode?,
@@ -43,47 +50,58 @@ fun ShelfItemRow(
 ) {
     val subtitleResId = item.subtitleId(episode)
     val isEnabled = item != ShelfItem.Transcript || isTranscriptAvailable
-    Row(
-        modifier = modifier
-            .fillMaxWidth()
-            .heightIn(min = 64.dp)
-            .alpha(if (isEnabled || isEditable) 1f else 0.4f)
-            .clickable { onClick?.invoke(item, isEnabled) },
-        verticalAlignment = Alignment.CenterVertically,
-    ) {
-        Icon(
-            painter = painterResource(item.iconId(episode)),
-            contentDescription = null,
-            modifier = Modifier
-                .padding(start = 16.dp)
-                .size(24.dp),
-            tint = MaterialTheme.theme.colors.playerContrast02,
-        )
-        Column(
-            modifier = Modifier
-                .weight(1f)
-                .padding(horizontal = 24.dp, vertical = 8.dp),
-        ) {
-            TextH40(
-                text = stringResource(item.titleId(episode)),
-                color = MaterialTheme.theme.colors.playerContrast01,
+    CompositionLocalProvider(
+        LocalRippleConfiguration provides if (isEditable) {
+            null
+        } else {
+            RippleConfiguration(
+                color = Color.White,
+                rippleAlpha = RippleDefaults.rippleAlpha(Color.White, true),
             )
-            if (isEditable && subtitleResId != null) {
-                TextH50(
-                    text = stringResource(subtitleResId),
-                    color = MaterialTheme.theme.colors.playerContrast03,
-                )
-            }
-        }
-        if (isEditable) {
+        },
+    ) {
+        Row(
+            modifier = modifier
+                .fillMaxWidth()
+                .heightIn(min = 64.dp)
+                .alpha(if (isEnabled || isEditable) 1f else 0.4f)
+                .clickable { onClick?.invoke(item, isEnabled) },
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
             Icon(
-                painter = painterResource(IR.drawable.ic_reorder),
-                contentDescription = stringResource(LR.string.rearrange_actions),
+                painter = painterResource(item.iconId(episode)),
+                contentDescription = null,
                 modifier = Modifier
-                    .padding(end = 16.dp)
+                    .padding(start = 16.dp)
                     .size(24.dp),
                 tint = MaterialTheme.theme.colors.playerContrast02,
             )
+            Column(
+                modifier = Modifier
+                    .weight(1f)
+                    .padding(horizontal = 24.dp, vertical = 8.dp),
+            ) {
+                TextH40(
+                    text = stringResource(item.titleId(episode)),
+                    color = MaterialTheme.theme.colors.playerContrast01,
+                )
+                if (isEditable && subtitleResId != null) {
+                    TextH50(
+                        text = stringResource(subtitleResId),
+                        color = MaterialTheme.theme.colors.playerContrast03,
+                    )
+                }
+            }
+            if (isEditable) {
+                Icon(
+                    painter = painterResource(IR.drawable.ic_reorder),
+                    contentDescription = stringResource(LR.string.rearrange_actions),
+                    modifier = Modifier
+                        .padding(end = 16.dp)
+                        .size(24.dp),
+                    tint = MaterialTheme.theme.colors.playerContrast02,
+                )
+            }
         }
     }
 }


### PR DESCRIPTION
## Description
This updates shelf row item ripple configuration to have a light color as the background is always dark.
Noticed in: https://github.com/Automattic/pocket-casts-android/pull/3214#discussion_r1839164893

## Testing Instructions
1. Choose a dark theme
2. Play an episode 
3. Open the full-screen button and tap more button in the shelf
4. Long press a shelf item in the more actions dialog
5. ✅ Notice that the ripple is light in color (before compose migration we used `selectableItemBackground` as item background in the XML which also uses a white color ripple)

## Screenshots or Screencast 

https://github.com/user-attachments/assets/55444626-2b72-4807-af1c-b325e831d33f


## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
