### PR TITLE
Suffix DAO methods that aren't Coroutines with 'blocking' to make upgrading easier

### DIFF
--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/models/db/AppDatabaseTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/models/db/AppDatabaseTest.kt
@@ -73,7 +73,7 @@ class AppDatabaseTest {
         val migratedDatabase = getMigratedRoomDatabase()
 
         val podcastDao = migratedDatabase.podcastDao()
-        val podcast = podcastDao.findByUuid("c33338e0-ea44-0134-ec45-4114446340cb")
+        val podcast = podcastDao.findByUuidBlocking("c33338e0-ea44-0134-ec45-4114446340cb")
         assertNotNull("Podcast should be found", podcast)
         assertEquals("MaxFun", podcast?.title)
         assertNotNull(podcast?.addedDate)

--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/models/db/AutoArchiveTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/models/db/AutoArchiveTest.kt
@@ -120,9 +120,9 @@ class AutoArchiveTest {
         val podcast = Podcast(UUID.randomUUID().toString())
         val podcastManager = podcastManagerThatReturns(podcast)
         val episode = PodcastEpisode(uuid = uuid, podcastUuid = podcast.uuid, isArchived = false, publishedDate = Date())
-        episodeDao.insert(episode)
+        episodeDao.insertBlocking(episode)
         assertTrue("Episode should not be archived before running", !episode.isArchived)
-        episodeManager.checkForEpisodesToAutoArchive(null, podcastManager)
+        episodeManager.checkForEpisodesToAutoArchiveBlocking(null, podcastManager)
 
         val updatedEpisode = episodeDao.findByUuid(uuid)!!
         assertTrue("Episode should not be archived after running", !updatedEpisode.isArchived)
@@ -141,11 +141,11 @@ class AutoArchiveTest {
         val episode = PodcastEpisode(uuid = uuid, isArchived = false, publishedDate = date, podcastUuid = podcastUUID, addedDate = date)
         val newUUID = UUID.randomUUID().toString()
         val newEpisode = PodcastEpisode(uuid = newUUID, podcastUuid = podcastUUID, addedDate = Date(), publishedDate = Date(), isArchived = false)
-        testDb.podcastDao().insert(podcast)
-        episodeDao.insert(episode)
-        episodeDao.insert(newEpisode)
+        testDb.podcastDao().insertBlocking(podcast)
+        episodeDao.insertBlocking(episode)
+        episodeDao.insertBlocking(newEpisode)
         assertTrue("Episode should not be archived before running", !episode.isArchived)
-        episodeManager.checkForEpisodesToAutoArchive(null, podcastManager)
+        episodeManager.checkForEpisodesToAutoArchiveBlocking(null, podcastManager)
 
         val updatedEpisode = episodeDao.findByUuid(uuid)!!
         assertTrue("Episode should be archived as it is older than 30 days", updatedEpisode.isArchived)
@@ -166,10 +166,10 @@ class AutoArchiveTest {
         val uuid = UUID.randomUUID().toString()
         val episode = PodcastEpisode(uuid = uuid, isArchived = false, publishedDate = date, podcastUuid = podcastUUID, addedDate = date, lastPlaybackInteraction = Date().time)
 
-        testDb.podcastDao().insert(podcast)
-        episodeDao.insert(episode)
+        testDb.podcastDao().insertBlocking(podcast)
+        episodeDao.insertBlocking(episode)
         assertTrue("Episode should not be archived before running", !episode.isArchived)
-        episodeManager.checkForEpisodesToAutoArchive(null, podcastManager)
+        episodeManager.checkForEpisodesToAutoArchiveBlocking(null, podcastManager)
 
         val updatedEpisode = episodeDao.findByUuid(uuid)!!
         assertTrue("Episode should be not be archived as it has been played recently", !updatedEpisode.isArchived)
@@ -187,10 +187,10 @@ class AutoArchiveTest {
         val uuid = UUID.randomUUID().toString()
         val episode = PodcastEpisode(uuid = uuid, isArchived = false, publishedDate = date, podcastUuid = podcastUUID, addedDate = date, lastDownloadAttemptDate = Date())
 
-        testDb.podcastDao().insert(podcast)
-        episodeDao.insert(episode)
+        testDb.podcastDao().insertBlocking(podcast)
+        episodeDao.insertBlocking(episode)
         assertTrue("Episode should not be archived before running", !episode.isArchived)
-        episodeManager.checkForEpisodesToAutoArchive(null, podcastManager)
+        episodeManager.checkForEpisodesToAutoArchiveBlocking(null, podcastManager)
 
         val updatedEpisode = episodeDao.findByUuid(uuid)!!
         assertTrue("Episode should be not be archived as it has been downloaded recently", !updatedEpisode.isArchived)
@@ -209,11 +209,11 @@ class AutoArchiveTest {
         val playedEpisode = PodcastEpisode(uuid = playedUuid, podcastUuid = podcast.uuid, isArchived = false, publishedDate = date, playingStatus = EpisodePlayingStatus.COMPLETED, lastPlaybackInteraction = date.time)
         val unplayedEpisode = PodcastEpisode(uuid = unplayedUuid, podcastUuid = podcast.uuid, isArchived = false, publishedDate = Date(), playingStatus = EpisodePlayingStatus.NOT_PLAYED)
 
-        episodeDao.insert(playedEpisode)
-        episodeDao.insert(unplayedEpisode)
+        episodeDao.insertBlocking(playedEpisode)
+        episodeDao.insertBlocking(unplayedEpisode)
 
         assertTrue("Episode should not be archived before running", !playedEpisode.isArchived)
-        episodeManager.checkForEpisodesToAutoArchive(null, podcastManager)
+        episodeManager.checkForEpisodesToAutoArchiveBlocking(null, podcastManager)
 
         val updatedPlayedEpisode = episodeDao.findByUuid(playedUuid)!!
         assertTrue("Episode should be archived as it was played 2 days ago", updatedPlayedEpisode.isArchived)
@@ -234,11 +234,11 @@ class AutoArchiveTest {
         val playedEpisode = PodcastEpisode(uuid = playedUuid, podcastUuid = podcast.uuid, isArchived = false, publishedDate = date, playingStatus = EpisodePlayingStatus.COMPLETED, lastPlaybackInteraction = date.time, isStarred = true)
         val unplayedEpisode = PodcastEpisode(uuid = unplayedUuid, podcastUuid = podcast.uuid, isArchived = false, publishedDate = Date(), playingStatus = EpisodePlayingStatus.NOT_PLAYED)
 
-        episodeDao.insert(playedEpisode)
-        episodeDao.insert(unplayedEpisode)
+        episodeDao.insertBlocking(playedEpisode)
+        episodeDao.insertBlocking(unplayedEpisode)
 
         assertTrue("Episode should not be archived before running", !playedEpisode.isArchived)
-        episodeManager.checkForEpisodesToAutoArchive(null, podcastManager)
+        episodeManager.checkForEpisodesToAutoArchiveBlocking(null, podcastManager)
 
         val updatedPlayedEpisode = episodeDao.findByUuid(playedUuid)!!
         assertTrue("Episode should not be archived as it is starred", !updatedPlayedEpisode.isArchived)
@@ -259,11 +259,11 @@ class AutoArchiveTest {
         val playedEpisode = PodcastEpisode(uuid = playedUuid, podcastUuid = podcast.uuid, isArchived = false, publishedDate = date, playingStatus = EpisodePlayingStatus.COMPLETED, lastPlaybackInteraction = date.time, isStarred = true)
         val unplayedEpisode = PodcastEpisode(uuid = unplayedUuid, podcastUuid = podcast.uuid, isArchived = false, publishedDate = Date(), playingStatus = EpisodePlayingStatus.NOT_PLAYED)
 
-        episodeDao.insert(playedEpisode)
-        episodeDao.insert(unplayedEpisode)
+        episodeDao.insertBlocking(playedEpisode)
+        episodeDao.insertBlocking(unplayedEpisode)
 
         assertTrue("Episode should not be archived before running", !playedEpisode.isArchived)
-        episodeManager.checkForEpisodesToAutoArchive(null, podcastManager)
+        episodeManager.checkForEpisodesToAutoArchiveBlocking(null, podcastManager)
 
         val updatedPlayedEpisode = episodeDao.findByUuid(playedUuid)!!
         assertTrue("Episode should be archived as it is starred and include starred is on", updatedPlayedEpisode.isArchived)
@@ -284,11 +284,11 @@ class AutoArchiveTest {
         val episode = PodcastEpisode(uuid = uuid, isArchived = false, publishedDate = date, podcastUuid = podcastUUID, addedDate = date, isStarred = true)
         val newUUID = UUID.randomUUID().toString()
         val newEpisode = PodcastEpisode(uuid = newUUID, podcastUuid = podcastUUID, addedDate = Date(), publishedDate = Date(), isArchived = false)
-        testDb.podcastDao().insert(podcast)
-        episodeDao.insert(episode)
-        episodeDao.insert(newEpisode)
+        testDb.podcastDao().insertBlocking(podcast)
+        episodeDao.insertBlocking(episode)
+        episodeDao.insertBlocking(newEpisode)
         assertTrue("Episode should not be archived before running", !episode.isArchived)
-        episodeManager.checkForEpisodesToAutoArchive(null, podcastManager)
+        episodeManager.checkForEpisodesToAutoArchiveBlocking(null, podcastManager)
 
         val updatedEpisode = episodeDao.findByUuid(uuid)!!
         assertTrue("Episode should not be archived as it is starred", !updatedEpisode.isArchived)
@@ -311,11 +311,11 @@ class AutoArchiveTest {
         val episode = PodcastEpisode(uuid = uuid, isArchived = false, publishedDate = date, podcastUuid = podcastUUID, addedDate = date, isStarred = true)
         val newUUID = UUID.randomUUID().toString()
         val newEpisode = PodcastEpisode(uuid = newUUID, podcastUuid = podcastUUID, addedDate = Date(), publishedDate = Date(), isArchived = false)
-        testDb.podcastDao().insert(podcast)
-        episodeDao.insert(episode)
-        episodeDao.insert(newEpisode)
+        testDb.podcastDao().insertBlocking(podcast)
+        episodeDao.insertBlocking(episode)
+        episodeDao.insertBlocking(newEpisode)
         assertTrue("Episode should not be archived before running", !episode.isArchived)
-        episodeManager.checkForEpisodesToAutoArchive(null, podcastManager)
+        episodeManager.checkForEpisodesToAutoArchiveBlocking(null, podcastManager)
 
         val updatedEpisode = episodeDao.findByUuid(uuid)!!
         assertTrue("Episode should be archived as it is starred and starred is included", updatedEpisode.isArchived)
@@ -347,12 +347,12 @@ class AutoArchiveTest {
         val newUUID = UUID.randomUUID().toString()
         val newEpisode = PodcastEpisode(uuid = newUUID, isArchived = false, publishedDate = date, podcastUuid = podcastUUID, addedDate = date, lastArchiveInteraction = time8Day)
 
-        testDb.podcastDao().insert(podcast)
-        episodeDao.insert(episode)
-        episodeDao.insert(newEpisode)
+        testDb.podcastDao().insertBlocking(podcast)
+        episodeDao.insertBlocking(episode)
+        episodeDao.insertBlocking(newEpisode)
 
         assertTrue("Episode should not be archived before running", !episode.isArchived || !newEpisode.isArchived)
-        episodeManager.checkForEpisodesToAutoArchive(null, podcastManager)
+        episodeManager.checkForEpisodesToAutoArchiveBlocking(null, podcastManager)
 
         val updatedEpisode = episodeDao.findByUuid(uuid)!!
         assertTrue("Episode should not be archived as it was archive modified 6 days ago (inactive setting = 7d)", !updatedEpisode.isArchived)
@@ -374,11 +374,11 @@ class AutoArchiveTest {
         val playedEpisode = PodcastEpisode(uuid = playedUuid, podcastUuid = podcast.uuid, isArchived = false, publishedDate = date, playingStatus = EpisodePlayingStatus.COMPLETED, lastPlaybackInteraction = date.time)
         val unplayedEpisode = PodcastEpisode(uuid = unplayedUuid, podcastUuid = podcast.uuid, isArchived = false, publishedDate = Date(), playingStatus = EpisodePlayingStatus.NOT_PLAYED)
 
-        episodeDao.insert(playedEpisode)
-        episodeDao.insert(unplayedEpisode)
+        episodeDao.insertBlocking(playedEpisode)
+        episodeDao.insertBlocking(unplayedEpisode)
 
         assertTrue("Episode should not be archived before running", !playedEpisode.isArchived)
-        episodeManager.checkForEpisodesToAutoArchive(null, podcastManager)
+        episodeManager.checkForEpisodesToAutoArchiveBlocking(null, podcastManager)
 
         val updatedPlayedEpisode = episodeDao.findByUuid(playedUuid)!!
         assertTrue("Episode should be archived as it was played 2 days ago and podcast settings are on override", updatedPlayedEpisode.isArchived)
@@ -399,11 +399,11 @@ class AutoArchiveTest {
         val episode = PodcastEpisode(uuid = uuid, isArchived = false, publishedDate = date, podcastUuid = podcastUUID, addedDate = date)
         val newUUID = UUID.randomUUID().toString()
         val newEpisode = PodcastEpisode(uuid = newUUID, podcastUuid = podcastUUID, addedDate = Date(), publishedDate = Date(), isArchived = false)
-        testDb.podcastDao().insert(podcast)
-        episodeDao.insert(episode)
-        episodeDao.insert(newEpisode)
+        testDb.podcastDao().insertBlocking(podcast)
+        episodeDao.insertBlocking(episode)
+        episodeDao.insertBlocking(newEpisode)
         assertTrue("Episode should not be archived before running", !episode.isArchived)
-        episodeManager.checkForEpisodesToAutoArchive(null, podcastManager)
+        episodeManager.checkForEpisodesToAutoArchiveBlocking(null, podcastManager)
 
         val updatedEpisode = episodeDao.findByUuid(uuid)!!
         assertTrue("Episode should be archived as it is older than 30 days and podcast is overriding global", updatedEpisode.isArchived)
@@ -425,11 +425,11 @@ class AutoArchiveTest {
         val episode = PodcastEpisode(uuid = uuid, isArchived = false, publishedDate = date, podcastUuid = podcastUUID, addedDate = date)
         val newUUID = UUID.randomUUID().toString()
         val newEpisode = PodcastEpisode(uuid = newUUID, podcastUuid = podcastUUID, addedDate = Date(), publishedDate = date, isArchived = false)
-        testDb.podcastDao().insert(podcast)
-        episodeDao.insert(episode)
-        episodeDao.insert(newEpisode)
+        testDb.podcastDao().insertBlocking(podcast)
+        episodeDao.insertBlocking(episode)
+        episodeDao.insertBlocking(newEpisode)
         assertTrue("Episode should not be archived before running", !episode.isArchived)
-        episodeManager.checkForEpisodesToAutoArchive(null, podcastManager)
+        episodeManager.checkForEpisodesToAutoArchiveBlocking(null, podcastManager)
 
         val updatedEpisode = episodeDao.findByUuid(uuid)!!
         assertTrue("Episode should be archived as it is older than 24 hours and podcast is overriding global", updatedEpisode.isArchived)
@@ -451,11 +451,11 @@ class AutoArchiveTest {
         val episode = PodcastEpisode(uuid = uuid, isArchived = false, publishedDate = date, podcastUuid = podcastUUID, addedDate = date, lastPlaybackInteraction = null, lastDownloadAttemptDate = null)
         val newUUID = UUID.randomUUID().toString()
         val newEpisode = PodcastEpisode(uuid = newUUID, podcastUuid = podcastUUID, addedDate = Date(), publishedDate = date, isArchived = false)
-        testDb.podcastDao().insert(podcast)
-        episodeDao.insert(episode)
-        episodeDao.insert(newEpisode)
+        testDb.podcastDao().insertBlocking(podcast)
+        episodeDao.insertBlocking(episode)
+        episodeDao.insertBlocking(newEpisode)
         assertTrue("Episode should not be archived before running", !episode.isArchived)
-        episodeManager.checkForEpisodesToAutoArchive(null, podcastManager)
+        episodeManager.checkForEpisodesToAutoArchiveBlocking(null, podcastManager)
 
         val updatedEpisode = episodeDao.findByUuid(uuid)!!
         assertTrue("Episode should be archived as it is older than 2 days and podcast is overriding global", updatedEpisode.isArchived)
@@ -477,11 +477,11 @@ class AutoArchiveTest {
         val oldestEpisode = PodcastEpisode(title = "Oldest", uuid = oldestUuid, podcastUuid = podcast.uuid, isArchived = false, publishedDate = date, playingStatus = EpisodePlayingStatus.COMPLETED, lastPlaybackInteraction = date.time)
         val unplayedEpisode = PodcastEpisode(title = "Newest", uuid = unplayedUuid, podcastUuid = podcast.uuid, isArchived = false, publishedDate = Date(), playingStatus = EpisodePlayingStatus.NOT_PLAYED)
 
-        episodeDao.insert(oldestEpisode)
-        episodeDao.insert(unplayedEpisode)
+        episodeDao.insertBlocking(oldestEpisode)
+        episodeDao.insertBlocking(unplayedEpisode)
 
         assertTrue("Episode should not be archived before running", !oldestEpisode.isArchived)
-        episodeManager.checkForEpisodesToAutoArchive(null, podcastManager)
+        episodeManager.checkForEpisodesToAutoArchiveBlocking(null, podcastManager)
 
         val updatedOldestEpisode = episodeDao.findByUuid(oldestUuid)!!
         assertTrue("Episode should be archived as it was the oldest", updatedOldestEpisode.isArchived)
@@ -500,10 +500,10 @@ class AutoArchiveTest {
         val oldestUuid = UUID.randomUUID().toString()
         val oldestEpisode = PodcastEpisode(title = "Oldest", uuid = oldestUuid, podcastUuid = podcast.uuid, isArchived = false, excludeFromEpisodeLimit = true, publishedDate = date, playingStatus = EpisodePlayingStatus.COMPLETED, lastPlaybackInteraction = date.time)
 
-        episodeDao.insert(oldestEpisode)
+        episodeDao.insertBlocking(oldestEpisode)
 
         assertTrue("Episode should not be archived before running", !oldestEpisode.isArchived)
-        episodeManager.checkForEpisodesToAutoArchive(null, podcastManager)
+        episodeManager.checkForEpisodesToAutoArchiveBlocking(null, podcastManager)
 
         val updatedOldestEpisode = episodeDao.findByUuid(oldestUuid)!!
         assertTrue("Episode should not be archived as global is off", !updatedOldestEpisode.isArchived)
@@ -530,21 +530,21 @@ class AutoArchiveTest {
         val newUUID = UUID.randomUUID().toString()
         val newEpisode = PodcastEpisode(uuid = newUUID, isArchived = false, publishedDate = date, podcastUuid = podcastUUID, addedDate = date, archivedModified = time8Day)
 
-        testDb.podcastDao().insert(podcast)
-        episodeDao.insert(newEpisode)
+        testDb.podcastDao().insertBlocking(podcast)
+        episodeDao.insertBlocking(newEpisode)
 
         assertTrue("Episode should not be archived before running", !newEpisode.isArchived)
-        episodeManager.checkForEpisodesToAutoArchive(null, podcastManager)
+        episodeManager.checkForEpisodesToAutoArchiveBlocking(null, podcastManager)
 
         val updatedNewEpisode = episodeDao.findByUuid(newUUID)!!
         assertTrue("Episode should be archived as it was archive modified 8 day ago (inactive setting = 7d)", updatedNewEpisode.isArchived)
 
-        runBlocking { upNext.playLast(updatedNewEpisode, downloadManager, null) }
+        runBlocking { upNext.playLastBlocking(updatedNewEpisode, downloadManager, null) }
 
         val updatedNewEpisodeInUpNext = episodeDao.findByUuid(newUUID)!!
         assertTrue("Episode should not be archived as it was added to up next", !updatedNewEpisodeInUpNext.isArchived)
 
-        episodeManager.checkForEpisodesToAutoArchive(null, podcastManager)
+        episodeManager.checkForEpisodesToAutoArchiveBlocking(null, podcastManager)
 
         val updatedNewEpisodeInUpNextAfterInactive = episodeDao.findByUuid(newUUID)!!
         assertTrue("Episode should not be archived as it was added to up next after being inactive", !updatedNewEpisodeInUpNextAfterInactive.isArchived)

--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/models/db/BookmarkDaoTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/models/db/BookmarkDaoTest.kt
@@ -139,7 +139,7 @@ class BookmarkDaoTest {
             bookmarkDao.insert(bookmark2)
 
             val episode = PodcastEpisode(uuid = defaultEpisodeUuid, podcastUuid = "1", isArchived = false, publishedDate = Date())
-            episodeDao.insert(episode)
+            episodeDao.insertBlocking(episode)
 
             val result = bookmarkDao.searchInPodcastByTitle(
                 title = searchTitle,
@@ -166,7 +166,7 @@ class BookmarkDaoTest {
             bookmarkDao.insert(bookmark2)
 
             val episode = PodcastEpisode(uuid = episodeUuid, podcastUuid = podcastUuid, title = searchTitle, isArchived = false, publishedDate = Date())
-            episodeDao.insert(episode)
+            episodeDao.insertBlocking(episode)
 
             val result = bookmarkDao.searchInPodcastByTitle(
                 title = searchTitle,
@@ -191,7 +191,7 @@ class BookmarkDaoTest {
             bookmarkDao.insert(bookmark3)
 
             val episode = PodcastEpisode(uuid = defaultEpisodeUuid, podcastUuid = defaultPodcastUuid, title = "", publishedDate = Date())
-            episodeDao.insert(episode)
+            episodeDao.insertBlocking(episode)
 
             val result = bookmarkDao.findByPodcastOrderCreatedAtFlow(
                 podcastUuid = defaultPodcastUuid,
@@ -216,7 +216,7 @@ class BookmarkDaoTest {
             bookmarkDao.insert(bookmark3)
 
             val episode = PodcastEpisode(uuid = defaultEpisodeUuid, podcastUuid = defaultPodcastUuid, title = "", publishedDate = Date())
-            episodeDao.insert(episode)
+            episodeDao.insertBlocking(episode)
 
             val result = bookmarkDao.findByPodcastOrderCreatedAtFlow(
                 podcastUuid = defaultPodcastUuid,
@@ -244,8 +244,8 @@ class BookmarkDaoTest {
 
             val episode1 = PodcastEpisode(uuid = episodeUuid1, podcastUuid = defaultPodcastUuid, publishedDate = Date(2000))
             val episode2 = PodcastEpisode(uuid = episodeUuid2, podcastUuid = defaultPodcastUuid, publishedDate = Date(1000))
-            episodeDao.insert(episode1)
-            episodeDao.insert(episode2)
+            episodeDao.insertBlocking(episode1)
+            episodeDao.insertBlocking(episode2)
             val result = bookmarkDao.findByPodcastOrderEpisodeAndTimeFlow(
                 podcastUuid = defaultPodcastUuid,
             ).first()

--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/models/db/ChapterDaoSelectionTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/models/db/ChapterDaoSelectionTest.kt
@@ -45,7 +45,7 @@ class ChapterDaoSelectionTest {
 
     @Test
     fun deselectPodcastEpisodeChapter() = runTest {
-        episodeDao.insert(PodcastEpisode(uuid = "id", publishedDate = Date()))
+        episodeDao.insertBlocking(PodcastEpisode(uuid = "id", publishedDate = Date()))
 
         chapterDao.selectChapter("id", 0, select = false)
 
@@ -70,7 +70,7 @@ class ChapterDaoSelectionTest {
 
     @Test
     fun deselectChapterUsingModificationDate() = runTest {
-        episodeDao.insert(PodcastEpisode(uuid = "id", publishedDate = Date()))
+        episodeDao.insertBlocking(PodcastEpisode(uuid = "id", publishedDate = Date()))
 
         val now = Date()
         chapterDao.selectChapter("id", 0, select = false, modifiedAt = now)
@@ -81,7 +81,7 @@ class ChapterDaoSelectionTest {
 
     @Test
     fun selectChapterBack() = runTest {
-        episodeDao.insert(PodcastEpisode(uuid = "id", publishedDate = Date()))
+        episodeDao.insertBlocking(PodcastEpisode(uuid = "id", publishedDate = Date()))
         chapterDao.selectChapter("id", 0, select = false)
 
         chapterDao.selectChapter("id", 0, select = true)
@@ -92,7 +92,7 @@ class ChapterDaoSelectionTest {
 
     @Test
     fun deselectedChapterIsAddedOnlyOnce() = runTest {
-        episodeDao.insert(PodcastEpisode(uuid = "id", publishedDate = Date()))
+        episodeDao.insertBlocking(PodcastEpisode(uuid = "id", publishedDate = Date()))
 
         repeat(10) {
             chapterDao.selectChapter("id", 0, select = false)
@@ -105,7 +105,7 @@ class ChapterDaoSelectionTest {
     @Test
     fun deselectMultipleChapters() = runTest {
         val chapters = List(10) { it }
-        episodeDao.insert(PodcastEpisode(uuid = "id", publishedDate = Date()))
+        episodeDao.insertBlocking(PodcastEpisode(uuid = "id", publishedDate = Date()))
 
         chapters.forEach {
             chapterDao.selectChapter("id", it, select = false)
@@ -118,7 +118,7 @@ class ChapterDaoSelectionTest {
     @Test
     fun selectMultipleChapters() = runTest {
         val chapters = List(10) { it }
-        episodeDao.insert(PodcastEpisode(uuid = "id", publishedDate = Date()))
+        episodeDao.insertBlocking(PodcastEpisode(uuid = "id", publishedDate = Date()))
         chapters.forEach {
             chapterDao.selectChapter("id", it, select = false)
         }

--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/models/db/EpisodeDaoTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/models/db/EpisodeDaoTest.kt
@@ -49,7 +49,7 @@ class EpisodeDaoTest {
     fun insertAndFindEpisode() = runBlocking {
         val episode = PodcastEpisode(uuid = "id", publishedDate = Date())
 
-        episodeDao.insert(episode)
+        episodeDao.insertBlocking(episode)
 
         assertEquals(episode, episodeDao.findByUuid(episode.uuid))
     }
@@ -61,7 +61,7 @@ class EpisodeDaoTest {
             PodcastEpisode(uuid = "2", publishedDate = Date()),
         )
 
-        episodeDao.insertAll(episodes)
+        episodeDao.insertAllBlocking(episodes)
 
         assertEquals(episodes[0], episodeDao.findByUuid(episodes[0].uuid))
         assertEquals(episodes[1], episodeDao.findByUuid(episodes[1].uuid))
@@ -87,7 +87,7 @@ class EpisodeDaoTest {
             episodeStatus = EpisodeStatusEnum.DOWNLOAD_FAILED,
             lastDownloadAttemptDate = Date.from(Instant.EPOCH),
         )
-        episodeDao.insert(episode)
+        episodeDao.insertBlocking(episode)
 
         val statistics = episodeDao.getFailedDownloadsStatistics()
 
@@ -109,7 +109,7 @@ class EpisodeDaoTest {
                 lastDownloadAttemptDate = Date.from(Instant.EPOCH.plusMillis(index.toLong())),
             )
         }
-        episodeDao.insertAll(episodes)
+        episodeDao.insertAllBlocking(episodes)
 
         val statistics = episodeDao.getFailedDownloadsStatistics()
 
@@ -131,7 +131,7 @@ class EpisodeDaoTest {
                 lastDownloadAttemptDate = null,
             )
         }
-        episodeDao.insertAll(episodes)
+        episodeDao.insertAllBlocking(episodes)
 
         val statistics = episodeDao.getFailedDownloadsStatistics()
 
@@ -153,7 +153,7 @@ class EpisodeDaoTest {
                 lastDownloadAttemptDate = Date.from(Instant.EPOCH.plusMillis(entry.ordinal.toLong())),
             )
         }
-        episodeDao.insertAll(episodes)
+        episodeDao.insertAllBlocking(episodes)
 
         val statistics = episodeDao.getFailedDownloadsStatistics()
 
@@ -170,8 +170,8 @@ class EpisodeDaoTest {
         val query = "test"
         val episodes = listOf(PodcastEpisode(uuid = "1", title = "Test Episode", podcastUuid = "podcast_uuid", publishedDate = Date(), lastPlaybackInteraction = 1000))
         val podcast = Podcast(uuid = "podcast_uuid")
-        episodeDao.insertAll(episodes)
-        podcastDao.insert(podcast)
+        episodeDao.insertAllBlocking(episodes)
+        podcastDao.insertBlocking(podcast)
 
         val result = episodeDao.filteredPlaybackHistoryFlow(query.escapeLike('\\')).first()
         assertEquals(episodes, result)
@@ -182,8 +182,8 @@ class EpisodeDaoTest {
         val query = "test"
         val episodes = listOf(PodcastEpisode(uuid = "1", title = "Episode", podcastUuid = "podcast_uuid", publishedDate = Date(), lastPlaybackInteraction = 1000))
         val podcast = Podcast(uuid = "podcast_uuid", title = "Test Podcast")
-        episodeDao.insertAll(episodes)
-        podcastDao.insert(podcast)
+        episodeDao.insertAllBlocking(episodes)
+        podcastDao.insertBlocking(podcast)
 
         val result = episodeDao.filteredPlaybackHistoryFlow(query.escapeLike('\\')).first()
         assertEquals(episodes, result)
@@ -195,7 +195,7 @@ class EpisodeDaoTest {
         val episode1 = PodcastEpisode(uuid = "1", title = "Test Episode 1", publishedDate = Date(), lastPlaybackInteraction = 1000)
         val episode2 = PodcastEpisode(uuid = "2", title = "Test Episode 2", publishedDate = Date(), lastPlaybackInteraction = 2000)
         val episodes = listOf(episode2, episode1)
-        episodeDao.insertAll(episodes)
+        episodeDao.insertAllBlocking(episodes)
 
         val result = episodeDao.filteredPlaybackHistoryFlow(query.escapeLike('\\')).first()
         assertEquals(episodes, result)
@@ -205,7 +205,7 @@ class EpisodeDaoTest {
     fun getFilteredPlaybackHistoryResultForNoMatch() = runTest {
         val query = "test"
         val episodes = listOf(PodcastEpisode(uuid = "1", title = "Episode", podcastUuid = "podcast_uuid", publishedDate = Date(), lastPlaybackInteraction = 1000))
-        episodeDao.insertAll(episodes)
+        episodeDao.insertAllBlocking(episodes)
 
         val result = episodeDao.filteredPlaybackHistoryFlow(query.escapeLike('\\')).first()
         assertEquals(emptyList<PodcastEpisode>(), result)
@@ -218,7 +218,7 @@ class EpisodeDaoTest {
         val episode1 = PodcastEpisode(uuid = "1", title = "%Test_ Episode", podcastUuid = "podcast_uuid", publishedDate = Date(), lastPlaybackInteraction = 1000)
         val episode2 = PodcastEpisode(uuid = "3", title = "Test Episode", podcastUuid = "podcast_uuid", publishedDate = Date(), lastPlaybackInteraction = 1000)
         val episodes = listOf(episode1, episode2)
-        episodeDao.insertAll(episodes)
+        episodeDao.insertAllBlocking(episodes)
 
         val result = episodeDao.filteredPlaybackHistoryFlow(query.escapeLike('\\')).first()
         assertEquals(listOf(episode1), result)

--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/models/db/ExternalDataDaoTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/models/db/ExternalDataDaoTest.kt
@@ -61,20 +61,20 @@ class ExternalDataDaoTest {
 
     @Test
     fun useCorrectReleaseTimestampsForSubscribedPodcasts() = runTest {
-        podcastDao.insert(Podcast(uuid = "id-1", title = "title-1", isSubscribed = true, podcastDescription = "description"))
-        podcastEpisodeDao.insert(PodcastEpisode(uuid = "id-1", publishedDate = Date(0), podcastUuid = "id-1", lastPlaybackInteraction = 10))
-        podcastEpisodeDao.insert(PodcastEpisode(uuid = "id-2", publishedDate = Date(2), podcastUuid = "id-1", lastPlaybackInteraction = null))
-        podcastEpisodeDao.insert(PodcastEpisode(uuid = "id-3", publishedDate = Date(1), podcastUuid = "id-1", lastPlaybackInteraction = 13))
+        podcastDao.insertBlocking(Podcast(uuid = "id-1", title = "title-1", isSubscribed = true, podcastDescription = "description"))
+        podcastEpisodeDao.insertBlocking(PodcastEpisode(uuid = "id-1", publishedDate = Date(0), podcastUuid = "id-1", lastPlaybackInteraction = 10))
+        podcastEpisodeDao.insertBlocking(PodcastEpisode(uuid = "id-2", publishedDate = Date(2), podcastUuid = "id-1", lastPlaybackInteraction = null))
+        podcastEpisodeDao.insertBlocking(PodcastEpisode(uuid = "id-3", publishedDate = Date(1), podcastUuid = "id-1", lastPlaybackInteraction = 13))
 
-        podcastDao.insert(Podcast(uuid = "id-2", title = "title-2", isSubscribed = true))
-        podcastEpisodeDao.insert(PodcastEpisode(uuid = "id-4", publishedDate = Date(5), podcastUuid = "id-2", lastPlaybackInteraction = 0))
-        podcastEpisodeDao.insert(PodcastEpisode(uuid = "id-5", publishedDate = Date(4), podcastUuid = "id-2", lastPlaybackInteraction = 20))
-        podcastEpisodeDao.insert(PodcastEpisode(uuid = "id-6", publishedDate = Date(3), podcastUuid = "id-2", lastPlaybackInteraction = 25))
+        podcastDao.insertBlocking(Podcast(uuid = "id-2", title = "title-2", isSubscribed = true))
+        podcastEpisodeDao.insertBlocking(PodcastEpisode(uuid = "id-4", publishedDate = Date(5), podcastUuid = "id-2", lastPlaybackInteraction = 0))
+        podcastEpisodeDao.insertBlocking(PodcastEpisode(uuid = "id-5", publishedDate = Date(4), podcastUuid = "id-2", lastPlaybackInteraction = 20))
+        podcastEpisodeDao.insertBlocking(PodcastEpisode(uuid = "id-6", publishedDate = Date(3), podcastUuid = "id-2", lastPlaybackInteraction = 25))
 
-        podcastDao.insert(Podcast(uuid = "id-3", title = "title-3", isSubscribed = true))
-        podcastEpisodeDao.insert(PodcastEpisode(uuid = "id-7", publishedDate = Date(12), podcastUuid = "id-3", lastPlaybackInteraction = 0))
+        podcastDao.insertBlocking(Podcast(uuid = "id-3", title = "title-3", isSubscribed = true))
+        podcastEpisodeDao.insertBlocking(PodcastEpisode(uuid = "id-7", publishedDate = Date(12), podcastUuid = "id-3", lastPlaybackInteraction = 0))
 
-        podcastDao.insert(Podcast(uuid = "id-4", title = "title-4", isSubscribed = true))
+        podcastDao.insertBlocking(Podcast(uuid = "id-4", title = "title-4", isSubscribed = true))
 
         val podcasts = externalDataDao.getSubscribedPodcasts(PodcastsSortType.NAME_A_TO_Z, limit = 100)
 
@@ -125,15 +125,15 @@ class ExternalDataDaoTest {
 
     @Test
     fun includeOnlySubscribedPodcastsForSubscribedPodcasts() = runTest {
-        podcastDao.insert(Podcast(uuid = "id-1", title = "title-1", isSubscribed = true))
-        podcastEpisodeDao.insert(PodcastEpisode(uuid = "id-1", publishedDate = Date(0), podcastUuid = "id-1"))
-        podcastEpisodeDao.insert(PodcastEpisode(uuid = "id-2", publishedDate = Date(0), podcastUuid = "id-1"))
-        podcastEpisodeDao.insert(PodcastEpisode(uuid = "id-3", publishedDate = Date(0), podcastUuid = "id-1"))
+        podcastDao.insertBlocking(Podcast(uuid = "id-1", title = "title-1", isSubscribed = true))
+        podcastEpisodeDao.insertBlocking(PodcastEpisode(uuid = "id-1", publishedDate = Date(0), podcastUuid = "id-1"))
+        podcastEpisodeDao.insertBlocking(PodcastEpisode(uuid = "id-2", publishedDate = Date(0), podcastUuid = "id-1"))
+        podcastEpisodeDao.insertBlocking(PodcastEpisode(uuid = "id-3", publishedDate = Date(0), podcastUuid = "id-1"))
 
-        podcastDao.insert(Podcast(uuid = "id-2", title = "title-2", isSubscribed = false))
-        podcastEpisodeDao.insert(PodcastEpisode(uuid = "id-4", publishedDate = Date(0), podcastUuid = "id-2"))
-        podcastEpisodeDao.insert(PodcastEpisode(uuid = "id-5", publishedDate = Date(0), podcastUuid = "id-2"))
-        podcastEpisodeDao.insert(PodcastEpisode(uuid = "id-6", publishedDate = Date(0), podcastUuid = "id-2"))
+        podcastDao.insertBlocking(Podcast(uuid = "id-2", title = "title-2", isSubscribed = false))
+        podcastEpisodeDao.insertBlocking(PodcastEpisode(uuid = "id-4", publishedDate = Date(0), podcastUuid = "id-2"))
+        podcastEpisodeDao.insertBlocking(PodcastEpisode(uuid = "id-5", publishedDate = Date(0), podcastUuid = "id-2"))
+        podcastEpisodeDao.insertBlocking(PodcastEpisode(uuid = "id-6", publishedDate = Date(0), podcastUuid = "id-2"))
 
         val podcasts = externalDataDao.getSubscribedPodcasts(PodcastsSortType.NAME_A_TO_Z, limit = 100)
 
@@ -154,7 +154,7 @@ class ExternalDataDaoTest {
 
     @Test
     fun includeCategoriesForSubscribedPodcasts() = runTest {
-        podcastDao.insert(Podcast(uuid = "id-1", title = "title-1", isSubscribed = true, podcastCategory = "category-1"))
+        podcastDao.insertBlocking(Podcast(uuid = "id-1", title = "title-1", isSubscribed = true, podcastCategory = "category-1"))
 
         val podcasts = externalDataDao.getSubscribedPodcasts(PodcastsSortType.NAME_A_TO_Z, limit = 100)
 
@@ -175,11 +175,11 @@ class ExternalDataDaoTest {
 
     @Test
     fun sortSubscribedPodcastsByAddedDate() = runTest {
-        podcastDao.insert(Podcast(uuid = "id-1", title = "title-1", isSubscribed = true, addedDate = Date(3)))
-        podcastDao.insert(Podcast(uuid = "id-2", title = "title-2", isSubscribed = true, addedDate = Date(4)))
-        podcastDao.insert(Podcast(uuid = "id-3", title = "title-3", isSubscribed = true, addedDate = Date(2)))
-        podcastDao.insert(Podcast(uuid = "id-4", title = "title-4", isSubscribed = true, addedDate = Date(1)))
-        podcastDao.insert(Podcast(uuid = "id-5", title = "title-5", isSubscribed = true, addedDate = null))
+        podcastDao.insertBlocking(Podcast(uuid = "id-1", title = "title-1", isSubscribed = true, addedDate = Date(3)))
+        podcastDao.insertBlocking(Podcast(uuid = "id-2", title = "title-2", isSubscribed = true, addedDate = Date(4)))
+        podcastDao.insertBlocking(Podcast(uuid = "id-3", title = "title-3", isSubscribed = true, addedDate = Date(2)))
+        podcastDao.insertBlocking(Podcast(uuid = "id-4", title = "title-4", isSubscribed = true, addedDate = Date(1)))
+        podcastDao.insertBlocking(Podcast(uuid = "id-5", title = "title-5", isSubscribed = true, addedDate = null))
 
         val podcastIds = externalDataDao.getSubscribedPodcasts(PodcastsSortType.DATE_ADDED_NEWEST_TO_OLDEST, limit = 100).map { it.id }
 
@@ -188,10 +188,10 @@ class ExternalDataDaoTest {
 
     @Test
     fun sortSubscribedPodcastsByTitle() = runTest {
-        podcastDao.insert(Podcast(uuid = "id-1", title = "title-4", isSubscribed = true))
-        podcastDao.insert(Podcast(uuid = "id-2", title = "title-3", isSubscribed = true))
-        podcastDao.insert(Podcast(uuid = "id-3", title = "title-1", isSubscribed = true))
-        podcastDao.insert(Podcast(uuid = "id-4", title = "title-2", isSubscribed = true))
+        podcastDao.insertBlocking(Podcast(uuid = "id-1", title = "title-4", isSubscribed = true))
+        podcastDao.insertBlocking(Podcast(uuid = "id-2", title = "title-3", isSubscribed = true))
+        podcastDao.insertBlocking(Podcast(uuid = "id-3", title = "title-1", isSubscribed = true))
+        podcastDao.insertBlocking(Podcast(uuid = "id-4", title = "title-2", isSubscribed = true))
 
         val podcastIds = externalDataDao.getSubscribedPodcasts(PodcastsSortType.NAME_A_TO_Z, limit = 100).map { it.id }
 
@@ -200,14 +200,14 @@ class ExternalDataDaoTest {
 
     @Test
     fun sortingSubscribedPodcastsByTitleOmitsEnglishArticles() = runTest {
-        podcastDao.insert(Podcast(uuid = "id-1", title = "The 1", isSubscribed = true))
-        podcastDao.insert(Podcast(uuid = "id-2", title = "An 2", isSubscribed = true))
-        podcastDao.insert(Podcast(uuid = "id-3", title = "A 3", isSubscribed = true))
-        podcastDao.insert(Podcast(uuid = "id-4", title = "4", isSubscribed = true))
-        podcastDao.insert(Podcast(uuid = "id-5", title = "the 5", isSubscribed = true))
-        podcastDao.insert(Podcast(uuid = "id-6", title = "an 6", isSubscribed = true))
-        podcastDao.insert(Podcast(uuid = "id-7", title = "a 7", isSubscribed = true))
-        podcastDao.insert(Podcast(uuid = "id-8", title = "8", isSubscribed = true))
+        podcastDao.insertBlocking(Podcast(uuid = "id-1", title = "The 1", isSubscribed = true))
+        podcastDao.insertBlocking(Podcast(uuid = "id-2", title = "An 2", isSubscribed = true))
+        podcastDao.insertBlocking(Podcast(uuid = "id-3", title = "A 3", isSubscribed = true))
+        podcastDao.insertBlocking(Podcast(uuid = "id-4", title = "4", isSubscribed = true))
+        podcastDao.insertBlocking(Podcast(uuid = "id-5", title = "the 5", isSubscribed = true))
+        podcastDao.insertBlocking(Podcast(uuid = "id-6", title = "an 6", isSubscribed = true))
+        podcastDao.insertBlocking(Podcast(uuid = "id-7", title = "a 7", isSubscribed = true))
+        podcastDao.insertBlocking(Podcast(uuid = "id-8", title = "8", isSubscribed = true))
 
         val podcastIds = externalDataDao.getSubscribedPodcasts(PodcastsSortType.NAME_A_TO_Z, limit = 100).map { it.id }
 
@@ -216,16 +216,16 @@ class ExternalDataDaoTest {
 
     @Test
     fun sortSubscribedPodcastsBylatestReleaseTimestamp() = runTest {
-        podcastDao.insert(Podcast(uuid = "id-1", title = "title-1", isSubscribed = true))
-        podcastEpisodeDao.insert(PodcastEpisode(uuid = "id-1", publishedDate = Date(0), podcastUuid = "id-1"))
+        podcastDao.insertBlocking(Podcast(uuid = "id-1", title = "title-1", isSubscribed = true))
+        podcastEpisodeDao.insertBlocking(PodcastEpisode(uuid = "id-1", publishedDate = Date(0), podcastUuid = "id-1"))
 
-        podcastDao.insert(Podcast(uuid = "id-2", title = "title-2", isSubscribed = true))
-        podcastEpisodeDao.insert(PodcastEpisode(uuid = "id-2", publishedDate = Date(100), podcastUuid = "id-2"))
+        podcastDao.insertBlocking(Podcast(uuid = "id-2", title = "title-2", isSubscribed = true))
+        podcastEpisodeDao.insertBlocking(PodcastEpisode(uuid = "id-2", publishedDate = Date(100), podcastUuid = "id-2"))
 
-        podcastDao.insert(Podcast(uuid = "id-3", title = "title-3", isSubscribed = true))
+        podcastDao.insertBlocking(Podcast(uuid = "id-3", title = "title-3", isSubscribed = true))
 
-        podcastDao.insert(Podcast(uuid = "id-4", title = "title-4", isSubscribed = true))
-        podcastEpisodeDao.insert(PodcastEpisode(uuid = "id-3", publishedDate = Date(200), podcastUuid = "id-4"))
+        podcastDao.insertBlocking(Podcast(uuid = "id-4", title = "title-4", isSubscribed = true))
+        podcastEpisodeDao.insertBlocking(PodcastEpisode(uuid = "id-3", publishedDate = Date(200), podcastUuid = "id-4"))
 
         val podcastIds = externalDataDao.getSubscribedPodcasts(PodcastsSortType.EPISODE_DATE_NEWEST_TO_OLDEST, limit = 100).map { it.id }
 
@@ -234,10 +234,10 @@ class ExternalDataDaoTest {
 
     @Test
     fun sortSubscribedPodcastsByCustomSortOrder() = runTest {
-        podcastDao.insert(Podcast(uuid = "id-1", title = "title-1", isSubscribed = true, sortPosition = 3))
-        podcastDao.insert(Podcast(uuid = "id-2", title = "title-2", isSubscribed = true, sortPosition = 1))
-        podcastDao.insert(Podcast(uuid = "id-3", title = "title-3", isSubscribed = true, sortPosition = 2))
-        podcastDao.insert(Podcast(uuid = "id-4", title = "title-4", isSubscribed = true, sortPosition = 4))
+        podcastDao.insertBlocking(Podcast(uuid = "id-1", title = "title-1", isSubscribed = true, sortPosition = 3))
+        podcastDao.insertBlocking(Podcast(uuid = "id-2", title = "title-2", isSubscribed = true, sortPosition = 1))
+        podcastDao.insertBlocking(Podcast(uuid = "id-3", title = "title-3", isSubscribed = true, sortPosition = 2))
+        podcastDao.insertBlocking(Podcast(uuid = "id-4", title = "title-4", isSubscribed = true, sortPosition = 4))
 
         val podcastIds = externalDataDao.getSubscribedPodcasts(PodcastsSortType.DRAG_DROP, limit = 100).map { it.id }
 
@@ -247,7 +247,7 @@ class ExternalDataDaoTest {
     @Test
     fun limitSubscribedPodcasts() = runTest {
         List(250) {
-            podcastDao.insert(Podcast(uuid = "id-$it", isSubscribed = true))
+            podcastDao.insertBlocking(Podcast(uuid = "id-$it", isSubscribed = true))
         }
 
         val podcasts = externalDataDao.getSubscribedPodcasts(PodcastsSortType.NAME_A_TO_Z, limit = 60)
@@ -308,8 +308,8 @@ class ExternalDataDaoTest {
             )
         }
         podcastDao.replaceAllCuratedPodcasts(trendingPodcasts)
-        podcastDao.insert(Podcast("id-0", isSubscribed = true))
-        podcastDao.insert(Podcast("id-1", isSubscribed = false))
+        podcastDao.insertBlocking(Podcast("id-0", isSubscribed = true))
+        podcastDao.insertBlocking(Podcast("id-1", isSubscribed = false))
 
         val podcasts = externalDataDao.getCuratedPodcastGroups(limitPerGroup = 100).trendingGroup()?.podcasts
 
@@ -373,8 +373,8 @@ class ExternalDataDaoTest {
             )
         }
         podcastDao.replaceAllCuratedPodcasts(trendingPodcasts)
-        podcastDao.insert(Podcast("id-0", isSubscribed = true))
-        podcastDao.insert(Podcast("id-1", isSubscribed = false))
+        podcastDao.insertBlocking(Podcast("id-0", isSubscribed = true))
+        podcastDao.insertBlocking(Podcast("id-1", isSubscribed = false))
 
         val podcasts = externalDataDao.getCuratedPodcastGroups(limitPerGroup = 100).featuruedGroup()?.podcasts
 
@@ -446,8 +446,8 @@ class ExternalDataDaoTest {
             )
         }
         podcastDao.replaceAllCuratedPodcasts(trendingPodcasts)
-        podcastDao.insert(Podcast("id-0", isSubscribed = true))
-        podcastDao.insert(Podcast("id-1", isSubscribed = false))
+        podcastDao.insertBlocking(Podcast("id-0", isSubscribed = true))
+        podcastDao.insertBlocking(Podcast("id-1", isSubscribed = false))
 
         val podcasts = externalDataDao.getCuratedPodcastGroups(limitPerGroup = 100).genericGroups()["bork"]?.podcasts
 
@@ -572,18 +572,18 @@ class ExternalDataDaoTest {
         val interactionDate1 = Date.from(Instant.now().minus(1, ChronoUnit.DAYS))
         val interactionDate2 = Date.from(Instant.now().minus(2, ChronoUnit.DAYS))
         val interactionDate3 = Date.from(Instant.now().minus(3, ChronoUnit.DAYS))
-        podcastDao.insert(Podcast(uuid = "id-1", title = "title-1", isSubscribed = true))
-        podcastEpisodeDao.insert(PodcastEpisode(uuid = "id-1", publishedDate = Date(0), podcastUuid = "id-1", lastPlaybackInteraction = interactionDate1.time))
-        podcastEpisodeDao.insert(PodcastEpisode(uuid = "id-2", publishedDate = Date(2), podcastUuid = "id-1", lastPlaybackInteraction = null))
-        podcastEpisodeDao.insert(PodcastEpisode(uuid = "id-3", publishedDate = Date(1), podcastUuid = "id-1", lastPlaybackInteraction = 13000))
+        podcastDao.insertBlocking(Podcast(uuid = "id-1", title = "title-1", isSubscribed = true))
+        podcastEpisodeDao.insertBlocking(PodcastEpisode(uuid = "id-1", publishedDate = Date(0), podcastUuid = "id-1", lastPlaybackInteraction = interactionDate1.time))
+        podcastEpisodeDao.insertBlocking(PodcastEpisode(uuid = "id-2", publishedDate = Date(2), podcastUuid = "id-1", lastPlaybackInteraction = null))
+        podcastEpisodeDao.insertBlocking(PodcastEpisode(uuid = "id-3", publishedDate = Date(1), podcastUuid = "id-1", lastPlaybackInteraction = 13000))
 
-        podcastDao.insert(Podcast(uuid = "id-2", title = "title-2", isSubscribed = false))
-        podcastEpisodeDao.insert(PodcastEpisode(uuid = "id-4", publishedDate = Date(5), podcastUuid = "id-2", lastPlaybackInteraction = 0))
-        podcastEpisodeDao.insert(PodcastEpisode(uuid = "id-5", publishedDate = Date(4), podcastUuid = "id-2", lastPlaybackInteraction = 20))
-        podcastEpisodeDao.insert(PodcastEpisode(uuid = "id-6", publishedDate = Date(3), podcastUuid = "id-2", lastPlaybackInteraction = interactionDate2.time))
+        podcastDao.insertBlocking(Podcast(uuid = "id-2", title = "title-2", isSubscribed = false))
+        podcastEpisodeDao.insertBlocking(PodcastEpisode(uuid = "id-4", publishedDate = Date(5), podcastUuid = "id-2", lastPlaybackInteraction = 0))
+        podcastEpisodeDao.insertBlocking(PodcastEpisode(uuid = "id-5", publishedDate = Date(4), podcastUuid = "id-2", lastPlaybackInteraction = 20))
+        podcastEpisodeDao.insertBlocking(PodcastEpisode(uuid = "id-6", publishedDate = Date(3), podcastUuid = "id-2", lastPlaybackInteraction = interactionDate2.time))
 
-        podcastDao.insert(Podcast(uuid = "id-3", title = "title-3", isSubscribed = true))
-        podcastEpisodeDao.insert(PodcastEpisode(uuid = "id-7", publishedDate = Date(12), podcastUuid = "id-3", lastPlaybackInteraction = interactionDate3.time))
+        podcastDao.insertBlocking(Podcast(uuid = "id-3", title = "title-3", isSubscribed = true))
+        podcastEpisodeDao.insertBlocking(PodcastEpisode(uuid = "id-7", publishedDate = Date(12), podcastUuid = "id-3", lastPlaybackInteraction = interactionDate3.time))
 
         val podcasts = externalDataDao.getRecentlyPlayedPodcasts(limit = 100)
 
@@ -625,13 +625,13 @@ class ExternalDataDaoTest {
     @Test
     fun includeOnlyInteractedWithPodcastsForRecentlyPlayedPodcasts() = runTest {
         val interactionDate = Date()
-        podcastDao.insert(Podcast(uuid = "id-1", title = "title-1"))
-        podcastEpisodeDao.insert(PodcastEpisode(uuid = "id-1", publishedDate = Date(0), podcastUuid = "id-1", lastPlaybackInteraction = interactionDate.time))
+        podcastDao.insertBlocking(Podcast(uuid = "id-1", title = "title-1"))
+        podcastEpisodeDao.insertBlocking(PodcastEpisode(uuid = "id-1", publishedDate = Date(0), podcastUuid = "id-1", lastPlaybackInteraction = interactionDate.time))
 
-        podcastDao.insert(Podcast(uuid = "id-2", title = "title-2"))
-        podcastEpisodeDao.insert(PodcastEpisode(uuid = "id-2", publishedDate = Date(0), podcastUuid = "id-2", lastPlaybackInteraction = null))
+        podcastDao.insertBlocking(Podcast(uuid = "id-2", title = "title-2"))
+        podcastEpisodeDao.insertBlocking(PodcastEpisode(uuid = "id-2", publishedDate = Date(0), podcastUuid = "id-2", lastPlaybackInteraction = null))
 
-        podcastDao.insert(Podcast(uuid = "id-3", title = "title-3"))
+        podcastDao.insertBlocking(Podcast(uuid = "id-3", title = "title-3"))
 
         val podcasts = externalDataDao.getRecentlyPlayedPodcasts(limit = 100)
 
@@ -655,14 +655,14 @@ class ExternalDataDaoTest {
         val interactionDate1 = Date.from(Instant.now().minus(3, ChronoUnit.DAYS))
         val interactionDate2 = Date.from(Instant.now().minus(1, ChronoUnit.DAYS))
         val interactionDate3 = Date.from(Instant.now().minus(2, ChronoUnit.DAYS))
-        podcastDao.insert(Podcast(uuid = "id-1", title = "title-1"))
-        podcastEpisodeDao.insert(PodcastEpisode(uuid = "id-1", publishedDate = Date(0), podcastUuid = "id-1", lastPlaybackInteraction = interactionDate1.time))
+        podcastDao.insertBlocking(Podcast(uuid = "id-1", title = "title-1"))
+        podcastEpisodeDao.insertBlocking(PodcastEpisode(uuid = "id-1", publishedDate = Date(0), podcastUuid = "id-1", lastPlaybackInteraction = interactionDate1.time))
 
-        podcastDao.insert(Podcast(uuid = "id-2", title = "title-2"))
-        podcastEpisodeDao.insert(PodcastEpisode(uuid = "id-2", publishedDate = Date(0), podcastUuid = "id-2", lastPlaybackInteraction = interactionDate2.time))
+        podcastDao.insertBlocking(Podcast(uuid = "id-2", title = "title-2"))
+        podcastEpisodeDao.insertBlocking(PodcastEpisode(uuid = "id-2", publishedDate = Date(0), podcastUuid = "id-2", lastPlaybackInteraction = interactionDate2.time))
 
-        podcastDao.insert(Podcast(uuid = "id-3", title = "title-3"))
-        podcastEpisodeDao.insert(PodcastEpisode(uuid = "id-3", publishedDate = Date(0), podcastUuid = "id-3", lastPlaybackInteraction = interactionDate3.time))
+        podcastDao.insertBlocking(Podcast(uuid = "id-3", title = "title-3"))
+        podcastEpisodeDao.insertBlocking(PodcastEpisode(uuid = "id-3", publishedDate = Date(0), podcastUuid = "id-3", lastPlaybackInteraction = interactionDate3.time))
 
         val podcasts = externalDataDao.getRecentlyPlayedPodcasts(limit = 100)
 
@@ -704,8 +704,8 @@ class ExternalDataDaoTest {
     @Test
     fun limitRecentlyPlayedPodcasts() = runTest {
         List(250) {
-            podcastDao.insert(Podcast(uuid = "id-$it"))
-            podcastEpisodeDao.insert(PodcastEpisode(uuid = "id-$it", podcastUuid = "id-$it", publishedDate = Date(), lastPlaybackInteraction = Date().time))
+            podcastDao.insertBlocking(Podcast(uuid = "id-$it"))
+            podcastEpisodeDao.insertBlocking(PodcastEpisode(uuid = "id-$it", podcastUuid = "id-$it", publishedDate = Date(), lastPlaybackInteraction = Date().time))
         }
 
         val podcasts = externalDataDao.getRecentlyPlayedPodcasts(limit = 100)
@@ -717,11 +717,11 @@ class ExternalDataDaoTest {
     fun ignoreRecentlyPlayedPodcastsThatAreAtLeast60DaysOld() = runTest {
         val interactionDate1 = Date.from(Instant.now().minus(61, ChronoUnit.DAYS))
         val interactionDate2 = Date.from(Instant.now().minus(59, ChronoUnit.DAYS))
-        podcastDao.insert(Podcast(uuid = "id-1", title = "title-1", isSubscribed = true))
-        podcastEpisodeDao.insert(PodcastEpisode(uuid = "id-1", publishedDate = Date(0), podcastUuid = "id-1", lastPlaybackInteraction = interactionDate1.time))
+        podcastDao.insertBlocking(Podcast(uuid = "id-1", title = "title-1", isSubscribed = true))
+        podcastEpisodeDao.insertBlocking(PodcastEpisode(uuid = "id-1", publishedDate = Date(0), podcastUuid = "id-1", lastPlaybackInteraction = interactionDate1.time))
 
-        podcastDao.insert(Podcast(uuid = "id-2", title = "title-2", isSubscribed = false))
-        podcastEpisodeDao.insert(PodcastEpisode(uuid = "id-2", publishedDate = Date(0), podcastUuid = "id-2", lastPlaybackInteraction = interactionDate2.time))
+        podcastDao.insertBlocking(Podcast(uuid = "id-2", title = "title-2", isSubscribed = false))
+        podcastEpisodeDao.insertBlocking(PodcastEpisode(uuid = "id-2", publishedDate = Date(0), podcastUuid = "id-2", lastPlaybackInteraction = interactionDate2.time))
 
         val podcasts = externalDataDao.getRecentlyPlayedPodcasts(limit = 100)
 
@@ -743,8 +743,8 @@ class ExternalDataDaoTest {
     @Test
     fun includeCategoriesForRecentlyPlayedPodcasts() = runTest {
         val interactionDate1 = Date.from(Instant.now().minus(1, ChronoUnit.DAYS))
-        podcastDao.insert(Podcast(uuid = "id-1", title = "title-1", podcastCategory = "category1"))
-        podcastEpisodeDao.insert(PodcastEpisode(uuid = "id-1", publishedDate = Date(0), podcastUuid = "id-1", lastPlaybackInteraction = interactionDate1.time))
+        podcastDao.insertBlocking(Podcast(uuid = "id-1", title = "title-1", podcastCategory = "category1"))
+        podcastEpisodeDao.insertBlocking(PodcastEpisode(uuid = "id-1", publishedDate = Date(0), podcastUuid = "id-1", lastPlaybackInteraction = interactionDate1.time))
 
         val podcasts = externalDataDao.getRecentlyPlayedPodcasts(limit = 100)
 
@@ -806,9 +806,9 @@ class ExternalDataDaoTest {
                 episodeStatus = EpisodeStatusEnum.DOWNLOADED,
             ),
         )
-        podcastEpisodeDao.insertAll(episodes)
-        podcastDao.insert(Podcast(uuid = "p-id-1", title = "p-title-1", isSubscribed = true))
-        podcastDao.insert(Podcast(uuid = "p-id-2", title = "p-title-2", isSubscribed = true))
+        podcastEpisodeDao.insertAllBlocking(episodes)
+        podcastDao.insertBlocking(Podcast(uuid = "p-id-1", title = "p-title-1", isSubscribed = true))
+        podcastDao.insertBlocking(Podcast(uuid = "p-id-2", title = "p-title-2", isSubscribed = true))
 
         val newEpisodes = externalDataDao.getNewEpisodes(limit = 100)
 
@@ -879,8 +879,8 @@ class ExternalDataDaoTest {
                 publishedDate = publishedDate3,
             ),
         )
-        podcastEpisodeDao.insertAll(episodes)
-        podcastDao.insert(Podcast(uuid = "", isSubscribed = true))
+        podcastEpisodeDao.insertAllBlocking(episodes)
+        podcastDao.insertBlocking(Podcast(uuid = "", isSubscribed = true))
 
         val newEpisodes = externalDataDao.getNewEpisodes(limit = 100)
 
@@ -939,8 +939,8 @@ class ExternalDataDaoTest {
                 publishedDate = Date(),
             )
         }
-        podcastEpisodeDao.insertAll(episodes)
-        podcastDao.insert(Podcast(uuid = "", isSubscribed = true))
+        podcastEpisodeDao.insertAllBlocking(episodes)
+        podcastDao.insertBlocking(Podcast(uuid = "", isSubscribed = true))
 
         val newEpisodes = externalDataDao.getNewEpisodes(limit = 75)
 
@@ -962,8 +962,8 @@ class ExternalDataDaoTest {
                 publishedDate = publishedDate,
             ),
         )
-        podcastEpisodeDao.insertAll(episodes)
-        podcastDao.insert(Podcast(uuid = "", isSubscribed = true))
+        podcastEpisodeDao.insertAllBlocking(episodes)
+        podcastDao.insertBlocking(Podcast(uuid = "", isSubscribed = true))
 
         val newEpisodes = externalDataDao.getNewEpisodes(limit = 100)
 
@@ -1006,8 +1006,8 @@ class ExternalDataDaoTest {
                 publishedDate = publishedDate,
             ),
         )
-        podcastEpisodeDao.insertAll(episodes)
-        podcastDao.insert(Podcast(uuid = "", isSubscribed = true))
+        podcastEpisodeDao.insertAllBlocking(episodes)
+        podcastDao.insertBlocking(Podcast(uuid = "", isSubscribed = true))
 
         val newEpisodes = externalDataDao.getNewEpisodes(limit = 100)
 
@@ -1044,8 +1044,8 @@ class ExternalDataDaoTest {
                 publishedDate = publishedDate2,
             ),
         )
-        podcastEpisodeDao.insertAll(episodes)
-        podcastDao.insert(Podcast(uuid = "", isSubscribed = true))
+        podcastEpisodeDao.insertAllBlocking(episodes)
+        podcastDao.insertBlocking(Podcast(uuid = "", isSubscribed = true))
 
         val newEpisodes = externalDataDao.getNewEpisodes(limit = 100)
 
@@ -1083,9 +1083,9 @@ class ExternalDataDaoTest {
                 publishedDate = publishedDate,
             ),
         )
-        podcastEpisodeDao.insertAll(episodes)
-        podcastDao.insert(Podcast(uuid = "p-id-1", isSubscribed = true))
-        podcastDao.insert(Podcast(uuid = "p-id-2", isSubscribed = false))
+        podcastEpisodeDao.insertAllBlocking(episodes)
+        podcastDao.insertBlocking(Podcast(uuid = "p-id-1", isSubscribed = true))
+        podcastDao.insertBlocking(Podcast(uuid = "p-id-2", isSubscribed = false))
 
         val newEpisodes = externalDataDao.getNewEpisodes(limit = 100)
 
@@ -1150,9 +1150,9 @@ class ExternalDataDaoTest {
                 fileType = "video/",
             ),
         )
-        podcastEpisodeDao.insertAll(episodes)
-        podcastDao.insert(Podcast(uuid = "p-id-1", title = "p-title-1"))
-        podcastDao.insert(Podcast(uuid = "p-id-2", title = "p-title-2"))
+        podcastEpisodeDao.insertAllBlocking(episodes)
+        podcastDao.insertBlocking(Podcast(uuid = "p-id-1", title = "p-title-1"))
+        podcastDao.insertBlocking(Podcast(uuid = "p-id-2", title = "p-title-2"))
 
         val inProgressEpisodes = externalDataDao.getInProgressEpisodes(limit = 100, currentTime = 0)
 
@@ -1225,8 +1225,8 @@ class ExternalDataDaoTest {
                 lastPlaybackInteraction = 3,
             ),
         )
-        podcastEpisodeDao.insertAll(episodes)
-        podcastDao.insert(Podcast())
+        podcastEpisodeDao.insertAllBlocking(episodes)
+        podcastDao.insertBlocking(Podcast())
 
         val inProgressEpisodes = externalDataDao.getInProgressEpisodes(limit = 100, currentTime = 0)
 
@@ -1286,8 +1286,8 @@ class ExternalDataDaoTest {
                 playingStatus = EpisodePlayingStatus.IN_PROGRESS,
             )
         }
-        podcastEpisodeDao.insertAll(episodes)
-        podcastDao.insert(Podcast())
+        podcastEpisodeDao.insertAllBlocking(episodes)
+        podcastDao.insertBlocking(Podcast())
 
         val inProgressEpisodes = externalDataDao.getInProgressEpisodes(limit = 20, currentTime = 0)
 
@@ -1310,8 +1310,8 @@ class ExternalDataDaoTest {
                 playingStatus = EpisodePlayingStatus.IN_PROGRESS,
             ),
         )
-        podcastEpisodeDao.insertAll(episodes)
-        podcastDao.insert(Podcast())
+        podcastEpisodeDao.insertAllBlocking(episodes)
+        podcastDao.insertBlocking(Podcast())
 
         val inProgressEpisodes = externalDataDao.getInProgressEpisodes(limit = 100, currentTime = 0)
 
@@ -1353,8 +1353,8 @@ class ExternalDataDaoTest {
                 playingStatus = EpisodePlayingStatus.COMPLETED,
             ),
         )
-        podcastEpisodeDao.insertAll(episodes)
-        podcastDao.insert(Podcast())
+        podcastEpisodeDao.insertAllBlocking(episodes)
+        podcastDao.insertBlocking(Podcast())
 
         val inProgressEpisodes = externalDataDao.getInProgressEpisodes(limit = 100, currentTime = 0)
 
@@ -1392,9 +1392,9 @@ class ExternalDataDaoTest {
             fileType = "video/*",
             episodeStatus = EpisodeStatusEnum.DOWNLOADED,
         )
-        podcastEpisodeDao.insert(podcastEpisode)
-        upNextDao.insert(UpNextEpisode(episodeUuid = "id-1"))
-        podcastDao.insert(Podcast(uuid = "p-id-1", title = "p-title-1", isSubscribed = true))
+        podcastEpisodeDao.insertBlocking(podcastEpisode)
+        upNextDao.insertBlocking(UpNextEpisode(episodeUuid = "id-1"))
+        podcastDao.insertBlocking(Podcast(uuid = "p-id-1", title = "p-title-1", isSubscribed = true))
 
         val episodes = externalDataDao.observeUpNextQueue(limit = 100).first()
 
@@ -1431,7 +1431,7 @@ class ExternalDataDaoTest {
             episodeStatus = EpisodeStatusEnum.DOWNLOADED,
         )
         userEpisodeDao.insert(userEpisode)
-        upNextDao.insert(UpNextEpisode(episodeUuid = "id-1"))
+        upNextDao.insertBlocking(UpNextEpisode(episodeUuid = "id-1"))
 
         val episodes = externalDataDao.observeUpNextQueue(limit = 100).first()
 
@@ -1453,13 +1453,13 @@ class ExternalDataDaoTest {
 
     @Test
     fun getUpNextEpisodesInCorrectOrder() = runTest {
-        podcastEpisodeDao.insert(PodcastEpisode(uuid = "id-1", publishedDate = Date()))
-        podcastEpisodeDao.insert(PodcastEpisode(uuid = "id-2", publishedDate = Date()))
-        podcastEpisodeDao.insert(PodcastEpisode(uuid = "id-3", publishedDate = Date()))
+        podcastEpisodeDao.insertBlocking(PodcastEpisode(uuid = "id-1", publishedDate = Date()))
+        podcastEpisodeDao.insertBlocking(PodcastEpisode(uuid = "id-2", publishedDate = Date()))
+        podcastEpisodeDao.insertBlocking(PodcastEpisode(uuid = "id-3", publishedDate = Date()))
         userEpisodeDao.insert(UserEpisode(uuid = "id-4", publishedDate = Date()))
         userEpisodeDao.insert(UserEpisode(uuid = "id-5", publishedDate = Date()))
-        podcastDao.insert(Podcast())
-        upNextDao.insertAll(
+        podcastDao.insertBlocking(Podcast())
+        upNextDao.insertAllBlocking(
             listOf(
                 UpNextEpisode(episodeUuid = "id-1", position = 0),
                 UpNextEpisode(episodeUuid = "id-2", position = 4),
@@ -1476,11 +1476,11 @@ class ExternalDataDaoTest {
 
     @Test
     fun ignoreUnknnownUpNextEpisodes() = runTest {
-        podcastEpisodeDao.insert(PodcastEpisode(uuid = "id-1", publishedDate = Date()))
-        podcastEpisodeDao.insert(PodcastEpisode(uuid = "id-3", publishedDate = Date()))
+        podcastEpisodeDao.insertBlocking(PodcastEpisode(uuid = "id-1", publishedDate = Date()))
+        podcastEpisodeDao.insertBlocking(PodcastEpisode(uuid = "id-3", publishedDate = Date()))
         userEpisodeDao.insert(UserEpisode(uuid = "id-5", publishedDate = Date()))
-        podcastDao.insert(Podcast())
-        upNextDao.insertAll(
+        podcastDao.insertBlocking(Podcast())
+        upNextDao.insertAllBlocking(
             listOf(
                 UpNextEpisode(episodeUuid = "id-1", position = 0),
                 UpNextEpisode(episodeUuid = "id-2", position = 1),
@@ -1498,9 +1498,9 @@ class ExternalDataDaoTest {
     @Test
     fun limitUpNextEpisodes() = runTest {
         val podcastEpisodes = List(30) { PodcastEpisode(uuid = "id-$it", publishedDate = Date()) }
-        podcastEpisodeDao.insertAll(podcastEpisodes)
-        podcastDao.insert(Podcast())
-        upNextDao.insertAll(podcastEpisodes.mapIndexed { index, episode -> UpNextEpisode(episodeUuid = episode.uuid, position = index) })
+        podcastEpisodeDao.insertAllBlocking(podcastEpisodes)
+        podcastDao.insertBlocking(Podcast())
+        upNextDao.insertAllBlocking(podcastEpisodes.mapIndexed { index, episode -> UpNextEpisode(episodeUuid = episode.uuid, position = index) })
 
         val episodes = externalDataDao.observeUpNextQueue(limit = 8).first()
 

--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/models/db/FolderDaoTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/models/db/FolderDaoTest.kt
@@ -103,7 +103,7 @@ class FolderDaoTest {
     @Test
     fun updateAllSyncedShouldUpdateTheSynModifiedFieldOfAllFolders() = runTest {
         folderDao.insert(fakeFolder)
-        folderDao.updateAllSynced()
+        folderDao.updateAllSyncedBlocking()
         val updatedFolder = folderDao.findFolders()
         assertTrue(updatedFolder.all { it.syncModified == 0L })
     }

--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/models/db/PodcastDaoTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/models/db/PodcastDaoTest.kt
@@ -44,59 +44,59 @@ class PodcastDaoTest {
     @Test
     fun testInsertPodcast() {
         val uuid = UUID.randomUUID().toString()
-        podcastDao.insert(Podcast(uuid = uuid, isSubscribed = true))
-        assertNotNull("Inserted podcast should be able to be found", podcastDao.findByUuid(uuid))
+        podcastDao.insertBlocking(Podcast(uuid = uuid, isSubscribed = true))
+        assertNotNull("Inserted podcast should be able to be found", podcastDao.findByUuidBlocking(uuid))
     }
 
     @Test
     fun testInsertPodcastRx() {
         val uuid = UUID.randomUUID().toString()
-        podcastDao.insertRx(Podcast(uuid = uuid)).blockingGet()
-        assertNotNull("Inserted podcast should be able to be found", podcastDao.findByUuid(uuid))
+        podcastDao.insertRxSingle(Podcast(uuid = uuid)).blockingGet()
+        assertNotNull("Inserted podcast should be able to be found", podcastDao.findByUuidBlocking(uuid))
     }
 
     @Test
     fun testInsertMultiple() {
         val uuid = UUID.randomUUID().toString()
         val podcast = Podcast(uuid = uuid, isSubscribed = false)
-        podcastDao.insert(podcast)
+        podcastDao.insertBlocking(podcast)
         val podcast2 = Podcast(uuid = uuid, isSubscribed = true)
-        podcastDao.insert(podcast2)
+        podcastDao.insertBlocking(podcast2)
 
-        assertEquals("Insert should replace, count should be 1", 1, podcastDao.countByUuid(uuid))
-        assertEquals("Podcast should be replaced, should be subscribed", true, podcastDao.findByUuid(uuid)?.isSubscribed)
+        assertEquals("Insert should replace, count should be 1", 1, podcastDao.countByUuidBlocking(uuid))
+        assertEquals("Podcast should be replaced, should be subscribed", true, podcastDao.findByUuidBlocking(uuid)?.isSubscribed)
     }
 
     @Test
     fun testUpdatePodcast() {
         val uuid = UUID.randomUUID().toString()
         val podcast = Podcast(uuid = uuid, isSubscribed = false)
-        podcastDao.insert(podcast)
-        assert(podcastDao.findByUuid(uuid)?.isSubscribed == false)
+        podcastDao.insertBlocking(podcast)
+        assert(podcastDao.findByUuidBlocking(uuid)?.isSubscribed == false)
         podcast.isSubscribed = true
-        podcastDao.update(podcast)
-        assertTrue("Podcast should be updated to subscribed", podcastDao.findByUuid(uuid)?.isSubscribed == true)
+        podcastDao.updateBlocking(podcast)
+        assertTrue("Podcast should be updated to subscribed", podcastDao.findByUuidBlocking(uuid)?.isSubscribed == true)
     }
 
     @Test
     fun testUpdatePodcastRx() {
         val uuid = UUID.randomUUID().toString()
         val podcast = Podcast(uuid = uuid, isSubscribed = false)
-        podcastDao.insert(podcast)
-        assert(podcastDao.findByUuid(uuid)?.isSubscribed == false)
+        podcastDao.insertBlocking(podcast)
+        assert(podcastDao.findByUuidBlocking(uuid)?.isSubscribed == false)
         podcast.isSubscribed = true
-        podcastDao.updateRx(podcast).blockingAwait()
-        assertTrue("Podcast should be updated to subscribed", podcastDao.findByUuid(uuid)?.isSubscribed == true)
+        podcastDao.updateRxCompletable(podcast).blockingAwait()
+        assertTrue("Podcast should be updated to subscribed", podcastDao.findByUuidBlocking(uuid)?.isSubscribed == true)
     }
 
     @Test
     fun testFindSubscribed() {
         val subscribed = Podcast(uuid = UUID.randomUUID().toString(), isSubscribed = true)
         val unsubscribed = Podcast(uuid = UUID.randomUUID().toString(), isSubscribed = false)
-        podcastDao.insert(subscribed)
-        podcastDao.insert(unsubscribed)
+        podcastDao.insertBlocking(subscribed)
+        podcastDao.insertBlocking(unsubscribed)
 
-        val subscribedList = podcastDao.findSubscribed()
+        val subscribedList = podcastDao.findSubscribedBlocking()
         assertEquals("Should only be 1 result", 1, subscribedList.count())
         assertEquals("Should only find the subscribed podcast", subscribed.uuid, subscribedList.first().uuid)
     }
@@ -105,10 +105,10 @@ class PodcastDaoTest {
     fun testFindSubscribedRx() {
         val subscribed = Podcast(uuid = UUID.randomUUID().toString(), isSubscribed = true)
         val unsubscribed = Podcast(uuid = UUID.randomUUID().toString(), isSubscribed = false)
-        podcastDao.insert(subscribed)
-        podcastDao.insert(unsubscribed)
+        podcastDao.insertBlocking(subscribed)
+        podcastDao.insertBlocking(unsubscribed)
 
-        val subscribedList = podcastDao.findSubscribedRx().blockingGet()
+        val subscribedList = podcastDao.findSubscribedRxSingle().blockingGet()
         assertEquals("Should only be 1 result", 1, subscribedList.count())
         assertEquals("Should only find the subscribed podcast", subscribed.uuid, subscribedList.first().uuid)
     }

--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/models/db/PodcastManagerTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/models/db/PodcastManagerTest.kt
@@ -117,7 +117,7 @@ class PodcastManagerTest {
 
     @Test
     fun testSubscribeToExistingPodcast() {
-        podcastDao.insert(Podcast(uuid, isSubscribed = true))
+        podcastDao.insertBlocking(Podcast(uuid, isSubscribed = true))
         podcastManagerSignedOut.subscribeToPodcastRx(uuid, sync = false).blockingGet()
         val subscribedList = podcastManagerSignedOut.getSubscribedPodcastUuids().blockingGet()
         assertTrue("Podcast uuid should be subscribed", subscribedList.contains(uuid))
@@ -133,18 +133,18 @@ class PodcastManagerTest {
     @Test
     fun testUnsubscribeSignedOut() {
         val playbackManager = mock<PlaybackManager> {}
-        podcastDao.insert(Podcast(uuid, isSubscribed = true))
+        podcastDao.insertBlocking(Podcast(uuid, isSubscribed = true))
         podcastManagerSignedOut.unsubscribe(uuid, playbackManager)
-        val daoPodcast = podcastDao.findByUuid(uuid)
+        val daoPodcast = podcastDao.findByUuidBlocking(uuid)
         assertTrue("Podcast should be null", daoPodcast == null)
     }
 
     @Test
     fun testUnsubscribeSignedIn() {
         val playbackManager = mock<PlaybackManager> {}
-        podcastDao.insert(Podcast(uuid, isSubscribed = true))
+        podcastDao.insertBlocking(Podcast(uuid, isSubscribed = true))
         podcastManagerSignedIn.unsubscribe(uuid, playbackManager)
-        val daoPodcast = podcastDao.findByUuid(uuid)
+        val daoPodcast = podcastDao.findByUuidBlocking(uuid)
         assertTrue("Podcast should be unsubscribed", daoPodcast?.isSubscribed == false)
     }
 }

--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/models/db/UpNextQueueTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/models/db/UpNextQueueTest.kt
@@ -48,7 +48,7 @@ class UpNextQueueTest {
         val syncManager = mock<SyncManager> {}
 
         upNextQueue = UpNextQueueImpl(appDatabase, settings, episodeManager, syncManager, context)
-        upNextQueue.setup()
+        upNextQueue.setupBlocking()
     }
 
     @Test
@@ -60,8 +60,8 @@ class UpNextQueueTest {
                 val uuid = UUID.randomUUID().toString()
                 val episode = PodcastEpisode(uuid = uuid, publishedDate = Date())
                 uuids.add(uuid)
-                appDatabase.episodeDao().insert(episode)
-                upNextQueue.playNext(episode, downloadManager, null)
+                appDatabase.episodeDao().insertBlocking(episode)
+                upNextQueue.playNextBlocking(episode, downloadManager, null)
             }
         }
 
@@ -79,7 +79,7 @@ class UpNextQueueTest {
             for (i in 0..25) {
                 val uuid = UUID.randomUUID().toString()
                 val episode = PodcastEpisode(uuid = uuid, publishedDate = Date())
-                appDatabase.episodeDao().insert(episode)
+                appDatabase.episodeDao().insertBlocking(episode)
                 episodes.add(episode)
             }
 
@@ -101,8 +101,8 @@ class UpNextQueueTest {
                 val uuid = UUID.randomUUID().toString()
                 val episode = PodcastEpisode(uuid = uuid, publishedDate = Date())
                 uuids.add(uuid)
-                appDatabase.episodeDao().insert(episode)
-                upNextQueue.playLast(episode, downloadManager, null)
+                appDatabase.episodeDao().insertBlocking(episode)
+                upNextQueue.playLastBlocking(episode, downloadManager, null)
             }
         }
 
@@ -120,7 +120,7 @@ class UpNextQueueTest {
             for (i in 0..5) {
                 val uuid = UUID.randomUUID().toString()
                 val episode = PodcastEpisode(uuid = uuid, publishedDate = Date())
-                appDatabase.episodeDao().insert(episode)
+                appDatabase.episodeDao().insertBlocking(episode)
                 episodes.add(episode)
             }
 
@@ -142,8 +142,8 @@ class UpNextQueueTest {
                 val uuid = UUID.randomUUID().toString()
                 val episode = PodcastEpisode(uuid = uuid, publishedDate = Date())
                 uuids.add(uuid)
-                appDatabase.episodeDao().insert(episode)
-                upNextQueue.playLast(episode, downloadManager, null)
+                appDatabase.episodeDao().insertBlocking(episode)
+                upNextQueue.playLastBlocking(episode, downloadManager, null)
             }
         }
 
@@ -169,8 +169,8 @@ class UpNextQueueTest {
                 val uuid = UUID.randomUUID().toString()
                 val episode = PodcastEpisode(uuid = uuid, publishedDate = Date())
                 uuids.add(uuid)
-                appDatabase.episodeDao().insert(episode)
-                upNextQueue.playLast(episode, downloadManager, null)
+                appDatabase.episodeDao().insertBlocking(episode)
+                upNextQueue.playLastBlocking(episode, downloadManager, null)
             }
         }
 
@@ -187,8 +187,8 @@ class UpNextQueueTest {
         val playLastEpisode = PodcastEpisode(uuid = lastUuid, publishedDate = Date())
         runBlocking {
             upNextQueue.removeEpisode(newCurrentEpisode!!)
-            appDatabase.episodeDao().insert(playLastEpisode)
-            upNextQueue.playLast(playLastEpisode, downloadManager, null)
+            appDatabase.episodeDao().insertBlocking(playLastEpisode)
+            upNextQueue.playLastBlocking(playLastEpisode, downloadManager, null)
         }
 
         val queue = upNextQueue.queueEpisodes
@@ -204,8 +204,8 @@ class UpNextQueueTest {
                 val uuid = UUID.randomUUID().toString()
                 val episode = PodcastEpisode(uuid = uuid, publishedDate = Date())
                 uuids.add(uuid)
-                appDatabase.episodeDao().insert(episode)
-                upNextQueue.playLast(episode, downloadManager, null)
+                appDatabase.episodeDao().insertBlocking(episode)
+                upNextQueue.playLastBlocking(episode, downloadManager, null)
             }
         }
 
@@ -222,8 +222,8 @@ class UpNextQueueTest {
         val playLastEpisode = PodcastEpisode(uuid = nextUuid, publishedDate = Date())
         runBlocking {
             upNextQueue.removeEpisode(newCurrentEpisode!!)
-            appDatabase.episodeDao().insert(playLastEpisode)
-            upNextQueue.playNext(playLastEpisode, downloadManager, null)
+            appDatabase.episodeDao().insertBlocking(playLastEpisode)
+            upNextQueue.playNextBlocking(playLastEpisode, downloadManager, null)
         }
 
         val queue = upNextQueue.queueEpisodes
@@ -239,8 +239,8 @@ class UpNextQueueTest {
                 val uuid = UUID.randomUUID().toString()
                 val episode = PodcastEpisode(uuid = uuid, publishedDate = Date())
                 uuids.add(uuid)
-                appDatabase.episodeDao().insert(episode)
-                upNextQueue.playLast(episode, downloadManager, null)
+                appDatabase.episodeDao().insertBlocking(episode)
+                upNextQueue.playLastBlocking(episode, downloadManager, null)
             }
 
             upNextQueue.clearUpNext()
@@ -262,8 +262,8 @@ class UpNextQueueTest {
                 val episode = PodcastEpisode(uuid = uuid, publishedDate = Date())
                 uuids.add(uuid)
                 episodes.add(episode)
-                appDatabase.episodeDao().insert(episode)
-                upNextQueue.playLast(episode, downloadManager, null)
+                appDatabase.episodeDao().insertBlocking(episode)
+                upNextQueue.playLastBlocking(episode, downloadManager, null)
             }
 
             val initialEpisode = upNextQueue.currentEpisode

--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/repositories/bookmark/BookmarkManagerTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/repositories/bookmark/BookmarkManagerTest.kt
@@ -52,7 +52,7 @@ class BookmarkManagerTest {
         val episodeUuid = UUID.randomUUID().toString()
         val podcastUuid = UUID.randomUUID().toString()
         val episode = PodcastEpisode(uuid = episodeUuid, podcastUuid = podcastUuid, publishedDate = Date())
-        episodeDao.insert(episode)
+        episodeDao.insertBlocking(episode)
 
         runTest {
             val bookmark = bookmarkManager.add(episode = episode, timeSecs = 61, title = "Bookmark Title", BookmarkManager.CreationSource.PLAYER)
@@ -76,7 +76,7 @@ class BookmarkManagerTest {
         val episodeUuid = UUID.randomUUID().toString()
         val podcastUuid = UUID.randomUUID().toString()
         val episode = PodcastEpisode(uuid = episodeUuid, podcastUuid = podcastUuid, publishedDate = Date())
-        episodeDao.insert(episode)
+        episodeDao.insertBlocking(episode)
 
         runTest {
             val bookmarkOne = bookmarkManager.add(episode = episode, timeSecs = 20, title = "", creationSource = BookmarkManager.CreationSource.PLAYER)

--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/repositories/download/UpdateEpisodeDetailsTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/repositories/download/UpdateEpisodeDetailsTest.kt
@@ -80,7 +80,7 @@ class UpdateEpisodeDetailsTest {
             val thirdRequest = server.takeRequest(1, TimeUnit.MILLISECONDS)
             assertNull("There shouldn't be a third request", thirdRequest)
 
-            verify(episodeManager, times(1)).updateSizeInBytes(episode, testFileSize)
+            verify(episodeManager, times(1)).updateSizeInBytesBlocking(episode, testFileSize)
         }
     }
 

--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/repositories/endofyear/EndOfYearManagerTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/repositories/endofyear/EndOfYearManagerTest.kt
@@ -94,7 +94,7 @@ class EndOfYearManagerTest {
 
     @Test
     fun getPlayedEpisodeCount() = runTest {
-        episodeDao.insertAll(
+        episodeDao.insertAllBlocking(
             listOf(
                 PodcastEpisode(
                     uuid = "id-1",
@@ -116,7 +116,7 @@ class EndOfYearManagerTest {
 
     @Test
     fun doNotCountOurOfRangeEpisodesForPlayedEpisodeCount() = runTest {
-        episodeDao.insertAll(
+        episodeDao.insertAllBlocking(
             listOf(
                 PodcastEpisode(
                     uuid = "id-1",
@@ -143,7 +143,7 @@ class EndOfYearManagerTest {
 
     @Test
     fun getCompletedEpisodeCount() = runTest {
-        episodeDao.insertAll(
+        episodeDao.insertAllBlocking(
             listOf(
                 PodcastEpisode(
                     uuid = "id-1",
@@ -167,7 +167,7 @@ class EndOfYearManagerTest {
 
     @Test
     fun doNotCountOurOfRangeEpisodesForCompletedEpisodeCount() = runTest {
-        episodeDao.insertAll(
+        episodeDao.insertAllBlocking(
             listOf(
                 PodcastEpisode(
                     uuid = "id-1",
@@ -197,7 +197,7 @@ class EndOfYearManagerTest {
 
     @Test
     fun doNotCountUncompletedEpisodesForCompletedEpisodeCount() = runTest {
-        episodeDao.insertAll(
+        episodeDao.insertAllBlocking(
             listOf(
                 PodcastEpisode(
                     uuid = "id-1",
@@ -221,8 +221,8 @@ class EndOfYearManagerTest {
 
     @Test
     fun getPlayedPodcast() = runTest {
-        podcastDao.insert(Podcast("p-id-1"))
-        episodeDao.insertAll(
+        podcastDao.insertBlocking(Podcast("p-id-1"))
+        episodeDao.insertAllBlocking(
             listOf(
                 PodcastEpisode(
                     uuid = "id-1",
@@ -239,8 +239,8 @@ class EndOfYearManagerTest {
             ),
         )
 
-        podcastDao.insert(Podcast("p-id-2"))
-        episodeDao.insertAll(
+        podcastDao.insertBlocking(Podcast("p-id-2"))
+        episodeDao.insertAllBlocking(
             listOf(
                 PodcastEpisode(
                     uuid = "id-3",
@@ -259,8 +259,8 @@ class EndOfYearManagerTest {
 
     @Test
     fun doNotCountTheSamePodcastTwiceForPlayedPodcastCount() = runTest {
-        podcastDao.insert(Podcast("p-id-1"))
-        episodeDao.insertAll(
+        podcastDao.insertBlocking(Podcast("p-id-1"))
+        episodeDao.insertAllBlocking(
             listOf(
                 PodcastEpisode(
                     uuid = "id-1",
@@ -285,8 +285,8 @@ class EndOfYearManagerTest {
 
     @Test
     fun doNotCountEpisodesOutOfRangeForPlayedPodcastCount() = runBlocking {
-        podcastDao.insert(Podcast("p-id-1"))
-        episodeDao.insertAll(
+        podcastDao.insertBlocking(Podcast("p-id-1"))
+        episodeDao.insertAllBlocking(
             listOf(
                 PodcastEpisode(
                     uuid = "id-1",
@@ -297,8 +297,8 @@ class EndOfYearManagerTest {
             ),
         )
 
-        podcastDao.insert(Podcast("p-id-2"))
-        episodeDao.insertAll(
+        podcastDao.insertBlocking(Podcast("p-id-2"))
+        episodeDao.insertAllBlocking(
             listOf(
                 PodcastEpisode(
                     uuid = "id-2",
@@ -309,8 +309,8 @@ class EndOfYearManagerTest {
             ),
         )
 
-        podcastDao.insert(Podcast("p-id-3"))
-        episodeDao.insertAll(
+        podcastDao.insertBlocking(Podcast("p-id-3"))
+        episodeDao.insertAllBlocking(
             listOf(
                 PodcastEpisode(
                     uuid = "id-3",
@@ -321,7 +321,7 @@ class EndOfYearManagerTest {
             ),
         )
 
-        podcastDao.insert(Podcast("p-id-4"))
+        podcastDao.insertBlocking(Podcast("p-id-4"))
 
         val stats = manager.getStats(year = Year.of(1000))
 
@@ -331,7 +331,7 @@ class EndOfYearManagerTest {
 
     @Test
     fun getThisYearPlaybackTime() = runTest {
-        episodeDao.insertAll(
+        episodeDao.insertAllBlocking(
             listOf(
                 PodcastEpisode(
                     uuid = "id-1",
@@ -355,7 +355,7 @@ class EndOfYearManagerTest {
 
     @Test
     fun doNotCountEpisodesOutOfRangeForThisYearPlaybackTime() = runTest {
-        episodeDao.insertAll(
+        episodeDao.insertAllBlocking(
             listOf(
                 PodcastEpisode(
                     uuid = "id-1",
@@ -385,7 +385,7 @@ class EndOfYearManagerTest {
 
     @Test
     fun getLastYearPlaybackTime() = runTest {
-        episodeDao.insertAll(
+        episodeDao.insertAllBlocking(
             listOf(
                 PodcastEpisode(
                     uuid = "id-1",
@@ -409,7 +409,7 @@ class EndOfYearManagerTest {
 
     @Test
     fun doNotCountEpisodesOutOfRangeForLastYearPlaybackTime() = runTest {
-        episodeDao.insertAll(
+        episodeDao.insertAllBlocking(
             listOf(
                 PodcastEpisode(
                     uuid = "id-1",
@@ -439,8 +439,8 @@ class EndOfYearManagerTest {
 
     @Test
     fun getTopPodcasts() = runTest {
-        podcastDao.insert(Podcast("p-id-1", title = "title-1", author = "author-1"))
-        episodeDao.insert(
+        podcastDao.insertBlocking(Podcast("p-id-1", title = "title-1", author = "author-1"))
+        episodeDao.insertBlocking(
             PodcastEpisode(
                 uuid = "id-1",
                 podcastUuid = "p-id-1",
@@ -450,8 +450,8 @@ class EndOfYearManagerTest {
             ),
         )
 
-        podcastDao.insert(Podcast("p-id-2", title = "title-2", author = "author-2"))
-        episodeDao.insert(
+        podcastDao.insertBlocking(Podcast("p-id-2", title = "title-2", author = "author-2"))
+        episodeDao.insertBlocking(
             PodcastEpisode(
                 uuid = "id-2",
                 podcastUuid = "p-id-2",
@@ -461,8 +461,8 @@ class EndOfYearManagerTest {
             ),
         )
 
-        podcastDao.insert(Podcast("p-id-3", title = "title-3", author = "author-3"))
-        episodeDao.insert(
+        podcastDao.insertBlocking(Podcast("p-id-3", title = "title-3", author = "author-3"))
+        episodeDao.insertBlocking(
             PodcastEpisode(
                 uuid = "id-3",
                 podcastUuid = "p-id-3",
@@ -472,8 +472,8 @@ class EndOfYearManagerTest {
             ),
         )
 
-        podcastDao.insert(Podcast("p-id-4", title = "title-4", author = "author-4"))
-        episodeDao.insert(
+        podcastDao.insertBlocking(Podcast("p-id-4", title = "title-4", author = "author-4"))
+        episodeDao.insertBlocking(
             PodcastEpisode(
                 uuid = "id-4",
                 podcastUuid = "p-id-4",
@@ -483,8 +483,8 @@ class EndOfYearManagerTest {
             ),
         )
 
-        podcastDao.insert(Podcast("p-id-5", title = "title-5", author = "author-5"))
-        episodeDao.insert(
+        podcastDao.insertBlocking(Podcast("p-id-5", title = "title-5", author = "author-5"))
+        episodeDao.insertBlocking(
             PodcastEpisode(
                 uuid = "id-5",
                 podcastUuid = "p-id-5",
@@ -494,8 +494,8 @@ class EndOfYearManagerTest {
             ),
         )
 
-        podcastDao.insert(Podcast("p-id-6", title = "title-6", author = "author-6"))
-        episodeDao.insert(
+        podcastDao.insertBlocking(Podcast("p-id-6", title = "title-6", author = "author-6"))
+        episodeDao.insertBlocking(
             PodcastEpisode(
                 uuid = "id-6",
                 podcastUuid = "p-id-6",
@@ -549,8 +549,8 @@ class EndOfYearManagerTest {
 
     @Test
     fun doNotCountTheSamePodcastTwiceForTopPodcasts() = runTest {
-        podcastDao.insert(Podcast("p-id-1", title = "title-1", author = "author-1"))
-        episodeDao.insertAll(
+        podcastDao.insertBlocking(Podcast("p-id-1", title = "title-1", author = "author-1"))
+        episodeDao.insertAllBlocking(
             listOf(
                 PodcastEpisode(
                     uuid = "id-1",
@@ -576,9 +576,9 @@ class EndOfYearManagerTest {
 
     @Test
     fun sortTopPodcastsByPlaybackTimeAndEpisodeCount() = runTest {
-        podcastDao.insert(Podcast("p-id-1", title = "title-1", author = "author-1"))
+        podcastDao.insertBlocking(Podcast("p-id-1", title = "title-1", author = "author-1"))
         repeat(2) { index ->
-            episodeDao.insert(
+            episodeDao.insertBlocking(
                 PodcastEpisode(
                     uuid = "id-$index-1",
                     podcastUuid = "p-id-1",
@@ -589,9 +589,9 @@ class EndOfYearManagerTest {
             )
         }
 
-        podcastDao.insert(Podcast("p-id-2", title = "title-2", author = "author-2"))
+        podcastDao.insertBlocking(Podcast("p-id-2", title = "title-2", author = "author-2"))
         repeat(4) { index ->
-            episodeDao.insert(
+            episodeDao.insertBlocking(
                 PodcastEpisode(
                     uuid = "id-$index-2",
                     podcastUuid = "p-id-2",
@@ -602,9 +602,9 @@ class EndOfYearManagerTest {
             )
         }
 
-        podcastDao.insert(Podcast("p-id-3", title = "title-3", author = "author-3"))
+        podcastDao.insertBlocking(Podcast("p-id-3", title = "title-3", author = "author-3"))
         repeat(10) { index ->
-            episodeDao.insert(
+            episodeDao.insertBlocking(
                 PodcastEpisode(
                     uuid = "id-$index-3",
                     podcastUuid = "p-id-3",
@@ -645,8 +645,8 @@ class EndOfYearManagerTest {
 
     @Test
     fun doNotCountEpisodesOutOfRangeForTopPodcasts() = runTest {
-        podcastDao.insert(Podcast("p-id-1", title = "title-1", author = "author-1"))
-        episodeDao.insertAll(
+        podcastDao.insertBlocking(Podcast("p-id-1", title = "title-1", author = "author-1"))
+        episodeDao.insertAllBlocking(
             listOf(
                 PodcastEpisode(
                     uuid = "id-1",
@@ -679,8 +679,8 @@ class EndOfYearManagerTest {
 
     @Test
     fun getLongestPlayedEpisode() = runTest {
-        podcastDao.insert(Podcast("p-id-1", title = "p-title-1"))
-        episodeDao.insert(
+        podcastDao.insertBlocking(Podcast("p-id-1", title = "p-title-1"))
+        episodeDao.insertBlocking(
             PodcastEpisode(
                 uuid = "id-1",
                 title = "title-1",
@@ -705,8 +705,8 @@ class EndOfYearManagerTest {
             manager.getStats(year = Year.of(1000)).longestEpisode,
         )
 
-        podcastDao.insert(Podcast("p-id-2", title = "p-title-2"))
-        episodeDao.insertAll(
+        podcastDao.insertBlocking(Podcast("p-id-2", title = "p-title-2"))
+        episodeDao.insertAllBlocking(
             listOf(
                 PodcastEpisode(
                     uuid = "id-2",
@@ -744,8 +744,8 @@ class EndOfYearManagerTest {
 
     @Test
     fun doNotCountEpisodesOutOfRangeForLongestPlayedEpisode() = runTest {
-        podcastDao.insert(Podcast("p-id-1"))
-        episodeDao.insertAll(
+        podcastDao.insertBlocking(Podcast("p-id-1"))
+        episodeDao.insertAllBlocking(
             listOf(
                 PodcastEpisode(
                     uuid = "id-1",
@@ -779,8 +779,8 @@ class EndOfYearManagerTest {
 
     @Test
     fun doNotCountUnplayedEpisodesForLongestPlayedEpisode() = runTest {
-        podcastDao.insert(Podcast("p-id-1"))
-        episodeDao.insertAll(
+        podcastDao.insertBlocking(Podcast("p-id-1"))
+        episodeDao.insertAllBlocking(
             listOf(
                 PodcastEpisode(
                     uuid = "id-1",

--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/repositories/sync/PodcastSyncProcessTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/repositories/sync/PodcastSyncProcessTest.kt
@@ -85,7 +85,7 @@ class PodcastSyncProcessTest {
             whenever(podcastManager.findPodcastsToSync()).thenReturn(emptyList())
 
             val episodeManager: EpisodeManager = mock()
-            whenever(episodeManager.findEpisodesToSync()).thenReturn(emptyList())
+            whenever(episodeManager.findEpisodesToSyncBlocking()).thenReturn(emptyList())
 
             val playlistManager: PlaylistManager = mock()
             whenever(playlistManager.findPlaylistsToSyncBlocking()).thenReturn(emptyList())

--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/ui/PlaybackServiceTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/ui/PlaybackServiceTest.kt
@@ -94,8 +94,8 @@ class PlaybackServiceTest {
         }
         service.podcastManager = podcastManager
         val episodeManager = mock<EpisodeManager> {
-            on { findEpisodesWhere(any(), any()) }.doReturn(filterEpisodes)
-            onBlocking { findLatestEpisodeToPlay() }.doReturn(latestEpisode)
+            on { findEpisodesWhereBlocking(any(), any()) }.doReturn(filterEpisodes)
+            onBlocking { findLatestEpisodeToPlayBlocking() }.doReturn(latestEpisode)
         }
         service.episodeManager = episodeManager
         val playlistManager = mock<PlaylistManager> {

--- a/app/src/main/java/au/com/shiftyjelly/pocketcasts/PocketCastsApplication.kt
+++ b/app/src/main/java/au/com/shiftyjelly/pocketcasts/PocketCastsApplication.kt
@@ -228,7 +228,7 @@ class PocketCastsApplication : Application(), Configuration.Provider {
                     val restoredFromBackup = podcasts.isNotEmpty()
                     if (restoredFromBackup) {
                         // check to see if the episode files already exist
-                        episodeManager.updateAllEpisodeStatus(EpisodeStatusEnum.NOT_DOWNLOADED)
+                        episodeManager.updateAllEpisodeStatusBlocking(EpisodeStatusEnum.NOT_DOWNLOADED)
                         fileStorage.fixBrokenFiles(episodeManager)
                         // reset stats
                         statsManager.reset()

--- a/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivityViewModel.kt
+++ b/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivityViewModel.kt
@@ -80,7 +80,7 @@ class MainActivityViewModel
         }
 
         viewModelScope.launch {
-            episodeManager.observeDownloadedEpisodes()
+            episodeManager.findDownloadedEpisodesRxFlowable()
                 .collect { result ->
                     _downloadedEpisodeState.update { state -> state.copy(downloadedEpisodes = result.sumOf { it.sizeInBytes }) }
                 }

--- a/app/src/test/java/au/com/shiftyjelly/pocketcasts/ui/MainActivityViewModelTest.kt
+++ b/app/src/test/java/au/com/shiftyjelly/pocketcasts/ui/MainActivityViewModelTest.kt
@@ -234,7 +234,7 @@ class MainActivityViewModelTest {
             ),
         )
 
-        whenever(episodeManager.observeDownloadedEpisodes()).thenReturn(Flowable.just(downloadedEpisodes))
+        whenever(episodeManager.findDownloadedEpisodesRxFlowable()).thenReturn(Flowable.just(downloadedEpisodes))
 
         viewModel = MainActivityViewModel(
             episodeManager = episodeManager,

--- a/automotive/src/androidTest/java/au/com/shiftyjelly/pocketcasts/AutoPlaybackServiceTest.kt
+++ b/automotive/src/androidTest/java/au/com/shiftyjelly/pocketcasts/AutoPlaybackServiceTest.kt
@@ -104,7 +104,7 @@ class AutoPlaybackServiceTest {
 
             service.playlistManager = mock { on { findByUuidBlocking(any()) }.doReturn(null) }
             service.podcastManager = mock { on { runBlocking { findPodcastByUuidSuspend(any()) } }.doReturn(podcast) }
-            service.episodeManager = mock { on { findEpisodesByPodcastOrdered(any()) }.doReturn(listOf(episode)) }
+            service.episodeManager = mock { on { findEpisodesByPodcastOrderedBlocking(any()) }.doReturn(listOf(episode)) }
 
             val episodes = service.loadEpisodeChildren(podcast.uuid)
             assertTrue("Episodes should have content", episodes.isNotEmpty())

--- a/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/viewmodel/DiscoverViewModel.kt
+++ b/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/viewmodel/DiscoverViewModel.kt
@@ -279,7 +279,7 @@ class DiscoverViewModel @Inject constructor(
         podcastManager.findOrDownloadPodcastRx(discoverEpisode.podcast_uuid)
             .flatMapMaybe {
                 @Suppress("DEPRECATION")
-                episodeManager.findByUuidRx(discoverEpisode.uuid)
+                episodeManager.findByUuidRxMaybe(discoverEpisode.uuid)
             }
             .subscribeOn(Schedulers.io())
             .observeOn(AndroidSchedulers.mainThread())

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/UpNextEpisodeViewHolder.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/UpNextEpisodeViewHolder.kt
@@ -101,7 +101,7 @@ class UpNextEpisodeViewHolder(
         val tintColor = itemView.context.getAttrTextStyleColor(UR.attr.textSubtitle1)
 
         disposable = episodeManager
-            .observeByUuid(episode.uuid)
+            .findByUuidFlow(episode.uuid)
             .asFlowable()
             .subscribeOn(Schedulers.io())
             .observeOn(AndroidSchedulers.mainThread())

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/chapters/ChaptersViewModel.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/chapters/ChaptersViewModel.kt
@@ -66,7 +66,7 @@ class ChaptersViewModel @AssistedInject constructor(
 
     private fun createUiStateFlow(episodeId: String) = combine(
         playbackManager.playbackStateFlow,
-        episodeManager.observeEpisodeByUuid(episodeId),
+        episodeManager.findEpisodeByUuidFlow(episodeId),
         chapterManager.observerChaptersForEpisode(episodeId),
         settings.cachedSubscriptionStatus.flow,
         isTogglingChapters,
@@ -99,7 +99,7 @@ class ChaptersViewModel @AssistedInject constructor(
                 playbackState.episodeUuid != episodeId -> {
                     val episode = episodeManager.findEpisodeByUuid(episodeId) ?: return@launch
                     episode.playedUpToMs = chapter.startTime.inWholeMilliseconds.toInt()
-                    episodeManager.updatePlayedUpTo(episode, chapter.startTime.inWholeSeconds.toDouble(), forceUpdate = true)
+                    episodeManager.updatePlayedUpToBlocking(episode, chapter.startTime.inWholeSeconds.toDouble(), forceUpdate = true)
                     playbackManager.playNowSuspend(episode)
                 }
             }

--- a/modules/features/player/src/test/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/ChaptersViewModelTest.kt
+++ b/modules/features/player/src/test/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/ChaptersViewModelTest.kt
@@ -88,7 +88,7 @@ class ChaptersViewModelTest {
     @Before
     fun setup() {
         whenever(playbackManager.playbackStateFlow).thenReturn(playbackStateFlow)
-        whenever(episodeManager.observeEpisodeByUuid("id")).thenReturn(episodeFlow)
+        whenever(episodeManager.findEpisodeByUuidFlow("id")).thenReturn(episodeFlow)
         whenever(chapterManager.observerChaptersForEpisode("id")).thenReturn(chaptersFlow)
         val userSetting = mock<UserSetting<SubscriptionStatus?>>()
         whenever(userSetting.flow).thenReturn(subscriptionStatusFlow)
@@ -274,7 +274,7 @@ class ChaptersViewModelTest {
 
         chaptersViewModel.playChapter(chapter)
 
-        verify(episodeManager, times(1)).updatePlayedUpTo(episode, chapter.startTime.inWholeSeconds.toDouble(), forceUpdate = true)
+        verify(episodeManager, times(1)).updatePlayedUpToBlocking(episode, chapter.startTime.inWholeSeconds.toDouble(), forceUpdate = true)
         verifyBlocking(playbackManager, times(1)) { playNowSuspend(episode) }
     }
 

--- a/modules/features/player/src/test/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/PlayerViewModelTest.kt
+++ b/modules/features/player/src/test/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/PlayerViewModelTest.kt
@@ -182,7 +182,7 @@ class PlayerViewModelTest {
         whenever(settings.globalPlaybackEffects).thenReturn(userSettingsGlobalEffects)
         whenever(podcastEpisode.podcastOrSubstituteUuid).thenReturn(podcastUuid)
         whenever(playbackManager.getCurrentEpisode()).thenReturn(currentEpisode)
-        whenever(episodeManager.observeEpisodeByUuidRx(anyOrNull())).thenReturn(Flowable.just(currentEpisode))
+        whenever(episodeManager.findEpisodeByUuidRxFlowable(anyOrNull())).thenReturn(Flowable.just(currentEpisode))
         whenever(podcast.playbackEffects).thenReturn(podcastPlaybackEffects)
         whenever(podcastManager.observePodcastByUuid(anyOrNull())).thenReturn(Flowable.just(podcast))
         val useRealTimeForPlaybackRemainingTimeMock = mock<UserSetting<Boolean>>()

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/helper/PlayButtonListener.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/helper/PlayButtonListener.kt
@@ -69,7 +69,7 @@ class PlayButtonListener @Inject constructor(
     override fun onPlayedClicked(episodeUuid: String) {
         launch {
             episodeManager.findEpisodeByUuid(episodeUuid)?.let { episode ->
-                episodeManager.markAsNotPlayed(episode)
+                episodeManager.markAsNotPlayedBlocking(episode)
             }
         }
     }
@@ -117,7 +117,7 @@ class PlayButtonListener @Inject constructor(
                         uuid = episodeUuid,
                     )
                     launch {
-                        episodeManager.unarchive(it)
+                        episodeManager.unarchiveBlocking(it)
                     }
                 }
             }

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/ProfileEpisodeListViewModel.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/ProfileEpisodeListViewModel.kt
@@ -49,9 +49,9 @@ class ProfileEpisodeListViewModel @Inject constructor(
     fun setup(mode: Mode) {
         this.mode = mode
         val episodeListFlowable = when (mode) {
-            is Mode.Downloaded -> episodeManager.observeDownloadEpisodes()
-            is Mode.Starred -> episodeManager.observeStarredEpisodes()
-            is Mode.History -> episodeManager.observePlaybackHistoryEpisodes()
+            is Mode.Downloaded -> episodeManager.findDownloadEpisodesRxFlowable()
+            is Mode.Starred -> episodeManager.findStarredEpisodesRxFlowable()
+            is Mode.History -> episodeManager.findPlaybackHistoryEpisodesRxFlowable()
         }
         viewModelScope.launch {
             val searchResultsFlow = _searchQueryFlow

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/PodcastViewModel.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/PodcastViewModel.kt
@@ -253,8 +253,8 @@ class PodcastViewModel
     fun onUnarchiveClicked() {
         launch {
             val p = podcast.value ?: return@launch
-            val episodes = episodeManager.findEpisodesByPodcastOrdered(p)
-            episodeManager.unarchiveAllInList(episodes)
+            val episodes = episodeManager.findEpisodesByPodcastOrderedBlocking(p)
+            episodeManager.unarchiveAllInListBlocking(episodes)
             trackEpisodeBulkEvent(AnalyticsEvent.EPISODE_BULK_UNARCHIVED, episodes.size)
         }
     }
@@ -351,7 +351,7 @@ class PodcastViewModel
     fun archivePlayed() {
         val podcast = this.podcast.value ?: return
         launch {
-            val episodes = episodeManager.findEpisodesByPodcastOrdered(podcast).filter { it.isFinished }
+            val episodes = episodeManager.findEpisodesByPodcastOrderedBlocking(podcast).filter { it.isFinished }
             episodeManager.archiveAllInList(episodes, playbackManager)
             trackEpisodeBulkEvent(AnalyticsEvent.EPISODE_BULK_ARCHIVED, episodes.size)
         }
@@ -370,7 +370,7 @@ class PodcastViewModel
     fun archiveEpisodeLimit() {
         launch {
             podcast.value?.let {
-                episodeManager.checkPodcastForEpisodeLimit(it, playbackManager)
+                episodeManager.checkPodcastForEpisodeLimitBlocking(it, playbackManager)
             }
         }
     }
@@ -641,7 +641,7 @@ private fun Flowable<CombinedEpisodeAndBookmarkData>.loadEpisodesAndBookmarks(
             "Observing podcast ${podcast.uuid} episode changes",
         )
         Flowable.combineLatest(
-            episodeManager.observeEpisodesByPodcastOrderedRx(podcast)
+            episodeManager.findEpisodesByPodcastOrderedRxFlowable(podcast)
                 .map {
                     val sortFunction = podcast.grouping.sortFunction
                     if (sortFunction != null) {

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/PodcastsViewModel.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/PodcastsViewModel.kt
@@ -174,8 +174,8 @@ class PodcastsViewModel
             .toFlowable(BackpressureStrategy.LATEST)
             .switchMap { badgeType ->
                 return@switchMap when (badgeType) {
-                    BadgeType.ALL_UNFINISHED -> episodeManager.getPodcastUuidToBadgeUnfinished()
-                    BadgeType.LATEST_EPISODE -> episodeManager.getPodcastUuidToBadgeLatest()
+                    BadgeType.ALL_UNFINISHED -> episodeManager.getPodcastUuidToBadgeUnfinishedRxFlowable()
+                    BadgeType.LATEST_EPISODE -> episodeManager.getPodcastUuidToBadgeLatestRxFlowable()
                     else -> Flowable.just(emptyMap())
                 }
             }.toLiveData()

--- a/modules/features/podcasts/src/test/java/au/com/shiftyjelly/pocketcasts/podcasts/view/ProfileEpisodeListViewModelTest.kt
+++ b/modules/features/podcasts/src/test/java/au/com/shiftyjelly/pocketcasts/podcasts/view/ProfileEpisodeListViewModelTest.kt
@@ -208,9 +208,9 @@ class ProfileEpisodeListViewModelTest {
         starredEpisodes: List<PodcastEpisode> = starredEpisodesMock,
         listeningHistoryEpisodes: List<PodcastEpisode> = listeningHistoryEpisodesMock,
     ) {
-        whenever(episodeManager.observeDownloadEpisodes()).thenReturn(flowOf(downloadedEpisodes).asFlowable())
-        whenever(episodeManager.observeStarredEpisodes()).thenReturn(flowOf(starredEpisodes).asFlowable())
-        whenever(episodeManager.observePlaybackHistoryEpisodes()).thenReturn(flowOf(listeningHistoryEpisodes).asFlowable())
+        whenever(episodeManager.findDownloadEpisodesRxFlowable()).thenReturn(flowOf(downloadedEpisodes).asFlowable())
+        whenever(episodeManager.findStarredEpisodesRxFlowable()).thenReturn(flowOf(starredEpisodes).asFlowable())
+        whenever(episodeManager.findPlaybackHistoryEpisodesRxFlowable()).thenReturn(flowOf(listeningHistoryEpisodes).asFlowable())
         whenever(episodeManager.filteredPlaybackHistoryEpisodesFlow(anyOrNull())).thenReturn(flowOf(emptyList()))
         doNothing().whenever(analyticsTracker).track(any(), any())
 

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/cloud/CloudBottomSheetViewModel.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/cloud/CloudBottomSheetViewModel.kt
@@ -125,7 +125,7 @@ class CloudBottomSheetViewModel @Inject constructor(
 
     fun markAsPlayed(episode: UserEpisode) {
         viewModelScope.launch(Dispatchers.Default) {
-            episodeManager.markAsPlayed(episode, playbackManager, podcastManager)
+            episodeManager.markAsPlayedBlocking(episode, playbackManager, podcastManager)
             episodeAnalytics.trackEvent(AnalyticsEvent.EPISODE_MARKED_AS_PLAYED, source, episode.uuid)
             trackOptionTapped(MARK_PLAYED)
         }
@@ -133,7 +133,7 @@ class CloudBottomSheetViewModel @Inject constructor(
 
     fun markAsUnplayed(episode: UserEpisode) {
         viewModelScope.launch(Dispatchers.Default) {
-            episodeManager.markAsNotPlayed(episode)
+            episodeManager.markAsNotPlayedBlocking(episode)
             episodeAnalytics.trackEvent(AnalyticsEvent.EPISODE_MARKED_AS_UNPLAYED, source, episode.uuid)
             trackOptionTapped(MARK_UNPLAYED)
         }

--- a/modules/features/reimagine/src/main/kotlin/au/com/shiftyjelly/pocketcasts/reimagine/ShareViewModel.kt
+++ b/modules/features/reimagine/src/main/kotlin/au/com/shiftyjelly/pocketcasts/reimagine/ShareViewModel.kt
@@ -44,7 +44,7 @@ class ShareViewModel @AssistedInject constructor(
     } else {
         combine(
             podcastManager.observePodcastByUuidFlow(initialPodcast.uuid),
-            episodeManager.observeEpisodeByUuid(initialEpisode.uuid),
+            episodeManager.findEpisodeByUuidFlow(initialEpisode.uuid),
             ::UiState,
         )
     }.stateIn(viewModelScope, started = SharingStarted.Lazily, initialValue = UiState(initialPodcast, initialEpisode))

--- a/modules/features/reimagine/src/main/kotlin/au/com/shiftyjelly/pocketcasts/reimagine/clip/ShareClipViewModel.kt
+++ b/modules/features/reimagine/src/main/kotlin/au/com/shiftyjelly/pocketcasts/reimagine/clip/ShareClipViewModel.kt
@@ -50,7 +50,7 @@ class ShareClipViewModel @AssistedInject constructor(
     private val sharingState = MutableStateFlow(SharingState(Step.ClipSelection, iSharing = false))
 
     val uiState = combine(
-        episodeManager.observeByUuid(episodeUuid),
+        episodeManager.findByUuidFlow(episodeUuid),
         podcastManager.observePodcastByEpisodeUuid(episodeUuid),
         clipRange,
         settings.artworkConfiguration.flow.map { it.useEpisodeArtwork },

--- a/modules/features/reimagine/src/main/kotlin/au/com/shiftyjelly/pocketcasts/reimagine/episode/ShareEpisodeViewModel.kt
+++ b/modules/features/reimagine/src/main/kotlin/au/com/shiftyjelly/pocketcasts/reimagine/episode/ShareEpisodeViewModel.kt
@@ -31,7 +31,7 @@ class ShareEpisodeViewModel @AssistedInject constructor(
 ) : ViewModel() {
     val uiState = combine(
         podcastManager.observePodcastByEpisodeUuid(episodeUuid),
-        episodeManager.observeByUuid(episodeUuid),
+        episodeManager.findByUuidFlow(episodeUuid),
         settings.artworkConfiguration.flow.map { it.useEpisodeArtwork },
         ::UiState,
     ).stateIn(viewModelScope, started = SharingStarted.Lazily, initialValue = UiState())

--- a/modules/features/reimagine/src/main/kotlin/au/com/shiftyjelly/pocketcasts/reimagine/timestamp/ShareEpisodeTimestampViewModel.kt
+++ b/modules/features/reimagine/src/main/kotlin/au/com/shiftyjelly/pocketcasts/reimagine/timestamp/ShareEpisodeTimestampViewModel.kt
@@ -31,7 +31,7 @@ class ShareEpisodeTimestampViewModel @AssistedInject constructor(
 ) : ViewModel() {
     val uiState = combine(
         podcastManager.observePodcastByEpisodeUuid(episodeUuid),
-        episodeManager.observeByUuid(episodeUuid),
+        episodeManager.findByUuidFlow(episodeUuid),
         settings.artworkConfiguration.flow.map { it.useEpisodeArtwork },
         ::UiState,
     ).stateIn(viewModelScope, started = SharingStarted.Lazily, initialValue = UiState())

--- a/modules/features/reimagine/src/test/kotlin/au/com/shiftyjelly/pocketcasts/reimagine/clip/ShareClipViewModelTest.kt
+++ b/modules/features/reimagine/src/test/kotlin/au/com/shiftyjelly/pocketcasts/reimagine/clip/ShareClipViewModelTest.kt
@@ -62,7 +62,7 @@ class ShareClipViewModelTest {
 
     @Before
     fun setUp() {
-        whenever(episodeManager.observeByUuid("episode-id")).thenReturn(flowOf(episode))
+        whenever(episodeManager.findByUuidFlow("episode-id")).thenReturn(flowOf(episode))
         whenever(podcastManager.observePodcastByEpisodeUuid("episode-id")).thenReturn(flowOf(podcast))
         val artworkSetting = mock<UserSetting<ArtworkConfiguration>>()
         whenever(artworkSetting.flow).thenReturn(MutableStateFlow(ArtworkConfiguration(useEpisodeArtwork = true)))

--- a/modules/features/reimagine/src/test/kotlin/au/com/shiftyjelly/pocketcasts/reimagine/episode/ShareEpisodeViewModelTest.kt
+++ b/modules/features/reimagine/src/test/kotlin/au/com/shiftyjelly/pocketcasts/reimagine/episode/ShareEpisodeViewModelTest.kt
@@ -44,7 +44,7 @@ class ShareEpisodeViewModelTest {
 
     @Before
     fun setUp() {
-        whenever(episodeManager.observeByUuid("episode-id")).thenReturn(flowOf(episode))
+        whenever(episodeManager.findByUuidFlow("episode-id")).thenReturn(flowOf(episode))
         whenever(podcastManager.observePodcastByEpisodeUuid("episode-id")).thenReturn(flowOf(podcast))
         val artworkSetting = mock<UserSetting<ArtworkConfiguration>>()
         whenever(artworkSetting.flow).thenReturn(MutableStateFlow(ArtworkConfiguration(useEpisodeArtwork = true)))

--- a/modules/features/reimagine/src/test/kotlin/au/com/shiftyjelly/pocketcasts/reimagine/timestamp/ShareEpisodeTimestampViewModelTest.kt
+++ b/modules/features/reimagine/src/test/kotlin/au/com/shiftyjelly/pocketcasts/reimagine/timestamp/ShareEpisodeTimestampViewModelTest.kt
@@ -44,7 +44,7 @@ class ShareEpisodeTimestampViewModelTest {
 
     @Before
     fun setUp() {
-        whenever(episodeManager.observeByUuid("episode-id")).thenReturn(flowOf(episode))
+        whenever(episodeManager.findByUuidFlow("episode-id")).thenReturn(flowOf(episode))
         whenever(podcastManager.observePodcastByEpisodeUuid("episode-id")).thenReturn(flowOf(podcast))
         val artworkSetting = mock<UserSetting<ArtworkConfiguration>>()
         whenever(artworkSetting.flow).thenReturn(MutableStateFlow(ArtworkConfiguration(useEpisodeArtwork = true)))

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/developer/DeveloperViewModel.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/developer/DeveloperViewModel.kt
@@ -51,18 +51,18 @@ class DeveloperViewModel
                     for (podcast in podcasts) {
                         if (podcast.isShowNotifications) {
                             // find first podcast with more than one episode
-                            val episodes = episodeManager.findEpisodesByPodcastOrderedByPublishDate(podcast)
+                            val episodes = episodeManager.findEpisodesByPodcastOrderedByPublishDateBlocking(podcast)
                             if (episodes.size <= 1) {
                                 continue
                             } else {
                                 val episode = episodes[1]
                                 // link the second oldest to the podcast
-                                episodeManager.markAsNotPlayed(episode)
+                                episodeManager.markAsNotPlayedBlocking(episode)
                                 podcastManager.updateLatestEpisode(podcast, episode)
                                 // remove the latest episode
                                 val episodeToDelete = episodes[0]
                                 Timber.i("Creating a notification for ${podcast.title} - ${episodeToDelete.title}")
-                                episodeManager.deleteEpisodeWithoutSync(episodeToDelete, playbackManager)
+                                episodeManager.deleteEpisodeWithoutSyncBlocking(episodeToDelete, playbackManager)
                                 settings.setNotificationLastSeenToNow()
                                 continue
                             }
@@ -88,7 +88,7 @@ class DeveloperViewModel
                 val podcasts = podcastManager.findSubscribed()
                 for (podcast in podcasts) {
                     // find first podcast with more than one episode
-                    val episodes = episodeManager.findEpisodesByPodcastOrderedByPublishDate(podcast)
+                    val episodes = episodeManager.findEpisodesByPodcastOrderedByPublishDateBlocking(podcast)
                     if (episodes.size <= 1) {
                         continue
                     } else {
@@ -96,7 +96,7 @@ class DeveloperViewModel
                         val episodeToDelete = episodes.first()
                         val newLatest = episodes.getOrNull(1)
                         Timber.i("Deleted episode ${podcast.title} - ${episodeToDelete.title}")
-                        episodeManager.deleteEpisodeWithoutSync(episodeToDelete, playbackManager)
+                        episodeManager.deleteEpisodeWithoutSyncBlocking(episodeToDelete, playbackManager)
 
                         podcast.latestEpisodeUuid = newLatest?.uuid
                         podcast.latestEpisodeDate = newLatest?.publishedDate

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/viewmodel/ManualCleanupViewModel.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/viewmodel/ManualCleanupViewModel.kt
@@ -71,7 +71,7 @@ class ManualCleanupViewModel
 
     init {
         viewModelScope.launch {
-            episodeManager.observeDownloadedEpisodes()
+            episodeManager.findDownloadedEpisodesRxFlowable()
                 .combineLatest(switchState.toFlowable(BackpressureStrategy.LATEST))
                 .collect { result ->
                     val (downloadedEpisodes, isStarredSwitchChecked) = result

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/viewmodel/StorageSettingsViewModel.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/viewmodel/StorageSettingsViewModel.kt
@@ -92,7 +92,7 @@ class StorageSettingsViewModel
         this.permissionGranted = permissionGranted
         this.sdkVersion = sdkVersion
         viewModelScope.launch {
-            episodeManager.observeDownloadedEpisodes()
+            episodeManager.findDownloadedEpisodesRxFlowable()
                 .collect { downloadedEpisodes ->
                     val downloadSize = downloadedEpisodes.sumOf { it.sizeInBytes }
                     mutableState.value = mutableState.value.copy(

--- a/modules/features/settings/src/test/java/au/com/shiftyjelly/pocketcasts/settings/viewmodel/ManualCleanupViewModelTest.kt
+++ b/modules/features/settings/src/test/java/au/com/shiftyjelly/pocketcasts/settings/viewmodel/ManualCleanupViewModelTest.kt
@@ -37,7 +37,7 @@ class ManualCleanupViewModelTest {
     fun setUp() {
         episodeManager = mock()
         playbackManager = mock()
-        whenever(episodeManager.observeDownloadedEpisodes())
+        whenever(episodeManager.findDownloadedEpisodesRxFlowable())
             .thenReturn(Flowable.generate { listOf(episodes) })
         viewModel = ManualCleanupViewModel(episodeManager, playbackManager, AnalyticsTracker.test())
     }
@@ -68,7 +68,7 @@ class ManualCleanupViewModelTest {
 
     @Test
     fun `given episodes selected, when delete button clicked, then delete action invoked`() {
-        whenever(episodeManager.observeDownloadedEpisodes())
+        whenever(episodeManager.findDownloadedEpisodesRxFlowable())
             .thenReturn(Flowable.generate { listOf(episode) })
         val deleteButtonClickAction = mock<() -> Unit>()
         viewModel.setup(deleteButtonClickAction)
@@ -81,7 +81,7 @@ class ManualCleanupViewModelTest {
 
     @Test
     fun `given episodes not selected, when delete button clicked, then episodes are not deleted`() {
-        whenever(episodeManager.observeDownloadedEpisodes())
+        whenever(episodeManager.findDownloadedEpisodesRxFlowable())
             .thenReturn(Flowable.generate { listOf(episode) })
         viewModel.onDiskSpaceCheckedChanged(isChecked = false, diskSpaceView = diskSpaceView)
 

--- a/modules/features/settings/src/test/java/au/com/shiftyjelly/pocketcasts/settings/viewmodel/StorageSettingsViewModelTest.kt
+++ b/modules/features/settings/src/test/java/au/com/shiftyjelly/pocketcasts/settings/viewmodel/StorageSettingsViewModelTest.kt
@@ -73,7 +73,7 @@ class StorageSettingsViewModelTest {
         whenever(settings.getStorageChoiceName()).thenReturn("")
         whenever(settings.backgroundRefreshPodcasts).thenReturn(UserSetting.Mock(true, mock()))
         whenever(settings.warnOnMeteredNetwork).thenReturn(UserSetting.Mock(true, mock()))
-        whenever(episodeManager.observeDownloadedEpisodes()).thenReturn(Flowable.empty())
+        whenever(episodeManager.findDownloadedEpisodesRxFlowable()).thenReturn(Flowable.empty())
         viewModel = StorageSettingsViewModel(
             episodeManager,
             fileStorage,

--- a/modules/features/taskerplugin/src/main/java/au/com/shiftyjelly/pocketcasts/taskerplugin/querypodcastepisodes/ActionRunnerQueryPodcastEpisodes.kt
+++ b/modules/features/taskerplugin/src/main/java/au/com/shiftyjelly/pocketcasts/taskerplugin/querypodcastepisodes/ActionRunnerQueryPodcastEpisodes.kt
@@ -17,7 +17,7 @@ class ActionRunnerQueryPodcastEpisodes : TaskerPluginRunnerAction<InputQueryPodc
         val titleOrId = input.regular.titleOrId.nullIfEmpty ?: return TaskerPluginResultSucess()
 
         val podcast = podcastManager.findSubscribed().firstOrNull { it.title.lowercase().contains(titleOrId.trim().lowercase()) || it.uuid == titleOrId } ?: return TaskerPluginResultSucess(arrayOf())
-        val episodes = context.episodeManager.findEpisodesByPodcastOrdered(podcast).take(50)
+        val episodes = context.episodeManager.findEpisodesByPodcastOrderedBlocking(podcast).take(50)
         val output = episodes.map { OutputQueryEpisodes(it) }.toTypedArray()
         return TaskerPluginResultSucess(output)
     }

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/BookmarkDao.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/BookmarkDao.kt
@@ -181,7 +181,7 @@ abstract class BookmarkDao {
     abstract suspend fun updateTitle(bookmarkUuid: String, title: String, titleModified: Long, syncStatus: SyncStatus)
 
     @Query("SELECT * FROM bookmarks WHERE sync_status = :syncStatus")
-    abstract fun findNotSynced(syncStatus: SyncStatus = SyncStatus.NOT_SYNCED): List<Bookmark>
+    abstract fun findNotSyncedBlocking(syncStatus: SyncStatus = SyncStatus.NOT_SYNCED): List<Bookmark>
 
     @Query(
         """SELECT bookmarks.*

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/EpisodeDao.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/EpisodeDao.kt
@@ -27,13 +27,13 @@ import kotlinx.coroutines.flow.Flow
 abstract class EpisodeDao {
 
     @RawQuery(observedEntities = [PodcastEpisode::class, Podcast::class])
-    abstract fun findEpisodes(query: SupportSQLiteQuery): List<PodcastEpisode>
+    abstract fun findEpisodesBlocking(query: SupportSQLiteQuery): List<PodcastEpisode>
 
     @RawQuery(observedEntities = [PodcastEpisode::class, Podcast::class])
-    abstract fun observeEpisodes(query: SupportSQLiteQuery): Flowable<List<PodcastEpisode>>
+    abstract fun findEpisodesRxFlowable(query: SupportSQLiteQuery): Flowable<List<PodcastEpisode>>
 
     @RawQuery(observedEntities = [PodcastEpisode::class, Podcast::class])
-    abstract fun observeCount(query: SupportSQLiteQuery): Flowable<Int>
+    abstract fun countRxFlowable(query: SupportSQLiteQuery): Flowable<Int>
 
     @Query("SELECT * FROM podcast_episodes WHERE uuid = :uuid")
     abstract suspend fun findByUuid(uuid: String): PodcastEpisode?
@@ -48,25 +48,25 @@ abstract class EpisodeDao {
     abstract suspend fun countEpisodesByPodcast(podcastUuid: String): Int
 
     @Query("SELECT * FROM podcast_episodes WHERE uuid = :uuid")
-    abstract fun findByUuidRx(uuid: String): Maybe<PodcastEpisode>
+    abstract fun findByUuidRxMaybe(uuid: String): Maybe<PodcastEpisode>
 
     @Query("SELECT * FROM podcast_episodes WHERE uuid = :uuid")
-    abstract fun observeByUuid(uuid: String): Flow<PodcastEpisode?>
+    abstract fun findByUuidFlow(uuid: String): Flow<PodcastEpisode?>
 
     @Transaction
     @Query("SELECT * FROM podcast_episodes WHERE download_task_id IS NOT NULL")
-    abstract fun observeDownloadingEpisodesRx(): Flowable<List<PodcastEpisode>>
+    abstract fun findDownloadingEpisodesRxFlowable(): Flowable<List<PodcastEpisode>>
 
     @Query("SELECT * FROM podcast_episodes WHERE UPPER(title) = UPPER(:query) LIMIT 1")
     abstract suspend fun findFirstBySearchQuery(query: String): PodcastEpisode?
 
     @Transaction
     @Query("SELECT * FROM podcast_episodes WHERE last_playback_interaction_sync_status <> 1 AND last_playback_interaction_date IS NOT NULL ORDER BY last_playback_interaction_date DESC LIMIT 1000")
-    abstract fun findEpisodesForHistorySync(): List<PodcastEpisode>
+    abstract fun findEpisodesForHistorySyncBlocking(): List<PodcastEpisode>
 
     @Transaction
     @Query("SELECT * FROM podcast_episodes WHERE playing_status = :episodePlayingStatus AND archived = :archived AND podcast_id = :podcastUuid")
-    abstract fun findByEpisodePlayingAndArchiveStatus(podcastUuid: String, episodePlayingStatus: EpisodePlayingStatus, archived: Boolean): List<PodcastEpisode>
+    abstract fun findByEpisodePlayingAndArchiveStatusBlocking(podcastUuid: String, episodePlayingStatus: EpisodePlayingStatus, archived: Boolean): List<PodcastEpisode>
 
     @Query(
         """
@@ -84,7 +84,7 @@ abstract class EpisodeDao {
         END) ASC
     """,
     )
-    abstract fun findByPodcastOrderTitleAsc(podcastUuid: String): List<PodcastEpisode>
+    abstract fun findByPodcastOrderTitleAscBlocking(podcastUuid: String): List<PodcastEpisode>
 
     @Query(
         """
@@ -102,7 +102,7 @@ abstract class EpisodeDao {
         END) ASC
     """,
     )
-    abstract suspend fun findByPodcastOrderTitleAscSuspend(podcastUuid: String): List<PodcastEpisode>
+    abstract suspend fun findByPodcastOrderTitleAsc(podcastUuid: String): List<PodcastEpisode>
 
     @Query(
         """
@@ -120,7 +120,7 @@ abstract class EpisodeDao {
         END) DESC
     """,
     )
-    abstract fun findByPodcastOrderTitleDesc(podcastUuid: String): List<PodcastEpisode>
+    abstract fun findByPodcastOrderTitleDescBlocking(podcastUuid: String): List<PodcastEpisode>
 
     @Query(
         """
@@ -138,42 +138,42 @@ abstract class EpisodeDao {
         END) DESC
     """,
     )
-    abstract suspend fun findByPodcastOrderTitleDescSuspend(podcastUuid: String): List<PodcastEpisode>
+    abstract suspend fun findByPodcastOrderTitleDesc(podcastUuid: String): List<PodcastEpisode>
 
     @Transaction
     @Query("SELECT * FROM podcast_episodes WHERE podcast_id = :podcastUuid ORDER BY published_date ASC")
-    abstract fun findByPodcastOrderPublishedDateAsc(podcastUuid: String): List<PodcastEpisode>
+    abstract fun findByPodcastOrderPublishedDateAscBlocking(podcastUuid: String): List<PodcastEpisode>
 
     @Transaction
     @Query("SELECT * FROM podcast_episodes WHERE podcast_id = :podcastUuid ORDER BY published_date ASC")
-    abstract suspend fun findByPodcastOrderPublishedDateAscSuspend(podcastUuid: String): List<PodcastEpisode>
+    abstract suspend fun findByPodcastOrderPublishedDateAsc(podcastUuid: String): List<PodcastEpisode>
 
     @Transaction
     @Query("SELECT * FROM podcast_episodes WHERE podcast_id = :podcastUuid ORDER BY published_date DESC")
-    abstract fun findByPodcastOrderPublishedDateDesc(podcastUuid: String): List<PodcastEpisode>
+    abstract fun findByPodcastOrderPublishedDateDescBlocking(podcastUuid: String): List<PodcastEpisode>
 
     @Transaction
     @Query("SELECT * FROM podcast_episodes WHERE podcast_id = :podcastUuid ORDER BY published_date DESC")
-    abstract suspend fun findByPodcastOrderPublishedDateDescSuspend(podcastUuid: String): List<PodcastEpisode>
+    abstract suspend fun findByPodcastOrderPublishedDateDesc(podcastUuid: String): List<PodcastEpisode>
 
     @Query("SELECT * FROM podcast_episodes WHERE podcast_id = :podcastUuid AND playing_status != 2 AND archived = 0 ORDER BY published_date DESC LIMIT 1")
-    abstract fun findLatestUnfinishedEpisodeByPodcast(podcastUuid: String): PodcastEpisode?
+    abstract fun findLatestUnfinishedEpisodeByPodcastBlocking(podcastUuid: String): PodcastEpisode?
 
     @Transaction
     @Query("SELECT * FROM podcast_episodes WHERE podcast_id = :podcastUuid ORDER BY duration ASC")
-    abstract fun findByPodcastOrderDurationAsc(podcastUuid: String): List<PodcastEpisode>
+    abstract fun findByPodcastOrderDurationAscBlocking(podcastUuid: String): List<PodcastEpisode>
 
     @Transaction
     @Query("SELECT * FROM podcast_episodes WHERE podcast_id = :podcastUuid ORDER BY duration ASC")
-    abstract suspend fun findByPodcastOrderDurationAscSuspend(podcastUuid: String): List<PodcastEpisode>
+    abstract suspend fun findByPodcastOrderDurationAsc(podcastUuid: String): List<PodcastEpisode>
 
     @Transaction
     @Query("SELECT * FROM podcast_episodes WHERE podcast_id = :podcastUuid ORDER BY duration DESC")
-    abstract fun findByPodcastOrderDurationDesc(podcastUuid: String): List<PodcastEpisode>
+    abstract fun findByPodcastOrderDurationDescBlocking(podcastUuid: String): List<PodcastEpisode>
 
     @Transaction
     @Query("SELECT * FROM podcast_episodes WHERE podcast_id = :podcastUuid ORDER BY duration DESC")
-    abstract suspend fun findByPodcastOrderDurationDescSuspend(podcastUuid: String): List<PodcastEpisode>
+    abstract suspend fun findByPodcastOrderDurationDesc(podcastUuid: String): List<PodcastEpisode>
 
     // Find new episodes to display in notifications.
     @Query(
@@ -185,7 +185,7 @@ abstract class EpisodeDao {
         AND podcast_episodes.archived = 0 AND podcast_episodes.playing_status = :playingStatus AND podcast_episodes.added_date >= :date
         ORDER BY podcast_episodes.added_date DESC, podcast_episodes.published_date DESC LIMIT 100""",
     )
-    abstract fun findNotificationEpisodes(date: Date, playingStatus: Int = EpisodePlayingStatus.NOT_PLAYED.ordinal): List<PodcastEpisode>
+    abstract fun findNotificationEpisodesBlocking(date: Date, playingStatus: Int = EpisodePlayingStatus.NOT_PLAYED.ordinal): List<PodcastEpisode>
 
     @Transaction
     @Query(
@@ -204,7 +204,7 @@ abstract class EpisodeDao {
         END) ASC
     """,
     )
-    abstract fun observeByPodcastOrderTitleAsc(podcastUuid: String): Flowable<List<PodcastEpisode>>
+    abstract fun findByPodcastOrderTitleAscRxFlowable(podcastUuid: String): Flowable<List<PodcastEpisode>>
 
     @Transaction
     @Query(
@@ -223,36 +223,36 @@ abstract class EpisodeDao {
         END) DESC
     """,
     )
-    abstract fun observeByPodcastOrderTitleDesc(podcastUuid: String): Flowable<List<PodcastEpisode>>
+    abstract fun findByPodcastOrderTitleDescRxFlowable(podcastUuid: String): Flowable<List<PodcastEpisode>>
 
     @Transaction
     @Query("SELECT * FROM podcast_episodes WHERE podcast_id = :podcastUuid ORDER BY published_date ASC")
-    abstract fun observeByPodcastOrderPublishedDateAsc(podcastUuid: String): Flowable<List<PodcastEpisode>>
+    abstract fun findByPodcastOrderPublishedDateAscRxFlowable(podcastUuid: String): Flowable<List<PodcastEpisode>>
 
     @Transaction
     @Query("SELECT * FROM podcast_episodes WHERE podcast_id = :podcastUuid ORDER BY published_date DESC")
-    abstract fun observeByPodcastOrderPublishedDateDesc(podcastUuid: String): Flowable<List<PodcastEpisode>>
+    abstract fun findByPodcastOrderPublishedDateDescFlowable(podcastUuid: String): Flowable<List<PodcastEpisode>>
 
     @Transaction
     @Query("SELECT * FROM podcast_episodes WHERE podcast_id = :podcastUuid ORDER BY duration ASC")
-    abstract fun observeByPodcastOrderDurationAsc(podcastUuid: String): Flowable<List<PodcastEpisode>>
+    abstract fun findByPodcastOrderDurationAscFlowable(podcastUuid: String): Flowable<List<PodcastEpisode>>
 
     @Transaction
     @Query("SELECT * FROM podcast_episodes WHERE podcast_id = :podcastUuid ORDER BY duration DESC")
-    abstract fun observeByPodcastOrderDurationDesc(podcastUuid: String): Flowable<List<PodcastEpisode>>
+    abstract fun findByPodcastOrderDurationDescFlowable(podcastUuid: String): Flowable<List<PodcastEpisode>>
 
     @Query("UPDATE podcast_episodes SET downloaded_error_details = NULL, episode_status = :episodeStatusNotDownloaded WHERE episode_status = :episodeStatusFailed")
-    abstract fun clearAllDownloadErrors(episodeStatusNotDownloaded: EpisodeStatusEnum, episodeStatusFailed: EpisodeStatusEnum)
+    abstract fun clearAllDownloadErrorsBlocking(episodeStatusNotDownloaded: EpisodeStatusEnum, episodeStatusFailed: EpisodeStatusEnum)
 
     @Query("SELECT * FROM podcast_episodes WHERE podcast_id = :podcastUuid ORDER BY published_date DESC, added_date DESC LIMIT 1")
-    abstract fun findLatest(podcastUuid: String): PodcastEpisode?
+    abstract fun findLatestBlocking(podcastUuid: String): PodcastEpisode?
 
     @Query("SELECT * FROM podcast_episodes WHERE podcast_id = :podcastUuid ORDER BY published_date DESC, added_date DESC LIMIT 1")
-    abstract fun findLatestRx(podcastUuid: String): Maybe<PodcastEpisode>
+    abstract fun findLatestRxMaybe(podcastUuid: String): Maybe<PodcastEpisode>
 
     @Transaction
     @Query("SELECT * FROM podcast_episodes WHERE (download_task_id IS NOT NULL OR episode_status == :downloadEpisodeStatusEnum OR (episode_status == :failedEpisodeStatusEnum AND last_download_attempt_date > :failedDownloadCutoff AND archived == 0)) ORDER BY last_download_attempt_date DESC")
-    abstract fun observeDownloadingEpisodesIncludingFailed(failedDownloadCutoff: Long, failedEpisodeStatusEnum: EpisodeStatusEnum = EpisodeStatusEnum.DOWNLOAD_FAILED, downloadEpisodeStatusEnum: EpisodeStatusEnum = EpisodeStatusEnum.DOWNLOADED): Flowable<List<PodcastEpisode>>
+    abstract fun findDownloadingEpisodesIncludingFailedRxFlowable(failedDownloadCutoff: Long, failedEpisodeStatusEnum: EpisodeStatusEnum = EpisodeStatusEnum.DOWNLOAD_FAILED, downloadEpisodeStatusEnum: EpisodeStatusEnum = EpisodeStatusEnum.DOWNLOADED): Flowable<List<PodcastEpisode>>
 
     @Transaction
     @Query("SELECT * FROM podcast_episodes WHERE (download_task_id IS NOT NULL AND episode_status == :notDownloaded)")
@@ -260,11 +260,11 @@ abstract class EpisodeDao {
 
     @Transaction
     @Query("SELECT * FROM podcast_episodes WHERE episode_status == :downloadEpisodeStatusEnum ORDER BY last_download_attempt_date DESC")
-    abstract fun observeDownloadedEpisodes(downloadEpisodeStatusEnum: EpisodeStatusEnum = EpisodeStatusEnum.DOWNLOADED): Flowable<List<PodcastEpisode>>
+    abstract fun findDownloadedEpisodesRxFlowable(downloadEpisodeStatusEnum: EpisodeStatusEnum = EpisodeStatusEnum.DOWNLOADED): Flowable<List<PodcastEpisode>>
 
     @Transaction
     @Query("SELECT * FROM podcast_episodes WHERE starred = 1")
-    abstract fun observeStarredEpisodes(): Flowable<List<PodcastEpisode>>
+    abstract fun findStarredEpisodesRxFlowable(): Flowable<List<PodcastEpisode>>
 
     @Transaction
     @Query("SELECT * FROM podcast_episodes WHERE starred = 1")
@@ -272,7 +272,7 @@ abstract class EpisodeDao {
 
     @Transaction
     @Query("SELECT * FROM podcast_episodes WHERE last_playback_interaction_date IS NOT NULL AND last_playback_interaction_date > 0 ORDER BY last_playback_interaction_date DESC LIMIT 1000")
-    abstract fun observePlaybackHistory(): Flowable<List<PodcastEpisode>>
+    abstract fun findPlaybackHistoryRxFlowable(): Flowable<List<PodcastEpisode>>
 
     @Transaction
     @Query(
@@ -295,40 +295,40 @@ abstract class EpisodeDao {
     abstract suspend fun findPlaybackHistoryEpisodes(): List<PodcastEpisode>
 
     @Update
-    abstract fun update(episode: PodcastEpisode)
+    abstract fun updateBlocking(episode: PodcastEpisode)
 
     @Update
-    abstract suspend fun updateSuspend(episode: PodcastEpisode)
+    abstract suspend fun update(episode: PodcastEpisode)
 
     @Delete
-    abstract fun delete(episode: PodcastEpisode)
+    abstract fun deleteBlocking(episode: PodcastEpisode)
 
     @Delete
-    abstract fun deleteAll(episode: List<PodcastEpisode>)
+    abstract fun deleteAllBlocking(episode: List<PodcastEpisode>)
 
     @Delete
-    abstract suspend fun deleteAllSuspend(episode: List<PodcastEpisode>)
+    abstract suspend fun deleteAll(episode: List<PodcastEpisode>)
 
     @Query("DELETE FROM podcast_episodes")
     abstract suspend fun deleteAll()
 
     @Insert(onConflict = OnConflictStrategy.IGNORE)
-    abstract fun insert(episode: PodcastEpisode)
+    abstract fun insertBlocking(episode: PodcastEpisode)
 
     @Insert(onConflict = OnConflictStrategy.IGNORE)
-    abstract suspend fun insertSuspend(episode: PodcastEpisode)
+    abstract suspend fun insert(episode: PodcastEpisode)
 
     @Insert(onConflict = OnConflictStrategy.IGNORE)
-    abstract fun insertAll(episodes: List<PodcastEpisode>)
+    abstract fun insertAllBlocking(episodes: List<PodcastEpisode>)
 
     @Insert(onConflict = OnConflictStrategy.IGNORE)
-    abstract suspend fun insertAllSuspend(episodes: List<PodcastEpisode>)
+    abstract suspend fun insertAll(episodes: List<PodcastEpisode>)
 
     @Query("UPDATE podcast_episodes SET file_type = :fileType WHERE uuid = :uuid")
-    abstract fun updateFileType(fileType: String, uuid: String)
+    abstract fun updateFileTypeBlocking(fileType: String, uuid: String)
 
     @Query("UPDATE podcast_episodes SET size_in_bytes = :sizeInBytes WHERE uuid = :uuid")
-    abstract fun updateSizeInBytes(sizeInBytes: Long, uuid: String)
+    abstract fun updateSizeInBytesBlocking(sizeInBytes: Long, uuid: String)
 
     @Query("UPDATE podcast_episodes SET download_url = :url WHERE uuid = :uuid")
     abstract suspend fun updateDownloadUrl(url: String, uuid: String)
@@ -337,71 +337,71 @@ abstract class EpisodeDao {
     abstract suspend fun updateDownloadTaskId(uuid: String, taskId: String?)
 
     @Query("UPDATE podcast_episodes SET last_download_attempt_date = :lastDownloadAttemptDate WHERE uuid = :uuid")
-    abstract fun updateLastDownloadAttemptDate(lastDownloadAttemptDate: Date, uuid: String)
+    abstract fun updateLastDownloadAttemptDateBlocking(lastDownloadAttemptDate: Date, uuid: String)
 
     @Query("UPDATE podcast_episodes SET downloaded_error_details = :errorMessage, episode_status = :episodeStatus WHERE uuid = :uuid")
-    abstract fun updateDownloadError(uuid: String, errorMessage: String?, episodeStatus: EpisodeStatusEnum)
+    abstract fun updateDownloadErrorBlocking(uuid: String, errorMessage: String?, episodeStatus: EpisodeStatusEnum)
 
     @Query("UPDATE podcast_episodes SET downloaded_file_path = :downloadedFilePath WHERE uuid = :uuid")
-    abstract fun updateDownloadedFilePath(downloadedFilePath: String, uuid: String)
+    abstract fun updateDownloadedFilePathBlocking(downloadedFilePath: String, uuid: String)
 
     @Query("UPDATE podcast_episodes SET auto_download_status = :autoDownloadStatus WHERE uuid = :uuid")
     abstract suspend fun updateAutoDownloadStatus(autoDownloadStatus: Int, uuid: String)
 
     @Query("UPDATE podcast_episodes SET play_error_details = :playErrorDetails WHERE uuid = :uuid")
-    abstract fun updatePlayErrorDetails(playErrorDetails: String?, uuid: String)
+    abstract fun updatePlayErrorDetailsBlocking(playErrorDetails: String?, uuid: String)
 
     @Query("UPDATE podcast_episodes SET downloaded_error_details = :downloadErrorDetails WHERE uuid = :uuid")
-    abstract fun updateDownloadErrorDetails(downloadErrorDetails: String?, uuid: String)
+    abstract fun updateDownloadErrorDetailsBlocking(downloadErrorDetails: String?, uuid: String)
 
     @Query("UPDATE podcast_episodes SET episode_status = :episodeStatus WHERE uuid = :uuid")
     abstract suspend fun updateEpisodeStatus(episodeStatus: EpisodeStatusEnum, uuid: String)
 
     @Query("UPDATE podcast_episodes SET episode_status = :episodeStatus")
-    abstract fun updateAllEpisodeStatus(episodeStatus: EpisodeStatusEnum)
+    abstract fun updateAllEpisodeStatusBlocking(episodeStatus: EpisodeStatusEnum)
 
     @Query("UPDATE podcast_episodes SET last_playback_interaction_date = 0 WHERE last_playback_interaction_date <= :lastCleared")
-    abstract fun clearEpisodePlaybackInteractionDatesBefore(lastCleared: Date)
+    abstract fun clearEpisodePlaybackInteractionDatesBeforeBlocking(lastCleared: Date)
 
     @Query("UPDATE podcast_episodes SET last_playback_interaction_date = 0, last_playback_interaction_sync_status = 1")
     abstract suspend fun clearAllEpisodePlaybackInteractions()
 
     @Query("UPDATE podcast_episodes SET last_playback_interaction_sync_status = 1")
-    abstract fun markPlaybackHistorySynced()
+    abstract fun markPlaybackHistorySyncedBlocking()
 
     @Query("SELECT COUNT(*) FROM podcast_episodes")
     abstract suspend fun count(): Int
 
     @Query("SELECT COUNT(*) FROM podcast_episodes WHERE uuid = :uuid")
-    abstract fun countByUuid(uuid: String): Int
+    abstract fun countByUuidBlocking(uuid: String): Int
 
-    fun exists(uuid: String): Boolean {
-        return countByUuid(uuid) != 0
+    fun existsBlocking(uuid: String): Boolean {
+        return countByUuidBlocking(uuid) != 0
     }
 
-    fun existsRx(uuid: String): Single<Boolean> {
-        return Single.fromCallable { exists(uuid) }
+    fun existsRxSingle(uuid: String): Single<Boolean> {
+        return Single.fromCallable { existsBlocking(uuid) }
     }
 
     @Query("UPDATE podcast_episodes SET starred_modified = NULL, archived_modified = NULL, duration_modified = NULL, played_up_to_modified = NULL, playing_status_modified = NULL WHERE uuid IN (:episodeUuids)")
-    abstract fun markAllSynced(episodeUuids: List<String>)
+    abstract fun markAllSyncedBlocking(episodeUuids: List<String>)
 
     @Query("SELECT podcasts.uuid AS uuid, count(podcast_episodes.uuid) AS count FROM podcast_episodes, podcasts WHERE podcast_episodes.podcast_id = podcasts.uuid AND (podcast_episodes.playing_status = :playingStatusNotPlayed OR podcast_episodes.playing_status = :playingStatusInProgress) AND podcast_episodes.archived = 0 GROUP BY podcasts.uuid")
-    protected abstract fun podcastToUnfinishedEpisodeCount(playingStatusNotPlayed: Int = EpisodePlayingStatus.NOT_PLAYED.ordinal, playingStatusInProgress: Int = EpisodePlayingStatus.IN_PROGRESS.ordinal): Flowable<List<UuidCount>>
+    protected abstract fun podcastToUnfinishedEpisodeCountRxFlowable(playingStatusNotPlayed: Int = EpisodePlayingStatus.NOT_PLAYED.ordinal, playingStatusInProgress: Int = EpisodePlayingStatus.IN_PROGRESS.ordinal): Flowable<List<UuidCount>>
 
     @Query("SELECT podcasts.uuid AS uuid, count(podcast_episodes.uuid) AS count FROM podcast_episodes, podcasts WHERE podcasts.latest_episode_uuid = podcast_episodes.uuid AND podcast_episodes.playing_status = :playingStatusNotPlayed AND podcast_episodes.archived = 0 GROUP BY podcasts.uuid")
-    protected abstract fun podcastToLatestEpisodeCount(playingStatusNotPlayed: Int = EpisodePlayingStatus.NOT_PLAYED.ordinal): Flowable<List<UuidCount>>
+    protected abstract fun podcastToLatestEpisodeCountRxFlowable(playingStatusNotPlayed: Int = EpisodePlayingStatus.NOT_PLAYED.ordinal): Flowable<List<UuidCount>>
 
-    fun podcastUuidToUnfinishedEpisodeCount(): Flowable<Map<String, Int>> {
-        return podcastToUnfinishedEpisodeCount().map { it.associateBy({ it.uuid }, { it.count }) }
+    fun podcastUuidToUnfinishedEpisodeCountRxFlowable(): Flowable<Map<String, Int>> {
+        return podcastToUnfinishedEpisodeCountRxFlowable().map { it.associateBy({ it.uuid }, { it.count }) }
     }
 
-    fun podcastUuidToLatestEpisodeCount(): Flowable<Map<String, Int>> {
-        return podcastToLatestEpisodeCount().map { it.associateBy({ it.uuid }, { it.count }) }
+    fun podcastUuidToLatestEpisodeCountRxFlowable(): Flowable<Map<String, Int>> {
+        return podcastToLatestEpisodeCountRxFlowable().map { it.associateBy({ it.uuid }, { it.count }) }
     }
 
     @Query("SELECT podcast_episodes.* FROM podcast_episodes JOIN podcasts ON podcast_episodes.podcast_id = podcasts.uuid WHERE podcasts.subscribed = 1 AND podcast_episodes.playing_status != 2 AND podcast_episodes.archived = 0 ORDER BY podcast_episodes.published_date DESC LIMIT 1")
-    abstract fun findLatestEpisodeToPlay(): PodcastEpisode?
+    abstract fun findLatestEpisodeToPlayBlocking(): PodcastEpisode?
 
     @Query("UPDATE podcast_episodes SET starred = :starred, starred_modified = :modified WHERE uuid = :uuid")
     abstract suspend fun updateStarred(starred: Boolean, modified: Long, uuid: String)
@@ -410,47 +410,47 @@ abstract class EpisodeDao {
     abstract suspend fun updateAllStarred(episodesUUIDs: List<String>, starred: Boolean, modified: Long)
 
     @Query("UPDATE podcast_episodes SET archived = 0, archived_modified = :modified, last_archive_interaction_date = :modified, exclude_from_episode_limit = 1 WHERE uuid = :uuid")
-    abstract fun unarchive(uuid: String, modified: Long)
+    abstract fun unarchiveBlocking(uuid: String, modified: Long)
 
     @Query("UPDATE podcast_episodes SET archived = :archived, archived_modified = :modified, last_archive_interaction_date = :modified WHERE uuid = :uuid")
-    abstract fun updateArchived(archived: Boolean, modified: Long, uuid: String)
+    abstract fun updateArchivedBlocking(archived: Boolean, modified: Long, uuid: String)
 
     @Query("UPDATE podcast_episodes SET archived = :archived, last_archive_interaction_date = :modified WHERE uuid = :uuid")
-    abstract fun updateArchivedNoSync(archived: Boolean, modified: Long, uuid: String)
+    abstract fun updateArchivedNoSyncBlocking(archived: Boolean, modified: Long, uuid: String)
 
     @Query("UPDATE podcast_episodes SET playing_status = :playingStatus, playing_status_modified = :modified WHERE uuid = :uuid")
-    abstract fun updatePlayingStatus(playingStatus: EpisodePlayingStatus, modified: Long, uuid: String)
+    abstract fun updatePlayingStatusBlocking(playingStatus: EpisodePlayingStatus, modified: Long, uuid: String)
 
     @Query("UPDATE podcast_episodes SET last_playback_interaction_date = :modified, last_playback_interaction_sync_status = 0 WHERE uuid = :uuid")
     abstract suspend fun updatePlaybackInteractionDate(uuid: String, modified: Long)
 
     @Query("UPDATE podcast_episodes SET duration = :duration, duration_modified = :modified WHERE uuid = :uuid")
-    abstract fun updateDuration(duration: Double, modified: Long, uuid: String)
+    abstract fun updateDurationBlocking(duration: Double, modified: Long, uuid: String)
 
     @Query("UPDATE podcast_episodes SET duration = :duration WHERE uuid = :uuid")
-    abstract fun updateDurationNoSync(duration: Double, uuid: String)
+    abstract fun updateDurationNoSyncBlocking(duration: Double, uuid: String)
 
     @Query("UPDATE podcast_episodes SET played_up_to = :playedUpTo, played_up_to_modified = :modified WHERE uuid = :uuid AND (played_up_to IS NULL OR played_up_to < :playedUpToMin OR played_up_to > :playedUpToMax)")
-    abstract fun updatePlayedUpToIfChanged(playedUpTo: Double, playedUpToMin: Double, playedUpToMax: Double, modified: Long, uuid: String)
+    abstract fun updatePlayedUpToIfChangedBlocking(playedUpTo: Double, playedUpToMin: Double, playedUpToMax: Double, modified: Long, uuid: String)
 
-    fun countWhere(queryAfterWhere: String, appDatabase: AppDatabase): Int {
-        val result = QueryHelper.firstRowArray("SELECT count(*) FROM podcast_episodes JOIN podcasts ON podcast_episodes.podcast_id = podcasts.uuid WHERE podcasts.subscribed = 1 AND $queryAfterWhere", null, appDatabase) ?: return 0
+    fun countWhereBlocking(queryAfterWhere: String, appDatabase: AppDatabase): Int {
+        val result = QueryHelper.firstRowArrayBlocking("SELECT count(*) FROM podcast_episodes JOIN podcasts ON podcast_episodes.podcast_id = podcasts.uuid WHERE podcasts.subscribed = 1 AND $queryAfterWhere", null, appDatabase) ?: return 0
         val firstResult = result[0] ?: return 0
         return Integer.parseInt(firstResult)
     }
 
     @Transaction
     @Query("SELECT * FROM podcast_episodes WHERE (playing_status_modified IS NOT NULL OR played_up_to_modified IS NOT NULL OR duration_modified IS NOT NULL OR archived_modified IS NOT NULL OR starred_modified IS NOT NULL OR deselected_chapters_modified IS NOT NULL) AND uuid IS NOT NULL LIMIT 2000")
-    abstract fun findEpisodesToSync(): List<PodcastEpisode>
+    abstract fun findEpisodesToSyncBlocking(): List<PodcastEpisode>
 
     @Query("SELECT podcast_episodes.* FROM podcasts, podcast_episodes WHERE podcast_episodes.podcast_id = podcasts.uuid AND podcast_episodes.podcast_id = :podcastUuid AND podcasts.subscribed = 1 AND podcast_episodes.archived = 0 AND (podcast_episodes.added_date < :inactiveTime AND (CASE WHEN podcast_episodes.last_playback_interaction_date IS NULL THEN 0 ELSE podcast_episodes.last_playback_interaction_date END) < :inactiveTime AND (CASE WHEN podcast_episodes.last_download_attempt_date IS NULL THEN 0 ELSE podcast_episodes.last_download_attempt_date END) < :inactiveDate AND (CASE WHEN podcast_episodes.last_archive_interaction_date IS NULL THEN 0 ELSE podcast_episodes.last_archive_interaction_date END) < :inactiveTime )")
-    abstract fun findInactiveEpisodes(podcastUuid: String, inactiveDate: Date, inactiveTime: Long = inactiveDate.time): List<PodcastEpisode>
+    abstract fun findInactiveEpisodesBlocking(podcastUuid: String, inactiveDate: Date, inactiveTime: Long = inactiveDate.time): List<PodcastEpisode>
 
     @Query("UPDATE podcast_episodes SET archived = 1, archived_modified = :modified, last_archive_interaction_date = :modified WHERE uuid IN (:episodesUUIDs)")
     abstract suspend fun archiveAllInList(episodesUUIDs: List<String>, modified: Long)
 
     @Query("UPDATE podcast_episodes SET archived = 0, archived_modified = :modified, last_archive_interaction_date = :modified WHERE uuid IN (:episodesUUIDs)")
-    abstract fun unarchiveAllInList(episodesUUIDs: List<String>, modified: Long)
+    abstract fun unarchiveAllInListBlocking(episodesUUIDs: List<String>, modified: Long)
 
     @Query("UPDATE podcast_episodes SET playing_status = :playingStatus, playing_status_modified = :modified WHERE uuid IN (:episodesUUIDs)")
     abstract suspend fun updateAllPlayingStatus(episodesUUIDs: List<String>, modified: Long, playingStatus: EpisodePlayingStatus)

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/FolderDao.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/FolderDao.kt
@@ -27,25 +27,25 @@ abstract class FolderDao {
     abstract suspend fun findByUuid(uuid: String): Folder?
 
     @Query("SELECT * FROM folders WHERE uuid = :uuid")
-    abstract fun findByUuidFlowable(uuid: String): Flowable<List<Folder>>
+    abstract fun findByUuidRxFlowable(uuid: String): Flowable<List<Folder>>
 
     @Query("SELECT * FROM folders WHERE uuid = :uuid")
     abstract fun findByUuidFlow(uuid: String): Flow<List<Folder>>
 
     @Query("SELECT * FROM folders WHERE deleted = 0")
-    abstract fun observeFolders(): Flowable<List<Folder>>
+    abstract fun findFoldersRxFlowable(): Flowable<List<Folder>>
 
     @Query("SELECT * FROM folders WHERE deleted = 0")
     abstract fun findFoldersFlow(): Flow<List<Folder>>
 
     @Query("SELECT * FROM folders WHERE deleted = 0")
-    abstract fun findFoldersSingle(): Single<List<Folder>>
+    abstract fun findFoldersRxSingle(): Single<List<Folder>>
 
     @Query("SELECT * FROM folders WHERE deleted = 0")
     abstract suspend fun findFolders(): List<Folder>
 
     @Query("SELECT * FROM folders WHERE sync_modified != 0")
-    abstract fun findNotSynced(): List<Folder>
+    abstract fun findNotSyncedBlocking(): List<Folder>
 
     @Query("UPDATE folders SET color = :color, sync_modified = :syncModified WHERE uuid = :uuid")
     abstract suspend fun updateFolderColor(uuid: String, color: Int, syncModified: Long)
@@ -63,7 +63,7 @@ abstract class FolderDao {
     abstract suspend fun updateSortPosition(sortPosition: Int, uuid: String, syncModified: Long)
 
     @Query("UPDATE folders SET sync_modified = 0")
-    abstract fun updateAllSynced()
+    abstract fun updateAllSyncedBlocking()
 
     @Transaction
     open suspend fun updateSortPositions(folders: List<Folder>, syncModified: Long) {
@@ -73,5 +73,5 @@ abstract class FolderDao {
     }
 
     @Query("SELECT COUNT(*) FROM folders WHERE deleted = 0")
-    abstract fun count(): Int
+    abstract fun countBlocking(): Int
 }

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/PodcastDao.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/PodcastDao.kt
@@ -27,13 +27,13 @@ import kotlinx.coroutines.flow.Flow
 abstract class PodcastDao {
 
     @Query("SELECT * FROM podcasts WHERE subscribed = 1 ORDER BY LOWER(title) ASC")
-    abstract fun findSubscribed(): List<Podcast>
+    abstract fun findSubscribedBlocking(): List<Podcast>
 
     @Query("SELECT * FROM podcasts WHERE subscribed = 1 ORDER BY LOWER(title) ASC")
     abstract fun findSubscribedFlow(): Flow<List<Podcast>>
 
     @Query("SELECT * FROM podcasts WHERE subscribed = 1 ORDER BY LOWER(title) ASC")
-    abstract fun findSubscribedRx(): Single<List<Podcast>>
+    abstract fun findSubscribedRxSingle(): Single<List<Podcast>>
 
     @Query("SELECT * FROM podcasts WHERE subscribed = 1")
     abstract suspend fun findSubscribedNoOrder(): List<Podcast>
@@ -42,61 +42,61 @@ abstract class PodcastDao {
     abstract suspend fun findSubscribedUuids(): List<String>
 
     @Query("SELECT * FROM podcasts WHERE subscribed = 0")
-    abstract fun findUnsubscribed(): List<Podcast>
+    abstract fun findUnsubscribedBlocking(): List<Podcast>
 
     @Query("SELECT podcasts.uuid FROM podcasts WHERE subscribed = 0")
-    abstract fun observeUnsubscribedUuid(): Flowable<List<String>>
+    abstract fun findUnsubscribedUuidRxFlowable(): Flowable<List<String>>
 
     @Query("SELECT * FROM podcasts WHERE subscribed = 1")
-    abstract fun observeSubscribed(): Flowable<List<Podcast>>
+    abstract fun findSubscribedRxFlowable(): Flowable<List<Podcast>>
 
     @Query("SELECT * FROM podcasts WHERE subscribed = 1 AND folder_uuid = :folderUuid ORDER BY CASE WHEN LOWER(SUBSTR(title,1,4)) = 'the ' THEN LOWER(SUBSTR(title,5)) ELSE LOWER(title) END ASC")
-    abstract fun observeFolderOrderByNameAsc(folderUuid: String): Flowable<List<Podcast>>
+    abstract fun findFolderOrderByNameAscRxFlowable(folderUuid: String): Flowable<List<Podcast>>
 
     @Query("SELECT * FROM podcasts WHERE subscribed = 1 AND folder_uuid = :folderUuid ORDER BY CASE WHEN LOWER(SUBSTR(title,1,4)) = 'the ' THEN LOWER(SUBSTR(title,5)) ELSE LOWER(title) END DESC")
-    abstract fun observeFolderOrderByNameDesc(folderUuid: String): Flowable<List<Podcast>>
+    abstract fun findFolderOrderByNameDescRxFlowable(folderUuid: String): Flowable<List<Podcast>>
 
-    fun observeFolderOrderByName(folderUuid: String, orderAsc: Boolean): Flowable<List<Podcast>> {
-        return if (orderAsc) observeFolderOrderByNameAsc(folderUuid = folderUuid) else observeFolderOrderByNameDesc(folderUuid = folderUuid)
+    fun findFolderOrderByNameRxFlowable(folderUuid: String, orderAsc: Boolean): Flowable<List<Podcast>> {
+        return if (orderAsc) findFolderOrderByNameAscRxFlowable(folderUuid = folderUuid) else findFolderOrderByNameDescRxFlowable(folderUuid = folderUuid)
     }
 
     @Query("SELECT * FROM podcasts WHERE auto_download_status = 1 AND subscribed = 1")
-    abstract fun findPodcastsAutodownload(): List<Podcast>
+    abstract fun findPodcastsAutoDownloadBlocking(): List<Podcast>
 
     @Query("SELECT * FROM podcasts WHERE subscribed = 1 AND folder_uuid = :folderUuid ORDER BY added_date ASC")
-    abstract fun observeFolderOrderByAddedDateAsc(folderUuid: String): Flowable<List<Podcast>>
+    abstract fun findFolderOrderByAddedDateAscRxFlowable(folderUuid: String): Flowable<List<Podcast>>
 
     @Query("SELECT * FROM podcasts WHERE subscribed = 1 AND folder_uuid = :folderUuid ORDER BY added_date DESC")
-    abstract fun observeFolderOrderByAddedDateDesc(folderUuid: String): Flowable<List<Podcast>>
+    abstract fun findFolderOrderByAddedDateDescRxFlowable(folderUuid: String): Flowable<List<Podcast>>
 
-    fun observeFolderOrderByAddedDate(folderUuid: String, orderAsc: Boolean): Flowable<List<Podcast>> {
-        return if (orderAsc) observeFolderOrderByAddedDateAsc(folderUuid = folderUuid) else observeFolderOrderByAddedDateDesc(folderUuid = folderUuid)
+    fun findFolderOrderByAddedDateRxFlowable(folderUuid: String, orderAsc: Boolean): Flowable<List<Podcast>> {
+        return if (orderAsc) findFolderOrderByAddedDateAscRxFlowable(folderUuid = folderUuid) else findFolderOrderByAddedDateDescRxFlowable(folderUuid = folderUuid)
     }
 
     @Query("SELECT * FROM podcasts WHERE subscribed = 1 AND auto_add_to_up_next > 0 ORDER BY LOWER(title) ASC")
-    abstract fun observeAutoAddToUpNextPodcasts(): Flowable<List<Podcast>>
+    abstract fun findAutoAddToUpNextPodcastsRxFlowable(): Flowable<List<Podcast>>
 
     @Query("SELECT * FROM podcasts WHERE auto_add_to_up_next > 0")
     abstract suspend fun findAutoAddToUpNextPodcasts(): List<Podcast>
 
     @Query("SELECT podcasts.* FROM podcasts LEFT JOIN podcast_episodes ON podcasts.uuid = podcast_episodes.podcast_id AND podcast_episodes.uuid = (SELECT podcast_episodes.uuid FROM podcast_episodes WHERE podcast_episodes.archived = 0 AND podcast_episodes.podcast_id = podcasts.uuid AND podcast_episodes.playing_status != 2 ORDER BY podcast_episodes.published_date DESC LIMIT 1) WHERE podcasts.subscribed = 1 ORDER BY CASE WHEN podcast_episodes.published_date IS NULL THEN 1 ELSE 0 END, podcast_episodes.published_date ASC, podcasts.latest_episode_date ASC")
-    abstract fun observeSubscribedOrderByLatestEpisodeAsc(): Flowable<List<Podcast>>
+    abstract fun findSubscribedOrderByLatestEpisodeAscRxFlowable(): Flowable<List<Podcast>>
 
     @Query("SELECT podcasts.* FROM podcasts LEFT JOIN podcast_episodes ON podcasts.uuid = podcast_episodes.podcast_id AND podcast_episodes.uuid = (SELECT podcast_episodes.uuid FROM podcast_episodes WHERE podcast_episodes.archived = 0 AND podcast_episodes.podcast_id = podcasts.uuid AND podcast_episodes.playing_status != 2 ORDER BY podcast_episodes.published_date DESC LIMIT 1) WHERE podcasts.subscribed = 1 ORDER BY CASE WHEN podcast_episodes.published_date IS NULL THEN 1 ELSE 0 END, podcast_episodes.published_date DESC, podcasts.latest_episode_date DESC")
-    abstract fun observeSubscribedOrderByLatestEpisodeDesc(): Flowable<List<Podcast>>
+    abstract fun findSubscribedOrderByLatestEpisodeDescRxFlowable(): Flowable<List<Podcast>>
 
-    fun observeSubscribedOrderByLatestEpisode(orderAsc: Boolean): Flowable<List<Podcast>> {
-        return if (orderAsc) observeSubscribedOrderByLatestEpisodeAsc() else observeSubscribedOrderByLatestEpisodeDesc()
+    fun findSubscribedOrderByLatestEpisodeRxFlowable(orderAsc: Boolean): Flowable<List<Podcast>> {
+        return if (orderAsc) findSubscribedOrderByLatestEpisodeAscRxFlowable() else findSubscribedOrderByLatestEpisodeDescRxFlowable()
     }
 
     @Query("SELECT podcasts.* FROM podcasts LEFT JOIN podcast_episodes ON podcasts.uuid = podcast_episodes.podcast_id AND podcast_episodes.uuid = (SELECT podcast_episodes.uuid FROM podcast_episodes WHERE podcast_episodes.archived = 0 AND podcast_episodes.podcast_id = podcasts.uuid AND podcast_episodes.playing_status != 2 ORDER BY podcast_episodes.published_date DESC LIMIT 1) WHERE podcasts.subscribed = 1 AND folder_uuid = :folderUuid ORDER BY CASE WHEN podcast_episodes.published_date IS NULL THEN 1 ELSE 0 END, podcast_episodes.published_date ASC, podcasts.latest_episode_date ASC")
-    abstract fun observeFolderOrderByLatestEpisodeAsc(folderUuid: String): Flowable<List<Podcast>>
+    abstract fun findFolderOrderByLatestEpisodeAscRxFlowable(folderUuid: String): Flowable<List<Podcast>>
 
     @Query("SELECT podcasts.* FROM podcasts LEFT JOIN podcast_episodes ON podcasts.uuid = podcast_episodes.podcast_id AND podcast_episodes.uuid = (SELECT podcast_episodes.uuid FROM podcast_episodes WHERE podcast_episodes.archived = 0 AND podcast_episodes.podcast_id = podcasts.uuid AND podcast_episodes.playing_status != 2 ORDER BY podcast_episodes.published_date DESC LIMIT 1) WHERE podcasts.subscribed = 1 AND folder_uuid = :folderUuid ORDER BY CASE WHEN podcast_episodes.published_date IS NULL THEN 1 ELSE 0 END, podcast_episodes.published_date DESC, podcasts.latest_episode_date DESC")
-    abstract fun observeFolderOrderByLatestEpisodeDesc(folderUuid: String): Flowable<List<Podcast>>
+    abstract fun findFolderOrderByLatestEpisodeDescRxFlowable(folderUuid: String): Flowable<List<Podcast>>
 
-    fun observeFolderOrderByLatestEpisode(folderUuid: String, orderAsc: Boolean): Flowable<List<Podcast>> {
-        return if (orderAsc) observeFolderOrderByLatestEpisodeAsc(folderUuid = folderUuid) else observeFolderOrderByLatestEpisodeDesc(folderUuid = folderUuid)
+    fun findFolderOrderByLatestEpisodeRxFlowable(folderUuid: String, orderAsc: Boolean): Flowable<List<Podcast>> {
+        return if (orderAsc) findFolderOrderByLatestEpisodeAscRxFlowable(folderUuid = folderUuid) else findFolderOrderByLatestEpisodeDescRxFlowable(folderUuid = folderUuid)
     }
 
     @Query("SELECT podcasts.* FROM podcasts LEFT JOIN podcast_episodes ON podcasts.uuid = podcast_episodes.podcast_id AND podcast_episodes.uuid = (SELECT podcast_episodes.uuid FROM podcast_episodes WHERE podcast_episodes.podcast_id = podcasts.uuid AND podcast_episodes.playing_status != 2 ORDER BY podcast_episodes.published_date DESC LIMIT 1) WHERE podcasts.subscribed = 1 ORDER BY CASE WHEN podcast_episodes.published_date IS NULL THEN 1 ELSE 0 END, podcast_episodes.published_date ASC, podcasts.latest_episode_date ASC")
@@ -110,43 +110,43 @@ abstract class PodcastDao {
     }
 
     @Query("SELECT podcasts.* FROM podcasts LEFT JOIN podcast_episodes ON podcasts.uuid = podcast_episodes.podcast_id AND podcast_episodes.uuid = (SELECT podcast_episodes.uuid FROM podcast_episodes WHERE podcast_episodes.podcast_id = podcasts.uuid AND podcast_episodes.playing_status != 2 ORDER BY podcast_episodes.published_date DESC LIMIT 1) WHERE podcasts.subscribed = 1 AND folder_uuid = :folderUuid ORDER BY CASE WHEN podcast_episodes.published_date IS NULL THEN 1 ELSE 0 END, podcast_episodes.published_date DESC, podcasts.latest_episode_date DESC")
-    abstract suspend fun findFolderPodcastsOrderByLatestEpisode(folderUuid: String): List<Podcast>
+    abstract suspend fun findFolderPodcastsOrderByLatestEpisodeBlocking(folderUuid: String): List<Podcast>
 
     @Query("SELECT * FROM podcasts WHERE subscribed = 1 AND folder_uuid = :folderUuid ORDER BY sort_order ASC")
-    abstract fun observeFolderOrderByUserSort(folderUuid: String): Flowable<List<Podcast>>
+    abstract fun findFolderOrderByUserSortRxFlowable(folderUuid: String): Flowable<List<Podcast>>
 
     @Query("SELECT * FROM podcasts WHERE uuid = :uuid")
-    abstract fun findByUuid(uuid: String): Podcast?
+    abstract fun findByUuidBlocking(uuid: String): Podcast?
 
     @Query("SELECT * FROM podcasts WHERE uuid = :uuid")
     abstract suspend fun findPodcastByUuidSuspend(uuid: String): Podcast?
 
     @Query("SELECT * FROM podcasts WHERE uuid = :uuid")
-    abstract fun observeByUuid(uuid: String): Flowable<Podcast>
+    abstract fun findByUuidRxFlowable(uuid: String): Flowable<Podcast>
 
     @Query("SELECT * FROM podcasts WHERE uuid = :uuid")
-    abstract fun observeByUuidFlow(uuid: String): Flow<Podcast>
+    abstract fun findByUuidFlow(uuid: String): Flow<Podcast>
 
     @Query("SELECT * FROM podcasts WHERE uuid = :uuid")
-    abstract fun findByUuidRx(uuid: String): Maybe<Podcast>
+    abstract fun findByUuidRxMaybe(uuid: String): Maybe<Podcast>
 
     @Query("SELECT * FROM podcasts WHERE uuid IN (:uuids)")
-    abstract fun findByUuids(uuids: Array<String>): List<Podcast>
+    abstract fun findByUuidsBlocking(uuids: Array<String>): List<Podcast>
 
     @Query("SELECT * FROM podcasts WHERE folder_uuid = :folderUuid")
     abstract suspend fun findPodcastsInFolder(folderUuid: String): List<Podcast>
 
     @Query("SELECT * FROM podcasts WHERE folder_uuid = :folderUuid")
-    abstract fun findPodcastsInFolderSingle(folderUuid: String): Single<List<Podcast>>
+    abstract fun findPodcastsInFolderRxSingle(folderUuid: String): Single<List<Podcast>>
 
     @Query("SELECT * FROM podcasts WHERE folder_uuid IS NULL")
     abstract suspend fun findPodcastsNotInFolder(): List<Podcast>
 
     @Query("SELECT * FROM podcasts WHERE UPPER(title) LIKE UPPER(:title)")
-    abstract fun searchByTitle(title: String): Podcast?
+    abstract fun searchByTitleBlocking(title: String): Podcast?
 
     @Query("UPDATE podcasts SET sync_status = :syncStatus WHERE uuid = :uuid")
-    abstract fun updateSyncStatus(syncStatus: Int, uuid: String)
+    abstract fun updateSyncStatusBlocking(syncStatus: Int, uuid: String)
 
     @Query("UPDATE podcasts SET show_archived = :showArchived, show_archived_modified = :modified, sync_status = 0 WHERE uuid = :uuid")
     abstract suspend fun updateShowArchived(uuid: String, showArchived: Boolean, modified: Date = Date())
@@ -157,12 +157,12 @@ abstract class PodcastDao {
     @Query("UPDATE podcasts SET folder_uuid = :folderUuid, sync_status = 0 WHERE uuid IN (:podcastUuids)")
     abstract suspend fun updateFolderUuid(folderUuid: String?, podcastUuids: List<String>)
 
-    fun updateSyncStatusRx(syncStatus: Int, uuid: String): Completable {
-        return Completable.fromAction { updateSyncStatus(syncStatus, uuid) }
+    fun updateSyncStatusRxCompletable(syncStatus: Int, uuid: String): Completable {
+        return Completable.fromAction { updateSyncStatusBlocking(syncStatus, uuid) }
     }
 
     @Query("UPDATE podcasts SET sync_status = :syncStatus")
-    abstract fun updateAllSyncStatus(syncStatus: Int)
+    abstract fun updateAllSyncStatusBlocking(syncStatus: Int)
 
     @Query("UPDATE podcasts SET sync_status = :syncStatus WHERE subscribed = 1")
     abstract suspend fun updateAllSubscribedSyncStatus(syncStatus: Int)
@@ -178,77 +178,77 @@ abstract class PodcastDao {
     }
 
     @Update
-    abstract fun update(podcast: Podcast)
+    abstract fun updateBlocking(podcast: Podcast)
 
     @Update
     abstract suspend fun updateSuspend(podcast: Podcast)
 
-    fun updateRx(podcast: Podcast): Completable {
-        return Completable.fromCallable { update(podcast) }
+    fun updateRxCompletable(podcast: Podcast): Completable {
+        return Completable.fromCallable { updateBlocking(podcast) }
     }
 
     @Query("DELETE FROM podcasts WHERE uuid = :uuid")
-    abstract fun deleteByUuid(uuid: String)
+    abstract fun deleteByUuidBlocking(uuid: String)
 
     @Delete
-    abstract fun delete(podcast: Podcast)
+    abstract fun deleteBlocking(podcast: Podcast)
 
     @Query("DELETE FROM podcasts")
     abstract suspend fun deleteAll()
 
     @Insert(onConflict = REPLACE)
-    abstract fun insert(podcast: Podcast): Long
+    abstract fun insertBlocking(podcast: Podcast): Long
 
     @Insert(onConflict = REPLACE)
     abstract suspend fun insertSuspend(podcast: Podcast): Long
 
-    fun insertRx(podcast: Podcast): Single<Podcast> {
+    fun insertRxSingle(podcast: Podcast): Single<Podcast> {
         return Single.fromCallable {
-            insert(podcast)
+            insertBlocking(podcast)
             podcast
         }
     }
 
     @Query("SELECT COUNT(*) FROM podcasts")
-    abstract fun count(): Int
+    abstract fun countBlocking(): Int
 
     @Query("SELECT COUNT(*) FROM podcasts WHERE uuid = :uuid")
-    abstract fun countByUuid(uuid: String): Int
+    abstract fun countByUuidBlocking(uuid: String): Int
 
     @Query("SELECT COUNT(*) FROM podcasts WHERE subscribed = 1")
     abstract suspend fun countSubscribed(): Int
 
     @Query("SELECT COUNT(*) FROM podcasts WHERE subscribed = 1 AND uuid = :uuid")
-    abstract fun countSubscribedByUuid(uuid: String): Int
+    abstract fun countSubscribedByUuidBlocking(uuid: String): Int
 
     @Query("SELECT COUNT(*) FROM podcasts WHERE subscribed = 1")
-    abstract fun countSubscribedRx(): Single<Int>
+    abstract fun countSubscribedRxSingle(): Single<Int>
 
     @Query("SELECT COUNT(*) FROM podcasts WHERE subscribed = 1")
-    abstract fun observeCountSubscribed(): Flowable<Int>
+    abstract fun countSubscribedRxFlowable(): Flowable<Int>
 
     @Query("SELECT COUNT(*) FROM podcasts WHERE subscribed = 1 AND show_notifications = 1")
-    abstract fun countNotificationsOn(): Int
+    abstract fun countNotificationsOnBlocking(): Int
 
     @Query("SELECT COUNT(*) FROM podcasts WHERE subscribed = 1 AND auto_download_status = :downloadStatus")
-    abstract fun countDownloadStatus(downloadStatus: Int): Int
+    abstract fun countDownloadStatusBlocking(downloadStatus: Int): Int
 
     @Query("SELECT COUNT(*) > 0 FROM podcasts WHERE subscribed = 1 AND auto_download_status = :downloadStatus")
     abstract suspend fun hasEpisodesWithAutoDownloadStatus(downloadStatus: Int): Boolean
 
-    fun exists(uuid: String): Boolean {
-        return countByUuid(uuid) != 0
+    fun existsBlocking(uuid: String): Boolean {
+        return countByUuidBlocking(uuid) != 0
     }
 
     @Query("SELECT COUNT(*) FROM podcast_episodes WHERE podcast_id IS :podcastUuid")
-    abstract fun episodeCount(podcastUuid: String): Flow<Int>
+    abstract fun episodeCountFlow(podcastUuid: String): Flow<Int>
 
-    fun isSubscribedToPodcast(uuid: String): Boolean {
-        return countSubscribedByUuid(uuid) != 0
+    fun isSubscribedToPodcastBlocking(uuid: String): Boolean {
+        return countSubscribedByUuidBlocking(uuid) != 0
     }
 
-    fun isSubscribedToPodcastRx(uuid: String): Single<Boolean> {
-        return Single.fromCallable { isSubscribedToPodcast(uuid) }
+    fun isSubscribedToPodcastRxSingle(uuid: String): Single<Boolean> {
+        return Single.fromCallable { isSubscribedToPodcastBlocking(uuid) }
     }
 
     @Query("UPDATE podcasts SET auto_add_to_up_next = :autoAddToUpNext, auto_add_to_up_next_modified = :modified, sync_status = 0 WHERE uuid = :uuid")
@@ -272,41 +272,41 @@ abstract class PodcastDao {
     }
 
     @Query("UPDATE podcasts SET exclude_from_auto_archive = :excludeFromAutoArchive WHERE uuid = :uuid")
-    abstract fun updateExcludeFromAutoArchive(excludeFromAutoArchive: Boolean, uuid: String)
+    abstract fun updateExcludeFromAutoArchiveBlocking(excludeFromAutoArchive: Boolean, uuid: String)
 
     @Query("UPDATE podcasts SET override_global_effects = :override, override_global_effects_modified = :modified, sync_status = 0 WHERE uuid = :uuid")
-    abstract fun updateOverrideGlobalEffects(override: Boolean, uuid: String, modified: Date = Date())
+    abstract fun updateOverrideGlobalEffectsBlocking(override: Boolean, uuid: String, modified: Date = Date())
 
     @Query("UPDATE podcasts SET trim_silence_level = :trimMode, trim_silence_level_modified = :modified, sync_status = 0 WHERE uuid = :uuid")
-    abstract fun updateTrimSilenceMode(trimMode: TrimMode, uuid: String, modified: Date = Date())
+    abstract fun updateTrimSilenceModeBlocking(trimMode: TrimMode, uuid: String, modified: Date = Date())
 
     @Query("UPDATE podcasts SET volume_boosted = :volumeBoosted, volume_boosted_modified = :modified, sync_status = 0 WHERE uuid = :uuid")
-    abstract fun updateVolumeBoosted(volumeBoosted: Boolean, uuid: String, modified: Date = Date())
+    abstract fun updateVolumeBoostedBlocking(volumeBoosted: Boolean, uuid: String, modified: Date = Date())
 
     @Query("UPDATE podcasts SET playback_speed = :speed, playback_speed_modified = :modified, sync_status = 0 WHERE uuid = :uuid")
-    abstract fun updatePlaybackSpeed(speed: Double, uuid: String, modified: Date = Date())
+    abstract fun updatePlaybackSpeedBlocking(speed: Double, uuid: String, modified: Date = Date())
 
     @Transaction
-    open fun updateEffects(speed: Double, volumeBoosted: Boolean, trimMode: TrimMode, uuid: String, modified: Date = Date()) {
-        updatePlaybackSpeed(speed, uuid, modified)
-        updateVolumeBoosted(volumeBoosted, uuid, modified)
-        updateTrimSilenceMode(trimMode, uuid, modified)
+    open fun updateEffectsBlocking(speed: Double, volumeBoosted: Boolean, trimMode: TrimMode, uuid: String, modified: Date = Date()) {
+        updatePlaybackSpeedBlocking(speed, uuid, modified)
+        updateVolumeBoostedBlocking(volumeBoosted, uuid, modified)
+        updateTrimSilenceModeBlocking(trimMode, uuid, modified)
     }
 
     @Query("UPDATE podcasts SET episodes_sort_order = :episodesSortType, episodes_sort_order_modified = :modified, sync_status = 0  WHERE uuid = :uuid")
-    abstract fun updateEpisodesSortType(episodesSortType: EpisodesSortType, uuid: String, modified: Date = Date())
+    abstract fun updateEpisodesSortTypeBlocking(episodesSortType: EpisodesSortType, uuid: String, modified: Date = Date())
 
     @Query("UPDATE podcasts SET show_notifications = :show, show_notifications_modified = :modified, sync_status = 0 WHERE uuid = :uuid")
-    abstract fun updateShowNotifications(show: Boolean, uuid: String, modified: Date = Date())
+    abstract fun updateShowNotificationsBlocking(show: Boolean, uuid: String, modified: Date = Date())
 
     @Query("UPDATE podcasts SET subscribed = :subscribed WHERE uuid = :uuid")
-    abstract fun updateSubscribed(subscribed: Boolean, uuid: String)
+    abstract fun updateSubscribedBlocking(subscribed: Boolean, uuid: String)
 
     @Query("UPDATE podcasts SET refresh_available = :refreshAvailable WHERE uuid = :uuid")
     abstract suspend fun updateRefreshAvailable(refreshAvailable: Boolean, uuid: String)
 
-    fun updateSubscribedRx(subscribed: Boolean, uuid: String): Completable {
-        return Completable.fromAction { updateSubscribed(subscribed, uuid) }
+    fun updateSubscribedRxCompletable(subscribed: Boolean, uuid: String): Completable {
+        return Completable.fromAction { updateSubscribedBlocking(subscribed, uuid) }
     }
 
     @Query("UPDATE podcasts SET start_from = :autoStartFrom, start_from_modified = :modified, sync_status = 0 WHERE uuid = :uuid")
@@ -316,22 +316,22 @@ abstract class PodcastDao {
     abstract suspend fun updateSkipLast(skipLast: Int, uuid: String, modified: Date = Date())
 
     @Query("UPDATE podcasts SET color_last_downloaded = :lastDownloaded WHERE uuid = :uuid")
-    abstract fun updateColorLastDownloaded(lastDownloaded: Long, uuid: String)
+    abstract fun updateColorLastDownloadedBlocking(lastDownloaded: Long, uuid: String)
 
     @Query("UPDATE podcasts SET override_global_settings = :override WHERE uuid = :uuid")
-    abstract fun updateOverrideGobalSettings(override: Boolean, uuid: String)
+    abstract fun updateOverrideGobalSettingsBlocking(override: Boolean, uuid: String)
 
     @Query("UPDATE podcasts SET episodes_to_keep = :episodeToKeep WHERE uuid = :uuid")
-    abstract fun updateEpisodesToKeep(episodeToKeep: Int, uuid: String)
+    abstract fun updateEpisodesToKeepBlocking(episodeToKeep: Int, uuid: String)
 
     @Query("UPDATE podcasts SET most_popular_color = :background, primary_color = :tintForLightBg, secondary_color = :tintForDarkBg, fab_for_light_bg = :fabForLightBg, light_overlay_color = :fabForDarkBg, link_for_light_bg = :linkForLightBg, link_for_dark_bg = :linkForDarkBg, color_last_downloaded = :colorLastDownloaded WHERE uuid = :uuid")
-    abstract fun updateColors(background: Int, tintForLightBg: Int, tintForDarkBg: Int, fabForLightBg: Int, fabForDarkBg: Int, linkForLightBg: Int, linkForDarkBg: Int, colorLastDownloaded: Long, uuid: String)
+    abstract fun updateColorsBlocking(background: Int, tintForLightBg: Int, tintForDarkBg: Int, fabForLightBg: Int, fabForDarkBg: Int, linkForLightBg: Int, linkForDarkBg: Int, colorLastDownloaded: Long, uuid: String)
 
     @Query("UPDATE podcasts SET latest_episode_uuid = :episodeUuid, latest_episode_date = :publishedDate WHERE uuid = :podcastUuid")
-    abstract fun updateLatestEpisode(episodeUuid: String, publishedDate: Date, podcastUuid: String)
+    abstract fun updateLatestEpisodeBlocking(episodeUuid: String, publishedDate: Date, podcastUuid: String)
 
-    fun updateLatestEpisodeRx(episodeUuid: String, publishedDate: Date, podcastUuid: String): Completable {
-        return Completable.fromAction { updateLatestEpisode(episodeUuid, publishedDate, podcastUuid) }
+    fun updateLatestEpisodeRxCompletable(episodeUuid: String, publishedDate: Date, podcastUuid: String): Completable {
+        return Completable.fromAction { updateLatestEpisodeBlocking(episodeUuid, publishedDate, podcastUuid) }
     }
 
     @Query("UPDATE podcasts SET auto_download_status = :autoDownloadStatus")
@@ -341,19 +341,19 @@ abstract class PodcastDao {
     abstract suspend fun updateAllShowNotifications(showNotifications: Boolean, modified: Date = Date())
 
     @Query("UPDATE podcasts SET auto_download_status = :autoDownloadStatus WHERE uuid = :uuid")
-    abstract fun updateAutoDownloadStatus(autoDownloadStatus: Int, uuid: String)
+    abstract fun updateAutoDownloadStatusBlocking(autoDownloadStatus: Int, uuid: String)
 
     @Query("SELECT * FROM podcasts WHERE sync_status = " + Podcast.SYNC_STATUS_NOT_SYNCED + " AND uuid IS NOT NULL")
-    abstract fun findNotSynced(): List<Podcast>
+    abstract fun findNotSyncedBlocking(): List<Podcast>
 
     @Query("SELECT COUNT(*) FROM podcast_episodes WHERE podcast_id = :podcastUuid AND episode_status = :episodeStatus")
-    abstract fun countEpisodesInPodcastWithStatus(podcastUuid: String, episodeStatus: EpisodeStatusEnum): Int
+    abstract fun countEpisodesInPodcastWithStatusBlocking(podcastUuid: String, episodeStatus: EpisodeStatusEnum): Int
 
     @Query("UPDATE podcasts SET grouping = :grouping, grouping_modified = :modified, sync_status = 0 WHERE uuid = :uuid")
-    abstract fun updateGrouping(grouping: PodcastGrouping, uuid: String, modified: Date = Date())
+    abstract fun updateGroupingBlocking(grouping: PodcastGrouping, uuid: String, modified: Date = Date())
 
     @Query("UPDATE podcasts SET grouping = :grouping, grouping_modified = :modified, sync_status = 0 WHERE subscribed = 1")
-    abstract fun updatePodcastGroupingForAll(grouping: PodcastGrouping, modified: Date = Date())
+    abstract fun updatePodcastGroupingForAllBlocking(grouping: PodcastGrouping, modified: Date = Date())
 
     @Query("SELECT * FROM podcasts ORDER BY random() LIMIT :limit")
     abstract suspend fun findRandomPodcasts(limit: Int): List<Podcast>

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/PodcastRatingsDao.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/PodcastRatingsDao.kt
@@ -12,7 +12,7 @@ import kotlinx.coroutines.flow.Flow
 @Dao
 abstract class PodcastRatingsDao {
     @Query("SELECT * FROM podcast_ratings WHERE podcast_uuid = :podcastUuid")
-    abstract fun podcastRatings(podcastUuid: String): Flow<List<PodcastRatings>>
+    abstract fun podcastRatingsFlow(podcastUuid: String): Flow<List<PodcastRatings>>
 
     @Insert(onConflict = REPLACE)
     abstract suspend fun insert(ratings: PodcastRatings)

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/TranscriptDao.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/TranscriptDao.kt
@@ -10,7 +10,7 @@ import kotlinx.coroutines.flow.Flow
 @Dao
 abstract class TranscriptDao {
     @Insert(onConflict = OnConflictStrategy.REPLACE)
-    abstract fun insert(transcript: Transcript)
+    abstract fun insertBlocking(transcript: Transcript)
 
     @Query("SELECT * FROM episode_transcript WHERE episode_uuid IS :episodeUuid")
     abstract fun observerTranscriptForEpisode(episodeUuid: String): Flow<Transcript?>

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/UpNextChangeDao.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/UpNextChangeDao.kt
@@ -11,48 +11,48 @@ import au.com.shiftyjelly.pocketcasts.models.entity.UpNextChange
 abstract class UpNextChangeDao {
 
     @Query("SELECT * FROM up_next_changes")
-    abstract fun findAll(): List<UpNextChange>
+    abstract fun findAllBlocking(): List<UpNextChange>
 
     @Query("DELETE FROM up_next_changes WHERE modified <= :modified")
     abstract suspend fun deleteChangesOlderOrEqualTo(modified: Long)
 
     @Query("DELETE FROM up_next_changes WHERE uuid = :uuid")
-    abstract fun deleteByUuid(uuid: String)
+    abstract fun deleteByUuidBlocking(uuid: String)
 
     @Query("DELETE FROM up_next_changes")
-    abstract fun deleteAll()
+    abstract fun deleteAllBlocking()
 
-    fun savePlayNow(episode: BaseEpisode) {
-        saveUpdate(episode, UpNextChange.ACTION_PLAY_NOW)
+    fun savePlayNowBlocking(episode: BaseEpisode) {
+        saveUpdateBlocking(episode, UpNextChange.ACTION_PLAY_NOW)
     }
 
-    fun savePlayNext(episode: BaseEpisode) {
-        saveUpdate(episode, UpNextChange.ACTION_PLAY_NEXT)
+    fun savePlayNextBlocking(episode: BaseEpisode) {
+        saveUpdateBlocking(episode, UpNextChange.ACTION_PLAY_NEXT)
     }
 
-    fun savePlayLast(episode: BaseEpisode) {
-        saveUpdate(episode, UpNextChange.ACTION_PLAY_LAST)
+    fun savePlayLastBlocking(episode: BaseEpisode) {
+        saveUpdateBlocking(episode, UpNextChange.ACTION_PLAY_LAST)
     }
 
-    fun saveRemove(episode: BaseEpisode) {
-        saveUpdate(episode, UpNextChange.ACTION_REMOVE)
+    fun saveRemoveBlocking(episode: BaseEpisode) {
+        saveUpdateBlocking(episode, UpNextChange.ACTION_REMOVE)
     }
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
-    abstract fun insert(upNextChange: UpNextChange)
+    abstract fun insertBlocking(upNextChange: UpNextChange)
 
-    private fun saveUpdate(episode: BaseEpisode, action: Int) {
+    private fun saveUpdateBlocking(episode: BaseEpisode, action: Int) {
         val change = UpNextChange(type = action, uuid = episode.uuid, modified = System.currentTimeMillis())
         // an update replaces any other update that is for the same episode, so delete any that might exist
-        deleteByUuid(episode.uuid)
-        insert(change)
+        deleteByUuidBlocking(episode.uuid)
+        insertBlocking(change)
     }
 
     fun saveReplace(episodeUuids: List<String>) {
         val episodeUuidsString = episodeUuids.joinToString(separator = ",")
         val change = UpNextChange(type = UpNextChange.ACTION_REPLACE, uuids = episodeUuidsString, modified = System.currentTimeMillis())
         // a replace literally replaces everything that came before it, so empty the table out
-        deleteAll()
-        insert(change)
+        deleteAllBlocking()
+        insertBlocking(change)
     }
 }

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/UserEpisodeDao.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/UserEpisodeDao.kt
@@ -22,7 +22,7 @@ abstract class UserEpisodeDao {
     abstract suspend fun insert(userEpisode: UserEpisode)
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
-    abstract fun insertRx(userEpisode: UserEpisode): Completable
+    abstract fun insertRxCompletable(userEpisode: UserEpisode): Completable
 
     @Insert(onConflict = OnConflictStrategy.IGNORE)
     abstract suspend fun insertAll(userEpisodes: List<UserEpisode>)
@@ -40,37 +40,37 @@ abstract class UserEpisodeDao {
     abstract suspend fun findAllUuids(): List<String>
 
     @Query("SELECT * FROM user_episodes ORDER BY added_date DESC")
-    abstract fun observeUserEpisodesDesc(): Flowable<List<UserEpisode>>
+    abstract fun findUserEpisodesDescRxFlowable(): Flowable<List<UserEpisode>>
 
     @Query("SELECT * FROM user_episodes ORDER BY added_date DESC")
     abstract suspend fun findUserEpisodesDesc(): List<UserEpisode>
 
     @Query("SELECT * FROM user_episodes ORDER BY added_date ASC")
-    abstract fun observeUserEpisodesAsc(): Flowable<List<UserEpisode>>
+    abstract fun findUserEpisodesAscRxFlowable(): Flowable<List<UserEpisode>>
 
     @Query("SELECT * FROM user_episodes ORDER BY title ASC")
-    abstract fun observeUserEpisodesTitleAsc(): Flowable<List<UserEpisode>>
+    abstract fun findUserEpisodesTitleAscRxFlowable(): Flowable<List<UserEpisode>>
 
     @Query("SELECT * FROM user_episodes ORDER BY title DESC")
-    abstract fun observeUserEpisodesTitleDesc(): Flowable<List<UserEpisode>>
+    abstract fun findUserEpisodesTitleDescRxFlowable(): Flowable<List<UserEpisode>>
 
     @Query("SELECT * FROM user_episodes ORDER BY duration ASC")
-    abstract fun observeUserEpisodesDurationAsc(): Flowable<List<UserEpisode>>
+    abstract fun findUserEpisodesDurationAscRxFlowable(): Flowable<List<UserEpisode>>
 
     @Query("SELECT * FROM user_episodes ORDER BY duration DESC")
-    abstract fun observeUserEpisodesDurationDesc(): Flowable<List<UserEpisode>>
+    abstract fun findUserEpisodesDurationDescRxFlowable(): Flowable<List<UserEpisode>>
 
     @Query("SELECT * FROM user_episodes WHERE download_task_id IS NOT NULL")
-    abstract fun observeDownloadingUserEpisodes(): Flowable<List<UserEpisode>>
+    abstract fun findDownloadingUserEpisodesRxFlowable(): Flowable<List<UserEpisode>>
 
     @Query("SELECT * FROM user_episodes WHERE uuid = :uuid")
-    abstract fun observeEpisodeRx(uuid: String): Flowable<UserEpisode>
+    abstract fun findEpisodeRxFlowable(uuid: String): Flowable<UserEpisode>
 
     @Query("SELECT * FROM user_episodes WHERE uuid = :uuid")
-    abstract fun observeEpisode(uuid: String): Flow<UserEpisode>
+    abstract fun findEpisodeFlow(uuid: String): Flow<UserEpisode>
 
     @Query("SELECT * FROM user_episodes WHERE uuid = :uuid")
-    abstract fun findEpisodeByUuidRx(uuid: String): Maybe<UserEpisode>
+    abstract fun findEpisodeByUuidRxMaybe(uuid: String): Maybe<UserEpisode>
 
     @Query("SELECT * FROM user_episodes WHERE uuid = :uuid")
     abstract suspend fun findEpisodeByUuid(uuid: String): UserEpisode?
@@ -79,22 +79,22 @@ abstract class UserEpisodeDao {
     abstract suspend fun findEpisodesByUuids(episodeUuids: List<String>): List<UserEpisode>
 
     @Query("UPDATE user_episodes SET played_up_to = :playedUpTo, played_up_to_modified = :modified WHERE uuid = :uuid AND (played_up_to IS NULL OR played_up_to < :playedUpToMin OR played_up_to > :playedUpToMax)")
-    abstract fun updatePlayedUpToIfChanged(playedUpTo: Double, playedUpToMin: Double, playedUpToMax: Double, modified: Long, uuid: String)
+    abstract fun updatePlayedUpToIfChangedBlocking(playedUpTo: Double, playedUpToMin: Double, playedUpToMax: Double, modified: Long, uuid: String)
 
     @Query("UPDATE user_episodes SET duration = :duration WHERE uuid = :uuid")
-    abstract fun updateDuration(duration: Double, uuid: String)
+    abstract fun updateDurationBlocking(duration: Double, uuid: String)
 
     @Query("UPDATE user_episodes SET playing_status = :playingStatus, playing_status_modified = :modified WHERE uuid = :uuid")
-    abstract fun updatePlayingStatus(playingStatus: EpisodePlayingStatus, modified: Long, uuid: String)
+    abstract fun updatePlayingStatusBlocking(playingStatus: EpisodePlayingStatus, modified: Long, uuid: String)
 
     @Query("UPDATE user_episodes SET episode_status = :episodeStatus WHERE uuid = :uuid")
-    abstract fun updateEpisodeStatus(uuid: String, episodeStatus: EpisodeStatusEnum)
+    abstract fun updateEpisodeStatusBlocking(uuid: String, episodeStatus: EpisodeStatusEnum)
 
     @Query("UPDATE user_episodes SET auto_download_status = :autoDownloadStatus WHERE uuid = :uuid")
-    abstract fun updateAutoDownloadStatus(autoDownloadStatus: Int, uuid: String)
+    abstract fun updateAutoDownloadStatusBlocking(autoDownloadStatus: Int, uuid: String)
 
     @Query("UPDATE user_episodes SET server_status = :serverStatus WHERE uuid = :uuid")
-    abstract fun updateServerStatusRx(uuid: String, serverStatus: UserEpisodeServerStatus): Completable
+    abstract fun updateServerStatusRxCompletable(uuid: String, serverStatus: UserEpisodeServerStatus): Completable
 
     @Query("UPDATE user_episodes SET server_status = :serverStatus WHERE uuid = :uuid")
     abstract suspend fun updateServerStatus(uuid: String, serverStatus: UserEpisodeServerStatus)
@@ -115,22 +115,22 @@ abstract class UserEpisodeDao {
     abstract suspend fun updateDownloadError(uuid: String, error: String?)
 
     @Query("UPDATE user_episodes SET play_error_details = :error WHERE uuid = :uuid")
-    abstract fun updatePlayError(uuid: String, error: String?)
+    abstract fun updatePlayErrorBlocking(uuid: String, error: String?)
 
     @Query("UPDATE user_episodes SET download_task_id = :taskId WHERE uuid = :uuid")
     abstract suspend fun updateDownloadTaskId(uuid: String, taskId: String?)
 
     @Query("UPDATE user_episodes SET upload_error_details = :uploadError WHERE uuid = :uuid")
-    abstract fun updateUploadErrorRx(uuid: String, uploadError: String?): Completable
+    abstract fun updateUploadErrorRxCompetable(uuid: String, uploadError: String?): Completable
 
     @Query("UPDATE user_episodes SET upload_error_details = :uploadError WHERE uuid = :uuid")
     abstract suspend fun updateUploadError(uuid: String, uploadError: String?)
 
     @Query("SELECT * FROM user_episodes WHERE (playing_status_modified IS NOT NULL OR played_up_to_modified IS NOT NULL) AND uuid IS NOT NULL LIMIT 2000")
-    abstract fun findUserEpisodesToSync(): List<UserEpisode>
+    abstract fun findUserEpisodesToSyncBlocking(): List<UserEpisode>
 
     @Query("UPDATE user_episodes SET played_up_to_modified = NULL, playing_status_modified = NULL")
-    abstract fun markAllSynced()
+    abstract fun markAllSyncedBlocking()
 
     @Query("UPDATE user_episodes SET upload_task_id = :uploadTaskId WHERE uuid = :uuid")
     abstract suspend fun updateUploadTaskId(uuid: String, uploadTaskId: String?)

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/helper/QueryHelper.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/helper/QueryHelper.kt
@@ -6,7 +6,7 @@ import au.com.shiftyjelly.pocketcasts.models.db.AppDatabase
 
 object QueryHelper {
 
-    fun firstRowArray(query: String, params: Array<String>?, appDatabase: AppDatabase): Array<String?>? {
+    fun firstRowArrayBlocking(query: String, params: Array<String>?, appDatabase: AppDatabase): Array<String?>? {
         appDatabase.query(query, params ?: arrayOf()).use { cursor ->
             if (cursor.moveToNext()) {
                 val result = arrayOfNulls<String>(cursor.columnCount)
@@ -20,7 +20,7 @@ object QueryHelper {
         }
     }
 
-    fun findAll(query: String, params: Array<String>?, db: SQLiteDatabase, rowParser: (Cursor) -> Boolean) {
+    fun findAllBlocking(query: String, params: Array<String>?, db: SQLiteDatabase, rowParser: (Cursor) -> Boolean) {
         db.rawQuery(query, params ?: arrayOf()).use { cursor ->
             if (cursor.moveToFirst()) {
                 var keepGoing: Boolean

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/bookmark/BookmarkManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/bookmark/BookmarkManager.kt
@@ -31,7 +31,7 @@ interface BookmarkManager {
     suspend fun deleteToSync(bookmarkUuid: String)
     suspend fun deleteSynced(bookmarkUuid: String)
     suspend fun upsertSynced(bookmark: Bookmark): Bookmark
-    fun findBookmarksToSync(): List<Bookmark>
+    fun findBookmarksToSyncBlocking(): List<Bookmark>
     suspend fun searchInPodcastByTitle(podcastUuid: String, title: String): List<String>
     suspend fun searchByBookmarkOrEpisodeTitle(title: String): List<String>
     fun findUserEpisodesBookmarksFlow(): Flow<List<Bookmark>>

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/bookmark/BookmarkManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/bookmark/BookmarkManagerImpl.kt
@@ -208,8 +208,8 @@ class BookmarkManagerImpl @Inject constructor(
     /**
      * Find all bookmarks that need to be synced.
      */
-    override fun findBookmarksToSync(): List<Bookmark> {
-        return bookmarkDao.findNotSynced()
+    override fun findBookmarksToSyncBlocking(): List<Bookmark> {
+        return bookmarkDao.findNotSyncedBlocking()
     }
 
     /**

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/download/FixDownloadsWorker.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/download/FixDownloadsWorker.kt
@@ -55,7 +55,7 @@ class FixDownloadsWorker @AssistedInject constructor(
         .fold(0) { fixedCount, (episode, _) ->
             val path = findExpectedDownloadPath(episode)
             if (path != null && path != episode.downloadedFilePath) {
-                episodeManager.updateDownloadFilePath(episode, path, markAsDownloaded = true)
+                episodeManager.updateDownloadFilePathBlocking(episode, path, markAsDownloaded = true)
                 fixedCount + 1
             } else {
                 fixedCount

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/download/UpdateEpisodeDetailsTask.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/download/UpdateEpisodeDetailsTask.kt
@@ -102,7 +102,7 @@ class UpdateEpisodeDetailsTask @AssistedInject constructor(
                     val contentType = response.header("Content-Type")
                     if (!contentType.isNullOrBlank()) {
                         if ((episode.fileType.isNullOrBlank() && (contentType.startsWith("audio") || contentType.startsWith("video"))) || contentType.startsWith("video")) {
-                            episodeManager.updateFileType(episode, contentType)
+                            episodeManager.updateFileTypeBlocking(episode, contentType)
                             episode.fileType = contentType
                         }
                     }
@@ -113,7 +113,7 @@ class UpdateEpisodeDetailsTask @AssistedInject constructor(
                             val contentLength = java.lang.Long.parseLong(contentLengthHeader)
                             val sizeInBytes = episode.sizeInBytes
                             if ((sizeInBytes == 0L || sizeInBytes != contentLength) && contentLength > 153600) {
-                                episodeManager.updateSizeInBytes(episode, contentLength)
+                                episodeManager.updateSizeInBytesBlocking(episode, contentLength)
                                 episode.sizeInBytes = contentLength
                             }
                         } catch (nfe: NumberFormatException) {

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/download/task/DownloadEpisodeTask.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/download/task/DownloadEpisodeTask.kt
@@ -159,7 +159,7 @@ class DownloadEpisodeTask @AssistedInject constructor(
 
             if (!isStopped) {
                 pathToSaveTo?.let {
-                    episodeManager.updateDownloadFilePath(episode, it, false)
+                    episodeManager.updateDownloadFilePathBlocking(episode, it, false)
                     runBlocking {
                         episodeManager.updateEpisodeStatus(episode, EpisodeStatusEnum.DOWNLOADED)
                     }
@@ -227,7 +227,7 @@ class DownloadEpisodeTask @AssistedInject constructor(
             episodeManager.updateEpisodeStatus(episode, EpisodeStatusEnum.DOWNLOAD_FAILED)
         }
         val message = if (downloadMessage.isNullOrBlank()) "Download Failed" else downloadMessage
-        episodeManager.updateDownloadErrorDetails(episode, message)
+        episodeManager.updateDownloadErrorDetailsBlocking(episode, message)
 
         LogBuffer.i(LogBuffer.TAG_BACKGROUND_TASKS, "Download failed ${episode.title} ${episode.uuid} - $message")
 
@@ -465,7 +465,7 @@ class DownloadEpisodeTask @AssistedInject constructor(
                     tempDownloadFile.delete()
 
                     if (episode.sizeInBytes != fullDownloadFile.length()) {
-                        episodeManager.updateSizeInBytes(episode, fullDownloadFile.length())
+                        episodeManager.updateSizeInBytesBlocking(episode, fullDownloadFile.length())
                     }
 
                     if (!emitter.isDisposed) {
@@ -577,7 +577,7 @@ class DownloadEpisodeTask @AssistedInject constructor(
                 }
 
                 val durationInSecs = (duration / 1000000).toDouble()
-                episodeManager.updateDuration(episode, durationInSecs, true)
+                episodeManager.updateDurationBlocking(episode, durationInSecs, true)
 
                 return
             }
@@ -589,7 +589,7 @@ class DownloadEpisodeTask @AssistedInject constructor(
     private fun fixInvalidContentType(contentType: MediaType?) {
         contentType ?: return
         if ((episode.fileType.isNullOrBlank() && (contentType.type == "audio" || contentType.type == "video")) || contentType.type == "video") {
-            episodeManager.updateFileType(episode, contentType.toString())
+            episodeManager.updateFileTypeBlocking(episode, contentType.toString())
             episode.fileType = contentType.toString()
         }
     }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/file/FileStorage.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/file/FileStorage.kt
@@ -179,7 +179,7 @@ open class FileStorage @Inject constructor(
                     .updateEpisodesWithNewFilePaths(episodesManager)
 
                 // Move episodes
-                episodesManager.observeDownloadedEpisodes().asFlow().first()
+                episodesManager.findDownloadedEpisodesRxFlowable().asFlow().first()
                     .onEach { episode -> LogBuffer.i(LogBuffer.TAG_BACKGROUND_TASKS, "Found downloaded episode ${episode.title}") }
                     .matchWithDownloadedFilePaths()
                     .filterNotExistingFiles()
@@ -218,7 +218,7 @@ open class FileStorage @Inject constructor(
     }
 
     private fun List<Pair<File, PodcastEpisode>>.updateEpisodesWithNewFilePaths(episodeManager: EpisodeManager) = forEach { (file, episode) ->
-        episodeManager.updateDownloadFilePath(episode, file.absolutePath, markAsDownloaded = true)
+        episodeManager.updateDownloadFilePathBlocking(episode, file.absolutePath, markAsDownloaded = true)
     }
 
     private fun List<PodcastEpisode>.matchWithDownloadedFilePaths() = mapNotNull { episode ->
@@ -233,7 +233,7 @@ open class FileStorage @Inject constructor(
 
     private fun List<Pair<PodcastEpisode, String>>.moveFilesToEpisodesDirAndUpdatePaths(episodeManager: EpisodeManager, episodesDir: File) = forEach { (episode, path) ->
         moveFileToDir(path, episodesDir)?.let { updatedPath ->
-            episodeManager.updateDownloadFilePath(episode, updatedPath, markAsDownloaded = false)
+            episodeManager.updateDownloadFilePathBlocking(episode, updatedPath, markAsDownloaded = false)
         }
     }
 
@@ -297,7 +297,7 @@ open class FileStorage @Inject constructor(
         // Link to the found episode
         episode.episodeStatus = EpisodeStatusEnum.DOWNLOADED
         episode.downloadedFilePath = file.absolutePath
-        episodeManager.update(episode)
+        episodeManager.updateBlocking(episode)
     }
 
     private companion object {

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/jobs/VersionMigrationsWorker.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/jobs/VersionMigrationsWorker.kt
@@ -198,16 +198,16 @@ class VersionMigrationsWorker @AssistedInject constructor(
     private suspend fun removeCustomEpisodes() {
         val customPodcastUuid = "customFolderPodcast"
         val podcast: Podcast = podcastManager.findPodcastByUuidSuspend(customPodcastUuid) ?: return
-        val episodes: List<PodcastEpisode> = episodeManager.findEpisodesByPodcastOrderedByPublishDate(podcast)
+        val episodes: List<PodcastEpisode> = episodeManager.findEpisodesByPodcastOrderedByPublishDateBlocking(podcast)
         episodes.forEach { episode ->
             playbackManager.removeEpisode(
                 episodeToRemove = episode,
                 source = SourceView.UNKNOWN,
                 userInitiated = false,
             )
-            appDatabase.episodeDao().delete(episode)
+            appDatabase.episodeDao().deleteBlocking(episode)
         }
-        appDatabase.podcastDao().deleteByUuid(customPodcastUuid)
+        appDatabase.podcastDao().deleteByUuidBlocking(customPodcastUuid)
     }
 
     private fun performV7Migration() {

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/MediaSessionManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/MediaSessionManager.kt
@@ -355,7 +355,7 @@ class MediaSessionManager(
                     if (state.isEmpty) {
                         Observable.just(Optional.empty())
                     } else {
-                        episodeManager.observeEpisodeByUuidRx(state.episodeUuid)
+                        episodeManager.findEpisodeByUuidRxFlowable(state.episodeUuid)
                             .distinctUntilChanged(BaseEpisode.isMediaSessionEqual)
                             .map { Optional.of(it) }
                             // if the episode is deleted from the database while playing catch the error and just return an empty state
@@ -744,7 +744,7 @@ class MediaSessionManager(
     private fun markAsPlayed() {
         launch {
             val episode = playbackManager.getCurrentEpisode()
-            episodeManager.markAsPlayed(episode, playbackManager, podcastManager)
+            episodeManager.markAsPlayedBlocking(episode, playbackManager, podcastManager)
             episode?.let {
                 episodeAnalytics.trackEvent(AnalyticsEvent.EPISODE_MARKED_AS_PLAYED, source, it.uuid)
             }
@@ -813,7 +813,7 @@ class MediaSessionManager(
             playbackManager.getCurrentEpisode()?.let {
                 if (it is PodcastEpisode) {
                     it.isArchived = true
-                    episodeManager.archive(it, playbackManager)
+                    episodeManager.archiveBlocking(it, playbackManager)
                     episodeAnalytics.trackEvent(AnalyticsEvent.EPISODE_ARCHIVED, source, it.uuid)
                 }
             }
@@ -921,7 +921,7 @@ class MediaSessionManager(
     }
 
     private suspend fun playPodcast(podcast: Podcast, sourceView: SourceView = SourceView.UNKNOWN) {
-        val latestEpisode = withContext(Dispatchers.Default) { episodeManager.findLatestUnfinishedEpisodeByPodcast(podcast) } ?: return
+        val latestEpisode = withContext(Dispatchers.Default) { episodeManager.findLatestUnfinishedEpisodeByPodcastBlocking(podcast) } ?: return
         playbackManager.playNow(episode = latestEpisode, sourceView = sourceView)
     }
 

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
@@ -241,7 +241,7 @@ open class PlaybackManager @Inject constructor(
         }
 
         // load an initial playback state
-        upNextQueue.setup()
+        upNextQueue.setupBlocking()
         mediaSessionManager.startObserving()
         val playbackManagerNetworkWatcher = playbackManagerNetworkWatcherFactory.create(::onSwitchedToMeteredConnection)
 
@@ -287,7 +287,7 @@ open class PlaybackManager @Inject constructor(
         val autoPlayEpisode = autoSelectNextEpisode() ?: return null
 
         withContext(Dispatchers.Default) {
-            upNextQueue.playNext(autoPlayEpisode, downloadManager) {
+            upNextQueue.playNextBlocking(autoPlayEpisode, downloadManager) {
                 launch {
                     loadCurrentEpisode(play = autoPlay, sourceView = SourceView.AUTO_PLAY)
                 }
@@ -493,11 +493,11 @@ open class PlaybackManager @Inject constructor(
 
         withContext(Dispatchers.IO) {
             if (episode.isArchived) {
-                episodeManager.unarchive(episode)
+                episodeManager.unarchiveBlocking(episode)
             }
 
             if (episode.playingStatus == EpisodePlayingStatus.COMPLETED) {
-                episodeManager.markAsNotPlayed(episode)
+                episodeManager.markAsNotPlayedBlocking(episode)
             }
         }
 
@@ -625,7 +625,7 @@ open class PlaybackManager @Inject constructor(
         userInitiated: Boolean = true,
     ) = withContext(Dispatchers.Default) {
         val wasEmpty: Boolean = upNextQueue.isEmpty
-        upNextQueue.playNext(episode, downloadManager, null)
+        upNextQueue.playNextBlocking(episode, downloadManager, null)
         if (userInitiated) {
             episodeAnalytics.trackEvent(AnalyticsEvent.EPISODE_ADDED_TO_UP_NEXT, source, true, episode)
         }
@@ -640,7 +640,7 @@ open class PlaybackManager @Inject constructor(
         userInitiated: Boolean = true,
     ) {
         val wasEmpty: Boolean = upNextQueue.isEmpty
-        upNextQueue.playLast(episode, downloadManager, null)
+        upNextQueue.playLastBlocking(episode, downloadManager, null)
         if (userInitiated) {
             episodeAnalytics.trackEvent(AnalyticsEvent.EPISODE_ADDED_TO_UP_NEXT, source, false, episode)
         }
@@ -697,7 +697,7 @@ open class PlaybackManager @Inject constructor(
             val topEpisode = episodes.first()
             playNowSync(episode = topEpisode, sourceView = sourceView)
             if (episodes.size > 1) {
-                upNextQueue.clearAndPlayAll(episodes.slice(1 until min(episodes.size, settings.getMaxUpNextEpisodes())), downloadManager)
+                upNextQueue.clearAndPlayAllBlocking(episodes.slice(1 until min(episodes.size, settings.getMaxUpNextEpisodes())), downloadManager)
             }
         }
     }
@@ -1163,7 +1163,7 @@ open class PlaybackManager @Inject constructor(
 
         val currentEpisode = getCurrentEpisode()
         if (currentEpisode is BaseEpisode) {
-            episodeManager.markAsPlaybackError(currentEpisode, event, isPlaybackRemote())
+            episodeManager.markAsPlaybackErrorBlocking(currentEpisode, event, isPlaybackRemote())
         }
 
         stop()
@@ -1226,7 +1226,7 @@ open class PlaybackManager @Inject constructor(
             playbackStateRelay.accept(playbackState.copy(state = PlaybackState.State.PLAYING, transientLoss = false, lastChangeFrom = LastChangeFrom.OnPlayerPlaying.value))
         }
 
-        episodeManager.updatePlayingStatus(episode, EpisodePlayingStatus.IN_PROGRESS)
+        episodeManager.updatePlayingStatusBlocking(episode, EpisodePlayingStatus.IN_PROGRESS)
 
         setupUpdateTimer()
         setupBufferUpdateTimer(episode)
@@ -1316,7 +1316,7 @@ open class PlaybackManager @Inject constructor(
             removeEpisodeFromQueue(episode, "finished", downloadManager)
 
             // mark as played
-            episodeManager.updatePlayingStatus(episode, EpisodePlayingStatus.COMPLETED)
+            episodeManager.updatePlayingStatusBlocking(episode, EpisodePlayingStatus.COMPLETED)
 
             // auto archive after playing
             if (episode is PodcastEpisode) {
@@ -1380,9 +1380,9 @@ open class PlaybackManager @Inject constructor(
         var episodeSource = settings.lastAutoPlaySource.value.toString().lowercase()
 
         val allEpisodes: List<BaseEpisode> = when (val autoSource = settings.lastAutoPlaySource.value) {
-            is AutoPlaySource.Downloads -> episodeManager.observeDownloadEpisodes().asFlow().firstOrNull()
+            is AutoPlaySource.Downloads -> episodeManager.findDownloadEpisodesRxFlowable().asFlow().firstOrNull()
             is AutoPlaySource.Files -> cloudFilesManager.sortedCloudFiles.firstOrNull()
-            is AutoPlaySource.Starred -> episodeManager.observeStarredEpisodes().asFlow().firstOrNull()
+            is AutoPlaySource.Starred -> episodeManager.findStarredEpisodesRxFlowable().asFlow().firstOrNull()
             // First check if it is a podcast uuid, then check if it is from a filter
             is AutoPlaySource.PodcastOrFilter -> {
                 episodeSource = "podcast"
@@ -1417,7 +1417,7 @@ open class PlaybackManager @Inject constructor(
 
         // If no matches found, play the latest episode on Android Automotive to avoid the player stopping
         when (Util.getAppPlatform(application)) {
-            AppPlatform.Automotive -> return episodeManager.findLatestEpisodeToPlay()
+            AppPlatform.Automotive -> return episodeManager.findLatestEpisodeToPlayBlocking()
             AppPlatform.WearOs -> return null
             AppPlatform.Phone -> {
                 analyticsTracker.track(AnalyticsEvent.AUTOPLAY_FINISHED_LAST_EPISODE, mapOf("episode_source" to episodeSource))
@@ -1428,7 +1428,7 @@ open class PlaybackManager @Inject constructor(
 
     private fun autoPlayOrderForPodcastEpisodes(podcast: Podcast): List<PodcastEpisode> {
         val episodes = episodeManager
-            .findEpisodesByPodcastOrdered(podcast)
+            .findEpisodesByPodcastOrderedBlocking(podcast)
 
         val modifiedEpisodes = when (podcast.grouping) {
             PodcastGrouping.None,
@@ -1490,7 +1490,7 @@ open class PlaybackManager @Inject constructor(
             val currentTimeMs = it.getCurrentPositionMs() - 5000
             if (currentTimeMs > 0) {
                 val currentTimeSecs = currentTimeMs.toDouble() / 1000.0
-                episodeManager.updatePlayedUpTo(episode, currentTimeSecs, false)
+                episodeManager.updatePlayedUpToBlocking(episode, currentTimeSecs, false)
             }
         }
 
@@ -1566,7 +1566,7 @@ open class PlaybackManager @Inject constructor(
         }
 
         val playerDurationSecs = durationMs.toDouble() / 1000.0
-        episodeManager.updateDuration(episode, playerDurationSecs, true)
+        episodeManager.updateDurationBlocking(episode, playerDurationSecs, true)
     }
 
     suspend fun onSeekComplete(positionMs: Int) {
@@ -1787,7 +1787,7 @@ open class PlaybackManager @Inject constructor(
 
         // completed episodes should play from the start
         if (episode.isFinished) {
-            episodeManager.markAsNotPlayed(episode)
+            episodeManager.markAsNotPlayedBlocking(episode)
         }
 
         // make sure we have the latest episode url
@@ -1847,7 +1847,7 @@ open class PlaybackManager @Inject constructor(
                 return
             } else {
                 val episodeObservable: Flowable<BaseEpisode>? = if (episode is PodcastEpisode) {
-                    episodeManager.observeByUuid(episode.uuid)
+                    episodeManager.findByUuidFlow(episode.uuid)
                         .asFlowable()
                         .cast(BaseEpisode::class.java)
                 } else if (episode is UserEpisode) {
@@ -1866,7 +1866,7 @@ open class PlaybackManager @Inject constructor(
                                     launch(Dispatchers.Default) {
                                         player?.let { player ->
                                             val currentTimeSecs = player.getCurrentPositionMs().toDouble() / 1000.0
-                                            episodeManager.updatePlayedUpTo(it, currentTimeSecs, true)
+                                            episodeManager.updatePlayedUpToBlocking(it, currentTimeSecs, true)
                                         }
                                         loadCurrentEpisode(isPlaying())
                                     }
@@ -1914,7 +1914,7 @@ open class PlaybackManager @Inject constructor(
                     // Make sure that the episode is updated with the latest position before resetting the player.
                     // This helps avoid having the audio jump "back" a second or so when the currently playing episode
                     // is downloaded.
-                    episodeManager.updatePlayedUpTo(episode, playerPositionSeconds, forceUpdate = true)
+                    episodeManager.updatePlayedUpToBlocking(episode, playerPositionSeconds, forceUpdate = true)
                     posUpdatedOnPlayerReset = true
                 }
 
@@ -2098,7 +2098,7 @@ open class PlaybackManager @Inject constructor(
 
         // clear the playback errors
         if (episode.playErrorDetails != null) {
-            episodeManager.clearPlaybackError(episode)
+            episodeManager.clearPlaybackErrorBlocking(episode)
         }
 
         audioNoisyManager.register(this)
@@ -2236,7 +2236,7 @@ open class PlaybackManager @Inject constructor(
         }
 
         val currentTimeSecs = currentTimeMs.toDouble() / 1000.0
-        episodeManager.updatePlayedUpTo(episode, currentTimeSecs, false)
+        episodeManager.updatePlayedUpToBlocking(episode, currentTimeSecs, false)
         episodeManager.updatePlaybackInteractionDate(episode)
         LogBuffer.i(LogBuffer.TAG_PLAYBACK, "Saved time in database %.3f", currentTimeSecs)
 
@@ -2271,7 +2271,7 @@ open class PlaybackManager @Inject constructor(
                     sleepEndOfEpisode(episode)
                 } else {
                     statsManager.addTimeSavedAutoSkipping(timeRemaining.toLong() * 1000L)
-                    episodeManager.markAsPlayed(episode, this, podcastManager)
+                    episodeManager.markAsPlayedBlocking(episode, this, podcastManager)
                     LogBuffer.i(LogBuffer.TAG_PLAYBACK, "Skipping remainder of ${episode.title} with skip last $skipLast")
                     showToast(application.getString(LR.string.player_skipped_last, skipLast))
                 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackService.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackService.kt
@@ -447,7 +447,7 @@ open class PlaybackService : MediaBrowserServiceCompat(), CoroutineScope {
         }
         // add the latest episode
         if (episodes.size < NUM_SUGGESTED_ITEMS) {
-            val latestEpisode = episodeManager.findLatestEpisodeToPlay()
+            val latestEpisode = episodeManager.findLatestEpisodeToPlayBlocking()
             if (latestEpisode != null && episodes.none { it.uuid == latestEpisode.uuid }) {
                 episodes.add(latestEpisode)
             }
@@ -545,7 +545,7 @@ open class PlaybackService : MediaBrowserServiceCompat(), CoroutineScope {
         if (playlist != null) {
             val episodeList = if (DOWNLOADS_ROOT == parentId) {
                 autoPlaySource = AutoPlaySource.Downloads
-                episodeManager.observeDownloadedEpisodes().blockingFirst()
+                episodeManager.findDownloadedEpisodesRxFlowable().blockingFirst()
             } else {
                 autoPlaySource = AutoPlaySource.fromId(parentId)
                 playlistManager.findEpisodesBlocking(playlist, episodeManager, playbackManager)
@@ -565,7 +565,7 @@ open class PlaybackService : MediaBrowserServiceCompat(), CoroutineScope {
 
                 val showPlayed = settings.autoShowPlayed.value
                 val episodes = episodeManager
-                    .findEpisodesByPodcastOrdered(podcast)
+                    .findEpisodesByPodcastOrderedBlocking(podcast)
                     .filterNot { !showPlayed && (it.isFinished || it.isArchived) }
                     .take(EPISODE_LIMIT)
                     .toMutableList()

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/ChapterManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/ChapterManagerImpl.kt
@@ -28,7 +28,7 @@ class ChapterManagerImpl @Inject constructor(
     }
 
     override fun observerChaptersForEpisode(episodeUuid: String) = combine(
-        episodeManager.observeEpisodeByUuid(episodeUuid).distinctUntilChangedBy(BaseEpisode::deselectedChapters),
+        episodeManager.findEpisodeByUuidFlow(episodeUuid).distinctUntilChangedBy(BaseEpisode::deselectedChapters),
         chapterDao.observerChaptersForEpisode(episodeUuid),
     ) { episode, dbChapters -> dbChapters.toChapters(episode) }
 

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManager.kt
@@ -15,119 +15,119 @@ import kotlinx.coroutines.flow.Flow
 
 interface EpisodeManager {
 
-    fun getPodcastUuidToBadgeUnfinished(): Flowable<Map<String, Int>>
-    fun getPodcastUuidToBadgeLatest(): Flowable<Map<String, Int>>
+    fun getPodcastUuidToBadgeUnfinishedRxFlowable(): Flowable<Map<String, Int>>
+    fun getPodcastUuidToBadgeLatestRxFlowable(): Flowable<Map<String, Int>>
 
     /** Find methods  */
 
     suspend fun findByUuid(uuid: String): PodcastEpisode?
 
     @Deprecated("Use findByUuid suspended function instead")
-    fun findByUuidRx(uuid: String): Maybe<PodcastEpisode>
+    fun findByUuidRxMaybe(uuid: String): Maybe<PodcastEpisode>
 
-    fun observeByUuid(uuid: String): Flow<PodcastEpisode>
-    fun observeEpisodeByUuidRx(uuid: String): Flowable<BaseEpisode>
-    fun observeEpisodeByUuid(uuid: String): Flow<BaseEpisode>
+    fun findByUuidFlow(uuid: String): Flow<PodcastEpisode>
+    fun findEpisodeByUuidRxFlowable(uuid: String): Flowable<BaseEpisode>
+    fun findEpisodeByUuidFlow(uuid: String): Flow<BaseEpisode>
     suspend fun findFirstBySearchQuery(query: String): PodcastEpisode?
 
-    fun findEpisodesWhere(queryAfterWhere: String, forSubscribedPodcastsOnly: Boolean = true): List<PodcastEpisode>
-    fun findEpisodesByPodcastOrdered(podcast: Podcast): List<PodcastEpisode>
+    fun findEpisodesWhereBlocking(queryAfterWhere: String, forSubscribedPodcastsOnly: Boolean = true): List<PodcastEpisode>
+    fun findEpisodesByPodcastOrderedBlocking(podcast: Podcast): List<PodcastEpisode>
     suspend fun findEpisodesByPodcastOrderedSuspend(podcast: Podcast): List<PodcastEpisode>
-    fun findEpisodesByPodcastOrderedByPublishDate(podcast: Podcast): List<PodcastEpisode>
-    suspend fun findEpisodesByPodcastOrderedByPublishDateSuspend(podcast: Podcast): List<PodcastEpisode>
-    fun findNotificationEpisodes(date: Date): List<PodcastEpisode>
-    fun findLatestUnfinishedEpisodeByPodcast(podcast: Podcast): PodcastEpisode?
-    fun findLatestEpisodeToPlay(): PodcastEpisode?
-    fun observeEpisodesByPodcastOrderedRx(podcast: Podcast): Flowable<List<PodcastEpisode>>
-    fun observeEpisodesWhere(queryAfterWhere: String): Flowable<List<PodcastEpisode>>
+    fun findEpisodesByPodcastOrderedByPublishDateBlocking(podcast: Podcast): List<PodcastEpisode>
+    suspend fun findEpisodesByPodcastOrderedByPublishDate(podcast: Podcast): List<PodcastEpisode>
+    fun findNotificationEpisodesBlocking(date: Date): List<PodcastEpisode>
+    fun findLatestUnfinishedEpisodeByPodcastBlocking(podcast: Podcast): PodcastEpisode?
+    fun findLatestEpisodeToPlayBlocking(): PodcastEpisode?
+    fun findEpisodesByPodcastOrderedRxFlowable(podcast: Podcast): Flowable<List<PodcastEpisode>>
+    fun findEpisodesWhereRxFlowable(queryAfterWhere: String): Flowable<List<PodcastEpisode>>
 
-    fun findEpisodesToSync(): List<PodcastEpisode>
-    fun findEpisodesForHistorySync(): List<PodcastEpisode>
-    fun markAllEpisodesSynced(episodes: List<PodcastEpisode>)
+    fun findEpisodesToSyncBlocking(): List<PodcastEpisode>
+    fun findEpisodesForHistorySyncBlocking(): List<PodcastEpisode>
+    fun markAllEpisodesSyncedBlocking(episodes: List<PodcastEpisode>)
 
-    fun findEpisodesDownloading(queued: Boolean = true, waitingForPower: Boolean = true, waitingForWifi: Boolean = true, downloading: Boolean = true): List<PodcastEpisode>
+    fun findEpisodesDownloadingBlocking(queued: Boolean = true, waitingForPower: Boolean = true, waitingForWifi: Boolean = true, downloading: Boolean = true): List<PodcastEpisode>
 
-    fun observeDownloadEpisodes(): Flowable<List<PodcastEpisode>>
-    fun observeDownloadedEpisodes(): Flowable<List<PodcastEpisode>>
-    fun observeStarredEpisodes(): Flowable<List<PodcastEpisode>>
+    fun findDownloadEpisodesRxFlowable(): Flowable<List<PodcastEpisode>>
+    fun findDownloadedEpisodesRxFlowable(): Flowable<List<PodcastEpisode>>
+    fun findStarredEpisodesRxFlowable(): Flowable<List<PodcastEpisode>>
     suspend fun findStarredEpisodes(): List<PodcastEpisode>
 
     /** Add methods  */
-    fun add(episode: PodcastEpisode, downloadMetaData: Boolean): Boolean
-    fun add(episodes: List<PodcastEpisode>, podcastUuid: String, downloadMetaData: Boolean): List<PodcastEpisode>
-    suspend fun addSuspend(episodes: List<PodcastEpisode>, podcastUuid: String, downloadMetaData: Boolean): List<PodcastEpisode>
-    fun insert(episodes: List<PodcastEpisode>)
+    fun addBlocking(episode: PodcastEpisode, downloadMetaData: Boolean): Boolean
+    fun addBlocking(episodes: List<PodcastEpisode>, podcastUuid: String, downloadMetaData: Boolean): List<PodcastEpisode>
+    suspend fun add(episodes: List<PodcastEpisode>, podcastUuid: String, downloadMetaData: Boolean): List<PodcastEpisode>
+    fun insertBlocking(episodes: List<PodcastEpisode>)
 
     /** Update methods  */
-    fun update(episode: PodcastEpisode?)
-    suspend fun updateSuspend(episode: PodcastEpisode?)
+    fun updateBlocking(episode: PodcastEpisode?)
+    suspend fun update(episode: PodcastEpisode?)
 
-    fun updatePlayedUpTo(episode: BaseEpisode?, playedUpTo: Double, forceUpdate: Boolean)
-    fun updateDuration(episode: BaseEpisode?, durationInSecs: Double, syncChanges: Boolean)
-    fun updatePlayingStatus(episode: BaseEpisode?, status: EpisodePlayingStatus)
+    fun updatePlayedUpToBlocking(episode: BaseEpisode?, playedUpTo: Double, forceUpdate: Boolean)
+    fun updateDurationBlocking(episode: BaseEpisode?, durationInSecs: Double, syncChanges: Boolean)
+    fun updatePlayingStatusBlocking(episode: BaseEpisode?, status: EpisodePlayingStatus)
     suspend fun updateImageUrls(updates: List<ImageUrlUpdate>)
     suspend fun updateEpisodeStatus(episode: BaseEpisode?, status: EpisodeStatusEnum)
     suspend fun updateAutoDownloadStatus(episode: BaseEpisode?, autoDownloadStatus: Int)
-    fun updateDownloadFilePath(episode: BaseEpisode?, filePath: String, markAsDownloaded: Boolean)
-    fun updateFileType(episode: BaseEpisode?, fileType: String)
-    fun updateSizeInBytes(episode: BaseEpisode?, sizeInBytes: Long)
+    fun updateDownloadFilePathBlocking(episode: BaseEpisode?, filePath: String, markAsDownloaded: Boolean)
+    fun updateFileTypeBlocking(episode: BaseEpisode?, fileType: String)
+    fun updateSizeInBytesBlocking(episode: BaseEpisode?, sizeInBytes: Long)
     suspend fun updateDownloadTaskId(episode: BaseEpisode, id: String?)
-    fun updateLastDownloadAttemptDate(episode: BaseEpisode?)
-    fun updateDownloadErrorDetails(episode: BaseEpisode?, message: String?)
+    fun updateLastDownloadAttemptDateBlocking(episode: BaseEpisode?)
+    fun updateDownloadErrorDetailsBlocking(episode: BaseEpisode?, message: String?)
 
-    fun updateAllEpisodeStatus(episodeStatus: EpisodeStatusEnum)
+    fun updateAllEpisodeStatusBlocking(episodeStatus: EpisodeStatusEnum)
 
-    fun markAsNotPlayed(episode: BaseEpisode?)
+    fun markAsNotPlayedBlocking(episode: BaseEpisode?)
     suspend fun markAllAsPlayed(episodes: List<BaseEpisode>, playbackManager: PlaybackManager, podcastManager: PodcastManager)
     fun markedAsPlayedExternally(episode: PodcastEpisode, playbackManager: PlaybackManager, podcastManager: PodcastManager)
     fun markAsPlayedAsync(episode: BaseEpisode?, playbackManager: PlaybackManager, podcastManager: PodcastManager, shouldShuffleUpNext: Boolean = false)
-    fun markAsPlayed(episode: BaseEpisode?, playbackManager: PlaybackManager, podcastManager: PodcastManager, shouldShuffleUpNext: Boolean = false)
-    fun markAsPlaybackError(episode: BaseEpisode?, errorMessage: String?)
-    fun markAsPlaybackError(episode: BaseEpisode?, event: PlayerEvent.PlayerError, isPlaybackRemote: Boolean)
+    fun markAsPlayedBlocking(episode: BaseEpisode?, playbackManager: PlaybackManager, podcastManager: PodcastManager, shouldShuffleUpNext: Boolean = false)
+    fun markAsPlaybackErrorBlocking(episode: BaseEpisode?, errorMessage: String?)
+    fun markAsPlaybackErrorBlocking(episode: BaseEpisode?, event: PlayerEvent.PlayerError, isPlaybackRemote: Boolean)
     suspend fun starEpisode(episode: PodcastEpisode, starred: Boolean, sourceView: SourceView)
     suspend fun updateAllStarred(episodes: List<PodcastEpisode>, starred: Boolean)
     suspend fun toggleStarEpisode(episode: PodcastEpisode, sourceView: SourceView)
-    fun clearPlaybackError(episode: BaseEpisode?)
-    fun clearDownloadError(episode: PodcastEpisode?)
-    fun archive(episode: PodcastEpisode, playbackManager: PlaybackManager, sync: Boolean = true, shouldShuffleUpNext: Boolean = false)
+    fun clearPlaybackErrorBlocking(episode: BaseEpisode?)
+    fun clearDownloadErrorBlocking(episode: PodcastEpisode?)
+    fun archiveBlocking(episode: PodcastEpisode, playbackManager: PlaybackManager, sync: Boolean = true, shouldShuffleUpNext: Boolean = false)
     fun archivePlayedEpisode(episode: BaseEpisode, playbackManager: PlaybackManager, podcastManager: PodcastManager, sync: Boolean)
-    fun unarchive(episode: BaseEpisode)
+    fun unarchiveBlocking(episode: BaseEpisode)
     suspend fun archiveAllInList(episodes: List<PodcastEpisode>, playbackManager: PlaybackManager?)
-    fun checkForEpisodesToAutoArchive(playbackManager: PlaybackManager?, podcastManager: PodcastManager)
+    fun checkForEpisodesToAutoArchiveBlocking(playbackManager: PlaybackManager?, podcastManager: PodcastManager)
     fun userHasInteractedWithEpisode(episode: PodcastEpisode, playbackManager: PlaybackManager): Boolean
-    fun clearEpisodePlaybackInteractionDatesBefore(lastCleared: Date)
+    fun clearEpisodePlaybackInteractionDatesBeforeBlocking(lastCleared: Date)
     suspend fun clearAllEpisodeHistory()
-    fun markPlaybackHistorySynced()
+    fun markPlaybackHistorySyncedBlocking()
     fun stopDownloadAndCleanUp(episodeUuid: String, from: String)
     fun stopDownloadAndCleanUp(episode: PodcastEpisode, from: String)
 
     /** Remove methods  */
     suspend fun deleteAll()
-    fun deleteEpisodesWithoutSync(episodes: List<PodcastEpisode>, playbackManager: PlaybackManager)
-    suspend fun deleteEpisodesWithoutSyncSuspend(episodes: List<PodcastEpisode>, playbackManager: PlaybackManager)
+    fun deleteEpisodesWithoutSyncBlocking(episodes: List<PodcastEpisode>, playbackManager: PlaybackManager)
+    suspend fun deleteEpisodesWithoutSync(episodes: List<PodcastEpisode>, playbackManager: PlaybackManager)
 
-    fun deleteEpisodeWithoutSync(episode: PodcastEpisode?, playbackManager: PlaybackManager)
+    fun deleteEpisodeWithoutSyncBlocking(episode: PodcastEpisode?, playbackManager: PlaybackManager)
     suspend fun deleteEpisodeFile(episode: BaseEpisode?, playbackManager: PlaybackManager?, disableAutoDownload: Boolean, updateDatabase: Boolean = true, removeFromUpNext: Boolean = true, shouldShuffleUpNext: Boolean = false)
 
     /** Utility methods  */
     suspend fun countEpisodes(): Int
-    fun countEpisodesWhere(queryAfterWhere: String): Int
-    fun downloadMissingEpisode(episodeUuid: String, podcastUuid: String, skeletonEpisode: PodcastEpisode, podcastManager: PodcastManager, downloadMetaData: Boolean, source: SourceView): Maybe<BaseEpisode>
+    fun countEpisodesWhereBlocking(queryAfterWhere: String): Int
+    fun downloadMissingEpisodeRxMaybe(episodeUuid: String, podcastUuid: String, skeletonEpisode: PodcastEpisode, podcastManager: PodcastManager, downloadMetaData: Boolean, source: SourceView): Maybe<BaseEpisode>
 
     fun deleteEpisodes(episodes: List<PodcastEpisode>, playbackManager: PlaybackManager)
-    fun unarchiveAllInList(episodes: List<PodcastEpisode>)
-    fun observePlaybackHistoryEpisodes(): Flowable<List<PodcastEpisode>>
+    fun unarchiveAllInListBlocking(episodes: List<PodcastEpisode>)
+    fun findPlaybackHistoryEpisodesRxFlowable(): Flowable<List<PodcastEpisode>>
     fun filteredPlaybackHistoryEpisodesFlow(query: String): Flow<List<PodcastEpisode>>
     suspend fun findPlaybackHistoryEpisodes(): List<PodcastEpisode>
-    fun checkPodcastForEpisodeLimit(podcast: Podcast, playbackManager: PlaybackManager?)
-    fun checkPodcastForAutoArchive(podcast: Podcast, playbackManager: PlaybackManager?)
+    fun checkPodcastForEpisodeLimitBlocking(podcast: Podcast, playbackManager: PlaybackManager?)
+    fun checkPodcastForAutoArchiveBlocking(podcast: Podcast, playbackManager: PlaybackManager?)
     fun episodeCanBeCleanedUp(episode: PodcastEpisode, playbackManager: PlaybackManager): Boolean
     fun markAsUnplayed(episodes: List<BaseEpisode>)
     suspend fun findEpisodeByUuid(uuid: String): BaseEpisode?
     suspend fun findEpisodesByUuids(uuids: List<String>): List<BaseEpisode>
-    fun observeDownloadingEpisodesRx(): Flowable<List<BaseEpisode>>
-    fun setDownloadFailed(episode: BaseEpisode, errorMessage: String)
-    fun observeEpisodeCount(queryAfterWhere: String): Flowable<Int>
+    fun findDownloadingEpisodesRxFlowable(): Flowable<List<BaseEpisode>>
+    fun setDownloadFailedBlocking(episode: BaseEpisode, errorMessage: String)
+    fun episodeCountRxFlowable(queryAfterWhere: String): Flowable<Int>
     suspend fun updatePlaybackInteractionDate(episode: BaseEpisode?)
     suspend fun deleteEpisodeFiles(episodes: List<PodcastEpisode>, playbackManager: PlaybackManager, removeFromUpNext: Boolean = true)
     suspend fun findStaleDownloads(): List<PodcastEpisode>

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/FolderManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/FolderManagerImpl.kt
@@ -112,7 +112,7 @@ class FolderManagerImpl @Inject constructor(
     }
 
     override fun observeFolders(): Flowable<List<Folder>> {
-        return folderDao.observeFolders()
+        return folderDao.findFoldersRxFlowable()
     }
 
     override fun findFoldersFlow(): Flow<List<Folder>> {
@@ -120,7 +120,7 @@ class FolderManagerImpl @Inject constructor(
     }
 
     override fun findFoldersSingle(): Single<List<Folder>> {
-        return folderDao.findFoldersSingle()
+        return folderDao.findFoldersRxSingle()
     }
 
     override suspend fun updatePositions(folders: List<Folder>) {
@@ -152,11 +152,11 @@ class FolderManagerImpl @Inject constructor(
     }
 
     override fun findFoldersToSync(): List<Folder> {
-        return folderDao.findNotSynced()
+        return folderDao.findNotSyncedBlocking()
     }
 
     override fun markAllSynced() {
-        folderDao.updateAllSynced()
+        folderDao.updateAllSyncedBlocking()
     }
 
     override suspend fun getHomeFolder(): List<FolderItem> {
@@ -208,5 +208,5 @@ class FolderManagerImpl @Inject constructor(
         return podcasts.sortedWith(folder.podcastsSortType.podcastComparator)
     }
 
-    override fun countFolders() = folderDao.count()
+    override fun countFolders() = folderDao.countBlocking()
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/HistoryManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/HistoryManager.kt
@@ -76,7 +76,7 @@ class HistoryManager @Inject constructor(
                     if ((episode.lastPlaybackInteraction ?: 0) < interactionDate) {
                         episode.lastPlaybackInteraction = interactionDate
                         episode.lastPlaybackInteractionSyncStatus = PodcastEpisode.LAST_PLAYBACK_INTERACTION_SYNCED
-                        episodeManager.update(episode)
+                        episodeManager.updateBlocking(episode)
                     }
                 } else if (podcastUuid != null) {
                     Timber.i("Listening history episode no longer exists. Episode: $episodeUuid podcast: $podcastUuid")
@@ -85,12 +85,12 @@ class HistoryManager @Inject constructor(
                 if (episode != null) {
                     episode.lastPlaybackInteraction = 0
                     episode.lastPlaybackInteractionSyncStatus = 1
-                    episodeManager.update(episode)
+                    episodeManager.updateBlocking(episode)
                 }
             }
         }
 
-        episodeManager.insert(skeletonEpisodes)
+        episodeManager.insertBlocking(skeletonEpisodes)
 
         if (updateServerModified) {
             settings.setHistoryServerModified(response.serverModified)

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PlaylistManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PlaylistManagerImpl.kt
@@ -151,7 +151,7 @@ class PlaylistManagerImpl @Inject constructor(
         val where = buildPlaylistWhere(playlist, playbackManager)
         val orderBy = getPlaylistOrderByString(playlist)
         val limit = if (playlist.sortOrder() == Playlist.SortOrder.LAST_DOWNLOAD_ATTEMPT_DATE) 1000 else 500
-        return episodeManager.findEpisodesWhere("$where ORDER BY $orderBy LIMIT $limit")
+        return episodeManager.findEpisodesWhereBlocking("$where ORDER BY $orderBy LIMIT $limit")
     }
 
     private fun getPlaylistQuery(playlist: Playlist, limit: Int?, playbackManager: PlaybackManager): String {
@@ -163,12 +163,12 @@ class PlaylistManagerImpl @Inject constructor(
     override fun observeEpisodesBlocking(playlist: Playlist, episodeManager: EpisodeManager, playbackManager: PlaybackManager): Flowable<List<PodcastEpisode>> {
         val limitCount = if (playlist.sortOrder() == Playlist.SortOrder.LAST_DOWNLOAD_ATTEMPT_DATE) 1000 else 500
         val queryAfterWhere = getPlaylistQuery(playlist, limit = limitCount, playbackManager = playbackManager)
-        return episodeManager.observeEpisodesWhere(queryAfterWhere)
+        return episodeManager.findEpisodesWhereRxFlowable(queryAfterWhere)
     }
 
     override fun observeEpisodesPreviewBlocking(playlist: Playlist, episodeManager: EpisodeManager, playbackManager: PlaybackManager): Flowable<List<PodcastEpisode>> {
         val queryAfterWhere = getPlaylistQuery(playlist, limit = 100, playbackManager = playbackManager)
-        return episodeManager.observeEpisodesWhere(queryAfterWhere)
+        return episodeManager.findEpisodesWhereRxFlowable(queryAfterWhere)
     }
 
     private fun getPlaylistOrderByString(playlist: Playlist): String? = when (playlist.sortOrder()) {
@@ -288,7 +288,7 @@ class PlaylistManagerImpl @Inject constructor(
 
     override fun countEpisodesRxFlowable(playlist: Playlist, episodeManager: EpisodeManager, playbackManager: PlaybackManager): Flowable<Int> {
         val query = getPlaylistQuery(playlist, limit = null, playbackManager = playbackManager)
-        return episodeManager.observeEpisodeCount(query)
+        return episodeManager.episodeCountRxFlowable(query)
     }
 
     override fun countEpisodesBlocking(id: Long?, episodeManager: EpisodeManager, playbackManager: PlaybackManager): Int {
@@ -297,7 +297,7 @@ class PlaylistManagerImpl @Inject constructor(
         }
         val playlist = findByIdBlocking(id) ?: return 0
         val where = buildPlaylistWhere(playlist, playbackManager)
-        return episodeManager.countEpisodesWhere(where)
+        return episodeManager.countEpisodesWhereBlocking(where)
     }
 
     override fun checkForEpisodesToDownloadBlocking(episodeManager: EpisodeManager, playbackManager: PlaybackManager) {

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/TranscriptsManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/TranscriptsManagerImpl.kt
@@ -53,7 +53,7 @@ class TranscriptsManagerImpl @Inject constructor(
         }
 
         findBestTranscript(transcripts)?.let { bestTranscript ->
-            transcriptDao.insert(bestTranscript)
+            transcriptDao.insertBlocking(bestTranscript)
 
             if (loadTranscriptSource == LoadTranscriptSource.DOWNLOAD_EPISODE) {
                 loadTranscriptCuesInfo(

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/ratings/RatingsManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/ratings/RatingsManagerImpl.kt
@@ -26,7 +26,7 @@ class RatingsManagerImpl @Inject constructor(
         get() = Dispatchers.Default
 
     override fun podcastRatings(podcastUuid: String) =
-        podcastRatingsDao.podcastRatings(podcastUuid)
+        podcastRatingsDao.podcastRatingsFlow(podcastUuid)
             .map { it.firstOrNull() ?: noRatings(podcastUuid) }
 
     override suspend fun refreshPodcastRatings(podcastUuid: String, useCache: Boolean) {

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/refresh/RefreshPodcastsThread.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/refresh/RefreshPodcastsThread.kt
@@ -217,7 +217,7 @@ class RefreshPodcastsThread(
 
         if (!emptyResponse) {
             var startTime = SystemClock.elapsedRealtime()
-            episodeManager.checkForEpisodesToAutoArchive(playbackManager, podcastManager)
+            episodeManager.checkForEpisodesToAutoArchiveBlocking(playbackManager, podcastManager)
             LogBuffer.i(LogBuffer.TAG_BACKGROUND_TASKS, "Refresh - checkForEpisodesToAutoArchive - ${String.format("%d ms", SystemClock.elapsedRealtime() - startTime)}")
             startTime = SystemClock.elapsedRealtime()
             podcastManager.checkForUnusedPodcasts(playbackManager)
@@ -319,7 +319,7 @@ class RefreshPodcastsThread(
             for (episode in episodes) {
                 episode.addedDate = addedDate
             }
-            episodes = episodeManager.add(episodes, podcast.uuid, downloadMetaData)
+            episodes = episodeManager.addBlocking(episodes, podcast.uuid, downloadMetaData)
 
             if (episodes.isEmpty()) {
                 // the server returned episodes, but none were added to the database. Update the podcast when it doesn't have the latest episode information.
@@ -411,7 +411,7 @@ class RefreshPodcastsThread(
             try {
                 val notificationsEpisodeAndPodcast = ArrayList<Pair<PodcastEpisode, Podcast>>()
 
-                val episodes = episodeManager.findNotificationEpisodes(lastSeen)
+                val episodes = episodeManager.findNotificationEpisodesBlocking(lastSeen)
                 for (episode in episodes) {
                     val podcast = podcastManager.findPodcastByUuid(episode.podcastUuid) ?: continue
                     notificationsEpisodeAndPodcast.add(Pair(episode, podcast))

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/support/Support.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/support/Support.kt
@@ -422,7 +422,7 @@ class Support @Inject constructor(
                 output.append("Episode Issues").append(eol).append("--------------").append(eol).append(eol)
 
                 try {
-                    val episodes = episodeManager.findEpisodesWhere("downloaded_error_details IS NOT NULL AND LENGTH(downloaded_error_details) > 0 LIMIT 100")
+                    val episodes = episodeManager.findEpisodesWhereBlocking("downloaded_error_details IS NOT NULL AND LENGTH(downloaded_error_details) > 0 LIMIT 100")
                     for (episode in episodes) {
                         output.append("Title: ").append(episode.title).append(eol)
                         output.append("Id: ").append(episode.uuid).append(eol)

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/NotificationBroadcastReceiver.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/NotificationBroadcastReceiver.kt
@@ -124,7 +124,7 @@ class NotificationBroadcastReceiver : BroadcastReceiver(), CoroutineScope {
     private fun markAsPlayed(episodeUuid: String) {
         launch {
             episodeManager.findEpisodeByUuid(episodeUuid)?.let { episode ->
-                episodeManager.markAsPlayed(episode, playbackManager, podcastManager)
+                episodeManager.markAsPlayedBlocking(episode, playbackManager, podcastManager)
                 episodeAnalytics.trackEvent(AnalyticsEvent.EPISODE_MARKED_AS_PLAYED, source, episodeUuid)
             }
         }
@@ -133,7 +133,7 @@ class NotificationBroadcastReceiver : BroadcastReceiver(), CoroutineScope {
     private fun archiveEpisode(episodeUuid: String) {
         launch {
             episodeManager.findByUuid(episodeUuid)?.let { episode ->
-                episodeManager.archive(episode, playbackManager, true)
+                episodeManager.archiveBlocking(episode, playbackManager, true)
                 episodeAnalytics.trackEvent(AnalyticsEvent.EPISODE_ARCHIVED, source, episodeUuid)
             }
         }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/PodcastRefresherImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/PodcastRefresherImpl.kt
@@ -49,7 +49,7 @@ class PodcastRefresherImpl @Inject constructor(
             existingPodcast.estimatedNextEpisode = updatedPodcast.estimatedNextEpisode
             existingPodcast.episodeFrequency = updatedPodcast.episodeFrequency
             existingPodcast.refreshAvailable = updatedPodcast.refreshAvailable
-            val existingEpisodes = episodeManager.findEpisodesByPodcastOrderedByPublishDateSuspend(existingPodcast)
+            val existingEpisodes = episodeManager.findEpisodesByPodcastOrderedByPublishDate(existingPodcast)
             val mostRecentEpisode = existingEpisodes.firstOrNull()
             val insertEpisodes = mutableListOf<PodcastEpisode>()
             updatedPodcast.episodes.map { newEpisode ->
@@ -74,7 +74,7 @@ class PodcastRefresherImpl @Inject constructor(
                     existingEpisode.type = newEpisode.type
                     // only update the db if the fields have changed
                     if (originalEpisode != existingEpisode) {
-                        episodeManager.updateSuspend(existingEpisode)
+                        episodeManager.update(existingEpisode)
                     }
                 } else {
                     // don't add anything newer than the latest episode so it runs through the refresh logic (auto download, auto add to Up Next etc
@@ -101,7 +101,7 @@ class PodcastRefresherImpl @Inject constructor(
                 }
             }
             if (insertEpisodes.isNotEmpty()) {
-                episodeManager.addSuspend(
+                episodeManager.add(
                     episodes = insertEpisodes,
                     podcastUuid = existingPodcast.uuid,
                     downloadMetaData = false,
@@ -118,7 +118,7 @@ class PodcastRefresherImpl @Inject constructor(
                         it.addedDate.before(twoWeeksAgo) && episodeManager.episodeCanBeCleanedUp(it, playbackManager)
                     }
             if (episodesToDelete.isNotEmpty()) {
-                episodeManager.deleteEpisodesWithoutSyncSuspend(episodesToDelete, playbackManager)
+                episodeManager.deleteEpisodesWithoutSync(episodesToDelete, playbackManager)
             }
 
             if (originalPodcast != existingPodcast) {

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/PodcastSyncProcess.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/PodcastSyncProcess.kt
@@ -521,7 +521,7 @@ class PodcastSyncProcess(
 
     private fun uploadEpisodesChanges(records: JSONArray): List<PodcastEpisode> {
         try {
-            val episodes = episodeManager.findEpisodesToSync()
+            val episodes = episodeManager.findEpisodesToSyncBlocking()
             episodes.forEach { episode ->
                 uploadEpisodeChanges(episode, records)
             }
@@ -588,7 +588,7 @@ class PodcastSyncProcess(
 
     private fun uploadBookmarksChanges(records: JSONArray) {
         try {
-            val bookmarks = bookmarkManager.findBookmarksToSync()
+            val bookmarks = bookmarkManager.findBookmarksToSyncBlocking()
             bookmarks.forEach { bookmark ->
                 @Suppress("DEPRECATION")
                 uploadBookmarkChanges(bookmark, records)
@@ -654,7 +654,7 @@ class PodcastSyncProcess(
     private fun markAllLocalItemsSynced(episodes: List<PodcastEpisode>): Completable {
         return Completable.fromAction {
             podcastManager.markAllPodcastsSynced()
-            episodeManager.markAllEpisodesSynced(episodes)
+            episodeManager.markAllEpisodesSyncedBlocking(episodes)
             playlistManager.markAllSyncedBlocking()
             folderManager.markAllSynced()
         }
@@ -887,7 +887,7 @@ class PodcastSyncProcess(
                 } else {
                     episode.archivedModified = null
                     if (newIsArchive) {
-                        episodeManager.archive(episode, playbackManager, sync = false)
+                        episodeManager.archiveBlocking(episode, playbackManager, sync = false)
                     } else {
                         episode.isArchived = false
                         episode.lastArchiveInteraction = Date().time
@@ -946,7 +946,7 @@ class PodcastSyncProcess(
                 episode.deselectedChaptersModified = sync.deselectedChaptersModified?.let(::Date)
             }
 
-            episodeManager.update(episode)
+            episodeManager.updateBlocking(episode)
 
             episode
         }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/SyncHistoryTask.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/SyncHistoryTask.kt
@@ -55,7 +55,7 @@ class SyncHistoryTask @AssistedInject constructor(
     override suspend fun doWork(): Result {
         LogBuffer.i(TAG, "Sync history running")
 
-        val episodes = episodeManager.findEpisodesForHistorySync()
+        val episodes = episodeManager.findEpisodesForHistorySyncBlocking()
 
         val changes = episodes.mapNotNull { episode ->
             val lastPlaybackInteraction = episode.lastPlaybackInteraction ?: return@mapNotNull null
@@ -103,10 +103,10 @@ class SyncHistoryTask @AssistedInject constructor(
                 // Clear history if they have cleared it on the server
                 if (response.lastCleared > 0) {
                     val lastCleared = Date(response.lastCleared)
-                    episodeManager.clearEpisodePlaybackInteractionDatesBefore(lastCleared)
+                    episodeManager.clearEpisodePlaybackInteractionDatesBeforeBlocking(lastCleared)
                 }
 
-                episodeManager.markPlaybackHistorySynced()
+                episodeManager.markPlaybackHistorySyncedBlocking()
                 if (wasHistoryCleared) {
                     settings.setClearHistoryTime(0L)
                 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/UpNextSyncWorker.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/UpNextSyncWorker.kt
@@ -93,7 +93,7 @@ class UpNextSyncWorker @AssistedInject constructor(
 
     private suspend fun performSync() {
         val upNextChangeDao = appDatabase.upNextChangeDao()
-        val changes = upNextChangeDao.findAll()
+        val changes = upNextChangeDao.findAllBlocking()
         val request = buildRequest(changes)
         try {
             val response = syncManager.upNextSync(request)
@@ -189,7 +189,7 @@ class UpNextSyncWorker @AssistedInject constructor(
                         .awaitSingleOrNull()
                 } else {
                     val skeletonEpisode = responseEpisode.toSkeletonEpisode(podcastUuid)
-                    episodeManager.downloadMissingEpisode(episodeUuid, podcastUuid, skeletonEpisode, podcastManager, false, source = SourceView.UP_NEXT)
+                    episodeManager.downloadMissingEpisodeRxMaybe(episodeUuid, podcastUuid, skeletonEpisode, podcastManager, false, source = SourceView.UP_NEXT)
                         .awaitSingleOrNull()
                 }
             } else {
@@ -198,7 +198,7 @@ class UpNextSyncWorker @AssistedInject constructor(
         } ?: emptyList()
 
         // import the server Up Next into the database
-        upNextQueue.importServerChanges(episodes, playbackManager, downloadManager)
+        upNextQueue.importServerChangesBlocking(episodes, playbackManager, downloadManager)
         // check the current episode it correct
         playbackManager.loadQueue()
         // save the server Up Next modified so we only apply changes

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/ChapterManagerImplTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/ChapterManagerImplTest.kt
@@ -29,7 +29,7 @@ class ChapterManagerImplTest {
         val episode = PodcastEpisode("id", publishedDate = Date(), duration = 0.001)
 
         whenever(chapterDao.observerChaptersForEpisode("id")).thenReturn(flowOf(emptyList()))
-        whenever(episodeManager.observeEpisodeByUuid("id")).thenReturn(flowOf(episode))
+        whenever(episodeManager.findEpisodeByUuidFlow("id")).thenReturn(flowOf(episode))
 
         chapterManager.observerChaptersForEpisode("id").test {
             assertEquals(Chapters(emptyList()), awaitItem())
@@ -51,7 +51,7 @@ class ChapterManagerImplTest {
         )
 
         whenever(chapterDao.observerChaptersForEpisode("id")).thenReturn(flowOf(listOf(dbChapter)))
-        whenever(episodeManager.observeEpisodeByUuid("id")).thenReturn(flowOf(episode))
+        whenever(episodeManager.findEpisodeByUuidFlow("id")).thenReturn(flowOf(episode))
 
         chapterManager.observerChaptersForEpisode("id").test {
             val expected = Chapter(
@@ -94,7 +94,7 @@ class ChapterManagerImplTest {
         )
 
         whenever(chapterDao.observerChaptersForEpisode("id")).thenReturn(flowOf(dbChapters))
-        whenever(episodeManager.observeEpisodeByUuid("id")).thenReturn(flowOf(episode))
+        whenever(episodeManager.findEpisodeByUuidFlow("id")).thenReturn(flowOf(episode))
 
         chapterManager.observerChaptersForEpisode("id").test {
             val expected = listOf(
@@ -139,7 +139,7 @@ class ChapterManagerImplTest {
         )
 
         whenever(chapterDao.observerChaptersForEpisode("id")).thenReturn(flowOf(listOf(dbChapter)))
-        whenever(episodeManager.observeEpisodeByUuid("id")).thenReturn(flowOf(episode))
+        whenever(episodeManager.findEpisodeByUuidFlow("id")).thenReturn(flowOf(episode))
 
         chapterManager.observerChaptersForEpisode("id").test {
             val expected = Chapter(
@@ -170,7 +170,7 @@ class ChapterManagerImplTest {
         )
 
         whenever(chapterDao.observerChaptersForEpisode("id")).thenReturn(flowOf(listOf(dbChapter)))
-        whenever(episodeManager.observeEpisodeByUuid("id")).thenReturn(flowOf(episode))
+        whenever(episodeManager.findEpisodeByUuidFlow("id")).thenReturn(flowOf(episode))
 
         chapterManager.observerChaptersForEpisode("id").test {
             val expected = Chapter(
@@ -201,7 +201,7 @@ class ChapterManagerImplTest {
         )
 
         whenever(chapterDao.observerChaptersForEpisode("id")).thenReturn(flowOf(listOf(dbChapter)))
-        whenever(episodeManager.observeEpisodeByUuid("id")).thenReturn(flowOf(episode))
+        whenever(episodeManager.findEpisodeByUuidFlow("id")).thenReturn(flowOf(episode))
 
         chapterManager.observerChaptersForEpisode("id").test {
             val expected = Chapter(
@@ -232,7 +232,7 @@ class ChapterManagerImplTest {
         )
 
         whenever(chapterDao.observerChaptersForEpisode("id")).thenReturn(flowOf(listOf(dbChapter)))
-        whenever(episodeManager.observeEpisodeByUuid("id")).thenReturn(flowOf(episode))
+        whenever(episodeManager.findEpisodeByUuidFlow("id")).thenReturn(flowOf(episode))
 
         chapterManager.observerChaptersForEpisode("id").test {
             val expected = Chapter(
@@ -281,7 +281,7 @@ class ChapterManagerImplTest {
         )
 
         whenever(chapterDao.observerChaptersForEpisode("id")).thenReturn(flowOf(dbChapters))
-        whenever(episodeManager.observeEpisodeByUuid("id")).thenReturn(flowOf(episode))
+        whenever(episodeManager.findEpisodeByUuidFlow("id")).thenReturn(flowOf(episode))
 
         chapterManager.observerChaptersForEpisode("id").test {
             val expected = listOf(
@@ -345,7 +345,7 @@ class ChapterManagerImplTest {
         )
 
         whenever(chapterDao.observerChaptersForEpisode("id")).thenReturn(flowOf(dbChapters))
-        whenever(episodeManager.observeEpisodeByUuid("id")).thenReturn(flowOf(episode))
+        whenever(episodeManager.findEpisodeByUuidFlow("id")).thenReturn(flowOf(episode))
 
         chapterManager.observerChaptersForEpisode("id").test {
             val expected = listOf(
@@ -396,7 +396,7 @@ class ChapterManagerImplTest {
         )
 
         whenever(chapterDao.observerChaptersForEpisode("id")).thenReturn(flowOf(dbChapters))
-        whenever(episodeManager.observeEpisodeByUuid("id")).thenReturn(flowOf(episode))
+        whenever(episodeManager.findEpisodeByUuidFlow("id")).thenReturn(flowOf(episode))
 
         chapterManager.observerChaptersForEpisode("id").test {
             val expected = listOf(
@@ -433,7 +433,7 @@ class ChapterManagerImplTest {
         )
 
         whenever(chapterDao.observerChaptersForEpisode("id")).thenReturn(flowOf(listOf(dbChapter)))
-        whenever(episodeManager.observeEpisodeByUuid("id")).thenReturn(episodesFlow)
+        whenever(episodeManager.findEpisodeByUuidFlow("id")).thenReturn(episodesFlow)
 
         chapterManager.observerChaptersForEpisode("id").test {
             val expectedSelected = Chapter(
@@ -473,7 +473,7 @@ class ChapterManagerImplTest {
         )
 
         whenever(chapterDao.observerChaptersForEpisode("id")).thenReturn(flowOf(dbChapters))
-        whenever(episodeManager.observeEpisodeByUuid("id")).thenReturn(flowOf(episode))
+        whenever(episodeManager.findEpisodeByUuidFlow("id")).thenReturn(flowOf(episode))
 
         chapterManager.observerChaptersForEpisode("id").test {
             val expected = listOf(
@@ -517,7 +517,7 @@ class ChapterManagerImplTest {
         )
 
         whenever(chapterDao.observerChaptersForEpisode("id")).thenReturn(flowOf(dbChapters))
-        whenever(episodeManager.observeEpisodeByUuid("id")).thenReturn(flowOf(episode))
+        whenever(episodeManager.findEpisodeByUuidFlow("id")).thenReturn(flowOf(episode))
 
         chapterManager.observerChaptersForEpisode("id").test {
             val expected = listOf(
@@ -579,7 +579,7 @@ class ChapterManagerImplTest {
         )
 
         whenever(chapterDao.observerChaptersForEpisode("id")).thenReturn(flowOf(dbChapters))
-        whenever(episodeManager.observeEpisodeByUuid("id")).thenReturn(flowOf(episode))
+        whenever(episodeManager.findEpisodeByUuidFlow("id")).thenReturn(flowOf(episode))
 
         chapterManager.observerChaptersForEpisode("id").test {
             val expected = listOf(

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/TranscriptsManagerImplTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/TranscriptsManagerImplTest.kt
@@ -145,7 +145,7 @@ class TranscriptsManagerImplTest {
 
         transcriptsManager.updateTranscripts(podcastId, "1", transcripts, LoadTranscriptSource.DEFAULT)
 
-        verify(transcriptDao).insert(transcripts[0])
+        verify(transcriptDao).insertBlocking(transcripts[0])
     }
 
     @Test
@@ -255,7 +255,7 @@ class TranscriptsManagerImplTest {
 
         transcriptsManager.failedTranscriptFormats.test {
             awaitItem()
-            verify(transcriptDao).insert(alternateTranscript)
+            verify(transcriptDao).insertBlocking(alternateTranscript)
             cancelAndIgnoreRemainingEvents()
         }
     }
@@ -272,7 +272,7 @@ class TranscriptsManagerImplTest {
 
         transcriptsManager.failedTranscriptFormats.test {
             awaitItem()
-            verify(transcriptDao).insert(alternateTranscript)
+            verify(transcriptDao).insertBlocking(alternateTranscript)
             cancelAndIgnoreRemainingEvents()
         }
     }
@@ -285,7 +285,7 @@ class TranscriptsManagerImplTest {
 
         transcriptsManager.failedTranscriptFormats.test {
             awaitItem()
-            verify(transcriptDao).insert(alternateTranscript)
+            verify(transcriptDao).insertBlocking(alternateTranscript)
             cancelAndConsumeRemainingEvents()
         }
     }
@@ -298,7 +298,7 @@ class TranscriptsManagerImplTest {
 
         transcriptsManager.failedTranscriptFormats.test {
             awaitItem()
-            verify(transcriptDao).insert(alternateTranscript)
+            verify(transcriptDao).insertBlocking(alternateTranscript)
             cancelAndIgnoreRemainingEvents()
         }
     }

--- a/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/helper/SwipeButtonLayoutViewModel.kt
+++ b/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/helper/SwipeButtonLayoutViewModel.kt
@@ -122,7 +122,7 @@ class SwipeButtonLayoutViewModel @Inject constructor(
         viewModelScope.launch(Dispatchers.Default) {
             if (!episode.isArchived) {
                 trackSwipeAction(swipeSource, EpisodeItemTouchHelper.SwipeAction.ARCHIVE)
-                episodeManager.archive(episode, playbackManager)
+                episodeManager.archiveBlocking(episode, playbackManager)
                 episodeAnalytics.trackEvent(
                     event = AnalyticsEvent.EPISODE_ARCHIVED,
                     source = swipeSourceToSourceView(swipeSource),
@@ -130,7 +130,7 @@ class SwipeButtonLayoutViewModel @Inject constructor(
                 )
             } else {
                 trackSwipeAction(swipeSource, EpisodeItemTouchHelper.SwipeAction.UNARCHIVE)
-                episodeManager.unarchive(episode)
+                episodeManager.unarchiveBlocking(episode)
                 episodeAnalytics.trackEvent(
                     event = AnalyticsEvent.EPISODE_UNARCHIVED,
                     source = swipeSourceToSourceView(swipeSource),

--- a/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/helper/WarningsHelper.kt
+++ b/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/helper/WarningsHelper.kt
@@ -121,7 +121,7 @@ class WarningsHelper @Inject constructor(
                     }
                     downloadManager.addEpisodeToQueue(it, from, fireEvent = true, source = SourceView.UNKNOWN)
                     launch {
-                        episodeManager.unarchive(it)
+                        episodeManager.unarchiveBlocking(it)
                     }
                 }
             }

--- a/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/multiselect/MultiSelectEpisodesHelper.kt
+++ b/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/multiselect/MultiSelectEpisodesHelper.kt
@@ -235,7 +235,7 @@ class MultiSelectEpisodesHelper @Inject constructor(
         launch {
             val list = selectedList.filterIsInstance<PodcastEpisode>().toList()
 
-            episodeManager.unarchiveAllInList(episodes = list)
+            episodeManager.unarchiveAllInListBlocking(episodes = list)
             episodeAnalytics.trackBulkEvent(AnalyticsEvent.EPISODE_BULK_UNARCHIVED, source, list.size)
             withContext(Dispatchers.Main) {
                 val snackText = resources.getStringPlural(selectedList.size, LR.string.unarchived_episodes_singular, LR.string.unarchived_episodes_plural)

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/component/EpisodeChipViewModel.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/component/EpisodeChipViewModel.kt
@@ -29,6 +29,6 @@ class EpisodeChipViewModel @Inject constructor(
 
     fun observeByUuid(episode: BaseEpisode): StateFlow<BaseEpisode> =
         episodeManager
-            .observeEpisodeByUuid(episode.uuid)
+            .findEpisodeByUuidFlow(episode.uuid)
             .stateIn(viewModelScope, SharingStarted.Eagerly, episode)
 }

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/downloads/DownloadsScreenViewModel.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/downloads/DownloadsScreenViewModel.kt
@@ -16,7 +16,7 @@ class DownloadsScreenViewModel @Inject constructor(
     settings: Settings,
 ) : ViewModel() {
 
-    val stateFlow = episodeManager.observeDownloadEpisodes()
+    val stateFlow = episodeManager.findDownloadEpisodesRxFlowable()
         .asFlow()
         .stateIn(viewModelScope, SharingStarted.Lazily, null)
 

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/podcast/PodcastViewModel.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/podcast/PodcastViewModel.kt
@@ -49,7 +49,7 @@ class PodcastViewModel @Inject constructor(
         viewModelScope.launch(Dispatchers.Default) {
             val podcast = podcastManager.findPodcastByUuidSuspend(podcastUuid)
             podcast?.let {
-                episodeManager.observeEpisodesByPodcastOrderedRx(it)
+                episodeManager.findEpisodesByPodcastOrderedRxFlowable(it)
                     .asFlow()
                     .map { podcastEpisodes ->
                         val sortFunction = podcast.grouping.sortFunction


### PR DESCRIPTION
## Description

We aim to switch to using Coroutines for calls to the database and move away from RxJava. When converting code, knowing which calls have already been converted can be tricky. To make this more straightforward, I have made the following changes:

- Any database call that doesn't use Coroutines has the suffix `Blocking`
- Any Rx call now has the suffix `Rx<ReturnType`
- Removed `Suspend` from the Coroutine calls
- Added the suffix `Flow` to Coroutine Flow calls

I have run out of time for today but didn't want to leave such a big change for another day. In a future PR I will also change methods in the manager classes to reflect if they are blocking or Rx.

## Testing Instructions

This is only a refactor but it would be worth looking through the code changes and smoke testing the filters section.

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 