### PR TITLE
Referrals - Attach screenshot while sharing guest pass

### DIFF
--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/sharing/SharingClientTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/sharing/SharingClientTest.kt
@@ -677,6 +677,7 @@ class SharingClientTest {
 
     @Test
     fun shareReferralLink() = runTest {
+        val file = File(context.cacheDir, "pocket-casts-plus-guest-pass.png").also { it.writeBytes(Random.nextBytes(8)) }
         val referralCode = "referral-code"
         val referralsOfferInfo = ReferralsOfferInfoMock
         val text = context.getString(LR.string.referrals_share_text, referralsOfferInfo.localizedOfferDurationAdjective.lowercase())
@@ -684,6 +685,7 @@ class SharingClientTest {
         val request = SharingRequest.referralLink(
             referralCode = referralCode,
             referralsOfferInfo = referralsOfferInfo,
+            screenshot = file,
         ).build()
 
         val response = client.share(request)
@@ -693,7 +695,8 @@ class SharingClientTest {
         val intent = shareStarter.requireChooserIntent
 
         assertEquals(ACTION_SEND, intent.action)
-        assertEquals("text/plain", intent.type)
+        assertEquals("image/png", intent.type)
+        assertEquals(FileUtil.getUriForFile(context, file), IntentCompat.getParcelableExtra(intent, EXTRA_STREAM, Uri::class.java))
         assertEquals("$text\n\nhttps://$WEB_BASE_HOST/redeem/$referralCode", intent.getStringExtra(EXTRA_TEXT))
         assertEquals(subject, intent.getStringExtra(EXTRA_SUBJECT))
         assertEquals(FLAG_GRANT_READ_URI_PERMISSION, intent.flags and FLAG_GRANT_READ_URI_PERMISSION)

--- a/modules/features/referrals/build.gradle.kts
+++ b/modules/features/referrals/build.gradle.kts
@@ -24,7 +24,7 @@ dependencies {
     api(projects.modules.services.views)
 
     implementation(platform(libs.compose.bom))
-
+    implementation(projects.modules.services.capturable)
     implementation(libs.compose.material)
     implementation(libs.compose.material3.window.size)
     implementation(libs.compose.ui)

--- a/modules/features/referrals/src/main/kotlin/au/com/shiftyjelly/pocketcasts/referrals/ReferralCaptureController.kt
+++ b/modules/features/referrals/src/main/kotlin/au/com/shiftyjelly/pocketcasts/referrals/ReferralCaptureController.kt
@@ -1,0 +1,60 @@
+package au.com.shiftyjelly.pocketcasts.referrals
+
+import android.graphics.Bitmap
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.graphics.asAndroidBitmap
+import androidx.compose.ui.platform.LocalContext
+import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
+import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer.TAG_CRASH
+import dev.shreyaspatil.capturable.controller.CaptureController
+import dev.shreyaspatil.capturable.controller.rememberCaptureController
+import java.io.File
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+@Composable
+internal fun rememberReferralCaptureController(): ReferralCaptureController {
+    val context = LocalContext.current
+    val referralCardController = rememberCaptureController()
+
+    return remember {
+        object : ReferralCaptureController {
+            override fun captureController() = referralCardController
+
+            override suspend fun capture() = runCatching {
+                val controller = captureController()
+                val capturedBitmap = controller.captureAsync().await()
+                val file = File(context.cacheDir, "pocket-casts-plus-guest-pass.png")
+                file.outputStream().use { stream ->
+                    withContext(Dispatchers.IO) {
+                        capturedBitmap.asAndroidBitmap()
+                            .copy(Bitmap.Config.ARGB_8888, false)
+                            .compress(Bitmap.CompressFormat.PNG, 100, stream)
+                    }
+                }
+                file
+            }.onFailure { LogBuffer.e(TAG_CRASH, it, "Failed to create a screenshot") }
+                .getOrNull()
+        }
+    }
+}
+
+internal interface ReferralCaptureController {
+    fun captureController(): CaptureController
+
+    suspend fun capture(): File?
+
+    companion object {
+        @Composable
+        fun preview() = object : ReferralCaptureController {
+            private val controller = rememberCaptureController()
+
+            override fun captureController() = controller
+
+            override suspend fun capture(): File? {
+                return null
+            }
+        }
+    }
+}

--- a/modules/features/referrals/src/main/kotlin/au/com/shiftyjelly/pocketcasts/referrals/ReferralsSendGuestPassViewModel.kt
+++ b/modules/features/referrals/src/main/kotlin/au/com/shiftyjelly/pocketcasts/referrals/ReferralsSendGuestPassViewModel.kt
@@ -17,6 +17,7 @@ import au.com.shiftyjelly.pocketcasts.sharing.SharingRequest
 import au.com.shiftyjelly.pocketcasts.utils.exception.NoNetworkException
 import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
 import dagger.hilt.android.lifecycle.HiltViewModel
+import java.io.File
 import javax.inject.Inject
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -82,11 +83,12 @@ class ReferralsSendGuestPassViewModel @Inject constructor(
         getReferralCode()
     }
 
-    fun onShareClick(referralCode: String) {
+    fun onShareClick(referralCode: String, file: File? = null) {
         if (_state.value !is UiState.Loaded) return
         val request = SharingRequest.referralLink(
             referralCode = referralCode,
             referralsOfferInfo = (_state.value as UiState.Loaded).referralsOfferInfo,
+            screenshot = file,
         ).setSourceView(SourceView.REFERRALS)
             .build()
         viewModelScope.launch {

--- a/modules/features/referrals/src/test/kotlin/au/com/shiftyjelly/pocketcasts/referrals/ReferralsSendGuestPassViewModelTest.kt
+++ b/modules/features/referrals/src/test/kotlin/au/com/shiftyjelly/pocketcasts/referrals/ReferralsSendGuestPassViewModelTest.kt
@@ -148,7 +148,6 @@ class ReferralsSendGuestPassViewModelTest {
             assertEquals(referralCode, (data as SharingRequest.Data.ReferralLink).referralCode)
             assertEquals(SocialPlatform.More, platform)
             assertEquals(AnalyticsEvent.REFERRAL_PASS_SHARED, analyticsEvent)
-            assertTrue(capturedRequest.backgroundImage?.isFile == true)
             assertEquals(
                 mapOf(
                     "code" to referralCode,

--- a/modules/features/referrals/src/test/kotlin/au/com/shiftyjelly/pocketcasts/referrals/ReferralsSendGuestPassViewModelTest.kt
+++ b/modules/features/referrals/src/test/kotlin/au/com/shiftyjelly/pocketcasts/referrals/ReferralsSendGuestPassViewModelTest.kt
@@ -27,6 +27,7 @@ import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
+import org.junit.rules.TemporaryFolder
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.times
 import org.mockito.Mockito.verify
@@ -37,6 +38,9 @@ import org.mockito.kotlin.whenever
 class ReferralsSendGuestPassViewModelTest {
     @get:Rule
     val coroutineRule = MainCoroutineRule()
+
+    @get:Rule
+    val tempDir = TemporaryFolder()
 
     private val referralManager = mock<ReferralManager>()
     private val sharingClient = mock<SharingClient>()
@@ -135,7 +139,7 @@ class ReferralsSendGuestPassViewModelTest {
         whenever(referralManager.getReferralCode()).thenReturn(referralCodeSuccessResult)
 
         initViewModel()
-        viewModel.onShareClick(referralCode)
+        viewModel.onShareClick(referralCode, tempDir.newFile())
 
         verify(referralManager).getReferralCode()
         verify(sharingClient).share(requestCaptor.capture())
@@ -144,6 +148,7 @@ class ReferralsSendGuestPassViewModelTest {
             assertEquals(referralCode, (data as SharingRequest.Data.ReferralLink).referralCode)
             assertEquals(SocialPlatform.More, platform)
             assertEquals(AnalyticsEvent.REFERRAL_PASS_SHARED, analyticsEvent)
+            assertTrue(capturedRequest.backgroundImage?.isFile == true)
             assertEquals(
                 mapOf(
                     "code" to referralCode,

--- a/modules/services/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/SharingClient.kt
+++ b/modules/services/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/SharingClient.kt
@@ -136,12 +136,14 @@ class SharingClient(
         is SharingRequest.Data.ReferralLink -> {
             val shareText = "${context.getString(LR.string.referrals_share_text, data.referralsOfferInfo.localizedOfferDurationAdjective.lowercase())}\n\n${data.sharingUrl(webBasedHost)}"
             val shareSubject = context.getString(LR.string.referrals_share_subject, data.referralsOfferInfo.localizedOfferDurationNoun)
+            val screenshot = data.screenshot
             Intent()
                 .setAction(Intent.ACTION_SEND)
-                .setType("text/plain")
+                .setType("image/png")
                 .putExtra(EXTRA_TEXT, shareText)
                 .putExtra(EXTRA_SUBJECT, shareSubject)
                 .addFlags(FLAG_GRANT_READ_URI_PERMISSION)
+                .apply { screenshot?.let { setExtraStream(it) } }
                 .toChooserIntent()
                 .share()
             SharingResponse(
@@ -380,10 +382,12 @@ data class SharingRequest internal constructor(
         fun referralLink(
             referralCode: String,
             referralsOfferInfo: ReferralsOfferInfo,
+            screenshot: File?,
         ) = Builder(
             Data.ReferralLink(
                 referralCode = referralCode,
                 referralsOfferInfo = referralsOfferInfo,
+                screenshot = screenshot,
             ),
         )
             .setAnalyticsEvent(AnalyticsEvent.REFERRAL_PASS_SHARED)
@@ -576,6 +580,7 @@ data class SharingRequest internal constructor(
         class ReferralLink internal constructor(
             val referralCode: String,
             val referralsOfferInfo: ReferralsOfferInfo,
+            val screenshot: File? = null,
         ) : Data {
             override val podcast = null
 

--- a/modules/services/sharing/src/test/kotlin/au/com/shiftyjelly/pocketcasts/sharing/SharingAnalyticsTest.kt
+++ b/modules/services/sharing/src/test/kotlin/au/com/shiftyjelly/pocketcasts/sharing/SharingAnalyticsTest.kt
@@ -449,7 +449,7 @@ class SharingAnalyticsTest {
     fun `log referral link sharing`() {
         val referralCode = "TEST_CODE"
         val referralsOfferInfo = ReferralsOfferInfoMock
-        val request = SharingRequest.referralLink(referralCode, referralsOfferInfo)
+        val request = SharingRequest.referralLink(referralCode, referralsOfferInfo, tempFolder.newFile())
             .setSourceView(SourceView.REFERRALS)
             .build()
 


### PR DESCRIPTION
## Description
This attaches screenshot while sharing referral guest pass.

** I'm not sending an image from landscape phone layout as the card isn't displayed in that layout. I think it should be fine as statistically, Profile screen is opened mostly in portrait mode.

## Testing Instructions

1. Tap referral icon on Profile tab
2. Tap Share Guest Pass
3. Share using email
4. ✅ Notice that guest pass image is attached to the email p1732059551376689-slack-C07HDV91FBQ

## Screenshots or Screencast 

<img width=200 src="https://github.com/user-attachments/assets/7e92bc9c-2459-4615-a83f-1d47f960146c"/>


## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [x] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
