### PR TITLE
Suffix Podcast Manager methods that aren't Coroutines with 'blocking' to make upgrading easier

### DIFF
--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/models/db/AutoArchiveTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/models/db/AutoArchiveTest.kt
@@ -99,8 +99,8 @@ class AutoArchiveTest {
 
     private fun podcastManagerThatReturns(podcast: Podcast): PodcastManager {
         return mock {
-            on { findPodcastByUuid(any()) } doReturn podcast
-            on { findSubscribed() } doReturn listOf(podcast)
+            on { findPodcastByUuidBlocking(any()) } doReturn podcast
+            on { findSubscribedBlocking() } doReturn listOf(podcast)
         }
     }
 

--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/models/db/PodcastManagerTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/models/db/PodcastManagerTest.kt
@@ -118,15 +118,15 @@ class PodcastManagerTest {
     @Test
     fun testSubscribeToExistingPodcast() {
         podcastDao.insertBlocking(Podcast(uuid, isSubscribed = true))
-        podcastManagerSignedOut.subscribeToPodcastRx(uuid, sync = false).blockingGet()
-        val subscribedList = podcastManagerSignedOut.getSubscribedPodcastUuids().blockingGet()
+        podcastManagerSignedOut.subscribeToPodcastRxSingle(uuid, sync = false).blockingGet()
+        val subscribedList = podcastManagerSignedOut.getSubscribedPodcastUuidsRxSingle().blockingGet()
         assertTrue("Podcast uuid should be subscribed", subscribedList.contains(uuid))
     }
 
     @Test
     fun testSubscribeToServerPodcast() {
-        podcastManagerSignedOut.subscribeToPodcastRx(uuid, sync = false).blockingGet()
-        val subscribedList = podcastManagerSignedOut.getSubscribedPodcastUuids().blockingGet()
+        podcastManagerSignedOut.subscribeToPodcastRxSingle(uuid, sync = false).blockingGet()
+        val subscribedList = podcastManagerSignedOut.getSubscribedPodcastUuidsRxSingle().blockingGet()
         assertTrue("Podcast uuid should be subscribed", subscribedList.contains(uuid))
     }
 
@@ -134,7 +134,7 @@ class PodcastManagerTest {
     fun testUnsubscribeSignedOut() {
         val playbackManager = mock<PlaybackManager> {}
         podcastDao.insertBlocking(Podcast(uuid, isSubscribed = true))
-        podcastManagerSignedOut.unsubscribe(uuid, playbackManager)
+        podcastManagerSignedOut.unsubscribeBlocking(uuid, playbackManager)
         val daoPodcast = podcastDao.findByUuidBlocking(uuid)
         assertTrue("Podcast should be null", daoPodcast == null)
     }
@@ -143,7 +143,7 @@ class PodcastManagerTest {
     fun testUnsubscribeSignedIn() {
         val playbackManager = mock<PlaybackManager> {}
         podcastDao.insertBlocking(Podcast(uuid, isSubscribed = true))
-        podcastManagerSignedIn.unsubscribe(uuid, playbackManager)
+        podcastManagerSignedIn.unsubscribeBlocking(uuid, playbackManager)
         val daoPodcast = podcastDao.findByUuidBlocking(uuid)
         assertTrue("Podcast should be unsubscribed", daoPodcast?.isSubscribed == false)
     }

--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/repositories/sync/PodcastSyncProcessTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/repositories/sync/PodcastSyncProcessTest.kt
@@ -82,7 +82,7 @@ class PodcastSyncProcessTest {
             val context = InstrumentationRegistry.getInstrumentation().targetContext
 
             val podcastManager: PodcastManager = mock()
-            whenever(podcastManager.findPodcastsToSync()).thenReturn(emptyList())
+            whenever(podcastManager.findPodcastsToSyncBlocking()).thenReturn(emptyList())
 
             val episodeManager: EpisodeManager = mock()
             whenever(episodeManager.findEpisodesToSyncBlocking()).thenReturn(emptyList())

--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/ui/PlaybackServiceTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/ui/PlaybackServiceTest.kt
@@ -89,8 +89,8 @@ class PlaybackServiceTest {
         }
         service.upNextQueue = upNextQueue
         val podcastManager = mock<PodcastManager> {
-            onBlocking { findPodcastByUuidSuspend(podcastOne.uuid) }.doReturn(podcastOne)
-            onBlocking { findPodcastByUuidSuspend(podcastTwo.uuid) }.doReturn(podcastTwo)
+            onBlocking { findPodcastByUuid(podcastOne.uuid) }.doReturn(podcastOne)
+            onBlocking { findPodcastByUuid(podcastTwo.uuid) }.doReturn(podcastTwo)
         }
         service.podcastManager = podcastManager
         val episodeManager = mock<EpisodeManager> {

--- a/app/src/main/java/au/com/shiftyjelly/pocketcasts/PocketCastsApplication.kt
+++ b/app/src/main/java/au/com/shiftyjelly/pocketcasts/PocketCastsApplication.kt
@@ -224,7 +224,7 @@ class PocketCastsApplication : Application(), Configuration.Provider {
 
                 // after the app is installed check it
                 if (isRestoreFromBackup) {
-                    val podcasts = podcastManager.findSubscribed()
+                    val podcasts = podcastManager.findSubscribedBlocking()
                     val restoredFromBackup = podcasts.isNotEmpty()
                     if (restoredFromBackup) {
                         // check to see if the episode files already exist

--- a/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivityViewModel.kt
+++ b/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivityViewModel.kt
@@ -152,7 +152,7 @@ class MainActivityViewModel
             val timeInSecs = bookmark?.timeSecs ?: currentEpisode?.let { playbackManager.getCurrentTimeMs(currentEpisode) / 1000 } ?: 0
 
             val podcast =
-                bookmark?.let { podcastManager.findPodcastByUuidSuspend(bookmark.podcastUuid) }
+                bookmark?.let { podcastManager.findPodcastByUuid(bookmark.podcastUuid) }
             val backgroundColor =
                 if (podcast == null) 0xFF000000.toInt() else theme.playerBackgroundColor(podcast)
             val tintColor =

--- a/automotive/src/androidTest/java/au/com/shiftyjelly/pocketcasts/AutoPlaybackServiceTest.kt
+++ b/automotive/src/androidTest/java/au/com/shiftyjelly/pocketcasts/AutoPlaybackServiceTest.kt
@@ -103,7 +103,7 @@ class AutoPlaybackServiceTest {
             val episode = PodcastEpisode(UUID.randomUUID().toString(), title = "Test episode", publishedDate = Date())
 
             service.playlistManager = mock { on { findByUuidBlocking(any()) }.doReturn(null) }
-            service.podcastManager = mock { on { runBlocking { findPodcastByUuidSuspend(any()) } }.doReturn(podcast) }
+            service.podcastManager = mock { on { runBlocking { findPodcastByUuid(any()) } }.doReturn(podcast) }
             service.episodeManager = mock { on { findEpisodesByPodcastOrderedBlocking(any()) }.doReturn(listOf(episode)) }
 
             val episodes = service.loadEpisodeChildren(podcast.uuid)

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/PromoCodeViewModel.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/PromoCodeViewModel.kt
@@ -37,7 +37,7 @@ class PromoCodeViewModel @Inject constructor(
     val state: MutableLiveData<ViewState> = MutableLiveData(ViewState.Loading)
 
     fun setup(code: String, context: Context) {
-        val signedInFlow = Single.defer<ViewState> { syncManager.redeemPromoCode(code).map { ViewState.Success(it) } }
+        val signedInFlow = Single.defer<ViewState> { syncManager.redeemPromoCodeRxSingle(code).map { ViewState.Success(it) } }
             .flatMap { viewState ->
                 subscriptionManager.getSubscriptionStatus(allowCache = false).map { viewState } // Force reloading of the new subscription status
             }
@@ -45,7 +45,7 @@ class PromoCodeViewModel @Inject constructor(
             .onErrorReturn(errorHandler(isSignedIn = true, resources = context.resources))
             .toFlowable()
 
-        val signedOutFlow = syncManager.validatePromoCode(code)
+        val signedOutFlow = syncManager.validatePromoCodeRxSingle(code)
             .observeOn(AndroidSchedulers.mainThread())
             .map<ViewState> { ViewState.NotSignedIn(it) }
             .onErrorReturn(errorHandler(isSignedIn = false, resources = context.resources))

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/recommendations/OnboardingRecommendationsSearchViewModel.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/recommendations/OnboardingRecommendationsSearchViewModel.kt
@@ -61,7 +61,7 @@ class OnboardingRecommendationsSearchViewModel @Inject constructor(
         viewModelScope.launch {
 
             val subscribedUuidFlow = podcastManager
-                .observeSubscribed()
+                .subscribedRxFlowable()
                 .asFlow()
                 .map { ls ->
                     ls.map { it.uuid }

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/OnboardingRecommendationsStartPageViewModel.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/OnboardingRecommendationsStartPageViewModel.kt
@@ -96,7 +96,7 @@ class OnboardingRecommendationsStartPageViewModel @Inject constructor(
             val sectionsFlow = MutableStateFlow<List<SectionInternal>>(emptyList())
             launch {
                 val subscriptionsFlow = podcastManager
-                    .observeSubscribed()
+                    .subscribedRxFlowable()
                     .asFlow()
                     .map { subscribed ->
                         subscribed.map { it.uuid }

--- a/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/viewmodel/DiscoverViewModel.kt
+++ b/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/viewmodel/DiscoverViewModel.kt
@@ -223,8 +223,8 @@ class DiscoverViewModel @Inject constructor(
     )
 
     private fun addSubscriptionStateToPodcasts(list: PodcastList): Flowable<PodcastList> {
-        return podcastManager.getSubscribedPodcastUuids().toFlowable() // Get the current subscribed list
-            .mergeWith(podcastManager.observePodcastSubscriptions()) // Get updated when it changes
+        return podcastManager.getSubscribedPodcastUuidsRxSingle().toFlowable() // Get the current subscribed list
+            .mergeWith(podcastManager.podcastSubscriptionsRxFlowable()) // Get updated when it changes
             .map { subscribedList ->
                 val updatedPodcasts = list.podcasts.map { podcast ->
                     val isSubscribed = subscribedList.contains(podcast.uuid)
@@ -276,7 +276,7 @@ class DiscoverViewModel @Inject constructor(
     }
 
     fun findOrDownloadEpisode(discoverEpisode: DiscoverEpisode, success: (episode: PodcastEpisode) -> Unit) {
-        podcastManager.findOrDownloadPodcastRx(discoverEpisode.podcast_uuid)
+        podcastManager.findOrDownloadPodcastRxSingle(discoverEpisode.podcast_uuid)
             .flatMapMaybe {
                 @Suppress("DEPRECATION")
                 episodeManager.findByUuidRxMaybe(discoverEpisode.uuid)

--- a/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/viewmodel/PodcastListViewModel.kt
+++ b/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/viewmodel/PodcastListViewModel.kt
@@ -112,8 +112,8 @@ class PodcastListViewModel @Inject constructor(
     }
 
     private fun addSubscriptionStateToFeed(feed: ListFeed): Flowable<ListFeed> {
-        return podcastManager.getSubscribedPodcastUuids().toFlowable() // Get the current subscribed list
-            .mergeWith(podcastManager.observePodcastSubscriptions()) // Get updated when it changes
+        return podcastManager.getSubscribedPodcastUuidsRxSingle().toFlowable() // Get the current subscribed list
+            .mergeWith(podcastManager.podcastSubscriptionsRxFlowable()) // Get updated when it changes
             .flatMap { subscribedList ->
                 val newPodcastList = feed.podcasts?.map { podcast ->
                     podcast.updateIsSubscribed(subscribedList.contains(podcast.uuid))
@@ -134,7 +134,7 @@ class PodcastListViewModel @Inject constructor(
     }
 
     fun findOrDownloadEpisode(discoverEpisode: DiscoverEpisode, success: (episode: PodcastEpisode) -> Unit) {
-        podcastManager.findOrDownloadPodcastRx(discoverEpisode.podcast_uuid)
+        podcastManager.findOrDownloadPodcastRxSingle(discoverEpisode.podcast_uuid)
             .flatMapMaybe {
                 rxMaybe {
                     episodeManager.findByUuid(discoverEpisode.uuid)

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/PodcastOptionsFragment.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/PodcastOptionsFragment.kt
@@ -79,7 +79,7 @@ class PodcastOptionsFragment : BaseFragment(), PodcastSelectFragment.Listener, C
         val btnClose = binding.btnClose
 
         launch {
-            val subscribedPodcasts = withContext(Dispatchers.Default) { podcastManager.findSubscribed() }.map { it.uuid }
+            val subscribedPodcasts = withContext(Dispatchers.Default) { podcastManager.findSubscribedBlocking() }.map { it.uuid }
             val playlistUuid = requireArguments().getString(ARG_PLAYLIST_UUID) ?: return@launch
             val playlist = playlistManager.findByUuid(playlistUuid) ?: return@launch
             this@PodcastOptionsFragment.playlist = playlist

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/BookmarksViewModel.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/BookmarksViewModel.kt
@@ -268,7 +268,7 @@ class BookmarksViewModel
     suspend fun getSharedBookmark(): Triple<Podcast, PodcastEpisode, Bookmark>? {
         return (_uiState.value as? UiState.Loaded)?.let {
             val bookmark = it.bookmarks.firstOrNull { bookmark -> multiSelectHelper.isSelected(bookmark) } ?: return null
-            val podcast = podcastManager.findPodcastByUuidSuspend(bookmark.podcastUuid) ?: return null
+            val podcast = podcastManager.findPodcastByUuid(bookmark.podcastUuid) ?: return null
             val episode = episodeManager.findEpisodeByUuid(bookmark.episodeUuid) as? PodcastEpisode ?: return null
             Triple(podcast, episode, bookmark)
         }
@@ -324,7 +324,7 @@ class BookmarksViewModel
             bookmark?.let {
                 val episodeUuid = bookmark.episodeUuid
                 viewModelScope.launch(ioDispatcher) {
-                    val podcast = podcastManager.findPodcastByUuidSuspend(bookmark.podcastUuid)
+                    val podcast = podcastManager.findPodcastByUuid(bookmark.podcastUuid)
                     val backgroundColor =
                         if (podcast == null) 0xFF000000.toInt() else theme.playerBackgroundColor(podcast)
                     val tintColor =

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/NotesViewModel.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/NotesViewModel.kt
@@ -63,7 +63,7 @@ class NotesViewModel
     private suspend fun loadPodcastAndShowNotes(episode: PodcastEpisode) {
         try {
             val podcastUuid = episode.podcastUuid
-            val podcast = podcastManager.findPodcastByUuidSuspend(podcastUuid)
+            val podcast = podcastManager.findPodcastByUuid(podcastUuid)
             if (podcast == null) {
                 showNotes.postValue(ShowNotesState.NotFound)
                 return

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/PlayerViewModel.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/PlayerViewModel.kt
@@ -236,7 +236,7 @@ class PlayerViewModel @Inject constructor(
         .switchMap { episodeManager.findEpisodeByUuidRxFlowable(it) }
         .switchMap {
             if (it is PodcastEpisode) {
-                podcastManager.observePodcastByUuid(it.podcastUuid)
+                podcastManager.podcastByUuidRxFlowable(it.podcastUuid)
             } else {
                 Flowable.just(Podcast.userPodcast.copy(overrideGlobalEffects = false))
             }
@@ -650,7 +650,7 @@ class PlayerViewModel @Inject constructor(
     fun saveEffects(effects: PlaybackEffects, podcast: Podcast) {
         launch {
             if (podcast.overrideGlobalEffects) {
-                podcastManager.updateEffects(podcast, effects)
+                podcastManager.updateEffectsBlocking(podcast, effects)
             } else {
                 settings.globalPlaybackEffects.set(effects, updateModifiedAt = true)
             }
@@ -664,7 +664,7 @@ class PlayerViewModel @Inject constructor(
         if (!isCurrentPodcast) return
         viewModelScope.launch(ioDispatcher) {
             val override = selectedTab == PlaybackEffectsSettingsTab.ThisPodcast
-            podcastManager.updateOverrideGlobalEffects(podcast, override)
+            podcastManager.updateOverrideGlobalEffectsBlocking(podcast, override)
 
             val effects = if (override) podcast.playbackEffects else settings.globalPlaybackEffects.value
             podcast.overrideGlobalEffects = override
@@ -675,7 +675,7 @@ class PlayerViewModel @Inject constructor(
 
     fun clearPodcastEffects(podcast: Podcast) {
         launch {
-            podcastManager.updateOverrideGlobalEffects(podcast, false)
+            podcastManager.updateOverrideGlobalEffectsBlocking(podcast, false)
             playbackManager.updatePlayerEffects(settings.globalPlaybackEffects.value)
         }
     }

--- a/modules/features/player/src/test/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/PlayerViewModelTest.kt
+++ b/modules/features/player/src/test/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/PlayerViewModelTest.kt
@@ -212,7 +212,7 @@ class PlayerViewModelTest {
 
         viewModel.onEffectsSettingsSegmentedTabSelected(podcast, PlaybackEffectsSettingsTab.AllPodcasts)
 
-        verify(podcastManager).updateOverrideGlobalEffects(podcast, false)
+        verify(podcastManager).updateOverrideGlobalEffectsBlocking(podcast, false)
     }
 
     @Test
@@ -221,7 +221,7 @@ class PlayerViewModelTest {
 
         viewModel.onEffectsSettingsSegmentedTabSelected(podcast, PlaybackEffectsSettingsTab.ThisPodcast)
 
-        verify(podcastManager).updateOverrideGlobalEffects(podcast, true)
+        verify(podcastManager).updateOverrideGlobalEffectsBlocking(podcast, true)
     }
 
     @Test
@@ -271,7 +271,7 @@ class PlayerViewModelTest {
         whenever(playbackManager.getCurrentEpisode()).thenReturn(currentEpisode)
         whenever(episodeManager.findEpisodeByUuidRxFlowable(anyOrNull())).thenReturn(Flowable.just(currentEpisode))
         whenever(podcast.playbackEffects).thenReturn(podcastPlaybackEffects)
-        whenever(podcastManager.observePodcastByUuid(anyOrNull())).thenReturn(Flowable.just(podcast))
+        whenever(podcastManager.podcastByUuidRxFlowable(anyOrNull())).thenReturn(Flowable.just(podcast))
         val useRealTimeForPlaybackRemainingTimeMock = mock<UserSetting<Boolean>>()
         whenever(useRealTimeForPlaybackRemainingTimeMock.flow).thenReturn(MutableStateFlow(false))
         whenever(settings.useRealTimeForPlaybackRemaingTime).thenReturn(useRealTimeForPlaybackRemainingTimeMock)

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/episode/EpisodeFragmentViewModel.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/episode/EpisodeFragmentViewModel.kt
@@ -95,7 +95,7 @@ class EpisodeFragmentViewModel @Inject constructor(
         // If we can't find it in the database and we know the podcast uuid we can try load it
         // from the server
         val onEmptyHandler = if (podcastUuid != null) {
-            podcastManager.findOrDownloadPodcastRx(podcastUuid).flatMapMaybe {
+            podcastManager.findOrDownloadPodcastRxSingle(podcastUuid).flatMapMaybe {
                 val episode = it.episodes.find { episode -> episode.uuid == episodeUuid }
                 if (episode != null) {
                     Maybe.just(episode)
@@ -126,7 +126,7 @@ class EpisodeFragmentViewModel @Inject constructor(
                 }
                 return@flatMapPublisher Flowable.combineLatest(
                     episodeManager.findByUuidFlow(episodeUuid).asFlowable(),
-                    podcastManager.findPodcastByUuidRx(episode.podcastUuid).toFlowable(),
+                    podcastManager.findPodcastByUuidRxMaybe(episode.podcastUuid).toFlowable(),
                     showNotesManager.loadShowNotesFlow(podcastUuid = episode.podcastUuid, episodeUuid = episode.uuid).asFlowable(),
                     progressUpdatesObservable,
                     zipper,

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/folders/FolderEditViewModel.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/folders/FolderEditViewModel.kt
@@ -91,9 +91,9 @@ class FolderEditViewModel
                     .toFlowable(BackpressureStrategy.LATEST)
                     .switchMap { podcastSortOrder ->
                         if (podcastSortOrder == PodcastsSortType.EPISODE_DATE_NEWEST_TO_OLDEST) {
-                            podcastManager.observePodcastsOrderByLatestEpisode()
+                            podcastManager.podcastsOrderByLatestEpisodeRxFlowable()
                         } else {
-                            podcastManager.observeSubscribed()
+                            podcastManager.subscribedRxFlowable()
                         }
                     }
                     .asFlow<List<Podcast>>(),
@@ -288,7 +288,7 @@ class FolderEditViewModel
 
     fun loadFolderForPodcast(podcastUuid: String) {
         viewModelScope.launch {
-            folderUuid.value = Optional.ofNullable(podcastManager.findPodcastByUuidSuspend(podcastUuid)?.folderUuid)
+            folderUuid.value = Optional.ofNullable(podcastManager.findPodcastByUuid(podcastUuid)?.folderUuid)
         }
     }
 

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastAutoArchiveViewModel.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastAutoArchiveViewModel.kt
@@ -27,7 +27,7 @@ class PodcastAutoArchiveViewModel @AssistedInject constructor(
     private val analyticsTracker: AnalyticsTracker,
 ) : ViewModel() {
     val state = combine(
-        podcastManager.observePodcastByUuidFlow(podcastUuid),
+        podcastManager.podcastByUuidFlow(podcastUuid),
         settings.autoArchiveAfterPlaying.flow,
         settings.autoArchiveInactive.flow,
     ) { podcast, archiveAfterPlaying, archiveInactive ->

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastFragment.kt
@@ -207,7 +207,7 @@ class PodcastFragment : BaseFragment(), Toolbar.OnMenuItemClickListener {
 
     private val onUnsubscribeClicked: (successCallback: () -> Unit) -> Unit = { successCallback ->
         lifecycleScope.launch {
-            val downloaded = withContext(Dispatchers.Default) { podcastManager.countEpisodesInPodcastWithStatus(podcastUuid, EpisodeStatusEnum.DOWNLOADED) }
+            val downloaded = withContext(Dispatchers.Default) { podcastManager.countEpisodesInPodcastWithStatusBlocking(podcastUuid, EpisodeStatusEnum.DOWNLOADED) }
             val title = when (downloaded) {
                 0 -> getString(LR.string.are_you_sure)
                 1 -> getString(LR.string.podcast_unsubscribe_downloaded_file_singular)

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastSettingsFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastSettingsFragment.kt
@@ -370,7 +370,7 @@ class PodcastSettingsFragment : BasePreferenceFragment(), FilterSelectFragment.L
         preferenceUnsubscribe?.setOnPreferenceClickListener {
             lifecycleScope.launch {
                 val resources = context?.resources ?: return@launch
-                val downloaded = withContext(Dispatchers.Default) { podcastManager.countEpisodesInPodcastWithStatus(podcastUuid, EpisodeStatusEnum.DOWNLOADED) }
+                val downloaded = withContext(Dispatchers.Default) { podcastManager.countEpisodesInPodcastWithStatusBlocking(podcastUuid, EpisodeStatusEnum.DOWNLOADED) }
                 val title = when (downloaded) {
                     0 -> resources.getString(LR.string.are_you_sure)
                     1 -> resources.getString(LR.string.podcast_unsubscribe_downloaded_file_singular)

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/share/ShareListIncomingViewModel.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/share/ShareListIncomingViewModel.kt
@@ -29,10 +29,10 @@ class ShareListIncomingViewModel
     var isFragmentChangingConfigurations: Boolean = false
     val share = MutableLiveData<ShareState>()
     val subscribedUuids =
-        podcastManager.getSubscribedPodcastUuids()
+        podcastManager.getSubscribedPodcastUuidsRxSingle()
             .subscribeOn(Schedulers.io())
             .toFlowable()
-            .mergeWith(podcastManager.observePodcastSubscriptions())
+            .mergeWith(podcastManager.podcastSubscriptionsRxFlowable())
             .toLiveData()
 
     override val coroutineContext: CoroutineContext
@@ -53,7 +53,7 @@ class ShareListIncomingViewModel
 
     fun subscribeToPodcast(uuid: String) {
         launch {
-            val podcast = podcastManager.findPodcastByUuid(uuid)
+            val podcast = podcastManager.findPodcastByUuidBlocking(uuid)
             if (podcast == null || !podcast.isSubscribed) {
                 podcastManager.subscribeToPodcast(uuid, true)
             }

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/GiveRatingViewModel.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/GiveRatingViewModel.kt
@@ -100,7 +100,7 @@ class GiveRatingViewModel @Inject constructor(
         viewModelScope.launch {
             _state.value = State.Loading
 
-            val podcast = podcastManager.findPodcastByUuidSuspend(podcastUuid)
+            val podcast = podcastManager.findPodcastByUuid(podcastUuid)
 
             if (podcast == null) {
                 _state.value = State.ErrorWhenLoadingPodcast

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/PodcastEffectsViewModel.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/PodcastEffectsViewModel.kt
@@ -40,7 +40,7 @@ class PodcastEffectsViewModel
 
     fun loadPodcast(uuid: String) {
         podcast = podcastManager
-            .observePodcastByUuid(uuid)
+            .podcastByUuidRxFlowable(uuid)
             .subscribeOn(Schedulers.io())
             .toLiveData()
     }
@@ -48,7 +48,7 @@ class PodcastEffectsViewModel
     fun updateOverrideGlobalEffects(override: Boolean) {
         val podcast = this.podcast.value ?: return
         launch {
-            podcastManager.updateOverrideGlobalEffects(podcast, override)
+            podcastManager.updateOverrideGlobalEffectsBlocking(podcast, override)
             if (shouldUpdatePlaybackManager()) {
                 val effects = if (override) podcast.playbackEffects else settings.globalPlaybackEffects.value
                 playbackManager.updatePlayerEffects(effects)
@@ -59,7 +59,7 @@ class PodcastEffectsViewModel
     fun updateTrimSilence(trimMode: TrimMode) {
         val podcast = this.podcast.value ?: return
         launch {
-            podcastManager.updateTrimMode(podcast, trimMode)
+            podcastManager.updateTrimModeBlocking(podcast, trimMode)
             if (shouldUpdatePlaybackManager()) {
                 playbackManager.updatePlayerEffects(podcast.playbackEffects)
             }
@@ -69,7 +69,7 @@ class PodcastEffectsViewModel
     fun updateBoostVolume(boostVolume: Boolean) {
         val podcast = this.podcast.value ?: return
         launch {
-            podcastManager.updateVolumeBoosted(podcast, boostVolume)
+            podcastManager.updateVolumeBoostedBlocking(podcast, boostVolume)
             if (shouldUpdatePlaybackManager()) {
                 playbackManager.updatePlayerEffects(podcast.playbackEffects)
             }
@@ -93,7 +93,7 @@ class PodcastEffectsViewModel
     private fun changePlaybackSpeed(speed: Double) {
         val podcast = this.podcast.value ?: return
         val roundedSpeed = speed.roundedSpeed()
-        podcastManager.updatePlaybackSpeed(podcast, roundedSpeed)
+        podcastManager.updatePlaybackSpeedBlocking(podcast, roundedSpeed)
         if (shouldUpdatePlaybackManager()) {
             playbackManager.updatePlayerEffects(podcast.playbackEffects)
         }

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/PodcastSettingsViewModel.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/PodcastSettingsViewModel.kt
@@ -50,7 +50,7 @@ class PodcastSettingsViewModel @Inject constructor(
     fun loadPodcast(uuid: String) {
         this.podcastUuid = uuid
         podcast = podcastManager
-            .observePodcastByUuid(uuid)
+            .podcastByUuidRxFlowable(uuid)
             .subscribeOn(Schedulers.io())
             .toLiveData()
 
@@ -88,14 +88,14 @@ class PodcastSettingsViewModel @Inject constructor(
         val podcast = this.podcast.value ?: return
         launch {
             val autoDownloadStatus = if (download) Podcast.AUTO_DOWNLOAD_NEW_EPISODES else Podcast.AUTO_DOWNLOAD_OFF
-            podcastManager.updateAutoDownloadStatus(podcast, autoDownloadStatus)
+            podcastManager.updateAutoDownloadStatusBlocking(podcast, autoDownloadStatus)
         }
     }
 
     fun showNotifications(show: Boolean) {
         val podcast = this.podcast.value ?: return
         launch {
-            podcastManager.updateShowNotifications(podcast, show)
+            podcastManager.updateShowNotificationsBlocking(podcast, show)
         }
     }
 
@@ -117,7 +117,7 @@ class PodcastSettingsViewModel @Inject constructor(
     fun unsubscribe() {
         val podcast = this.podcast.value ?: return
         launch {
-            podcastManager.unsubscribe(podcast.uuid, playbackManager)
+            podcastManager.unsubscribeBlocking(podcast.uuid, playbackManager)
             analyticsTracker.track(
                 AnalyticsEvent.PODCAST_UNSUBSCRIBED,
                 AnalyticsProp.podcastUnsubscribed(SourceView.PODCAST_SETTINGS, podcast.uuid),

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/PodcastsViewModel.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/PodcastsViewModel.kt
@@ -60,7 +60,7 @@ class PodcastsViewModel
 
     val folderState: LiveData<FolderState> = combineLatest(
         // monitor all subscribed podcasts, get the podcast in 'Episode release date' as the rest can be done in memory
-        podcastManager.observePodcastsOrderByLatestEpisode(),
+        podcastManager.podcastsOrderByLatestEpisodeRxFlowable(),
         // monitor all the folders
         folderManager.observeFolders()
             .switchMap { folders ->
@@ -70,7 +70,7 @@ class PodcastsViewModel
                     // monitor the folder podcasts
                     val observeFolderPodcasts = folders.map { folder ->
                         podcastManager
-                            .observePodcastsInFolderOrderByUserChoice(folder)
+                            .podcastsInFolderOrderByUserChoiceRxFlowable(folder)
                             .map { podcasts ->
                                 FolderItem.Folder(
                                     folder = folder,

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/AccountDetailsViewModel.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/AccountDetailsViewModel.kt
@@ -154,7 +154,7 @@ class AccountDetailsViewModel
     fun deleteAccount() {
         viewModelScope.launch {
             try {
-                val response = withContext(Dispatchers.IO) { syncManager.deleteAccount().await() }
+                val response = withContext(Dispatchers.IO) { syncManager.deleteAccountRxSingle().await() }
                 val success = response.success ?: false
                 deleteAccountState.value = if (success) {
                     DeleteAccountState.Success("OK")

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/ProfileViewModel.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/ProfileViewModel.kt
@@ -81,7 +81,7 @@ class ProfileViewModel @Inject constructor(
 
     internal val profileStatsState = combine(
         refreshStatsTrigger.onStart { emit(Unit) },
-        podcastManager.observeCountSubscribed().asFlow(),
+        podcastManager.countSubscribedRxFlowable().asFlow(),
     ) { _, count ->
         ProfileStatsState(
             podcastsCount = count,

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/cloud/AddFileViewModel.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/cloud/AddFileViewModel.kt
@@ -23,7 +23,7 @@ class AddFileViewModel @Inject constructor(
     val signInState: LiveData<SignInState> = userManager.getSignInState().toLiveData()
 
     suspend fun updateImageOnServer(userEpisode: UserEpisode, imageFile: File) = withContext(Dispatchers.IO) {
-        userEpisodeManager.uploadImageToServer(userEpisode, imageFile).await()
+        userEpisodeManager.uploadImageToServerRxCompletable(userEpisode, imageFile).await()
     }
 
     suspend fun updateFileMetadataOnServer(userEpisode: UserEpisode) {

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/cloud/CloudBottomSheetViewModel.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/cloud/CloudBottomSheetViewModel.kt
@@ -47,7 +47,7 @@ class CloudBottomSheetViewModel @Inject constructor(
     fun setup(uuid: String) {
         val isPlayingFlowable = playbackManager.playbackStateRelay.filter { it.episodeUuid == uuid }.map { it.isPlaying }.startWith(false).toFlowable(BackpressureStrategy.LATEST)
         val inUpNextFlowable = playbackManager.upNextQueue.changesObservable.containsUuid(uuid).toFlowable(BackpressureStrategy.LATEST)
-        val episodeFlowable = userEpisodeManager.observeEpisodeRx(uuid)
+        val episodeFlowable = userEpisodeManager.episodeRxFlowable(uuid)
         val combined = Flowables.combineLatest(episodeFlowable, inUpNextFlowable, isPlayingFlowable) { episode, inUpNext, isPlaying ->
             BottomSheetState(episode, inUpNext, isPlaying)
         }

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/cloud/CloudFilesViewModel.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/cloud/CloudFilesViewModel.kt
@@ -33,7 +33,7 @@ class CloudFilesViewModel @Inject constructor(
     private val bookmarkManager: BookmarkManager,
 ) : ViewModel() {
 
-    val accountUsage = userEpisodeManager.observeAccountUsage().toLiveData()
+    val accountUsage = userEpisodeManager.accountUsageRxFlowable().toLiveData()
     val signInState = userManager.getSignInState().toLiveData()
 
     data class UiState(

--- a/modules/features/reimagine/src/main/kotlin/au/com/shiftyjelly/pocketcasts/reimagine/ShareViewModel.kt
+++ b/modules/features/reimagine/src/main/kotlin/au/com/shiftyjelly/pocketcasts/reimagine/ShareViewModel.kt
@@ -43,7 +43,7 @@ class ShareViewModel @AssistedInject constructor(
         }
     } else {
         combine(
-            podcastManager.observePodcastByUuidFlow(initialPodcast.uuid),
+            podcastManager.podcastByUuidFlow(initialPodcast.uuid),
             episodeManager.findEpisodeByUuidFlow(initialEpisode.uuid),
             ::UiState,
         )

--- a/modules/features/reimagine/src/main/kotlin/au/com/shiftyjelly/pocketcasts/reimagine/clip/ShareClipViewModel.kt
+++ b/modules/features/reimagine/src/main/kotlin/au/com/shiftyjelly/pocketcasts/reimagine/clip/ShareClipViewModel.kt
@@ -51,7 +51,7 @@ class ShareClipViewModel @AssistedInject constructor(
 
     val uiState = combine(
         episodeManager.findByUuidFlow(episodeUuid),
-        podcastManager.observePodcastByEpisodeUuid(episodeUuid),
+        podcastManager.podcastByEpisodeUuidFlow(episodeUuid),
         clipRange,
         settings.artworkConfiguration.flow.map { it.useEpisodeArtwork },
         clipPlayer.playbackProgress,

--- a/modules/features/reimagine/src/main/kotlin/au/com/shiftyjelly/pocketcasts/reimagine/episode/ShareEpisodeViewModel.kt
+++ b/modules/features/reimagine/src/main/kotlin/au/com/shiftyjelly/pocketcasts/reimagine/episode/ShareEpisodeViewModel.kt
@@ -30,7 +30,7 @@ class ShareEpisodeViewModel @AssistedInject constructor(
     private val tracker: AnalyticsTracker,
 ) : ViewModel() {
     val uiState = combine(
-        podcastManager.observePodcastByEpisodeUuid(episodeUuid),
+        podcastManager.podcastByEpisodeUuidFlow(episodeUuid),
         episodeManager.findByUuidFlow(episodeUuid),
         settings.artworkConfiguration.flow.map { it.useEpisodeArtwork },
         ::UiState,

--- a/modules/features/reimagine/src/main/kotlin/au/com/shiftyjelly/pocketcasts/reimagine/podcast/SharePodcastViewModel.kt
+++ b/modules/features/reimagine/src/main/kotlin/au/com/shiftyjelly/pocketcasts/reimagine/podcast/SharePodcastViewModel.kt
@@ -23,8 +23,8 @@ class SharePodcastViewModel @AssistedInject constructor(
     private val tracker: AnalyticsTracker,
 ) : ViewModel() {
     val uiState = combine(
-        podcastManager.observePodcastByUuidFlow(podcastUuid),
-        podcastManager.observeEpisodeCountByPodcatUuid(podcastUuid),
+        podcastManager.podcastByUuidFlow(podcastUuid),
+        podcastManager.episodeCountByPodcatUuidFlow(podcastUuid),
         ::UiState,
     ).stateIn(viewModelScope, started = SharingStarted.Lazily, initialValue = UiState())
 

--- a/modules/features/reimagine/src/main/kotlin/au/com/shiftyjelly/pocketcasts/reimagine/timestamp/ShareEpisodeTimestampViewModel.kt
+++ b/modules/features/reimagine/src/main/kotlin/au/com/shiftyjelly/pocketcasts/reimagine/timestamp/ShareEpisodeTimestampViewModel.kt
@@ -30,7 +30,7 @@ class ShareEpisodeTimestampViewModel @AssistedInject constructor(
     private val tracker: AnalyticsTracker,
 ) : ViewModel() {
     val uiState = combine(
-        podcastManager.observePodcastByEpisodeUuid(episodeUuid),
+        podcastManager.podcastByEpisodeUuidFlow(episodeUuid),
         episodeManager.findByUuidFlow(episodeUuid),
         settings.artworkConfiguration.flow.map { it.useEpisodeArtwork },
         ::UiState,

--- a/modules/features/reimagine/src/test/kotlin/au/com/shiftyjelly/pocketcasts/reimagine/clip/ShareClipViewModelTest.kt
+++ b/modules/features/reimagine/src/test/kotlin/au/com/shiftyjelly/pocketcasts/reimagine/clip/ShareClipViewModelTest.kt
@@ -63,7 +63,7 @@ class ShareClipViewModelTest {
     @Before
     fun setUp() {
         whenever(episodeManager.findByUuidFlow("episode-id")).thenReturn(flowOf(episode))
-        whenever(podcastManager.observePodcastByEpisodeUuid("episode-id")).thenReturn(flowOf(podcast))
+        whenever(podcastManager.podcastByEpisodeUuidFlow("episode-id")).thenReturn(flowOf(podcast))
         val artworkSetting = mock<UserSetting<ArtworkConfiguration>>()
         whenever(artworkSetting.flow).thenReturn(MutableStateFlow(ArtworkConfiguration(useEpisodeArtwork = true)))
         whenever(settings.artworkConfiguration).thenReturn(artworkSetting)

--- a/modules/features/reimagine/src/test/kotlin/au/com/shiftyjelly/pocketcasts/reimagine/episode/ShareEpisodeViewModelTest.kt
+++ b/modules/features/reimagine/src/test/kotlin/au/com/shiftyjelly/pocketcasts/reimagine/episode/ShareEpisodeViewModelTest.kt
@@ -45,7 +45,7 @@ class ShareEpisodeViewModelTest {
     @Before
     fun setUp() {
         whenever(episodeManager.findByUuidFlow("episode-id")).thenReturn(flowOf(episode))
-        whenever(podcastManager.observePodcastByEpisodeUuid("episode-id")).thenReturn(flowOf(podcast))
+        whenever(podcastManager.podcastByEpisodeUuidFlow("episode-id")).thenReturn(flowOf(podcast))
         val artworkSetting = mock<UserSetting<ArtworkConfiguration>>()
         whenever(artworkSetting.flow).thenReturn(MutableStateFlow(ArtworkConfiguration(useEpisodeArtwork = true)))
         whenever(settings.artworkConfiguration).thenReturn(artworkSetting)

--- a/modules/features/reimagine/src/test/kotlin/au/com/shiftyjelly/pocketcasts/reimagine/podcast/SharePodcastViewModelTest.kt
+++ b/modules/features/reimagine/src/test/kotlin/au/com/shiftyjelly/pocketcasts/reimagine/podcast/SharePodcastViewModelTest.kt
@@ -34,8 +34,8 @@ class SharePodcastViewModelTest {
 
     @Before
     fun setUp() {
-        whenever(podcastManager.observePodcastByUuidFlow("podcast-id")).thenReturn(flowOf(podcast))
-        whenever(podcastManager.observeEpisodeCountByPodcatUuid("podcast-id")).thenReturn(flowOf(50))
+        whenever(podcastManager.podcastByUuidFlow("podcast-id")).thenReturn(flowOf(podcast))
+        whenever(podcastManager.episodeCountByPodcatUuidFlow("podcast-id")).thenReturn(flowOf(50))
 
         viewModel = SharePodcastViewModel(
             podcast.uuid,

--- a/modules/features/reimagine/src/test/kotlin/au/com/shiftyjelly/pocketcasts/reimagine/timestamp/ShareEpisodeTimestampViewModelTest.kt
+++ b/modules/features/reimagine/src/test/kotlin/au/com/shiftyjelly/pocketcasts/reimagine/timestamp/ShareEpisodeTimestampViewModelTest.kt
@@ -45,7 +45,7 @@ class ShareEpisodeTimestampViewModelTest {
     @Before
     fun setUp() {
         whenever(episodeManager.findByUuidFlow("episode-id")).thenReturn(flowOf(episode))
-        whenever(podcastManager.observePodcastByEpisodeUuid("episode-id")).thenReturn(flowOf(podcast))
+        whenever(podcastManager.podcastByEpisodeUuidFlow("episode-id")).thenReturn(flowOf(podcast))
         val artworkSetting = mock<UserSetting<ArtworkConfiguration>>()
         whenever(artworkSetting.flow).thenReturn(MutableStateFlow(ArtworkConfiguration(useEpisodeArtwork = true)))
         whenever(settings.artworkConfiguration).thenReturn(artworkSetting)

--- a/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/SearchHandler.kt
+++ b/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/SearchHandler.kt
@@ -68,7 +68,7 @@ class SearchHandler @Inject constructor(
                             .filter { it.name.contains(query, ignoreCase = true) }
                             .switchMapSingle { folder ->
                                 podcastManager
-                                    .findPodcastsInFolderSingle(folderUuid = folder.uuid)
+                                    .findPodcastsInFolderRxSingle(folderUuid = folder.uuid)
                                     .map { podcasts -> FolderItem.Folder(folder = folder, podcasts = podcasts) }
                             }
                             .toList()
@@ -77,7 +77,7 @@ class SearchHandler @Inject constructor(
                     }
 
                 // search podcasts
-                val podcastSearch = podcastManager.findSubscribedRx()
+                val podcastSearch = podcastManager.findSubscribedRxSingle()
                     .subscribeOn(Schedulers.io())
                     .flatMapObservable { Observable.fromIterable(it) }
                     .filter { it.title.contains(query, ignoreCase = true) || it.author.contains(query, ignoreCase = true) }
@@ -96,7 +96,7 @@ class SearchHandler @Inject constructor(
         }
 
     private val subscribedPodcastUuids = podcastManager
-        .findSubscribedRx()
+        .findSubscribedRxSingle()
         .subscribeOn(Schedulers.io())
         .toObservable()
         .map { podcasts -> podcasts.map(Podcast::uuid).toHashSet() }

--- a/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/SearchViewModel.kt
+++ b/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/SearchViewModel.kt
@@ -59,7 +59,7 @@ class SearchViewModel @Inject constructor(
 
         viewModelScope.launch {
             val subscribedUuidFlow = podcastManager
-                .observeSubscribed()
+                .subscribedRxFlowable()
                 .asFlow()
                 .map { ls ->
                     ls.map { it.uuid }

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/NotificationsSettingsFragment.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/NotificationsSettingsFragment.kt
@@ -183,8 +183,8 @@ class NotificationsSettingsFragment :
 
     override fun podcastSelectFragmentSelectionChanged(newSelection: List<String>) {
         launch(Dispatchers.Default) {
-            podcastManager.findSubscribed().forEach {
-                podcastManager.updateShowNotifications(it, newSelection.contains(it.uuid))
+            podcastManager.findSubscribedBlocking().forEach {
+                podcastManager.updateShowNotificationsBlocking(it, newSelection.contains(it.uuid))
             }
         }
     }
@@ -192,7 +192,7 @@ class NotificationsSettingsFragment :
     override fun podcastSelectFragmentGetCurrentSelection(): List<String> {
         return runBlocking {
             async(Dispatchers.Default) {
-                val uuids = podcastManager.findSubscribed().filter { it.isShowNotifications }.map { it.uuid }
+                val uuids = podcastManager.findSubscribedBlocking().filter { it.isShowNotifications }.map { it.uuid }
                 uuids
             }.await()
         }

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/PlaybackSettingsFragment.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/PlaybackSettingsFragment.kt
@@ -694,7 +694,7 @@ class PlaybackSettingsFragment : BaseFragment() {
             .setIconId(R.drawable.ic_podcasts)
             .setOnConfirm {
                 applicationScope.launch {
-                    podcastManager.updateGroupingForAll(grouping)
+                    podcastManager.updateGroupingForAllBlocking(grouping)
                 }
             }
             .show(parentFragmentManager, "podcast_grouping_set_all_warning")

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/developer/DeveloperViewModel.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/developer/DeveloperViewModel.kt
@@ -41,7 +41,7 @@ class DeveloperViewModel
     fun triggerNotification() {
         viewModelScope.launch(Dispatchers.IO) {
             try {
-                val podcasts = podcastManager.findSubscribed()
+                val podcasts = podcastManager.findSubscribedBlocking()
                 val countNotificationsOn = podcasts.count { it.isShowNotifications }
                 if (countNotificationsOn == 0) {
                     withContext(Dispatchers.Main) {
@@ -58,7 +58,7 @@ class DeveloperViewModel
                                 val episode = episodes[1]
                                 // link the second oldest to the podcast
                                 episodeManager.markAsNotPlayedBlocking(episode)
-                                podcastManager.updateLatestEpisode(podcast, episode)
+                                podcastManager.updateLatestEpisodeBlocking(podcast, episode)
                                 // remove the latest episode
                                 val episodeToDelete = episodes[0]
                                 Timber.i("Creating a notification for ${podcast.title} - ${episodeToDelete.title}")
@@ -85,7 +85,7 @@ class DeveloperViewModel
     fun deleteFirstEpisode() {
         viewModelScope.launch(Dispatchers.IO) {
             try {
-                val podcasts = podcastManager.findSubscribed()
+                val podcasts = podcastManager.findSubscribedBlocking()
                 for (podcast in podcasts) {
                     // find first podcast with more than one episode
                     val episodes = episodeManager.findEpisodesByPodcastOrderedByPublishDateBlocking(podcast)
@@ -100,7 +100,7 @@ class DeveloperViewModel
 
                         podcast.latestEpisodeUuid = newLatest?.uuid
                         podcast.latestEpisodeDate = newLatest?.publishedDate
-                        podcastManager.updatePodcast(podcast)
+                        podcastManager.updatePodcastBlocking(podcast)
 
                         continue
                     }

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/viewmodel/AutoAddSettingsViewModel.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/viewmodel/AutoAddSettingsViewModel.kt
@@ -39,7 +39,7 @@ class AutoAddSettingsViewModel @Inject constructor(
     }
 
     val autoAddPodcasts =
-        podcastManager.observeAutoAddToUpNextPodcasts()
+        podcastManager.autoAddToUpNextPodcastsRxFlowable()
             .combineLatest(
                 settings.autoAddUpNextLimit.flow
                     .asObservable(viewModelScope.coroutineContext)

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/viewmodel/AutoDownloadSettingsViewModel.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/viewmodel/AutoDownloadSettingsViewModel.kt
@@ -88,7 +88,7 @@ class AutoDownloadSettingsViewModel @Inject constructor(
 
     fun clearDownloadErrors() {
         launch {
-            podcastManager.clearAllDownloadErrors()
+            podcastManager.clearAllDownloadErrorsBlocking()
         }
         analyticsTracker.track(AnalyticsEvent.SETTINGS_AUTO_DOWNLOAD_CLEAR_DOWNLOAD_ERRORS)
     }

--- a/modules/features/taskerplugin/src/main/java/au/com/shiftyjelly/pocketcasts/taskerplugin/controlplayback/ActionRunnerControlPlayback.kt
+++ b/modules/features/taskerplugin/src/main/java/au/com/shiftyjelly/pocketcasts/taskerplugin/controlplayback/ActionRunnerControlPlayback.kt
@@ -84,7 +84,7 @@ class ActionRunnerControlPlayback : TaskerPluginRunnerActionNoOutput<InputContro
         }
         playbackEffects.updater()
         if (overrideGlobalEffects) {
-            podcastManager.updateEffects(currentPodcast, playbackEffects)
+            podcastManager.updateEffectsBlocking(currentPodcast, playbackEffects)
         } else {
             settings.globalPlaybackEffects.set(playbackEffects, updateModifiedAt = true)
         }

--- a/modules/features/taskerplugin/src/main/java/au/com/shiftyjelly/pocketcasts/taskerplugin/querypodcastepisodes/ActionRunnerQueryPodcastEpisodes.kt
+++ b/modules/features/taskerplugin/src/main/java/au/com/shiftyjelly/pocketcasts/taskerplugin/querypodcastepisodes/ActionRunnerQueryPodcastEpisodes.kt
@@ -16,7 +16,7 @@ class ActionRunnerQueryPodcastEpisodes : TaskerPluginRunnerAction<InputQueryPodc
         val podcastManager = context.podcastManager
         val titleOrId = input.regular.titleOrId.nullIfEmpty ?: return TaskerPluginResultSucess()
 
-        val podcast = podcastManager.findSubscribed().firstOrNull { it.title.lowercase().contains(titleOrId.trim().lowercase()) || it.uuid == titleOrId } ?: return TaskerPluginResultSucess(arrayOf())
+        val podcast = podcastManager.findSubscribedBlocking().firstOrNull { it.title.lowercase().contains(titleOrId.trim().lowercase()) || it.uuid == titleOrId } ?: return TaskerPluginResultSucess(arrayOf())
         val episodes = context.episodeManager.findEpisodesByPodcastOrderedBlocking(podcast).take(50)
         val output = episodes.map { OutputQueryEpisodes(it) }.toTypedArray()
         return TaskerPluginResultSucess(output)

--- a/modules/features/taskerplugin/src/main/java/au/com/shiftyjelly/pocketcasts/taskerplugin/querypodcasts/ActionRunnerQueryPodcasts.kt
+++ b/modules/features/taskerplugin/src/main/java/au/com/shiftyjelly/pocketcasts/taskerplugin/querypodcasts/ActionRunnerQueryPodcasts.kt
@@ -13,7 +13,7 @@ class ActionRunnerQueryPodcasts : TaskerPluginRunnerAction<InputQueryPodcasts, A
 
     override fun run(context: Context, input: TaskerInput<InputQueryPodcasts>): TaskerPluginResult<Array<OutputQueryPodcasts>> {
         val podcastManager = context.podcastManager
-        val output = podcastManager.findSubscribed().filter { it.isSubscribed }.map {
+        val output = podcastManager.findSubscribedBlocking().filter { it.isSubscribed }.map {
             OutputQueryPodcasts(it.uuid, it.title.formattedForTasker, it.author.formattedForTasker, it.podcastUrl, it.thumbnailUrl ?: PodcastImage.getArtworkUrl(480, it.uuid), it.podcastCategory.formattedForTasker, it.addedDate?.formattedForTasker, it.latestEpisodeDate?.formattedForTasker)
         }.toTypedArray()
         return TaskerPluginResultSucess(output)

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/PodcastDao.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/PodcastDao.kt
@@ -119,7 +119,7 @@ abstract class PodcastDao {
     abstract fun findByUuidBlocking(uuid: String): Podcast?
 
     @Query("SELECT * FROM podcasts WHERE uuid = :uuid")
-    abstract suspend fun findPodcastByUuidSuspend(uuid: String): Podcast?
+    abstract suspend fun findPodcastByUuid(uuid: String): Podcast?
 
     @Query("SELECT * FROM podcasts WHERE uuid = :uuid")
     abstract fun findByUuidRxFlowable(uuid: String): Flowable<Podcast>

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/colors/ColorManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/colors/ColorManager.kt
@@ -51,7 +51,7 @@ class ColorManager @Inject constructor(
 
         try {
             val colors = staticServiceManager.getColors(podcast.uuid) ?: return
-            podcastManager.updateColors(
+            podcastManager.updateColorsBlocking(
                 podcast.uuid,
                 colors.background,
                 colors.tintForLightBg,

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/download/DownloadManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/download/DownloadManagerImpl.kt
@@ -548,7 +548,7 @@ class DownloadManagerImpl @Inject constructor(
             }
 
             val episodeOne: PodcastEpisode = episodeManager.findByUuid(firstUuid) ?: return@launch
-            val podcastOneName = podcastManager.findPodcastByUuid(episodeOne.podcastUuid)?.title
+            val podcastOneName = podcastManager.findPodcastByUuidBlocking(episodeOne.podcastUuid)?.title
                 ?: ""
 
             val title: String

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/download/task/DownloadEpisodeTask.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/download/task/DownloadEpisodeTask.kt
@@ -282,7 +282,7 @@ class DownloadEpisodeTask @AssistedInject constructor(
         try {
             var downloadUrl = episode.downloadUrl?.toHttpUrlOrNull()
             if (downloadUrl == null && episode is UserEpisode) {
-                downloadUrl = runBlocking { userEpisodeManager.getPlaybackUrl(episode).await()?.toHttpUrlOrNull() }
+                downloadUrl = runBlocking { userEpisodeManager.getPlaybackUrlRxSingle(episode).await()?.toHttpUrlOrNull() }
             }
 
             if (downloadUrl == null) {

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/download/task/UploadEpisodeTask.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/download/task/UploadEpisodeTask.kt
@@ -39,9 +39,9 @@ class UploadEpisodeTask @AssistedInject constructor(
             return Single.just(Result.failure(outputData.build()))
         }
 
-        return userEpisodeManager.findEpisodeByUuidRx(episodeUUID)
+        return userEpisodeManager.findEpisodeByUuidRxMaybe(episodeUUID)
             .flatMapCompletable { userEpisode ->
-                userEpisodeManager.performUploadToServer(userEpisode, playbackManager)
+                userEpisodeManager.performUploadToServerRxCompletable(userEpisode, playbackManager)
             }
             .andThen(Single.just(Result.success(outputData.build())))
             .onErrorReturn {

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/file/CloudFilesManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/file/CloudFilesManager.kt
@@ -12,5 +12,5 @@ class CloudFilesManager @Inject constructor(
     private val userEpisodeManager: UserEpisodeManager,
 ) {
     @OptIn(ExperimentalCoroutinesApi::class)
-    val sortedCloudFiles = settings.cloudSortOrder.flow.flatMapLatest { userEpisodeManager.observeUserEpisodesSorted(it).asFlow() }
+    val sortedCloudFiles = settings.cloudSortOrder.flow.flatMapLatest { userEpisodeManager.userEpisodesSortedRxFlowable(it).asFlow() }
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/jobs/VersionMigrationsWorker.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/jobs/VersionMigrationsWorker.kt
@@ -197,7 +197,7 @@ class VersionMigrationsWorker @AssistedInject constructor(
 
     private suspend fun removeCustomEpisodes() {
         val customPodcastUuid = "customFolderPodcast"
-        val podcast: Podcast = podcastManager.findPodcastByUuidSuspend(customPodcastUuid) ?: return
+        val podcast: Podcast = podcastManager.findPodcastByUuid(customPodcastUuid) ?: return
         val episodes: List<PodcastEpisode> = episodeManager.findEpisodesByPodcastOrderedByPublishDateBlocking(podcast)
         episodes.forEach { episode ->
             playbackManager.removeEpisode(
@@ -247,10 +247,10 @@ class VersionMigrationsWorker @AssistedInject constructor(
 
     private suspend fun upgradeTrimSilenceMode() {
         try {
-            val podcasts = podcastManager.findSubscribed()
+            val podcasts = podcastManager.findSubscribedBlocking()
             podcasts.forEach { podcast ->
                 if (podcast.isSilenceRemoved && podcast.trimMode == TrimMode.OFF) {
-                    podcastManager.updateTrimMode(podcast, TrimMode.LOW)
+                    podcastManager.updateTrimModeBlocking(podcast, TrimMode.LOW)
                 }
             }
         } catch (e: Exception) {

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/notification/NotificationDrawerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/notification/NotificationDrawerImpl.kt
@@ -100,7 +100,7 @@ class NotificationDrawerImpl @Inject constructor(
 
     private fun getNotificationData(episodeUuid: String?, useEpisodeArtwork: Boolean): NotificationData {
         val episode: BaseEpisode? = if (episodeUuid == null) null else runBlocking { episodeManager.findEpisodeByUuid(episodeUuid) }
-        val podcast: Podcast? = if (episode == null || episode !is PodcastEpisode) null else podcastManager.findPodcastByUuid(episode.podcastUuid)
+        val podcast: Podcast? = if (episode == null || episode !is PodcastEpisode) null else podcastManager.findPodcastByUuidBlocking(episode.podcastUuid)
 
         if (episodeUuid == null || episode == null) {
             return NotificationData()

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/opml/OpmlImportTask.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/opml/OpmlImportTask.kt
@@ -242,7 +242,7 @@ class OpmlImportTask @AssistedInject constructor(
 
     private suspend fun processUrls(urls: List<String>) {
         val podcastCount = urls.size
-        val initialDatabaseCount = podcastManager.countPodcasts()
+        val initialDatabaseCount = podcastManager.countPodcastsBlocking()
 
         // keep the job running the in foreground with a notification
         setForeground(createForegroundInfo(0, podcastCount))
@@ -296,7 +296,7 @@ class OpmlImportTask @AssistedInject constructor(
     }
 
     private fun updateNotification(initialDatabaseCount: Int, podcastCount: Int) {
-        val databaseCount = podcastManager.countPodcasts()
+        val databaseCount = podcastManager.countPodcastsBlocking()
         val progress = (databaseCount - initialDatabaseCount).coerceIn(0, podcastCount)
         notificationManager.notify(Settings.NotificationId.OPML.value, buildNotification(progress, podcastCount))
     }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/MediaSessionManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/MediaSessionManager.kt
@@ -310,7 +310,7 @@ class MediaSessionManager(
 
                 val items = upNext.queue.map { episode ->
                     val podcastUuid = if (episode is PodcastEpisode) episode.podcastUuid else null
-                    val podcast = podcastUuid?.let { podcastManager.findPodcastByUuid(it) }
+                    val podcast = podcastUuid?.let { podcastManager.findPodcastByUuidBlocking(it) }
                     val podcastTitle = episode.displaySubtitle(podcast)
                     val localUri = AutoConverter.getPodcastArtworkUri(podcast, episode, context, settings.artworkConfiguration.value.useEpisodeArtwork)
                     val description = MediaDescriptionCompat.Builder()
@@ -392,7 +392,7 @@ class MediaSessionManager(
         }
 
         val podcastUuid = if (episode is PodcastEpisode) episode.podcastUuid else null
-        val podcast = podcastUuid?.let { podcastManager.findPodcastByUuid(it) }
+        val podcast = podcastUuid?.let { podcastManager.findPodcastByUuidBlocking(it) }
 
         val podcastTitle = episode.displaySubtitle(podcast)
         val safeCharacterPodcastTitle = podcastTitle.replace("%", "pct")
@@ -792,10 +792,10 @@ class MediaSessionManager(
             val episode = playbackManager.getCurrentEpisode() ?: return@launch
             if (episode is PodcastEpisode) {
                 // update per podcast playback speed
-                val podcast = podcastManager.findPodcastByUuidSuspend(episode.podcastUuid)
+                val podcast = podcastManager.findPodcastByUuid(episode.podcastUuid)
                 if (podcast != null && podcast.overrideGlobalEffects) {
                     podcast.playbackSpeed = newSpeed
-                    podcastManager.updatePlaybackSpeed(podcast = podcast, speed = newSpeed)
+                    podcastManager.updatePlaybackSpeedBlocking(podcast = podcast, speed = newSpeed)
                     playbackManager.updatePlayerEffects(effects = podcast.playbackEffects)
                     return@launch
                 }
@@ -859,7 +859,7 @@ class MediaSessionManager(
 
             val options = calculateSearchQueryOptions(query)
             for (option in options) {
-                val matchingPodcast: Podcast? = podcastManager.searchPodcastByTitle(option)
+                val matchingPodcast: Podcast? = podcastManager.searchPodcastByTitleBlocking(option)
                 if (matchingPodcast != null) {
                     LogBuffer.i(LogBuffer.TAG_PLAYBACK, "User played podcast from search %s.", option)
                     playPodcast(podcast = matchingPodcast, sourceView = sourceView)

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/UpNextQueue.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/UpNextQueue.kt
@@ -86,7 +86,7 @@ interface UpNextQueue {
                 if (state.podcast != null) {
                     // If we have a podcast we need to observe its effects state as well to ensure it updates when the global override changes
                     episodeManager.findEpisodeByUuidRxFlowable(state.episode.uuid)
-                        .combineLatest(podcastManager.observePodcastByUuid(state.podcast.uuid).distinctUntilChanged { t1, t2 -> t1.isUsingEffects == t2.isUsingEffects })
+                        .combineLatest(podcastManager.podcastByUuidRxFlowable(state.podcast.uuid).distinctUntilChanged { t1, t2 -> t1.isUsingEffects == t2.isUsingEffects })
                         .map<State> { State.Loaded(it.first, it.second, state.queue) }
                         .onErrorReturn { State.Empty }
                         .toObservable()
@@ -110,7 +110,7 @@ interface UpNextQueue {
                     episodeManager.findEpisodeByUuidFlow(state.episode.uuid)
                         .combine<BaseEpisode, Podcast, State>(
                             podcastManager
-                                .observePodcastByUuidFlow(state.podcast.uuid)
+                                .podcastByUuidFlow(state.podcast.uuid)
                                 .distinctUntilChanged { t1, t2 -> t1.isUsingEffects == t2.isUsingEffects },
                         ) { episode, podcast ->
                             val loadedState = State.Loaded(episode, podcast, state.queue)

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/FolderManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/FolderManagerImpl.kt
@@ -165,7 +165,7 @@ class FolderManagerImpl @Inject constructor(
         val podcasts = if (sortType == EPISODE_DATE_NEWEST_TO_OLDEST) {
             podcastManager.findPodcastsOrderByLatestEpisode(orderAsc = false)
         } else {
-            podcastManager.findSubscribed()
+            podcastManager.findSubscribedBlocking()
         }
         val folders = folderDao.findFolders()
         val folderItems = combineFoldersPodcasts(folders, podcasts)

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/HistoryManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/HistoryManager.kt
@@ -52,7 +52,7 @@ class HistoryManager @Inject constructor(
             .observeOn(Schedulers.io())
             .flatMap(
                 { podcastUuid ->
-                    podcastManager.addPodcast(podcastUuid = podcastUuid, sync = false, subscribed = false, shouldAutoDownload = false)
+                    podcastManager.addPodcastRxSingle(podcastUuid = podcastUuid, sync = false, subscribed = false, shouldAutoDownload = false)
                         .doOnError { throwable -> LogBuffer.e(LogBuffer.TAG_BACKGROUND_TASKS, throwable, "History manager could not add podcast") }
                         .onErrorReturn { Podcast(uuid = podcastUuid) }
                         .toObservable()

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PodcastManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PodcastManager.kt
@@ -23,99 +23,98 @@ import kotlinx.coroutines.flow.Flow
 interface PodcastManager {
 
     /** Find methods  */
-    fun searchPodcastByTitle(title: String): Podcast?
-    fun findPodcastByUuid(uuid: String): Podcast?
-    suspend fun findPodcastByUuidSuspend(uuid: String): Podcast?
-    fun findPodcastByUuidRx(uuid: String): Maybe<Podcast>
-    fun observePodcastByUuid(uuid: String): Flowable<Podcast>
-    fun observePodcastByUuidFlow(uuid: String): Flow<Podcast>
-    fun observePodcastByEpisodeUuid(uuid: String): Flow<Podcast>
-    fun observePodcastSubscriptions(): Flowable<List<String>>
+    fun searchPodcastByTitleBlocking(title: String): Podcast?
+    fun findPodcastByUuidBlocking(uuid: String): Podcast?
+    suspend fun findPodcastByUuid(uuid: String): Podcast?
+    fun findPodcastByUuidRxMaybe(uuid: String): Maybe<Podcast>
+    fun podcastByUuidRxFlowable(uuid: String): Flowable<Podcast>
+    fun podcastByUuidFlow(uuid: String): Flow<Podcast>
+    fun podcastByEpisodeUuidFlow(uuid: String): Flow<Podcast>
+    fun podcastSubscriptionsRxFlowable(): Flowable<List<String>>
 
-    fun findSubscribed(): List<Podcast>
-    fun findSubscribedRx(): Single<List<Podcast>>
+    fun findSubscribedBlocking(): List<Podcast>
+    fun findSubscribedRxSingle(): Single<List<Podcast>>
     fun findSubscribedFlow(): Flow<List<Podcast>>
     suspend fun findSubscribedSorted(): List<Podcast>
     suspend fun findSubscribedNoOrder(): List<Podcast>
     suspend fun findPodcastsInFolder(folderUuid: String): List<Podcast>
-    fun findPodcastsInFolderSingle(folderUuid: String): Single<List<Podcast>>
+    fun findPodcastsInFolderRxSingle(folderUuid: String): Single<List<Podcast>>
     suspend fun findPodcastsNotInFolder(): List<Podcast>
-    fun observePodcastsInFolderOrderByUserChoice(folder: Folder): Flowable<List<Podcast>>
+    fun podcastsInFolderOrderByUserChoiceRxFlowable(folder: Folder): Flowable<List<Podcast>>
     suspend fun findSubscribedUuids(): List<String>
 
-    fun observePodcastsOrderByLatestEpisode(): Flowable<List<Podcast>>
-    fun observeSubscribed(): Flowable<List<Podcast>>
+    fun podcastsOrderByLatestEpisodeRxFlowable(): Flowable<List<Podcast>>
+    fun subscribedRxFlowable(): Flowable<List<Podcast>>
     suspend fun findPodcastsOrderByTitle(): List<Podcast>
-    fun findPodcastsToSync(): List<Podcast>
+    fun findPodcastsToSyncBlocking(): List<Podcast>
     suspend fun findPodcastsOrderByLatestEpisode(orderAsc: Boolean): List<Podcast>
     suspend fun findFolderPodcastsOrderByLatestEpisode(folderUuid: String): List<Podcast>
 
-    fun findPodcastsAutodownload(): List<Podcast>
+    fun findPodcastsAutodownloadBlocking(): List<Podcast>
 
-    fun observeEpisodeCountByPodcatUuid(uuid: String): Flow<Int>
+    fun episodeCountByPodcatUuidFlow(uuid: String): Flow<Int>
 
     /** Add methods  */
     fun subscribeToPodcast(podcastUuid: String, sync: Boolean, shouldAutoDownload: Boolean = true)
 
-    suspend fun subscribeToPodcastSuspend(podcastUuid: String, sync: Boolean = false): Podcast
-    fun subscribeToPodcastRx(podcastUuid: String, sync: Boolean = false, shouldAutoDownload: Boolean = true): Single<Podcast>
-    fun findOrDownloadPodcastRx(podcastUuid: String): Single<Podcast>
+    fun subscribeToPodcastRxSingle(podcastUuid: String, sync: Boolean = false, shouldAutoDownload: Boolean = true): Single<Podcast>
+    fun findOrDownloadPodcastRxSingle(podcastUuid: String): Single<Podcast>
     fun isSubscribingToPodcasts(): Boolean
-    fun getSubscribedPodcastUuids(): Single<List<String>>
+    fun getSubscribedPodcastUuidsRxSingle(): Single<List<String>>
     fun isSubscribingToPodcast(podcastUuid: String): Boolean
-    fun addPodcast(podcastUuid: String, sync: Boolean, subscribed: Boolean, shouldAutoDownload: Boolean): Single<Podcast>
+    fun addPodcastRxSingle(podcastUuid: String, sync: Boolean, subscribed: Boolean, shouldAutoDownload: Boolean): Single<Podcast>
 
     suspend fun replaceCuratedPodcasts(podcasts: List<CuratedPodcast>)
 
     /** Update methods  */
-    fun updatePodcast(podcast: Podcast)
+    fun updatePodcastBlocking(podcast: Podcast)
 
     suspend fun updateAllAutoDownloadStatus(autoDownloadStatus: Int)
     suspend fun updateAllShowNotifications(showNotifications: Boolean)
-    fun updateAutoDownloadStatus(podcast: Podcast, autoDownloadStatus: Int)
+    fun updateAutoDownloadStatusBlocking(podcast: Podcast, autoDownloadStatus: Int)
     suspend fun updateAutoAddToUpNext(podcast: Podcast, autoAddToUpNext: Podcast.AutoAddUpNext)
     suspend fun updateAutoAddToUpNexts(podcastUuids: List<String>, autoAddToUpNext: Podcast.AutoAddUpNext)
     suspend fun updateAutoAddToUpNextsIf(podcastUuids: List<String>, newValue: Podcast.AutoAddUpNext, onlyIfValue: Podcast.AutoAddUpNext)
-    fun updateOverrideGlobalEffects(podcast: Podcast, override: Boolean)
-    suspend fun updateTrimMode(podcast: Podcast, trimMode: TrimMode)
-    fun updateVolumeBoosted(podcast: Podcast, override: Boolean)
-    fun updatePlaybackSpeed(podcast: Podcast, speed: Double)
-    fun updateEffects(podcast: Podcast, effects: PlaybackEffects)
-    fun updateEpisodesSortType(podcast: Podcast, episodesSortType: EpisodesSortType)
-    fun updateShowNotifications(podcast: Podcast, show: Boolean)
+    fun updateOverrideGlobalEffectsBlocking(podcast: Podcast, override: Boolean)
+    suspend fun updateTrimModeBlocking(podcast: Podcast, trimMode: TrimMode)
+    fun updateVolumeBoostedBlocking(podcast: Podcast, override: Boolean)
+    fun updatePlaybackSpeedBlocking(podcast: Podcast, speed: Double)
+    fun updateEffectsBlocking(podcast: Podcast, effects: PlaybackEffects)
+    fun updateEpisodesSortTypeBlocking(podcast: Podcast, episodesSortType: EpisodesSortType)
+    fun updateShowNotificationsBlocking(podcast: Podcast, show: Boolean)
     suspend fun updatePodcastPositions(podcasts: List<Podcast>)
     suspend fun updateRefreshAvailable(podcastUuid: String, refreshAvailable: Boolean)
     suspend fun updateStartFromInSec(podcast: Podcast, autoStartFrom: Int)
-    fun updateColors(podcastUuid: String, background: Int, tintForLightBg: Int, tintForDarkBg: Int, fabForLightBg: Int, fabForDarkBg: Int, linkForLightBg: Int, linkForDarkBg: Int, colorLastDownloaded: Long)
-    fun updateLatestEpisode(podcast: Podcast, latestEpisode: PodcastEpisode)
-    fun updateGrouping(podcast: Podcast, grouping: PodcastGrouping)
+    fun updateColorsBlocking(podcastUuid: String, background: Int, tintForLightBg: Int, tintForDarkBg: Int, fabForLightBg: Int, fabForDarkBg: Int, linkForLightBg: Int, linkForDarkBg: Int, colorLastDownloaded: Long)
+    fun updateLatestEpisodeBlocking(podcast: Podcast, latestEpisode: PodcastEpisode)
+    fun updateGroupingBlocking(podcast: Podcast, grouping: PodcastGrouping)
     suspend fun updateSkipLastInSec(podcast: Podcast, skipLast: Int)
     suspend fun updateShowArchived(podcast: Podcast, showArchived: Boolean)
     suspend fun updateAllShowArchived(showArchived: Boolean)
     suspend fun updateFolderUuid(folderUuid: String?, podcastUuids: List<String>)
 
-    fun markPodcastUuidAsNotSynced(podcastUuid: String)
-    fun markAllPodcastsSynced()
+    fun markPodcastUuidAsNotSyncedBlocking(podcastUuid: String)
+    fun markAllPodcastsSyncedBlocking()
     suspend fun markAllPodcastsUnsynced()
 
-    fun clearAllDownloadErrors()
+    fun clearAllDownloadErrorsBlocking()
 
     /** Remove methods  */
-    fun checkForUnusedPodcasts(playbackManager: PlaybackManager)
-    fun deletePodcastIfUnused(podcast: Podcast, playbackManager: PlaybackManager): Boolean
+    fun checkForUnusedPodcastsBlocking(playbackManager: PlaybackManager)
+    fun deletePodcastIfUnusedBlocking(podcast: Podcast, playbackManager: PlaybackManager): Boolean
     suspend fun deleteAllPodcasts()
-    fun unsubscribe(podcastUuid: String, playbackManager: PlaybackManager)
+    fun unsubscribeBlocking(podcastUuid: String, playbackManager: PlaybackManager)
     fun unsubscribeAsync(podcastUuid: String, playbackManager: PlaybackManager)
 
     /** Utility methods  */
-    fun countPodcasts(): Int
+    fun countPodcastsBlocking(): Int
     suspend fun countSubscribed(): Int
-    fun countSubscribedRx(): Single<Int>
-    fun observeCountSubscribed(): Flowable<Int>
-    fun countDownloadStatus(downloadStatus: Int): Int
+    fun countSubscribedRxSingle(): Single<Int>
+    fun countSubscribedRxFlowable(): Flowable<Int>
+    fun countDownloadStatusBlocking(downloadStatus: Int): Int
     suspend fun hasEpisodesWithAutoDownloadStatus(downloadStatus: Int): Boolean
-    fun countDownloadStatusRx(downloadStatus: Int): Single<Int>
-    fun countNotificationsOn(): Int
+    fun countDownloadStatusRxSingle(downloadStatus: Int): Single<Int>
+    fun countNotificationsOnBlocking(): Int
 
     fun refreshPodcastsIfRequired(fromLog: String)
     fun refreshPodcasts(fromLog: String)
@@ -123,13 +122,13 @@ interface PodcastManager {
     suspend fun refreshPodcast(existingPodcast: Podcast, playbackManager: PlaybackManager)
     fun reloadFoldersFromServer()
 
-    fun checkForEpisodesToDownload(episodeUuidsAdded: List<String>, downloadManager: DownloadManager)
+    fun checkForEpisodesToDownloadBlocking(episodeUuidsAdded: List<String>, downloadManager: DownloadManager)
 
-    fun countEpisodesInPodcastWithStatus(podcastUuid: String, episodeStatus: EpisodeStatusEnum): Int
-    fun updateGroupingForAll(grouping: PodcastGrouping)
+    fun countEpisodesInPodcastWithStatusBlocking(podcastUuid: String, episodeStatus: EpisodeStatusEnum): Int
+    fun updateGroupingForAllBlocking(grouping: PodcastGrouping)
 
     fun buildUserEpisodePodcast(episode: UserEpisode): Podcast
-    fun observeAutoAddToUpNextPodcasts(): Flowable<List<Podcast>>
+    fun autoAddToUpNextPodcastsRxFlowable(): Flowable<List<Podcast>>
     suspend fun findAutoAddToUpNextPodcasts(): List<Podcast>
 
     suspend fun refreshPodcastFeed(podcastUuid: String): Boolean
@@ -144,5 +143,5 @@ interface PodcastManager {
     suspend fun updateArchiveAfterInactive(uuid: String, value: AutoArchiveInactive)
     suspend fun updateArchiveEpisodeLimit(uuid: String, value: AutoArchiveLimit)
 
-    fun updatePodcastLatestEpisode(podcast: Podcast)
+    fun updatePodcastLatestEpisodeBlocking(podcast: Podcast)
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/SubscribeManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/SubscribeManager.kt
@@ -85,7 +85,7 @@ class SubscribeManager @Inject constructor(
             .flatMap({ info ->
                 // shouldAutoDownload = true because the user manually subscribed to the podcast,
                 // so we want to automatically download episodes at this moment.
-                addPodcast(info.podcastUuid, sync = info.sync, subscribed = true, shouldAutoDownload = info.shouldAutoDownload).toObservable()
+                addPodcastRxSingle(info.podcastUuid, sync = info.sync, subscribed = true, shouldAutoDownload = info.shouldAutoDownload).toObservable()
             }, true, 5)
             .doOnError { throwable -> LogBuffer.e(LogBuffer.TAG_BACKGROUND_TASKS, throwable, "Could not subscribe to podcast") }
             .subscribeBy(
@@ -112,11 +112,11 @@ class SubscribeManager @Inject constructor(
     /**
      * Subscribe to a podcast and wait.
      */
-    fun addPodcast(podcastUuid: String, sync: Boolean = false, subscribed: Boolean = false, shouldAutoDownload: Boolean): Single<Podcast> {
-        return subscribeToExistingOrServerPodcast(podcastUuid, sync, subscribed, shouldAutoDownload)
+    fun addPodcastRxSingle(podcastUuid: String, sync: Boolean = false, subscribed: Boolean = false, shouldAutoDownload: Boolean): Single<Podcast> {
+        return subscribeToExistingOrServerPodcastRxSingle(podcastUuid, sync, subscribed, shouldAutoDownload)
             .flatMap {
                 LogBuffer.i(LogBuffer.TAG_BACKGROUND_TASKS, "Adding podcast $podcastUuid to database")
-                cacheArtwork(it).toSingleDefault(it)
+                cacheArtworkRxCompletable(it).toSingleDefault(it)
             }
             .doOnSuccess {
                 LogBuffer.i(LogBuffer.TAG_BACKGROUND_TASKS, "Added podcast $podcastUuid to database")
@@ -148,7 +148,7 @@ class SubscribeManager @Inject constructor(
             }
     }
 
-    private fun cacheArtwork(podcast: Podcast): Completable {
+    private fun cacheArtworkRxCompletable(podcast: Podcast): Completable {
         return Completable.fromAction {
             val request = imageRequestFactory.create(podcast)
                 .newBuilder()
@@ -166,20 +166,20 @@ class SubscribeManager @Inject constructor(
         return uuidsInQueue
     }
 
-    private fun subscribeToExistingOrServerPodcast(podcastUuid: String, sync: Boolean, subscribed: Boolean, shouldAutoDownload: Boolean): Single<Podcast> {
+    private fun subscribeToExistingOrServerPodcastRxSingle(podcastUuid: String, sync: Boolean, subscribed: Boolean, shouldAutoDownload: Boolean): Single<Podcast> {
         // check if the podcast exists already
         val subscribedObservable = podcastDao.isSubscribedToPodcastRxSingle(podcastUuid)
         return subscribedObservable.flatMap { isSubscribed ->
             // download the podcast json and add to the database if it doesn't exist
             if (isSubscribed) {
-                subscribeToExistingPodcast(podcastUuid, sync)
+                subscribeToExistingPodcastRxSingle(podcastUuid, sync)
             } else {
-                subscribeToServerPodcast(podcastUuid, sync, subscribed, shouldAutoDownload)
+                subscribeToServerPodcastRxSingle(podcastUuid, sync, subscribed, shouldAutoDownload)
             }
         }
     }
 
-    private fun subscribeToExistingPodcast(podcastUuid: String, sync: Boolean): Single<Podcast> {
+    private fun subscribeToExistingPodcastRxSingle(podcastUuid: String, sync: Boolean): Single<Podcast> {
         // set subscribed to true and update the sync status
         val updateObservable = podcastDao.updateSubscribedRxCompletable(subscribed = true, uuid = podcastUuid)
             .andThen(podcastDao.updateSyncStatusRxCompletable(syncStatus = if (sync) Podcast.SYNC_STATUS_NOT_SYNCED else Podcast.SYNC_STATUS_SYNCED, uuid = podcastUuid))
@@ -190,9 +190,9 @@ class SubscribeManager @Inject constructor(
         return updateObservable.andThen(findObservable.toSingle())
     }
 
-    private fun subscribeToServerPodcast(podcastUuid: String, sync: Boolean, subscribed: Boolean, shouldAutoDownload: Boolean): Single<Podcast> {
+    private fun subscribeToServerPodcastRxSingle(podcastUuid: String, sync: Boolean, subscribed: Boolean, shouldAutoDownload: Boolean): Single<Podcast> {
         // download the podcast
-        val podcastObservable = downloadPodcast(podcastUuid)
+        val podcastObservable = downloadPodcastRxSingle(podcastUuid)
             .doOnSuccess { podcast ->
                 // mark sync status
                 podcast.syncStatus = if (sync) Podcast.SYNC_STATUS_NOT_SYNCED else Podcast.SYNC_STATUS_SYNCED
@@ -216,7 +216,7 @@ class SubscribeManager @Inject constructor(
             podcastDao.insertRxSingle(podcast)
         }
         // insert episodes
-        return insertPodcastObservable.flatMap { podcast -> subscribeInsertEpisodes(podcast).toSingle { podcast } }
+        return insertPodcastObservable.flatMap { podcast -> subscribeInsertEpisodesRxCompletable(podcast).toSingle { podcast } }
     }
 
     private fun canDownloadEpisodesAfterSubscription(
@@ -237,7 +237,7 @@ class SubscribeManager @Inject constructor(
             FeatureFlag.isEnabled(Feature.AUTO_DOWNLOAD)
     }
 
-    private fun downloadPodcast(podcastUuid: String): Single<Podcast> {
+    private fun downloadPodcastRxSingle(podcastUuid: String): Single<Podcast> {
         // download the podcast
         val serverPodcastObservable = podcastCacheServiceManager.getPodcast(podcastUuid)
             .subscribeOn(Schedulers.io())
@@ -260,7 +260,7 @@ class SubscribeManager @Inject constructor(
         )
         // add sync information
         if (syncManager.isLoggedIn()) {
-            val syncPodcastObservable = syncManager.getPodcastEpisodes(podcastUuid).subscribeOn(Schedulers.io())
+            val syncPodcastObservable = syncManager.getPodcastEpisodesRxSingle(podcastUuid).subscribeOn(Schedulers.io())
             return Single.zip(cleanPodcastObservable, syncPodcastObservable, BiFunction<Podcast, PodcastEpisodesResponse, Podcast>(this::mergeSyncPodcast))
                 .onErrorResumeNext(cleanPodcastObservable)
         } else {
@@ -268,7 +268,7 @@ class SubscribeManager @Inject constructor(
         }
     }
 
-    private fun subscribeInsertEpisodes(podcast: Podcast): Completable {
+    private fun subscribeInsertEpisodesRxCompletable(podcast: Podcast): Completable {
         // insert the episodes
         return Completable.fromAction {
             podcast.episodes.chunked(250).forEach { episodes ->
@@ -276,7 +276,7 @@ class SubscribeManager @Inject constructor(
             }
         }
             // make sure the podcast has the latest episode uuid
-            .andThen(updateLatestEpisodeUuid(podcast.uuid))
+            .andThen(updateLatestEpisodeUuidRxCompletable(podcast.uuid))
     }
 
     private fun cleanPodcast(podcast: Podcast, colors: Optional<ArtworkColors>, allPodcasts: List<Podcast>): Podcast {
@@ -332,7 +332,7 @@ class SubscribeManager @Inject constructor(
     }
 
     // WARNING: only call this when NEW episodes are added, not old ones
-    private fun updateLatestEpisodeUuid(podcastUuid: String): Completable {
+    private fun updateLatestEpisodeUuidRxCompletable(podcastUuid: String): Completable {
         return episodeDao.findLatestRxMaybe(podcastUuid)
             .flatMapCompletable { episode -> podcastDao.updateLatestEpisodeRxCompletable(episode.uuid, episode.publishedDate, podcastUuid) }
     }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/subscription/SubscriptionManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/subscription/SubscriptionManagerImpl.kt
@@ -122,7 +122,7 @@ class SubscriptionManagerImpl @Inject constructor(
             return Single.just(cache)
         }
 
-        return syncManager.subscriptionStatus()
+        return syncManager.subscriptionStatusRxSingle()
             .subscribeOn(Schedulers.io())
             .observeOn(AndroidSchedulers.mainThread())
             .map {
@@ -299,7 +299,7 @@ class SubscriptionManagerImpl @Inject constructor(
             LogBuffer.e(LogBuffer.TAG_SUBSCRIPTIONS, "expected 1 product when sending purchase to server, but there were ${purchase.products.size}")
         }
 
-        val response = syncManager.subscriptionPurchase(SubscriptionPurchaseRequest(purchase.purchaseToken, purchase.products.first())).await()
+        val response = syncManager.subscriptionPurchaseRxSingle(SubscriptionPurchaseRequest(purchase.purchaseToken, purchase.products.first())).await()
         val newStatus = response.toStatus()
         cachedSubscriptionStatus = newStatus
         subscriptionStatus.accept(Optional.of(newStatus))

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/support/Support.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/support/Support.kt
@@ -255,7 +255,7 @@ class Support @Inject constructor(
             val autoDownloadOn = booleanArrayOf(false)
             val uuidToPodcast = HashMap<String, Podcast>()
             try {
-                val podcasts = podcastManager.findSubscribed()
+                val podcasts = podcastManager.findSubscribedBlocking()
                 for (podcast in podcasts) {
                     if (podcast.isAutoDownloadNewEpisodes) {
                         autoDownloadOn[0] = true
@@ -395,7 +395,7 @@ class Support @Inject constructor(
                     .append(" Volume boost: ").append(if (effects.isVolumeBoosted) "on" else "off").append(eol).append(eol)
 
                 output.append("Database").append(eol)
-                    .append(" ").append(podcastManager.countPodcasts()).append(" Podcasts ").append(eol)
+                    .append(" ").append(podcastManager.countPodcastsBlocking()).append(" Podcasts ").append(eol)
                     .append(" ").append(episodeManager.countEpisodes()).append(" Episodes ").append(eol)
                     .append(" ").append(playlistManager.findAllBlocking().size).append(" Playlists ").append(eol)
                     .append(" ").append(queue.size).append(" Up Next ").append(eol).append(eol)

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/SyncHistoryTask.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/SyncHistoryTask.kt
@@ -89,7 +89,7 @@ class SyncHistoryTask @AssistedInject constructor(
 
         try {
             val response = syncManager
-                .historySync(request)
+                .historySyncRxSingle(request)
                 .toMaybe()
                 .onErrorComplete { it is HttpException && it.code() == 304 }
                 .blockingGet()

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/SyncManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/SyncManager.kt
@@ -49,7 +49,7 @@ interface SyncManager : NamedSettingsCaller {
     fun isLoggedIn(): Boolean
     fun getLoginIdentity(): LoginIdentity?
     fun getEmail(): String?
-    fun observeEmail(): Flow<String?>
+    fun emailFlow(): Flow<String?>
     fun signOut(action: () -> Unit = {})
     suspend fun loginWithGoogle(idToken: String, signInSource: SignInSource): LoginResult
     suspend fun loginWithEmailAndPassword(email: String, password: String, signInSource: SignInSource): LoginResult
@@ -59,39 +59,39 @@ interface SyncManager : NamedSettingsCaller {
     suspend fun getAccessToken(account: Account): AccessToken
     fun getRefreshToken(): RefreshToken?
     suspend fun emailChange(newEmail: String, password: String): UserChangeResponse
-    fun deleteAccount(): Single<UserChangeResponse>
+    fun deleteAccountRxSingle(): Single<UserChangeResponse>
     suspend fun updatePassword(newPassword: String, oldPassword: String)
 
     // User Episodes / Files
-    fun getFiles(): Single<Response<FilesResponse>>
-    fun getFileUploadStatus(episodeUuid: String): Single<Boolean>
-    fun uploadFileToServer(episode: UserEpisode): Completable
-    fun uploadImageToServer(episode: UserEpisode, imageFile: File): Completable
-    fun postFiles(files: List<FilePost>): Single<Response<Void>>
-    fun getUserEpisode(uuid: String): Maybe<ServerFile>
-    fun getFileUsage(): Single<FileAccount>
-    fun deleteImageFromServer(episode: UserEpisode): Single<Response<Void>>
-    fun deleteFromServer(episode: UserEpisode): Single<Response<Void>>
-    fun getPlaybackUrl(episode: UserEpisode): Single<String>
+    fun getFilesRxSingle(): Single<Response<FilesResponse>>
+    fun getFileUploadStatusRxSingle(episodeUuid: String): Single<Boolean>
+    fun uploadFileToServerRxCompletable(episode: UserEpisode): Completable
+    fun uploadImageToServerRxCompletable(episode: UserEpisode, imageFile: File): Completable
+    fun postFilesRxSingle(files: List<FilePost>): Single<Response<Void>>
+    fun getUserEpisodeRxMaybe(uuid: String): Maybe<ServerFile>
+    fun getFileUsageRxSingle(): Single<FileAccount>
+    fun deleteImageFromServerRxSingle(episode: UserEpisode): Single<Response<Void>>
+    fun deleteFromServerRxSingle(episode: UserEpisode): Single<Response<Void>>
+    fun getPlaybackUrlRxSingle(episode: UserEpisode): Single<String>
 
     // History
-    fun historySync(request: HistorySyncRequest): Single<HistorySyncResponse>
+    fun historySyncRxSingle(request: HistorySyncRequest): Single<HistorySyncResponse>
     suspend fun historyYear(year: Int, count: Boolean): HistoryYearResponse
 
     // Subscription
-    fun subscriptionStatus(): Single<SubscriptionStatusResponse>
-    fun subscriptionPurchase(request: SubscriptionPurchaseRequest): Single<SubscriptionStatusResponse>
-    fun redeemPromoCode(code: String): Single<PromoCodeResponse>
-    fun validatePromoCode(code: String): Single<PromoCodeResponse>
+    fun subscriptionStatusRxSingle(): Single<SubscriptionStatusResponse>
+    fun subscriptionPurchaseRxSingle(request: SubscriptionPurchaseRequest): Single<SubscriptionStatusResponse>
+    fun redeemPromoCodeRxSingle(code: String): Single<PromoCodeResponse>
+    fun validatePromoCodeRxSingle(code: String): Single<PromoCodeResponse>
 
     // Sync
-    fun getLastSyncAt(): Single<String>
+    fun getLastSyncAtRxSingle(): Single<String>
     suspend fun getHomeFolder(): UserPodcastListResponse
-    fun getPodcastEpisodes(podcastUuid: String): Single<PodcastEpisodesResponse>
+    fun getPodcastEpisodesRxSingle(podcastUuid: String): Single<PodcastEpisodesResponse>
 
     suspend fun syncUpdate(data: String, lastSyncTime: Instant): SyncUpdateResponse
 
-    fun episodeSync(request: EpisodeSyncRequest): Completable
+    fun episodeSyncRxCompletable(request: EpisodeSyncRequest): Completable
 
     // Rating
     suspend fun addPodcastRating(podcastUuid: String, rate: Int): PodcastRatingResponse
@@ -100,7 +100,7 @@ interface SyncManager : NamedSettingsCaller {
 
     // Other
     suspend fun exchangeSonos(): ExchangeSonosResponse
-    fun getFilters(): Single<List<Playlist>>
+    fun getFiltersRxSingle(): Single<List<Playlist>>
     suspend fun loadStats(): StatsBundle
     suspend fun upNextSync(request: UpNextSyncRequest): UpNextSyncResponse
     suspend fun getBookmarks(): List<Bookmark>

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/SyncManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/SyncManagerImpl.kt
@@ -100,7 +100,7 @@ class SyncManagerImpl @Inject constructor(
         return result
     }
 
-    override fun deleteAccount(): Single<UserChangeResponse> =
+    override fun deleteAccountRxSingle(): Single<UserChangeResponse> =
         getCacheTokenOrLoginRxSingle { token ->
             syncServiceManager.deleteAccount(token)
         }.doOnSuccess {
@@ -130,7 +130,7 @@ class SyncManagerImpl @Inject constructor(
     override fun getEmail(): String? =
         syncAccountManager.getEmail()
 
-    override fun observeEmail() = syncAccountManager.observeEmail().distinctUntilChanged()
+    override fun emailFlow() = syncAccountManager.observeEmail().distinctUntilChanged()
 
     override suspend fun getAccessToken(account: Account): AccessToken =
         syncAccountManager.peekAccessToken(account)
@@ -244,27 +244,27 @@ class SyncManagerImpl @Inject constructor(
 
 // User Episodes / Files
 
-    override fun getFiles(): Single<Response<FilesResponse>> =
+    override fun getFilesRxSingle(): Single<Response<FilesResponse>> =
         getCacheTokenOrLoginRxSingle { token ->
             syncServiceManager.getFiles(token)
         }
 
-    override fun getFileUsage(): Single<FileAccount> =
+    override fun getFileUsageRxSingle(): Single<FileAccount> =
         getCacheTokenOrLoginRxSingle { token ->
             syncServiceManager.getFileUsage(token)
         }
 
-    override fun postFiles(files: List<FilePost>): Single<Response<Void>> =
+    override fun postFilesRxSingle(files: List<FilePost>): Single<Response<Void>> =
         getCacheTokenOrLoginRxSingle { token ->
             syncServiceManager.postFiles(files, token)
         }
 
-    override fun getFileUploadStatus(episodeUuid: String): Single<Boolean> =
+    override fun getFileUploadStatusRxSingle(episodeUuid: String): Single<Boolean> =
         getCacheTokenOrLoginRxSingle { token ->
             syncServiceManager.getFileUploadStatus(episodeUuid, token)
         }
 
-    override fun uploadFileToServer(episode: UserEpisode): Completable =
+    override fun uploadFileToServerRxCompletable(episode: UserEpisode): Completable =
         getCacheTokenOrLoginRxSingle { token ->
             syncServiceManager.getFileUploadUrl(episode.toUploadData(), token)
         }.flatMapCompletable { url ->
@@ -279,7 +279,7 @@ class SyncManagerImpl @Inject constructor(
                 .ignoreElements()
         }
 
-    override fun uploadImageToServer(
+    override fun uploadImageToServerRxCompletable(
         episode: UserEpisode,
         imageFile: File,
     ): Completable =
@@ -291,22 +291,22 @@ class SyncManagerImpl @Inject constructor(
                 .ignoreElement()
         }
 
-    override fun deleteImageFromServer(episode: UserEpisode): Single<Response<Void>> =
+    override fun deleteImageFromServerRxSingle(episode: UserEpisode): Single<Response<Void>> =
         getCacheTokenOrLoginRxSingle { token ->
             syncServiceManager.deleteImageFromServer(episode, token)
         }
 
-    override fun deleteFromServer(episode: UserEpisode): Single<Response<Void>> =
+    override fun deleteFromServerRxSingle(episode: UserEpisode): Single<Response<Void>> =
         getCacheTokenOrLoginRxSingle { token ->
             syncServiceManager.deleteFromServer(episode, token)
         }
 
-    override fun getPlaybackUrl(episode: UserEpisode): Single<String> =
+    override fun getPlaybackUrlRxSingle(episode: UserEpisode): Single<String> =
         getCacheTokenOrLoginRxSingle { token ->
             syncServiceManager.getPlaybackUrl(episode, token)
         }
 
-    override fun getUserEpisode(uuid: String): Maybe<ServerFile> =
+    override fun getUserEpisodeRxMaybe(uuid: String): Maybe<ServerFile> =
         getCacheTokenOrLoginRxSingle { token ->
             syncServiceManager.getUserEpisode(uuid, token)
         }.flatMapMaybe {
@@ -321,7 +321,7 @@ class SyncManagerImpl @Inject constructor(
 
 // History
 
-    override fun historySync(request: HistorySyncRequest): Single<HistorySyncResponse> =
+    override fun historySyncRxSingle(request: HistorySyncRequest): Single<HistorySyncResponse> =
         getCacheTokenOrLoginRxSingle { token ->
             syncServiceManager.historySync(request, token)
         }
@@ -333,22 +333,22 @@ class SyncManagerImpl @Inject constructor(
 
 // Subscription
 
-    override fun subscriptionStatus(): Single<SubscriptionStatusResponse> =
+    override fun subscriptionStatusRxSingle(): Single<SubscriptionStatusResponse> =
         getCacheTokenOrLoginRxSingle { token ->
             syncServiceManager.subscriptionStatus(token)
         }
 
-    override fun subscriptionPurchase(request: SubscriptionPurchaseRequest): Single<SubscriptionStatusResponse> =
+    override fun subscriptionPurchaseRxSingle(request: SubscriptionPurchaseRequest): Single<SubscriptionStatusResponse> =
         getCacheTokenOrLoginRxSingle { token ->
             syncServiceManager.subscriptionPurchase(request, token)
         }
 
-    override fun redeemPromoCode(code: String): Single<PromoCodeResponse> =
+    override fun redeemPromoCodeRxSingle(code: String): Single<PromoCodeResponse> =
         getCacheTokenOrLoginRxSingle { token ->
             syncServiceManager.redeemPromoCode(code, token)
         }
 
-    override fun validatePromoCode(code: String): Single<PromoCodeResponse> =
+    override fun validatePromoCodeRxSingle(code: String): Single<PromoCodeResponse> =
         syncServiceManager.validatePromoCode(code)
 
 // Sync
@@ -360,7 +360,7 @@ class SyncManagerImpl @Inject constructor(
             }
         } ?: throw Exception("Not logged in")
 
-    override fun getLastSyncAt(): Single<String> =
+    override fun getLastSyncAtRxSingle(): Single<String> =
         getCacheTokenOrLoginRxSingle { token ->
             syncServiceManager.getLastSyncAt(token)
         }
@@ -370,12 +370,12 @@ class SyncManagerImpl @Inject constructor(
             syncServiceManager.getHomeFolder(token)
         }
 
-    override fun getPodcastEpisodes(podcastUuid: String): Single<PodcastEpisodesResponse> =
+    override fun getPodcastEpisodesRxSingle(podcastUuid: String): Single<PodcastEpisodesResponse> =
         getCacheTokenOrLoginRxSingle { token ->
             syncServiceManager.getPodcastEpisodes(podcastUuid, token)
         }
 
-    override fun episodeSync(request: EpisodeSyncRequest): Completable =
+    override fun episodeSyncRxCompletable(request: EpisodeSyncRequest): Completable =
         getCacheTokenOrLoginRxCompletable { token ->
             syncServiceManager.episodeSync(request, token)
         }
@@ -404,7 +404,7 @@ class SyncManagerImpl @Inject constructor(
             syncServiceManager.exchangeSonos(token)
         }
 
-    override fun getFilters(): Single<List<Playlist>> =
+    override fun getFiltersRxSingle(): Single<List<Playlist>> =
         getCacheTokenOrLoginRxSingle { token ->
             syncServiceManager.getFilters(token)
         }
@@ -587,7 +587,7 @@ class SyncManagerImpl @Inject constructor(
                 // refresh invalid
                 .onErrorResumeNext { throwable ->
                     return@onErrorResumeNext if (isHttpUnauthorized(throwable)) {
-                        refreshToken().flatMap { token -> serverCall(token) }
+                        refreshTokenRxSingle().flatMap { token -> serverCall(token) }
                     }
                     // re-throw this error because it's not recoverable from here
                     else {
@@ -595,7 +595,7 @@ class SyncManagerImpl @Inject constructor(
                     }
                 }
         } else {
-            return refreshToken().flatMap { token -> serverCall(token) }
+            return refreshTokenRxSingle().flatMap { token -> serverCall(token) }
         }
     }
 
@@ -605,7 +605,7 @@ class SyncManagerImpl @Inject constructor(
         }.ignoreElement()
     }
 
-    private fun refreshToken(): Single<AccessToken> {
+    private fun refreshTokenRxSingle(): Single<AccessToken> {
         syncAccountManager.invalidateAccessToken()
         return rxSingle {
             syncAccountManager.getAccessToken() ?: throw RuntimeException("Failed to get token")

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/UpNextSyncWorker.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/UpNextSyncWorker.kt
@@ -176,7 +176,7 @@ class UpNextSyncWorker @AssistedInject constructor(
         // import missing podcasts
         val podcastUuids: List<String> = response.episodes?.mapNotNull { it.podcast }?.filter { it != Podcast.userPodcast.uuid } ?: emptyList()
         podcastUuids.forEach { podcastUuid ->
-            podcastManager.findOrDownloadPodcastRx(podcastUuid).await()
+            podcastManager.findOrDownloadPodcastRxSingle(podcastUuid).await()
         }
 
         // import missing episodes
@@ -185,7 +185,7 @@ class UpNextSyncWorker @AssistedInject constructor(
             val podcastUuid = responseEpisode.podcast
             if (podcastUuid != null) {
                 if (podcastUuid == Podcast.userPodcast.uuid) {
-                    userEpisodeManager.downloadMissingUserEpisode(episodeUuid, placeholderTitle = responseEpisode.title, placeholderPublished = responseEpisode.published?.parseIsoDate())
+                    userEpisodeManager.downloadMissingUserEpisodeRxMaybe(episodeUuid, placeholderTitle = responseEpisode.title, placeholderPublished = responseEpisode.published?.parseIsoDate())
                         .awaitSingleOrNull()
                 } else {
                     val skeletonEpisode = responseEpisode.toSkeletonEpisode(podcastUuid)

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/user/UserManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/user/UserManager.kt
@@ -100,7 +100,7 @@ class UserManagerImpl @Inject constructor(
                                 subscriptionManager.getSubscriptionStatus(allowCache = false)
                             }
                         }
-                        .combineLatest(syncManager.observeEmail().map { Optional.of(it) }.asFlowable())
+                        .combineLatest(syncManager.emailFlow().map { Optional.of(it) }.asFlowable())
                         .map { (status, maybeEmail) ->
                             analyticsTracker.refreshMetadata()
                             SignInState.SignedIn(email = maybeEmail.get() ?: "", subscriptionStatus = status)

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/widget/WidgetManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/widget/WidgetManagerImpl.kt
@@ -109,7 +109,7 @@ class WidgetManagerImpl @Inject constructor(
 
     private fun findPodcastByEpisode(episode: BaseEpisode): Podcast? {
         return when (episode) {
-            is PodcastEpisode -> podcastManager.findPodcastByUuid(episode.podcastUuid)
+            is PodcastEpisode -> podcastManager.findPodcastByUuidBlocking(episode.podcastUuid)
             is UserEpisode -> podcastManager.buildUserEpisodePodcast(episode)
             else -> null
         }

--- a/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/fragments/PodcastSelectFragment.kt
+++ b/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/fragments/PodcastSelectFragment.kt
@@ -113,7 +113,7 @@ class PodcastSelectFragment : BaseFragment() {
         if (args.tintColor != null) {
             binding.btnSelect.setTextColor(args.tintColor)
         }
-        podcastManager.findSubscribedRx()
+        podcastManager.findSubscribedRxSingle()
             .zipWith(Single.fromCallable { listener.podcastSelectFragmentGetCurrentSelection() })
             .map { pair ->
                 val podcasts = pair.first

--- a/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/helper/OpmlExporter.kt
+++ b/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/helper/OpmlExporter.kt
@@ -55,7 +55,7 @@ class OpmlExporter(
         showProgressDialog()
 
         applicationScope.launch(Dispatchers.IO) {
-            val uuidToTitle = podcastManager.findSubscribed().associateBy({ it.uuid }, { it.title })
+            val uuidToTitle = podcastManager.findSubscribedBlocking().associateBy({ it.uuid }, { it.title })
             val uuids = uuidToTitle.keys.toList()
 
             serviceTask = serviceManager.exportFeedUrls(

--- a/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/helper/SwipeButtonLayoutViewModel.kt
+++ b/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/helper/SwipeButtonLayoutViewModel.kt
@@ -49,7 +49,7 @@ class SwipeButtonLayoutViewModel @Inject constructor(
                 swipeAction = EpisodeItemTouchHelper.SwipeAction.SHARE,
             )
 
-            val podcast = podcastManager.findPodcastByUuidSuspend(episode.podcastUuid) ?: return@launch
+            val podcast = podcastManager.findPodcastByUuid(episode.podcastUuid) ?: return@launch
 
             shareDialogFactory
                 .shareEpisode(podcast, episode, SourceView.EPISODE_SWIPE_ACTION)

--- a/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/multiselect/MultiSelectEpisodesHelper.kt
+++ b/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/multiselect/MultiSelectEpisodesHelper.kt
@@ -433,7 +433,7 @@ class MultiSelectEpisodesHelper @Inject constructor(
         }
 
         launch {
-            val podcast = podcastManager.findPodcastByUuidSuspend(episode.podcastUuid) ?: run {
+            val podcast = podcastManager.findPodcastByUuid(episode.podcastUuid) ?: run {
                 LogBuffer.e(LogBuffer.TAG_INVALID_STATE, "Share failed because unable to find podcast from uuid")
                 return@launch
             }

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/FilesViewModel.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/FilesViewModel.kt
@@ -14,7 +14,7 @@ class FilesViewModel @Inject constructor(
 ) : ViewModel() {
 
     val userEpisodes = userEpisodeManager
-        .observeUserEpisodesSorted(settings.cloudSortOrder.value)
+        .userEpisodesSortedRxFlowable(settings.cloudSortOrder.value)
         .asFlow()
 
     val artworkConfiguration = settings.artworkConfiguration.flow

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/episode/EpisodeViewModel.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/episode/EpisodeViewModel.kt
@@ -141,7 +141,7 @@ class EpisodeViewModel @Inject constructor(
 
         val podcastFlow = episodeFlow
             .filterIsInstance<PodcastEpisode>()
-            .map { podcastManager.findPodcastByUuidSuspend(it.podcastUuid) }
+            .map { podcastManager.findPodcastByUuid(it.podcastUuid) }
 
         val isPlayingEpisodeFlow = playbackManager.playbackStateRelay.asFlow()
             .filter { it.episodeUuid == episodeUuid }

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/podcast/PodcastViewModel.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/podcast/PodcastViewModel.kt
@@ -47,7 +47,7 @@ class PodcastViewModel @Inject constructor(
 
     init {
         viewModelScope.launch(Dispatchers.Default) {
-            val podcast = podcastManager.findPodcastByUuidSuspend(podcastUuid)
+            val podcast = podcastManager.findPodcastByUuid(podcastUuid)
             podcast?.let {
                 episodeManager.findEpisodesByPodcastOrderedRxFlowable(it)
                     .asFlow()


### PR DESCRIPTION
## Description

We aim to switch to using Coroutines for calls to the database and move away from RxJava. When converting code, knowing which calls have already been converted can be tricky. To make this more straightforward, I have made the following changes:

- Any database call that doesn't use Coroutines has the suffix `Blocking`
- Any Rx call now has the suffix `Rx<ReturnType>`
- Removed `Suspend` from the Coroutine calls
- Added the suffix `Flow` to Coroutine Flow calls

I have converted the DAO classes already. This was the reminder code I didn't have time to change as part of the last PR. https://github.com/Automattic/pocket-casts-android/pull/3258

## Testing Instructions

This is only a refactor but it would be worth looking through the code changes and smoke testing the app.

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 