### PR TITLE
Migrate to `about libraries` in mobile app

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -8,8 +8,6 @@ plugins {
     alias(libs.plugins.compose.compiler)
 }
 
-apply(plugin = "com.google.android.gms.oss-licenses-plugin")
-
 android {
     namespace = "au.com.shiftyjelly.pocketcasts"
 

--- a/app/lint-baseline.xml
+++ b/app/lint-baseline.xml
@@ -134,28 +134,6 @@
     </issue>
 
     <issue
-        id="MissingClass"
-        message="Class referenced in the manifest, `com.google.android.gms.oss.licenses.OssLicensesMenuActivity`, was not found in the project or the libraries"
-        errorLine1="        &lt;activity android:name=&quot;com.google.android.gms.oss.licenses.OssLicensesMenuActivity&quot;"
-        errorLine2="                                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
-        <location
-            file="src/main/AndroidManifest.xml"
-            line="528"
-            column="33"/>
-    </issue>
-
-    <issue
-        id="MissingClass"
-        message="Class referenced in the manifest, `com.google.android.gms.oss.licenses.OssLicensesActivity`, was not found in the project or the libraries"
-        errorLine1="        &lt;activity android:name=&quot;com.google.android.gms.oss.licenses.OssLicensesActivity&quot;"
-        errorLine2="                                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
-        <location
-            file="src/main/AndroidManifest.xml"
-            line="530"
-            column="33"/>
-    </issue>
-
-    <issue
         id="NotSibling"
         message="`btnFav` is not a sibling in the same `ConstraintLayout`"
         errorLine1="            app:constraint_referenced_ids=&quot;lblDate,lblTimeLeft,btnDownload, btnShare, btnFav, btnAddToUpNext, btnArchive, btnPlay, btnPlayed&quot;"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -525,11 +525,6 @@
 
         <activity android:name=".profile.sonos.SonosAppLinkActivity" android:label="@string/profile_sonos"/>
 
-        <activity android:name="com.google.android.gms.oss.licenses.OssLicensesMenuActivity"
-            android:theme="@style/Theme.AppCompat.DayNight"/>
-        <activity android:name="com.google.android.gms.oss.licenses.OssLicensesActivity"
-            android:theme="@style/Theme.AppCompat.DayNight"/>
-
         <!-- services which are periodic or trigerred by the app automatically triggered, eg: can run in the background -->
         <service android:name="au.com.shiftyjelly.pocketcasts.repositories.download.UpdateEpisodeDetailsJob"
                  android:permission="android.permission.BIND_JOB_SERVICE"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -17,15 +17,6 @@ import org.jetbrains.kotlin.gradle.dsl.KotlinJvmCompilerOptions
 import org.jetbrains.kotlin.gradle.plugin.KotlinBasePlugin
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompilationTask
 
-// Top-level build file where you can add configuration options common to all sub-projects/modules.
-buildscript {
-    // Gradle Plugins
-    dependencies {
-        // Open source licenses plugin
-        classpath(libs.osslicenses.plugin)
-    }
-}
-
 plugins {
     alias(libs.plugins.android.application) apply false
     alias(libs.plugins.android.library) apply false

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -124,9 +124,6 @@ fragment-ktx = { module = "androidx.fragment:fragment-ktx", version.ref = "fragm
 glance-appwidget = { module = "androidx.glance:glance-appwidget", version.ref = "glance" }
 glance-material3 = { module = "androidx.glance:glance-material3", version.ref = "glance" }
 
-# Google Play Services OSS Licenses - (The following line is still needed as there is no plugin marker available as of yet)
-osslicenses-plugin = "com.google.android.gms:oss-licenses-plugin:0.10.6"
-
 # Horologist
 horologist-audio-ui = { module = "com.google.android.horologist:horologist-audio-ui", version.ref = "horologist" }
 horologist-audio = { module = "com.google.android.horologist:horologist-audio", version.ref = "horologist" }
@@ -283,7 +280,6 @@ material-dialogs = "com.afollestad.material-dialogs:core:3.3.0"
 material-progressbar = "me.zhanghai.android.materialprogressbar:library:1.6.1"
 play-auth = "com.google.android.gms:play-services-auth:20.4.0"
 play-cast = "com.google.android.gms:play-services-cast-framework:22.0.0"
-play-oss-licenses = "com.google.android.gms:play-services-oss-licenses:17.0.1"
 play-review = "com.google.android.play:review-ktx:2.0.2"
 play-wearable = "com.google.android.gms:play-services-wearable:18.0.0"
 reorderable = "sh.calvin.reorderable:reorderable:2.4.0"

--- a/modules/features/settings/build.gradle.kts
+++ b/modules/features/settings/build.gradle.kts
@@ -68,7 +68,6 @@ dependencies {
     implementation(libs.material.dialogs)
     implementation(libs.okhttp)
     implementation(libs.play.cast)
-    implementation(libs.play.oss.licenses)
     implementation(libs.rx2.android)
     implementation(libs.rx2.java)
     implementation(libs.rx2.kotlin)

--- a/modules/features/settings/build.gradle.kts
+++ b/modules/features/settings/build.gradle.kts
@@ -5,6 +5,7 @@ plugins {
     alias(libs.plugins.hilt)
     alias(libs.plugins.kotlin.parcelize)
     alias(libs.plugins.compose.compiler)
+    alias(libs.plugins.aboutlibraries)
 }
 
 android {
@@ -45,6 +46,8 @@ dependencies {
     implementation(platform(libs.compose.bom))
     implementation(platform(libs.firebase.bom))
 
+    implementation(libs.aboutlibraries.compose)
+    implementation(libs.aboutlibraries.core)
     implementation(libs.androidx.core.ktx)
     implementation(libs.compose.animation)
     implementation(libs.compose.material)

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/LicensesFragment.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/LicensesFragment.kt
@@ -4,13 +4,11 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.unit.dp
 import androidx.fragment.compose.content
 import au.com.shiftyjelly.pocketcasts.compose.AppThemeWithBackground
 import au.com.shiftyjelly.pocketcasts.compose.bars.ThemedTopAppBar

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/LicensesFragment.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/LicensesFragment.kt
@@ -1,0 +1,71 @@
+package au.com.shiftyjelly.pocketcasts.settings
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.fragment.compose.content
+import au.com.shiftyjelly.pocketcasts.compose.AppThemeWithBackground
+import au.com.shiftyjelly.pocketcasts.compose.bars.ThemedTopAppBar
+import au.com.shiftyjelly.pocketcasts.compose.theme
+import au.com.shiftyjelly.pocketcasts.localization.R
+import au.com.shiftyjelly.pocketcasts.ui.helper.FragmentHostListener
+import au.com.shiftyjelly.pocketcasts.views.fragments.BaseFragment
+import com.mikepenz.aboutlibraries.Libs
+import com.mikepenz.aboutlibraries.ui.compose.LibrariesContainer
+import com.mikepenz.aboutlibraries.ui.compose.LibraryDefaults
+import com.mikepenz.aboutlibraries.ui.compose.util.author
+import com.mikepenz.aboutlibraries.util.withContext
+import kotlinx.collections.immutable.toImmutableList
+
+class LicensesFragment : BaseFragment() {
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?,
+    ) = content {
+        AppThemeWithBackground(theme.activeTheme) {
+            LicensesPage(onBackPressed = { closeFragment() })
+        }
+    }
+
+    private fun closeFragment() {
+        (activity as? FragmentHostListener)?.closeModal(this)
+    }
+
+    @Composable
+    private fun LicensesPage(onBackPressed: () -> Unit, modifier: Modifier = Modifier) {
+        Column {
+            ThemedTopAppBar(
+                title = stringResource(R.string.settings_about_acknowledgements),
+                onNavigationClick = onBackPressed,
+            )
+            LibrariesContainer(
+                modifier = modifier.fillMaxSize(),
+                showAuthor = true,
+                showVersion = false,
+                showLicenseBadges = true,
+                colors = LibraryDefaults.libraryColors(
+                    backgroundColor = MaterialTheme.colors.background,
+                    contentColor = MaterialTheme.theme.colors.primaryText01,
+                ),
+                itemContentPadding = PaddingValues(horizontal = 32.dp, vertical = 16.dp),
+                librariesBlock = { context ->
+                    val libs = Libs.Builder().withContext(context).build()
+                    // without displaying the artifact id the libraries seem to appear twice
+                    libs.copy(
+                        libs.libraries.distinctBy { "${it.name}##${it.author}" }.toImmutableList(),
+                    )
+                },
+            )
+        }
+    }
+}

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/LicensesFragment.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/LicensesFragment.kt
@@ -2,6 +2,7 @@ package au.com.shiftyjelly.pocketcasts.settings
 
 import android.os.Bundle
 import android.view.LayoutInflater
+import android.view.View
 import android.view.ViewGroup
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
@@ -9,11 +10,16 @@ import androidx.compose.material.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.core.view.updatePadding
 import androidx.fragment.compose.content
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
 import au.com.shiftyjelly.pocketcasts.compose.AppThemeWithBackground
 import au.com.shiftyjelly.pocketcasts.compose.bars.ThemedTopAppBar
 import au.com.shiftyjelly.pocketcasts.compose.theme
 import au.com.shiftyjelly.pocketcasts.localization.R
+import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.ui.helper.FragmentHostListener
 import au.com.shiftyjelly.pocketcasts.views.fragments.BaseFragment
 import com.mikepenz.aboutlibraries.Libs
@@ -21,9 +27,16 @@ import com.mikepenz.aboutlibraries.ui.compose.LibrariesContainer
 import com.mikepenz.aboutlibraries.ui.compose.LibraryDefaults
 import com.mikepenz.aboutlibraries.ui.compose.util.author
 import com.mikepenz.aboutlibraries.util.withContext
+import dagger.hilt.android.AndroidEntryPoint
+import javax.inject.Inject
 import kotlinx.collections.immutable.toImmutableList
+import kotlinx.coroutines.launch
 
+@AndroidEntryPoint
 class LicensesFragment : BaseFragment() {
+
+    @Inject
+    lateinit var settings: Settings
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -32,6 +45,17 @@ class LicensesFragment : BaseFragment() {
     ) = content {
         AppThemeWithBackground(theme.activeTheme) {
             LicensesPage(onBackPressed = { closeFragment() })
+        }
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        viewLifecycleOwner.lifecycleScope.launch {
+            viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
+                settings.bottomInset.collect {
+                    view.updatePadding(bottom = it)
+                }
+            }
         }
     }
 

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/LicensesFragment.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/LicensesFragment.kt
@@ -57,7 +57,6 @@ class LicensesFragment : BaseFragment() {
                     backgroundColor = MaterialTheme.colors.background,
                     contentColor = MaterialTheme.theme.colors.primaryText01,
                 ),
-                itemContentPadding = PaddingValues(horizontal = 32.dp, vertical = 16.dp),
                 librariesBlock = { context ->
                     val libs = Libs.Builder().withContext(context).build()
                     // without displaying the artifact id the libraries seem to appear twice

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/about/AboutFragment.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/about/AboutFragment.kt
@@ -48,6 +48,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.fragment.app.Fragment
 import androidx.fragment.compose.content
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
@@ -59,6 +60,7 @@ import au.com.shiftyjelly.pocketcasts.compose.components.HorizontalDivider
 import au.com.shiftyjelly.pocketcasts.compose.theme
 import au.com.shiftyjelly.pocketcasts.localization.BuildConfig
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
+import au.com.shiftyjelly.pocketcasts.settings.LicensesFragment
 import au.com.shiftyjelly.pocketcasts.settings.R
 import au.com.shiftyjelly.pocketcasts.settings.components.RowTextButton
 import au.com.shiftyjelly.pocketcasts.ui.extensions.getComposeThemeColor
@@ -93,6 +95,9 @@ class AboutFragment : BaseFragment() {
 
         AppThemeWithBackground(theme.activeTheme) {
             AboutPage(
+                openFragment = { fragment ->
+                    (activity as? FragmentHostListener)?.addFragment(fragment)
+                },
                 onBackPressed = { closeFragment() },
                 bottomInset = bottomInset.value.pxToDp(LocalContext.current).dp,
             )
@@ -174,6 +179,7 @@ private val icons = listOf(
 private fun AboutPage(
     onBackPressed: () -> Unit,
     bottomInset: Dp,
+    openFragment: (Fragment) -> Unit,
 ) {
     val context = LocalContext.current
     LazyColumn(
@@ -254,7 +260,7 @@ private fun AboutPage(
             HorizontalDivider(modifier = Modifier.padding(bottom = 8.dp))
         }
         item {
-            LegalAndMoreRow()
+            LegalAndMoreRow(openFragment)
         }
         item {
             HorizontalDivider(modifier = Modifier.padding(vertical = 8.dp))
@@ -326,7 +332,7 @@ fun AutomatticFamilyRow() {
 }
 
 @Composable
-fun LegalAndMoreRow() {
+fun LegalAndMoreRow(openFragment: (Fragment) -> Unit) {
     val context = LocalContext.current
     var legalExpanded by rememberSaveable { mutableStateOf(false) }
     val target = if (legalExpanded) 360f else 180f
@@ -362,7 +368,7 @@ fun LegalAndMoreRow() {
             )
             RowTextButton(
                 text = stringResource(LR.string.settings_about_acknowledgements),
-                onClick = { openAcknowledgements(context) },
+                onClick = { openFragment(LicensesFragment()) },
             )
         }
     }
@@ -420,5 +426,6 @@ private fun AboutPagePreview() {
     AboutPage(
         onBackPressed = {},
         bottomInset = 0.dp,
+        openFragment = {},
     )
 }

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/about/AboutFragment.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/about/AboutFragment.kt
@@ -69,7 +69,6 @@ import au.com.shiftyjelly.pocketcasts.ui.helper.FragmentHostListener
 import au.com.shiftyjelly.pocketcasts.utils.extensions.pxToDp
 import au.com.shiftyjelly.pocketcasts.utils.rateUs
 import au.com.shiftyjelly.pocketcasts.views.fragments.BaseFragment
-import com.google.android.gms.oss.licenses.OssLicensesMenuActivity
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
 import timber.log.Timber
@@ -372,11 +371,6 @@ fun LegalAndMoreRow(openFragment: (Fragment) -> Unit) {
             )
         }
     }
-}
-
-fun openAcknowledgements(context: Context) {
-    OssLicensesMenuActivity.setActivityTitle(context.getString(LR.string.settings_licenses))
-    context.startActivity(Intent(context, OssLicensesMenuActivity::class.java))
 }
 
 private fun shareWithFriends(context: Context) {


### PR DESCRIPTION
## Description
<!-- Please include a summary of what this PR is changing and why these changes are needed. -->

This PR replaces OSS Gradle Plugin with, already used in `automotive`, About Libraries to display list of dependencies, and their licenses, in "Acknowledgments" section of the app.

This change is motivated by lack of support of OSS Gradle Plugin for Gradle's Configuration Cache
<img width="1576" alt="Screenshot 2024-11-20 at 16 41 33" src="https://github.com/user-attachments/assets/194a8c87-e75e-4359-a5fc-cf09df4c4576">


## Testing Instructions
1. Open Settings > About > Legal and more > Acknowledgements
2. Verify that you can see dependencies used in the app. Tapping on a dependency shows details about its license

## Screenshots or Screencast 
<!-- if applicable -->

### Before 

https://github.com/user-attachments/assets/a7f9051c-9b0b-4e9d-8c9e-a61defaa184c

### After

https://github.com/user-attachments/assets/263e869b-6203-4a9c-9829-27ed88d5c678


## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [-] Any jetpack compose components I added or changed are covered by compose previews (list of dependencies won't be rendered, so I don't think it's necessary to provide a preview)
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
