### PR TITLE
[Auto Downloading] - Add the auto download toggle for new podcast following

### DIFF
--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/models/db/PodcastManagerTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/models/db/PodcastManagerTest.kt
@@ -59,6 +59,7 @@ class PodcastManagerTest {
             on { podcastGroupingDefault } doReturn UserSetting.Mock(PodcastGrouping.None, mock())
             on { showArchivedDefault } doReturn UserSetting.Mock(false, mock())
             on { autoDownloadNewEpisodes } doReturn UserSetting.Mock(Podcast.AUTO_DOWNLOAD_NEW_EPISODES, mock())
+            on { autoDownloadOnFollowPodcast } doReturn UserSetting.Mock(false, mock())
             on { autoDownloadLimit } doReturn UserSetting.Mock(AutoDownloadLimitSetting.TWO_LATEST_EPISODE, mock())
         }
 

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/AutoDownloadSettingsFragment.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/AutoDownloadSettingsFragment.kt
@@ -285,7 +285,6 @@ class AutoDownloadSettingsFragment :
 
     private fun updateNewEpisodesPreferencesVisibility(status: Int) {
         val podcastsPreference = podcastsPreference ?: return
-        val podcastsLimitPreference = podcastsAutoDownloadLimitPreference ?: return
         val podcastsCategory = podcastsCategory ?: return
 
         val isAutoDownloadEnabled = if (status == GLOBAL_AUTO_DOWNLOAD_NONE) {
@@ -296,10 +295,8 @@ class AutoDownloadSettingsFragment :
 
         if (isAutoDownloadEnabled) {
             podcastsCategory.addPreference(podcastsPreference)
-            podcastsCategory.addPreference(podcastsLimitPreference)
         } else {
             podcastsCategory.removePreference(podcastsPreference)
-            podcastsCategory.removePreference(podcastsLimitPreference)
         }
     }
 

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/AutoDownloadSettingsFragment.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/AutoDownloadSettingsFragment.kt
@@ -212,6 +212,7 @@ class AutoDownloadSettingsFragment :
                     viewModel.onLimitDownloadsChange(autoDownloadLimitSetting)
 
                     updateLimitDownloadsSummary()
+                    updateOnFollowSummary()
                     true
                 }
             }
@@ -481,9 +482,26 @@ class AutoDownloadSettingsFragment :
             value = settings.autoDownloadLimit.value.id.toString()
         }
         updateLimitDownloadsSummary()
+        updateOnFollowSummary()
     }
 
     private fun updateLimitDownloadsSummary() {
         podcastsAutoDownloadLimitPreference?.summary = getString(settings.autoDownloadLimit.value.titleRes)
+    }
+
+    private fun updateOnFollowSummary() {
+        val limitDownloads = AutoDownloadLimitSetting.getNumberOfEpisodes(viewModel.getLimitDownload())
+
+        val localizedLimitDownloads = when (limitDownloads) {
+            2 -> resources.getString(LR.string.number_two)
+            3 -> resources.getString(LR.string.number_three)
+            5 -> resources.getString(LR.string.number_five)
+            10 -> resources.getString(LR.string.number_ten)
+            else -> limitDownloads.toString()
+        }
+
+        onFollowPodcastPreference?.summary = resources.getQuantityString(
+            LR.plurals.settings_auto_download_on_follow_podcast_description, limitDownloads, localizedLimitDownloads,
+        )
     }
 }

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/AutoDownloadSettingsFragment.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/AutoDownloadSettingsFragment.kt
@@ -76,6 +76,7 @@ class AutoDownloadSettingsFragment :
     companion object {
         const val PREFERENCE_PODCASTS_CATEGORY = "podcasts_category"
         const val PREFERENCE_NEW_EPISODES = "autoDownloadNewEpisodes"
+        const val PREFERENCE_ON_FOLLOW_PODCASTS = "onFollowPodcast"
         const val PREFERENCE_CHOOSE_PODCASTS = "autoDownloadPodcastsPreference"
         const val PREFERENCE_AUTO_DOWNLOAD_PODCAST_LIMIT = "autoDownloadPodcastsLimit"
         const val PREFERENCE_CHOOSE_FILTERS = "autoDownloadPlaylists"
@@ -110,6 +111,7 @@ class AutoDownloadSettingsFragment :
     private var podcastsCategory: PreferenceCategory? = null
     private lateinit var upNextPreference: SwitchPreference
     private var newEpisodesPreference: SwitchPreference? = null
+    private var onFollowPodcastPreference: SwitchPreference? = null
     private var podcastsPreference: Preference? = null
     private var podcastsAutoDownloadLimitPreference: ListPreference? = null
     private var filtersPreference: Preference? = null
@@ -174,6 +176,15 @@ class AutoDownloadSettingsFragment :
                         viewLifecycleOwner.lifecycleScope.launch {
                             if (newValue && isDeviceRunningOnLowStorage()) lowStorageListener?.showModal(SourceView.AUTO_DOWNLOAD)
                         }
+                    }
+                    true
+                }
+            }
+        onFollowPodcastPreference = preferenceManager.findPreference<SwitchPreference>(PREFERENCE_ON_FOLLOW_PODCASTS)
+            ?.apply {
+                setOnPreferenceChangeListener { _, newValue ->
+                    if (newValue is Boolean) {
+                        viewModel.onOnFollowPodcastChange(newValue)
                     }
                     true
                 }
@@ -377,6 +388,7 @@ class AutoDownloadSettingsFragment :
 
         upNextPreference.isChecked = viewModel.getAutoDownloadUpNext()
         setupNewEpisodesToggleStatusCheck()
+        setupOnFollowPodcastToggleStatusCheck()
         autoDownloadOnlyDownloadOnWifi.isChecked = viewModel.getAutoDownloadUnmeteredOnly()
         autoDownloadOnlyWhenCharging.isChecked = viewModel.getAutoDownloadOnlyWhenCharging()
         if (FeatureFlag.isEnabled(Feature.AUTO_DOWNLOAD)) {
@@ -433,6 +445,10 @@ class AutoDownloadSettingsFragment :
                 newEpisodesPreference?.isChecked = viewModel.hasEpisodesWithAutoDownloadEnabled.value
             }
         }
+    }
+
+    private fun setupOnFollowPodcastToggleStatusCheck() {
+        onFollowPodcastPreference?.isChecked = viewModel.isAutoDownloadOnFollowPodcastEnabled()
     }
 
     override fun onBackPressed(): Boolean {

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/AutoDownloadSettingsFragment.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/AutoDownloadSettingsFragment.kt
@@ -130,7 +130,13 @@ class AutoDownloadSettingsFragment :
         toolbar?.setup(title = getString(LR.string.settings_title_auto_download), navigationIcon = BackArrow, activity = activity, theme = theme)
         toolbar?.isVisible = showToolbar
 
-        podcastsAutoDownloadLimitPreference?.isVisible = FeatureFlag.isEnabled(Feature.AUTO_DOWNLOAD)
+        if (FeatureFlag.isEnabled(Feature.AUTO_DOWNLOAD)) {
+            onFollowPodcastPreference?.let { podcastsCategory?.addPreference(it) }
+            podcastsAutoDownloadLimitPreference?.let { podcastsCategory?.addPreference(it) }
+        } else {
+            onFollowPodcastPreference?.let { podcastsCategory?.removePreference(it) }
+            podcastsAutoDownloadLimitPreference?.let { podcastsCategory?.removePreference(it) }
+        }
 
         if (!showToolbar) {
             val listContainer = view.findViewById<View>(android.R.id.list_container)

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/viewmodel/AutoDownloadSettingsViewModel.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/viewmodel/AutoDownloadSettingsViewModel.kt
@@ -59,6 +59,8 @@ class AutoDownloadSettingsViewModel @Inject constructor(
 
     fun getAutoDownloadNewEpisodes() = settings.autoDownloadNewEpisodes.value
 
+    fun getLimitDownload() = settings.autoDownloadLimit.value
+
     fun isAutoDownloadOnFollowPodcastEnabled() = settings.autoDownloadOnFollowPodcast.value
 
     fun onNewEpisodesChange(newValue: Boolean) {
@@ -79,12 +81,8 @@ class AutoDownloadSettingsViewModel @Inject constructor(
         )
     }
 
-    fun setLimitDownloads(value: AutoDownloadLimitSetting) {
-        settings.autoDownloadLimit.set(value, updateModifiedAt = true)
-    }
-
     fun onLimitDownloadsChange(value: AutoDownloadLimitSetting) {
-        setLimitDownloads(value)
+        settings.autoDownloadLimit.set(value, updateModifiedAt = true)
 
         analyticsTracker.track(
             AnalyticsEvent.SETTINGS_AUTO_DOWNLOAD_LIMIT_DOWNLOADS_CHANGED,

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/viewmodel/AutoDownloadSettingsViewModel.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/viewmodel/AutoDownloadSettingsViewModel.kt
@@ -59,11 +59,22 @@ class AutoDownloadSettingsViewModel @Inject constructor(
 
     fun getAutoDownloadNewEpisodes() = settings.autoDownloadNewEpisodes.value
 
+    fun isAutoDownloadOnFollowPodcastEnabled() = settings.autoDownloadOnFollowPodcast.value
+
     fun onNewEpisodesChange(newValue: Boolean) {
         settings.autoDownloadNewEpisodes.set(newValue.toAutoDownloadStatus(), updateModifiedAt = true)
 
         analyticsTracker.track(
             AnalyticsEvent.SETTINGS_AUTO_DOWNLOAD_NEW_EPISODES_TOGGLED,
+            mapOf("enabled" to newValue),
+        )
+    }
+
+    fun onOnFollowPodcastChange(newValue: Boolean) {
+        settings.autoDownloadOnFollowPodcast.set(newValue, updateModifiedAt = true)
+
+        analyticsTracker.track(
+            AnalyticsEvent.SETTINGS_AUTO_DOWNLOAD_ON_FOLLOW_PODCAST_TOGGLED,
             mapOf("enabled" to newValue),
         )
     }

--- a/modules/features/settings/src/main/res/xml/preferences_auto_download.xml
+++ b/modules/features/settings/src/main/res/xml/preferences_auto_download.xml
@@ -25,6 +25,11 @@
             android:summary="@string/settings_podcasts_selected_zero"
             android:persistent="false" />
 
+        <SwitchPreference
+            android:key="onFollowPodcast"
+            android:title="@string/settings_auto_download_on_follow_podcast"
+            android:persistent="false" />
+
         <ListPreference
             android:key="autoDownloadPodcastsLimit"
             android:dialogTitle="@string/settings_auto_download_limit_auto_downloads"

--- a/modules/features/settings/src/main/res/xml/preferences_auto_download.xml
+++ b/modules/features/settings/src/main/res/xml/preferences_auto_download.xml
@@ -25,15 +25,16 @@
             android:summary="@string/settings_podcasts_selected_zero"
             android:persistent="false" />
 
-        <SwitchPreference
-            android:key="onFollowPodcast"
-            android:title="@string/settings_auto_download_on_follow_podcast"
-            android:persistent="false" />
-
         <ListPreference
             android:key="autoDownloadPodcastsLimit"
             android:dialogTitle="@string/settings_auto_download_limit_auto_downloads"
             android:title="@string/settings_auto_download_limit"
+            android:persistent="false" />
+
+        <SwitchPreference
+            android:key="onFollowPodcast"
+            android:title="@string/settings_auto_download_on_follow_podcast"
+            android:summary="@string/settings_auto_download_on_follow_podcast_description"
             android:persistent="false" />
 
     </PreferenceCategory>

--- a/modules/features/settings/src/main/res/xml/preferences_auto_download.xml
+++ b/modules/features/settings/src/main/res/xml/preferences_auto_download.xml
@@ -25,15 +25,15 @@
             android:summary="@string/settings_podcasts_selected_zero"
             android:persistent="false" />
 
+        <SwitchPreference
+            android:key="onFollowPodcast"
+            android:title="@string/settings_auto_download_on_follow_podcast"
+            android:persistent="false" />
+
         <ListPreference
             android:key="autoDownloadPodcastsLimit"
             android:dialogTitle="@string/settings_auto_download_limit_auto_downloads"
             android:title="@string/settings_auto_download_limit"
-            android:persistent="false" />
-
-        <SwitchPreference
-            android:key="onFollowPodcast"
-            android:title="@string/settings_auto_download_on_follow_podcast"
             android:persistent="false" />
 
     </PreferenceCategory>

--- a/modules/features/settings/src/main/res/xml/preferences_auto_download.xml
+++ b/modules/features/settings/src/main/res/xml/preferences_auto_download.xml
@@ -34,7 +34,6 @@
         <SwitchPreference
             android:key="onFollowPodcast"
             android:title="@string/settings_auto_download_on_follow_podcast"
-            android:summary="@string/settings_auto_download_on_follow_podcast_description"
             android:persistent="false" />
 
     </PreferenceCategory>

--- a/modules/features/shared/src/main/java/au/com/shiftyjelly/pocketcasts/shared/AppLifecycleObserver.kt
+++ b/modules/features/shared/src/main/java/au/com/shiftyjelly/pocketcasts/shared/AppLifecycleObserver.kt
@@ -117,6 +117,9 @@ class AppLifecycleObserver constructor(
 
                     // For new users we want to auto download new episodes by default
                     settings.autoDownloadNewEpisodes.set(AUTO_DOWNLOAD_NEW_EPISODES, updateModifiedAt = false)
+
+                    // For new users we want to auto download on follow podcast by default
+                    settings.autoDownloadOnFollowPodcast.set(true, updateModifiedAt = false)
                 }
             }
         } else if (previousVersionCode < versionCode) {

--- a/modules/features/shared/src/main/java/au/com/shiftyjelly/pocketcasts/shared/AppLifecycleObserver.kt
+++ b/modules/features/shared/src/main/java/au/com/shiftyjelly/pocketcasts/shared/AppLifecycleObserver.kt
@@ -6,7 +6,6 @@ import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.ProcessLifecycleOwner
 import au.com.shiftyjelly.pocketcasts.analytics.AppLifecycleAnalytics
-import au.com.shiftyjelly.pocketcasts.models.entity.Podcast.Companion.AUTO_DOWNLOAD_NEW_EPISODES
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.repositories.di.ApplicationScope
 import au.com.shiftyjelly.pocketcasts.utils.AppPlatform
@@ -114,9 +113,6 @@ class AppLifecycleObserver constructor(
                 AppPlatform.Phone -> {
                     // For new users we want to auto play when the queue is empty by default
                     settings.autoPlayNextEpisodeOnEmpty.set(true, updateModifiedAt = false)
-
-                    // For new users we want to auto download new episodes by default
-                    settings.autoDownloadNewEpisodes.set(AUTO_DOWNLOAD_NEW_EPISODES, updateModifiedAt = false)
 
                     // For new users we want to auto download on follow podcast by default
                     settings.autoDownloadOnFollowPodcast.set(true, updateModifiedAt = false)

--- a/modules/features/shared/src/test/java/au/com/shiftyjelly/pocketcasts/shared/AppLifecycleObserverTest.kt
+++ b/modules/features/shared/src/test/java/au/com/shiftyjelly/pocketcasts/shared/AppLifecycleObserverTest.kt
@@ -44,6 +44,8 @@ class AppLifecycleObserverTest {
 
     @Mock private lateinit var useUpNextDarkThemeSetting: UserSetting<Boolean>
 
+    @Mock private lateinit var autoDownloadOnFollowPodcastSetting: UserSetting<Boolean>
+
     @Mock private lateinit var appLifecycleAnalytics: AppLifecycleAnalytics
 
     @Mock private lateinit var preferencesFeatureProvider: PreferencesFeatureProvider
@@ -64,6 +66,7 @@ class AppLifecycleObserverTest {
     fun setUp() {
         whenever(settings.autoPlayNextEpisodeOnEmpty).thenReturn(autoPlayNextEpisodeSetting)
         whenever(settings.autoDownloadNewEpisodes).thenReturn(autoDownloadNewEpisodesSetting)
+        whenever(settings.autoDownloadOnFollowPodcast).thenReturn(autoDownloadOnFollowPodcastSetting)
         whenever(settings.useDarkUpNextTheme).thenReturn(useUpNextDarkThemeSetting)
 
         whenever(appLifecycleOwner.lifecycle).thenReturn(appLifecycle)
@@ -95,6 +98,7 @@ class AppLifecycleObserverTest {
 
         verify(appLifecycleAnalytics).onNewApplicationInstall()
         verify(autoPlayNextEpisodeSetting).set(true, updateModifiedAt = false)
+        verify(autoDownloadOnFollowPodcastSetting).set(true, updateModifiedAt = false)
         verify(autoDownloadNewEpisodesSetting).set(Podcast.AUTO_DOWNLOAD_NEW_EPISODES, updateModifiedAt = false)
         verify(useUpNextDarkThemeSetting).set(false, updateModifiedAt = false)
 
@@ -114,6 +118,7 @@ class AppLifecycleObserverTest {
 
         verify(autoPlayNextEpisodeSetting, never()).set(any(), any(), any(), any())
         verify(autoDownloadNewEpisodesSetting, never()).set(any(), any(), any(), any())
+        verify(autoDownloadOnFollowPodcastSetting, never()).set(any(), any(), any(), any())
         verify(useUpNextDarkThemeSetting).set(false, updateModifiedAt = false)
         verify(appLifecycleAnalytics, never()).onApplicationUpgrade(any())
     }
@@ -131,6 +136,7 @@ class AppLifecycleObserverTest {
 
         verify(autoPlayNextEpisodeSetting, never()).set(any(), any(), any(), any())
         verify(autoDownloadNewEpisodesSetting, never()).set(any(), any(), any(), any())
+        verify(autoDownloadOnFollowPodcastSetting, never()).set(any(), any(), any(), any())
         verify(useUpNextDarkThemeSetting).set(false, updateModifiedAt = false)
         verify(appLifecycleAnalytics, never()).onApplicationUpgrade(any())
     }
@@ -148,6 +154,7 @@ class AppLifecycleObserverTest {
         verify(appLifecycleAnalytics, never()).onNewApplicationInstall()
         verify(autoPlayNextEpisodeSetting, never()).set(any(), any(), any(), any())
         verify(autoDownloadNewEpisodesSetting, never()).set(any(), any(), any(), any())
+        verify(autoDownloadOnFollowPodcastSetting, never()).set(any(), any(), any(), any())
         verify(useUpNextDarkThemeSetting, never()).set(any(), any(), any(), any())
     }
 }

--- a/modules/features/shared/src/test/java/au/com/shiftyjelly/pocketcasts/shared/AppLifecycleObserverTest.kt
+++ b/modules/features/shared/src/test/java/au/com/shiftyjelly/pocketcasts/shared/AppLifecycleObserverTest.kt
@@ -4,7 +4,6 @@ import android.content.Context
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleOwner
 import au.com.shiftyjelly.pocketcasts.analytics.AppLifecycleAnalytics
-import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.preferences.UserSetting
 import au.com.shiftyjelly.pocketcasts.utils.AppPlatform
@@ -40,8 +39,6 @@ class AppLifecycleObserverTest {
 
     @Mock private lateinit var autoPlayNextEpisodeSetting: UserSetting<Boolean>
 
-    @Mock private lateinit var autoDownloadNewEpisodesSetting: UserSetting<Int>
-
     @Mock private lateinit var useUpNextDarkThemeSetting: UserSetting<Boolean>
 
     @Mock private lateinit var autoDownloadOnFollowPodcastSetting: UserSetting<Boolean>
@@ -65,7 +62,6 @@ class AppLifecycleObserverTest {
     @Before
     fun setUp() {
         whenever(settings.autoPlayNextEpisodeOnEmpty).thenReturn(autoPlayNextEpisodeSetting)
-        whenever(settings.autoDownloadNewEpisodes).thenReturn(autoDownloadNewEpisodesSetting)
         whenever(settings.autoDownloadOnFollowPodcast).thenReturn(autoDownloadOnFollowPodcastSetting)
         whenever(settings.useDarkUpNextTheme).thenReturn(useUpNextDarkThemeSetting)
 
@@ -99,7 +95,6 @@ class AppLifecycleObserverTest {
         verify(appLifecycleAnalytics).onNewApplicationInstall()
         verify(autoPlayNextEpisodeSetting).set(true, updateModifiedAt = false)
         verify(autoDownloadOnFollowPodcastSetting).set(true, updateModifiedAt = false)
-        verify(autoDownloadNewEpisodesSetting).set(Podcast.AUTO_DOWNLOAD_NEW_EPISODES, updateModifiedAt = false)
         verify(useUpNextDarkThemeSetting).set(false, updateModifiedAt = false)
 
         verify(appLifecycleAnalytics, never()).onApplicationUpgrade(any())
@@ -117,7 +112,6 @@ class AppLifecycleObserverTest {
         verify(appLifecycleAnalytics).onNewApplicationInstall()
 
         verify(autoPlayNextEpisodeSetting, never()).set(any(), any(), any(), any())
-        verify(autoDownloadNewEpisodesSetting, never()).set(any(), any(), any(), any())
         verify(autoDownloadOnFollowPodcastSetting, never()).set(any(), any(), any(), any())
         verify(useUpNextDarkThemeSetting).set(false, updateModifiedAt = false)
         verify(appLifecycleAnalytics, never()).onApplicationUpgrade(any())
@@ -135,7 +129,6 @@ class AppLifecycleObserverTest {
         verify(appLifecycleAnalytics).onNewApplicationInstall()
 
         verify(autoPlayNextEpisodeSetting, never()).set(any(), any(), any(), any())
-        verify(autoDownloadNewEpisodesSetting, never()).set(any(), any(), any(), any())
         verify(autoDownloadOnFollowPodcastSetting, never()).set(any(), any(), any(), any())
         verify(useUpNextDarkThemeSetting).set(false, updateModifiedAt = false)
         verify(appLifecycleAnalytics, never()).onApplicationUpgrade(any())
@@ -153,7 +146,6 @@ class AppLifecycleObserverTest {
 
         verify(appLifecycleAnalytics, never()).onNewApplicationInstall()
         verify(autoPlayNextEpisodeSetting, never()).set(any(), any(), any(), any())
-        verify(autoDownloadNewEpisodesSetting, never()).set(any(), any(), any(), any())
         verify(autoDownloadOnFollowPodcastSetting, never()).set(any(), any(), any(), any())
         verify(useUpNextDarkThemeSetting, never()).set(any(), any(), any(), any())
     }

--- a/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
+++ b/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
@@ -477,6 +477,7 @@ enum class AnalyticsEvent(val key: String) {
     SETTINGS_AUTO_DOWNLOAD_SHOWN("settings_auto_download_shown"),
     SETTINGS_AUTO_DOWNLOAD_UP_NEXT_TOGGLED("settings_auto_download_up_next_toggled"),
     SETTINGS_AUTO_DOWNLOAD_NEW_EPISODES_TOGGLED("settings_auto_download_new_episodes_toggled"),
+    SETTINGS_AUTO_DOWNLOAD_ON_FOLLOW_PODCAST_TOGGLED("settings_auto_download_on_follow_podcast_toggled"),
     SETTINGS_AUTO_DOWNLOAD_LIMIT_DOWNLOADS_CHANGED("settings_auto_download_limit_downloads_changed"),
     SETTINGS_AUTO_DOWNLOAD_PODCASTS_CHANGED("settings_auto_download_podcasts_changed"),
     SETTINGS_AUTO_DOWNLOAD_FILTERS_CHANGED("settings_auto_download_filters_changed"),

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -1187,7 +1187,8 @@
     <string name="settings_auto_download_filters">Auto download filters</string>
     <string name="settings_auto_download_filters_episodes">All filter episodes</string>
     <string name="settings_auto_download_new_episodes">New episodes</string>
-    <string name="settings_auto_download_on_follow_podcast">On follow podcast</string>
+    <string name="settings_auto_download_on_follow_podcast">On Follow</string>
+    <string name="settings_auto_download_on_follow_podcast_description">Automatically download the latest two episodes from new shows you follow.</string>
     <string name="settings_auto_download_podcasts">Auto download podcasts</string>
     <string name="settings_auto_download_new_episodes_description">Download new episodes as they’re released, and manage your storage by setting a limit on how many episodes are saved.</string>
     <string name="settings_auto_download_limit">Limit downloads</string>

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -1187,6 +1187,7 @@
     <string name="settings_auto_download_filters">Auto download filters</string>
     <string name="settings_auto_download_filters_episodes">All filter episodes</string>
     <string name="settings_auto_download_new_episodes">New episodes</string>
+    <string name="settings_auto_download_on_follow_podcast">On follow podcast</string>
     <string name="settings_auto_download_podcasts">Auto download podcasts</string>
     <string name="settings_auto_download_new_episodes_description">Download new episodes as they’re released, and manage your storage by setting a limit on how many episodes are saved.</string>
     <string name="settings_auto_download_limit">Limit downloads</string>

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -1188,7 +1188,17 @@
     <string name="settings_auto_download_filters_episodes">All filter episodes</string>
     <string name="settings_auto_download_new_episodes">New episodes</string>
     <string name="settings_auto_download_on_follow_podcast">On Follow</string>
-    <string name="settings_auto_download_on_follow_podcast_description">Automatically download the latest two episodes from new shows you follow.</string>
+
+    <plurals name="settings_auto_download_on_follow_podcast_description">
+        <item quantity="one">Automatically download the latest episode from new shows you follow.</item>
+        <item quantity="other">Automatically download the latest %s episodes from new shows you follow.</item>
+    </plurals>
+
+    <string name="number_two">two</string>
+    <string name="number_three">three</string>
+    <string name="number_five">five</string>
+    <string name="number_ten">ten</string>
+
     <string name="settings_auto_download_podcasts">Auto download podcasts</string>
     <string name="settings_auto_download_new_episodes_description">Download new episodes as they’re released, and manage your storage by setting a limit on how many episodes are saved.</string>
     <string name="settings_auto_download_limit">Limit downloads</string>

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
@@ -336,6 +336,7 @@ interface Settings {
     val autoDownloadUnmeteredOnly: UserSetting<Boolean>
     val autoDownloadOnlyWhenCharging: UserSetting<Boolean>
     val autoDownloadUpNext: UserSetting<Boolean>
+    val autoDownloadOnFollowPodcast: UserSetting<Boolean>
     val autoDownloadNewEpisodes: UserSetting<Int>
 
     val artworkConfiguration: UserSetting<ArtworkConfiguration>

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
@@ -569,6 +569,12 @@ class SettingsImpl @Inject constructor(
         sharedPrefs = sharedPreferences,
     )
 
+    override val autoDownloadOnFollowPodcast = UserSetting.BoolPref(
+        sharedPrefKey = "autoDownloadOnFollowPodcast",
+        defaultValue = false,
+        sharedPrefs = sharedPreferences,
+    )
+
     override val autoDownloadNewEpisodes = UserSetting.IntPref(
         sharedPrefKey = "globalAutoDownloadNewEpisodes",
         defaultValue = GLOBAL_AUTO_DOWNLOAD_NONE,

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/SubscribeManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/SubscribeManager.kt
@@ -13,7 +13,6 @@ import au.com.shiftyjelly.pocketcasts.models.type.EpisodePlayingStatus
 import au.com.shiftyjelly.pocketcasts.models.type.EpisodeStatusEnum
 import au.com.shiftyjelly.pocketcasts.models.type.EpisodesSortType
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
-import au.com.shiftyjelly.pocketcasts.preferences.Settings.Companion.GLOBAL_AUTO_DOWNLOAD_NONE
 import au.com.shiftyjelly.pocketcasts.repositories.download.DownloadHelper
 import au.com.shiftyjelly.pocketcasts.repositories.download.DownloadManager
 import au.com.shiftyjelly.pocketcasts.repositories.images.PocketCastsImageRequestFactory
@@ -40,10 +39,6 @@ import io.reactivex.schedulers.Schedulers
 import java.util.Date
 import javax.inject.Inject
 import javax.inject.Singleton
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.launch
 import kotlinx.coroutines.rx2.rxCompletable
 import timber.log.Timber
 
@@ -62,19 +57,12 @@ class SubscribeManager @Inject constructor(
     private val subscribeRelay: PublishRelay<PodcastSubscribe> by lazy { setupSubscribeRelay() }
     val subscriptionChangedRelay: PublishRelay<String> = PublishRelay.create()
 
-    private var _hasEpisodesWithAutoDownloadEnabled: MutableStateFlow<Boolean> = MutableStateFlow(false)
     private val uuidsInQueue = HashSet<String>()
     private val podcastDao = appDatabase.podcastDao()
     private val episodeDao = appDatabase.episodeDao()
     private val imageRequestFactory = PocketCastsImageRequestFactory(context, isDarkTheme = true)
 
     data class PodcastSubscribe(val podcastUuid: String, val sync: Boolean, val shouldAutoDownload: Boolean)
-
-    init {
-        CoroutineScope(Dispatchers.IO).launch {
-            _hasEpisodesWithAutoDownloadEnabled.value = podcastDao.hasEpisodesWithAutoDownloadStatus(AUTO_DOWNLOAD_NEW_EPISODES)
-        }
-    }
 
     @SuppressLint("CheckResult")
     private fun setupSubscribeRelay(): PublishRelay<PodcastSubscribe> {
@@ -123,7 +111,7 @@ class SubscribeManager @Inject constructor(
                 // update the notification time as any podcasts added after this date will be ignored
                 settings.setNotificationLastSeenToNow()
 
-                if (canDownloadEpisodesAfterSubscription(subscribed, shouldAutoDownload)) {
+                if (canDownloadEpisodesAfterFollowPodcast(subscribed, shouldAutoDownload)) {
                     podcastDao.findByUuidBlocking(podcastUuid)?.let { podcast ->
                         val episodes = episodeManager.findEpisodesByPodcastOrderedByPublishDateBlocking(podcast)
                         val numberOfEpisodes = AutoDownloadLimitSetting.getNumberOfEpisodes(settings.autoDownloadLimit.value)
@@ -206,7 +194,7 @@ class SubscribeManager @Inject constructor(
                         )
                     }
                 }
-                if (canDownloadEpisodesAfterSubscription(subscribed, shouldAutoDownload)) {
+                if (canDownloadEpisodesAfterFollowPodcast(subscribed, shouldAutoDownload)) {
                     LogBuffer.i(LogBuffer.TAG_BACKGROUND_TASKS, "Update auto download status for $podcastUuid")
                     podcast.autoDownloadStatus = AUTO_DOWNLOAD_NEW_EPISODES
                 }
@@ -219,23 +207,13 @@ class SubscribeManager @Inject constructor(
         return insertPodcastObservable.flatMap { podcast -> subscribeInsertEpisodes(podcast).toSingle { podcast } }
     }
 
-    private fun canDownloadEpisodesAfterSubscription(
+    private fun canDownloadEpisodesAfterFollowPodcast(
         subscribed: Boolean,
         shouldAutoDownload: Boolean,
-    ): Boolean {
-        val autoDownloadStatus = settings.autoDownloadNewEpisodes.value
-
-        val isAutoDownloadEnabled = if (autoDownloadStatus == GLOBAL_AUTO_DOWNLOAD_NONE) {
-            _hasEpisodesWithAutoDownloadEnabled.value
-        } else {
-            autoDownloadStatus == AUTO_DOWNLOAD_NEW_EPISODES
-        }
-
-        return subscribed &&
-            isAutoDownloadEnabled &&
-            shouldAutoDownload &&
-            FeatureFlag.isEnabled(Feature.AUTO_DOWNLOAD)
-    }
+    ): Boolean = subscribed &&
+        settings.autoDownloadOnFollowPodcast.value &&
+        shouldAutoDownload &&
+        FeatureFlag.isEnabled(Feature.AUTO_DOWNLOAD)
 
     private fun downloadPodcast(podcastUuid: String): Single<Podcast> {
         // download the podcast


### PR DESCRIPTION
## Description
- This splits the responsibility of New Episodes toggle in order to have the new toggle On Follow Podcast exclusive for auto download episodes when following new podcasts
- Context: p1732795876867519-slack-C06EHRAPW12
- This new toggle will be enabled by default for new users only 65ee94b3e966fed4a0f264e5a06bd7deb5b40323
- Added the new event for On Follow toggle: `settings_auto_download_on_follow_podcast_toggled`
- I reverted the New Episodes toggle being enabled by default to new users: [2968919](https://github.com/Automattic/pocket-casts-android/pull/3303/commits/296891957a0141a00aea99b1a961c1ae3b8fa2cf)


## Testing Instructions

### Fresh install
1. Have a fresh install
2. Open the App
3. Go to Profile -> Settings -> Auto download
4. Verify you have Limit download sets to two latest as default ✅
5. Verify you have `On Follow` enabled as default ✅
6. Verify you have `New episodes` disabled as default ✅
7. Go to discover and follow a new podcast
8. Ensure you have the latest two episodes downloaded  ✅
9. Ensure the Podcast auto download setting was enabled ✅
10. Go to Profile -> Settings -> Auto download
11. Verify the global `New episodes` was enabled ✅
12. Verify the podcast was added to choose podcasts section ✅
13. Disable `On Follow` toggle
14. Follow another podcast
15. Ensure you did not get any episode auto downloaded from this podcast you just followed ✅

### Existing user
1. Checkout to `release/7.78` branch
2. Install the app and log in
3. Have some podcasts with auto download enabled
4. Install the app from this branch
5. Ensure you have `On Follow` disabled as default ✅
6. Follow a new podcast
7. Ensure you did not get any episode auto downloaded from this podcast you just followed ✅

### Feature Flag disabled
1. Disable the auto download feature flag
2. Go to Profile -> Settings -> Auto download
3. Ensure you don't see `On Follow` and `Limit downloads`

## Screenshots or Screencast 
[Uploading Screen_recording_20241202_102317.webm…]()


## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack