### PR TITLE
Do not stop view setup when there is no toolbar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 *   Bug Fixes
     *   Fix effects being lost when paused
         ([#3219](https://github.com/Automattic/pocket-casts-android/pull/3219))
+    *   Fix account details not working in Automotive app
+        ([#3266](https://github.com/Automattic/pocket-casts-android/pull/3266))
 *   Updates
     *   Update profile header UI
         ([#3235](https://github.com/Automattic/pocket-casts-android/pull/3235))

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/AccountDetailsFragment.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/AccountDetailsFragment.kt
@@ -108,12 +108,13 @@ class AccountDetailsFragment : BaseFragment(), OnUserViewClickListener {
         super.onViewCreated(view, savedInstanceState)
 
         val binding = binding ?: return
-        val toolbar = binding.toolbar ?: return
-        setupToolbarAndStatusBar(
-            toolbar = toolbar,
-            title = getString(LR.string.profile_pocket_casts_account),
-            navigationIcon = NavigationIcon.BackArrow,
-        )
+        binding.toolbar?.let { toolbar ->
+            setupToolbarAndStatusBar(
+                toolbar = toolbar,
+                title = getString(LR.string.profile_pocket_casts_account),
+                navigationIcon = NavigationIcon.BackArrow,
+            )
+        }
 
         viewModel.signInState.observe(viewLifecycleOwner) { signInState ->
             binding.userView.signedInState = signInState


### PR DESCRIPTION
## Description

Closes #3263

## Testing Instructions

1. Run the Automotive app.
2. Login to a Pocket Casts account.
3. Sign out.

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] ~I have considered whether it makes sense to add tests for my changes~
- [ ] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [ ] ~Any jetpack compose components I added or changed are covered by compose previews~
- [ ] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~