### PR TITLE
Suffix filter DAO methods that aren't Coroutines with 'blocking' to make upgrading easier

### DIFF
--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/repositories/sync/PodcastSyncProcessTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/repositories/sync/PodcastSyncProcessTest.kt
@@ -88,7 +88,7 @@ class PodcastSyncProcessTest {
             whenever(episodeManager.findEpisodesToSync()).thenReturn(emptyList())
 
             val playlistManager: PlaylistManager = mock()
-            whenever(playlistManager.findPlaylistsToSync()).thenReturn(emptyList())
+            whenever(playlistManager.findPlaylistsToSyncBlocking()).thenReturn(emptyList())
 
             val folderManager: FolderManager = mock()
             whenever(folderManager.findFoldersToSync()).thenReturn(emptyList())

--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/ui/PlaybackServiceTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/ui/PlaybackServiceTest.kt
@@ -99,9 +99,9 @@ class PlaybackServiceTest {
         }
         service.episodeManager = episodeManager
         val playlistManager = mock<PlaylistManager> {
-            onBlocking { findAllSuspend() }.doReturn(filters)
+            onBlocking { findAll() }.doReturn(filters)
             onBlocking { findByUuid(filter.uuid) }.doReturn(filter)
-            on { findEpisodes(playlist = filters.first(), episodeManager = episodeManager, playbackManager = service.playbackManager) }.doReturn(filterEpisodes)
+            on { findEpisodesBlocking(playlist = filters.first(), episodeManager = episodeManager, playbackManager = service.playbackManager) }.doReturn(filterEpisodes)
         }
         service.playlistManager = playlistManager
 

--- a/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
+++ b/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
@@ -1314,7 +1314,7 @@ class MainActivity :
                 }
                 is ShowFilterDeepLink -> {
                     launch(Dispatchers.Default) {
-                        playlistManager.findById(deepLink.filterId)?.let {
+                        playlistManager.findByIdBlocking(deepLink.filterId)?.let {
                             withContext(Dispatchers.Main) {
                                 settings.setSelectedFilter(it.uuid)
                                 // HACK: Go diving to find if a filter fragment

--- a/automotive/src/androidTest/java/au/com/shiftyjelly/pocketcasts/AutoPlaybackServiceTest.kt
+++ b/automotive/src/androidTest/java/au/com/shiftyjelly/pocketcasts/AutoPlaybackServiceTest.kt
@@ -70,7 +70,7 @@ class AutoPlaybackServiceTest {
     fun testLoadFilters() {
         runBlocking {
             val playlist = Playlist(uuid = UUID.randomUUID().toString(), title = "Test title", iconId = 0)
-            service.playlistManager = mock { on { findAll() }.doReturn(listOf(playlist)) }
+            service.playlistManager = mock { on { findAllBlocking() }.doReturn(listOf(playlist)) }
 
             val filtersRoot = service.loadFiltersRoot()
             assertTrue("Filters should not be empty", filtersRoot.isNotEmpty())
@@ -102,7 +102,7 @@ class AutoPlaybackServiceTest {
             val podcast = Podcast(UUID.randomUUID().toString(), title = "Test podcast")
             val episode = PodcastEpisode(UUID.randomUUID().toString(), title = "Test episode", publishedDate = Date())
 
-            service.playlistManager = mock { on { findByUuidSync(any()) }.doReturn(null) }
+            service.playlistManager = mock { on { findByUuidBlocking(any()) }.doReturn(null) }
             service.podcastManager = mock { on { runBlocking { findPodcastByUuidSuspend(any()) } }.doReturn(podcast) }
             service.episodeManager = mock { on { findEpisodesByPodcastOrdered(any()) }.doReturn(listOf(episode)) }
 

--- a/automotive/src/main/java/au/com/shiftyjelly/pocketcasts/AutoPlaybackService.kt
+++ b/automotive/src/main/java/au/com/shiftyjelly/pocketcasts/AutoPlaybackService.kt
@@ -125,7 +125,7 @@ class AutoPlaybackService : PlaybackService() {
     }
 
     suspend fun loadFiltersRoot(): List<MediaBrowserCompat.MediaItem> {
-        return playlistManager.findAllSuspend().mapNotNull {
+        return playlistManager.findAll().mapNotNull {
             Log.d(Settings.LOG_TAG_AUTO, "Filters ${it.title}")
 
             try {

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/DurationOptionsFragment.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/DurationOptionsFragment.kt
@@ -155,7 +155,7 @@ class DurationOptionsFragment : BaseFragment() {
                     } else {
                         null
                     }
-                    playlistManager.update(playlist, userPlaylistUpdate)
+                    playlistManager.updateBlocking(playlist, userPlaylistUpdate)
                     launch(Dispatchers.Main) { (activity as FragmentHostListener).closeModal(this@DurationOptionsFragment) }
                 }
             }

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/EpisodeOptionsFragment.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/EpisodeOptionsFragment.kt
@@ -116,7 +116,7 @@ class EpisodeOptionsFragment : BaseFragment(), CoroutineScope {
                     } else {
                         null
                     }
-                    playlistManager.update(playlist, userPlaylistUpdate)
+                    playlistManager.updateBlocking(playlist, userPlaylistUpdate)
 
                     launch(Dispatchers.Main) { (activity as FragmentHostListener).closeModal(this@EpisodeOptionsFragment) }
                 }

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/FilterEpisodeListViewModel.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/FilterEpisodeListViewModel.kt
@@ -67,13 +67,13 @@ class FilterEpisodeListViewModel @Inject constructor(
             settings.streamingMode.flow.asObservable(coroutineContext),
         )
             .toFlowable(BackpressureStrategy.LATEST)
-            .switchMap { playlistManager.observeByUuidAsList(playlistUUID) }
+            .switchMap { playlistManager.findByUuidAsListRxFlowable(playlistUUID) }
             .switchMap { playlists ->
                 Timber.d("Loading playlist $playlist")
                 val playlist = playlists.firstOrNull() // We observe as a list to get notified on delete
                 if (playlist != null) {
                     this.playlist.postValue(playlist)
-                    playlistManager.observeEpisodes(playlist, episodeManager, playbackManager)
+                    playlistManager.observeEpisodesBlocking(playlist, episodeManager, playbackManager)
                 } else {
                     this.playlistDeleted.postValue(true)
                     Flowable.just(emptyList())
@@ -92,7 +92,7 @@ class FilterEpisodeListViewModel @Inject constructor(
     fun deletePlaylist() {
         launch {
             playlistManager.findByUuid(playlistUUID)?.let { playlist ->
-                playlistManager.delete(playlist)
+                playlistManager.deleteBlocking(playlist)
                 analyticsTracker.track(AnalyticsEvent.FILTER_DELETED)
             }
         }
@@ -119,7 +119,7 @@ class FilterEpisodeListViewModel @Inject constructor(
                     listOf(PlaylistProperty.Sort(sortOrder)),
                     PlaylistUpdateSource.FILTER_EPISODE_LIST,
                 )
-                playlistManager.update(playlist, userPlaylistUpdate)
+                playlistManager.updateBlocking(playlist, userPlaylistUpdate)
             }
         }
     }
@@ -133,7 +133,7 @@ class FilterEpisodeListViewModel @Inject constructor(
                     listOf(PlaylistProperty.Starred),
                     PlaylistUpdateSource.FILTER_EPISODE_LIST,
                 )
-                playlistManager.update(playlist, userPlaylistUpdate)
+                playlistManager.updateBlocking(playlist, userPlaylistUpdate)
             }
         }
     }

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/FiltersFragmentViewModel.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/FiltersFragmentViewModel.kt
@@ -37,10 +37,10 @@ class FiltersFragmentViewModel @Inject constructor(
     override val coroutineContext: CoroutineContext
         get() = Dispatchers.Default
 
-    val filters: LiveData<List<Playlist>> = playlistManager.observeAll().toLiveData()
+    val filters: LiveData<List<Playlist>> = playlistManager.findAllRxFlowable().toLiveData()
 
     val countGenerator = { playlist: Playlist ->
-        playlistManager.countEpisodesRx(playlist, episodeManager, playbackManager).onErrorReturn { 0 }
+        playlistManager.countEpisodesRxFlowable(playlist, episodeManager, playbackManager).onErrorReturn { 0 }
     }
 
     var adapterState: MutableList<Playlist> = mutableListOf()
@@ -66,7 +66,7 @@ class FiltersFragmentViewModel @Inject constructor(
         }
 
         runBlocking(Dispatchers.Default) {
-            playlistManager.updateAll(playlists)
+            playlistManager.updateAllBlocking(playlists)
             if (moved) {
                 analyticsTracker.track(AnalyticsEvent.FILTER_LIST_REORDERED)
             }

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/PodcastOptionsFragment.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/PodcastOptionsFragment.kt
@@ -141,7 +141,7 @@ class PodcastOptionsFragment : BaseFragment(), PodcastSelectFragment.Listener, C
                     } else {
                         null
                     }
-                    playlistManager.update(playlist, userPlaylistUpdate)
+                    playlistManager.updateBlocking(playlist, userPlaylistUpdate)
 
                     launch(Dispatchers.Main) { (activity as? FragmentHostListener)?.closeModal(this@PodcastOptionsFragment) }
                 }

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/TimeOptionsFragment.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/TimeOptionsFragment.kt
@@ -252,7 +252,7 @@ class TimeOptionsFragment : BaseFragment(), CoroutineScope {
                         null
                     }
 
-                    playlistManager.update(playlist, userPlaylistUpdate)
+                    playlistManager.updateBlocking(playlist, userPlaylistUpdate)
                     launch(Dispatchers.Main) { (activity as FragmentHostListener).closeModal(this@TimeOptionsFragment) }
                 }
             }

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/PodcastSettingsViewModel.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/PodcastSettingsViewModel.kt
@@ -54,12 +54,12 @@ class PodcastSettingsViewModel @Inject constructor(
             .subscribeOn(Schedulers.io())
             .toLiveData()
 
-        val filters = playlistManager.observeAll().map {
+        val filters = playlistManager.findAllRxFlowable().map {
             it.filter { filter -> filter.podcastUuidList.contains(uuid) }
         }
         includedFilters = filters.toLiveData()
 
-        val availablePodcastFilters = playlistManager.observeAll().map {
+        val availablePodcastFilters = playlistManager.findAllRxFlowable().map {
             it.filter { filter -> !filter.allPodcasts }
         }
         availableFilters = availablePodcastFilters.toLiveData()
@@ -128,7 +128,7 @@ class PodcastSettingsViewModel @Inject constructor(
     fun filterSelectionChanged(newSelection: List<String>) {
         launch {
             podcastUuid?.let { podcastUuid ->
-                playlistManager.findAll().forEach { playlist ->
+                playlistManager.findAllBlocking().forEach { playlist ->
                     val currentSelection = playlist.podcastUuidList.toMutableList()
                     val included = newSelection.contains(playlist.uuid)
 
@@ -150,7 +150,7 @@ class PodcastSettingsViewModel @Inject constructor(
                             listOf(PlaylistProperty.Podcasts),
                             PlaylistUpdateSource.PODCAST_SETTINGS,
                         )
-                        playlistManager.update(playlist, userPlaylistUpdate)
+                        playlistManager.updateBlocking(playlist, userPlaylistUpdate)
                     }
                 }
             }

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/AutoDownloadFiltersFragment.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/AutoDownloadFiltersFragment.kt
@@ -71,7 +71,7 @@ class AutoDownloadFiltersFragment : androidx.fragment.app.Fragment(), FilterAuto
     }
 
     private fun loadFilters() {
-        playlistManager.observeAll()
+        playlistManager.findAllRxFlowable()
             .firstOrError()
             .subscribeOn(Schedulers.io())
             .observeOn(AndroidSchedulers.mainThread())
@@ -89,7 +89,7 @@ class AutoDownloadFiltersFragment : androidx.fragment.app.Fragment(), FilterAuto
     }
 
     override fun onAutoDownloadChanged(filter: Playlist, on: Boolean) {
-        playlistManager.rxUpdateAutoDownloadStatus(filter, on, true, false)
+        playlistManager.updateAutoDownloadStatusRxCompletable(filter, on, true, false)
             .subscribeOn(Schedulers.io())
             .observeOn(AndroidSchedulers.mainThread())
             .subscribeWith(object : DisposableCompletableObserver() {

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/AutoDownloadSettingsFragment.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/AutoDownloadSettingsFragment.kt
@@ -337,14 +337,14 @@ class AutoDownloadSettingsFragment :
 
     override fun filterSelectFragmentGetCurrentSelection(): List<String> {
         return runBlocking {
-            val filters = withContext(Dispatchers.Default) { playlistManager.findAll() }.filter { it.autoDownload }
+            val filters = withContext(Dispatchers.Default) { playlistManager.findAllBlocking() }.filter { it.autoDownload }
             filters.map { it.uuid }
         }
     }
 
     override fun filterSelectFragmentSelectionChanged(newSelection: List<String>) {
         lifecycleScope.launch(Dispatchers.Default) {
-            playlistManager.findAll().forEach {
+            playlistManager.findAllBlocking().forEach {
                 val autoDownloadStatus = newSelection.contains(it.uuid)
                 val userChanged = autoDownloadStatus != it.autoDownload
                 it.autoDownload = autoDownloadStatus
@@ -357,7 +357,7 @@ class AutoDownloadSettingsFragment :
                 } else {
                     null
                 }
-                playlistManager.update(it, userPlaylistUpdate)
+                playlistManager.updateBlocking(it, userPlaylistUpdate)
             }
             launch(Dispatchers.Main) { updateFiltersSelectedSummary() }
         }
@@ -365,7 +365,7 @@ class AutoDownloadSettingsFragment :
 
     private fun updateFiltersSelectedSummary() {
         lifecycleScope.launch {
-            val count = withContext(Dispatchers.Default) { playlistManager.findAll() }.filter { it.autoDownload }.count()
+            val count = withContext(Dispatchers.Default) { playlistManager.findAllBlocking() }.filter { it.autoDownload }.count()
             val preference = preferenceManager.findPreference<Preference>(PREFERENCE_CHOOSE_FILTERS)
             preference?.summary = context?.resources?.getStringPlural(count = count, singular = LR.string.filters_chosen_singular, plural = LR.string.filters_chosen_plural)
         }

--- a/modules/features/taskerplugin/src/main/java/au/com/shiftyjelly/pocketcasts/taskerplugin/playplaylist/ActionRunnerPlayPlaylist.kt
+++ b/modules/features/taskerplugin/src/main/java/au/com/shiftyjelly/pocketcasts/taskerplugin/playplaylist/ActionRunnerPlayPlaylist.kt
@@ -26,9 +26,9 @@ class ActionRunnerPlayPlaylist : TaskerPluginRunnerActionNoOutput<InputPlayPlayl
 
         playbackManager.upNextQueue.removeAll()
 
-        val playlist = playlistManager.findFirstByTitle(title) ?: return TaskerPluginResultError(ERROR_PLAYLIST_NOT_FOUND, context.getString(R.string.filter_x_not_found, title))
+        val playlist = playlistManager.findFirstByTitleBlocking(title) ?: return TaskerPluginResultError(ERROR_PLAYLIST_NOT_FOUND, context.getString(R.string.filter_x_not_found, title))
 
-        val episodes = playlistManager.findEpisodes(playlist, episodeManager, playbackManager)
+        val episodes = playlistManager.findEpisodesBlocking(playlist, episodeManager, playbackManager)
         if (episodes.isEmpty()) return TaskerPluginResultError(ERROR_PLAYLIST_NO_EPISODES, context.getString(R.string.no_episodes_in_filter_x, title))
 
         playbackManager.playEpisodes(episodes, SourceView.TASKER)

--- a/modules/features/taskerplugin/src/main/java/au/com/shiftyjelly/pocketcasts/taskerplugin/queryfilterepisodes/ActionRunnerQueryFilterEpisodes.kt
+++ b/modules/features/taskerplugin/src/main/java/au/com/shiftyjelly/pocketcasts/taskerplugin/queryfilterepisodes/ActionRunnerQueryFilterEpisodes.kt
@@ -17,8 +17,8 @@ class ActionRunnerQueryFilterEpisodes : TaskerPluginRunnerAction<InputQueryFilte
         val playlistManager = context.playlistManager
         val titleOrId = input.regular.titleOrId.nullIfEmpty ?: return TaskerPluginResultSucess()
 
-        val playlist = playlistManager.findAll().firstOrNull { it.title.lowercase().contains(titleOrId.trim().lowercase()) || it.uuid == titleOrId } ?: return TaskerPluginResultSucess(arrayOf())
-        val episodes = playlistManager.findEpisodes(playlist, context.episodeManager, context.playbackManager).take(50)
+        val playlist = playlistManager.findAllBlocking().firstOrNull { it.title.lowercase().contains(titleOrId.trim().lowercase()) || it.uuid == titleOrId } ?: return TaskerPluginResultSucess(arrayOf())
+        val episodes = playlistManager.findEpisodesBlocking(playlist, context.episodeManager, context.playbackManager).take(50)
         val output = episodes.map { OutputQueryEpisodes(it) }.toTypedArray()
         return TaskerPluginResultSucess(output)
     }

--- a/modules/features/taskerplugin/src/main/java/au/com/shiftyjelly/pocketcasts/taskerplugin/queryfilters/ActionRunnerQueryFilters.kt
+++ b/modules/features/taskerplugin/src/main/java/au/com/shiftyjelly/pocketcasts/taskerplugin/queryfilters/ActionRunnerQueryFilters.kt
@@ -11,7 +11,7 @@ class ActionRunnerQueryFilters : TaskerPluginRunnerAction<InputQueryFilters, Arr
 
     override fun run(context: Context, input: TaskerInput<InputQueryFilters>): TaskerPluginResult<Array<OutputQueryFilters>> {
         val playlistManager = context.playlistManager
-        val output = playlistManager.findAll().map {
+        val output = playlistManager.findAllBlocking().map {
             OutputQueryFilters(it.uuid, it.title, it.episodeCount)
         }.toTypedArray()
         return TaskerPluginResultSucess(output)

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/PlaylistDao.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/PlaylistDao.kt
@@ -16,80 +16,80 @@ import kotlinx.coroutines.flow.Flow
 abstract class PlaylistDao {
 
     @Query("SELECT * FROM filters WHERE _id = :id")
-    abstract fun findById(id: Long): Playlist?
+    abstract fun findByIdBlocking(id: Long): Playlist?
 
     @Query("SELECT * FROM filters WHERE manual = 0 AND deleted = 0 AND draft = 0 ORDER BY sortPosition ASC")
-    abstract fun findAll(): List<Playlist>
+    abstract fun findAllBlocking(): List<Playlist>
 
     @Query("SELECT * FROM filters WHERE manual = 0 AND deleted = 0 AND draft = 0 ORDER BY sortPosition ASC")
-    abstract suspend fun findAllSuspend(): List<Playlist>
+    abstract suspend fun findAll(): List<Playlist>
 
     @Query("SELECT * FROM filters WHERE manual = 0 AND deleted = 0 AND draft = 0 ORDER BY sortPosition ASC")
-    abstract fun findAllState(): Flow<List<Playlist>>
+    abstract fun findAllFlow(): Flow<List<Playlist>>
 
     @Query("SELECT * FROM filters WHERE manual = 0 AND deleted = 0 AND draft = 0 ORDER BY sortPosition ASC")
-    abstract fun observeAll(): Flowable<List<Playlist>>
+    abstract fun findAllRxFlowable(): Flowable<List<Playlist>>
 
     @Query("SELECT * FROM filters WHERE uuid = :uuid LIMIT 1")
-    abstract fun findByUuidSync(uuid: String): Playlist?
+    abstract fun findByUuidBlocking(uuid: String): Playlist?
 
     @Query("SELECT * FROM filters WHERE uuid = :uuid LIMIT 1")
     abstract suspend fun findByUuid(uuid: String): Playlist?
 
     @Query("SELECT * FROM filters WHERE uuid = :uuid LIMIT 1")
-    abstract fun findByUUIDRx(uuid: String): Maybe<Playlist>
+    abstract fun findByUuidRxMaybe(uuid: String): Maybe<Playlist>
 
     @Query("SELECT * FROM filters WHERE uuid = :uuid LIMIT 1")
-    abstract fun observeByUUID(uuid: String): Flowable<Playlist>
+    abstract fun findByUuidRxFlowable(uuid: String): Flowable<Playlist>
 
     @Query("SELECT * FROM filters WHERE uuid = :uuid")
-    abstract fun observeByUUIDAsList(uuid: String): Flowable<List<Playlist>>
+    abstract fun findByUuidAsListRxFlowable(uuid: String): Flowable<List<Playlist>>
 
     @Query("SELECT COUNT(*) FROM filters")
-    abstract fun count(): Int
+    abstract fun countBlocking(): Int
 
     @Update
-    abstract fun update(playlist: Playlist)
+    abstract fun updateBlocking(playlist: Playlist)
 
     @Update
-    abstract fun updateAll(playlists: List<Playlist>)
+    abstract fun updateAllBlocking(playlists: List<Playlist>)
 
     @Delete
-    abstract fun delete(playlist: Playlist)
+    abstract fun deleteBlocking(playlist: Playlist)
 
     @Query("DELETE FROM filters")
     abstract suspend fun deleteAll()
 
     @Query("DELETE FROM filters WHERE deleted = 1")
-    abstract fun deleteDeleted()
+    abstract fun deleteDeletedBlocking()
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
-    abstract fun insert(playlist: Playlist): Long
+    abstract fun insertBlocking(playlist: Playlist): Long
 
     @Query("UPDATE filters SET sortPosition = :position WHERE uuid = :uuid")
-    abstract fun updateSortPosition(position: Int, uuid: String)
+    abstract fun updateSortPositionBlocking(position: Int, uuid: String)
 
     @Query("UPDATE filters SET syncStatus = :syncStatus WHERE uuid = :uuid")
-    abstract fun updateSyncStatus(syncStatus: Int, uuid: String)
+    abstract fun updateSyncStatusBlocking(syncStatus: Int, uuid: String)
 
     @Query("UPDATE filters SET syncStatus = :syncStatus")
-    abstract fun updateAllSyncStatus(syncStatus: Int)
+    abstract fun updateAllSyncStatusBlocking(syncStatus: Int)
 
     @Query("SELECT * FROM filters WHERE UPPER(title) = UPPER(:title)")
-    abstract fun searchByTitle(title: String): Playlist?
+    abstract fun searchByTitleBlocking(title: String): Playlist?
 
     @Query("SELECT * FROM filters WHERE manual = 0 AND draft = 0 AND syncStatus = " + Playlist.SYNC_STATUS_NOT_SYNCED)
-    abstract fun findNotSynced(): List<Playlist>
+    abstract fun findNotSyncedBlocking(): List<Playlist>
 
     @Transaction
-    open fun updateSortPositions(playlists: List<Playlist>) {
+    open fun updateSortPositionsBlocking(playlists: List<Playlist>) {
         for (index in playlists.indices) {
             val playlist = playlists[index]
             val position = index + 1
             playlist.sortPosition = position
             playlist.syncStatus = Playlist.SYNC_STATUS_NOT_SYNCED
-            updateSortPosition(position, playlist.uuid)
-            updateSyncStatus(Playlist.SYNC_STATUS_NOT_SYNCED, playlist.uuid)
+            updateSortPositionBlocking(position, playlist.uuid)
+            updateSyncStatusBlocking(Playlist.SYNC_STATUS_NOT_SYNCED, playlist.uuid)
         }
     }
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/MediaSessionManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/MediaSessionManager.kt
@@ -875,14 +875,14 @@ class MediaSessionManager(
             }
 
             for (option in options) {
-                val playlist = playlistManager.findFirstByTitle(option) ?: continue
+                val playlist = playlistManager.findFirstByTitleBlocking(option) ?: continue
 
                 Timber.i("Playing matched playlist '$option'")
 
-                val episodeCount = playlistManager.countEpisodes(playlist.id, episodeManager, playbackManager)
+                val episodeCount = playlistManager.countEpisodesBlocking(playlist.id, episodeManager, playbackManager)
                 if (episodeCount == 0) return@launch
 
-                val episodesToPlay = playlistManager.findEpisodes(playlist, episodeManager, playbackManager).take(5)
+                val episodesToPlay = playlistManager.findEpisodesBlocking(playlist, episodeManager, playbackManager).take(5)
                 if (episodesToPlay.isEmpty()) return@launch
 
                 playEpisodes(episodesToPlay, sourceView)

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
@@ -1362,10 +1362,10 @@ open class PlaybackManager @Inject constructor(
                 episodeSource = "podcast"
                 podcastManager.findPodcastByUuid(autoSource.uuid)
                     ?.let { podcast -> autoPlayOrderForPodcastEpisodes(podcast) }
-                    ?: playlistManager.findByUuidSync(autoSource.uuid)
+                    ?: playlistManager.findByUuidBlocking(autoSource.uuid)
                         ?.let { playlist ->
                             episodeSource = "filter"
-                            playlistManager.findEpisodes(playlist, episodeManager, this)
+                            playlistManager.findEpisodesBlocking(playlist, episodeManager, this)
                         }
             }
             is AutoPlaySource.None -> null

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackService.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackService.kt
@@ -432,9 +432,9 @@ open class PlaybackService : MediaBrowserServiceCompat(), CoroutineScope {
         episodes.addAll(upNextQueue.queueEpisodes.take(NUM_SUGGESTED_ITEMS - 1))
         // add episodes from the top filter
         if (episodes.size < NUM_SUGGESTED_ITEMS) {
-            val topFilter = playlistManager.findAllSuspend().firstOrNull()
+            val topFilter = playlistManager.findAll().firstOrNull()
             if (topFilter != null) {
-                val filterEpisodes = playlistManager.findEpisodes(topFilter, episodeManager, playbackManager)
+                val filterEpisodes = playlistManager.findEpisodesBlocking(topFilter, episodeManager, playbackManager)
                 for (filterEpisode in filterEpisodes) {
                     if (episodes.size >= NUM_SUGGESTED_ITEMS) {
                         break
@@ -483,7 +483,7 @@ open class PlaybackService : MediaBrowserServiceCompat(), CoroutineScope {
         rootItems.add(podcastItem)
 
         // playlists
-        for (playlist in playlistManager.findAll().filterNot { it.manual }) {
+        for (playlist in playlistManager.findAllBlocking().filterNot { it.manual }) {
             if (playlist.title.equals("video", ignoreCase = true)) continue
 
             val playlistItem = AutoConverter.convertPlaylistToMediaItem(this, playlist)
@@ -541,14 +541,14 @@ open class PlaybackService : MediaBrowserServiceCompat(), CoroutineScope {
         val episodeItems = mutableListOf<MediaBrowserCompat.MediaItem>()
         val autoPlaySource: AutoPlaySource
 
-        val playlist = if (DOWNLOADS_ROOT == parentId) playlistManager.getSystemDownloadsFilter() else playlistManager.findByUuidSync(parentId)
+        val playlist = if (DOWNLOADS_ROOT == parentId) playlistManager.getSystemDownloadsFilter() else playlistManager.findByUuidBlocking(parentId)
         if (playlist != null) {
             val episodeList = if (DOWNLOADS_ROOT == parentId) {
                 autoPlaySource = AutoPlaySource.Downloads
                 episodeManager.observeDownloadedEpisodes().blockingFirst()
             } else {
                 autoPlaySource = AutoPlaySource.fromId(parentId)
-                playlistManager.findEpisodes(playlist, episodeManager, playbackManager)
+                playlistManager.findEpisodesBlocking(playlist, episodeManager, playbackManager)
             }
             val topEpisodes = episodeList.take(EPISODE_LIMIT)
             if (topEpisodes.isNotEmpty()) {

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PlaylistManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PlaylistManager.kt
@@ -9,47 +9,47 @@ import io.reactivex.Maybe
 import kotlinx.coroutines.flow.Flow
 
 interface PlaylistManager {
-    fun findAll(): List<Playlist>
-    suspend fun findAllSuspend(): List<Playlist>
+    fun findAllBlocking(): List<Playlist>
+    suspend fun findAll(): List<Playlist>
     fun findAllFlow(): Flow<List<Playlist>>
-    fun observeAll(): Flowable<List<Playlist>>
+    fun findAllRxFlowable(): Flowable<List<Playlist>>
 
-    fun findById(id: Long): Playlist?
+    fun findByIdBlocking(id: Long): Playlist?
     suspend fun findByUuid(playlistUuid: String): Playlist?
-    fun findByUuidSync(playlistUuid: String): Playlist?
-    fun findByUuidRx(playlistUuid: String): Maybe<Playlist>
-    fun observeByUuid(playlistUuid: String): Flowable<Playlist>
-    fun observeByUuidAsList(playlistUuid: String): Flowable<List<Playlist>>
+    fun findByUuidBlocking(playlistUuid: String): Playlist?
+    fun findByUuidRxMaybe(playlistUuid: String): Maybe<Playlist>
+    fun findByUuidRxFlowable(playlistUuid: String): Flowable<Playlist>
+    fun findByUuidAsListRxFlowable(playlistUuid: String): Flowable<List<Playlist>>
 
-    fun findFirstByTitle(title: String): Playlist?
-    fun findPlaylistsToSync(): List<Playlist>
-    fun findEpisodes(playlist: Playlist, episodeManager: EpisodeManager, playbackManager: PlaybackManager): List<PodcastEpisode>
-    fun observeEpisodes(playlist: Playlist, episodeManager: EpisodeManager, playbackManager: PlaybackManager): Flowable<List<PodcastEpisode>>
+    fun findFirstByTitleBlocking(title: String): Playlist?
+    fun findPlaylistsToSyncBlocking(): List<Playlist>
+    fun findEpisodesBlocking(playlist: Playlist, episodeManager: EpisodeManager, playbackManager: PlaybackManager): List<PodcastEpisode>
+    fun observeEpisodesBlocking(playlist: Playlist, episodeManager: EpisodeManager, playbackManager: PlaybackManager): Flowable<List<PodcastEpisode>>
 
-    fun createPlaylist(name: String, iconId: Int, draft: Boolean): Playlist
+    fun createPlaylistBlocking(name: String, iconId: Int, draft: Boolean): Playlist
 
-    fun create(playlist: Playlist): Long
-    fun update(playlist: Playlist, userPlaylistUpdate: UserPlaylistUpdate?, isCreatingFilter: Boolean = false)
+    fun createBlocking(playlist: Playlist): Long
+    fun updateBlocking(playlist: Playlist, userPlaylistUpdate: UserPlaylistUpdate?, isCreatingFilter: Boolean = false)
 
     fun updateAutoDownloadStatus(playlist: Playlist, autoDownloadEnabled: Boolean, unmeteredOnly: Boolean, powerOnly: Boolean)
-    fun rxUpdateAutoDownloadStatus(playlist: Playlist, autoDownloadEnabled: Boolean, unmeteredOnly: Boolean, powerOnly: Boolean): Completable
+    fun updateAutoDownloadStatusRxCompletable(playlist: Playlist, autoDownloadEnabled: Boolean, unmeteredOnly: Boolean, powerOnly: Boolean): Completable
 
-    fun delete(playlist: Playlist)
+    fun deleteBlocking(playlist: Playlist)
     suspend fun resetDb()
-    fun deleteSynced()
-    fun deleteSynced(playlist: Playlist)
+    fun deleteSyncedBlocking()
+    fun deleteSyncedBlocking(playlist: Playlist)
 
-    fun countEpisodes(id: Long?, episodeManager: EpisodeManager, playbackManager: PlaybackManager): Int
-    fun countEpisodesRx(playlist: Playlist, episodeManager: EpisodeManager, playbackManager: PlaybackManager): Flowable<Int>
+    fun countEpisodesBlocking(id: Long?, episodeManager: EpisodeManager, playbackManager: PlaybackManager): Int
+    fun countEpisodesRxFlowable(playlist: Playlist, episodeManager: EpisodeManager, playbackManager: PlaybackManager): Flowable<Int>
 
-    fun checkForEpisodesToDownload(episodeManager: EpisodeManager, playbackManager: PlaybackManager)
+    fun checkForEpisodesToDownloadBlocking(episodeManager: EpisodeManager, playbackManager: PlaybackManager)
 
-    fun removePodcastFromPlaylists(podcastUuid: String)
+    fun removePodcastFromPlaylistsBlocking(podcastUuid: String)
 
     fun getSystemDownloadsFilter(): Playlist
 
-    fun markAllSynced()
+    fun markAllSyncedBlocking()
 
-    fun updateAll(playlists: List<Playlist>)
-    fun observeEpisodesPreview(playlist: Playlist, episodeManager: EpisodeManager, playbackManager: PlaybackManager): Flowable<List<PodcastEpisode>>
+    fun updateAllBlocking(playlists: List<Playlist>)
+    fun observeEpisodesPreviewBlocking(playlist: Playlist, episodeManager: EpisodeManager, playbackManager: PlaybackManager): Flowable<List<PodcastEpisode>>
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PodcastManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PodcastManagerImpl.kt
@@ -95,7 +95,7 @@ class PodcastManagerImpl @Inject constructor(
                     podcastDao.delete(podcast)
                     episodeDao.deleteAll(episodes)
                 }
-                playlistManager.removePodcastFromPlaylists(podcastUuid)
+                playlistManager.removePodcastFromPlaylistsBlocking(podcastUuid)
 
                 unsubscribeRelay.accept(podcastUuid)
             }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/refresh/RefreshPodcastsThread.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/refresh/RefreshPodcastsThread.kt
@@ -223,7 +223,7 @@ class RefreshPodcastsThread(
             podcastManager.checkForUnusedPodcasts(playbackManager)
             LogBuffer.i(LogBuffer.TAG_BACKGROUND_TASKS, "Refresh - checkForUnusedPodcasts - ${String.format("%d ms", SystemClock.elapsedRealtime() - startTime)}")
             startTime = SystemClock.elapsedRealtime()
-            playlistManager.checkForEpisodesToDownload(episodeManager, playbackManager)
+            playlistManager.checkForEpisodesToDownloadBlocking(episodeManager, playbackManager)
             LogBuffer.i(LogBuffer.TAG_BACKGROUND_TASKS, "Refresh - playlist checkForEpisodesToDownload - ${String.format("%d ms", SystemClock.elapsedRealtime() - startTime)}")
             startTime = SystemClock.elapsedRealtime()
             podcastManager.checkForEpisodesToDownload(episodeUuidsAdded, downloadManager)

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/shortcuts/PocketCastsShortcuts.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/shortcuts/PocketCastsShortcuts.kt
@@ -38,7 +38,7 @@ object PocketCastsShortcuts {
         val shortcutManager = context.getSystemService(ShortcutManager::class.java) ?: return
 
         coroutineScope.launch(Dispatchers.Default) {
-            val topPlaylist = playlistManager.findAll().firstOrNull()
+            val topPlaylist = playlistManager.findAllBlocking().firstOrNull()
 
             if (topPlaylist == null) {
                 if (shortcutManager.dynamicShortcuts.size == 1) {

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/support/Support.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/support/Support.kt
@@ -397,7 +397,7 @@ class Support @Inject constructor(
                 output.append("Database").append(eol)
                     .append(" ").append(podcastManager.countPodcasts()).append(" Podcasts ").append(eol)
                     .append(" ").append(episodeManager.countEpisodes()).append(" Episodes ").append(eol)
-                    .append(" ").append(playlistManager.findAll().size).append(" Playlists ").append(eol)
+                    .append(" ").append(playlistManager.findAllBlocking().size).append(" Playlists ").append(eol)
                     .append(" ").append(queue.size).append(" Up Next ").append(eol).append(eol)
 
                 output.append(podcastsOutput.toString())
@@ -405,7 +405,7 @@ class Support @Inject constructor(
                 output.append("Filters").append(eol).append("-------").append(eol).append(eol)
 
                 try {
-                    val playlists = playlistManager.findAll()
+                    val playlists = playlistManager.findAllBlocking()
                     for (playlist in playlists) {
                         output.append(playlist.title).append(eol)
                         output.append("Auto Download? ").append(playlist.autoDownload).append(" Unmetered only? ").append(playlist.autoDownloadUnmeteredOnly).append(" Power only? ").append(playlist.autoDownloadPowerOnly).append(eol)

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/PodcastSyncProcess.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/PodcastSyncProcess.kt
@@ -96,7 +96,7 @@ class PodcastSyncProcess(
 
     fun run(): Completable {
         if (!syncManager.isLoggedIn()) {
-            playlistManager.deleteSynced()
+            playlistManager.deleteSyncedBlocking()
 
             Timber.i("SyncProcess: User not logged in")
             return Completable.complete()
@@ -410,7 +410,7 @@ class PodcastSyncProcess(
 
     private fun uploadPlaylistChanges(records: JSONArray) {
         try {
-            val playlists = playlistManager.findPlaylistsToSync()
+            val playlists = playlistManager.findPlaylistsToSyncBlocking()
             for (playlist in playlists) {
                 val fields = JSONObject()
 
@@ -655,7 +655,7 @@ class PodcastSyncProcess(
         return Completable.fromAction {
             podcastManager.markAllPodcastsSynced()
             episodeManager.markAllEpisodesSynced(episodes)
-            playlistManager.markAllSynced()
+            playlistManager.markAllSyncedBlocking()
             folderManager.markAllSynced()
         }
     }
@@ -747,9 +747,9 @@ class PodcastSyncProcess(
                 return@fromCallable null
             }
 
-            var playlist = playlistManager.findByUuidSync(uuid)
+            var playlist = playlistManager.findByUuidBlocking(uuid)
             if (sync.deleted) {
-                playlist?.let { playlistManager.deleteSynced(it) }
+                playlist?.let { playlistManager.deleteSyncedBlocking(it) }
                 return@fromCallable null
             }
 
@@ -781,9 +781,9 @@ class PodcastSyncProcess(
             }
 
             if (playlist.id == null) {
-                playlist.id = playlistManager.create(playlist)
+                playlist.id = playlistManager.createBlocking(playlist)
             } else {
-                playlistManager.update(playlist, userPlaylistUpdate = null)
+                playlistManager.updateBlocking(playlist, userPlaylistUpdate = null)
             }
 
             return@fromCallable playlist

--- a/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/fragments/FilterSelectFragment.kt
+++ b/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/fragments/FilterSelectFragment.kt
@@ -88,7 +88,7 @@ class FilterSelectFragment private constructor() : BaseFragment() {
 
         val layoutManager = LinearLayoutManager(context, RecyclerView.VERTICAL, false)
 
-        playlistManager.observeAll().firstOrError()
+        playlistManager.findAllRxFlowable().firstOrError()
             .zipWith(Single.fromCallable { listener.filterSelectFragmentGetCurrentSelection() })
             .map {
                 val filters = it.first

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/filter/FilterViewModel.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/filter/FilterViewModel.kt
@@ -40,11 +40,11 @@ class FilterViewModel @Inject constructor(
         ) : UiState()
     }
 
-    val uiState = playlistManager.observeByUuidAsList(filterUuid)
+    val uiState = playlistManager.findByUuidAsListRxFlowable(filterUuid)
         .switchMap { filters ->
             val filter = filters.firstOrNull()
             if (filter != null) {
-                playlistManager.observeEpisodes(filter, episodeManager, playbackManager)
+                playlistManager.observeEpisodesBlocking(filter, episodeManager, playbackManager)
                     .map {
                         if (it.isEmpty()) UiState.Empty(filter) else UiState.Loaded(filter = filter, episodes = it)
                     }


### PR DESCRIPTION
## Description

We aim to switch to using Coroutines for calls to the database and move away from RxJava. When converting code, knowing which calls have already been converted can be tricky. To make this more straightforward, I have made the following changes:

- Any database call that doesn't use Coroutines has the suffix `Blocking`
- Any Rx call now has the suffix `Rx<ReturnType`
- Removed `Suspend` from the Coroutine calls
- Added the suffix `Flow` to Coroutine Flow calls

I have only changed the filters DAO in this pull request while we make sure everyone agrees with the changes and so I'm not changing too much code at once.

## Testing Instructions

This is only a refactor but it would be worth looking through the code changes and smoke testing the filters section.

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 