### PR TITLE
Fix clip sharing memory leak

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -383,7 +383,7 @@ subprojects {
         }
 
         // Set Gradle property 'au.com.shiftyjelly.pocketcasts.leakcanary=true' to enable Leak Canary.
-        // You can do this using the local.properties file or any other avaialable Gradle mechanism.
+        // You can do this using the gradle.properties file or any other avaialable Gradle mechanism.
         // See: https://docs.gradle.org/current/userguide/build_environment.html#sec:project_properties
         if (properties["au.com.shiftyjelly.pocketcasts.leakcanary"]?.toString().toBoolean()) {
             dependencies {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -383,7 +383,7 @@ subprojects {
         }
 
         // Set Gradle property 'au.com.shiftyjelly.pocketcasts.leakcanary=true' to enable Leak Canary.
-        // You can do this using the gradle.properties file or any other avaialable Gradle mechanism.
+        // You can do this using the gradle.properties file or any other available Gradle mechanism.
         // See: https://docs.gradle.org/current/userguide/build_environment.html#sec:project_properties
         if (properties["au.com.shiftyjelly.pocketcasts.leakcanary"]?.toString().toBoolean()) {
             dependencies {

--- a/modules/features/reimagine/src/main/kotlin/au/com/shiftyjelly/pocketcasts/reimagine/clip/ShareClipViewModel.kt
+++ b/modules/features/reimagine/src/main/kotlin/au/com/shiftyjelly/pocketcasts/reimagine/clip/ShareClipViewModel.kt
@@ -222,7 +222,7 @@ class ShareClipViewModel @AssistedInject constructor(
                 -> {
                     clipAnalytics.clipShared(clipRange, ClipShareType.Video, cardType)
                     createBackgroundAsset(cardType).map { asset ->
-                        videoClipReequest(podcast, episode, clipRange, platform, cardType, asset, sourceView)
+                        videoClipRequest(podcast, episode, clipRange, platform, cardType, asset, sourceView)
                     }
                 }
             }
@@ -257,7 +257,7 @@ class ShareClipViewModel @AssistedInject constructor(
             .build()
     }
 
-    private fun videoClipReequest(
+    private fun videoClipRequest(
         podcast: Podcast,
         episode: PodcastEpisode,
         clipRange: Clip.Range,

--- a/modules/services/media-ffmpeg/src/main/kotlin/au/com/shiftyjelly/pocketcasts/media/FFmpegMediaService.kt
+++ b/modules/services/media-ffmpeg/src/main/kotlin/au/com/shiftyjelly/pocketcasts/media/FFmpegMediaService.kt
@@ -9,6 +9,7 @@ import au.com.shiftyjelly.pocketcasts.sharing.MediaService
 import au.com.shiftyjelly.pocketcasts.sharing.VisualCardType
 import au.com.shiftyjelly.pocketcasts.utils.toSecondsWithSingleMilli
 import com.arthenica.ffmpegkit.FFmpegKit
+import com.arthenica.ffmpegkit.FFmpegKitConfig
 import com.arthenica.ffmpegkit.FFmpegSession
 import com.arthenica.ffmpegkit.FFmpegSessionCompleteCallback
 import com.arthenica.ffmpegkit.ReturnCode
@@ -150,6 +151,7 @@ internal class FFmpegMediaService(
             command,
             object : FFmpegSessionCompleteCallback {
                 override fun apply(session: FFmpegSession) {
+                    FFmpegKitConfig.clearSessions()
                     when {
                         ReturnCode.isSuccess(session.returnCode) -> {
                             continuation.resume(Result.success(Unit))
@@ -166,7 +168,10 @@ internal class FFmpegMediaService(
                 }
             },
         )
-        continuation.invokeOnCancellation { session.cancel() }
+        continuation.invokeOnCancellation {
+            FFmpegKitConfig.clearSessions()
+            session.cancel()
+        }
     }
 
     private companion object {


### PR DESCRIPTION
## Description

`FFmpegKitConfig` retains session history. Sessions hold references to callbacks, which, in turn, hold references to view models and fragments. There is no mechanism in the FFMpegKit library to clear a single session or to retain no history. For this reason, I clear the entire history after a session completes its task.

Issue reported here: https://github.com/arthenica/ffmpeg-kit/issues/1066

## Testing Instructions

1. Share an audio or a video clip.
2. Close the sharing flow.
3. Using Leak Canary or Android Studio's memory profiler verify that `ShareClipFragment` and `ShareClipViewModel` do not leak.

## Checklist
- [ ] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] ~I have considered whether it makes sense to add tests for my changes~
- [ ] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [ ] ~Any jetpack compose components I added or changed are covered by compose previews~
- [ ] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~