### PR TITLE
Improve episode sort order syncing

### DIFF
--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/SubscribeManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/SubscribeManager.kt
@@ -11,7 +11,6 @@ import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.models.type.AutoDownloadLimitSetting
 import au.com.shiftyjelly.pocketcasts.models.type.EpisodePlayingStatus
 import au.com.shiftyjelly.pocketcasts.models.type.EpisodeStatusEnum
-import au.com.shiftyjelly.pocketcasts.models.type.EpisodesSortType
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.preferences.Settings.Companion.GLOBAL_AUTO_DOWNLOAD_NONE
 import au.com.shiftyjelly.pocketcasts.repositories.download.DownloadHelper
@@ -305,7 +304,7 @@ class SubscribeManager @Inject constructor(
         podcast.autoDownloadStatus = if (foundEpisodes && allAutoDownloading) Podcast.AUTO_DOWNLOAD_NEW_EPISODES else Podcast.AUTO_DOWNLOAD_OFF
         podcast.isShowNotifications = foundEpisodes && allSendingNotifications
         podcast.sortPosition = count
-        podcast.episodesSortType = if (podcast.episodesSortType.ordinal == 0) EpisodesSortType.EPISODES_SORT_BY_DATE_DESC else podcast.episodesSortType
+        podcast.episodesSortType = podcast.episodesSortType
         podcast.episodes.firstOrNull()?.let { episode ->
             podcast.latestEpisodeUuid = episode.uuid
             podcast.latestEpisodeDate = episode.publishedDate

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/SubscribeManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/SubscribeManager.kt
@@ -304,7 +304,6 @@ class SubscribeManager @Inject constructor(
         podcast.autoDownloadStatus = if (foundEpisodes && allAutoDownloading) Podcast.AUTO_DOWNLOAD_NEW_EPISODES else Podcast.AUTO_DOWNLOAD_OFF
         podcast.isShowNotifications = foundEpisodes && allSendingNotifications
         podcast.sortPosition = count
-        podcast.episodesSortType = podcast.episodesSortType
         podcast.episodes.firstOrNull()?.let { episode ->
             podcast.latestEpisodeUuid = episode.uuid
             podcast.latestEpisodeDate = episode.publishedDate


### PR DESCRIPTION
## Description

A recent change to the sync logic means the default episode sort order returned from the server will now be published date in descending order. This fixes an issue that if you subscribe to a podcast and set the sort order to title ascending, the Android app would still show as sorted by published date.

## Testing Instructions
1. Open the web player
2. Subscribe to a new podcast
3. Change the sort order to Episode Name (A -> Z)
4. Open the Android app
5. Refresh 
6. ✅ Verify the podcast sort order is Episode Name A -> Z
7. Subscribe to a new podcast
8. ✅ Verify the podcast sort order is Release Date (New -> Old)

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [ ] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
