### PR TITLE
Profile screen cleanup

### DIFF
--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/ProfileFragment.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/ProfileFragment.kt
@@ -56,7 +56,6 @@ import au.com.shiftyjelly.pocketcasts.referrals.ReferralsClaimGuestPassBannerCar
 import au.com.shiftyjelly.pocketcasts.referrals.ReferralsIconWithTooltip
 import au.com.shiftyjelly.pocketcasts.repositories.endofyear.EndOfYearManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
-import au.com.shiftyjelly.pocketcasts.repositories.user.UserManager
 import au.com.shiftyjelly.pocketcasts.settings.HelpFragment
 import au.com.shiftyjelly.pocketcasts.settings.SettingsFragment
 import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingFlow
@@ -81,9 +80,6 @@ class ProfileFragment : BaseFragment() {
 
     @Inject
     lateinit var settings: Settings
-
-    @Inject
-    lateinit var userManager: UserManager
 
     @Inject
     lateinit var analyticsTracker: AnalyticsTracker

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/ProfileFragment.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/ProfileFragment.kt
@@ -1,59 +1,25 @@
 package au.com.shiftyjelly.pocketcasts.profile
 
-import android.content.res.Configuration
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.ViewGroup
-import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.ColumnScope
-import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.verticalScroll
-import androidx.compose.material.Icon
-import androidx.compose.material.IconButton
-import androidx.compose.material.MaterialTheme
-import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.platform.LocalConfiguration
-import androidx.compose.ui.platform.LocalDensity
-import androidx.compose.ui.res.painterResource
-import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.fragment.app.viewModels
 import androidx.fragment.compose.content
-import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTracker
 import au.com.shiftyjelly.pocketcasts.analytics.SourceView
-import au.com.shiftyjelly.pocketcasts.compose.AppTheme
-import au.com.shiftyjelly.pocketcasts.compose.CallOnce
-import au.com.shiftyjelly.pocketcasts.compose.theme
 import au.com.shiftyjelly.pocketcasts.endofyear.StoriesActivity.StoriesSource
-import au.com.shiftyjelly.pocketcasts.endofyear.ui.EndOfYearPromptCard
-import au.com.shiftyjelly.pocketcasts.models.to.RefreshState
-import au.com.shiftyjelly.pocketcasts.models.type.SubscriptionTier
 import au.com.shiftyjelly.pocketcasts.player.view.bookmark.BookmarksContainerFragment
 import au.com.shiftyjelly.pocketcasts.podcasts.view.ProfileEpisodeListFragment
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.profile.cloud.CloudFilesFragment
-import au.com.shiftyjelly.pocketcasts.referrals.ReferralsClaimGuestPassBannerCard
-import au.com.shiftyjelly.pocketcasts.referrals.ReferralsIconWithTooltip
+import au.com.shiftyjelly.pocketcasts.referrals.ReferralsGuestPassFragment
+import au.com.shiftyjelly.pocketcasts.referrals.ReferralsGuestPassFragment.ReferralsPageType
+import au.com.shiftyjelly.pocketcasts.referrals.ReferralsViewModel
 import au.com.shiftyjelly.pocketcasts.repositories.endofyear.EndOfYearManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
 import au.com.shiftyjelly.pocketcasts.settings.HelpFragment
@@ -63,14 +29,12 @@ import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingLauncher
 import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingUpgradeSource
 import au.com.shiftyjelly.pocketcasts.settings.stats.StatsFragment
 import au.com.shiftyjelly.pocketcasts.ui.helper.FragmentHostListener
+import au.com.shiftyjelly.pocketcasts.utils.extensions.pxToDp
 import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
 import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
 import au.com.shiftyjelly.pocketcasts.views.fragments.BaseFragment
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
-import kotlin.time.Duration
-import au.com.shiftyjelly.pocketcasts.images.R as IR
-import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 @AndroidEntryPoint
 class ProfileFragment : BaseFragment() {
@@ -84,232 +48,103 @@ class ProfileFragment : BaseFragment() {
     @Inject
     lateinit var analyticsTracker: AnalyticsTracker
 
-    private val viewModel: ProfileViewModel by viewModels()
-
-    override fun onResume() {
-        super.onResume()
-        viewModel.clearFailedRefresh()
-    }
+    private val profileViewModel by viewModels<ProfileViewModel>()
+    private val referralsViewModel by viewModels<ReferralsViewModel>()
 
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
         savedInstanceState: Bundle?,
     ) = content {
-        AppTheme(theme.activeTheme) {
-            CallOnce {
-                analyticsTracker.track(AnalyticsEvent.PROFILE_SHOWN)
-            }
+        val state = ProfilePageState(
+            isSendReferralsEnabled = FeatureFlag.isEnabled(Feature.REFERRALS_SEND),
+            isPlaybackEnabled = profileViewModel.isEndOfYearStoriesEligible.collectAsState().value,
+            isClaimReferralsEnabled = FeatureFlag.isEnabled(Feature.REFERRALS_CLAIM),
+            isUpgradeBannerVisible = profileViewModel.showUpgradeBanner.collectAsState(false).value,
+            miniPlayerPadding = settings.bottomInset.collectAsState(0).value.pxToDp(requireContext()).dp,
+            headerState = profileViewModel.profileHeaderState.collectAsState().value,
+            statsState = profileViewModel.profileStatsState.collectAsState().value,
+            referralsState = referralsViewModel.state.collectAsState().value,
+            refreshState = profileViewModel.refreshState.collectAsState().value,
+        )
 
-            Column(
-                verticalArrangement = Arrangement.spacedBy(16.dp),
-                modifier = Modifier
-                    .background(MaterialTheme.theme.colors.primaryUi03)
-                    .fillMaxSize()
-                    .verticalScroll(rememberScrollState()),
-            ) {
-                Toolbar()
-                HeaderWithStats()
-                EndOfYearBanner()
-                ReferralsClaimGuestPassBannerCard(
-                    modifier = Modifier.padding(horizontal = 16.dp),
-                )
-                Sections()
-                Refresh()
-                UpgradeProfile()
-                MiniPlayerPadding()
-            }
-        }
-    }
-
-    @Composable
-    private fun Toolbar() {
-        Row(
-            horizontalArrangement = Arrangement.End,
-            verticalAlignment = Alignment.CenterVertically,
-            modifier = Modifier
-                .fillMaxWidth()
-                .height(64.dp)
-                .padding(horizontal = 16.dp),
-        ) {
-            if (FeatureFlag.isEnabled(Feature.REFERRALS_SEND)) {
-                ReferralsIconWithTooltip()
-            }
-            if (LocalConfiguration.current.orientation != Configuration.ORIENTATION_LANDSCAPE) {
-                Spacer(
-                    modifier = Modifier.weight(1f),
-                )
-            }
-            IconButton(
-                onClick = {
-                    analyticsTracker.track(AnalyticsEvent.PROFILE_SETTINGS_BUTTON_TAPPED)
-                    (requireActivity() as FragmentHostListener).addFragment(SettingsFragment())
-                },
-            ) {
-                Icon(
-                    painter = painterResource(IR.drawable.ic_profile_settings),
-                    contentDescription = stringResource(LR.string.settings),
-                    tint = MaterialTheme.theme.colors.primaryIcon01,
-                )
-            }
-        }
-    }
-
-    @Composable
-    private fun ColumnScope.HeaderWithStats() {
-        if (LocalConfiguration.current.orientation != Configuration.ORIENTATION_LANDSCAPE) {
-            Header(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(horizontal = 16.dp),
-            )
-            Stats(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(horizontal = 16.dp),
-            )
-        } else {
-            Row(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(horizontal = 16.dp),
-            ) {
-                Header(
-                    modifier = Modifier.weight(1f),
-                )
-                Stats(
-                    modifier = Modifier.weight(1f),
-                )
-            }
-        }
-    }
-
-    @Composable
-    private fun Header(
-        modifier: Modifier = Modifier,
-    ) {
-        val headerState by viewModel.profileHeaderState
-            .collectAsStateWithLifecycle(
-                ProfileHeaderState(
-                    imageUrl = null,
-                    subscriptionTier = SubscriptionTier.NONE,
-                    email = null,
-                    expiresIn = null,
-                ),
-            )
-
-        ProfileHeader(
-            state = headerState,
-            onClick = {
+        ProfilePage(
+            state = state,
+            themeType = theme.activeTheme,
+            onSendReferralsClick = {
+                referralsViewModel.onIconClick()
+                val fragment = ReferralsGuestPassFragment.newInstance(ReferralsPageType.Send)
+                (requireActivity() as FragmentHostListener).showBottomSheet(fragment)
+            },
+            onReferralsTooltipClick = {
+                referralsViewModel.onTooltipClick()
+            },
+            onReferralsTooltipShown = {
+                referralsViewModel.onTooltipShown()
+            },
+            onSettingsClick = {
+                analyticsTracker.track(AnalyticsEvent.PROFILE_SETTINGS_BUTTON_TAPPED)
+                (requireActivity() as FragmentHostListener).addFragment(SettingsFragment())
+            },
+            onHeaderClick = {
                 analyticsTracker.track(AnalyticsEvent.PROFILE_ACCOUNT_BUTTON_TAPPED)
-                if (viewModel.isSignedIn) {
+                if (profileViewModel.isSignedIn) {
                     val fragment = AccountDetailsFragment.newInstance()
                     (activity as FragmentHostListener).addFragment(fragment)
                 } else {
                     OnboardingLauncher.openOnboardingFlow(activity, OnboardingFlow.LoggedOut)
                 }
             },
-            modifier = modifier,
-        )
-    }
-
-    @Composable
-    private fun Stats(
-        modifier: Modifier = Modifier,
-    ) {
-        val headerState by viewModel.profileStatsState
-            .collectAsStateWithLifecycle(
-                ProfileStatsState(
-                    podcastsCount = 0,
-                    listenedDuration = Duration.ZERO,
-                    savedDuration = Duration.ZERO,
-                ),
-            )
-
-        ProfileStats(
-            state = headerState,
-            modifier = modifier,
-        )
-    }
-
-    @Composable
-    private fun ColumnScope.EndOfYearBanner() {
-        val isEligibleForEoY by viewModel.isEndOfYearStoriesEligible.collectAsState()
-
-        if (isEligibleForEoY) {
-            EndOfYearPromptCard(
-                onClick = {
-                    analyticsTracker.track(
-                        AnalyticsEvent.END_OF_YEAR_PROFILE_CARD_TAPPED,
-                        mapOf("year" to EndOfYearManager.YEAR_TO_SYNC.value),
-                    )
-                    // once stories prompt card is tapped, we don't want to show stories launch modal if not already shown
-                    if (settings.getEndOfYearShowModal()) {
-                        settings.setEndOfYearShowModal(false)
-                    }
-                    (activity as? FragmentHostListener)?.showStoriesOrAccount(StoriesSource.PROFILE.value)
-                },
-                modifier = Modifier.padding(horizontal = 16.dp),
-            )
-        }
-    }
-
-    @Composable
-    private fun Sections() {
-        ProfileSections(
-            sections = ProfileSection.entries,
-            onClick = ::goToSection,
-            modifier = Modifier.fillMaxWidth(),
-        )
-    }
-
-    @Composable
-    private fun Refresh() {
-        val viewModelState by viewModel.refreshState.collectAsState(null)
-        var state by remember(viewModelState) { mutableStateOf(viewModelState) }
-
-        RefreshSection(
-            refreshState = state,
-            onClick = {
-                state = RefreshState.Refreshing
+            onPlaybackClick = {
+                analyticsTracker.track(
+                    AnalyticsEvent.END_OF_YEAR_PROFILE_CARD_TAPPED,
+                    mapOf("year" to EndOfYearManager.YEAR_TO_SYNC.value),
+                )
+                // once stories prompt card is tapped, we don't want to show stories launch modal if not already shown
+                if (settings.getEndOfYearShowModal()) {
+                    settings.setEndOfYearShowModal(false)
+                }
+                (activity as? FragmentHostListener)?.showStoriesOrAccount(StoriesSource.PROFILE.value)
+            },
+            onClaimReferralsClick = {
+                val fragment = ReferralsGuestPassFragment.newInstance(ReferralsPageType.Claim)
+                (requireActivity() as FragmentHostListener).showBottomSheet(fragment)
+            },
+            onHideReferralsCardClick = {
+                referralsViewModel.onHideBannerClick()
+            },
+            onReferralsCardShown = {
+                referralsViewModel.onBannerShown()
+            },
+            onShowReferralsSheet = {
+                val activity = requireActivity()
+                activity.supportFragmentManager.findFragmentByTag(ReferralsGuestPassFragment::class.java.name)?.let {
+                    (activity as FragmentHostListener).showBottomSheet(it)
+                }
+            },
+            onSectionClick = { section ->
+                goToSection(section)
+            },
+            onRefreshClick = {
                 podcastManager.refreshPodcasts("profile")
                 analyticsTracker.track(AnalyticsEvent.PROFILE_REFRESH_BUTTON_TAPPED)
             },
-            modifier = Modifier.fillMaxWidth(),
-        )
-    }
-
-    @Composable
-    private fun ColumnScope.UpgradeProfile() {
-        val showUpgradeBanner by viewModel.showUpgradeBanner.collectAsState(false)
-        ProfileUpgradeSection(
-            isVisible = showUpgradeBanner,
-            contentPadding = PaddingValues(horizontal = 64.dp, vertical = 16.dp),
-            onClick = {
+            onUpgradeProfileClick = {
                 OnboardingLauncher.openOnboardingFlow(
-                    activity = activity,
+                    activity = requireActivity(),
                     onboardingFlow = OnboardingFlow.Upsell(OnboardingUpgradeSource.PROFILE),
                 )
             },
-            onCloseClick = {
-                viewModel.closeUpgradeProfile()
+            onCloseUpgradeProfileClick = {
+                profileViewModel.closeUpgradeProfile()
             },
-            modifier = Modifier
-                .background(MaterialTheme.colors.background)
-                .fillMaxWidth(),
+            modifier = Modifier.fillMaxSize(),
         )
     }
 
-    @Composable
-    private fun MiniPlayerPadding() {
-        val bottomPadding by settings.bottomInset.collectAsState(0)
-        val showUpgradeBanner by viewModel.showUpgradeBanner.collectAsState(false)
-        Box(
-            modifier = Modifier
-                .background(if (showUpgradeBanner) MaterialTheme.colors.background else Color.Transparent)
-                .fillMaxWidth()
-                .height(LocalDensity.current.run { bottomPadding.toDp() }),
-        )
+    override fun onResume() {
+        super.onResume()
+        profileViewModel.clearFailedRefresh()
     }
 
     private fun goToSection(section: ProfileSection) {
@@ -353,7 +188,7 @@ class ProfileFragment : BaseFragment() {
     }
 
     override fun onBackPressed(): Boolean {
-        viewModel.refreshStats()
+        profileViewModel.refreshStats()
         return super.onBackPressed()
     }
 }

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/ProfileHeader.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/ProfileHeader.kt
@@ -212,13 +212,19 @@ private fun HorizontalProfileHeader(
             }
             OutlinedButton(
                 border = ButtonDefaults.outlinedBorder.copy(
-                    brush = SolidColor(MaterialTheme.theme.colors.secondaryUi02),
+                    brush = SolidColor(MaterialTheme.theme.colors.primaryUi05),
+                    width = 2.dp,
                 ),
+                colors = ButtonDefaults.outlinedButtonColors(
+                    backgroundColor = Color.Transparent,
+                ),
+                shape = RoundedCornerShape(10.dp),
                 onClick = onClick,
             ) {
-                TextH50(
+                TextP50(
                     text = accountLabel,
                     fontScale = config.infoFontScale,
+                    letterSpacing = 0.5.sp,
                 )
             }
         }

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/ProfilePage.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/ProfilePage.kt
@@ -236,6 +236,7 @@ private fun ColumnScope.HeaderWithStats(
         VerticalSpacer()
     } else {
         Row(
+            verticalAlignment = Alignment.CenterVertically,
             modifier = Modifier
                 .fillMaxWidth()
                 .padding(horizontal = 16.dp),

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/ProfilePage.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/ProfilePage.kt
@@ -169,7 +169,7 @@ private val verticalSpacing = 16.dp
 @Composable
 private fun VerticalSpacer() {
     Spacer(
-        modifier = Modifier.height(16.dp),
+        modifier = Modifier.height(verticalSpacing),
     )
 }
 
@@ -227,14 +227,14 @@ private fun ColumnScope.HeaderWithStats(
             onClick = onHeaderClick,
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(horizontal = 16.dp),
+                .padding(horizontal = horizontalPadding),
         )
         VerticalSpacer()
         ProfileStats(
             state = statsState,
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(horizontal = 16.dp),
+                .padding(horizontal = horizontalPadding),
         )
         VerticalSpacer()
     } else {
@@ -242,7 +242,7 @@ private fun ColumnScope.HeaderWithStats(
             verticalAlignment = Alignment.CenterVertically,
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(horizontal = 16.dp),
+                .padding(horizontal = horizontalPadding),
         ) {
             ProfileHeader(
                 state = headerState,

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/ProfilePage.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/ProfilePage.kt
@@ -188,7 +188,7 @@ private fun Toolbar(
         verticalAlignment = Alignment.CenterVertically,
         modifier = Modifier
             .fillMaxWidth()
-            .height(64.dp)
+            .height(56.dp)
             .background(MaterialTheme.theme.colors.secondaryUi01)
             .padding(horizontal = horizontalPadding),
     ) {

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/ProfilePage.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/ProfilePage.kt
@@ -29,6 +29,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
@@ -74,7 +75,7 @@ internal fun ProfilePage(
         Column(
             modifier = modifier
                 .fillMaxSize()
-                .background(MaterialTheme.theme.colors.primaryUi01)
+                .background(MaterialTheme.theme.colors.primaryUi02)
                 .verticalScroll(rememberScrollState()),
         ) {
             Toolbar(
@@ -188,6 +189,7 @@ private fun Toolbar(
         modifier = Modifier
             .fillMaxWidth()
             .height(64.dp)
+            .background(MaterialTheme.theme.colors.secondaryUi01)
             .padding(horizontal = horizontalPadding),
     ) {
         if (showReferralsIcon) {
@@ -209,7 +211,7 @@ private fun Toolbar(
             Icon(
                 painter = painterResource(R.drawable.ic_profile_settings),
                 contentDescription = stringResource(au.com.shiftyjelly.pocketcasts.localization.R.string.settings),
-                tint = MaterialTheme.theme.colors.primaryIcon01,
+                tint = MaterialTheme.theme.colors.secondaryIcon01,
             )
         }
     }
@@ -273,8 +275,21 @@ private fun MiniPlayerPadding(
 
 @OrientationPreview
 @Composable
-private fun ProfilePagePreview(
+private fun ProfilePagePreview() {
+    ProfilePageStub(Theme.ThemeType.ROSE)
+}
+
+@Preview
+@Composable
+private fun ProfilePageThemePreview(
     @PreviewParameter(ThemePreviewParameterProvider::class) theme: Theme.ThemeType,
+) {
+    ProfilePageStub(theme)
+}
+
+@Composable
+private fun ProfilePageStub(
+    theme: Theme.ThemeType,
 ) {
     ProfilePage(
         state = ProfilePageState(

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/ProfilePage.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/ProfilePage.kt
@@ -1,0 +1,314 @@
+package au.com.shiftyjelly.pocketcasts.profile
+
+import android.content.res.Configuration
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.Icon
+import androidx.compose.material.IconButton
+import androidx.compose.material.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import au.com.shiftyjelly.pocketcasts.compose.AppTheme
+import au.com.shiftyjelly.pocketcasts.compose.OrientationPreview
+import au.com.shiftyjelly.pocketcasts.compose.components.HorizontalDivider
+import au.com.shiftyjelly.pocketcasts.compose.theme
+import au.com.shiftyjelly.pocketcasts.endofyear.ui.EndOfYearPromptCard
+import au.com.shiftyjelly.pocketcasts.images.R
+import au.com.shiftyjelly.pocketcasts.models.to.RefreshState
+import au.com.shiftyjelly.pocketcasts.models.type.ReferralsOfferInfoMock
+import au.com.shiftyjelly.pocketcasts.models.type.SubscriptionTier
+import au.com.shiftyjelly.pocketcasts.referrals.ReferralsClaimGuestPassBannerCard
+import au.com.shiftyjelly.pocketcasts.referrals.ReferralsIconWithTooltip
+import au.com.shiftyjelly.pocketcasts.referrals.ReferralsViewModel
+import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
+import java.util.Date
+import kotlin.time.Duration.Companion.hours
+import kotlin.time.Duration.Companion.minutes
+
+@Composable
+internal fun ProfilePage(
+    state: ProfilePageState,
+    themeType: Theme.ThemeType,
+    onSendReferralsClick: () -> Unit,
+    onReferralsTooltipClick: () -> Unit,
+    onReferralsTooltipShown: () -> Unit,
+    onSettingsClick: () -> Unit,
+    onHeaderClick: () -> Unit,
+    onPlaybackClick: () -> Unit,
+    onClaimReferralsClick: () -> Unit,
+    onHideReferralsCardClick: () -> Unit,
+    onReferralsCardShown: () -> Unit,
+    onShowReferralsSheet: () -> Unit,
+    onSectionClick: (ProfileSection) -> Unit,
+    onRefreshClick: () -> Unit,
+    onUpgradeProfileClick: () -> Unit,
+    onCloseUpgradeProfileClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    AppTheme(themeType) {
+        Column(
+            modifier = modifier
+                .fillMaxSize()
+                .background(MaterialTheme.theme.colors.primaryUi03)
+                .verticalScroll(rememberScrollState()),
+        ) {
+            Toolbar(
+                showReferralsIcon = state.isSendReferralsEnabled,
+                state = state.referralsState,
+                onSendReferralsClick = onSendReferralsClick,
+                onReferralsTooltipClick = onReferralsTooltipClick,
+                onReferralsTooltipShown = onReferralsTooltipShown,
+                onSettingsClick = onSettingsClick,
+            )
+            VerticalSpacer()
+            HeaderWithStats(
+                headerState = state.headerState,
+                statsState = state.statsState,
+                onHeaderClick = onHeaderClick,
+            )
+            VerticalSpacer()
+            if (state.isPlaybackEnabled) {
+                EndOfYearPromptCard(
+                    onClick = onPlaybackClick,
+                    modifier = Modifier.padding(horizontal = horizontalPadding),
+                )
+                VerticalSpacer()
+            }
+            if (state.isClaimReferralsEnabled) {
+                ReferralsClaimGuestPassBannerCard(
+                    state = state.referralsState,
+                    onClick = onClaimReferralsClick,
+                    onHideBannerClick = onHideReferralsCardClick,
+                    onBannerShown = onReferralsCardShown,
+                    onShowReferralsSheet = onShowReferralsSheet,
+                    modifier = Modifier.padding(horizontal = horizontalPadding),
+                )
+                if ((state.referralsState as ReferralsViewModel.UiState.Loaded?)?.showProfileBanner == true) {
+                    VerticalSpacer()
+                }
+            }
+            HorizontalDivider()
+            ProfileSections(
+                sections = ProfileSection.entries,
+                onClick = onSectionClick,
+                modifier = Modifier.fillMaxWidth(),
+            )
+            VerticalSpacer()
+            var localRefreshState by remember(state.refreshState) { mutableStateOf(state.refreshState) }
+            RefreshSection(
+                refreshState = localRefreshState,
+                onClick = {
+                    localRefreshState = RefreshState.Refreshing
+                    onRefreshClick()
+                },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = horizontalPadding),
+            )
+            VerticalSpacer()
+            ProfileUpgradeSection(
+                isVisible = state.isUpgradeBannerVisible,
+                contentPadding = PaddingValues(
+                    horizontal = 64.dp,
+                    vertical = verticalSpacing,
+                ),
+                onClick = onUpgradeProfileClick,
+                onCloseClick = onCloseUpgradeProfileClick,
+                modifier = Modifier
+                    .background(MaterialTheme.colors.background)
+                    .fillMaxWidth(),
+            )
+            MiniPlayerPadding(
+                padding = state.miniPlayerPadding,
+                isUpgradeBannerVisible = state.isUpgradeBannerVisible,
+            )
+        }
+    }
+}
+
+internal data class ProfilePageState(
+    val isSendReferralsEnabled: Boolean,
+    val isPlaybackEnabled: Boolean,
+    val isClaimReferralsEnabled: Boolean,
+    val isUpgradeBannerVisible: Boolean,
+    val miniPlayerPadding: Dp,
+    val headerState: ProfileHeaderState,
+    val statsState: ProfileStatsState,
+    val referralsState: ReferralsViewModel.UiState,
+    val refreshState: RefreshState?,
+)
+
+private val horizontalPadding = 16.dp
+private val verticalSpacing = 16.dp
+
+@Composable
+private fun VerticalSpacer() {
+    Spacer(
+        modifier = Modifier.height(16.dp),
+    )
+}
+
+@Composable
+private fun Toolbar(
+    showReferralsIcon: Boolean,
+    state: ReferralsViewModel.UiState,
+    onSendReferralsClick: () -> Unit,
+    onReferralsTooltipClick: () -> Unit,
+    onReferralsTooltipShown: () -> Unit,
+    onSettingsClick: () -> Unit,
+) {
+    Row(
+        horizontalArrangement = Arrangement.End,
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(64.dp)
+            .padding(horizontal = horizontalPadding),
+    ) {
+        if (showReferralsIcon) {
+            ReferralsIconWithTooltip(
+                state = state,
+                onIconClick = onSendReferralsClick,
+                onTooltipClick = onReferralsTooltipClick,
+                onTooltipShown = onReferralsTooltipShown,
+            )
+        }
+        if (LocalConfiguration.current.orientation != Configuration.ORIENTATION_LANDSCAPE) {
+            Spacer(
+                modifier = Modifier.weight(1f),
+            )
+        }
+        IconButton(
+            onClick = onSettingsClick,
+        ) {
+            Icon(
+                painter = painterResource(R.drawable.ic_profile_settings),
+                contentDescription = stringResource(au.com.shiftyjelly.pocketcasts.localization.R.string.settings),
+                tint = MaterialTheme.theme.colors.primaryIcon01,
+            )
+        }
+    }
+}
+
+@Composable
+private fun ColumnScope.HeaderWithStats(
+    headerState: ProfileHeaderState,
+    statsState: ProfileStatsState,
+    onHeaderClick: () -> Unit,
+) {
+    if (LocalConfiguration.current.orientation != Configuration.ORIENTATION_LANDSCAPE) {
+        ProfileHeader(
+            state = headerState,
+            onClick = onHeaderClick,
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp),
+        )
+        ProfileStats(
+            state = statsState,
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp),
+        )
+    } else {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp),
+        ) {
+            ProfileHeader(
+                state = headerState,
+                onClick = onHeaderClick,
+                modifier = Modifier.weight(1f),
+            )
+            ProfileStats(
+                state = statsState,
+                modifier = Modifier.weight(1f),
+            )
+        }
+    }
+}
+
+@Composable
+private fun MiniPlayerPadding(
+    padding: Dp,
+    isUpgradeBannerVisible: Boolean,
+) {
+    Box(
+        modifier = Modifier
+            .background(if (isUpgradeBannerVisible) MaterialTheme.colors.background else Color.Transparent)
+            .fillMaxWidth()
+            .height(padding),
+    )
+}
+
+@OrientationPreview
+@Composable
+private fun ProfilePagePreview() {
+    ProfilePage(
+        state = ProfilePageState(
+            isSendReferralsEnabled = true,
+            isPlaybackEnabled = true,
+            isClaimReferralsEnabled = true,
+            isUpgradeBannerVisible = true,
+            miniPlayerPadding = 64.dp,
+            headerState = ProfileHeaderState(
+                email = "noreply@pocketcasts.com",
+                imageUrl = null,
+                subscriptionTier = SubscriptionTier.NONE,
+                expiresIn = null,
+            ),
+            statsState = ProfileStatsState(
+                podcastsCount = 50,
+                listenedDuration = 75.hours,
+                savedDuration = 35.minutes,
+            ),
+            referralsState = ReferralsViewModel.UiState.Loaded(
+                showIcon = true,
+                showTooltip = false,
+                showProfileBanner = true,
+                showHideBannerPopup = false,
+                referralsOfferInfo = ReferralsOfferInfoMock,
+            ),
+            refreshState = RefreshState.Success(Date()),
+        ),
+        themeType = Theme.ThemeType.ROSE,
+        onClaimReferralsClick = {},
+        onReferralsTooltipClick = {},
+        onReferralsTooltipShown = {},
+        onSettingsClick = {},
+        onHeaderClick = {},
+        onPlaybackClick = {},
+        onSendReferralsClick = {},
+        onHideReferralsCardClick = {},
+        onReferralsCardShown = {},
+        onShowReferralsSheet = {},
+        onSectionClick = {},
+        onRefreshClick = {},
+        onUpgradeProfileClick = {},
+        onCloseUpgradeProfileClick = {},
+    )
+}

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/ProfilePage.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/ProfilePage.kt
@@ -29,11 +29,13 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import au.com.shiftyjelly.pocketcasts.compose.AppTheme
 import au.com.shiftyjelly.pocketcasts.compose.OrientationPreview
 import au.com.shiftyjelly.pocketcasts.compose.components.HorizontalDivider
+import au.com.shiftyjelly.pocketcasts.compose.preview.ThemePreviewParameterProvider
 import au.com.shiftyjelly.pocketcasts.compose.theme
 import au.com.shiftyjelly.pocketcasts.endofyear.ui.EndOfYearPromptCard
 import au.com.shiftyjelly.pocketcasts.images.R
@@ -72,7 +74,7 @@ internal fun ProfilePage(
         Column(
             modifier = modifier
                 .fillMaxSize()
-                .background(MaterialTheme.theme.colors.primaryUi03)
+                .background(MaterialTheme.theme.colors.primaryUi01)
                 .verticalScroll(rememberScrollState()),
         ) {
             Toolbar(
@@ -89,6 +91,7 @@ internal fun ProfilePage(
                 statsState = state.statsState,
                 onHeaderClick = onHeaderClick,
             )
+            VerticalSpacer()
             if (state.isPlaybackEnabled) {
                 EndOfYearPromptCard(
                     onClick = onPlaybackClick,
@@ -270,7 +273,9 @@ private fun MiniPlayerPadding(
 
 @OrientationPreview
 @Composable
-private fun ProfilePagePreview() {
+private fun ProfilePagePreview(
+    @PreviewParameter(ThemePreviewParameterProvider::class) theme: Theme.ThemeType,
+) {
     ProfilePage(
         state = ProfilePageState(
             isSendReferralsEnabled = true,
@@ -298,7 +303,7 @@ private fun ProfilePagePreview() {
             ),
             refreshState = RefreshState.Success(Date()),
         ),
-        themeType = Theme.ThemeType.ROSE,
+        themeType = theme,
         onClaimReferralsClick = {},
         onReferralsTooltipClick = {},
         onReferralsTooltipShown = {},

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/ProfilePage.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/ProfilePage.kt
@@ -89,7 +89,6 @@ internal fun ProfilePage(
                 statsState = state.statsState,
                 onHeaderClick = onHeaderClick,
             )
-            VerticalSpacer()
             if (state.isPlaybackEnabled) {
                 EndOfYearPromptCard(
                     onClick = onPlaybackClick,
@@ -106,7 +105,7 @@ internal fun ProfilePage(
                     onShowReferralsSheet = onShowReferralsSheet,
                     modifier = Modifier.padding(horizontal = horizontalPadding),
                 )
-                if ((state.referralsState as ReferralsViewModel.UiState.Loaded?)?.showProfileBanner == true) {
+                if ((state.referralsState as? ReferralsViewModel.UiState.Loaded)?.showProfileBanner == true) {
                     VerticalSpacer()
                 }
             }
@@ -227,12 +226,14 @@ private fun ColumnScope.HeaderWithStats(
                 .fillMaxWidth()
                 .padding(horizontal = 16.dp),
         )
+        VerticalSpacer()
         ProfileStats(
             state = statsState,
             modifier = Modifier
                 .fillMaxWidth()
                 .padding(horizontal = 16.dp),
         )
+        VerticalSpacer()
     } else {
         Row(
             modifier = Modifier
@@ -249,6 +250,7 @@ private fun ColumnScope.HeaderWithStats(
                 modifier = Modifier.weight(1f),
             )
         }
+        VerticalSpacer()
     }
 }
 

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/ProfileSections.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/ProfileSections.kt
@@ -3,6 +3,7 @@ package au.com.shiftyjelly.pocketcasts.profile
 import androidx.annotation.DrawableRes
 import androidx.annotation.StringRes
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -12,7 +13,9 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.material.Icon
 import androidx.compose.material.MaterialTheme
+import androidx.compose.material.ripple
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
@@ -47,7 +50,13 @@ internal fun ProfileSections(
                 modifier = Modifier
                     .fillMaxWidth()
                     .heightIn(min = 60.dp)
-                    .clickable { onClick(section) }
+                    .clickable(
+                        interactionSource = remember(::MutableInteractionSource),
+                        indication = ripple(
+                            color = MaterialTheme.theme.colors.primaryIcon01,
+                        ),
+                        onClick = { onClick(section) },
+                    )
                     .semantics(mergeDescendants = true) {
                         role = Role.Button
                     }

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/ProfileStats.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/ProfileStats.kt
@@ -26,6 +26,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.tooling.preview.PreviewParameterProvider
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import au.com.shiftyjelly.pocketcasts.compose.AppTheme
 import au.com.shiftyjelly.pocketcasts.compose.components.TextP30
 import au.com.shiftyjelly.pocketcasts.compose.components.TextP60
@@ -106,7 +107,9 @@ private fun RowScope.StatsColumn(
             text = labelText,
             textAlign = TextAlign.Center,
             color = MaterialTheme.theme.colors.primaryText02,
-            fontWeight = FontWeight.SemiBold,
+            fontSize = 12.sp,
+            fontWeight = FontWeight.Medium,
+            letterSpacing = 0.5.sp,
         )
     }
 }

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/ProfileViewModel.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/ProfileViewModel.kt
@@ -1,10 +1,9 @@
 package au.com.shiftyjelly.pocketcasts.profile
 
-import androidx.lifecycle.LiveData
 import androidx.lifecycle.ViewModel
-import androidx.lifecycle.asFlow
-import androidx.lifecycle.toLiveData
 import androidx.lifecycle.viewModelScope
+import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
+import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTracker
 import au.com.shiftyjelly.pocketcasts.models.to.RefreshState
 import au.com.shiftyjelly.pocketcasts.models.to.SignInState
 import au.com.shiftyjelly.pocketcasts.models.type.SubscriptionTier
@@ -34,20 +33,24 @@ import java.time.Duration as JavaDuration
 
 @HiltViewModel
 class ProfileViewModel @Inject constructor(
-    val settings: Settings,
-    val podcastManager: PodcastManager,
-    val statsManager: StatsManager,
-    val userManager: UserManager,
+    private val settings: Settings,
+    private val podcastManager: PodcastManager,
+    private val statsManager: StatsManager,
+    private val userManager: UserManager,
     private val endOfYearManager: EndOfYearManager,
+    private val tracker: AnalyticsTracker,
 ) : ViewModel() {
     private val refreshStatsTrigger = MutableSharedFlow<Unit>(extraBufferCapacity = 1)
 
-    val isSignedIn: Boolean
-        get() = signInState.value?.isSignedIn ?: false
+    private val signInState = userManager.getSignInState().asFlow().stateIn(
+        scope = viewModelScope,
+        started = SharingStarted.Eagerly,
+        initialValue = SignInState.SignedOut,
+    )
 
-    val signInState: LiveData<SignInState> = userManager.getSignInState().toLiveData()
+    internal val isSignedIn get() = signInState.value.isSignedIn
 
-    internal val profileHeaderState = userManager.getSignInState().asFlow().map { state ->
+    internal val profileHeaderState = signInState.map { state ->
         when (state) {
             is SignInState.SignedIn -> ProfileHeaderState(
                 imageUrl = Gravatar.getUrl(state.email),
@@ -97,22 +100,7 @@ class ProfileViewModel @Inject constructor(
         ),
     )
 
-    val refreshState = settings.refreshStateObservable.asFlow().stateIn(
-        scope = viewModelScope,
-        started = SharingStarted.Eagerly,
-        initialValue = null,
-    )
-
-    val showUpgradeBanner = combine(
-        settings.upgradeProfileClosed.flow,
-        signInState.asFlow().map { it.isSignedInAsPlusOrPatron },
-    ) { closedClicked, isPlusOrPatron -> !closedClicked && !isPlusOrPatron }
-
-    fun closeUpgradeProfile() {
-        settings.upgradeProfileClosed.set(true, updateModifiedAt = false)
-    }
-
-    val isEndOfYearStoriesEligible = flow {
+    internal val isPlaybackAvailable = flow {
         while (true) {
             emit(endOfYearManager.isEligibleForEndOfYear())
             delay(10_000)
@@ -123,15 +111,77 @@ class ProfileViewModel @Inject constructor(
         initialValue = false,
     )
 
-    fun clearFailedRefresh() {
+    internal val refreshState = settings.refreshStateObservable.asFlow().stateIn(
+        scope = viewModelScope,
+        started = SharingStarted.Eagerly,
+        initialValue = null,
+    )
+
+    internal val showUpgradeBanner = combine(
+        settings.upgradeProfileClosed.flow,
+        signInState.map { it.isSignedInAsPlusOrPatron },
+    ) { closedClicked, isPlusOrPatron -> !closedClicked && !isPlusOrPatron }
+
+    internal val miniPlayerInset = settings.bottomInset.stateIn(
+        scope = viewModelScope,
+        started = SharingStarted.Eagerly,
+        initialValue = 0,
+    )
+
+    internal fun onScreenShown() {
+        tracker.track(AnalyticsEvent.PROFILE_SHOWN)
+    }
+
+    internal fun onSettingsClick() {
+        tracker.track(AnalyticsEvent.PROFILE_SETTINGS_BUTTON_TAPPED)
+    }
+
+    internal fun onHeaderClick() {
+        tracker.track(AnalyticsEvent.PROFILE_ACCOUNT_BUTTON_TAPPED)
+    }
+
+    internal fun refreshStats() {
+        refreshStatsTrigger.tryEmit(Unit)
+    }
+
+    internal fun onPlaybackClick() {
+        tracker.track(
+            AnalyticsEvent.END_OF_YEAR_PROFILE_CARD_TAPPED,
+            mapOf("year" to EndOfYearManager.YEAR_TO_SYNC.value),
+        )
+        // once stories prompt card is tapped, we don't want to show stories launch modal if not already shown
+        if (settings.getEndOfYearShowModal()) {
+            settings.setEndOfYearShowModal(false)
+        }
+    }
+
+    internal fun onSectionClick(section: ProfileSection) {
+        val event = when (section) {
+            ProfileSection.Stats -> AnalyticsEvent.STATS_SHOWN
+            ProfileSection.Downloads -> AnalyticsEvent.DOWNLOADS_SHOWN
+            ProfileSection.CloudFiles -> AnalyticsEvent.UPLOADED_FILES_SHOWN
+            ProfileSection.Starred -> AnalyticsEvent.STARRED_SHOWN
+            ProfileSection.Bookmarks -> AnalyticsEvent.PROFILE_BOOKMARKS_SHOWN
+            ProfileSection.ListeningHistory -> AnalyticsEvent.LISTENING_HISTORY_SHOWN
+            ProfileSection.Help -> AnalyticsEvent.SETTINGS_HELP_SHOWN
+        }
+        tracker.track(event)
+    }
+
+    internal fun refreshProfile() {
+        tracker.track(AnalyticsEvent.PROFILE_REFRESH_BUTTON_TAPPED)
+        podcastManager.refreshPodcasts("profile")
+    }
+
+    internal fun clearFailedRefresh() {
         val lastSuccess = settings.getLastSuccessRefreshState()
         if (settings.getRefreshState() is RefreshState.Failed && lastSuccess != null) {
             settings.setRefreshState(lastSuccess)
         }
     }
 
-    fun refreshStats() {
-        refreshStatsTrigger.tryEmit(Unit)
+    internal fun closeUpgradeProfile() {
+        settings.upgradeProfileClosed.set(true, updateModifiedAt = false)
     }
 
     private fun expiresIn(expiryDate: Instant): Duration {

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/ProfileViewModel.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/ProfileViewModel.kt
@@ -67,7 +67,16 @@ class ProfileViewModel @Inject constructor(
                 expiresIn = null,
             )
         }
-    }
+    }.stateIn(
+        scope = viewModelScope,
+        started = SharingStarted.Eagerly,
+        initialValue = ProfileHeaderState(
+            imageUrl = null,
+            subscriptionTier = SubscriptionTier.NONE,
+            email = null,
+            expiresIn = null,
+        ),
+    )
 
     internal val profileStatsState = combine(
         refreshStatsTrigger.onStart { emit(Unit) },
@@ -78,9 +87,21 @@ class ProfileViewModel @Inject constructor(
             listenedDuration = statsManager.mergedTotalListeningTimeSec.seconds,
             savedDuration = statsManager.mergedTotalTimeSaved.seconds,
         )
-    }
+    }.stateIn(
+        scope = viewModelScope,
+        started = SharingStarted.Eagerly,
+        initialValue = ProfileStatsState(
+            podcastsCount = 0,
+            listenedDuration = Duration.ZERO,
+            savedDuration = Duration.ZERO,
+        ),
+    )
 
-    val refreshState = settings.refreshStateObservable.asFlow()
+    val refreshState = settings.refreshStateObservable.asFlow().stateIn(
+        scope = viewModelScope,
+        started = SharingStarted.Eagerly,
+        initialValue = null,
+    )
 
     val showUpgradeBanner = combine(
         settings.upgradeProfileClosed.flow,
@@ -96,7 +117,11 @@ class ProfileViewModel @Inject constructor(
             emit(endOfYearManager.isEligibleForEndOfYear())
             delay(10_000)
         }
-    }.stateIn(viewModelScope, started = SharingStarted.Eagerly, initialValue = false)
+    }.stateIn(
+        scope = viewModelScope,
+        started = SharingStarted.Eagerly,
+        initialValue = false,
+    )
 
     fun clearFailedRefresh() {
         val lastSuccess = settings.getLastSuccessRefreshState()

--- a/modules/features/referrals/src/main/kotlin/au/com/shiftyjelly/pocketcasts/referrals/ReferralsClaimGuestPassBannerCard.kt
+++ b/modules/features/referrals/src/main/kotlin/au/com/shiftyjelly/pocketcasts/referrals/ReferralsClaimGuestPassBannerCard.kt
@@ -26,7 +26,6 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.intl.Locale
 import androidx.compose.ui.tooling.preview.Preview
@@ -34,8 +33,6 @@ import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.min
-import androidx.hilt.navigation.compose.hiltViewModel
-import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import au.com.shiftyjelly.pocketcasts.compose.AppTheme
 import au.com.shiftyjelly.pocketcasts.compose.CallOnce
 import au.com.shiftyjelly.pocketcasts.compose.components.TextC70
@@ -43,44 +40,35 @@ import au.com.shiftyjelly.pocketcasts.compose.components.TextH40
 import au.com.shiftyjelly.pocketcasts.compose.preview.ThemePreviewParameterProvider
 import au.com.shiftyjelly.pocketcasts.compose.theme
 import au.com.shiftyjelly.pocketcasts.models.type.ReferralsOfferInfoMock
-import au.com.shiftyjelly.pocketcasts.referrals.ReferralsGuestPassFragment.ReferralsPageType
 import au.com.shiftyjelly.pocketcasts.referrals.ReferralsViewModel.UiState
-import au.com.shiftyjelly.pocketcasts.ui.helper.FragmentHostListener
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
-import au.com.shiftyjelly.pocketcasts.utils.extensions.getActivity
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 @Composable
 fun ReferralsClaimGuestPassBannerCard(
+    state: UiState,
+    onClick: () -> Unit,
+    onHideBannerClick: () -> Unit,
+    onBannerShown: () -> Unit,
+    onShowReferralsSheet: () -> Unit,
     modifier: Modifier = Modifier,
-    viewModel: ReferralsViewModel = hiltViewModel(),
 ) {
-    val state by viewModel.state.collectAsStateWithLifecycle()
-    val activity = LocalContext.current.getActivity()
-
     CallOnce {
-        viewModel.onBannerShown()
+        onBannerShown()
+    }
+    LaunchedEffect(Unit) {
+        onShowReferralsSheet()
     }
 
     when (state) {
-        UiState.Loading -> Unit
+        is UiState.Loading -> Unit
         is UiState.Loaded -> {
-            val loadedState = state as UiState.Loaded
             ReferralsClaimGuestPassBannerCard(
-                state = loadedState,
+                state = state,
                 modifier = modifier,
-                onClick = {
-                    val fragment = ReferralsGuestPassFragment.newInstance(ReferralsPageType.Claim)
-                    (activity as FragmentHostListener).showBottomSheet(fragment)
-                },
-                onHideBannerClick = viewModel::onHideBannerClick,
+                onClick = onClick,
+                onHideBannerClick = onHideBannerClick,
             )
-        }
-    }
-
-    LaunchedEffect(Unit) {
-        activity?.supportFragmentManager?.findFragmentByTag(ReferralsGuestPassFragment::class.java.name)?.let {
-            (activity as FragmentHostListener).showBottomSheet(it)
         }
     }
 }
@@ -89,9 +77,9 @@ fun ReferralsClaimGuestPassBannerCard(
 @Composable
 private fun ReferralsClaimGuestPassBannerCard(
     state: UiState.Loaded,
-    modifier: Modifier = Modifier,
     onClick: () -> Unit,
     onHideBannerClick: () -> Unit,
+    modifier: Modifier = Modifier,
 ) {
     if (state.showProfileBanner) {
         var showPopupToHideBanner by remember { mutableStateOf(false) }
@@ -180,6 +168,8 @@ private fun ReferralsClaimGuestPassBannerCardPreview(
             ),
             onClick = {},
             onHideBannerClick = {},
+            onBannerShown = {},
+            onShowReferralsSheet = {},
         )
     }
 }

--- a/modules/features/referrals/src/main/kotlin/au/com/shiftyjelly/pocketcasts/referrals/ReferralsIconWithTooltip.kt
+++ b/modules/features/referrals/src/main/kotlin/au/com/shiftyjelly/pocketcasts/referrals/ReferralsIconWithTooltip.kt
@@ -1,11 +1,13 @@
 package au.com.shiftyjelly.pocketcasts.referrals
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.Icon
 import androidx.compose.material.IconButton
+import androidx.compose.material.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
@@ -14,6 +16,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.dp
+import au.com.shiftyjelly.pocketcasts.compose.AppTheme
 import au.com.shiftyjelly.pocketcasts.compose.AppThemeWithBackground
 import au.com.shiftyjelly.pocketcasts.compose.CallOnce
 import au.com.shiftyjelly.pocketcasts.compose.Devices
@@ -22,6 +25,7 @@ import au.com.shiftyjelly.pocketcasts.compose.ThemeColors
 import au.com.shiftyjelly.pocketcasts.compose.components.TextH40
 import au.com.shiftyjelly.pocketcasts.compose.components.Tooltip
 import au.com.shiftyjelly.pocketcasts.compose.preview.ThemePreviewParameterProvider
+import au.com.shiftyjelly.pocketcasts.compose.theme
 import au.com.shiftyjelly.pocketcasts.models.type.ReferralsOfferInfo
 import au.com.shiftyjelly.pocketcasts.models.type.ReferralsOfferInfoMock
 import au.com.shiftyjelly.pocketcasts.referrals.ReferralsViewModel.UiState
@@ -102,14 +106,12 @@ private fun Icon(
     onIconClick: () -> Unit,
     colors: ThemeColors,
 ) {
-    Box {
-        IconButton(onClick = onIconClick) {
-            Icon(
-                painter = painterResource(id = R.drawable.ic_gift),
-                contentDescription = stringResource(LR.string.gift),
-                tint = colors.primaryIcon01,
-            )
-        }
+    IconButton(onClick = onIconClick) {
+        Icon(
+            painter = painterResource(id = R.drawable.ic_gift),
+            contentDescription = stringResource(LR.string.gift),
+            tint = colors.secondaryIcon01,
+        )
     }
 }
 
@@ -118,11 +120,15 @@ private fun Icon(
 private fun IconWithBadgePreview(
     @PreviewParameter(ThemePreviewParameterProvider::class) themeType: Theme.ThemeType,
 ) {
-    AppThemeWithBackground(themeType) {
-        Icon(
-            onIconClick = {},
-            colors = LocalColors.current.colors,
-        )
+    AppTheme(themeType) {
+        Box(
+            modifier = Modifier.background(MaterialTheme.theme.colors.secondaryUi01),
+        ) {
+            Icon(
+                onIconClick = {},
+                colors = LocalColors.current.colors,
+            )
+        }
     }
 }
 

--- a/modules/features/referrals/src/main/kotlin/au/com/shiftyjelly/pocketcasts/referrals/ReferralsIconWithTooltip.kt
+++ b/modules/features/referrals/src/main/kotlin/au/com/shiftyjelly/pocketcasts/referrals/ReferralsIconWithTooltip.kt
@@ -9,14 +9,11 @@ import androidx.compose.material.IconButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.dp
-import androidx.hilt.navigation.compose.hiltViewModel
-import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import au.com.shiftyjelly.pocketcasts.compose.AppThemeWithBackground
 import au.com.shiftyjelly.pocketcasts.compose.CallOnce
 import au.com.shiftyjelly.pocketcasts.compose.Devices
@@ -27,35 +24,28 @@ import au.com.shiftyjelly.pocketcasts.compose.components.Tooltip
 import au.com.shiftyjelly.pocketcasts.compose.preview.ThemePreviewParameterProvider
 import au.com.shiftyjelly.pocketcasts.models.type.ReferralsOfferInfo
 import au.com.shiftyjelly.pocketcasts.models.type.ReferralsOfferInfoMock
-import au.com.shiftyjelly.pocketcasts.referrals.ReferralsGuestPassFragment.ReferralsPageType
 import au.com.shiftyjelly.pocketcasts.referrals.ReferralsViewModel.UiState
-import au.com.shiftyjelly.pocketcasts.ui.helper.FragmentHostListener
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
-import au.com.shiftyjelly.pocketcasts.utils.extensions.getActivity
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 @Composable
 fun ReferralsIconWithTooltip(
-    viewModel: ReferralsViewModel = hiltViewModel(),
+    state: ReferralsViewModel.UiState,
+    onIconClick: () -> Unit,
+    onTooltipClick: () -> Unit,
+    onTooltipShown: () -> Unit,
 ) {
-    val state by viewModel.state.collectAsStateWithLifecycle()
-    val activity = LocalContext.current.getActivity()
-
     CallOnce {
-        viewModel.onTooltipShown()
+        onTooltipShown()
     }
 
     when (state) {
-        UiState.Loading -> Unit
+        is UiState.Loading -> Unit
         is UiState.Loaded -> {
             ReferralsIconWithTooltip(
-                state = state as UiState.Loaded,
-                onIconClick = {
-                    viewModel.onIconClick()
-                    val fragment = ReferralsGuestPassFragment.newInstance(ReferralsPageType.Send)
-                    (activity as FragmentHostListener).showBottomSheet(fragment)
-                },
-                onTooltipClick = viewModel::onTooltipClick,
+                state = state,
+                onIconClick = onIconClick,
+                onTooltipClick = onTooltipClick,
             )
         }
     }

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/Devices.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/Devices.kt
@@ -1,5 +1,7 @@
 package au.com.shiftyjelly.pocketcasts.compose
 
+import androidx.compose.ui.tooling.preview.Preview
+
 object Devices {
     const val PortraitRegular = "spec:width=800px,height=1600px,dpi=320"
     const val PortraitSmall = "spec:width=720px,height=1280px,dpi=320"
@@ -11,3 +13,7 @@ object Devices {
     const val LandscapeTablet = "$PortraitTablet,orientation=landscape"
     const val LandscapeFoldable = "$PortraitFoldable,orientation=landscape"
 }
+
+@Preview(device = Devices.PortraitRegular)
+@Preview(device = Devices.LandscapeRegular)
+annotation class OrientationPreview

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/TextStyles.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/TextStyles.kt
@@ -314,6 +314,7 @@ fun TextP60(
     style: TextStyle = TextStyle(),
     disableAutoScale: Boolean = false,
     fontScale: Float = 1f,
+    letterSpacing: TextUnit = 0.sp,
 ) {
     val fontSizeUpdated = fontSize ?: 13.sp
     Text(
@@ -321,7 +322,7 @@ fun TextP60(
         color = color,
         fontSize = (if (disableAutoScale) fontSizeUpdated.value.nonScaledSp else fontSizeUpdated) * fontScale,
         lineHeight = (if (disableAutoScale) 15.nonScaledSp else 15.sp) * fontScale,
-        letterSpacing = 0.sp,
+        letterSpacing = letterSpacing,
         maxLines = maxLines,
         overflow = TextOverflow.Ellipsis,
         textAlign = textAlign,


### PR DESCRIPTION
## Description

After completing migration this is the last PR that cleans things up:
* Moved the whole Profile screen to a separate composable.
* Decoupled referrals card and tooltip from the view model.
* Moved logic from `ProfileFragment` to the view model.

## Testing Instructions

Do monkey testing of the profile screen. Check orientation, theming, tapping on things, different accounts, etc.

## Checklist
- [ ] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] ~I have considered whether it makes sense to add tests for my changes~
- [ ] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [ ] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack
