### PR TITLE
Clean up Pocket Casts colors

### DIFF
--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeHelper.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeHelper.kt
@@ -48,6 +48,7 @@ import androidx.constraintlayout.compose.ConstraintLayout
 import androidx.constraintlayout.compose.ConstraintLayoutScope
 import au.com.shiftyjelly.pocketcasts.account.onboarding.upgrade.OnboardingUpgradeHelper.UpgradeRowButton
 import au.com.shiftyjelly.pocketcasts.account.onboarding.upgrade.OnboardingUpgradeHelper.plusGradientBrush
+import au.com.shiftyjelly.pocketcasts.compose.PocketCastsColors
 import au.com.shiftyjelly.pocketcasts.compose.buttons.GradientRowButton
 import au.com.shiftyjelly.pocketcasts.compose.components.AutoResizeText
 import au.com.shiftyjelly.pocketcasts.compose.components.Clickable
@@ -63,12 +64,12 @@ import au.com.shiftyjelly.pocketcasts.ui.R as UR
 
 object OnboardingUpgradeHelper {
     val plusGradientBrush = Brush.horizontalGradient(
-        0f to Color(0xFFFED745),
-        1f to Color(0xFFFEB525),
+        0f to PocketCastsColors.plusGoldLight,
+        1f to PocketCastsColors.plusGoldDark,
     )
     val patronGradientBrush = Brush.horizontalGradient(
-        0f to Color(0xFFAFA2fA),
-        1f to Color(0xFFAFA2fA),
+        0f to PocketCastsColors.patronPurpleLight,
+        1f to PocketCastsColors.patronPurpleDark,
     )
 
     private val unselectedColor = Color(0xFF666666)

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeHelper.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeHelper.kt
@@ -30,6 +30,7 @@ import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.BlendMode
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.graphics.drawscope.withTransform
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalConfiguration
@@ -48,7 +49,6 @@ import androidx.constraintlayout.compose.ConstraintLayout
 import androidx.constraintlayout.compose.ConstraintLayoutScope
 import au.com.shiftyjelly.pocketcasts.account.onboarding.upgrade.OnboardingUpgradeHelper.UpgradeRowButton
 import au.com.shiftyjelly.pocketcasts.account.onboarding.upgrade.OnboardingUpgradeHelper.plusGradientBrush
-import au.com.shiftyjelly.pocketcasts.compose.PocketCastsColors
 import au.com.shiftyjelly.pocketcasts.compose.buttons.GradientRowButton
 import au.com.shiftyjelly.pocketcasts.compose.components.AutoResizeText
 import au.com.shiftyjelly.pocketcasts.compose.components.Clickable
@@ -56,6 +56,9 @@ import au.com.shiftyjelly.pocketcasts.compose.components.ClickableTextHelper
 import au.com.shiftyjelly.pocketcasts.compose.components.TextH30
 import au.com.shiftyjelly.pocketcasts.compose.components.TextP60
 import au.com.shiftyjelly.pocketcasts.compose.extensions.brush
+import au.com.shiftyjelly.pocketcasts.compose.patronPurpleLight
+import au.com.shiftyjelly.pocketcasts.compose.plusGoldDark
+import au.com.shiftyjelly.pocketcasts.compose.plusGoldLight
 import au.com.shiftyjelly.pocketcasts.models.type.SubscriptionTier
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.images.R as IR
@@ -64,13 +67,10 @@ import au.com.shiftyjelly.pocketcasts.ui.R as UR
 
 object OnboardingUpgradeHelper {
     val plusGradientBrush = Brush.horizontalGradient(
-        0f to PocketCastsColors.plusGoldLight,
-        1f to PocketCastsColors.plusGoldDark,
+        0f to Color.plusGoldLight,
+        1f to Color.plusGoldDark,
     )
-    val patronGradientBrush = Brush.horizontalGradient(
-        0f to PocketCastsColors.patronPurpleLight,
-        1f to PocketCastsColors.patronPurpleDark,
-    )
+    val patronGradientBrush = SolidColor(Color.patronPurpleLight)
 
     private val unselectedColor = Color(0xFF666666)
 

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/AccountSections.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/AccountSections.kt
@@ -35,11 +35,11 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import au.com.shiftyjelly.pocketcasts.compose.AppTheme
-import au.com.shiftyjelly.pocketcasts.compose.PocketCastsColors
 import au.com.shiftyjelly.pocketcasts.compose.ThemeColors
 import au.com.shiftyjelly.pocketcasts.compose.components.HorizontalDivider
 import au.com.shiftyjelly.pocketcasts.compose.components.TextH40
 import au.com.shiftyjelly.pocketcasts.compose.components.TextP50
+import au.com.shiftyjelly.pocketcasts.compose.patronPurple
 import au.com.shiftyjelly.pocketcasts.compose.theme
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import au.com.shiftyjelly.pocketcasts.images.R as IR
@@ -212,8 +212,8 @@ internal enum class AccountSection(
     UpgradeToPatron(
         iconId = IR.drawable.ic_patron,
         titleId = LR.string.profile_upgrade_to_patron,
-        iconTint = { PocketCastsColors.patronPurple },
-        titleColor = { PocketCastsColors.patronPurple },
+        iconTint = { Color.patronPurple },
+        titleColor = { Color.patronPurple },
     ),
     CancelSubscription(
         iconId = IR.drawable.ic_subscription_cancel,

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/AccountSections.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/AccountSections.kt
@@ -35,6 +35,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import au.com.shiftyjelly.pocketcasts.compose.AppTheme
+import au.com.shiftyjelly.pocketcasts.compose.PocketCastsColors
 import au.com.shiftyjelly.pocketcasts.compose.ThemeColors
 import au.com.shiftyjelly.pocketcasts.compose.components.HorizontalDivider
 import au.com.shiftyjelly.pocketcasts.compose.components.TextH40
@@ -211,8 +212,8 @@ internal enum class AccountSection(
     UpgradeToPatron(
         iconId = IR.drawable.ic_patron,
         titleId = LR.string.profile_upgrade_to_patron,
-        iconTint = { Color(0xFF6046F5) },
-        titleColor = { Color(0xFF6046F5) },
+        iconTint = { PocketCastsColors.patronPurple },
+        titleColor = { PocketCastsColors.patronPurple },
     ),
     CancelSubscription(
         iconId = IR.drawable.ic_subscription_cancel,

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/HeadphoneControlsSettingsPageViewModel.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/HeadphoneControlsSettingsPageViewModel.kt
@@ -5,7 +5,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTracker
-import au.com.shiftyjelly.pocketcasts.compose.PocketCastsColors
+import au.com.shiftyjelly.pocketcasts.compose.plusGold
 import au.com.shiftyjelly.pocketcasts.images.R
 import au.com.shiftyjelly.pocketcasts.models.to.SubscriptionStatus
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
@@ -44,8 +44,8 @@ class HeadphoneControlsSettingsPageViewModel @Inject constructor(
                             isAddBookmarkEnabled = isAddBookmarkEnabled,
                             addBookmarkIconId = R.drawable.ic_plus
                                 .takeIf { !isAddBookmarkEnabled },
-                            addBookmarkIconColor = PocketCastsColors.plusGold
-                                .takeIf { !isAddBookmarkEnabled } ?: PocketCastsColors.plusGold,
+                            addBookmarkIconColor = Color.plusGold
+                                .takeIf { !isAddBookmarkEnabled } ?: Color.plusGold,
                         )
                     }
 
@@ -128,7 +128,7 @@ class HeadphoneControlsSettingsPageViewModel @Inject constructor(
         val isAddBookmarkEnabled: Boolean = false,
         val startUpsellFromSource: UpsellSourceAction? = null,
         val addBookmarkIconId: Int? = null,
-        val addBookmarkIconColor: Color = PocketCastsColors.plusGold,
+        val addBookmarkIconColor: Color = Color.plusGold,
     )
 
     enum class UpsellSourceAction {

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/HeadphoneControlsSettingsPageViewModel.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/HeadphoneControlsSettingsPageViewModel.kt
@@ -5,7 +5,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTracker
-import au.com.shiftyjelly.pocketcasts.compose.images.SubscriptionTierColor
+import au.com.shiftyjelly.pocketcasts.compose.PocketCastsColors
 import au.com.shiftyjelly.pocketcasts.images.R
 import au.com.shiftyjelly.pocketcasts.models.to.SubscriptionStatus
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
@@ -44,8 +44,8 @@ class HeadphoneControlsSettingsPageViewModel @Inject constructor(
                             isAddBookmarkEnabled = isAddBookmarkEnabled,
                             addBookmarkIconId = R.drawable.ic_plus
                                 .takeIf { !isAddBookmarkEnabled },
-                            addBookmarkIconColor = SubscriptionTierColor.plusGold
-                                .takeIf { !isAddBookmarkEnabled } ?: SubscriptionTierColor.plusGold,
+                            addBookmarkIconColor = PocketCastsColors.plusGold
+                                .takeIf { !isAddBookmarkEnabled } ?: PocketCastsColors.plusGold,
                         )
                     }
 
@@ -128,7 +128,7 @@ class HeadphoneControlsSettingsPageViewModel @Inject constructor(
         val isAddBookmarkEnabled: Boolean = false,
         val startUpsellFromSource: UpsellSourceAction? = null,
         val addBookmarkIconId: Int? = null,
-        val addBookmarkIconColor: Color = SubscriptionTierColor.plusGold,
+        val addBookmarkIconColor: Color = PocketCastsColors.plusGold,
     )
 
     enum class UpsellSourceAction {

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/PocketCastsColors.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/PocketCastsColors.kt
@@ -2,13 +2,19 @@ package au.com.shiftyjelly.pocketcasts.compose
 
 import androidx.compose.ui.graphics.Color
 
-object PocketCastsColors {
-    val pocketRed = Color(0xFFF43E37)
+val Color.Companion.pocketRed get() = PocketCastsColors.pocketRed
+val Color.Companion.plusGold get() = PocketCastsColors.plusGold
+val Color.Companion.plusGoldLight get() = PocketCastsColors.plusGoldLight
+val Color.Companion.plusGoldDark get() = PocketCastsColors.plusGoldDark
+val Color.Companion.patronPurple get() = PocketCastsColors.patronPurple
+val Color.Companion.patronPurpleLight get() = PocketCastsColors.patronPurpleLight
+val Color.Companion.patronPurpleDark get() = PocketCastsColors.patronPurpleDark
 
+private object PocketCastsColors {
+    val pocketRed = Color(0xFFF43E37)
     val plusGold = Color(0xFFFFD846)
     val plusGoldLight = plusGold
     val plusGoldDark = Color(0xFFFEB525)
-
     val patronPurple = Color(0xFF6046F5)
     val patronPurpleLight = Color(0xFFAFA2FA)
     val patronPurpleDark = patronPurple

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/PocketCastsColors.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/PocketCastsColors.kt
@@ -1,0 +1,13 @@
+package au.com.shiftyjelly.pocketcasts.compose
+
+import androidx.compose.ui.graphics.Color
+
+object PocketCastsColors {
+    val plusGold = Color(0xFFFFD846)
+    val plusGoldLight = plusGold
+    val plusGoldDark = Color(0xFFFEB525)
+
+    val patronPurple = Color(0xFF6046F5)
+    val patronPurpleLight = Color(0xFFAFA2FA)
+    val patronPurpleDark = patronPurple
+}

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/PocketCastsColors.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/PocketCastsColors.kt
@@ -3,6 +3,8 @@ package au.com.shiftyjelly.pocketcasts.compose
 import androidx.compose.ui.graphics.Color
 
 object PocketCastsColors {
+    val pocketRed = Color(0xFFF43E37)
+
     val plusGold = Color(0xFFFFD846)
     val plusGoldLight = plusGold
     val plusGoldDark = Color(0xFFFEB525)

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/buttons/GradientRowButton.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/buttons/GradientRowButton.kt
@@ -18,14 +18,15 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import au.com.shiftyjelly.pocketcasts.compose.PocketCastsColors
 import au.com.shiftyjelly.pocketcasts.compose.components.AutoResizeText
 import au.com.shiftyjelly.pocketcasts.compose.components.TextP60
+import au.com.shiftyjelly.pocketcasts.compose.plusGoldDark
+import au.com.shiftyjelly.pocketcasts.compose.plusGoldLight
 import com.airbnb.android.showkase.annotation.ShowkaseComposable
 
 private val plusBackgroundBrush = Brush.horizontalGradient(
-    0f to PocketCastsColors.plusGoldLight,
-    1f to PocketCastsColors.plusGoldDark,
+    0f to Color.plusGoldLight,
+    1f to Color.plusGoldDark,
 )
 
 @Composable

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/buttons/GradientRowButton.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/buttons/GradientRowButton.kt
@@ -18,13 +18,14 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import au.com.shiftyjelly.pocketcasts.compose.PocketCastsColors
 import au.com.shiftyjelly.pocketcasts.compose.components.AutoResizeText
 import au.com.shiftyjelly.pocketcasts.compose.components.TextP60
 import com.airbnb.android.showkase.annotation.ShowkaseComposable
 
 private val plusBackgroundBrush = Brush.horizontalGradient(
-    0f to Color(0xFFFED745),
-    1f to Color(0xFFFEB525),
+    0f to PocketCastsColors.plusGoldLight,
+    1f to PocketCastsColors.plusGoldDark,
 )
 
 @Composable

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/PocketCastsPill.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/PocketCastsPill.kt
@@ -19,6 +19,7 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import au.com.shiftyjelly.pocketcasts.compose.PocketCastsColors
 import au.com.shiftyjelly.pocketcasts.images.R as IR
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
@@ -29,7 +30,7 @@ fun PocketCastsPill(
 ) = Row(
     verticalAlignment = Alignment.CenterVertically,
     modifier = modifier
-        .background(Color(0xFFF43E37), RoundedCornerShape(24.dp))
+        .background(PocketCastsColors.pocketRed, RoundedCornerShape(24.dp))
         .defaultMinSize(minHeight = 24.dp)
         .padding(start = 4.dp, end = 8.dp),
 ) {
@@ -55,7 +56,7 @@ fun PocketCastsLogo(
     painter = painterResource(id = IR.drawable.ic_logo_foreground),
     contentDescription = null,
     modifier = Modifier
-        .background(Color(0xFFF43E37), CircleShape)
+        .background(PocketCastsColors.pocketRed, CircleShape)
         .size(24.dp)
         .then(modifier),
 )

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/PocketCastsPill.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/PocketCastsPill.kt
@@ -19,7 +19,7 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import au.com.shiftyjelly.pocketcasts.compose.PocketCastsColors
+import au.com.shiftyjelly.pocketcasts.compose.pocketRed
 import au.com.shiftyjelly.pocketcasts.images.R as IR
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
@@ -30,7 +30,7 @@ fun PocketCastsPill(
 ) = Row(
     verticalAlignment = Alignment.CenterVertically,
     modifier = modifier
-        .background(PocketCastsColors.pocketRed, RoundedCornerShape(24.dp))
+        .background(Color.pocketRed, RoundedCornerShape(24.dp))
         .defaultMinSize(minHeight = 24.dp)
         .padding(start = 4.dp, end = 8.dp),
 ) {
@@ -56,7 +56,7 @@ fun PocketCastsLogo(
     painter = painterResource(id = IR.drawable.ic_logo_foreground),
     contentDescription = null,
     modifier = Modifier
-        .background(PocketCastsColors.pocketRed, CircleShape)
+        .background(Color.pocketRed, CircleShape)
         .size(24.dp)
         .then(modifier),
 )

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/UserAvatar.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/UserAvatar.kt
@@ -30,9 +30,12 @@ import androidx.compose.ui.unit.TextUnit
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import au.com.shiftyjelly.pocketcasts.compose.AppTheme
-import au.com.shiftyjelly.pocketcasts.compose.PocketCastsColors
 import au.com.shiftyjelly.pocketcasts.compose.images.SubscriptionBadgeDisplayMode
 import au.com.shiftyjelly.pocketcasts.compose.images.SubscriptionBadgeForTier
+import au.com.shiftyjelly.pocketcasts.compose.patronPurpleDark
+import au.com.shiftyjelly.pocketcasts.compose.patronPurpleLight
+import au.com.shiftyjelly.pocketcasts.compose.plusGoldDark
+import au.com.shiftyjelly.pocketcasts.compose.plusGoldLight
 import au.com.shiftyjelly.pocketcasts.compose.preview.ThemePreviewParameterProvider
 import au.com.shiftyjelly.pocketcasts.compose.theme
 import au.com.shiftyjelly.pocketcasts.models.type.SubscriptionTier
@@ -189,14 +192,14 @@ data class UserAvatarConfig(
 
 private fun SubscriptionTier.toLightColor() = when (this) {
     NONE -> Color.Transparent
-    PLUS -> PocketCastsColors.plusGoldLight
-    PATRON -> PocketCastsColors.patronPurpleLight
+    PLUS -> Color.plusGoldLight
+    PATRON -> Color.patronPurpleLight
 }
 
 private fun SubscriptionTier.toDarkColor() = when (this) {
     NONE -> Color.Transparent
-    PLUS -> PocketCastsColors.plusGoldDark
-    PATRON -> PocketCastsColors.patronPurpleDark
+    PLUS -> Color.plusGoldDark
+    PATRON -> Color.patronPurpleDark
 }
 
 @Composable

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/UserAvatar.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/UserAvatar.kt
@@ -19,7 +19,6 @@ import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.graphics.StrokeCap
 import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.layout.SubcomposeLayout
-import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
@@ -31,6 +30,7 @@ import androidx.compose.ui.unit.TextUnit
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import au.com.shiftyjelly.pocketcasts.compose.AppTheme
+import au.com.shiftyjelly.pocketcasts.compose.PocketCastsColors
 import au.com.shiftyjelly.pocketcasts.compose.images.SubscriptionBadgeDisplayMode
 import au.com.shiftyjelly.pocketcasts.compose.images.SubscriptionBadgeForTier
 import au.com.shiftyjelly.pocketcasts.compose.preview.ThemePreviewParameterProvider
@@ -42,7 +42,6 @@ import au.com.shiftyjelly.pocketcasts.models.type.SubscriptionTier.PLUS
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import coil.compose.AsyncImage
 import au.com.shiftyjelly.pocketcasts.images.R as IR
-import au.com.shiftyjelly.pocketcasts.ui.R as UR
 
 @Composable
 fun UserAvatar(
@@ -80,7 +79,7 @@ fun UserAvatar(
             subcompose("badge") {
                 SubscriptionBadgeForTier(
                     tier = subscriptionTier,
-                    displayMode = SubscriptionBadgeDisplayMode.Colored,
+                    displayMode = SubscriptionBadgeDisplayMode.ColoredDark,
                     fontSize = config.badgeFontSize,
                     iconSize = config.badgeIconSize,
                     padding = config.badgeContentPadding,
@@ -188,18 +187,16 @@ data class UserAvatarConfig(
     val badgeContentPadding: Dp = 4.dp,
 )
 
-@Composable
 private fun SubscriptionTier.toLightColor() = when (this) {
     NONE -> Color.Transparent
-    PLUS -> colorResource(UR.color.plus_gold_light)
-    PATRON -> colorResource(UR.color.patron_purple_light)
+    PLUS -> PocketCastsColors.plusGoldLight
+    PATRON -> PocketCastsColors.patronPurpleLight
 }
 
-@Composable
 private fun SubscriptionTier.toDarkColor() = when (this) {
     NONE -> Color.Transparent
-    PLUS -> colorResource(UR.color.plus_gold_dark)
-    PATRON -> colorResource(UR.color.patron_purple)
+    PLUS -> PocketCastsColors.plusGoldDark
+    PATRON -> PocketCastsColors.patronPurpleDark
 }
 
 @Composable

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/extensions/Brush.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/extensions/Brush.kt
@@ -3,7 +3,8 @@ package au.com.shiftyjelly.pocketcasts.compose.extensions
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
-import au.com.shiftyjelly.pocketcasts.compose.PocketCastsColors
+import au.com.shiftyjelly.pocketcasts.compose.plusGoldDark
+import au.com.shiftyjelly.pocketcasts.compose.plusGoldLight
 
 fun rainbowBrush(
     start: Offset = Offset.Zero,
@@ -20,6 +21,6 @@ fun rainbowBrush(
 
 val plusBackgroundBrush =
     Brush.horizontalGradient(
-        0f to PocketCastsColors.plusGoldLight,
-        1f to PocketCastsColors.plusGoldDark,
+        0f to Color.plusGoldLight,
+        1f to Color.plusGoldDark,
     )

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/extensions/Brush.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/extensions/Brush.kt
@@ -3,6 +3,7 @@ package au.com.shiftyjelly.pocketcasts.compose.extensions
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
+import au.com.shiftyjelly.pocketcasts.compose.PocketCastsColors
 
 fun rainbowBrush(
     start: Offset = Offset.Zero,
@@ -19,6 +20,6 @@ fun rainbowBrush(
 
 val plusBackgroundBrush =
     Brush.horizontalGradient(
-        0f to Color(0xFFFED745),
-        1f to Color(0xFFFEB525),
+        0f to PocketCastsColors.plusGoldLight,
+        1f to PocketCastsColors.plusGoldDark,
     )

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/images/SubscriptionBadge.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/images/SubscriptionBadge.kt
@@ -30,7 +30,6 @@ import au.com.shiftyjelly.pocketcasts.compose.AppThemeWithBackground
 import au.com.shiftyjelly.pocketcasts.compose.PocketCastsColors
 import au.com.shiftyjelly.pocketcasts.compose.components.TextH50
 import au.com.shiftyjelly.pocketcasts.compose.theme
-import au.com.shiftyjelly.pocketcasts.images.R
 import au.com.shiftyjelly.pocketcasts.models.type.SubscriptionTier
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import com.airbnb.android.showkase.annotation.ShowkaseComposable
@@ -132,8 +131,7 @@ fun SubscriptionBadgeForTier(
             iconColor = when (displayMode) {
                 SubscriptionBadgeDisplayMode.Black -> PocketCastsColors.plusGold
                 SubscriptionBadgeDisplayMode.Colored,
-                SubscriptionBadgeDisplayMode.ColoredDark,
-                -> MaterialTheme.theme.colors.primaryUi01
+                SubscriptionBadgeDisplayMode.ColoredDark -> MaterialTheme.theme.colors.primaryUi01
                 SubscriptionBadgeDisplayMode.ColoredWithWhiteForeground -> Color.White
                 SubscriptionBadgeDisplayMode.ColoredWithBlackForeground -> Color.Black
             },
@@ -148,8 +146,7 @@ fun SubscriptionBadgeForTier(
             textColor = when (displayMode) {
                 SubscriptionBadgeDisplayMode.Black -> Color.White
                 SubscriptionBadgeDisplayMode.Colored,
-                SubscriptionBadgeDisplayMode.ColoredDark,
-                -> MaterialTheme.theme.colors.primaryUi01
+                SubscriptionBadgeDisplayMode.ColoredDark -> MaterialTheme.theme.colors.primaryUi01
                 SubscriptionBadgeDisplayMode.ColoredWithWhiteForeground -> Color.White
                 SubscriptionBadgeDisplayMode.ColoredWithBlackForeground -> Color.Black
             },
@@ -165,8 +162,7 @@ fun SubscriptionBadgeForTier(
             iconColor = when (displayMode) {
                 SubscriptionBadgeDisplayMode.Black -> PocketCastsColors.patronPurpleLight
                 SubscriptionBadgeDisplayMode.Colored,
-                SubscriptionBadgeDisplayMode.ColoredDark,
-                -> MaterialTheme.theme.colors.primaryUi01
+                SubscriptionBadgeDisplayMode.ColoredDark -> if (MaterialTheme.theme.isLight) Color.White else Color.Black
                 SubscriptionBadgeDisplayMode.ColoredWithWhiteForeground -> Color.White
                 SubscriptionBadgeDisplayMode.ColoredWithBlackForeground -> Color.Black
             },
@@ -181,8 +177,7 @@ fun SubscriptionBadgeForTier(
             textColor = when (displayMode) {
                 SubscriptionBadgeDisplayMode.Black -> Color.White
                 SubscriptionBadgeDisplayMode.Colored,
-                SubscriptionBadgeDisplayMode.ColoredDark,
-                -> MaterialTheme.theme.colors.primaryUi01
+                SubscriptionBadgeDisplayMode.ColoredDark -> if (MaterialTheme.theme.isLight) Color.White else Color.Black
                 SubscriptionBadgeDisplayMode.ColoredWithWhiteForeground -> Color.White
                 SubscriptionBadgeDisplayMode.ColoredWithBlackForeground -> Color.Black
             },
@@ -289,6 +284,30 @@ fun SubscriptionBadgePlusColoredDarkThemePreview() {
     }
 }
 
+@ShowkaseComposable(name = "SubscriptionBadge", group = "Images", styleName = "Plus - Colored Dark on light theme", defaultStyle = true)
+@Preview(name = "Colored")
+@Composable
+fun SubscriptionBadgePlusColoredDarkLightThemePreview() {
+    AppThemeWithBackground(Theme.ThemeType.LIGHT) {
+        SubscriptionBadgeForTier(
+            tier = SubscriptionTier.PLUS,
+            displayMode = SubscriptionBadgeDisplayMode.ColoredDark,
+        )
+    }
+}
+
+@ShowkaseComposable(name = "SubscriptionBadge", group = "Images", styleName = "Plus - Colored Dark on dark theme")
+@Preview(name = "Colored")
+@Composable
+fun SubscriptionBadgePlusColoredDarkDarkThemePreview() {
+    AppThemeWithBackground(Theme.ThemeType.DARK) {
+        SubscriptionBadgeForTier(
+            tier = SubscriptionTier.PLUS,
+            displayMode = SubscriptionBadgeDisplayMode.ColoredDark,
+        )
+    }
+}
+
 @ShowkaseComposable(name = "SubscriptionBadge", group = "Images", styleName = "Plus - Colored with white foreground")
 @Preview(name = "Colored")
 @Composable
@@ -309,10 +328,68 @@ fun SubscriptionBadgePlusBlackPreview() {
     )
 }
 
+@ShowkaseComposable(name = "SubscriptionBadge", group = "Images", styleName = "Plus - Colored with black foreground")
+@Preview(name = "ColoredWithBlackForeground")
+@Composable
+fun SubscriptionBadgePlusColoredWithBlackForegroundPreview() {
+    SubscriptionBadgeForTier(
+        tier = SubscriptionTier.PLUS,
+        displayMode = SubscriptionBadgeDisplayMode.ColoredWithBlackForeground,
+    )
+}
+
+@ShowkaseComposable(name = "SubscriptionBadge", group = "Images", styleName = "Patron - Colored on light theme", defaultStyle = true)
+@Preview(name = "Colored")
+@Composable
+fun SubscriptionBadgePatronColoredLightThemePreview() {
+    AppThemeWithBackground(Theme.ThemeType.LIGHT) {
+        SubscriptionBadgeForTier(
+            tier = SubscriptionTier.PATRON,
+            displayMode = SubscriptionBadgeDisplayMode.Colored,
+        )
+    }
+}
+
+@ShowkaseComposable(name = "SubscriptionBadge", group = "Images", styleName = "Patron - Colored on dark theme")
+@Preview(name = "Colored")
+@Composable
+fun SubscriptionBadgePatronColoredDarkThemePreview() {
+    AppThemeWithBackground(Theme.ThemeType.DARK) {
+        SubscriptionBadgeForTier(
+            tier = SubscriptionTier.PATRON,
+            displayMode = SubscriptionBadgeDisplayMode.Colored,
+        )
+    }
+}
+
+@ShowkaseComposable(name = "SubscriptionBadge", group = "Images", styleName = "Patron - Colored Dark on light theme", defaultStyle = true)
+@Preview(name = "Colored")
+@Composable
+fun SubscriptionBadgePatronColoredDarkLightThemePreview() {
+    AppThemeWithBackground(Theme.ThemeType.LIGHT) {
+        SubscriptionBadgeForTier(
+            tier = SubscriptionTier.PATRON,
+            displayMode = SubscriptionBadgeDisplayMode.ColoredDark,
+        )
+    }
+}
+
+@ShowkaseComposable(name = "SubscriptionBadge", group = "Images", styleName = "Patron - Colored Dark on dark theme")
+@Preview(name = "Colored")
+@Composable
+fun SubscriptionBadgePatronColoredDarkDarkThemePreview() {
+    AppThemeWithBackground(Theme.ThemeType.DARK) {
+        SubscriptionBadgeForTier(
+            tier = SubscriptionTier.PATRON,
+            displayMode = SubscriptionBadgeDisplayMode.ColoredDark,
+        )
+    }
+}
+
 @ShowkaseComposable(name = "SubscriptionBadge", group = "Images", styleName = "Patron - Colored with white foreground")
 @Preview(name = "Colored")
 @Composable
-fun SubscriptionBadgePatronColoredPreview() {
+fun SubscriptionBadgePatronColoredWhiteForegroundPreview() {
     SubscriptionBadgeForTier(
         tier = SubscriptionTier.PATRON,
         displayMode = SubscriptionBadgeDisplayMode.ColoredWithWhiteForeground,
@@ -329,16 +406,6 @@ fun SubscriptionBadgePatronBlackPreview() {
     )
 }
 
-@ShowkaseComposable(name = "SubscriptionBadge", group = "Images", styleName = "Plus - Colored with black foreground")
-@Preview(name = "ColoredWithBlackForeground")
-@Composable
-fun SubscriptionBadgePlusColoredWithBlackForegroundPreview() {
-    SubscriptionBadgeForTier(
-        tier = SubscriptionTier.PLUS,
-        displayMode = SubscriptionBadgeDisplayMode.ColoredWithBlackForeground,
-    )
-}
-
 @ShowkaseComposable(name = "SubscriptionBadge", group = "Images", styleName = "Patron - Colored with black foreground")
 @Preview(name = "ColoredWithBlackForeground")
 @Composable
@@ -352,11 +419,11 @@ fun SubscriptionBadgePatronColoredWithBlackForegroundPreview() {
 @ShowkaseComposable(name = "SubscriptionBadge", group = "Images", styleName = "Plus - Colored with gradient background")
 @Preview(name = "ColoredWithBlackForegroundAndGradientBackground")
 @Composable
-fun SubscriptionBadgeWithGradientBackgroundPreview() {
+fun SubscriptionBadgePlusWithGradientBackgroundPreview() {
     SubscriptionBadge(
         fontSize = 16.sp,
         padding = 4.dp,
-        iconRes = R.drawable.ic_plus,
+        iconRes = IR.drawable.ic_plus,
         shortNameRes = LR.string.pocket_casts_plus_short,
         iconColor = Color.Black,
         backgroundBrush = Brush.horizontalGradient(

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/images/SubscriptionBadge.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/images/SubscriptionBadge.kt
@@ -27,6 +27,7 @@ import androidx.compose.ui.unit.TextUnit
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import au.com.shiftyjelly.pocketcasts.compose.AppThemeWithBackground
+import au.com.shiftyjelly.pocketcasts.compose.PocketCastsColors
 import au.com.shiftyjelly.pocketcasts.compose.components.TextH50
 import au.com.shiftyjelly.pocketcasts.compose.theme
 import au.com.shiftyjelly.pocketcasts.images.R
@@ -129,21 +130,26 @@ fun SubscriptionBadgeForTier(
             iconRes = IR.drawable.ic_plus,
             shortNameRes = LR.string.pocket_casts_plus_short,
             iconColor = when (displayMode) {
-                SubscriptionBadgeDisplayMode.Black -> SubscriptionTierColor.plusGold
-                SubscriptionBadgeDisplayMode.Colored -> MaterialTheme.theme.colors.primaryUi01
+                SubscriptionBadgeDisplayMode.Black -> PocketCastsColors.plusGold
+                SubscriptionBadgeDisplayMode.Colored,
+                SubscriptionBadgeDisplayMode.ColoredDark,
+                -> MaterialTheme.theme.colors.primaryUi01
                 SubscriptionBadgeDisplayMode.ColoredWithWhiteForeground -> Color.White
                 SubscriptionBadgeDisplayMode.ColoredWithBlackForeground -> Color.Black
             },
             backgroundColor = when (displayMode) {
                 SubscriptionBadgeDisplayMode.Black -> Color.Black
+                SubscriptionBadgeDisplayMode.ColoredDark -> PocketCastsColors.plusGoldDark
                 SubscriptionBadgeDisplayMode.Colored,
                 SubscriptionBadgeDisplayMode.ColoredWithWhiteForeground,
                 SubscriptionBadgeDisplayMode.ColoredWithBlackForeground,
-                -> SubscriptionTierColor.plusGold
+                -> PocketCastsColors.plusGold
             },
             textColor = when (displayMode) {
                 SubscriptionBadgeDisplayMode.Black -> Color.White
-                SubscriptionBadgeDisplayMode.Colored -> MaterialTheme.theme.colors.primaryUi01
+                SubscriptionBadgeDisplayMode.Colored,
+                SubscriptionBadgeDisplayMode.ColoredDark,
+                -> MaterialTheme.theme.colors.primaryUi01
                 SubscriptionBadgeDisplayMode.ColoredWithWhiteForeground -> Color.White
                 SubscriptionBadgeDisplayMode.ColoredWithBlackForeground -> Color.Black
             },
@@ -157,24 +163,27 @@ fun SubscriptionBadgeForTier(
             iconRes = IR.drawable.ic_patron,
             shortNameRes = LR.string.pocket_casts_patron_short,
             iconColor = when (displayMode) {
-                SubscriptionBadgeDisplayMode.Black -> SubscriptionTierColor.patronPurpleLight
+                SubscriptionBadgeDisplayMode.Black -> PocketCastsColors.patronPurpleLight
                 SubscriptionBadgeDisplayMode.Colored,
-                SubscriptionBadgeDisplayMode.ColoredWithWhiteForeground,
-                -> Color.White
+                SubscriptionBadgeDisplayMode.ColoredDark,
+                -> MaterialTheme.theme.colors.primaryUi01
+                SubscriptionBadgeDisplayMode.ColoredWithWhiteForeground -> Color.White
                 SubscriptionBadgeDisplayMode.ColoredWithBlackForeground -> Color.Black
             },
             backgroundColor = when (displayMode) {
                 SubscriptionBadgeDisplayMode.Black -> Color.Black
+                SubscriptionBadgeDisplayMode.ColoredDark -> PocketCastsColors.patronPurpleDark
                 SubscriptionBadgeDisplayMode.Colored,
                 SubscriptionBadgeDisplayMode.ColoredWithWhiteForeground,
                 SubscriptionBadgeDisplayMode.ColoredWithBlackForeground,
-                -> SubscriptionTierColor.patronPurple
+                -> PocketCastsColors.patronPurple
             },
             textColor = when (displayMode) {
                 SubscriptionBadgeDisplayMode.Black -> Color.White
                 SubscriptionBadgeDisplayMode.Colored,
-                SubscriptionBadgeDisplayMode.ColoredWithWhiteForeground,
-                -> Color.White
+                SubscriptionBadgeDisplayMode.ColoredDark,
+                -> MaterialTheme.theme.colors.primaryUi01
+                SubscriptionBadgeDisplayMode.ColoredWithWhiteForeground -> Color.White
                 SubscriptionBadgeDisplayMode.ColoredWithBlackForeground -> Color.Black
             },
             iconSize = iconSize,
@@ -194,7 +203,7 @@ fun SubscriptionIconForTier(
         SubscriptionTier.PLUS -> Icon(
             painter = painterResource(IR.drawable.ic_plus),
             contentDescription = stringResource(LR.string.pocket_casts_plus_short),
-            tint = SubscriptionTierColor.plusGold,
+            tint = PocketCastsColors.plusGold,
             modifier = Modifier
                 .size(iconSize),
         )
@@ -203,9 +212,9 @@ fun SubscriptionIconForTier(
             painter = painterResource(IR.drawable.ic_patron),
             contentDescription = stringResource(LR.string.pocket_casts_patron_short),
             tint = if (MaterialTheme.theme.isLight) {
-                SubscriptionTierColor.patronPurple
+                PocketCastsColors.patronPurple
             } else {
-                SubscriptionTierColor.patronPurpleLight
+                PocketCastsColors.patronPurpleLight
             },
             modifier = Modifier
                 .size(iconSize),
@@ -251,14 +260,9 @@ fun OfferBadge(
 enum class SubscriptionBadgeDisplayMode {
     Black,
     Colored,
+    ColoredDark,
     ColoredWithWhiteForeground,
     ColoredWithBlackForeground,
-}
-
-object SubscriptionTierColor {
-    val plusGold = Color(0xFFFFD846)
-    val patronPurple = Color(0xFF6046F5)
-    val patronPurpleLight = Color(0xFFAFA2FA)
 }
 
 @ShowkaseComposable(name = "SubscriptionBadge", group = "Images", styleName = "Plus - Colored on light theme", defaultStyle = true)
@@ -356,8 +360,8 @@ fun SubscriptionBadgeWithGradientBackgroundPreview() {
         shortNameRes = LR.string.pocket_casts_plus_short,
         iconColor = Color.Black,
         backgroundBrush = Brush.horizontalGradient(
-            0f to Color(0xFFFED745),
-            1f to Color(0xFFFEB525),
+            0f to PocketCastsColors.plusGoldLight,
+            1f to PocketCastsColors.plusGoldDark,
         ),
         textColor = Color.Black,
     )

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/images/SubscriptionBadge.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/images/SubscriptionBadge.kt
@@ -27,8 +27,13 @@ import androidx.compose.ui.unit.TextUnit
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import au.com.shiftyjelly.pocketcasts.compose.AppThemeWithBackground
-import au.com.shiftyjelly.pocketcasts.compose.PocketCastsColors
 import au.com.shiftyjelly.pocketcasts.compose.components.TextH50
+import au.com.shiftyjelly.pocketcasts.compose.patronPurple
+import au.com.shiftyjelly.pocketcasts.compose.patronPurpleDark
+import au.com.shiftyjelly.pocketcasts.compose.patronPurpleLight
+import au.com.shiftyjelly.pocketcasts.compose.plusGold
+import au.com.shiftyjelly.pocketcasts.compose.plusGoldDark
+import au.com.shiftyjelly.pocketcasts.compose.plusGoldLight
 import au.com.shiftyjelly.pocketcasts.compose.theme
 import au.com.shiftyjelly.pocketcasts.models.type.SubscriptionTier
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
@@ -129,7 +134,7 @@ fun SubscriptionBadgeForTier(
             iconRes = IR.drawable.ic_plus,
             shortNameRes = LR.string.pocket_casts_plus_short,
             iconColor = when (displayMode) {
-                SubscriptionBadgeDisplayMode.Black -> PocketCastsColors.plusGold
+                SubscriptionBadgeDisplayMode.Black -> Color.plusGold
                 SubscriptionBadgeDisplayMode.Colored,
                 SubscriptionBadgeDisplayMode.ColoredDark,
                 -> MaterialTheme.theme.colors.primaryUi01
@@ -138,11 +143,11 @@ fun SubscriptionBadgeForTier(
             },
             backgroundColor = when (displayMode) {
                 SubscriptionBadgeDisplayMode.Black -> Color.Black
-                SubscriptionBadgeDisplayMode.ColoredDark -> PocketCastsColors.plusGoldDark
+                SubscriptionBadgeDisplayMode.ColoredDark -> Color.plusGoldDark
                 SubscriptionBadgeDisplayMode.Colored,
                 SubscriptionBadgeDisplayMode.ColoredWithWhiteForeground,
                 SubscriptionBadgeDisplayMode.ColoredWithBlackForeground,
-                -> PocketCastsColors.plusGold
+                -> Color.plusGold
             },
             textColor = when (displayMode) {
                 SubscriptionBadgeDisplayMode.Black -> Color.White
@@ -162,7 +167,7 @@ fun SubscriptionBadgeForTier(
             iconRes = IR.drawable.ic_patron,
             shortNameRes = LR.string.pocket_casts_patron_short,
             iconColor = when (displayMode) {
-                SubscriptionBadgeDisplayMode.Black -> PocketCastsColors.patronPurpleLight
+                SubscriptionBadgeDisplayMode.Black -> Color.patronPurpleLight
                 SubscriptionBadgeDisplayMode.Colored,
                 SubscriptionBadgeDisplayMode.ColoredDark,
                 SubscriptionBadgeDisplayMode.ColoredWithWhiteForeground,
@@ -171,11 +176,11 @@ fun SubscriptionBadgeForTier(
             },
             backgroundColor = when (displayMode) {
                 SubscriptionBadgeDisplayMode.Black -> Color.Black
-                SubscriptionBadgeDisplayMode.ColoredDark -> PocketCastsColors.patronPurpleDark
+                SubscriptionBadgeDisplayMode.ColoredDark -> Color.patronPurpleDark
                 SubscriptionBadgeDisplayMode.Colored,
                 SubscriptionBadgeDisplayMode.ColoredWithWhiteForeground,
                 SubscriptionBadgeDisplayMode.ColoredWithBlackForeground,
-                -> PocketCastsColors.patronPurple
+                -> Color.patronPurple
             },
             textColor = when (displayMode) {
                 SubscriptionBadgeDisplayMode.Black -> Color.White
@@ -202,7 +207,7 @@ fun SubscriptionIconForTier(
         SubscriptionTier.PLUS -> Icon(
             painter = painterResource(IR.drawable.ic_plus),
             contentDescription = stringResource(LR.string.pocket_casts_plus_short),
-            tint = PocketCastsColors.plusGold,
+            tint = Color.plusGold,
             modifier = Modifier
                 .size(iconSize),
         )
@@ -211,9 +216,9 @@ fun SubscriptionIconForTier(
             painter = painterResource(IR.drawable.ic_patron),
             contentDescription = stringResource(LR.string.pocket_casts_patron_short),
             tint = if (MaterialTheme.theme.isLight) {
-                PocketCastsColors.patronPurple
+                Color.patronPurple
             } else {
-                PocketCastsColors.patronPurpleLight
+                Color.patronPurpleLight
             },
             modifier = Modifier
                 .size(iconSize),
@@ -431,8 +436,8 @@ fun SubscriptionBadgePlusWithGradientBackgroundPreview() {
         shortNameRes = LR.string.pocket_casts_plus_short,
         iconColor = Color.Black,
         backgroundBrush = Brush.horizontalGradient(
-            0f to PocketCastsColors.plusGoldLight,
-            1f to PocketCastsColors.plusGoldDark,
+            0f to Color.plusGoldLight,
+            1f to Color.plusGoldDark,
         ),
         textColor = Color.Black,
     )

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/images/SubscriptionBadge.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/images/SubscriptionBadge.kt
@@ -131,7 +131,8 @@ fun SubscriptionBadgeForTier(
             iconColor = when (displayMode) {
                 SubscriptionBadgeDisplayMode.Black -> PocketCastsColors.plusGold
                 SubscriptionBadgeDisplayMode.Colored,
-                SubscriptionBadgeDisplayMode.ColoredDark -> MaterialTheme.theme.colors.primaryUi01
+                SubscriptionBadgeDisplayMode.ColoredDark,
+                -> MaterialTheme.theme.colors.primaryUi01
                 SubscriptionBadgeDisplayMode.ColoredWithWhiteForeground -> Color.White
                 SubscriptionBadgeDisplayMode.ColoredWithBlackForeground -> Color.Black
             },
@@ -146,7 +147,8 @@ fun SubscriptionBadgeForTier(
             textColor = when (displayMode) {
                 SubscriptionBadgeDisplayMode.Black -> Color.White
                 SubscriptionBadgeDisplayMode.Colored,
-                SubscriptionBadgeDisplayMode.ColoredDark -> MaterialTheme.theme.colors.primaryUi01
+                SubscriptionBadgeDisplayMode.ColoredDark,
+                -> MaterialTheme.theme.colors.primaryUi01
                 SubscriptionBadgeDisplayMode.ColoredWithWhiteForeground -> Color.White
                 SubscriptionBadgeDisplayMode.ColoredWithBlackForeground -> Color.Black
             },
@@ -162,8 +164,9 @@ fun SubscriptionBadgeForTier(
             iconColor = when (displayMode) {
                 SubscriptionBadgeDisplayMode.Black -> PocketCastsColors.patronPurpleLight
                 SubscriptionBadgeDisplayMode.Colored,
-                SubscriptionBadgeDisplayMode.ColoredDark -> if (MaterialTheme.theme.isLight) Color.White else Color.Black
-                SubscriptionBadgeDisplayMode.ColoredWithWhiteForeground -> Color.White
+                SubscriptionBadgeDisplayMode.ColoredDark,
+                SubscriptionBadgeDisplayMode.ColoredWithWhiteForeground,
+                -> Color.White
                 SubscriptionBadgeDisplayMode.ColoredWithBlackForeground -> Color.Black
             },
             backgroundColor = when (displayMode) {
@@ -177,8 +180,9 @@ fun SubscriptionBadgeForTier(
             textColor = when (displayMode) {
                 SubscriptionBadgeDisplayMode.Black -> Color.White
                 SubscriptionBadgeDisplayMode.Colored,
-                SubscriptionBadgeDisplayMode.ColoredDark -> if (MaterialTheme.theme.isLight) Color.White else Color.Black
-                SubscriptionBadgeDisplayMode.ColoredWithWhiteForeground -> Color.White
+                SubscriptionBadgeDisplayMode.ColoredDark,
+                SubscriptionBadgeDisplayMode.ColoredWithWhiteForeground,
+                -> Color.White
                 SubscriptionBadgeDisplayMode.ColoredWithBlackForeground -> Color.Black
             },
             iconSize = iconSize,
@@ -284,7 +288,7 @@ fun SubscriptionBadgePlusColoredDarkThemePreview() {
     }
 }
 
-@ShowkaseComposable(name = "SubscriptionBadge", group = "Images", styleName = "Plus - Colored Dark on light theme", defaultStyle = true)
+@ShowkaseComposable(name = "SubscriptionBadge", group = "Images", styleName = "Plus - Colored Dark on light theme")
 @Preview(name = "Colored")
 @Composable
 fun SubscriptionBadgePlusColoredDarkLightThemePreview() {
@@ -297,7 +301,7 @@ fun SubscriptionBadgePlusColoredDarkLightThemePreview() {
 }
 
 @ShowkaseComposable(name = "SubscriptionBadge", group = "Images", styleName = "Plus - Colored Dark on dark theme")
-@Preview(name = "Colored")
+@Preview(name = "ColoredDark")
 @Composable
 fun SubscriptionBadgePlusColoredDarkDarkThemePreview() {
     AppThemeWithBackground(Theme.ThemeType.DARK) {
@@ -309,7 +313,7 @@ fun SubscriptionBadgePlusColoredDarkDarkThemePreview() {
 }
 
 @ShowkaseComposable(name = "SubscriptionBadge", group = "Images", styleName = "Plus - Colored with white foreground")
-@Preview(name = "Colored")
+@Preview(name = "ColoredWithWhiteForeground")
 @Composable
 fun SubscriptionBadgePlusColoredWhiteForegroundPreview() {
     SubscriptionBadgeForTier(
@@ -338,7 +342,7 @@ fun SubscriptionBadgePlusColoredWithBlackForegroundPreview() {
     )
 }
 
-@ShowkaseComposable(name = "SubscriptionBadge", group = "Images", styleName = "Patron - Colored on light theme", defaultStyle = true)
+@ShowkaseComposable(name = "SubscriptionBadge", group = "Images", styleName = "Patron - Colored on light theme")
 @Preview(name = "Colored")
 @Composable
 fun SubscriptionBadgePatronColoredLightThemePreview() {
@@ -362,8 +366,8 @@ fun SubscriptionBadgePatronColoredDarkThemePreview() {
     }
 }
 
-@ShowkaseComposable(name = "SubscriptionBadge", group = "Images", styleName = "Patron - Colored Dark on light theme", defaultStyle = true)
-@Preview(name = "Colored")
+@ShowkaseComposable(name = "SubscriptionBadge", group = "Images", styleName = "Patron - Colored Dark on light theme")
+@Preview(name = "ColoredDark")
 @Composable
 fun SubscriptionBadgePatronColoredDarkLightThemePreview() {
     AppThemeWithBackground(Theme.ThemeType.LIGHT) {
@@ -375,7 +379,7 @@ fun SubscriptionBadgePatronColoredDarkLightThemePreview() {
 }
 
 @ShowkaseComposable(name = "SubscriptionBadge", group = "Images", styleName = "Patron - Colored Dark on dark theme")
-@Preview(name = "Colored")
+@Preview(name = "ColoredDark")
 @Composable
 fun SubscriptionBadgePatronColoredDarkDarkThemePreview() {
     AppThemeWithBackground(Theme.ThemeType.DARK) {
@@ -387,7 +391,7 @@ fun SubscriptionBadgePatronColoredDarkDarkThemePreview() {
 }
 
 @ShowkaseComposable(name = "SubscriptionBadge", group = "Images", styleName = "Patron - Colored with white foreground")
-@Preview(name = "Colored")
+@Preview(name = "ColoredWithWhiteForeground")
 @Composable
 fun SubscriptionBadgePatronColoredWhiteForegroundPreview() {
     SubscriptionBadgeForTier(


### PR DESCRIPTION
## Description

This PR standardizes colors used for PC, Plus, and Patron. Also I added `ColoredDark` theme to the `SubscriptionBadge` component to match it with the `UserAvatar` component.

## Testing Instructions

Smoke testing if badges, upsell buttons and avatar use correct colors should be enough.

## Checklist
- [ ] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] ~I have considered whether it makes sense to add tests for my changes~
- [ ] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [ ] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [ ] ~with a landscape orientation~
- [ ] ~with the device set to have a large display and font size~
- [ ] ~for accessibility with TalkBack~
