### PR TITLE
Migrate Plus upgrade in profile tab to Compose UI

### DIFF
--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/ProfileUpgradeSection.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/ProfileUpgradeSection.kt
@@ -1,0 +1,126 @@
+package au.com.shiftyjelly.pocketcasts.profile
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.material.Icon
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.ripple
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.role
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewParameter
+import androidx.compose.ui.unit.dp
+import au.com.shiftyjelly.pocketcasts.compose.AppThemeWithBackground
+import au.com.shiftyjelly.pocketcasts.compose.components.TextH40
+import au.com.shiftyjelly.pocketcasts.compose.components.TextH50
+import au.com.shiftyjelly.pocketcasts.compose.preview.ThemePreviewParameterProvider
+import au.com.shiftyjelly.pocketcasts.compose.theme
+import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
+import au.com.shiftyjelly.pocketcasts.images.R as IR
+import au.com.shiftyjelly.pocketcasts.localization.R as LR
+
+@Composable
+internal fun ProfileUpgradeSection(
+    isVisible: Boolean,
+    contentPadding: PaddingValues,
+    onClick: () -> Unit,
+    onCloseClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    AnimatedVisibility(isVisible, modifier = modifier) {
+        Box {
+            Column(
+                verticalArrangement = Arrangement.spacedBy(16.dp),
+                horizontalAlignment = Alignment.CenterHorizontally,
+                modifier = Modifier
+                    .clickable(
+                        role = Role.Button,
+                        interactionSource = remember(::MutableInteractionSource),
+                        indication = ripple(
+                            color = MaterialTheme.theme.colors.primaryIcon01,
+                        ),
+                        onClick = onClick,
+                    )
+                    .fillMaxWidth()
+                    .padding(contentPadding),
+            ) {
+                val logoResource = if (MaterialTheme.theme.isLight) {
+                    IR.drawable.plus_logo_horizontal_light
+                } else {
+                    IR.drawable.plus_logo_horizontal_dark
+                }
+                Image(
+                    painter = painterResource(logoResource),
+                    contentDescription = null,
+                    modifier = Modifier.widthIn(max = 232.dp),
+                )
+                TextH40(
+                    text = stringResource(LR.string.profile_help_support),
+                    color = MaterialTheme.theme.colors.primaryText02,
+                    textAlign = TextAlign.Center,
+                )
+                TextH50(
+                    text = stringResource(LR.string.plus_learn_more_about_plus),
+                    color = MaterialTheme.theme.colors.primaryInteractive01,
+                    textAlign = TextAlign.Center,
+                )
+            }
+            Icon(
+                painter = painterResource(IR.drawable.ic_close),
+                tint = MaterialTheme.theme.colors.primaryText02,
+                contentDescription = stringResource(LR.string.settings_close_upgrade_offer),
+                modifier = Modifier
+                    .align(Alignment.TopEnd)
+                    .clickable(
+                        role = Role.Button,
+                        interactionSource = remember(::MutableInteractionSource),
+                        indication = ripple(
+                            color = MaterialTheme.theme.colors.primaryIcon01,
+                            bounded = false,
+                        ),
+                        onClick = onCloseClick,
+                    )
+                    .size(48.dp)
+                    .padding(12.dp),
+            )
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun ProfileUpgradeSectionPreview(
+    @PreviewParameter(ThemePreviewParameterProvider::class) theme: Theme.ThemeType,
+) {
+    AppThemeWithBackground(theme) {
+        var isVisible by remember { mutableStateOf(true) }
+
+        ProfileUpgradeSection(
+            isVisible = isVisible,
+            contentPadding = PaddingValues(16.dp),
+            onClick = {},
+            onCloseClick = { isVisible = false },
+        )
+    }
+}

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/ProfileViewModel.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/ProfileViewModel.kt
@@ -2,6 +2,7 @@ package au.com.shiftyjelly.pocketcasts.profile
 
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.asFlow
 import androidx.lifecycle.toLiveData
 import au.com.shiftyjelly.pocketcasts.models.to.RefreshState
 import au.com.shiftyjelly.pocketcasts.models.to.SignInState
@@ -76,6 +77,15 @@ class ProfileViewModel @Inject constructor(
     }
 
     val refreshState = settings.refreshStateObservable.asFlow()
+
+    val showUpgradeBanner = combine(
+        settings.upgradeProfileClosed.flow,
+        signInState.asFlow().map { it.isSignedInAsPlusOrPatron },
+    ) { closedClicked, isPlusOrPatron -> !closedClicked && !isPlusOrPatron }
+
+    fun closeUpgradeProfile() {
+        settings.upgradeProfileClosed.set(true, updateModifiedAt = false)
+    }
 
     suspend fun isEndOfYearStoriesEligible() = endOfYearManager.isEligibleForEndOfYear()
 

--- a/modules/features/profile/src/main/res/layout-land/fragment_profile.xml
+++ b/modules/features/profile/src/main/res/layout-land/fragment_profile.xml
@@ -75,13 +75,11 @@
                 app:layout_constraintRight_toRightOf="parent"
                 app:layout_constraintTop_toBottomOf="@+id/sectionsView" />
 
-            <include
-                android:id="@+id/upgradeLayout"
-                layout="@layout/layout_plus_callout"
-                android:layout_width="match_parent"
+            <androidx.compose.ui.platform.ComposeView
+                android:id="@+id/upgradeView"
+                android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="16dp"
-                app:layout_constraintBottom_toBottomOf="parent"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toBottomOf="@+id/refreshView" />

--- a/modules/features/profile/src/main/res/layout/fragment_profile.xml
+++ b/modules/features/profile/src/main/res/layout/fragment_profile.xml
@@ -75,16 +75,14 @@
                 app:layout_constraintRight_toRightOf="parent"
                 app:layout_constraintTop_toBottomOf="@+id/sectionsView" />
 
-            <include
-                android:id="@+id/upgradeLayout"
-                layout="@layout/layout_plus_callout"
+            <androidx.compose.ui.platform.ComposeView
+                android:id="@+id/upgradeView"
+                android:layout_width="0dp"
                 android:layout_height="wrap_content"
-                android:layout_width="match_parent"
                 android:layout_marginTop="16dp"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/refreshView"
-                app:layout_constraintBottom_toBottomOf="parent"/>
+                app:layout_constraintTop_toBottomOf="@+id/refreshView" />
 
             <androidx.compose.ui.platform.ComposeView
                 android:id="@+id/btnGift"

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
@@ -424,8 +424,7 @@ interface Settings {
     val cachedSubscriptionStatus: UserSetting<SubscriptionStatus?>
     val userTier: UserTier
 
-    fun setUpgradeClosedProfile(value: Boolean)
-    fun getUpgradeClosedProfile(): Boolean
+    val upgradeProfileClosed: UserSetting<Boolean>
     fun getUpgradeClosedAddFile(): Boolean
     fun setUpgradeClosedAddFile(value: Boolean)
     fun getUpgradeClosedCloudSettings(): Boolean

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
@@ -1156,13 +1156,11 @@ class SettingsImpl @Inject constructor(
         sharedPrefs = sharedPreferences,
     )
 
-    override fun getUpgradeClosedProfile(): Boolean {
-        return getBoolean("upgradeClosedProfile", false)
-    }
-
-    override fun setUpgradeClosedProfile(value: Boolean) {
-        setBoolean("upgradeClosedProfile", value)
-    }
+    override val upgradeProfileClosed = UserSetting.BoolPref(
+        sharedPrefKey = "upgradeClosedProfile",
+        defaultValue = false,
+        sharedPrefs = sharedPreferences,
+    )
 
     override fun getUpgradeClosedAddFile(): Boolean {
         return getBoolean("upgradeClosedAddFile", false)


### PR DESCRIPTION
## Description

This migrates Plus offer to Compose UI.

## Testing Instructions

1. Start with a fresh install.
2. Do not sign in.
3. Go to the Profile tab.
4. Scroll down.
5. You should see the Plus offer.
6. Play any podcast.
7. Go back to the Profile tab.
8. Scroll down and notice that mini player does not obstruct the UI.
9. Sign in.
10. Notice that there is no Plus offer in the Profile tab.
11. Sign out.
12. Scroll down to the Plus offer.
13. Tap on the close button.
14. Plus offer should be gone.
15. Close the app.
16. Reopen the app.
17. Plus offer should still be gone.

* Verify UI in landscape mode.
* Verify UI with different themes.

## Screenshots or Screencast 

![Screenshot 2024-11-20 at 13 38 50](https://github.com/user-attachments/assets/157cb9a9-037a-44de-aaae-0a7b8b3c4fe7)

## Checklist
- [ ] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] ~I have considered whether it makes sense to add tests for my changes~
- [ ] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [ ] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack
