### PR TITLE
Extract subscription badge to a separate composable

### DIFF
--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/SubscriptionBadge.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/SubscriptionBadge.kt
@@ -1,0 +1,104 @@
+package au.com.shiftyjelly.pocketcasts.compose.components
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.res.colorResource
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.TextUnit
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import au.com.shiftyjelly.pocketcasts.models.type.SubscriptionTier
+import au.com.shiftyjelly.pocketcasts.images.R as IR
+import au.com.shiftyjelly.pocketcasts.localization.R as LR
+import au.com.shiftyjelly.pocketcasts.ui.R as UR
+
+@Composable
+fun SubscriptionBadge(
+    subscriptionTier: SubscriptionTier,
+    modifier: Modifier = Modifier,
+    backgroundColor: Color = Color.Black,
+    fontSize: TextUnit = 12.sp,
+    fontColor: Color = Color.White,
+    iconSize: Dp = 12.dp,
+    iconColor: Color? = null,
+    contentPadding: PaddingValues = PaddingValues(horizontal = 8.dp, vertical = 6.dp),
+) {
+    val (textId, iconId) = when (subscriptionTier) {
+        SubscriptionTier.NONE -> return
+        SubscriptionTier.PLUS -> LR.string.pocket_casts_plus_short to IR.drawable.ic_plus
+        SubscriptionTier.PATRON -> LR.string.pocket_casts_patron_short to IR.drawable.ic_patron
+    }
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.Start,
+        modifier = modifier
+            .background(backgroundColor, RoundedCornerShape(50))
+            .padding(contentPadding),
+    ) {
+        Image(
+            painter = painterResource(iconId),
+            colorFilter = iconColor?.let(ColorFilter::tint),
+            contentDescription = null,
+            modifier = Modifier.size(iconSize),
+        )
+        Spacer(
+            modifier = Modifier.width(4.dp),
+        )
+        TextH50(
+            text = stringResource(textId),
+            color = fontColor,
+            fontSize = fontSize,
+            lineHeight = fontSize,
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun BadgesPreview() {
+    Column(
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+        modifier = Modifier
+            .background(Color.White)
+            .padding(8.dp),
+    ) {
+        SubscriptionBadge(
+            subscriptionTier = SubscriptionTier.PATRON,
+        )
+        SubscriptionBadge(
+            subscriptionTier = SubscriptionTier.PATRON,
+            backgroundColor = colorResource(UR.color.patron_purple),
+            fontColor = Color.White,
+            iconColor = Color.White,
+        )
+        SubscriptionBadge(
+            subscriptionTier = SubscriptionTier.PLUS,
+        )
+        SubscriptionBadge(
+            subscriptionTier = SubscriptionTier.PLUS,
+            backgroundColor = colorResource(UR.color.plus_gold_dark),
+            fontColor = Color.Black,
+            iconColor = Color.Black,
+        )
+        SubscriptionBadge(
+            subscriptionTier = SubscriptionTier.NONE,
+        )
+    }
+}

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/UserAvatar.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/UserAvatar.kt
@@ -3,17 +3,11 @@ package au.com.shiftyjelly.pocketcasts.compose.components
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material.Icon
 import androidx.compose.material.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -28,7 +22,6 @@ import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.layout.SubcomposeLayout
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.painterResource
-import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.tooling.preview.PreviewParameterProvider
@@ -48,7 +41,6 @@ import au.com.shiftyjelly.pocketcasts.models.type.SubscriptionTier.PLUS
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import coil.compose.AsyncImage
 import au.com.shiftyjelly.pocketcasts.images.R as IR
-import au.com.shiftyjelly.pocketcasts.localization.R as LR
 import au.com.shiftyjelly.pocketcasts.ui.R as UR
 
 @Composable
@@ -85,9 +77,14 @@ fun UserAvatar(
 
         val badge = if (subscriptionTier == PATRON && showPatronBadge) {
             subcompose("badge") {
-                UserBadge(
-                    subscriptionTier = subscriptionTier,
-                    config = config,
+                SubscriptionBadge(
+                    subscriptionTier = PATRON,
+                    backgroundColor = subscriptionTier.toDarkColor(),
+                    fontSize = config.badgeFontSize,
+                    fontColor = Color.White,
+                    iconSize = config.badgeIconSize,
+                    iconColor = Color.White,
+                    contentPadding = config.badgeContentPadding,
                 )
             }[0].measure(constraints)
         } else {
@@ -179,37 +176,6 @@ private fun UserPictureBorder(
             sweepAngle = 360f * -borderCompletion,
             useCenter = false,
             style = Stroke(borderWidthPx, cap = StrokeCap.Round),
-        )
-    }
-}
-
-@Composable
-private fun UserBadge(
-    config: UserAvatarConfig,
-    subscriptionTier: SubscriptionTier,
-    modifier: Modifier = Modifier,
-) {
-    Row(
-        verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.Start,
-        modifier = modifier
-            .background(subscriptionTier.toDarkColor(), RoundedCornerShape(50))
-            .padding(config.badgeContentPadding),
-    ) {
-        Icon(
-            painter = painterResource(IR.drawable.ic_patron),
-            tint = Color.White,
-            contentDescription = null,
-            modifier = Modifier.size(config.badgeIconSize),
-        )
-        Spacer(
-            modifier = Modifier.width(4.dp),
-        )
-        TextH50(
-            text = stringResource(LR.string.pocket_casts_patron_short),
-            color = Color.White,
-            fontSize = config.badgeFontSize,
-            lineHeight = config.badgeFontSize,
         )
     }
 }


### PR DESCRIPTION
## Description

In preparation of migrating account details to Compose this is a small PR that extracts badge component to a separate UI component.

## Testing Instructions

1. Sign in with a Patron account.
2. Go to the profile tab.
3. You should see a patron badge below your avatar.

## Screenshots or Screencast 

![Screenshot 2024-11-26 at 16 41 06](https://github.com/user-attachments/assets/c7bde35a-56a9-4035-999a-d3c98a9fd3e3)

## Checklist
- [ ] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] ~I have considered whether it makes sense to add tests for my changes~
- [ ] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [ ] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~