### PR TITLE
Fix shelf row position for tablet

### DIFF
--- a/modules/features/player/src/main/res/layout-sw600dp/adapter_player_header.xml
+++ b/modules/features/player/src/main/res/layout-sw600dp/adapter_player_header.xml
@@ -248,7 +248,6 @@ Player controls and seekbar are centered horizontally on this layout, which make
             android:layout_height="wrap_content"
             android:layout_margin="16dp"
             android:weightSum="5"
-            app:layout_constraintTop_toBottomOf="@+id/playerControlsComposeView"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"/>


### PR DESCRIPTION
## Description
This fixes shelf row position for tablets. It was broken in  #3254

## Testing Instructions

1. Play an episode on tablet
2. Open full screen player
3. ✅ Notice that Player UI elements are rendered properly

## Screenshots or Screencast 

Before #3254 | In #3254 | Now
-----|---|----
![before_shelf_bar](https://github.com/user-attachments/assets/5bdfb78e-0d9e-46ef-bd88-f51b08b2c06f) | ![before_shelf_bar_](https://github.com/user-attachments/assets/8d017f56-8dae-4a70-bf64-8b669c2652b8) | ![after_shelf](https://github.com/user-attachments/assets/174a858a-3f58-4443-a325-f160aa03797a)


## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
