### PR TITLE
Use content extension to set up fragments

### DIFF
--- a/automotive/build.gradle.kts
+++ b/automotive/build.gradle.kts
@@ -62,6 +62,7 @@ dependencies {
     implementation(libs.dagger.hilt.android)
     implementation(libs.dagger.hilt.core)
     implementation(libs.encryptedlogging)
+    implementation(libs.fragment.compose)
     implementation(libs.guava)
     implementation(libs.hilt.work)
     implementation(libs.lifecycle.reactivestreams.ktx)

--- a/automotive/src/main/java/au/com/shiftyjelly/pocketcasts/AutomotiveAboutFragment.kt
+++ b/automotive/src/main/java/au/com/shiftyjelly/pocketcasts/AutomotiveAboutFragment.kt
@@ -29,6 +29,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.fragment.app.Fragment
 import androidx.fragment.compose.content
+import au.com.shiftyjelly.pocketcasts.compose.AutomotiveTheme
 import au.com.shiftyjelly.pocketcasts.compose.components.HorizontalDivider
 import au.com.shiftyjelly.pocketcasts.compose.theme
 import au.com.shiftyjelly.pocketcasts.extensions.openUrl
@@ -49,11 +50,13 @@ class AutomotiveAboutFragment : Fragment() {
         container: ViewGroup?,
         savedInstanceState: Bundle?,
     ) = content {
-        AboutPage(
-            onOpenLicenses = { openLicenses() },
-            onOpenLogs = { onOpenLogs() },
-            onOpenUrl = { openUrl(it) },
-        )
+        AutomotiveTheme {
+            AboutPage(
+                onOpenLicenses = { openLicenses() },
+                onOpenLogs = { onOpenLogs() },
+                onOpenUrl = { openUrl(it) },
+            )
+        }
     }
 
     private fun openLicenses() {

--- a/automotive/src/main/java/au/com/shiftyjelly/pocketcasts/AutomotiveAboutFragment.kt
+++ b/automotive/src/main/java/au/com/shiftyjelly/pocketcasts/AutomotiveAboutFragment.kt
@@ -2,7 +2,6 @@ package au.com.shiftyjelly.pocketcasts
 
 import android.os.Bundle
 import android.view.LayoutInflater
-import android.view.View
 import android.view.ViewGroup
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.clickable
@@ -21,7 +20,6 @@ import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
@@ -30,7 +28,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.fragment.app.Fragment
-import au.com.shiftyjelly.pocketcasts.compose.AutomotiveTheme
+import androidx.fragment.compose.content
 import au.com.shiftyjelly.pocketcasts.compose.components.HorizontalDivider
 import au.com.shiftyjelly.pocketcasts.compose.theme
 import au.com.shiftyjelly.pocketcasts.extensions.openUrl
@@ -46,18 +44,16 @@ import au.com.shiftyjelly.pocketcasts.ui.R as UR
 @AndroidEntryPoint
 class AutomotiveAboutFragment : Fragment() {
 
-    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
-        return ComposeView(requireContext()).apply {
-            setContent {
-                AutomotiveTheme {
-                    AboutPage(
-                        onOpenLicenses = { openLicenses() },
-                        onOpenLogs = { onOpenLogs() },
-                        onOpenUrl = { openUrl(it) },
-                    )
-                }
-            }
-        }
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?,
+    ) = content {
+        AboutPage(
+            onOpenLicenses = { openLicenses() },
+            onOpenLogs = { onOpenLogs() },
+            onOpenUrl = { openUrl(it) },
+        )
     }
 
     private fun openLicenses() {

--- a/automotive/src/main/java/au/com/shiftyjelly/pocketcasts/AutomotiveLicensesFragment.kt
+++ b/automotive/src/main/java/au/com/shiftyjelly/pocketcasts/AutomotiveLicensesFragment.kt
@@ -2,16 +2,15 @@ package au.com.shiftyjelly.pocketcasts
 
 import android.os.Bundle
 import android.view.LayoutInflater
-import android.view.View
 import android.view.ViewGroup
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.unit.dp
 import androidx.fragment.app.Fragment
+import androidx.fragment.compose.content
 import au.com.shiftyjelly.pocketcasts.compose.AutomotiveTheme
 import au.com.shiftyjelly.pocketcasts.compose.theme
 import au.com.shiftyjelly.pocketcasts.extensions.openUrl
@@ -24,13 +23,13 @@ import kotlinx.collections.immutable.toImmutableList
 
 class AutomotiveLicensesFragment : Fragment() {
 
-    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
-        return ComposeView(requireContext()).apply {
-            setContent {
-                AutomotiveTheme {
-                    LicensesPage()
-                }
-            }
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?,
+    ) = content {
+        AutomotiveTheme {
+            LicensesPage()
         }
     }
 

--- a/modules/features/account/build.gradle.kts
+++ b/modules/features/account/build.gradle.kts
@@ -58,6 +58,7 @@ dependencies {
     implementation(libs.coroutines.core)
     implementation(libs.coroutines.play.services)
     implementation(libs.coroutines.rx2)
+    implementation(libs.fragment.compose)
     implementation(libs.fragment.ktx)
     implementation(libs.hilt.navigation.compose)
     implementation(libs.lifecycle.reactivestreams.ktx)

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/ChangeDoneFragment.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/ChangeDoneFragment.kt
@@ -2,11 +2,10 @@ package au.com.shiftyjelly.pocketcasts.account
 
 import android.os.Bundle
 import android.view.LayoutInflater
-import android.view.View
 import android.view.ViewGroup
-import androidx.compose.ui.platform.ComposeView
 import androidx.core.os.bundleOf
 import androidx.fragment.app.activityViewModels
+import androidx.fragment.compose.content
 import au.com.shiftyjelly.pocketcasts.account.viewmodel.DoneViewModel
 import au.com.shiftyjelly.pocketcasts.compose.AppThemeWithBackground
 import au.com.shiftyjelly.pocketcasts.views.fragments.BaseFragment
@@ -29,18 +28,18 @@ class ChangeDoneFragment : BaseFragment() {
     private val shouldCloseParent: Boolean
         get() = arguments?.getBoolean(ARG_CLOSE_PARENT) ?: false
 
-    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
-        return ComposeView(requireContext()).apply {
-            setContent {
-                AppThemeWithBackground(theme.activeTheme) {
-                    ChangeDonePage(
-                        viewModel = viewModel,
-                        closeForm = {
-                            closeForm()
-                        },
-                    )
-                }
-            }
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?,
+    ) = content {
+        AppThemeWithBackground(theme.activeTheme) {
+            ChangeDonePage(
+                viewModel = viewModel,
+                closeForm = {
+                    closeForm()
+                },
+            )
         }
     }
 

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/ChangeEmailFragment.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/ChangeEmailFragment.kt
@@ -7,10 +7,10 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.livedata.observeAsState
-import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 import androidx.fragment.app.activityViewModels
+import androidx.fragment.compose.content
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import au.com.shiftyjelly.pocketcasts.account.AccountActivity.AccountUpdatedSource
 import au.com.shiftyjelly.pocketcasts.account.viewmodel.ChangeEmailViewModel
@@ -37,45 +37,45 @@ class ChangeEmailFragment : BaseFragment() {
 
     @Inject lateinit var settings: Settings
 
-    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
-        return ComposeView(requireContext()).apply {
-            setContent {
-                val email: String by viewModel.email.observeAsState("")
-                val password: String by viewModel.password.observeAsState("")
-                val bottomOffset by settings.bottomInset.collectAsStateWithLifecycle(initialValue = 0)
-                AppThemeWithBackground(theme.activeTheme) {
-                    ChangeEmailFragmentPage(
-                        changeEmailState = viewModel.changeEmailState.value,
-                        email = email,
-                        password = password,
-                        updateEmail = viewModel::updateEmail,
-                        updatePassword = viewModel::updatePassword,
-                        onBackPressed = {
-                            @Suppress("DEPRECATION")
-                            activity?.onBackPressed()
-                        },
-                        changeEmail = viewModel::changeEmail,
-                        clearServerError = viewModel::clearServerError,
-                        onSuccess = {
-                            val second = viewModel.email.value ?: ""
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?,
+    ) = content {
+        val email: String by viewModel.email.observeAsState("")
+        val password: String by viewModel.password.observeAsState("")
+        val bottomOffset by settings.bottomInset.collectAsStateWithLifecycle(initialValue = 0)
+        AppThemeWithBackground(theme.activeTheme) {
+            ChangeEmailFragmentPage(
+                changeEmailState = viewModel.changeEmailState.value,
+                email = email,
+                password = password,
+                updateEmail = viewModel::updateEmail,
+                updatePassword = viewModel::updatePassword,
+                onBackPressed = {
+                    @Suppress("DEPRECATION")
+                    activity?.onBackPressed()
+                },
+                changeEmail = viewModel::changeEmail,
+                clearServerError = viewModel::clearServerError,
+                onSuccess = {
+                    val second = viewModel.email.value ?: ""
 
-                            doneViewModel.setChangedEmailState(detail = second)
+                    doneViewModel.setChangedEmailState(detail = second)
 
-                            doneViewModel.trackShown(AccountUpdatedSource.CHANGE_EMAIL)
+                    doneViewModel.trackShown(AccountUpdatedSource.CHANGE_EMAIL)
 
-                            val activity = requireActivity()
+                    val activity = requireActivity()
 
-                            @Suppress("DEPRECATION")
-                            activity.onBackPressed() // done fragment needs to back to profile page
+                    @Suppress("DEPRECATION")
+                    activity.onBackPressed() // done fragment needs to back to profile page
 
-                            val fragment = ChangeDoneFragment.newInstance()
-                            (activity as FragmentHostListener).addFragment(fragment)
-                        },
-                        existingEmail = viewModel.existingEmail ?: "",
-                        bottomOffset = bottomOffset.pxToDp(LocalContext.current).dp,
-                    )
-                }
-            }
+                    val fragment = ChangeDoneFragment.newInstance()
+                    (activity as FragmentHostListener).addFragment(fragment)
+                },
+                existingEmail = viewModel.existingEmail ?: "",
+                bottomOffset = bottomOffset.pxToDp(LocalContext.current).dp,
+            )
         }
     }
 

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/ChangePwdFragment.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/ChangePwdFragment.kt
@@ -5,11 +5,11 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.compose.runtime.getValue
-import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 import androidx.fragment.app.activityViewModels
 import androidx.fragment.app.viewModels
+import androidx.fragment.compose.content
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import au.com.shiftyjelly.pocketcasts.account.viewmodel.ChangePwdViewModel
 import au.com.shiftyjelly.pocketcasts.account.viewmodel.DoneViewModel
@@ -36,32 +36,32 @@ class ChangePwdFragment : BaseFragment() {
     private val doneViewModel: DoneViewModel by activityViewModels()
     private val viewModel: ChangePwdViewModel by viewModels()
 
-    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
-        return ComposeView(requireContext()).apply {
-            setContent {
-                val bottomOffset by settings.bottomInset.collectAsStateWithLifecycle(initialValue = 0)
-                AppThemeWithBackground(theme.activeTheme) {
-                    ChangePasswordPage(
-                        viewModel = viewModel,
-                        onBackPressed = {
-                            @Suppress("DEPRECATION")
-                            activity?.onBackPressed()
-                        },
-                        changePassword = {
-                            viewModel.changePassword()
-                        },
-                        onSuccess = {
-                            doneViewModel.setChangedPasswordState(detail = getString(LR.string.profile_password_changed_successful))
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?,
+    ) = content {
+        val bottomOffset by settings.bottomInset.collectAsStateWithLifecycle(initialValue = 0)
+        AppThemeWithBackground(theme.activeTheme) {
+            ChangePasswordPage(
+                viewModel = viewModel,
+                onBackPressed = {
+                    @Suppress("DEPRECATION")
+                    activity?.onBackPressed()
+                },
+                changePassword = {
+                    viewModel.changePassword()
+                },
+                onSuccess = {
+                    doneViewModel.setChangedPasswordState(detail = getString(LR.string.profile_password_changed_successful))
 
-                            doneViewModel.trackShown(AccountActivity.AccountUpdatedSource.CHANGE_PASSWORD)
+                    doneViewModel.trackShown(AccountActivity.AccountUpdatedSource.CHANGE_PASSWORD)
 
-                            val fragment = ChangeDoneFragment.newInstance(closeParent = true)
-                            (activity as FragmentHostListener).addFragment(fragment)
-                        },
-                        bottomOffset = bottomOffset.pxToDp(LocalContext.current).dp,
-                    )
-                }
-            }
+                    val fragment = ChangeDoneFragment.newInstance(closeParent = true)
+                    (activity as FragmentHostListener).addFragment(fragment)
+                },
+                bottomOffset = bottomOffset.pxToDp(LocalContext.current).dp,
+            )
         }
     }
 

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/bookmark/BookmarkFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/bookmark/BookmarkFragment.kt
@@ -3,16 +3,15 @@ package au.com.shiftyjelly.pocketcasts.player.view.bookmark
 import android.app.Activity
 import android.os.Bundle
 import android.view.LayoutInflater
-import android.view.View
 import android.view.ViewGroup
 import androidx.compose.foundation.background
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.ComposeView
-import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
+import androidx.fragment.compose.content
 import au.com.shiftyjelly.pocketcasts.compose.AppThemeWithBackground
 import au.com.shiftyjelly.pocketcasts.models.entity.Bookmark
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
@@ -27,26 +26,20 @@ class BookmarkFragment : Fragment() {
         inflater: LayoutInflater,
         container: ViewGroup?,
         savedInstanceState: Bundle?,
-    ): View {
-        viewModel.load(BookmarkArguments.createFromArguments(arguments))
-        return ComposeView(requireContext()).apply {
-            setContent {
-                AppThemeWithBackground(Theme.ThemeType.DARK) {
-                    setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
-
-                    val uiState: BookmarkViewModel.UiState by viewModel.uiState.collectAsState()
-                    BookmarkPage(
-                        isNewBookmark = uiState.isNewBookmark,
-                        title = uiState.title,
-                        tintColor = uiState.tintColor,
-                        backgroundColor = uiState.backgroundColor,
-                        onTitleChange = { viewModel.changeTitle(it) },
-                        onSave = ::saveBookmark,
-                        onClose = ::close,
-                        modifier = Modifier.background(uiState.backgroundColor),
-                    )
-                }
-            }
+    ) = content {
+        LaunchedEffect(Unit) { viewModel.load(BookmarkArguments.createFromArguments(arguments)) }
+        AppThemeWithBackground(Theme.ThemeType.DARK) {
+            val uiState: BookmarkViewModel.UiState by viewModel.uiState.collectAsState()
+            BookmarkPage(
+                isNewBookmark = uiState.isNewBookmark,
+                title = uiState.title,
+                tintColor = uiState.tintColor,
+                backgroundColor = uiState.backgroundColor,
+                onTitleChange = { viewModel.changeTitle(it) },
+                onSave = ::saveBookmark,
+                onClose = ::close,
+                modifier = Modifier.background(uiState.backgroundColor),
+            )
         }
     }
 

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/chapters/ChaptersFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/chapters/ChaptersFragment.kt
@@ -12,12 +12,12 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
-import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.rememberNestedScrollInteropConnection
 import androidx.core.net.toUri
 import androidx.core.os.BundleCompat
 import androidx.core.os.bundleOf
 import androidx.fragment.app.viewModels
+import androidx.fragment.compose.content
 import au.com.shiftyjelly.pocketcasts.compose.AppThemeWithBackground
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.to.Chapter
@@ -57,45 +57,43 @@ class ChaptersFragment : BaseFragment() {
         inflater: LayoutInflater,
         container: ViewGroup?,
         savedInstanceState: Bundle?,
-    ) = ComposeView(requireContext()).apply {
-        setContent {
-            val state by viewModel.uiState.collectAsState()
+    ) = content {
+        val state by viewModel.uiState.collectAsState()
 
-            AppThemeWithBackground(mode.themeType) {
-                ChaptersTheme(state.podcast) {
-                    val lazyListState = rememberLazyListState()
+        AppThemeWithBackground(mode.themeType) {
+            ChaptersTheme(state.podcast) {
+                val lazyListState = rememberLazyListState()
 
-                    ChaptersPage(
-                        lazyListState = lazyListState,
-                        chapters = state.chapters,
-                        showHeader = state.showHeader,
-                        totalChaptersCount = state.chaptersCount,
-                        isTogglingChapters = state.isTogglingChapters,
-                        showSubscriptionIcon = state.showSubscriptionIcon,
-                        onChapterClick = viewModel::playChapter,
-                        onSkipChaptersClick = viewModel::enableTogglingOrUpsell,
-                        onSelectionChange = viewModel::selectChapter,
-                        onUrlClick = ::openChapterUrl,
-                        modifier = Modifier.nestedScroll(rememberNestedScrollInteropConnection()),
-                    )
+                ChaptersPage(
+                    lazyListState = lazyListState,
+                    chapters = state.chapters,
+                    showHeader = state.showHeader,
+                    totalChaptersCount = state.chaptersCount,
+                    isTogglingChapters = state.isTogglingChapters,
+                    showSubscriptionIcon = state.showSubscriptionIcon,
+                    onChapterClick = viewModel::playChapter,
+                    onSkipChaptersClick = viewModel::enableTogglingOrUpsell,
+                    onSelectionChange = viewModel::selectChapter,
+                    onUrlClick = ::openChapterUrl,
+                    modifier = Modifier.nestedScroll(rememberNestedScrollInteropConnection()),
+                )
 
-                    LaunchedEffect(Unit) {
-                        viewModel.scrollToChapter.collect {
-                            delay(250)
-                            lazyListState.animateScrollToItem(it.index)
-                        }
+                LaunchedEffect(Unit) {
+                    viewModel.scrollToChapter.collect {
+                        delay(250)
+                        lazyListState.animateScrollToItem(it.index)
                     }
+                }
 
-                    LaunchedEffect(Unit) {
-                        viewModel.showPlayer.collect {
-                            showPlayer()
-                        }
+                LaunchedEffect(Unit) {
+                    viewModel.showPlayer.collect {
+                        showPlayer()
                     }
+                }
 
-                    LaunchedEffect(Unit) {
-                        viewModel.showUpsell.collect {
-                            showUpsell()
-                        }
+                LaunchedEffect(Unit) {
+                    viewModel.showUpsell.collect {
+                        showUpsell()
                     }
                 }
             }

--- a/modules/features/podcasts/build.gradle.kts
+++ b/modules/features/podcasts/build.gradle.kts
@@ -56,6 +56,7 @@ dependencies {
     implementation(libs.compose.ui.tooling.preview)
     implementation(libs.coroutines.core)
     implementation(libs.coroutines.rx2)
+    implementation(libs.fragment.compose)
     implementation(libs.fragment.ktx)
     implementation(libs.hilt.navigation.compose)
     implementation(libs.lifecycle.reactivestreams.ktx)

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/components/ratings/GiveRatingFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/components/ratings/GiveRatingFragment.kt
@@ -3,13 +3,13 @@ package au.com.shiftyjelly.pocketcasts.podcasts.view.components.ratings
 import android.content.DialogInterface
 import android.os.Bundle
 import android.view.LayoutInflater
-import android.view.View
 import android.view.ViewGroup
 import android.widget.Toast
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
-import androidx.compose.ui.platform.ComposeView
 import androidx.core.os.bundleOf
 import androidx.fragment.app.viewModels
+import androidx.fragment.compose.content
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
 import au.com.shiftyjelly.pocketcasts.compose.AppThemeWithBackground
 import au.com.shiftyjelly.pocketcasts.podcasts.viewmodel.GiveRatingViewModel
@@ -42,50 +42,48 @@ class GiveRatingFragment : BaseDialogFragment() {
         inflater: LayoutInflater,
         container: ViewGroup?,
         savedInstanceState: Bundle?,
-    ): View = ComposeView(requireContext()).apply {
-        val podcastUuid = arguments?.getString(ARG_PODCAST_UUID)
+    ) = content {
+        val podcastUuid = remember { arguments?.getString(ARG_PODCAST_UUID) }
         if (podcastUuid == null) {
             exitWithError("${this@GiveRatingFragment::class.simpleName} is missing podcastUuid argument")
-            return@apply
+            return@content
         }
 
-        setContent {
-            AppThemeWithBackground(theme.activeTheme) {
-                val coroutineScope = rememberCoroutineScope()
-                val context = requireContext()
+        AppThemeWithBackground(theme.activeTheme) {
+            val coroutineScope = rememberCoroutineScope()
+            val context = requireContext()
 
-                GiveRatingPage(
-                    podcastUuid = podcastUuid,
-                    viewModel = viewModel,
-                    submitRating = {
-                        coroutineScope.launch {
-                            viewModel.submitRating(
-                                podcastUuid = podcastUuid,
-                                context = context,
-                                onSuccess = {
-                                    displayMessage(getString(LR.string.thank_you_for_rating))
-                                    dismiss()
-                                },
-                                onError = {
-                                    displayMessage(getString(LR.string.something_went_wrong_to_rate_this_podcast))
-                                    dismiss()
-                                },
-                            )
-                        }
-                    },
-                    onDismiss = ::dismiss,
-                    onUserSignedOut = {
-                        OnboardingLauncher.openOnboardingFlow(requireActivity(), OnboardingFlow.LoggedOut)
-                        Toast.makeText(context, context.getString(LR.string.podcast_log_in_to_rate), Toast.LENGTH_LONG)
-                            .show()
-                        coroutineScope.launch {
-                            // a short delay prevents the screen from flashing before the onboarding flow is shown
-                            delay(1.seconds)
-                            dismiss()
-                        }
-                    },
-                )
-            }
+            GiveRatingPage(
+                podcastUuid = podcastUuid,
+                viewModel = viewModel,
+                submitRating = {
+                    coroutineScope.launch {
+                        viewModel.submitRating(
+                            podcastUuid = podcastUuid,
+                            context = context,
+                            onSuccess = {
+                                displayMessage(getString(LR.string.thank_you_for_rating))
+                                dismiss()
+                            },
+                            onError = {
+                                displayMessage(getString(LR.string.something_went_wrong_to_rate_this_podcast))
+                                dismiss()
+                            },
+                        )
+                    }
+                },
+                onDismiss = ::dismiss,
+                onUserSignedOut = {
+                    OnboardingLauncher.openOnboardingFlow(requireActivity(), OnboardingFlow.LoggedOut)
+                    Toast.makeText(context, context.getString(LR.string.podcast_log_in_to_rate), Toast.LENGTH_LONG)
+                        .show()
+                    coroutineScope.launch {
+                        // a short delay prevents the screen from flashing before the onboarding flow is shown
+                        delay(1.seconds)
+                        dismiss()
+                    }
+                },
+            )
         }
     }
 

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/folders/FolderChooserFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/folders/FolderChooserFragment.kt
@@ -3,11 +3,10 @@ package au.com.shiftyjelly.pocketcasts.podcasts.view.folders
 import android.app.Dialog
 import android.os.Bundle
 import android.view.LayoutInflater
-import android.view.View
 import android.view.ViewGroup
-import androidx.compose.ui.platform.ComposeView
 import androidx.core.os.bundleOf
 import androidx.fragment.app.viewModels
+import androidx.fragment.compose.content
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
@@ -57,57 +56,57 @@ class FolderChooserFragment : BaseDialogFragment() {
         }
     }
 
-    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
-        return ComposeView(requireContext()).apply {
-            setContent {
-                AppThemeWithBackground(theme.activeTheme) {
-                    navHostController = rememberNavController()
-                    val navController = navHostController ?: return@AppThemeWithBackground
-                    NavHost(navController = navController, startDestination = NavRoutes.folders) {
-                        composable(NavRoutes.folders) {
-                            FolderChooserPage(
-                                podcastUuid = podcastUuid,
-                                onCloseClick = { dismiss() },
-                                onNewFolderClick = {
-                                    val uuid = podcastUuid
-                                    if (uuid != null) {
-                                        viewModel.addPodcast(uuid)
-                                        viewModel.removePodcastFromFolder(uuid)
-                                        navController.navigate(NavRoutes.podcasts)
-                                    }
-                                },
-                                viewModel = viewModel,
-                            )
-                        }
-                        composable(NavRoutes.podcasts) {
-                            FolderEditPodcastsPage(
-                                onCloseClick = { navController.popBackStack() },
-                                navigationButton = NavigationButton.Back,
-                                onNextClick = { navController.navigate(NavRoutes.name) },
-                                viewModel = viewModel,
-                                settings = settings,
-                                fragmentManager = parentFragmentManager,
-                            )
-                        }
-                        composable(NavRoutes.name) {
-                            FolderEditNamePage(
-                                onBackClick = { navController.popBackStack() },
-                                onNextClick = { navController.navigate(NavRoutes.color) },
-                                viewModel = viewModel,
-                            )
-                        }
-                        composable(NavRoutes.color) {
-                            FolderEditColorPage(
-                                onBackClick = { navController.popBackStack() },
-                                onSaveClick = {
-                                    viewModel.saveFolder(resources = resources) {
-                                        dismiss()
-                                    }
-                                },
-                                viewModel = viewModel,
-                            )
-                        }
-                    }
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?,
+    ) = content {
+        AppThemeWithBackground(theme.activeTheme) {
+            navHostController = rememberNavController()
+            val navController = navHostController ?: return@AppThemeWithBackground
+            NavHost(navController = navController, startDestination = NavRoutes.folders) {
+                composable(NavRoutes.folders) {
+                    FolderChooserPage(
+                        podcastUuid = podcastUuid,
+                        onCloseClick = { dismiss() },
+                        onNewFolderClick = {
+                            val uuid = podcastUuid
+                            if (uuid != null) {
+                                viewModel.addPodcast(uuid)
+                                viewModel.removePodcastFromFolder(uuid)
+                                navController.navigate(NavRoutes.podcasts)
+                            }
+                        },
+                        viewModel = viewModel,
+                    )
+                }
+                composable(NavRoutes.podcasts) {
+                    FolderEditPodcastsPage(
+                        onCloseClick = { navController.popBackStack() },
+                        navigationButton = NavigationButton.Back,
+                        onNextClick = { navController.navigate(NavRoutes.name) },
+                        viewModel = viewModel,
+                        settings = settings,
+                        fragmentManager = parentFragmentManager,
+                    )
+                }
+                composable(NavRoutes.name) {
+                    FolderEditNamePage(
+                        onBackClick = { navController.popBackStack() },
+                        onNextClick = { navController.navigate(NavRoutes.color) },
+                        viewModel = viewModel,
+                    )
+                }
+                composable(NavRoutes.color) {
+                    FolderEditColorPage(
+                        onBackClick = { navController.popBackStack() },
+                        onSaveClick = {
+                            viewModel.saveFolder(resources = resources) {
+                                dismiss()
+                            }
+                        },
+                        viewModel = viewModel,
+                    )
                 }
             }
         }

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/folders/FolderCreateFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/folders/FolderCreateFragment.kt
@@ -3,13 +3,12 @@ package au.com.shiftyjelly.pocketcasts.podcasts.view.folders
 import android.app.Dialog
 import android.os.Bundle
 import android.view.LayoutInflater
-import android.view.View
 import android.view.ViewGroup
 import androidx.compose.material.MaterialTheme
 import androidx.compose.ui.graphics.toArgb
-import androidx.compose.ui.platform.ComposeView
 import androidx.fragment.app.activityViewModels
 import androidx.fragment.app.viewModels
+import androidx.fragment.compose.content
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
@@ -38,51 +37,51 @@ class FolderCreateFragment : BaseDialogFragment() {
         const val color = "folder_color"
     }
 
-    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
-        return ComposeView(requireContext()).apply {
-            setContent {
-                AppThemeWithBackground(theme.activeTheme) {
-                    navHostController = rememberNavController()
-                    val navController = navHostController ?: return@AppThemeWithBackground
-                    NavHost(navController = navController, startDestination = NavRoutes.podcasts) {
-                        composable(NavRoutes.podcasts) {
-                            FolderEditPodcastsPage(
-                                onCloseClick = { dismiss() },
-                                onNextClick = {
-                                    viewModel.trackCreateFolderNavigation(AnalyticsEvent.FOLDER_CREATE_NAME_SHOWN)
-                                    navController.navigate(NavRoutes.name)
-                                },
-                                viewModel = viewModel,
-                                settings = settings,
-                                fragmentManager = parentFragmentManager,
-                            )
-                        }
-                        composable(NavRoutes.name) {
-                            FolderEditNamePage(
-                                onBackClick = { navController.popBackStack() },
-                                onNextClick = {
-                                    viewModel.trackCreateFolderNavigation(AnalyticsEvent.FOLDER_CREATE_COLOR_SHOWN)
-                                    navController.navigate(NavRoutes.color)
-                                },
-                                viewModel = viewModel,
-                            )
-                        }
-                        composable(NavRoutes.color) {
-                            val colors = MaterialTheme.theme.colors
-                            FolderEditColorPage(
-                                onBackClick = { navController.popBackStack() },
-                                onSaveClick = {
-                                    viewModel.saveFolder(resources = resources) { folder ->
-                                        sharedViewModel.folderUuid = folder.uuid
-                                        val colorHex = ColorUtils.colorIntToHexString(colors.getFolderColor(folder.color).toArgb())
-                                        viewModel.trackCreateFolderNavigation(AnalyticsEvent.FOLDER_SAVED, mapOf(COLOR_KEY to colorHex))
-                                        dismiss()
-                                    }
-                                },
-                                viewModel = viewModel,
-                            )
-                        }
-                    }
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?,
+    ) = content {
+        AppThemeWithBackground(theme.activeTheme) {
+            navHostController = rememberNavController()
+            val navController = navHostController ?: return@AppThemeWithBackground
+            NavHost(navController = navController, startDestination = NavRoutes.podcasts) {
+                composable(NavRoutes.podcasts) {
+                    FolderEditPodcastsPage(
+                        onCloseClick = { dismiss() },
+                        onNextClick = {
+                            viewModel.trackCreateFolderNavigation(AnalyticsEvent.FOLDER_CREATE_NAME_SHOWN)
+                            navController.navigate(NavRoutes.name)
+                        },
+                        viewModel = viewModel,
+                        settings = settings,
+                        fragmentManager = parentFragmentManager,
+                    )
+                }
+                composable(NavRoutes.name) {
+                    FolderEditNamePage(
+                        onBackClick = { navController.popBackStack() },
+                        onNextClick = {
+                            viewModel.trackCreateFolderNavigation(AnalyticsEvent.FOLDER_CREATE_COLOR_SHOWN)
+                            navController.navigate(NavRoutes.color)
+                        },
+                        viewModel = viewModel,
+                    )
+                }
+                composable(NavRoutes.color) {
+                    val colors = MaterialTheme.theme.colors
+                    FolderEditColorPage(
+                        onBackClick = { navController.popBackStack() },
+                        onSaveClick = {
+                            viewModel.saveFolder(resources = resources) { folder ->
+                                sharedViewModel.folderUuid = folder.uuid
+                                val colorHex = ColorUtils.colorIntToHexString(colors.getFolderColor(folder.color).toArgb())
+                                viewModel.trackCreateFolderNavigation(AnalyticsEvent.FOLDER_SAVED, mapOf(COLOR_KEY to colorHex))
+                                dismiss()
+                            }
+                        },
+                        viewModel = viewModel,
+                    )
                 }
             }
         }

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/folders/FolderEditFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/folders/FolderEditFragment.kt
@@ -3,11 +3,10 @@ package au.com.shiftyjelly.pocketcasts.podcasts.view.folders
 import android.content.DialogInterface
 import android.os.Bundle
 import android.view.LayoutInflater
-import android.view.View
 import android.view.ViewGroup
-import androidx.compose.ui.platform.ComposeView
 import androidx.core.os.bundleOf
 import androidx.fragment.app.viewModels
+import androidx.fragment.compose.content
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTracker
 import au.com.shiftyjelly.pocketcasts.compose.AppThemeWithBackground
@@ -48,17 +47,17 @@ class FolderEditFragment : BaseDialogFragment() {
         }
     }
 
-    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
-        return ComposeView(requireContext()).apply {
-            setContent {
-                AppThemeWithBackground(theme.activeTheme) {
-                    FolderEditPage(
-                        viewModel = viewModel,
-                        onDeleteClick = { confirmFolderDelete() },
-                        onBackClick = { dismiss() },
-                    )
-                }
-            }
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?,
+    ) = content {
+        AppThemeWithBackground(theme.activeTheme) {
+            FolderEditPage(
+                viewModel = viewModel,
+                onDeleteClick = { confirmFolderDelete() },
+                onBackClick = { dismiss() },
+            )
         }
     }
 

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/folders/FolderEditPodcastsFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/folders/FolderEditPodcastsFragment.kt
@@ -3,11 +3,10 @@ package au.com.shiftyjelly.pocketcasts.podcasts.view.folders
 import android.content.DialogInterface
 import android.os.Bundle
 import android.view.LayoutInflater
-import android.view.View
 import android.view.ViewGroup
-import androidx.compose.ui.platform.ComposeView
 import androidx.core.os.bundleOf
 import androidx.fragment.app.viewModels
+import androidx.fragment.compose.content
 import au.com.shiftyjelly.pocketcasts.compose.AppThemeWithBackground
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.views.fragments.BaseDialogFragment
@@ -17,7 +16,9 @@ import javax.inject.Inject
 @AndroidEntryPoint
 class FolderEditPodcastsFragment : BaseDialogFragment() {
 
-    @Inject lateinit var settings: Settings
+    @Inject
+    lateinit var settings: Settings
+
     private val viewModel: FolderEditViewModel by viewModels()
 
     companion object {
@@ -40,23 +41,23 @@ class FolderEditPodcastsFragment : BaseDialogFragment() {
         }
     }
 
-    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
-        return ComposeView(requireContext()).apply {
-            setContent {
-                AppThemeWithBackground(theme.activeTheme) {
-                    FolderEditPodcastsPage(
-                        onCloseClick = { dismiss() },
-                        onNextClick = {
-                            viewModel.saveFolderPodcasts {
-                                dismiss()
-                            }
-                        },
-                        viewModel = viewModel,
-                        settings = settings,
-                        fragmentManager = parentFragmentManager,
-                    )
-                }
-            }
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?,
+    ) = content {
+        AppThemeWithBackground(theme.activeTheme) {
+            FolderEditPodcastsPage(
+                onCloseClick = { dismiss() },
+                onNextClick = {
+                    viewModel.saveFolderPodcasts {
+                        dismiss()
+                    }
+                },
+                viewModel = viewModel,
+                settings = settings,
+                fragmentManager = parentFragmentManager,
+            )
         }
     }
 

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastAutoArchiveFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastAutoArchiveFragment.kt
@@ -3,7 +3,6 @@ package au.com.shiftyjelly.pocketcasts.podcasts.view.podcast
 import android.os.Bundle
 import android.os.Parcelable
 import android.view.LayoutInflater
-import android.view.View
 import android.view.ViewGroup
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
@@ -21,13 +20,13 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
 import androidx.core.graphics.ColorUtils
 import androidx.core.os.BundleCompat
 import androidx.core.os.bundleOf
 import androidx.fragment.app.viewModels
+import androidx.fragment.compose.content
 import au.com.shiftyjelly.pocketcasts.compose.AppThemeWithBackground
 import au.com.shiftyjelly.pocketcasts.compose.bars.ThemedTopAppBar
 import au.com.shiftyjelly.pocketcasts.compose.components.SettingInfoRow
@@ -61,26 +60,25 @@ class PodcastAutoArchiveFragment : BaseFragment() {
     private var podcastTint: PodcastTint? = null
     private val fallbackToolbarColors get() = podcastTint?.let { ToolbarColors.podcast(it.lightTint, it.darkTint, theme) } ?: args.toolbarColors
 
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        podcastTint = savedInstanceState?.let { BundleCompat.getParcelable(it, PODCAST_TINT_KEY, PodcastTint::class.java) }
+    }
+
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
         savedInstanceState: Bundle?,
-    ): View {
-        podcastTint = savedInstanceState?.let { BundleCompat.getParcelable(it, PODCAST_TINT_KEY, PodcastTint::class.java) }
-        return ComposeView(requireContext()).apply {
-            setContent {
-                val state by viewModel.state.collectAsState(PodcastAutoArchiveViewModel.State())
-
-                AppThemeWithBackground(themeType = theme.activeTheme) {
-                    AutoArchiveSettings(
-                        state = state,
-                        onBackPressed = {
-                            @Suppress("DEPRECATION")
-                            activity?.onBackPressed()
-                        },
-                    )
-                }
-            }
+    ) = content {
+        val state by viewModel.state.collectAsState(PodcastAutoArchiveViewModel.State())
+        AppThemeWithBackground(themeType = theme.activeTheme) {
+            AutoArchiveSettings(
+                state = state,
+                onBackPressed = {
+                    @Suppress("DEPRECATION")
+                    activity?.onBackPressed()
+                },
+            )
         }
     }
 

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/share/ShareListCreateFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/share/ShareListCreateFragment.kt
@@ -2,10 +2,9 @@ package au.com.shiftyjelly.pocketcasts.podcasts.view.share
 
 import android.os.Bundle
 import android.view.LayoutInflater
-import android.view.View
 import android.view.ViewGroup
-import androidx.compose.ui.platform.ComposeView
 import androidx.fragment.app.viewModels
+import androidx.fragment.compose.content
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
@@ -29,50 +28,52 @@ class ShareListCreateFragment : BaseFragment() {
         const val failed = "failed"
     }
 
-    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View = ComposeView(requireContext()).apply {
-        setContent {
-            AppThemeWithBackground(theme.activeTheme) {
-                navHostController = rememberNavController()
-                val navController = navHostController ?: return@AppThemeWithBackground
-                NavHost(navController = navController, startDestination = NavRoutes.podcasts) {
-                    composable(NavRoutes.podcasts) {
-                        ShareListCreatePodcastsPage(
-                            onCloseClick = { activity?.finish() },
-                            onNextClick = { selectedPodcastsCount ->
-                                viewModel.trackShareEvent(
-                                    AnalyticsEvent.SHARE_PODCASTS_PODCASTS_SELECTED,
-                                    AnalyticsProp.countMap(selectedPodcastsCount),
-                                )
-                                navController.navigate(NavRoutes.title)
-                            },
-                            viewModel = viewModel,
-                        )
-                    }
-                    composable(NavRoutes.title) {
-                        ShareListCreateTitlePage(
-                            onBackClick = { navController.popBackStack() },
-                            onNextClick = { createShareLink(navController) },
-                            viewModel = viewModel,
-                        )
-                    }
-                    composable(NavRoutes.building) {
-                        ShareListCreateBuildingPage(
-                            onCloseClick = { activity?.finish() },
-                            viewModel = viewModel,
-                        )
-                    }
-                    composable(NavRoutes.failed) {
-                        ShareListCreateFailedPage(
-                            onCloseClick = { activity?.finish() },
-                            onRetryClick = { createShareLink(navController) },
-                        )
-                    }
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?,
+    ) = content {
+        AppThemeWithBackground(theme.activeTheme) {
+            navHostController = rememberNavController()
+            val navController = navHostController ?: return@AppThemeWithBackground
+            NavHost(navController = navController, startDestination = NavRoutes.podcasts) {
+                composable(NavRoutes.podcasts) {
+                    ShareListCreatePodcastsPage(
+                        onCloseClick = { activity?.finish() },
+                        onNextClick = { selectedPodcastsCount ->
+                            viewModel.trackShareEvent(
+                                AnalyticsEvent.SHARE_PODCASTS_PODCASTS_SELECTED,
+                                AnalyticsProp.countMap(selectedPodcastsCount),
+                            )
+                            navController.navigate(NavRoutes.title)
+                        },
+                        viewModel = viewModel,
+                    )
+                }
+                composable(NavRoutes.title) {
+                    ShareListCreateTitlePage(
+                        onBackClick = { navController.popBackStack() },
+                        onNextClick = { createShareLink(navController) },
+                        viewModel = viewModel,
+                    )
+                }
+                composable(NavRoutes.building) {
+                    ShareListCreateBuildingPage(
+                        onCloseClick = { activity?.finish() },
+                        viewModel = viewModel,
+                    )
+                }
+                composable(NavRoutes.failed) {
+                    ShareListCreateFailedPage(
+                        onCloseClick = { activity?.finish() },
+                        onRetryClick = { createShareLink(navController) },
+                    )
                 }
             }
+        }
 
-            if (!viewModel.isFragmentChangingConfigurations) {
-                viewModel.trackShareEvent(AnalyticsEvent.SHARE_PODCASTS_SHOWN)
-            }
+        if (!viewModel.isFragmentChangingConfigurations) {
+            viewModel.trackShareEvent(AnalyticsEvent.SHARE_PODCASTS_SHOWN)
         }
     }
 

--- a/modules/features/profile/build.gradle.kts
+++ b/modules/features/profile/build.gradle.kts
@@ -54,6 +54,7 @@ dependencies {
     implementation(libs.coroutines.rx2)
     implementation(libs.firebase.analytics)
     implementation(libs.firebase.config)
+    implementation(libs.fragment.compose)
     implementation(libs.fragment.ktx)
     implementation(libs.lifecycle.reactivestreams.ktx)
     implementation(libs.media3.datasource)

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/CancelConfirmationFragment.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/CancelConfirmationFragment.kt
@@ -23,8 +23,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.input.nestedscroll.nestedScroll
-import androidx.compose.ui.platform.ComposeView
-import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.clearAndSetSemantics
@@ -34,6 +32,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.dp
 import androidx.fragment.app.viewModels
+import androidx.fragment.compose.content
 import au.com.shiftyjelly.pocketcasts.compose.AppThemeWithBackground
 import au.com.shiftyjelly.pocketcasts.compose.bars.BottomSheetAppBar
 import au.com.shiftyjelly.pocketcasts.compose.bars.NavigationButton
@@ -69,20 +68,17 @@ class CancelConfirmationFragment : BaseDialogFragment() {
         inflater: LayoutInflater,
         container: ViewGroup?,
         savedInstanceState: Bundle?,
-    ) = ComposeView(requireContext()).apply {
-        setContent {
-            AppThemeWithBackground(theme.activeTheme) {
-                setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
-                CancelConfirmationPage(
-                    rows = getRows(),
-                    onStayClicked = {
-                        viewModel.onStayClicked()
-                        closeScreen()
-                    },
-                    onCloseClicked = ::closeScreen,
-                    onCancelClicked = ::onCancelClicked,
-                )
-            }
+    ) = content {
+        AppThemeWithBackground(theme.activeTheme) {
+            CancelConfirmationPage(
+                rows = getRows(),
+                onStayClicked = {
+                    viewModel.onStayClicked()
+                    closeScreen()
+                },
+                onCloseClicked = ::closeScreen,
+                onCancelClicked = ::onCancelClicked,
+            )
         }
     }
 

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/champion/PocketCastsChampionBottomSheetDialog.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/champion/PocketCastsChampionBottomSheetDialog.kt
@@ -5,8 +5,9 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.FrameLayout
-import androidx.compose.ui.platform.ComposeView
+import androidx.compose.ui.platform.LocalContext
 import androidx.core.view.doOnLayout
+import androidx.fragment.compose.content
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTracker
 import au.com.shiftyjelly.pocketcasts.compose.AppTheme
@@ -26,22 +27,22 @@ class PocketCastsChampionBottomSheetDialog : BottomSheetDialogFragment() {
 
     @Inject lateinit var analyticsTracker: AnalyticsTracker
 
-    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
-        val context = context ?: throw Exception("Context not found")
-        return ComposeView(context).apply {
-            setContent {
-                AppTheme(theme.activeTheme) {
-                    CallOnce {
-                        analyticsTracker.track(AnalyticsEvent.POCKET_CASTS_CHAMPION_DIALOG_SHOWN)
-                    }
-                    ChampionDialog(
-                        onRateClick = {
-                            analyticsTracker.track(AnalyticsEvent.POCKET_CASTS_CHAMPION_DIALOG_RATE_BUTTON_TAPPED)
-                            rateUs(context)
-                        },
-                    )
-                }
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?,
+    ) = content {
+        AppTheme(theme.activeTheme) {
+            CallOnce {
+                analyticsTracker.track(AnalyticsEvent.POCKET_CASTS_CHAMPION_DIALOG_SHOWN)
             }
+            val context = LocalContext.current
+            ChampionDialog(
+                onRateClick = {
+                    analyticsTracker.track(AnalyticsEvent.POCKET_CASTS_CHAMPION_DIALOG_RATE_BUTTON_TAPPED)
+                    rateUs(context)
+                },
+            )
         }
     }
 

--- a/modules/features/reimagine/build.gradle.kts
+++ b/modules/features/reimagine/build.gradle.kts
@@ -43,6 +43,7 @@ dependencies {
     implementation(libs.compose.ui.tooling.preview)
     implementation(libs.compose.ui.util)
     implementation(libs.coroutines.core)
+    implementation(libs.fragment.compose)
     implementation(libs.fragment.ktx)
     implementation(libs.media3.exoplayer)
     implementation(libs.timber)

--- a/modules/features/reimagine/src/main/kotlin/au/com/shiftyjelly/pocketcasts/reimagine/clip/ShareClipFragment.kt
+++ b/modules/features/reimagine/src/main/kotlin/au/com/shiftyjelly/pocketcasts/reimagine/clip/ShareClipFragment.kt
@@ -13,10 +13,10 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
-import androidx.compose.ui.platform.ComposeView
 import androidx.core.os.BundleCompat
 import androidx.core.os.bundleOf
 import androidx.fragment.app.viewModels
+import androidx.fragment.compose.content
 import au.com.shiftyjelly.pocketcasts.analytics.SourceView
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.reimagine.clip.ShareClipViewModel.SnackbarMessage
@@ -91,43 +91,41 @@ class ShareClipFragment : BaseDialogFragment() {
         inflater: LayoutInflater,
         container: ViewGroup?,
         savedInstanceState: Bundle?,
-    ) = ComposeView(requireActivity()).apply {
-        val platforms = SocialPlatform.getAvailablePlatforms(requireContext())
-        val isTalkbackOn = Util.isTalkbackOn(requireContext())
+    ) = content {
+        val platforms = remember { SocialPlatform.getAvailablePlatforms(requireContext()) }
+        val isTalkbackOn = remember { Util.isTalkbackOn(requireContext()) }
 
-        setContent {
-            val assetController = rememberBackgroundAssetControler(shareColors)
-            val listener = remember { ShareClipListener(this@ShareClipFragment, viewModel, assetController, args.source) }
-            val snackbarHostState = remember { SnackbarHostState() }
+        val assetController = rememberBackgroundAssetControler(shareColors)
+        val listener = remember { ShareClipListener(this@ShareClipFragment, viewModel, assetController, args.source) }
+        val snackbarHostState = remember { SnackbarHostState() }
 
-            val uiState by viewModel.uiState.collectAsState()
-            ShareClipPage(
-                episode = uiState.episode,
-                podcast = uiState.podcast,
-                clipRange = uiState.clipRange,
-                playbackProgress = uiState.playbackProgress,
-                isPlaying = uiState.isPlaying,
-                sharingState = uiState.sharingState,
-                useEpisodeArtwork = uiState.useEpisodeArtwork,
-                platforms = platforms,
-                shareColors = shareColors,
-                useKeyboardInput = isTalkbackOn,
-                assetController = assetController,
-                listener = listener,
-                snackbarHostState = snackbarHostState,
-            )
+        val uiState by viewModel.uiState.collectAsState()
+        ShareClipPage(
+            episode = uiState.episode,
+            podcast = uiState.podcast,
+            clipRange = uiState.clipRange,
+            playbackProgress = uiState.playbackProgress,
+            isPlaying = uiState.isPlaying,
+            sharingState = uiState.sharingState,
+            useEpisodeArtwork = uiState.useEpisodeArtwork,
+            platforms = platforms,
+            shareColors = shareColors,
+            useKeyboardInput = isTalkbackOn,
+            assetController = assetController,
+            listener = listener,
+            snackbarHostState = snackbarHostState,
+        )
 
-            LaunchedEffect(Unit) {
-                viewModel.snackbarMessages.collect { message ->
-                    val text = when (message) {
-                        is SnackbarMessage.SharingResponse -> message.message
-                        is SnackbarMessage.PlayerIssue -> getString(LR.string.podcast_episode_playback_error)
-                        is SnackbarMessage.GenericIssue -> getString(LR.string.share_error_message)
-                        is SnackbarMessage.ClipStartAfterEnd -> getString(LR.string.share_invalid_clip_message)
-                        is SnackbarMessage.ClipEndAfterEpisodeDuration -> getString(LR.string.share_clip_too_long_message, message.episodeDuration.toHhMmSs())
-                    }
-                    snackbarHostState.showSnackbar(text)
+        LaunchedEffect(Unit) {
+            viewModel.snackbarMessages.collect { message ->
+                val text = when (message) {
+                    is SnackbarMessage.SharingResponse -> message.message
+                    is SnackbarMessage.PlayerIssue -> getString(LR.string.podcast_episode_playback_error)
+                    is SnackbarMessage.GenericIssue -> getString(LR.string.share_error_message)
+                    is SnackbarMessage.ClipStartAfterEnd -> getString(LR.string.share_invalid_clip_message)
+                    is SnackbarMessage.ClipEndAfterEpisodeDuration -> getString(LR.string.share_clip_too_long_message, message.episodeDuration.toHhMmSs())
                 }
+                snackbarHostState.showSnackbar(text)
             }
         }
     }

--- a/modules/features/reimagine/src/main/kotlin/au/com/shiftyjelly/pocketcasts/reimagine/episode/ShareEpisodeFragment.kt
+++ b/modules/features/reimagine/src/main/kotlin/au/com/shiftyjelly/pocketcasts/reimagine/episode/ShareEpisodeFragment.kt
@@ -11,10 +11,10 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
-import androidx.compose.ui.platform.ComposeView
 import androidx.core.os.BundleCompat
 import androidx.core.os.bundleOf
 import androidx.fragment.app.viewModels
+import androidx.fragment.compose.content
 import au.com.shiftyjelly.pocketcasts.analytics.SourceView
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.reimagine.ui.ShareColors
@@ -59,23 +59,21 @@ class ShareEpisodeFragment : BaseDialogFragment() {
         inflater: LayoutInflater,
         container: ViewGroup?,
         savedInstanceState: Bundle?,
-    ) = ComposeView(requireActivity()).apply {
-        val platforms = SocialPlatform.getAvailablePlatforms(requireContext())
-        setContent {
-            val assetController = rememberBackgroundAssetControler(shareColors)
-            val listener = remember { shareListenerFactory.create(this@ShareEpisodeFragment, assetController, args.source) }
+    ) = content {
+        val platforms = remember { SocialPlatform.getAvailablePlatforms(requireContext()) }
+        val assetController = rememberBackgroundAssetControler(shareColors)
+        val listener = remember { shareListenerFactory.create(this@ShareEpisodeFragment, assetController, args.source) }
 
-            val uiState by viewModel.uiState.collectAsState()
-            ShareEpisodePage(
-                podcast = uiState.podcast,
-                episode = uiState.episode,
-                useEpisodeArtwork = uiState.useEpisodeArtwork,
-                socialPlatforms = platforms,
-                shareColors = shareColors,
-                assetController = assetController,
-                listener = listener,
-            )
-        }
+        val uiState by viewModel.uiState.collectAsState()
+        ShareEpisodePage(
+            podcast = uiState.podcast,
+            episode = uiState.episode,
+            useEpisodeArtwork = uiState.useEpisodeArtwork,
+            socialPlatforms = platforms,
+            shareColors = shareColors,
+            assetController = assetController,
+            listener = listener,
+        )
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {

--- a/modules/features/reimagine/src/main/kotlin/au/com/shiftyjelly/pocketcasts/reimagine/podcast/SharePodcastFragment.kt
+++ b/modules/features/reimagine/src/main/kotlin/au/com/shiftyjelly/pocketcasts/reimagine/podcast/SharePodcastFragment.kt
@@ -10,10 +10,10 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
-import androidx.compose.ui.platform.ComposeView
 import androidx.core.os.BundleCompat
 import androidx.core.os.bundleOf
 import androidx.fragment.app.viewModels
+import androidx.fragment.compose.content
 import au.com.shiftyjelly.pocketcasts.analytics.SourceView
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.reimagine.ui.ShareColors
@@ -57,22 +57,20 @@ class SharePodcastFragment : BaseDialogFragment() {
         inflater: LayoutInflater,
         container: ViewGroup?,
         savedInstanceState: Bundle?,
-    ) = ComposeView(requireActivity()).apply {
-        val platforms = SocialPlatform.getAvailablePlatforms(requireContext())
-        setContent {
-            val assetController = rememberBackgroundAssetControler(shareColors)
-            val listener = remember { shareListenerFactory.create(this@SharePodcastFragment, assetController, args.source) }
+    ) = content {
+        val platforms = remember { SocialPlatform.getAvailablePlatforms(requireContext()) }
+        val assetController = rememberBackgroundAssetControler(shareColors)
+        val listener = remember { shareListenerFactory.create(this@SharePodcastFragment, assetController, args.source) }
 
-            val uiState by viewModel.uiState.collectAsState()
-            SharePodcastPage(
-                podcast = uiState.podcast,
-                episodeCount = uiState.episodeCount,
-                socialPlatforms = platforms,
-                shareColors = shareColors,
-                assetController = assetController,
-                listener = listener,
-            )
-        }
+        val uiState by viewModel.uiState.collectAsState()
+        SharePodcastPage(
+            podcast = uiState.podcast,
+            episodeCount = uiState.episodeCount,
+            socialPlatforms = platforms,
+            shareColors = shareColors,
+            assetController = assetController,
+            listener = listener,
+        )
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {

--- a/modules/features/reimagine/src/main/kotlin/au/com/shiftyjelly/pocketcasts/reimagine/timestamp/ShareEpisodeTimestampFragment.kt
+++ b/modules/features/reimagine/src/main/kotlin/au/com/shiftyjelly/pocketcasts/reimagine/timestamp/ShareEpisodeTimestampFragment.kt
@@ -11,10 +11,10 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
-import androidx.compose.ui.platform.ComposeView
 import androidx.core.os.BundleCompat
 import androidx.core.os.bundleOf
 import androidx.fragment.app.viewModels
+import androidx.fragment.compose.content
 import au.com.shiftyjelly.pocketcasts.analytics.SourceView
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.reimagine.ui.ShareColors
@@ -50,7 +50,8 @@ class ShareEpisodeTimestampFragment : BaseDialogFragment() {
         },
     )
 
-    @Inject internal lateinit var shareListenerFactory: ShareEpisodeTimestampListener.Factory
+    @Inject
+    internal lateinit var shareListenerFactory: ShareEpisodeTimestampListener.Factory
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -63,24 +64,22 @@ class ShareEpisodeTimestampFragment : BaseDialogFragment() {
         inflater: LayoutInflater,
         container: ViewGroup?,
         savedInstanceState: Bundle?,
-    ) = ComposeView(requireActivity()).apply {
-        val platforms = SocialPlatform.getAvailablePlatforms(requireContext())
-        setContent {
-            val assetController = rememberBackgroundAssetControler(shareColors)
-            val listener = remember { shareListenerFactory.create(this@ShareEpisodeTimestampFragment, assetController, args.timestampType, args.source) }
+    ) = content {
+        val platforms = remember { SocialPlatform.getAvailablePlatforms(requireContext()) }
+        val assetController = rememberBackgroundAssetControler(shareColors)
+        val listener = remember { shareListenerFactory.create(this@ShareEpisodeTimestampFragment, assetController, args.timestampType, args.source) }
 
-            val uiState by viewModel.uiState.collectAsState()
-            ShareEpisodeTimestampPage(
-                podcast = uiState.podcast,
-                episode = uiState.episode,
-                timestamp = args.timestamp,
-                useEpisodeArtwork = uiState.useEpisodeArtwork,
-                socialPlatforms = platforms,
-                shareColors = shareColors,
-                assetController = assetController,
-                listener = listener,
-            )
-        }
+        val uiState by viewModel.uiState.collectAsState()
+        ShareEpisodeTimestampPage(
+            podcast = uiState.podcast,
+            episode = uiState.episode,
+            timestamp = args.timestamp,
+            useEpisodeArtwork = uiState.useEpisodeArtwork,
+            socialPlatforms = platforms,
+            shareColors = shareColors,
+            assetController = assetController,
+            listener = listener,
+        )
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {

--- a/modules/features/search/build.gradle.kts
+++ b/modules/features/search/build.gradle.kts
@@ -38,6 +38,7 @@ dependencies {
     implementation(libs.compose.ui.tooling.preview)
     implementation(libs.coroutines.core)
     implementation(libs.coroutines.reactive)
+    implementation(libs.fragment.compose)
     implementation(libs.fragment.ktx)
     implementation(libs.lifecycle.reactivestreams.ktx)
     implementation(libs.lifecycle.runtime.compose)

--- a/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/SearchResultsFragment.kt
+++ b/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/SearchResultsFragment.kt
@@ -6,11 +6,10 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.compose.runtime.getValue
-import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.compose.ui.unit.dp
 import androidx.fragment.app.viewModels
+import androidx.fragment.compose.content
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import au.com.shiftyjelly.pocketcasts.analytics.SourceView
 import au.com.shiftyjelly.pocketcasts.compose.AppThemeWithBackground
@@ -61,34 +60,31 @@ class SearchResultsFragment : BaseFragment() {
         inflater: LayoutInflater,
         container: ViewGroup?,
         savedInstanceState: Bundle?,
-    ) = ComposeView(requireContext()).apply {
-        setContent {
-            val bottomInset by settings.bottomInset.collectAsStateWithLifecycle(initialValue = 0)
-            val bottomInsetDp = bottomInset.pxToDp(LocalContext.current).dp
-            AppThemeWithBackground(theme.activeTheme) {
-                setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
-                when (type) {
-                    ResultsType.PODCASTS -> {
-                        SearchPodcastResultsPage(
-                            viewModel = viewModel,
-                            onFolderClick = ::onFolderClick,
-                            onPodcastClick = ::onPodcastClick,
-                            onBackClick = ::onBackClick,
-                            bottomInset = bottomInsetDp,
-                        )
-                    }
-
-                    ResultsType.EPISODES -> {
-                        SearchEpisodeResultsPage(
-                            viewModel = viewModel,
-                            onBackClick = ::onBackClick,
-                            onEpisodeClick = ::onEpisodeClick,
-                            bottomInset = bottomInsetDp,
-                        )
-                    }
-
-                    ResultsType.UNKNOWN -> throw IllegalStateException("Unknown search results type")
+    ) = content {
+        val bottomInset by settings.bottomInset.collectAsStateWithLifecycle(initialValue = 0)
+        val bottomInsetDp = bottomInset.pxToDp(LocalContext.current).dp
+        AppThemeWithBackground(theme.activeTheme) {
+            when (type) {
+                ResultsType.PODCASTS -> {
+                    SearchPodcastResultsPage(
+                        viewModel = viewModel,
+                        onFolderClick = ::onFolderClick,
+                        onPodcastClick = ::onPodcastClick,
+                        onBackClick = ::onBackClick,
+                        bottomInset = bottomInsetDp,
+                    )
                 }
+
+                ResultsType.EPISODES -> {
+                    SearchEpisodeResultsPage(
+                        viewModel = viewModel,
+                        onBackClick = ::onBackClick,
+                        onEpisodeClick = ::onEpisodeClick,
+                        bottomInset = bottomInsetDp,
+                    )
+                }
+
+                ResultsType.UNKNOWN -> throw IllegalStateException("Unknown search results type")
             }
         }
     }

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/AutoArchiveFragment.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/AutoArchiveFragment.kt
@@ -2,12 +2,11 @@ package au.com.shiftyjelly.pocketcasts.settings
 
 import android.os.Bundle
 import android.view.LayoutInflater
-import android.view.View
 import android.view.ViewGroup
-import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 import androidx.fragment.app.viewModels
+import androidx.fragment.compose.content
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import au.com.shiftyjelly.pocketcasts.compose.AppThemeWithBackground
 import au.com.shiftyjelly.pocketcasts.compose.CallOnce
@@ -26,26 +25,26 @@ class AutoArchiveFragment : BaseFragment() {
 
     private val viewModel: AutoArchiveFragmentViewModel by viewModels()
 
-    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
-        return ComposeView(requireContext()).apply {
-            setContent {
-                CallOnce {
-                    viewModel.trackOnViewShownEvent()
-                }
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?,
+    ) = content {
+        CallOnce {
+            viewModel.trackOnViewShownEvent()
+        }
 
-                val bottomInset = settings.bottomInset.collectAsStateWithLifecycle(initialValue = 0)
+        val bottomInset = settings.bottomInset.collectAsStateWithLifecycle(initialValue = 0)
 
-                AppThemeWithBackground(theme.activeTheme) {
-                    AutoArchiveSettingsPage(
-                        viewModel = viewModel,
-                        bottomInset = bottomInset.value.pxToDp(LocalContext.current).dp,
-                        onBackPressed = {
-                            @Suppress("DEPRECATION")
-                            activity?.onBackPressed()
-                        },
-                    )
-                }
-            }
+        AppThemeWithBackground(theme.activeTheme) {
+            AutoArchiveSettingsPage(
+                viewModel = viewModel,
+                bottomInset = bottomInset.value.pxToDp(LocalContext.current).dp,
+                onBackPressed = {
+                    @Suppress("DEPRECATION")
+                    activity?.onBackPressed()
+                },
+            )
         }
     }
 }

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/EpisodeArtworkConfigurationFragment.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/EpisodeArtworkConfigurationFragment.kt
@@ -2,7 +2,6 @@ package au.com.shiftyjelly.pocketcasts.settings
 
 import android.os.Bundle
 import android.view.LayoutInflater
-import android.view.View
 import android.view.ViewGroup
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Column
@@ -15,11 +14,12 @@ import androidx.compose.material.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
+import androidx.fragment.compose.content
 import au.com.shiftyjelly.pocketcasts.compose.AppThemeWithBackground
 import au.com.shiftyjelly.pocketcasts.compose.bars.ThemedTopAppBar
 import au.com.shiftyjelly.pocketcasts.compose.components.SettingRow
@@ -36,30 +36,29 @@ import au.com.shiftyjelly.pocketcasts.ui.R as UR
 
 @AndroidEntryPoint
 class EpisodeArtworkConfigurationFragment : BaseFragment() {
-    @Inject lateinit var settings: Settings
+    @Inject
+    lateinit var settings: Settings
 
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
         savedInstanceState: Bundle?,
-    ): View = ComposeView(requireContext()).apply {
-        val sortedElements = ArtworkConfiguration.Element.entries.sortedBy { getString(it.titleId) }
-        setContent {
-            AppThemeWithBackground(theme.activeTheme) {
-                val artworkConfiguration by settings.artworkConfiguration.flow.collectAsState()
+    ) = content {
+        val sortedElements = remember { ArtworkConfiguration.Element.entries.sortedBy { getString(it.titleId) } }
+        AppThemeWithBackground(theme.activeTheme) {
+            val artworkConfiguration by settings.artworkConfiguration.flow.collectAsState()
 
-                EpisodeArtworkSettings(
-                    artworkConfiguration = artworkConfiguration,
-                    elements = sortedElements,
-                    onUpdateConfiguration = { configuration ->
-                        settings.artworkConfiguration.set(configuration, updateModifiedAt = true)
-                    },
-                    onBackPressed = {
-                        @Suppress("DEPRECATION")
-                        activity?.onBackPressed()
-                    },
-                )
-            }
+            EpisodeArtworkSettings(
+                artworkConfiguration = artworkConfiguration,
+                elements = sortedElements,
+                onUpdateConfiguration = { configuration ->
+                    settings.artworkConfiguration.set(configuration, updateModifiedAt = true)
+                },
+                onBackPressed = {
+                    @Suppress("DEPRECATION")
+                    activity?.onBackPressed()
+                },
+            )
         }
     }
 
@@ -128,14 +127,15 @@ class EpisodeArtworkConfigurationFragment : BaseFragment() {
         )
     }
 
-    private val ArtworkConfiguration.Element.titleId get() = when (this) {
-        ArtworkConfiguration.Element.Filters -> LR.string.filters
-        ArtworkConfiguration.Element.UpNext -> LR.string.up_next
-        ArtworkConfiguration.Element.Downloads -> LR.string.profile_navigation_downloads
-        ArtworkConfiguration.Element.Files -> LR.string.profile_navigation_files
-        ArtworkConfiguration.Element.Starred -> LR.string.profile_navigation_starred
-        ArtworkConfiguration.Element.Bookmarks -> LR.string.bookmarks
-        ArtworkConfiguration.Element.ListeningHistory -> LR.string.profile_navigation_listening_history
-        ArtworkConfiguration.Element.Podcasts -> LR.string.podcasts
-    }
+    private val ArtworkConfiguration.Element.titleId
+        get() = when (this) {
+            ArtworkConfiguration.Element.Filters -> LR.string.filters
+            ArtworkConfiguration.Element.UpNext -> LR.string.up_next
+            ArtworkConfiguration.Element.Downloads -> LR.string.profile_navigation_downloads
+            ArtworkConfiguration.Element.Files -> LR.string.profile_navigation_files
+            ArtworkConfiguration.Element.Starred -> LR.string.profile_navigation_starred
+            ArtworkConfiguration.Element.Bookmarks -> LR.string.bookmarks
+            ArtworkConfiguration.Element.ListeningHistory -> LR.string.profile_navigation_listening_history
+            ArtworkConfiguration.Element.Podcasts -> LR.string.podcasts
+        }
 }

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/LogsFragment.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/LogsFragment.kt
@@ -2,7 +2,6 @@ package au.com.shiftyjelly.pocketcasts.settings
 
 import android.os.Bundle
 import android.view.LayoutInflater
-import android.view.View
 import android.view.ViewGroup
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -23,7 +22,6 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.LocalClipboardManager
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalView
@@ -33,6 +31,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import androidx.fragment.compose.content
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import au.com.shiftyjelly.pocketcasts.compose.AppThemeWithBackground
@@ -57,19 +56,20 @@ import au.com.shiftyjelly.pocketcasts.localization.R as LR
 class LogsFragment : BaseFragment() {
     @Inject lateinit var settings: Settings
 
-    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View =
-        ComposeView(requireContext()).apply {
-            setContent {
-                UiUtil.hideKeyboard(LocalView.current)
-                AppThemeWithBackground(theme.activeTheme) {
-                    val bottomInset = settings.bottomInset.collectAsStateWithLifecycle(initialValue = 0)
-                    LogsPage(
-                        onBackPressed = ::closeFragment,
-                        bottomInset = bottomInset.value.pxToDp(LocalContext.current).dp,
-                    )
-                }
-            }
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?,
+    ) = content {
+        UiUtil.hideKeyboard(LocalView.current)
+        AppThemeWithBackground(theme.activeTheme) {
+            val bottomInset = settings.bottomInset.collectAsStateWithLifecycle(initialValue = 0)
+            LogsPage(
+                onBackPressed = ::closeFragment,
+                bottomInset = bottomInset.value.pxToDp(LocalContext.current).dp,
+            )
         }
+    }
 
     private fun closeFragment() {
         (activity as? FragmentHostListener)?.closeModal(this)

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/PlaybackSettingsFragment.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/PlaybackSettingsFragment.kt
@@ -2,7 +2,6 @@ package au.com.shiftyjelly.pocketcasts.settings
 
 import android.os.Bundle
 import android.view.LayoutInflater
-import android.view.View
 import android.view.ViewGroup
 import androidx.annotation.StringRes
 import androidx.compose.foundation.background
@@ -31,7 +30,6 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
-import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
@@ -40,6 +38,7 @@ import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import androidx.fragment.compose.content
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTracker
@@ -92,22 +91,20 @@ class PlaybackSettingsFragment : BaseFragment() {
         inflater: LayoutInflater,
         container: ViewGroup?,
         savedInstanceState: Bundle?,
-    ): View = ComposeView(requireContext()).apply {
-        setContent {
-            val scrollToSleepTimer = arguments?.getBoolean(SCROLL_TO_SLEEP_TIMER, false) ?: false
+    ) = content {
+        val scrollToSleepTimer = arguments?.getBoolean(SCROLL_TO_SLEEP_TIMER, false) ?: false
 
-            AppThemeWithBackground(theme.activeTheme) {
-                val bottomInset = settings.bottomInset.collectAsStateWithLifecycle(0)
-                PlaybackSettings(
-                    settings = settings,
-                    onBackClick = {
-                        @Suppress("DEPRECATION")
-                        activity?.onBackPressed()
-                    },
-                    scrollToSleepTimer = scrollToSleepTimer,
-                    bottomInset = bottomInset.value.pxToDp(LocalContext.current).dp,
-                )
-            }
+        AppThemeWithBackground(theme.activeTheme) {
+            val bottomInset = settings.bottomInset.collectAsStateWithLifecycle(0)
+            PlaybackSettings(
+                settings = settings,
+                onBackClick = {
+                    @Suppress("DEPRECATION")
+                    activity?.onBackPressed()
+                },
+                scrollToSleepTimer = scrollToSleepTimer,
+                bottomInset = bottomInset.value.pxToDp(LocalContext.current).dp,
+            )
         }
     }
 

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/SettingsFragment.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/SettingsFragment.kt
@@ -2,7 +2,6 @@ package au.com.shiftyjelly.pocketcasts.settings
 
 import android.os.Bundle
 import android.view.LayoutInflater
-import android.view.View
 import android.view.ViewGroup
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.getValue
@@ -10,9 +9,9 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rxjava2.subscribeAsState
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
+import androidx.fragment.compose.content
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -42,45 +41,42 @@ class SettingsFragment : BaseFragment() {
         inflater: LayoutInflater,
         container: ViewGroup?,
         savedInstanceState: Bundle?,
-    ): View =
-        ComposeView(requireContext()).apply {
-            setContent {
-                AppThemeWithBackground(theme.activeTheme) {
-                    var isUnrestrictedBattery by remember { mutableStateOf(batteryRestrictions.isUnrestricted()) }
-                    DisposableEffect(this) {
-                        val observer = LifecycleEventObserver { _, event ->
-                            if (event == Lifecycle.Event.ON_RESUME) {
-                                isUnrestrictedBattery = batteryRestrictions.isUnrestricted()
-                            }
-                        }
-
-                        lifecycle.addObserver(observer)
-                        onDispose {
-                            lifecycle.removeObserver(observer)
-                        }
+    ) = content {
+        AppThemeWithBackground(theme.activeTheme) {
+            var isUnrestrictedBattery by remember { mutableStateOf(batteryRestrictions.isUnrestricted()) }
+            DisposableEffect(this) {
+                val observer = LifecycleEventObserver { _, event ->
+                    if (event == Lifecycle.Event.ON_RESUME) {
+                        isUnrestrictedBattery = batteryRestrictions.isUnrestricted()
                     }
+                }
 
-                    userManager
-                        .getSignInState()
-                        .subscribeAsState(null)
-                        .value
-                        ?.let { signInState ->
-                            val bottomInset = settings.bottomInset.collectAsStateWithLifecycle(0)
-                            SettingsFragmentPage(
-                                signInState = signInState,
-                                onBackPressed = {
-                                    @Suppress("DEPRECATION")
-                                    activity?.onBackPressed()
-                                },
-                                isDebug = BuildConfig.DEBUG,
-                                isUnrestrictedBattery = isUnrestrictedBattery,
-                                openFragment = { fragment ->
-                                    (activity as? FragmentHostListener)?.addFragment(fragment)
-                                },
-                                bottomInset = bottomInset.value.pxToDp(LocalContext.current).dp,
-                            )
-                        }
+                lifecycle.addObserver(observer)
+                onDispose {
+                    lifecycle.removeObserver(observer)
                 }
             }
+
+            userManager
+                .getSignInState()
+                .subscribeAsState(null)
+                .value
+                ?.let { signInState ->
+                    val bottomInset = settings.bottomInset.collectAsStateWithLifecycle(0)
+                    SettingsFragmentPage(
+                        signInState = signInState,
+                        onBackPressed = {
+                            @Suppress("DEPRECATION")
+                            activity?.onBackPressed()
+                        },
+                        isDebug = BuildConfig.DEBUG,
+                        isUnrestrictedBattery = isUnrestrictedBattery,
+                        openFragment = { fragment ->
+                            (activity as? FragmentHostListener)?.addFragment(fragment)
+                        },
+                        bottomInset = bottomInset.value.pxToDp(LocalContext.current).dp,
+                    )
+                }
         }
+    }
 }

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/about/AboutFragment.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/about/AboutFragment.kt
@@ -5,7 +5,6 @@ import android.content.Intent
 import android.net.Uri
 import android.os.Bundle
 import android.view.LayoutInflater
-import android.view.View
 import android.view.ViewGroup
 import androidx.annotation.AttrRes
 import androidx.annotation.StringRes
@@ -41,7 +40,6 @@ import androidx.compose.ui.draw.rotate
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.graphics.painter.Painter
-import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
@@ -50,6 +48,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.fragment.compose.content
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTracker
@@ -82,21 +81,21 @@ class AboutFragment : BaseFragment() {
 
     @Inject lateinit var settings: Settings
 
-    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
-        return ComposeView(requireContext()).apply {
-            setContent {
-                val bottomInset = settings.bottomInset.collectAsStateWithLifecycle(initialValue = 0)
-                CallOnce {
-                    analyticsTracker.track(AnalyticsEvent.SETTINGS_ABOUT_SHOWN)
-                }
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?,
+    ) = content {
+        val bottomInset = settings.bottomInset.collectAsStateWithLifecycle(initialValue = 0)
+        CallOnce {
+            analyticsTracker.track(AnalyticsEvent.SETTINGS_ABOUT_SHOWN)
+        }
 
-                AppThemeWithBackground(theme.activeTheme) {
-                    AboutPage(
-                        onBackPressed = { closeFragment() },
-                        bottomInset = bottomInset.value.pxToDp(LocalContext.current).dp,
-                    )
-                }
-            }
+        AppThemeWithBackground(theme.activeTheme) {
+            AboutPage(
+                onBackPressed = { closeFragment() },
+                bottomInset = bottomInset.value.pxToDp(LocalContext.current).dp,
+            )
         }
     }
 

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/privacy/PrivacyFragment.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/privacy/PrivacyFragment.kt
@@ -2,7 +2,6 @@ package au.com.shiftyjelly.pocketcasts.settings.privacy
 
 import android.os.Bundle
 import android.view.LayoutInflater
-import android.view.View
 import android.view.ViewGroup
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Column
@@ -13,10 +12,10 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.selection.toggleable
 import androidx.compose.material.MaterialTheme
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
@@ -24,6 +23,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.fragment.app.viewModels
+import androidx.fragment.compose.content
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTracker
@@ -45,47 +45,48 @@ import au.com.shiftyjelly.pocketcasts.localization.R as LR
 @AndroidEntryPoint
 class PrivacyFragment : BaseFragment() {
 
-    @Inject lateinit var analyticsTracker: AnalyticsTracker
+    @Inject
+    lateinit var analyticsTracker: AnalyticsTracker
 
-    @Inject lateinit var settings: Settings
+    @Inject
+    lateinit var settings: Settings
     private val viewModel: PrivacyViewModel by viewModels()
 
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
         savedInstanceState: Bundle?,
-    ): View {
-        if (!viewModel.isFragmentChangingConfigurations) {
-            analyticsTracker.track(AnalyticsEvent.PRIVACY_SHOWN)
-        }
-        return ComposeView(requireContext()).apply {
-            setContent {
-                val bottomInset = settings.bottomInset.collectAsStateWithLifecycle(initialValue = 0)
-                AppThemeWithBackground(theme.activeTheme) {
-                    val state: PrivacyViewModel.UiState by viewModel.uiState.collectAsState()
-                    PrivacySettings(
-                        state = state,
-                        onAnalyticsClick = {
-                            viewModel.updateAnalyticsSetting(it)
-                        },
-                        onCrashReportsClick = {
-                            viewModel.updateCrashReportsSetting(it)
-                        },
-                        onLinkAccountClick = {
-                            viewModel.updateLinkAccountSetting(it)
-                        },
-                        onPrivacyPolicyClick = {
-                            analyticsTracker.track(AnalyticsEvent.SETTINGS_SHOW_PRIVACY_POLICY)
-                            context.startActivityViewUrl(Settings.INFO_PRIVACY_URL)
-                        },
-                        onBackClick = {
-                            @Suppress("DEPRECATION")
-                            activity?.onBackPressed()
-                        },
-                        bottomInset = bottomInset.value.pxToDp(LocalContext.current).dp,
-                    )
-                }
+    ) = content {
+        LaunchedEffect(Unit) {
+            if (!viewModel.isFragmentChangingConfigurations) {
+                analyticsTracker.track(AnalyticsEvent.PRIVACY_SHOWN)
             }
+        }
+        val bottomInset = settings.bottomInset.collectAsStateWithLifecycle(initialValue = 0)
+        val context = LocalContext.current
+        AppThemeWithBackground(theme.activeTheme) {
+            val state: PrivacyViewModel.UiState by viewModel.uiState.collectAsState()
+            PrivacySettings(
+                state = state,
+                onAnalyticsClick = {
+                    viewModel.updateAnalyticsSetting(it)
+                },
+                onCrashReportsClick = {
+                    viewModel.updateCrashReportsSetting(it)
+                },
+                onLinkAccountClick = {
+                    viewModel.updateLinkAccountSetting(it)
+                },
+                onPrivacyPolicyClick = {
+                    analyticsTracker.track(AnalyticsEvent.SETTINGS_SHOW_PRIVACY_POLICY)
+                    context.startActivityViewUrl(Settings.INFO_PRIVACY_URL)
+                },
+                onBackClick = {
+                    @Suppress("DEPRECATION")
+                    activity?.onBackPressed()
+                },
+                bottomInset = bottomInset.value.pxToDp(LocalContext.current).dp,
+            )
         }
     }
 

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/stats/StatsFragment.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/stats/StatsFragment.kt
@@ -2,7 +2,6 @@ package au.com.shiftyjelly.pocketcasts.settings.stats
 
 import android.os.Bundle
 import android.view.LayoutInflater
-import android.view.View
 import android.view.ViewGroup
 import androidx.annotation.DrawableRes
 import androidx.annotation.StringRes
@@ -30,7 +29,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
@@ -44,6 +42,7 @@ import androidx.compose.ui.unit.TextUnit
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.fragment.app.viewModels
+import androidx.fragment.compose.content
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTracker
@@ -70,27 +69,31 @@ import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 @AndroidEntryPoint
 class StatsFragment : BaseFragment() {
-    @Inject lateinit var analyticsTracker: AnalyticsTracker
+    @Inject
+    lateinit var analyticsTracker: AnalyticsTracker
 
-    @Inject lateinit var settings: Settings
+    @Inject
+    lateinit var settings: Settings
     private val viewModel: StatsViewModel by viewModels()
 
-    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View = ComposeView(requireContext()).apply {
-        setContent {
-            val bottomInset = settings.bottomInset.collectAsStateWithLifecycle(0)
-            AppThemeWithBackground(theme.activeTheme) {
-                val state: StatsViewModel.State by viewModel.state.collectAsState()
-                StatsPage(
-                    state = state,
-                    onBackClick = {
-                        @Suppress("DEPRECATION")
-                        activity?.onBackPressed()
-                    },
-                    onRetryClick = { viewModel.loadStats() },
-                    launchReviewDialog = { viewModel.launchAppReviewDialog(it) },
-                    bottomInset = bottomInset.value.pxToDp(LocalContext.current).dp,
-                )
-            }
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?,
+    ) = content {
+        val bottomInset = settings.bottomInset.collectAsStateWithLifecycle(0)
+        AppThemeWithBackground(theme.activeTheme) {
+            val state: StatsViewModel.State by viewModel.state.collectAsState()
+            StatsPage(
+                state = state,
+                onBackClick = {
+                    @Suppress("DEPRECATION")
+                    activity?.onBackPressed()
+                },
+                onRetryClick = { viewModel.loadStats() },
+                launchReviewDialog = { viewModel.launchAppReviewDialog(it) },
+                bottomInset = bottomInset.value.pxToDp(LocalContext.current).dp,
+            )
         }
     }
 

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/status/StatusFragment.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/status/StatusFragment.kt
@@ -2,7 +2,6 @@ package au.com.shiftyjelly.pocketcasts.settings.status
 
 import android.os.Bundle
 import android.view.LayoutInflater
-import android.view.View
 import android.view.ViewGroup
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -26,7 +25,6 @@ import androidx.compose.material.icons.filled.Done
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.res.stringResource
@@ -35,6 +33,7 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.fragment.app.viewModels
+import androidx.fragment.compose.content
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import au.com.shiftyjelly.pocketcasts.compose.AppThemeWithBackground
 import au.com.shiftyjelly.pocketcasts.compose.bars.ThemedTopAppBar
@@ -54,19 +53,19 @@ class StatusFragment : BaseFragment() {
     lateinit var settings: Settings
     private val viewModel: StatusViewModel by viewModels()
 
-    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
-        return ComposeView(requireContext()).apply {
-            setContent {
-                UiUtil.hideKeyboard(LocalView.current)
-                val bottomInset = settings.bottomInset.collectAsStateWithLifecycle(initialValue = 0)
-                AppThemeWithBackground(theme.activeTheme) {
-                    StatusPage(
-                        viewModel = viewModel,
-                        onBackPressed = { closeFragment() },
-                        bottomInset = bottomInset.value.pxToDp(LocalContext.current).dp,
-                    )
-                }
-            }
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?,
+    ) = content {
+        UiUtil.hideKeyboard(LocalView.current)
+        val bottomInset = settings.bottomInset.collectAsStateWithLifecycle(initialValue = 0)
+        AppThemeWithBackground(theme.activeTheme) {
+            StatusPage(
+                viewModel = viewModel,
+                onBackPressed = { closeFragment() },
+                bottomInset = bottomInset.value.pxToDp(LocalContext.current).dp,
+            )
         }
     }
 

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/whatsnew/WhatsNewFragment.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/whatsnew/WhatsNewFragment.kt
@@ -2,17 +2,13 @@ package au.com.shiftyjelly.pocketcasts.settings.whatsnew
 
 import android.os.Bundle
 import android.view.LayoutInflater
-import android.view.View
 import android.view.ViewGroup
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.toArgb
-import androidx.compose.ui.platform.ComposeView
-import androidx.compose.ui.platform.ViewCompositionStrategy
+import androidx.fragment.compose.content
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTracker
 import au.com.shiftyjelly.pocketcasts.compose.AppTheme
@@ -40,56 +36,51 @@ class WhatsNewFragment : BaseFragment() {
         inflater: LayoutInflater,
         container: ViewGroup?,
         savedInstanceState: Bundle?,
-    ): View =
-        ComposeView(requireContext()).apply {
-            setBackgroundColor(Color.Transparent.toArgb())
-            setContent {
-                AppTheme(theme.activeTheme) {
-                    CallOnce {
-                        analyticsTracker.track(
-                            AnalyticsEvent.WHATSNEW_SHOWN,
-                            mapOf("version" to Settings.WHATS_NEW_VERSION_CODE),
-                        )
-                    }
+    ) = content {
+        AppTheme(theme.activeTheme) {
+            CallOnce {
+                analyticsTracker.track(
+                    AnalyticsEvent.WHATSNEW_SHOWN,
+                    mapOf("version" to Settings.WHATS_NEW_VERSION_CODE),
+                )
+            }
 
-                    setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
-                    val onClose: () -> Unit = {
-                        @Suppress("DEPRECATION")
-                        activity?.onBackPressed()
-                    }
-                    var confirmActionClicked: Boolean by remember { mutableStateOf(false) }
-                    WhatsNewPage(
-                        onConfirm = {
-                            analyticsTracker.track(
-                                AnalyticsEvent.WHATSNEW_CONFIRM_BUTTON_TAPPED,
-                                mapOf("version" to Settings.WHATS_NEW_VERSION_CODE),
-                            )
-                            if (it.shouldCloseOnConfirm) {
-                                onClose()
-                            }
-                            performConfirmAction(it)
-                            confirmActionClicked = true
-                        },
-                        onClose = {
-                            analyticsTracker.track(
-                                AnalyticsEvent.WHATSNEW_DISMISSED,
-                                mapOf("version" to Settings.WHATS_NEW_VERSION_CODE),
-                            )
-                            onClose()
-                        },
-
+            val onClose: () -> Unit = {
+                @Suppress("DEPRECATION")
+                activity?.onBackPressed()
+            }
+            var confirmActionClicked: Boolean by remember { mutableStateOf(false) }
+            WhatsNewPage(
+                onConfirm = {
+                    analyticsTracker.track(
+                        AnalyticsEvent.WHATSNEW_CONFIRM_BUTTON_TAPPED,
+                        mapOf("version" to Settings.WHATS_NEW_VERSION_CODE),
                     )
-
-                    DisposableEffect(Unit) {
-                        onDispose {
-                            val fragmentHostListener = activity as? FragmentHostListener
-                                ?: throw IllegalStateException(FRAGMENT_HOST_LISTENER_NOT_IMPLEMENTED)
-                            fragmentHostListener.whatsNewDismissed(fromConfirmAction = confirmActionClicked)
-                        }
+                    if (it.shouldCloseOnConfirm) {
+                        onClose()
                     }
+                    performConfirmAction(it)
+                    confirmActionClicked = true
+                },
+                onClose = {
+                    analyticsTracker.track(
+                        AnalyticsEvent.WHATSNEW_DISMISSED,
+                        mapOf("version" to Settings.WHATS_NEW_VERSION_CODE),
+                    )
+                    onClose()
+                },
+
+            )
+
+            DisposableEffect(Unit) {
+                onDispose {
+                    val fragmentHostListener = activity as? FragmentHostListener
+                        ?: throw IllegalStateException(FRAGMENT_HOST_LISTENER_NOT_IMPLEMENTED)
+                    fragmentHostListener.whatsNewDismissed(fromConfirmAction = confirmActionClicked)
                 }
             }
         }
+    }
 
     private fun performConfirmAction(navigationState: NavigationState) {
         when (navigationState) {
@@ -107,6 +98,7 @@ class WhatsNewFragment : BaseFragment() {
             showPatronOnly = when (source) {
                 OnboardingUpgradeSource.WHATS_NEW_SKIP_CHAPTERS -> FeatureFlag.isEnabled(Feature.DESELECT_CHAPTERS) &&
                     Subscription.SubscriptionTier.fromFeatureTier(Feature.DESELECT_CHAPTERS) == Subscription.SubscriptionTier.PATRON
+
                 else -> false
             },
         )

--- a/modules/services/views/build.gradle.kts
+++ b/modules/services/views/build.gradle.kts
@@ -52,6 +52,7 @@ dependencies {
     implementation(libs.compose.ui)
     implementation(libs.compose.ui.tooling.preview)
     implementation(libs.coroutines.core)
+    implementation(libs.fragment.compose)
     implementation(libs.fragment.ktx)
     implementation(libs.lifecycle.reactivestreams.ktx)
     implementation(libs.okhttp)

--- a/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/dialog/OptionsDialog.kt
+++ b/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/dialog/OptionsDialog.kt
@@ -12,8 +12,8 @@ import androidx.annotation.ColorInt
 import androidx.annotation.ColorRes
 import androidx.annotation.DrawableRes
 import androidx.annotation.StringRes
-import androidx.compose.ui.platform.ComposeView
 import androidx.core.view.doOnLayout
+import androidx.fragment.compose.content
 import au.com.shiftyjelly.pocketcasts.compose.AppTheme
 import au.com.shiftyjelly.pocketcasts.compose.buttons.ToggleButtonOption
 import au.com.shiftyjelly.pocketcasts.compose.dialogs.OptionsDialogComponent
@@ -93,14 +93,13 @@ class OptionsDialog : BottomSheetDialogFragment() {
         options.add(OptionsDialogOption(titleId = titleId, titleString = titleString, titleColor = titleColor, valueId = valueId, imageId = imageId, imageColor = imageColor, checked = checked, click = closeAndClick, toggleOptions = toggleOptions, onSwitch = onSwitch))
     }
 
-    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
-        val context = if (forceDarkTheme) ContextThemeWrapper(context, UR.style.ThemeDark) else context ?: throw Exception("Context not found")
-        return ComposeView(context).apply {
-            setContent {
-                AppTheme(if (forceDarkTheme) Theme.ThemeType.DARK else theme.activeTheme) {
-                    OptionsDialogComponent(title = title, iconColor = iconColor, options = options)
-                }
-            }
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?,
+    ) = content {
+        AppTheme(if (forceDarkTheme) Theme.ThemeType.DARK else theme.activeTheme) {
+            OptionsDialogComponent(title = title, iconColor = iconColor, options = options)
         }
     }
 

--- a/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/fragments/BatteryRestrictionsSettingsFragment.kt
+++ b/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/fragments/BatteryRestrictionsSettingsFragment.kt
@@ -4,7 +4,6 @@ import android.content.Intent
 import android.net.Uri
 import android.os.Bundle
 import android.view.LayoutInflater
-import android.view.View
 import android.view.ViewGroup
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
@@ -26,7 +25,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.ComposeView
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
@@ -36,6 +35,7 @@ import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.dp
+import androidx.fragment.compose.content
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import au.com.shiftyjelly.pocketcasts.compose.AppThemeWithBackground
@@ -73,46 +73,44 @@ class BatteryRestrictionsSettingsFragment : BaseFragment() {
         inflater: LayoutInflater,
         container: ViewGroup?,
         savedInstanceState: Bundle?,
-    ): View =
-        ComposeView(requireContext()).apply {
-            setContent {
-                AppThemeWithBackground(theme.activeTheme) {
-                    var isUnrestricted by remember { mutableStateOf(batteryRestrictions.isUnrestricted()) }
-                    DisposableEffect(this) {
-                        val observer = LifecycleEventObserver { _, event ->
-                            if (event == Lifecycle.Event.ON_RESUME) {
-                                isUnrestricted = batteryRestrictions.isUnrestricted()
-                            }
-                        }
-
-                        lifecycle.addObserver(observer)
-                        onDispose {
-                            lifecycle.removeObserver(observer)
-                        }
+    ) = content {
+        AppThemeWithBackground(theme.activeTheme) {
+            var isUnrestricted by remember { mutableStateOf(batteryRestrictions.isUnrestricted()) }
+            DisposableEffect(this) {
+                val observer = LifecycleEventObserver { _, event ->
+                    if (event == Lifecycle.Event.ON_RESUME) {
+                        isUnrestricted = batteryRestrictions.isUnrestricted()
                     }
+                }
 
-                    val navigationButton = if (arguments?.getBoolean(ARG_CLOSE_BUTTON) == true) {
-                        NavigationButton.Close
-                    } else {
-                        NavigationButton.Back
-                    }
-                    Page(
-                        isUnrestricted = isUnrestricted,
-                        navigationButton = navigationButton,
-                        onBackPressed = {
-                            @Suppress("DEPRECATION")
-                            activity?.onBackPressed()
-                        },
-                        onClick = { batteryRestrictions.promptToUpdateBatteryRestriction(context) },
-                        openUrl = { url ->
-                            startActivity(
-                                Intent(Intent.ACTION_VIEW, Uri.parse(url)),
-                            )
-                        },
-                    )
+                lifecycle.addObserver(observer)
+                onDispose {
+                    lifecycle.removeObserver(observer)
                 }
             }
+
+            val navigationButton = if (arguments?.getBoolean(ARG_CLOSE_BUTTON) == true) {
+                NavigationButton.Close
+            } else {
+                NavigationButton.Back
+            }
+            val context = LocalContext.current
+            Page(
+                isUnrestricted = isUnrestricted,
+                navigationButton = navigationButton,
+                onBackPressed = {
+                    @Suppress("DEPRECATION")
+                    activity?.onBackPressed()
+                },
+                onClick = { batteryRestrictions.promptToUpdateBatteryRestriction(context) },
+                openUrl = { url ->
+                    startActivity(
+                        Intent(Intent.ACTION_VIEW, Uri.parse(url)),
+                    )
+                },
+            )
         }
+    }
 }
 
 @Composable


### PR DESCRIPTION
## Description

This PR changes all of our fragments that manually use `ComposeView` to use `content()` extension instead. There are no functional changes. It makes things a bit cleaner and ensures that the correct `ViewCompositionStrategy` is applied.

## Testing Instructions

1. Smoke test the app and navigate through it.
2. Check things like bottom sheets and dialogs.

## Checklist
- [ ] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] ~I have considered whether it makes sense to add tests for my changes~
- [ ] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [ ] ~Any jetpack compose components I added or changed are covered by compose previews~
- [ ] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [ ] ~with the device set to have a large display and font size~
- [ ] ~for accessibility with TalkBack~