### PR TITLE
Remove effects bug fix from 7.78 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,6 @@
     *   Add episode basic authentication support
         ([#3213](https://github.com/Automattic/pocket-casts-android/pull/3213))
 *   Bug Fixes
-    *   Fix effects being lost when paused
-        ([#3219](https://github.com/Automattic/pocket-casts-android/pull/3219))
     *   Fix account details not working in Automotive app
         ([#3266](https://github.com/Automattic/pocket-casts-android/pull/3266))
 *   Updates


### PR DESCRIPTION
## Description

This got cherry-picked (https://github.com/Automattic/pocket-casts-android/pull/3227) to `7.77` and is available in that changelog.

## Testing Instructions

Green CI.