### PR TITLE
Use played up to time for longest episode calculation

### DIFF
--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/repositories/endofyear/EndOfYearManagerTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/repositories/endofyear/EndOfYearManagerTest.kt
@@ -690,6 +690,7 @@ class EndOfYearManagerTest {
                 playingStatus = EpisodePlayingStatus.COMPLETED,
                 duration = 20.0,
                 imageUrl = "image-url-1",
+                playedUpTo = 20.0,
             ),
         )
 
@@ -716,6 +717,7 @@ class EndOfYearManagerTest {
                     lastPlaybackInteraction = Year.of(1000).toEpochMillis(zone),
                     playingStatus = EpisodePlayingStatus.COMPLETED,
                     duration = 40.0,
+                    playedUpTo = 35.0,
                 ),
                 PodcastEpisode(
                     uuid = "id-3",
@@ -725,17 +727,18 @@ class EndOfYearManagerTest {
                     lastPlaybackInteraction = Year.of(1001).toEpochMillis(zone) - 1,
                     playingStatus = EpisodePlayingStatus.IN_PROGRESS,
                     duration = 80.0,
+                    playedUpTo = 30.0,
                 ),
             ),
         )
 
         assertEquals(
             LongestEpisode(
-                episodeId = "id-3",
-                episodeTitle = "title-3",
+                episodeId = "id-2",
+                episodeTitle = "title-2",
                 podcastId = "p-id-2",
                 podcastTitle = "p-title-2",
-                durationSeconds = 80.0,
+                durationSeconds = 40.0,
                 coverUrl = null,
             ),
             manager.getStats(year = Year.of(1000)).longestEpisode,
@@ -754,6 +757,7 @@ class EndOfYearManagerTest {
                     lastPlaybackInteraction = Year.of(1000).toEpochMillis(zone) - 1,
                     playingStatus = EpisodePlayingStatus.COMPLETED,
                     duration = 10.0,
+                    playedUpTo = 5.0,
                 ),
                 PodcastEpisode(
                     uuid = "id-2",
@@ -762,6 +766,7 @@ class EndOfYearManagerTest {
                     lastPlaybackInteraction = Year.of(1001).toEpochMillis(zone),
                     playingStatus = EpisodePlayingStatus.COMPLETED,
                     duration = 10.0,
+                    playedUpTo = 5.0,
                 ),
                 PodcastEpisode(
                     uuid = "id-3",
@@ -770,25 +775,7 @@ class EndOfYearManagerTest {
                     lastPlaybackInteraction = null,
                     playingStatus = EpisodePlayingStatus.COMPLETED,
                     duration = 10.0,
-                ),
-            ),
-        )
-
-        assertNull(manager.getStats(year = Year.of(1000)).longestEpisode)
-    }
-
-    @Test
-    fun doNotCountUnplayedEpisodesForLongestPlayedEpisode() = runTest {
-        podcastDao.insert(Podcast("p-id-1"))
-        episodeDao.insertAll(
-            listOf(
-                PodcastEpisode(
-                    uuid = "id-1",
-                    podcastUuid = "p-id-1",
-                    publishedDate = Date(),
-                    lastPlaybackInteraction = Year.of(1000).toEpochMillis(zone),
-                    playingStatus = EpisodePlayingStatus.NOT_PLAYED,
-                    duration = 10.0,
+                    playedUpTo = 5.0,
                 ),
             ),
         )

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/EndOfYearDao.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/EndOfYearDao.kt
@@ -100,8 +100,7 @@ abstract class EndOfYearDao {
           episode.last_playback_interaction_date IS NOT NULL
           AND episode.last_playback_interaction_date >= :fromEpochMs
           AND episode.last_playback_interaction_date < :toEpochMs
-          AND episode.playing_status IN (1, 2)
-        ORDER BY episode.duration DESC
+        ORDER BY episode.played_up_to DESC
         LIMIT 1
         """,
     )


### PR DESCRIPTION
## Description

This PR updates how the longest episode is calculated for the PB24. Previously it used episode's duration, not it uses played up to time. It's late into the beta release but the feature is heavily tested in different layers so I feel safe about changing it.

## Testing Instructions

1. Sign up with a new account.
2. Play some episode and scrub it until the end.
3. Play this episode https://pca.st/iytpbo1t and pause it after a couple of seconds of playback.
4. Start PB24.
5. You should see the episode you scrubbed to the end as the longest episode.

## Checklist
- [ ] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [ ] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [ ] ~Any jetpack compose components I added or changed are covered by compose previews~
- [ ] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~