### PR TITLE
Do not request orientation in StoriesActivity

### DIFF
--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/StoriesActivity.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/StoriesActivity.kt
@@ -1,9 +1,7 @@
 package au.com.shiftyjelly.pocketcasts.endofyear
 
-import android.annotation.SuppressLint
 import android.app.Activity
 import android.content.Intent
-import android.content.pm.ActivityInfo
 import android.graphics.Color
 import android.os.Bundle
 import android.view.WindowManager
@@ -108,8 +106,6 @@ class StoriesActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         if (!isTablet) {
-            @SuppressLint("SourceLockedOrientationActivity")
-            requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
             enableEdgeToEdge(SystemBarStyle.light(Color.TRANSPARENT, Color.TRANSPARENT))
             hideSystemBars()
         }


### PR DESCRIPTION
## Description

This issue fixes a crash on SDK 26 when starting PB24. The crash happens due to an issue in SDK 26 where an `Activity` with a translucent window cannot be shown on top of another `Activity` and request orientation.

I've decided to remove orientation request completely instead of only on SDK 26. I want to avoid any potential issues with some obscure OEMs, etc. While a landscape preview suffers from it users can always rotate their device.

## Testing Instructions

1. Start PB24 on a device with SDK 26.
2. It should not crash.

## Checklist
- [ ] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] ~I have considered whether it makes sense to add tests for my changes~
- [ ] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [ ] ~Any jetpack compose components I added or changed are covered by compose previews~
- [ ] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~