### PR TITLE
[Tooling] Automate creation of backmerge PRs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,6 @@ source 'https://rubygems.org'
 gem 'danger-dangermattic', '~> 1.2.1'
 gem 'fastlane', '~> 2.216'
 # These lines are kept to help with testing Release Toolkit changes
-gem 'fastlane-plugin-wpmreleasetoolkit', '~> 12.0'
+gem 'fastlane-plugin-wpmreleasetoolkit', '~> 12.3'
 # gem 'fastlane-plugin-wpmreleasetoolkit', path: '../../release-toolkit'
 # gem 'fastlane-plugin-wpmreleasetoolkit', git: 'https://github.com/wordpress-mobile/release-toolkit', branch: ''

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,7 +5,7 @@ GEM
       base64
       nkf
       rexml
-    activesupport (7.2.2)
+    activesupport (8.0.0)
       base64
       benchmark (>= 0.3)
       bigdecimal
@@ -17,14 +17,15 @@ GEM
       minitest (>= 5.1)
       securerandom (>= 0.3)
       tzinfo (~> 2.0, >= 2.0.5)
+      uri (>= 0.13.1)
     addressable (2.8.7)
       public_suffix (>= 2.0.2, < 7.0)
     artifactory (3.0.17)
     ast (2.4.2)
     atomos (0.1.3)
     aws-eventstream (1.3.0)
-    aws-partitions (1.1001.0)
-    aws-sdk-core (3.211.0)
+    aws-partitions (1.1006.0)
+    aws-sdk-core (3.212.0)
       aws-eventstream (~> 1, >= 1.3.0)
       aws-partitions (~> 1, >= 1.992.0)
       aws-sigv4 (~> 1.9)
@@ -32,7 +33,7 @@ GEM
     aws-sdk-kms (1.95.0)
       aws-sdk-core (~> 3, >= 3.210.0)
       aws-sigv4 (~> 1.5)
-    aws-sdk-s3 (1.169.0)
+    aws-sdk-s3 (1.170.1)
       aws-sdk-core (~> 3, >= 3.210.0)
       aws-sdk-kms (~> 1)
       aws-sigv4 (~> 1.5)
@@ -40,7 +41,7 @@ GEM
       aws-eventstream (~> 1, >= 1.0.2)
     babosa (1.0.4)
     base64 (0.2.0)
-    benchmark (0.3.0)
+    benchmark (0.4.0)
     bigdecimal (3.1.8)
     buildkit (1.6.1)
       sawyer (>= 0.6)
@@ -164,7 +165,7 @@ GEM
       xcodeproj (>= 1.13.0, < 2.0.0)
       xcpretty (~> 0.3.0)
       xcpretty-travis-formatter (>= 0.0.3, < 2.0.0)
-    fastlane-plugin-wpmreleasetoolkit (12.3.0)
+    fastlane-plugin-wpmreleasetoolkit (12.3.1)
       activesupport (>= 6.1.7.1)
       buildkit (~> 1.5)
       chroma (= 0.2.0)
@@ -231,7 +232,7 @@ GEM
       concurrent-ruby (~> 1.0)
     java-properties (0.3.0)
     jmespath (1.6.2)
-    json (2.7.6)
+    json (2.8.1)
     jwt (2.9.3)
       base64
     kramdown (2.4.0)
@@ -262,7 +263,7 @@ GEM
       sawyer (~> 0.9)
     open4 (1.3.4)
     options (2.3.2)
-    optparse (0.5.0)
+    optparse (0.6.0)
     os (1.1.4)
     parallel (1.26.3)
     parser (3.3.6.0)
@@ -306,7 +307,7 @@ GEM
     sawyer (0.9.2)
       addressable (>= 2.3.5)
       faraday (>= 0.17.3, < 3)
-    securerandom (0.3.1)
+    securerandom (0.3.2)
     security (0.1.5)
     signet (0.19.0)
       addressable (~> 2.8)
@@ -329,6 +330,7 @@ GEM
       concurrent-ruby (~> 1.0)
     uber (0.1.0)
     unicode-display_width (2.6.0)
+    uri (1.0.1)
     word_wrap (1.0.0)
     xcodeproj (1.27.0)
       CFPropertyList (>= 2.3.3, < 4.0)
@@ -354,7 +356,7 @@ PLATFORMS
 DEPENDENCIES
   danger-dangermattic (~> 1.2.1)
   fastlane (~> 2.216)
-  fastlane-plugin-wpmreleasetoolkit (~> 12.0)
+  fastlane-plugin-wpmreleasetoolkit (~> 12.3)
 
 BUNDLED WITH
    2.4.21

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -541,19 +541,6 @@ platform :android do
       labels: ['Releases'],
       milestone_title: release_version_next
     )
-  rescue StandardError => e
-    error_message = <<-MESSAGE
-      Error creating backmerge pull request:
-
-      #{e.message}
-
-      If this is not the first time you are running the release task, the backmerge PR for the version `#{version}` might have already been previously created.
-      Please close any previous backmerge PR for `#{version}`, delete the previous merge branch, then run the release task again.
-    MESSAGE
-
-    buildkite_annotate(style: 'error', context: 'error-creating-backmerge', message: error_message) if is_ci
-
-    UI.user_error!(error_message)
   end
 
   #####################################################################################

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -129,25 +129,14 @@ platform :android do
     )
     push_to_git_remote(tags: false)
 
+    trigger_release_build(branch_to_build: "release/#{new_version}")
+    create_backmerge_pr
+
     # We cannot use the `copy_branch_protection` action here as it would create a branch protection rule with the same
-    # restrictions we have in `trunk`, and the release managers wouldn't be able to push due to permissions.
+    # restrictions we have in `main`, and the release managers wouldn't be able to push due to permissions.
     # This should be changed only when we have PC Android releases done on CI, when the CI bot is the one running `git push`.
     set_branch_protection(repository: GH_REPOSITORY, branch: "release/#{new_version}")
     set_milestone_frozen_marker(repository: GH_REPOSITORY, milestone: new_version)
-  end
-
-  lane :complete_code_freeze do |options|
-    ensure_git_branch(branch: '^release/') # Match branch names that begin with `release/`
-    ensure_git_status_clean
-
-    new_version = release_version_current
-
-    UI.important("Completing code freeze for: #{new_version}")
-    unless options[:skip_confirm] || UI.confirm('Do you want to continue?')
-      UI.user_error!("Terminating as requested. Don't forget to run the remainder of this automation manually.")
-    end
-
-    trigger_release_build(branch_to_build: "release/#{new_version}")
   end
 
   # @option [String] base_version The "x.y" version number to create a beta from. Defaults to the current version as defined in the version file of `main` branch
@@ -197,6 +186,7 @@ platform :android do
     push_to_git_remote(tags: false)
 
     trigger_release_build(branch_to_build: "release/#{release_version_current}")
+    create_backmerge_pr
   end
 
   # Sets the stage to start working on a hotfix
@@ -259,12 +249,15 @@ platform :android do
     ensure_git_branch(branch: '^release/') # Match branch names that begin with `release/`
     ensure_git_status_clean
 
-    UI.important("Triggering hotfix build for version: #{release_version_current}")
+    version = release_version_current
+
+    UI.important("Triggering hotfix build for version: #{version}")
     unless options[:skip_confirm] || UI.confirm('Do you want to continue?')
       UI.user_error!("Terminating as requested. Don't forget to run the remainder of this automation manually.")
     end
 
-    trigger_release_build(branch_to_build: "release/#{release_version_current}")
+    trigger_release_build(branch_to_build: "release/#{version}")
+    create_backmerge_pr
   end
 
   # @param [String] branch_to_build (default: current git branch) The branch to build
@@ -389,6 +382,7 @@ platform :android do
 
     push_to_git_remote(tags: false)
     trigger_release_build(branch_to_build: "release/#{version}")
+    create_backmerge_pr
   end
 
   # @param [String] version The version to create
@@ -537,6 +531,29 @@ platform :android do
       is_draft: !prerelease,
       release_assets: release_assets.join(',')
     )
+  end
+
+  lane :create_backmerge_pr do |version: release_version_current|
+    create_release_backmerge_pull_request(
+      repository: GH_REPOSITORY,
+      source_branch: "release/#{version}",
+      default_branch: DEFAULT_BRANCH,
+      labels: ['Releases'],
+      milestone_title: release_version_next
+    )
+  rescue StandardError => e
+    error_message = <<-MESSAGE
+      Error creating backmerge pull request:
+
+      #{e.message}
+
+      If this is not the first time you are running the release task, the backmerge PR for the version `#{version}` might have already been previously created.
+      Please close any previous backmerge PR for `#{version}`, delete the previous merge branch, then run the release task again.
+    MESSAGE
+
+    buildkite_annotate(style: 'error', context: 'error-creating-backmerge', message: error_message) if is_ci
+
+    UI.user_error!(error_message)
   end
 
   #####################################################################################


### PR DESCRIPTION
## Description

This PR automates 🤖  the creation of the backmerge PR after having triggered a new beta build (post-code-freeze or post-beta) and after having finalized the final release.

It also removes the `complete_code_freeze` lane after having moved the action that it did (triggering a new build) directly in the `code_freeze` lane. That way, Release Managers don't have to run `code_freeze` then `complete_code_freeze` lanes back-to-back every time, and will instead now just have a single `code_freeze` lane to run instead of two. 🎉 

> [!NOTE]
> This PR has a corresponding diff on the ReleasesV2 scenario (see D166226-code) to adjust the tasks in the checklist accordingly.

## Testing Instructions

The whole scenario is not easily testable without going through the real release steps.

But if there are new commits on the current `release/*` branch that have not been merged yet, we can at least test the `create_backmerge_pr` lane in isolation:
 - Run `bundle exec fastlane create_backmerge_pr`
 - Validate that it creates an intermediate branch, push it, and [creates the PR in GitHub](https://github.com/Automattic/pocket-casts-android/pull/3225) with the appropriate commits.

## Extras

This PR also updates the `release-toolkit` to [its latest version `12.3.1`](https://github.com/wordpress-mobile/release-toolkit/releases/tag/12.3.1)—which amongst other things will [fix the issue reported recently](https://github.com/wordpress-mobile/release-toolkit/pull/610) by @MiSikora about links not working on GitHub Releases (internal ref: p1731397370353649/1729610708.303749-slack-C028JAG44VD)