### PR TITLE
Make seen EoY segments filled

### DIFF
--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/ui/StoriesPage.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/ui/StoriesPage.kt
@@ -274,7 +274,6 @@ internal fun BoxScope.TopControls(
             state = pagerState,
             progress = progress,
             activeColor = Color.Black,
-            isProgressedActive = false,
         )
         Spacer(
             modifier = Modifier.height(10.dp),


### PR DESCRIPTION
## Description

This changes PB24 segments filing back.

See: p1731478656991879-slack-C041BGTFQ5R

## Testing Instructions

1. Start PB24.
2. Make sure that segments for seen stories are filled in with an active color.

## Screenshots or Screencast 

| Before | After |
| - | - |
|  ![Screenshot 2024-11-06 at 10 52 24](https://github.com/user-attachments/assets/7bb0722f-7b50-4be7-990d-a3327aee9b2c) | ![Screenshot 2024-11-06 at 10 52 58](https://github.com/user-attachments/assets/1da34290-48d5-4173-85c2-c40efd85293d) |

## Checklist
- [ ] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [z] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] ~I have considered whether it makes sense to add tests for my changes~
- [ ] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [ ] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~