### PR TITLE
Improve syncing of deselected chapters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@
     *   Add new podcast subscriptions to the top instead of bottom for Data Added podcast sort order 
         ([#3192](https://github.com/Automattic/pocket-casts-android/pull/3192)) 
 *   Bug Fixes
+    *   Improve syncing of deselected chapters
+        ([#3256](https://github.com/Automattic/pocket-casts-android/pull/3256))
     *   Use red color for the notification icons
         ([#3154](https://github.com/Automattic/pocket-casts-android/pull/3154))
     *   Fix effects being lost when paused

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/PodcastSyncProcess.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/PodcastSyncProcess.kt
@@ -943,7 +943,7 @@ class PodcastSyncProcess(
 
             sync.deselectedChapters?.let {
                 episode.deselectedChapters = it
-                episode.deselectedChaptersModified = sync.deselectedChaptersModified?.let(::Date)
+                episode.deselectedChaptersModified = null
             }
 
             episodeManager.update(episode)


### PR DESCRIPTION
## Description

There was an issue in the sync process that would cause the deselect chapters to keep syncing. This was because the modified value wasn't set to null after it was synced, causing the new sync to send it again.

## Testing Instructions
- Fresh install the app
- Create a new account
- Upgrade it to Plus 
- Subscribe to a podcast with chapters for example Upgrade https://pca.st/upgrade
- Play an episode
- Open the full screen player and chapters tab
- Tap "Preselect chapters" 
- Unselect a chapter and tap Done
- Open the Android Studio window "App Inspection" and the "Network Inspector" tab
- Back in the app tap the Profile tab -> refresh button
- Find the `/sync/update` call
- The request is encoded but you should be able to see the `deselected_chapters` being sent and an episode being returned in the response
- Wait a little while then tap the refresh button again
- ✅ Verify that the request is empty and doesn't send the episode with the `deselected_chapters` field. The response should also be empty.

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.