### PR TITLE
Fix episode not loading on Wear OS

### DIFF
--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackState.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackState.kt
@@ -66,6 +66,7 @@ data class PlaybackState(
             }
 
             return PlaybackState(
+                state = state,
                 isBuffering = !episode.isDownloaded && state == State.PLAYING,
                 isPrepared = isPrepared,
                 isSleepTimerRunning = previousPlaybackState?.isSleepTimerRunning ?: false,


### PR DESCRIPTION
## Description

I noticed on Wear OS that there's an issue with the current episode not being loaded into the Now Play page. When building the initial playback state I missed setting the state variable.

## Testing Instructions

1. Open Wear OS
2. Play an episode so there is an episode loaded in the now playing page
3. Reload the app
4. Tap the now playing chip

✅ Verify episode is loaded 

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack
