### PR TITLE
Fix account header label weights

### DIFF
--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/AccountHeader.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/AccountHeader.kt
@@ -100,7 +100,7 @@ internal fun AccountHeader(
                 )
             }
             Spacer(
-                modifier = Modifier.width(8.dp),
+                modifier = Modifier.width(16.dp),
             )
             if (labels.end != null) {
                 TextH50(

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/AccountHeader.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/AccountHeader.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
 import androidx.compose.material.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
@@ -95,10 +96,11 @@ internal fun AccountHeader(
                     fontScale = config.infoFontScale,
                     color = labels.start.color(MaterialTheme.theme.colors),
                     textAlign = TextAlign.Start,
+                    modifier = Modifier.weight(1f),
                 )
             }
             Spacer(
-                modifier = Modifier.weight(1f),
+                modifier = Modifier.width(8.dp),
             )
             if (labels.end != null) {
                 TextH50(
@@ -106,6 +108,7 @@ internal fun AccountHeader(
                     fontScale = config.infoFontScale,
                     color = labels.end.color(MaterialTheme.theme.colors),
                     textAlign = TextAlign.End,
+                    modifier = Modifier.weight(1f),
                 )
             }
         }
@@ -286,6 +289,40 @@ private fun AccountHeaderPreview(
         ) {
             AccountHeader(
                 state = state,
+                config = AccountHeaderConfig(
+                    avatarConfig = UserAvatarConfig(
+                        imageSize = 66.dp,
+                        strokeWidth = 3.dp,
+                    ),
+                ),
+                onClick = {},
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(16.dp),
+            )
+        }
+    }
+}
+
+@Preview(fontScale = 2f)
+@Composable
+private fun AccountHeaderFontSizePreview() {
+    AppTheme(Theme.ThemeType.ELECTRIC) {
+        Box(
+            modifier = Modifier.background(MaterialTheme.theme.colors.primaryUi02),
+        ) {
+            AccountHeader(
+                state = AccountHeaderState(
+                    email = "noreply@pocketcasts.com",
+                    imageUrl = null,
+                    subscription = SubscriptionHeaderState.PaidCancel(
+                        tier = SubscriptionTier.PLUS,
+                        expiresIn = 10.days,
+                        isChampion = true,
+                        platform = SubscriptionPlatform.ANDROID,
+                        giftDaysLeft = 0,
+                    ),
+                ),
                 config = AccountHeaderConfig(
                     avatarConfig = UserAvatarConfig(
                         imageSize = 66.dp,


### PR DESCRIPTION
## Description

This fixes label positioning under account header and matches it with how they behaved before Compose migration.

## Testing Instructions

1. Sign in with an account that would show 2 labels. Like, for example, a champion account.
2. Go to the account details.
3. Increase the OS font size.
4. Verify labels under the profile header.

## Screenshots or Screencast 

| Before | After |
| - | - |
| ![vef](https://github.com/user-attachments/assets/af40aec1-f1e5-4a32-8d57-901b7110a723) | ![Screenshot 2024-11-29 at 11 17 23](https://github.com/user-attachments/assets/5f18a2ab-136b-4df1-bb37-b48e1aa066af) |

## Checklist
- [ ] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] ~I have considered whether it makes sense to add tests for my changes~
- [ ] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [ ] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [ ] ~for accessibility with TalkBack~