### PR TITLE
Move Brush Gradient to Pocket Casts Colors

### DIFF
--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/OnboardingWelcomePage.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/OnboardingWelcomePage.kt
@@ -43,7 +43,6 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
-import au.com.shiftyjelly.pocketcasts.account.onboarding.upgrade.OnboardingUpgradeHelper
 import au.com.shiftyjelly.pocketcasts.account.viewmodel.OnboardingWelcomeState
 import au.com.shiftyjelly.pocketcasts.account.viewmodel.OnboardingWelcomeViewModel
 import au.com.shiftyjelly.pocketcasts.compose.AppThemeWithBackground
@@ -57,6 +56,7 @@ import au.com.shiftyjelly.pocketcasts.compose.components.TextH10
 import au.com.shiftyjelly.pocketcasts.compose.components.TextH40
 import au.com.shiftyjelly.pocketcasts.compose.components.TextP60
 import au.com.shiftyjelly.pocketcasts.compose.extensions.brush
+import au.com.shiftyjelly.pocketcasts.compose.plusGradientBrush
 import au.com.shiftyjelly.pocketcasts.compose.preview.ThemePreviewParameterProvider
 import au.com.shiftyjelly.pocketcasts.compose.theme
 import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingFlow
@@ -300,7 +300,7 @@ private fun NewsletterSwitch(
 
 @Composable
 private fun PlusPersonCheckmark() {
-    PersonCheckmark(OnboardingUpgradeHelper.plusGradientBrush)
+    PersonCheckmark(Brush.plusGradientBrush)
 }
 
 @Composable

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeBottomSheet.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeBottomSheet.kt
@@ -24,6 +24,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalView
@@ -43,6 +44,7 @@ import au.com.shiftyjelly.pocketcasts.account.viewmodel.OnboardingUpgradeBottomS
 import au.com.shiftyjelly.pocketcasts.compose.bottomsheet.Pill
 import au.com.shiftyjelly.pocketcasts.compose.components.TextH20
 import au.com.shiftyjelly.pocketcasts.compose.components.TextP60
+import au.com.shiftyjelly.pocketcasts.compose.plusGradientBrush
 import au.com.shiftyjelly.pocketcasts.localization.R
 import au.com.shiftyjelly.pocketcasts.models.type.OfferSubscriptionPricingPhase
 import au.com.shiftyjelly.pocketcasts.models.type.RecurringSubscriptionPricingPhase
@@ -274,7 +276,7 @@ fun SubscriptionTier.toSubscribeButton(res: Resources) =
         },
     )
 fun SubscriptionTier.toOutlinedButtonBrush() = when (this) {
-    SubscriptionTier.PLUS -> OnboardingUpgradeHelper.plusGradientBrush
+    SubscriptionTier.PLUS -> Brush.plusGradientBrush
     SubscriptionTier.PATRON -> OnboardingUpgradeHelper.patronGradientBrush
     SubscriptionTier.NONE -> throw IllegalStateException(UNKNOWN_TIER)
 }

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeBottomSheet.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeBottomSheet.kt
@@ -44,6 +44,7 @@ import au.com.shiftyjelly.pocketcasts.account.viewmodel.OnboardingUpgradeBottomS
 import au.com.shiftyjelly.pocketcasts.compose.bottomsheet.Pill
 import au.com.shiftyjelly.pocketcasts.compose.components.TextH20
 import au.com.shiftyjelly.pocketcasts.compose.components.TextP60
+import au.com.shiftyjelly.pocketcasts.compose.patronGradientBrush
 import au.com.shiftyjelly.pocketcasts.compose.plusGradientBrush
 import au.com.shiftyjelly.pocketcasts.localization.R
 import au.com.shiftyjelly.pocketcasts.models.type.OfferSubscriptionPricingPhase
@@ -277,6 +278,6 @@ fun SubscriptionTier.toSubscribeButton(res: Resources) =
     )
 fun SubscriptionTier.toOutlinedButtonBrush() = when (this) {
     SubscriptionTier.PLUS -> Brush.plusGradientBrush
-    SubscriptionTier.PATRON -> OnboardingUpgradeHelper.patronGradientBrush
+    SubscriptionTier.PATRON -> Brush.patronGradientBrush
     SubscriptionTier.NONE -> throw IllegalStateException(UNKNOWN_TIER)
 }

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeFlow.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeFlow.kt
@@ -12,6 +12,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.tooling.preview.Preview
@@ -23,6 +24,7 @@ import au.com.shiftyjelly.pocketcasts.account.viewmodel.OnboardingUpgradeBottomS
 import au.com.shiftyjelly.pocketcasts.account.viewmodel.OnboardingUpgradeBottomSheetViewModel
 import au.com.shiftyjelly.pocketcasts.account.viewmodel.OnboardingUpgradeFeaturesViewModel
 import au.com.shiftyjelly.pocketcasts.compose.bars.SystemBarsStyles
+import au.com.shiftyjelly.pocketcasts.compose.plusGradientBrush
 import au.com.shiftyjelly.pocketcasts.models.type.SubscriptionTier
 import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingFlow
 import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingUpgradeSource
@@ -32,7 +34,6 @@ import kotlinx.coroutines.launch
 
 private const val NULL_ACTIVITY_ERROR = "Activity is null when attempting subscription"
 
-@OptIn(ExperimentalMaterialApi::class)
 @Composable
 fun OnboardingUpgradeFlow(
     flow: OnboardingFlow,
@@ -173,7 +174,7 @@ private fun OutlinedButtonPreview() {
     Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
         OutlinedRowButton(
             text = "one this is way too long | | | | | | | | | | |",
-            brush = OnboardingUpgradeHelper.plusGradientBrush,
+            brush = Brush.plusGradientBrush,
             selectedCheckMark = true,
             subscriptionTier = SubscriptionTier.PLUS,
             onClick = {},
@@ -181,7 +182,7 @@ private fun OutlinedButtonPreview() {
         OutlinedRowButton(
             text = "two",
             topText = "woohoo!",
-            brush = OnboardingUpgradeHelper.plusGradientBrush,
+            brush = Brush.plusGradientBrush,
             subscriptionTier = SubscriptionTier.PLUS,
             selectedCheckMark = true,
             onClick = {},

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeHelper.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeHelper.kt
@@ -30,7 +30,6 @@ import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.BlendMode
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.graphics.drawscope.withTransform
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalConfiguration
@@ -55,7 +54,7 @@ import au.com.shiftyjelly.pocketcasts.compose.components.ClickableTextHelper
 import au.com.shiftyjelly.pocketcasts.compose.components.TextH30
 import au.com.shiftyjelly.pocketcasts.compose.components.TextP60
 import au.com.shiftyjelly.pocketcasts.compose.extensions.brush
-import au.com.shiftyjelly.pocketcasts.compose.patronPurpleLight
+import au.com.shiftyjelly.pocketcasts.compose.patronGradientBrush
 import au.com.shiftyjelly.pocketcasts.compose.plusGradientBrush
 import au.com.shiftyjelly.pocketcasts.models.type.SubscriptionTier
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
@@ -64,7 +63,6 @@ import au.com.shiftyjelly.pocketcasts.localization.R as LR
 import au.com.shiftyjelly.pocketcasts.ui.R as UR
 
 object OnboardingUpgradeHelper {
-    val patronGradientBrush = SolidColor(Color.patronPurpleLight)
 
     private val unselectedColor = Color(0xFF666666)
 
@@ -241,7 +239,7 @@ object OnboardingUpgradeHelper {
     ) {
         val brush = when (subscriptionTier) {
             SubscriptionTier.PLUS -> Brush.plusGradientBrush
-            SubscriptionTier.PATRON -> patronGradientBrush
+            SubscriptionTier.PATRON -> Brush.patronGradientBrush
             SubscriptionTier.NONE -> throw IllegalStateException("Unknown subscription tier")
         }
         val textColor = when (subscriptionTier) {

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeHelper.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeHelper.kt
@@ -48,7 +48,6 @@ import androidx.constraintlayout.compose.ConstrainedLayoutReference
 import androidx.constraintlayout.compose.ConstraintLayout
 import androidx.constraintlayout.compose.ConstraintLayoutScope
 import au.com.shiftyjelly.pocketcasts.account.onboarding.upgrade.OnboardingUpgradeHelper.UpgradeRowButton
-import au.com.shiftyjelly.pocketcasts.account.onboarding.upgrade.OnboardingUpgradeHelper.plusGradientBrush
 import au.com.shiftyjelly.pocketcasts.compose.buttons.GradientRowButton
 import au.com.shiftyjelly.pocketcasts.compose.components.AutoResizeText
 import au.com.shiftyjelly.pocketcasts.compose.components.Clickable
@@ -57,8 +56,7 @@ import au.com.shiftyjelly.pocketcasts.compose.components.TextH30
 import au.com.shiftyjelly.pocketcasts.compose.components.TextP60
 import au.com.shiftyjelly.pocketcasts.compose.extensions.brush
 import au.com.shiftyjelly.pocketcasts.compose.patronPurpleLight
-import au.com.shiftyjelly.pocketcasts.compose.plusGoldDark
-import au.com.shiftyjelly.pocketcasts.compose.plusGoldLight
+import au.com.shiftyjelly.pocketcasts.compose.plusGradientBrush
 import au.com.shiftyjelly.pocketcasts.models.type.SubscriptionTier
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.images.R as IR
@@ -66,10 +64,6 @@ import au.com.shiftyjelly.pocketcasts.localization.R as LR
 import au.com.shiftyjelly.pocketcasts.ui.R as UR
 
 object OnboardingUpgradeHelper {
-    val plusGradientBrush = Brush.horizontalGradient(
-        0f to Color.plusGoldLight,
-        1f to Color.plusGoldDark,
-    )
     val patronGradientBrush = SolidColor(Color.patronPurpleLight)
 
     private val unselectedColor = Color(0xFF666666)
@@ -246,7 +240,7 @@ object OnboardingUpgradeHelper {
         selected: Boolean = true,
     ) {
         val brush = when (subscriptionTier) {
-            SubscriptionTier.PLUS -> plusGradientBrush
+            SubscriptionTier.PLUS -> Brush.plusGradientBrush
             SubscriptionTier.PATRON -> patronGradientBrush
             SubscriptionTier.NONE -> throw IllegalStateException("Unknown subscription tier")
         }
@@ -432,7 +426,7 @@ fun UpgradeRowButtonWithGradientBackgroundPreview() {
         primaryText = "Upgrade Now",
         textColor = Color.Black,
         onClick = {},
-        gradientBackgroundColor = plusGradientBrush,
+        gradientBackgroundColor = Brush.plusGradientBrush,
     )
 }
 

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/UpgradeButton.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/UpgradeButton.kt
@@ -4,7 +4,7 @@ import androidx.annotation.ColorRes
 import androidx.annotation.StringRes
 import androidx.compose.ui.graphics.Brush
 import au.com.shiftyjelly.pocketcasts.account.onboarding.upgrade.OnboardingUpgradeHelper.patronGradientBrush
-import au.com.shiftyjelly.pocketcasts.account.onboarding.upgrade.OnboardingUpgradeHelper.plusGradientBrush
+import au.com.shiftyjelly.pocketcasts.compose.plusGradientBrush
 import au.com.shiftyjelly.pocketcasts.models.type.Subscription
 import au.com.shiftyjelly.pocketcasts.models.type.SubscriptionTier
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
@@ -27,7 +27,7 @@ sealed class UpgradeButton(
         textColorRes = UR.color.black,
         subscription = subscription,
         planType = planType,
-        gradientBackgroundColor = plusGradientBrush,
+        gradientBackgroundColor = Brush.plusGradientBrush,
     )
 
     data class Patron(

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/UpgradeButton.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/UpgradeButton.kt
@@ -3,7 +3,7 @@ package au.com.shiftyjelly.pocketcasts.account.onboarding.upgrade
 import androidx.annotation.ColorRes
 import androidx.annotation.StringRes
 import androidx.compose.ui.graphics.Brush
-import au.com.shiftyjelly.pocketcasts.account.onboarding.upgrade.OnboardingUpgradeHelper.patronGradientBrush
+import au.com.shiftyjelly.pocketcasts.compose.patronGradientBrush
 import au.com.shiftyjelly.pocketcasts.compose.plusGradientBrush
 import au.com.shiftyjelly.pocketcasts.models.type.Subscription
 import au.com.shiftyjelly.pocketcasts.models.type.SubscriptionTier
@@ -39,7 +39,7 @@ sealed class UpgradeButton(
         textColorRes = UR.color.white,
         subscription = subscription,
         planType = planType,
-        gradientBackgroundColor = patronGradientBrush,
+        gradientBackgroundColor = Brush.patronGradientBrush,
     )
 
     enum class PlanType { RENEW, SUBSCRIBE, UPGRADE }

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/UpgradeLayoutComponents.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/UpgradeLayoutComponents.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.stringResource
@@ -17,8 +18,8 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import au.com.shiftyjelly.pocketcasts.account.onboarding.upgrade.OnboardingUpgradeHelper.UpgradeRowButton
-import au.com.shiftyjelly.pocketcasts.account.onboarding.upgrade.OnboardingUpgradeHelper.plusGradientBrush
 import au.com.shiftyjelly.pocketcasts.compose.components.TextP50
+import au.com.shiftyjelly.pocketcasts.compose.plusGradientBrush
 import au.com.shiftyjelly.pocketcasts.localization.R
 import au.com.shiftyjelly.pocketcasts.models.type.Subscription
 import au.com.shiftyjelly.pocketcasts.ui.R as UR
@@ -73,7 +74,7 @@ private fun SubscribeButtonContent(
     ) {
         UpgradeRowButton(
             primaryText = stringResource(R.string.get_pocket_casts_plus),
-            gradientBackgroundColor = plusGradientBrush,
+            gradientBackgroundColor = Brush.plusGradientBrush,
             textColor = colorResource(UR.color.black),
             onClick = onClickSubscribe,
         )

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/paywallfeatures/UpgradeLayoutFeatures.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/paywallfeatures/UpgradeLayoutFeatures.kt
@@ -21,6 +21,7 @@ import androidx.compose.material.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.res.stringResource
@@ -28,7 +29,6 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import au.com.shiftyjelly.pocketcasts.account.onboarding.upgrade.OnboardingUpgradeHelper.plusGradientBrush
 import au.com.shiftyjelly.pocketcasts.account.onboarding.upgrade.SubscribeButton
 import au.com.shiftyjelly.pocketcasts.account.onboarding.upgrade.calculateMinimumHeightWithInsets
 import au.com.shiftyjelly.pocketcasts.account.viewmodel.OnboardingUpgradeFeaturesState
@@ -36,6 +36,7 @@ import au.com.shiftyjelly.pocketcasts.compose.AppTheme
 import au.com.shiftyjelly.pocketcasts.compose.buttons.RowTextButton
 import au.com.shiftyjelly.pocketcasts.compose.components.AutoResizeText
 import au.com.shiftyjelly.pocketcasts.compose.images.SubscriptionBadge
+import au.com.shiftyjelly.pocketcasts.compose.plusGradientBrush
 import au.com.shiftyjelly.pocketcasts.compose.theme
 import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingUpgradeSource
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
@@ -131,7 +132,7 @@ private fun Content(
                 iconRes = IR.drawable.ic_plus,
                 shortNameRes = LR.string.pocket_casts_plus_short,
                 iconColor = Color.Black,
-                backgroundBrush = plusGradientBrush,
+                backgroundBrush = Brush.plusGradientBrush,
                 textColor = Color.Black,
             )
         }
@@ -201,7 +202,7 @@ private fun SmallDeviceContent(
                 iconRes = IR.drawable.ic_plus,
                 shortNameRes = LR.string.pocket_casts_plus_short,
                 iconColor = Color.Black,
-                backgroundBrush = plusGradientBrush,
+                backgroundBrush = Brush.plusGradientBrush,
                 textColor = Color.Black,
             )
         }

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/paywallreviews/UpgradeLayoutReviews.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/paywallreviews/UpgradeLayoutReviews.kt
@@ -37,7 +37,6 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import au.com.shiftyjelly.pocketcasts.account.onboarding.components.UpgradeFeatureItem
-import au.com.shiftyjelly.pocketcasts.account.onboarding.upgrade.OnboardingUpgradeHelper.plusGradientBrush
 import au.com.shiftyjelly.pocketcasts.account.onboarding.upgrade.PlusUpgradeLayoutReviewsItem
 import au.com.shiftyjelly.pocketcasts.account.onboarding.upgrade.SubscribeButton
 import au.com.shiftyjelly.pocketcasts.account.viewmodel.OnboardingUpgradeFeaturesState
@@ -49,6 +48,7 @@ import au.com.shiftyjelly.pocketcasts.compose.components.TextH50
 import au.com.shiftyjelly.pocketcasts.compose.components.TextP50
 import au.com.shiftyjelly.pocketcasts.compose.components.TextP60
 import au.com.shiftyjelly.pocketcasts.compose.images.SubscriptionBadge
+import au.com.shiftyjelly.pocketcasts.compose.plusGradientBrush
 import au.com.shiftyjelly.pocketcasts.localization.R
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import au.com.shiftyjelly.pocketcasts.utils.rateUs
@@ -197,7 +197,7 @@ private fun PlusBenefits(
                 .padding(top = 16.dp)
                 .border(
                     width = 3.dp,
-                    brush = plusGradientBrush,
+                    brush = Brush.plusGradientBrush,
                     shape = RoundedCornerShape(10.dp),
                 ),
         ) {
@@ -221,7 +221,7 @@ private fun PlusBenefits(
                 iconRes = IR.drawable.ic_plus,
                 shortNameRes = LR.string.pocket_casts_plus_short,
                 iconColor = Color.Black,
-                backgroundBrush = plusGradientBrush,
+                backgroundBrush = Brush.plusGradientBrush,
                 textColor = Color.Black,
             )
         }

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/PocketCastsColors.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/PocketCastsColors.kt
@@ -1,5 +1,6 @@
 package au.com.shiftyjelly.pocketcasts.compose
 
+import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 
 val Color.Companion.pocketRed get() = PocketCastsColors.pocketRed
@@ -9,6 +10,7 @@ val Color.Companion.plusGoldDark get() = PocketCastsColors.plusGoldDark
 val Color.Companion.patronPurple get() = PocketCastsColors.patronPurple
 val Color.Companion.patronPurpleLight get() = PocketCastsColors.patronPurpleLight
 val Color.Companion.patronPurpleDark get() = PocketCastsColors.patronPurpleDark
+val Brush.Companion.plusGradientBrush get() = PocketCastsColors.plusGradientBrush
 
 private object PocketCastsColors {
     val pocketRed = Color(0xFFF43E37)
@@ -18,4 +20,8 @@ private object PocketCastsColors {
     val patronPurple = Color(0xFF6046F5)
     val patronPurpleLight = Color(0xFFAFA2FA)
     val patronPurpleDark = patronPurple
+    val plusGradientBrush = Brush.horizontalGradient(
+        0f to Color.plusGoldLight,
+        1f to Color.plusGoldDark,
+    )
 }

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/PocketCastsColors.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/PocketCastsColors.kt
@@ -2,6 +2,7 @@ package au.com.shiftyjelly.pocketcasts.compose
 
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.SolidColor
 
 val Color.Companion.pocketRed get() = PocketCastsColors.pocketRed
 val Color.Companion.plusGold get() = PocketCastsColors.plusGold
@@ -11,6 +12,7 @@ val Color.Companion.patronPurple get() = PocketCastsColors.patronPurple
 val Color.Companion.patronPurpleLight get() = PocketCastsColors.patronPurpleLight
 val Color.Companion.patronPurpleDark get() = PocketCastsColors.patronPurpleDark
 val Brush.Companion.plusGradientBrush get() = PocketCastsColors.plusGradientBrush
+val Brush.Companion.patronGradientBrush get() = PocketCastsColors.patronGradientBrush
 
 private object PocketCastsColors {
     val pocketRed = Color(0xFFF43E37)
@@ -24,4 +26,5 @@ private object PocketCastsColors {
         0f to Color.plusGoldLight,
         1f to Color.plusGoldDark,
     )
+    val patronGradientBrush = SolidColor(Color.patronPurpleLight)
 }


### PR DESCRIPTION
## Description
- This just moves the brush gradient to Pocket Casts Colors

## Testing Instructions
- Code review and CI should be fine, but you can check the gradient background colors and subscription badge if you wanted

## Checklist
- [ ] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] ~I have considered whether it makes sense to add tests for my changes~
- [ ] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [ ] ~I have updated (or requested that someone edit) [the spreadsheet]~(https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
