### PR TITLE
Support edge-to-edge for the whole podcasts section

### DIFF
--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/FiltersFragment.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/FiltersFragment.kt
@@ -72,8 +72,6 @@ class FiltersFragment : BaseFragment(), CoroutineScope, Toolbar.OnMenuItemClickL
 
         val binding = binding ?: return
 
-        binding.appBarLayout.hideShadow()
-
         setupToolbarAndStatusBar(
             toolbar = binding.toolbar,
             title = getString(LR.string.filters),

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/FiltersFragment.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/FiltersFragment.kt
@@ -20,7 +20,6 @@ import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.repositories.chromecast.CastManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.PlaylistManager
 import au.com.shiftyjelly.pocketcasts.ui.helper.FragmentHostListener
-import au.com.shiftyjelly.pocketcasts.utils.extensions.hideShadow
 import au.com.shiftyjelly.pocketcasts.views.fragments.BaseFragment
 import au.com.shiftyjelly.pocketcasts.views.fragments.BaseFragmentToolbar.ChromeCastButton.Shown
 import au.com.shiftyjelly.pocketcasts.views.helper.NavigationIcon.None

--- a/modules/features/filters/src/main/res/layout/fragment_filters.xml
+++ b/modules/features/filters/src/main/res/layout/fragment_filters.xml
@@ -4,30 +4,24 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-    <FrameLayout
+    <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"
+        android:orientation="vertical"
         android:importantForAccessibility="no">
-        <com.google.android.material.appbar.AppBarLayout
-            android:id="@+id/appBarLayout"
+        <androidx.appcompat.widget.Toolbar
+            android:id="@+id/toolbar"
             android:layout_width="match_parent"
-            android:layout_height="wrap_content">
-            <androidx.appcompat.widget.Toolbar
-                android:id="@+id/toolbar"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:background="?attr/secondary_ui_01"
-                android:minHeight="?android:attr/actionBarSize" />
-        </com.google.android.material.appbar.AppBarLayout>
+            android:layout_height="wrap_content"
+            android:background="?attr/secondary_ui_01" />
 
         <androidx.recyclerview.widget.RecyclerView
             android:id="@+id/recyclerView"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            android:layout_marginTop="?android:actionBarSize"
             android:clipToPadding="false"
             android:paddingBottom="16dp" />
-    </FrameLayout>
+    </LinearLayout>
 
     <FrameLayout
         android:id="@+id/filterFrameChildFragment"

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastAutoArchiveFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastAutoArchiveFragment.kt
@@ -124,7 +124,6 @@ class PodcastAutoArchiveFragment : BaseFragment() {
             ThemedTopAppBar(
                 title = stringResource(LR.string.settings_title_auto_archive),
                 onNavigationClick = onBackPressed,
-                bottomShadow = true,
                 iconColor = Color(toolbarColors.iconColor),
                 textColor = Color(toolbarColors.titleColor),
                 backgroundColor = Color(toolbarColors.backgroundColor),

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastEffectsFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastEffectsFragment.kt
@@ -19,14 +19,13 @@ import au.com.shiftyjelly.pocketcasts.ui.extensions.getThemeColor
 import au.com.shiftyjelly.pocketcasts.ui.extensions.getTintedDrawable
 import au.com.shiftyjelly.pocketcasts.ui.helper.StatusBarColor
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
+import au.com.shiftyjelly.pocketcasts.views.extensions.includeStatusBarPadding
 import au.com.shiftyjelly.pocketcasts.views.extensions.setup
-import au.com.shiftyjelly.pocketcasts.views.extensions.updateColors
-import au.com.shiftyjelly.pocketcasts.views.helper.NavigationIcon
+import au.com.shiftyjelly.pocketcasts.views.helper.NavigationIcon.BackArrow
 import au.com.shiftyjelly.pocketcasts.views.helper.ToolbarColors
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
 import au.com.shiftyjelly.pocketcasts.images.R as IR
-import au.com.shiftyjelly.pocketcasts.localization.R as LR
 import au.com.shiftyjelly.pocketcasts.ui.R as UR
 
 @AndroidEntryPoint
@@ -43,6 +42,7 @@ class PodcastEffectsFragment : PreferenceFragmentCompat() {
     private var preferenceTrimMode: ListPreference? = null
 
     private val viewModel: PodcastEffectsViewModel by viewModels()
+    private var toolbar: Toolbar? = null
 
     companion object {
         const val ARG_PODCAST_UUID = "ARG_PODCAST_UUID"
@@ -64,6 +64,11 @@ class PodcastEffectsFragment : PreferenceFragmentCompat() {
         viewModel.loadPodcast(podcastUuid)
     }
 
+    override fun onDestroyView() {
+        toolbar = null
+        super.onDestroyView()
+    }
+
     override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {
         setPreferencesFromResource(R.xml.preferences_podcast_effects, rootKey)
 
@@ -80,15 +85,8 @@ class PodcastEffectsFragment : PreferenceFragmentCompat() {
         view.setBackgroundColor(view.context.getThemeColor(UR.attr.primary_ui_01))
         view.isClickable = true
 
-        val toolbar = view.findViewById<Toolbar>(R.id.toolbar)
-
-        toolbar.setup(
-            title = getString(LR.string.podcast_playback_effects),
-            navigationIcon = NavigationIcon.BackArrow,
-            activity = activity,
-            theme = theme,
-            toolbarColors = ToolbarColors.theme(theme = theme, context = toolbar.context),
-        )
+        toolbar = view.findViewById(R.id.toolbar)
+        toolbar?.includeStatusBarPadding()
 
         preferencePlaybackSpeed?.isVisible = false
         preferenceTrimSilence?.isVisible = false
@@ -96,12 +94,25 @@ class PodcastEffectsFragment : PreferenceFragmentCompat() {
         preferenceTrimMode?.isVisible = false
 
         viewModel.podcast.observe(viewLifecycleOwner) { podcast ->
+            val context = context ?: return@observe
 
             val colors = ToolbarColors.podcast(podcast = podcast, theme = theme)
 
             updateTintColor(colors.iconColor)
-            toolbar.updateColors(toolbarColors = colors, navigationIcon = NavigationIcon.BackArrow)
-            theme.updateWindowStatusBarIcons(window = requireActivity().window, statusBarColor = StatusBarColor.Custom(colors.backgroundColor, true), context = requireContext())
+            toolbar?.setup(
+                title = podcast.title,
+                navigationIcon = BackArrow,
+                toolbarColors = colors,
+                theme = theme,
+                activity = activity,
+                includeStatusBarPadding = false,
+            )
+
+            theme.updateWindowStatusBarIcons(
+                window = requireActivity().window,
+                statusBarColor = StatusBarColor.Custom(colors.backgroundColor, isWhiteIcons = theme.activeTheme.defaultLightIcons),
+                context = context,
+            )
 
             preferenceCustomForPodcast?.isChecked = podcast.overrideGlobalEffects
 

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastFragment.kt
@@ -73,6 +73,7 @@ import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
 import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
 import au.com.shiftyjelly.pocketcasts.views.dialog.ConfirmationDialog
 import au.com.shiftyjelly.pocketcasts.views.dialog.OptionsDialog
+import au.com.shiftyjelly.pocketcasts.views.extensions.includeStatusBarPadding
 import au.com.shiftyjelly.pocketcasts.views.extensions.setupChromeCastButton
 import au.com.shiftyjelly.pocketcasts.views.extensions.smoothScrollToTop
 import au.com.shiftyjelly.pocketcasts.views.extensions.tintIcons
@@ -631,6 +632,7 @@ class PodcastFragment : BaseFragment(), Toolbar.OnMenuItemClickListener {
                 theme.toggleDarkLightThemeActivity(activity as AppCompatActivity)
                 true
             }
+            it.includeStatusBarPadding()
         }
 
         playButtonListener.source = SourceView.PODCAST_SCREEN

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastSettingsFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastSettingsFragment.kt
@@ -32,6 +32,7 @@ import au.com.shiftyjelly.pocketcasts.ui.helper.StatusBarColor
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import au.com.shiftyjelly.pocketcasts.utils.combineLatest
 import au.com.shiftyjelly.pocketcasts.views.dialog.ConfirmationDialog
+import au.com.shiftyjelly.pocketcasts.views.extensions.includeStatusBarPadding
 import au.com.shiftyjelly.pocketcasts.views.extensions.setInputAsSeconds
 import au.com.shiftyjelly.pocketcasts.views.extensions.setup
 import au.com.shiftyjelly.pocketcasts.views.fragments.BasePreferenceFragment
@@ -136,6 +137,7 @@ class PodcastSettingsFragment : BasePreferenceFragment(), FilterSelectFragment.L
         view.isClickable = true
 
         toolbar = view.findViewById(R.id.toolbar)
+        toolbar?.includeStatusBarPadding()
 
         preferenceAddToUpNextOrder?.isVisible = false
 
@@ -152,7 +154,14 @@ class PodcastSettingsFragment : BasePreferenceFragment(), FilterSelectFragment.L
             preferencePlaybackEffects?.summary = buildEffectsSummary(podcast)
 
             updateTintColor(colors.iconColor)
-            toolbar?.setup(title = podcast.title, navigationIcon = BackArrow, toolbarColors = colors, theme = theme, activity = activity)
+            toolbar?.setup(
+                title = podcast.title,
+                navigationIcon = BackArrow,
+                toolbarColors = colors,
+                theme = theme,
+                activity = activity,
+                includeStatusBarPadding = false,
+            )
 
             theme.updateWindowStatusBarIcons(
                 window = requireActivity().window,

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/share/ShareListCreateActivity.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/share/ShareListCreateActivity.kt
@@ -1,6 +1,7 @@
 package au.com.shiftyjelly.pocketcasts.podcasts.view.share
 
 import android.os.Bundle
+import androidx.activity.enableEdgeToEdge
 import androidx.appcompat.app.AppCompatActivity
 import au.com.shiftyjelly.pocketcasts.podcasts.R
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
@@ -18,6 +19,7 @@ class ShareListCreateActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         theme.setupThemeForConfig(this, resources.configuration)
+        enableEdgeToEdge(navigationBarStyle = theme.getNavigationBarStyle(this))
 
         setContentView(R.layout.activity_blank_fragment)
 

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/share/ShareListCreateFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/share/ShareListCreateFragment.kt
@@ -3,6 +3,12 @@ package au.com.shiftyjelly.pocketcasts.podcasts.view.share
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.ViewGroup
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.WindowInsetsSides
+import androidx.compose.foundation.layout.only
+import androidx.compose.foundation.layout.safeDrawing
+import androidx.compose.foundation.layout.windowInsetsPadding
+import androidx.compose.ui.Modifier
 import androidx.fragment.app.viewModels
 import androidx.fragment.compose.content
 import androidx.navigation.NavHostController
@@ -36,7 +42,11 @@ class ShareListCreateFragment : BaseFragment() {
         AppThemeWithBackground(theme.activeTheme) {
             navHostController = rememberNavController()
             val navController = navHostController ?: return@AppThemeWithBackground
-            NavHost(navController = navController, startDestination = NavRoutes.podcasts) {
+            NavHost(
+                navController = navController,
+                startDestination = NavRoutes.podcasts,
+                modifier = Modifier.windowInsetsPadding(WindowInsets.safeDrawing.only(WindowInsetsSides.Horizontal + WindowInsetsSides.Bottom)),
+            ) {
                 composable(NavRoutes.podcasts) {
                     ShareListCreatePodcastsPage(
                         onCloseClick = { activity?.finish() },

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/share/ShareListCreatePodcastsPage.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/share/ShareListCreatePodcastsPage.kt
@@ -1,9 +1,6 @@
 package au.com.shiftyjelly.pocketcasts.podcasts.view.share
 
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.WindowInsets
-import androidx.compose.foundation.layout.navigationBars
-import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.material.Icon
 import androidx.compose.material.IconButton
 import androidx.compose.material.icons.Icons
@@ -53,7 +50,6 @@ fun ShareListCreatePodcastsPage(
             onPodcastUnselected = { podcast -> viewModel.unselectPodcast(podcast) },
             onSelectAll = { viewModel.selectAll() },
             onSelectNone = { viewModel.selectNone() },
-            modifier = Modifier.windowInsetsPadding(WindowInsets.navigationBars),
         )
     }
 }

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/share/ShareListCreatePodcastsPage.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/share/ShareListCreatePodcastsPage.kt
@@ -1,6 +1,9 @@
 package au.com.shiftyjelly.pocketcasts.podcasts.view.share
 
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.navigationBars
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.material.Icon
 import androidx.compose.material.IconButton
 import androidx.compose.material.icons.Icons
@@ -26,7 +29,7 @@ fun ShareListCreatePodcastsPage(
     modifier: Modifier = Modifier,
 ) {
     val state: ShareListCreateViewModel.State by viewModel.state.collectAsState()
-    Column {
+    Column(modifier = modifier) {
         ThemedTopAppBar(
             title = stringResource(LR.string.podcasts_share_select_podcasts),
             navigationButton = NavigationButton.Close,
@@ -50,7 +53,7 @@ fun ShareListCreatePodcastsPage(
             onPodcastUnselected = { podcast -> viewModel.unselectPodcast(podcast) },
             onSelectAll = { viewModel.selectAll() },
             onSelectNone = { viewModel.selectNone() },
-            modifier = modifier,
+            modifier = Modifier.windowInsetsPadding(WindowInsets.navigationBars),
         )
     }
 }

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/share/ShareListCreateTitlePage.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/share/ShareListCreateTitlePage.kt
@@ -97,7 +97,7 @@ private fun ShareListCreateTitleContent(
                 onDescriptionChange = onDescriptionChange,
                 onDoneClick = onDoneClick,
                 focusRequester = focusRequester,
-                modifier = Modifier.padding(horizontal = 16.dp),
+                modifier = Modifier.padding(start = 16.dp, end = 16.dp, top = 8.dp),
             )
         }
         LazyVerticalGrid(

--- a/modules/features/podcasts/src/main/res/layout/fragment_podcast.xml
+++ b/modules/features/podcasts/src/main/res/layout/fragment_podcast.xml
@@ -10,7 +10,7 @@
     <androidx.appcompat.widget.Toolbar
         android:id="@+id/toolbar"
         android:layout_width="match_parent"
-        android:layout_height="?android:attr/actionBarSize"
+        android:layout_height="wrap_content"
         android:elevation="0dp"
         android:minHeight="?android:attr/actionBarSize"
         android:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar"

--- a/modules/features/profile/src/main/res/layout-land/fragment_profile.xml
+++ b/modules/features/profile/src/main/res/layout-land/fragment_profile.xml
@@ -6,7 +6,7 @@
     android:layout_height="match_parent"
     android:orientation="vertical">
 
-    <au.com.shiftyjelly.pocketcasts.player.view.StatusBarSpacer
+    <au.com.shiftyjelly.pocketcasts.views.component.StatusBarSpacer
         android:layout_width="match_parent"
         android:layout_height="0dp"
         android:background="?attr/secondary_ui_01" />

--- a/modules/features/profile/src/main/res/layout/fragment_profile.xml
+++ b/modules/features/profile/src/main/res/layout/fragment_profile.xml
@@ -6,7 +6,7 @@
     android:layout_height="match_parent"
     android:orientation="vertical">
 
-    <au.com.shiftyjelly.pocketcasts.player.view.StatusBarSpacer
+    <au.com.shiftyjelly.pocketcasts.views.component.StatusBarSpacer
         android:layout_width="match_parent"
         android:layout_height="0dp"
         android:background="?attr/secondary_ui_01" />

--- a/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/SearchEpisodeResultsPage.kt
+++ b/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/SearchEpisodeResultsPage.kt
@@ -9,6 +9,7 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
 import au.com.shiftyjelly.pocketcasts.compose.bars.ThemedTopAppBar
 import au.com.shiftyjelly.pocketcasts.models.to.EpisodeItem
 import au.com.shiftyjelly.pocketcasts.preferences.Settings.MediaNotificationControls.Companion.items
@@ -26,7 +27,6 @@ fun SearchEpisodeResultsPage(
     Column {
         ThemedTopAppBar(
             title = stringResource(LR.string.search_results_all_episodes),
-            bottomShadow = true,
             onNavigationClick = { onBackClick() },
         )
         SearchEpisodeResultsView(
@@ -44,7 +44,7 @@ private fun SearchEpisodeResultsView(
     bottomInset: Dp,
 ) {
     LazyColumn(
-        contentPadding = PaddingValues(bottom = bottomInset),
+        contentPadding = PaddingValues(top = 16.dp, bottom = bottomInset + 16.dp),
     ) {
         items(
             items = state.episodes,

--- a/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/SearchPodcastResultsPage.kt
+++ b/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/SearchPodcastResultsPage.kt
@@ -12,6 +12,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
 import au.com.shiftyjelly.pocketcasts.compose.bars.ThemedTopAppBar
 import au.com.shiftyjelly.pocketcasts.compose.components.PodcastItem
 import au.com.shiftyjelly.pocketcasts.compose.theme
@@ -33,7 +34,6 @@ fun SearchPodcastResultsPage(
     Column {
         ThemedTopAppBar(
             title = stringResource(LR.string.search_results_all_podcasts),
-            bottomShadow = true,
             onNavigationClick = { onBackClick() },
         )
         SearchPodcastResultsView(
@@ -55,7 +55,7 @@ private fun SearchPodcastResultsView(
     bottomInset: Dp,
 ) {
     LazyColumn(
-        contentPadding = PaddingValues(bottom = bottomInset),
+        contentPadding = PaddingValues(top = 8.dp, bottom = bottomInset + 8.dp),
     ) {
         items(
             items = state.podcasts,

--- a/modules/features/search/src/main/res/layout/fragment_search.xml
+++ b/modules/features/search/src/main/res/layout/fragment_search.xml
@@ -11,6 +11,11 @@
         android:background="?attr/primary_ui_01"
         tools:context=".SearchFragment">
 
+        <au.com.shiftyjelly.pocketcasts.views.component.StatusBarSpacer
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:background="?attr/secondary_ui_01" />
+
         <FrameLayout
             android:id="@+id/floatingLayout"
             android:layout_width="match_parent"

--- a/modules/services/ui/src/main/res/layout/settings_pocketcasts_settings_fragment.xml
+++ b/modules/services/ui/src/main/res/layout/settings_pocketcasts_settings_fragment.xml
@@ -13,7 +13,7 @@
 
     <FrameLayout
         android:layout_width="match_parent"
-        android:layout_height="wrap_content">
+        android:layout_height="match_parent">
 
         <!-- Required ViewGroup for PreferenceFragmentCompat -->
         <FrameLayout

--- a/modules/services/ui/src/main/res/layout/settings_pocketcasts_settings_fragment.xml
+++ b/modules/services/ui/src/main/res/layout/settings_pocketcasts_settings_fragment.xml
@@ -1,37 +1,34 @@
 <?xml version="1.0" encoding="utf-8"?>
-<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    android:orientation="vertical">
 
-    <com.google.android.material.appbar.AppBarLayout
+    <androidx.appcompat.widget.Toolbar
+        android:id="@+id/toolbar"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="?attr/secondary_ui_01" />
+
+    <FrameLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content">
 
-        <androidx.appcompat.widget.Toolbar
-            android:id="@+id/toolbar"
+        <!-- Required ViewGroup for PreferenceFragmentCompat -->
+        <FrameLayout
+            android:id="@android:id/list_container"
             android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:background="?attr/secondary_ui_01"
-            android:minHeight="?android:attr/actionBarSize" />
+            android:layout_height="match_parent"
+            android:background="?attr/primary_ui_02"
+            android:clickable="true"
+            android:focusable="true">
+        </FrameLayout>
 
-    </com.google.android.material.appbar.AppBarLayout>
-
-    <!-- Required ViewGroup for PreferenceFragmentCompat -->
-    <FrameLayout
-        android:id="@android:id/list_container"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:layout_marginTop="?android:attr/actionBarSize"
-        android:background="?attr/primary_ui_02"
-        android:clickable="true"
-        android:focusable="true">
+        <FrameLayout
+            android:id="@+id/frameChildFragment"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"/>
     </FrameLayout>
 
-    <FrameLayout
-        android:id="@+id/frameChildFragment"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:layout_marginTop="?android:attr/actionBarSize"/>
-
-</FrameLayout>
+</LinearLayout>

--- a/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/component/StatusBarSpacer.kt
+++ b/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/component/StatusBarSpacer.kt
@@ -1,4 +1,4 @@
-package au.com.shiftyjelly.pocketcasts.player.view
+package au.com.shiftyjelly.pocketcasts.views.component
 
 import android.content.Context
 import android.util.AttributeSet

--- a/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/extensions/Toolbar.kt
+++ b/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/extensions/Toolbar.kt
@@ -30,6 +30,7 @@ fun Toolbar.setup(
     activity: Activity?,
     theme: Theme,
     toolbarColors: ToolbarColors? = ToolbarColors.theme(theme = theme, context = context),
+    includeStatusBarPadding: Boolean = true,
 ) {
     if (title != null) {
         setTitle(title)
@@ -67,7 +68,9 @@ fun Toolbar.setup(
             true
         }
     }
-    includeStatusBarPadding()
+    if (includeStatusBarPadding) {
+        includeStatusBarPadding()
+    }
 }
 
 fun Toolbar.setupChromeCastButton(context: Context?, onClick: () -> Unit) {

--- a/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/extensions/View.kt
+++ b/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/extensions/View.kt
@@ -52,7 +52,7 @@ fun View.setSystemWindowInsetToPadding(
     top: Boolean = false,
     right: Boolean = false,
     bottom: Boolean = false,
-    consumeInsets: Boolean = true,
+    consumeInsets: Boolean = false,
 ) {
     ViewCompat.setOnApplyWindowInsetsListener(this) { view, windowInsets ->
         val insets = windowInsets.getInsets(
@@ -86,7 +86,7 @@ fun View.setSystemWindowInsetToPadding(
 fun View.setSystemWindowInsetToHeight(
     top: Boolean = false,
     bottom: Boolean = false,
-    consumeInsets: Boolean = true,
+    consumeInsets: Boolean = false,
 ) {
     ViewCompat.setOnApplyWindowInsetsListener(this) { view, windowInsets ->
         val insets = windowInsets.getInsets(WindowInsetsCompat.Type.systemBars())


### PR DESCRIPTION
## Description

This change focuses on all the screens in the podcasts tab. Please ignore the other tabs for now.

One issue I'm struggling to solve at the moment is the bottom sheet navigation bar color. I will have another attempt at fixing it in a future PR.

There will be multiple pull requests required to support Android 15 edge-to-edge but I'm going to break them down into smaller PRs. I will merge them all into a `task/android-15` branch, and after all the work is completed, raise a PR to merge into `main`.

## Testing Instructions

It would be good if you could try tapping around in the podcasts tab to find issues with the edge-to-edge changes. Areas I have found issues with are:
- Older versions of Android versions
- Themes
- Content under the system bars 
- End of pages / lists under the bottom navigation or mini player

Here are some test steps I have followed in case you want to try them too:

1. Open the podcasts tab
2. ✅ Verify the next pages aren't under the status bar and you can get to the bottom of the page, even with the mini player open.
3. Tap on a podcast
4. Tap on the podcast settings cog
5. Tap on Auto archive and back
7. Tap on Playback effects and back
8. Tap on Filters and go back to the podcasts list
9. Tap on the search podcasts icon, search for a podcast, and come back to the list
10. Tap on the three dots, share podcasts, and go through the screens to create a list

## Screenshots

| Before | After |
| --- | --- |
| ![before-podcast-page](https://github.com/user-attachments/assets/222e3222-9046-46f5-a868-a002a4faf413) | ![after-podcast-page](https://github.com/user-attachments/assets/188db3c1-1e14-48c3-a32d-c8d0ce2a617d) | 
| ![before-podcast-settings-page](https://github.com/user-attachments/assets/a2340202-18e6-4045-8d9c-a140684cf0d9) | ![after-podcast-settings-page](https://github.com/user-attachments/assets/804c157f-7f2a-40e2-a7b6-5a31aa1dbfb2) | 
| ![before-podcast-auto-archive-page](https://github.com/user-attachments/assets/dcd3a2c1-68b5-4bca-b15c-64e6e9569e26) | ![after-podcast-auto-archive-page](https://github.com/user-attachments/assets/a93aa188-a3aa-4a6a-ba6f-8fdab2d57d3f) | 
| ![before-podcast-select-filters-page](https://github.com/user-attachments/assets/5fe2f7ff-1d64-49f0-9f69-49daa2a21ba3) | ![after-podcast-select-filters-page](https://github.com/user-attachments/assets/c4f73001-a2a8-46f4-9128-f275f7b8372a) | 
| ![before-podcast-effects-page](https://github.com/user-attachments/assets/8a077de9-cf32-4cca-b006-278ffc0d1388) | ![after-podcast-effects-page](https://github.com/user-attachments/assets/6cf54be7-4063-4735-b340-a2b5117e2bed) | 
| ![before-podcast-search](https://github.com/user-attachments/assets/2488d800-eedc-4787-b690-6cf6c5f998f8) | ![after-podcast-search](https://github.com/user-attachments/assets/d5c67c19-f40e-4c2c-b699-122c27a151df) | 
| ![before-podcast-search-results](https://github.com/user-attachments/assets/93047e02-7923-4191-b7a3-158867d0ad06) | ![after-podcast-search-results](https://github.com/user-attachments/assets/31e7c3eb-d1c5-4e91-b500-f5d05a44d9a6) | 
| ![before-podcast-share-list](https://github.com/user-attachments/assets/a2f4685f-b4ab-470f-8f2b-b363bf9c90af) | ![after-podcast-share-list](https://github.com/user-attachments/assets/e0fcbd13-24ef-43f7-8bf3-401359ce0d29) | 
| ![before-podcast-page-landscape](https://github.com/user-attachments/assets/51217f7b-de2c-49e9-a3f2-adafd12ec5c1) | ![after-podcast-page-landscape](https://github.com/user-attachments/assets/60768b87-f6f7-43c1-820e-7fab7213c139) | 
| ![before-podcast-list-landscape](https://github.com/user-attachments/assets/0ecaca99-4299-4de7-8508-6e2e807a6ed2) | ![after-podcast-list-landscape](https://github.com/user-attachments/assets/6a7e7045-6c80-4959-ae7d-fd7bdb769d8e) | 

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack
