### PR TITLE
Fix low storage card theme colors

### DIFF
--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/ProfileEpisodeListFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/ProfileEpisodeListFragment.kt
@@ -8,6 +8,12 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.widget.Toolbar
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.MaterialTheme
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
 import androidx.core.view.isVisible
 import androidx.core.view.updatePadding
 import androidx.fragment.app.Fragment
@@ -23,6 +29,7 @@ import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTracker
 import au.com.shiftyjelly.pocketcasts.analytics.SourceView
 import au.com.shiftyjelly.pocketcasts.compose.AppTheme
 import au.com.shiftyjelly.pocketcasts.compose.CallOnce
+import au.com.shiftyjelly.pocketcasts.compose.theme
 import au.com.shiftyjelly.pocketcasts.models.entity.BaseEpisode
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.models.type.EpisodeViewSource
@@ -425,13 +432,19 @@ class ProfileEpisodeListFragment : BaseFragment(), Toolbar.OnMenuItemClickListen
                         CallOnce {
                             analyticsTracker.track(AnalyticsEvent.FREE_UP_SPACE_BANNER_SHOWN)
                         }
-                        ManageDownloadsCard(
-                            totalDownloadSize = downloadedEpisodesSize,
-                            onManageDownloadsClick = {
-                                analyticsTracker.track(AnalyticsEvent.FREE_UP_SPACE_MANAGE_DOWNLOADS_TAPPED, mapOf("source" to SourceView.DOWNLOADS.analyticsValue))
-                                showFragment(ManualCleanupFragment.newInstance())
-                            },
-                        )
+                        Box(
+                            modifier = Modifier
+                                .background(color = MaterialTheme.theme.colors.primaryUi02)
+                                .padding(start = 16.dp, end = 16.dp, top = 16.dp),
+                        ) {
+                            ManageDownloadsCard(
+                                totalDownloadSize = downloadedEpisodesSize,
+                                onManageDownloadsClick = {
+                                    analyticsTracker.track(AnalyticsEvent.FREE_UP_SPACE_MANAGE_DOWNLOADS_TAPPED, mapOf("source" to SourceView.DOWNLOADS.analyticsValue))
+                                    showFragment(ManualCleanupFragment.newInstance())
+                                },
+                            )
+                        }
                     }
                 }
             }

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/ProfileManageDownloadsCard.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/ProfileManageDownloadsCard.kt
@@ -15,7 +15,6 @@ import androidx.compose.material.MaterialTheme
 import androidx.compose.material.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
@@ -59,7 +58,8 @@ fun ManageDownloadsCard(
             modifier = Modifier
                 .padding(end = 12.dp)
                 .size(24.dp),
-            tint = Color.Black,
+            // The icon isn't clickable so the design matches the title color
+            tint = MaterialTheme.theme.colors.primaryText01,
         )
 
         Column(

--- a/modules/features/podcasts/src/main/res/layout/fragment_profile_episode_list.xml
+++ b/modules/features/podcasts/src/main/res/layout/fragment_profile_episode_list.xml
@@ -50,10 +50,7 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         app:layout_constraintTop_toBottomOf="@id/appBar"
-        android:visibility="gone"
-        android:layout_marginHorizontal="16dp"
-        android:layout_marginTop="16dp"
-        />
+        android:visibility="gone" />
 
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/recyclerView"

--- a/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/lowstorage/LowStorageDialog.kt
+++ b/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/lowstorage/LowStorageDialog.kt
@@ -110,14 +110,14 @@ internal fun LowStorageDialog(
         TextH20(
             text = stringResource(LR.string.need_to_free_up_space),
             textAlign = TextAlign.Center,
-            modifier = modifier.padding(bottom = 10.dp, start = 21.dp, end = 21.dp),
+            modifier = Modifier.padding(bottom = 10.dp, start = 21.dp, end = 21.dp),
         )
 
         TextH50(
             text = stringResource(LR.string.save_space_by_managing_downloaded_episodes, formattedTotalDownloadSize),
             fontWeight = FontWeight.W500,
             textAlign = TextAlign.Center,
-            modifier = modifier.padding(bottom = 57.dp, start = 21.dp, end = 21.dp),
+            modifier = Modifier.padding(bottom = 57.dp, start = 21.dp, end = 21.dp),
         )
 
         RowButton(
@@ -128,7 +128,7 @@ internal fun LowStorageDialog(
             colors = ButtonDefaults.buttonColors(
                 backgroundColor = MaterialTheme.theme.colors.primaryInteractive01,
             ),
-            modifier = modifier
+            modifier = Modifier
                 .padding(horizontal = 21.dp)
                 .padding(bottom = 12.dp),
         )
@@ -137,7 +137,7 @@ internal fun LowStorageDialog(
             text = stringResource(LR.string.maybe_later),
             onClick = { onMaybeLaterClick.invoke() },
             includePadding = false,
-            modifier = modifier
+            modifier = Modifier
                 .padding(bottom = 12.dp)
                 .padding(horizontal = 21.dp),
             border = null,


### PR DESCRIPTION
## Description

During beta testing, it was noticed that the theming on the low storage card wasn't correct. The icon color didn't work on different themes and the background around the card was incorrect. 

<img  width="300" src="https://github.com/user-attachments/assets/5ba8e3c6-4618-4a26-9479-9f3e828a1a0d" /> 

## Testing Instructions

1. In the method `ProfileEpisodeListFragment.updateManageDownloadsCard` change the `isVisible` to true while testing
2. Tap the Profile tab -> Downloads
3. ✅ Verify the theme looks correct

## Screenshots 

|  |  |  |
|--------|--------|--------|
| ![Screenshot_20241115_115558](https://github.com/user-attachments/assets/b7ea6e0b-98dd-4c86-aece-ddc274bd50b7) | ![Screenshot_20241115_115544](https://github.com/user-attachments/assets/9e3426d6-4c03-4754-9e9a-33cec4ed187b) | ![Screenshot_20241115_115515](https://github.com/user-attachments/assets/fc5160aa-23ff-4340-9807-56b03afe6e7c) |
| ![Screenshot_20241115_115416](https://github.com/user-attachments/assets/f6fde33c-fb91-4eba-8d8d-8d169110b3bd) | ![Screenshot_20241115_115259](https://github.com/user-attachments/assets/95c7bb14-4136-4ece-bee8-770b5133bbb2) | ![Screenshot_20241115_115245](https://github.com/user-attachments/assets/be427035-021d-4199-9304-530368cb8539) | 
| ![Screenshot_20241115_115213](https://github.com/user-attachments/assets/e105d43c-cde2-47c1-bf63-6c63d7607898) | ![Screenshot_20241115_115153](https://github.com/user-attachments/assets/ad8a16ee-348c-4e1a-a106-fe7c01248c95) |  |

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack
