### PR TITLE
Fix edge-to-edge for the Discover region select page

### DIFF
--- a/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
+++ b/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
@@ -681,7 +681,7 @@ class MainActivity :
     }
 
     override fun updateStatusBar() {
-        val topFragment = supportFragmentManager.fragments.last()
+        val topFragment = supportFragmentManager.fragments.lastOrNull()
         val color = if (binding.playerBottomSheet.isPlayerOpen) {
             StatusBarIconColor.Light
         } else if (topFragment is BaseFragment) {

--- a/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
+++ b/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
@@ -139,7 +139,7 @@ import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingUpgradeSourc
 import au.com.shiftyjelly.pocketcasts.settings.whatsnew.WhatsNewFragment
 import au.com.shiftyjelly.pocketcasts.ui.MainActivityViewModel.NavigationState
 import au.com.shiftyjelly.pocketcasts.ui.helper.FragmentHostListener
-import au.com.shiftyjelly.pocketcasts.ui.helper.StatusBarColor
+import au.com.shiftyjelly.pocketcasts.ui.helper.StatusBarIconColor
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import au.com.shiftyjelly.pocketcasts.ui.theme.ThemeColor
 import au.com.shiftyjelly.pocketcasts.utils.Network
@@ -681,18 +681,17 @@ class MainActivity :
     }
 
     override fun updateStatusBar() {
-        val topFragment = navigator.currentFragment()
+        val topFragment = supportFragmentManager.fragments.last()
         val color = if (binding.playerBottomSheet.isPlayerOpen) {
-            val playerBgColor = theme.playerBackgroundColor(viewModel.lastPlaybackState?.podcast)
-            StatusBarColor.Custom(playerBgColor, true)
+            StatusBarIconColor.Light
         } else if (topFragment is BaseFragment) {
-            topFragment.statusBarColor
+            topFragment.statusBarIconColor
         } else {
             null
         }
 
         if (color != null) {
-            theme.updateWindowStatusBarIcons(window = window, statusBarColor = color, context = this)
+            theme.updateWindowStatusBarIcons(window = window, statusBarIconColor = color)
         }
     }
 

--- a/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/DiscoverFragment.kt
+++ b/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/DiscoverFragment.kt
@@ -34,7 +34,6 @@ import au.com.shiftyjelly.pocketcasts.servers.model.ExpandedStyle
 import au.com.shiftyjelly.pocketcasts.servers.model.ListType
 import au.com.shiftyjelly.pocketcasts.servers.model.NetworkLoadableList
 import au.com.shiftyjelly.pocketcasts.ui.helper.FragmentHostListener
-import au.com.shiftyjelly.pocketcasts.ui.helper.StatusBarColor
 import au.com.shiftyjelly.pocketcasts.views.fragments.BaseFragment
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
@@ -42,7 +41,6 @@ import kotlinx.coroutines.launch
 
 @AndroidEntryPoint
 class DiscoverFragment : BaseFragment(), DiscoverAdapter.Listener, RegionSelectFragment.Listener {
-    override var statusBarColor: StatusBarColor = StatusBarColor.Light
 
     @Inject lateinit var settings: Settings
 

--- a/modules/features/discover/src/main/res/layout/fragment_region_select.xml
+++ b/modules/features/discover/src/main/res/layout/fragment_region_select.xml
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
-<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    tools:context=".discover.view.PodcastListFragment">
+    android:orientation="vertical"
+    tools:context="au.com.shiftyjelly.pocketcasts.discover.view.PodcastListFragment">
 
     <androidx.appcompat.widget.Toolbar
         android:id="@+id/toolbar"
@@ -16,7 +17,6 @@
         android:id="@+id/recyclerView"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:layout_marginTop="?android:actionBarSize"
         android:clipToPadding="false" />
 
-</FrameLayout>
+</LinearLayout>

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/CreateFilterContainerFragment.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/CreateFilterContainerFragment.kt
@@ -23,7 +23,7 @@ import au.com.shiftyjelly.pocketcasts.ui.extensions.setupKeyboardModeResize
 import au.com.shiftyjelly.pocketcasts.ui.extensions.themeColors
 import au.com.shiftyjelly.pocketcasts.ui.helper.ColorUtils
 import au.com.shiftyjelly.pocketcasts.ui.helper.FragmentHostListener
-import au.com.shiftyjelly.pocketcasts.ui.helper.StatusBarColor
+import au.com.shiftyjelly.pocketcasts.ui.helper.StatusBarIconColor
 import au.com.shiftyjelly.pocketcasts.ui.theme.ThemeColor
 import au.com.shiftyjelly.pocketcasts.views.extensions.includeStatusBarPadding
 import au.com.shiftyjelly.pocketcasts.views.extensions.setSystemWindowInsetToPadding
@@ -115,7 +115,7 @@ class CreateFilterContainerFragment : BaseFragment() {
         val filterUi01 = ThemeColor.filterUi01(theme.activeTheme, tintColor)
         toolbar.setBackgroundColor(filterUi01)
         toolbar.setTitleTextColor(ThemeColor.filterText01(theme.activeTheme, tintColor))
-        theme.updateWindowStatusBarIcons(window = requireActivity().window, statusBarColor = StatusBarColor.Custom(filterUi01, theme.activeTheme.defaultLightIcons), context = requireContext())
+        theme.updateWindowStatusBarIcons(window = requireActivity().window, statusBarIconColor = StatusBarIconColor.Theme)
     }
 
     private fun observeLockedFirstPage(adapter: CreatePagerAdapter) {

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/CreateFilterFragment.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/CreateFilterFragment.kt
@@ -26,7 +26,6 @@ import au.com.shiftyjelly.pocketcasts.ui.extensions.getColor
 import au.com.shiftyjelly.pocketcasts.ui.extensions.getColors
 import au.com.shiftyjelly.pocketcasts.ui.extensions.getThemeColor
 import au.com.shiftyjelly.pocketcasts.ui.extensions.themeColors
-import au.com.shiftyjelly.pocketcasts.ui.helper.StatusBarColor
 import au.com.shiftyjelly.pocketcasts.ui.theme.ThemeColor
 import au.com.shiftyjelly.pocketcasts.utils.extensions.dpToPx
 import au.com.shiftyjelly.pocketcasts.views.adapter.ColorAdapter
@@ -69,7 +68,6 @@ class CreateFilterFragment : BaseFragment(), CoroutineScope {
         }
     }
 
-    override var statusBarColor: StatusBarColor = StatusBarColor.Light
     override val coroutineContext: CoroutineContext
         get() = Dispatchers.Main
 

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/FilterEpisodeListFragment.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/FilterEpisodeListFragment.kt
@@ -45,7 +45,6 @@ import au.com.shiftyjelly.pocketcasts.ui.extensions.getColor
 import au.com.shiftyjelly.pocketcasts.ui.extensions.getStringForDuration
 import au.com.shiftyjelly.pocketcasts.ui.extensions.themed
 import au.com.shiftyjelly.pocketcasts.ui.helper.FragmentHostListener
-import au.com.shiftyjelly.pocketcasts.ui.helper.StatusBarColor
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import au.com.shiftyjelly.pocketcasts.ui.theme.ThemeColor
 import au.com.shiftyjelly.pocketcasts.utils.extensions.dpToPx
@@ -199,10 +198,7 @@ class FilterEpisodeListFragment : BaseFragment() {
 
         binding = null
 
-        activity?.let {
-            statusBarColor = StatusBarColor.Light
-            updateStatusBar()
-        }
+        updateStatusBar()
     }
 
     private fun onRowClick(episode: BaseEpisode) {

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/EffectsFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/EffectsFragment.kt
@@ -42,7 +42,7 @@ import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
 import au.com.shiftyjelly.pocketcasts.repositories.user.StatsManager
 import au.com.shiftyjelly.pocketcasts.ui.extensions.themed
 import au.com.shiftyjelly.pocketcasts.ui.helper.ColorUtils
-import au.com.shiftyjelly.pocketcasts.ui.helper.StatusBarColor
+import au.com.shiftyjelly.pocketcasts.ui.helper.StatusBarIconColor
 import au.com.shiftyjelly.pocketcasts.ui.theme.ThemeColor
 import au.com.shiftyjelly.pocketcasts.utils.Debouncer
 import au.com.shiftyjelly.pocketcasts.utils.extensions.dpToPx
@@ -70,7 +70,7 @@ class EffectsFragment : BaseDialogFragment(), CompoundButton.OnCheckedChangeList
 
     @Inject lateinit var playbackManager: PlaybackManager
 
-    override val statusBarColor: StatusBarColor? = null
+    override val statusBarIconColor: StatusBarIconColor? = null
 
     private val viewModel: PlayerViewModel by activityViewModels()
     private lateinit var imageRequestFactory: PocketCastsImageRequestFactory

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/LongPressOptionsFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/LongPressOptionsFragment.kt
@@ -8,7 +8,7 @@ import androidx.core.view.isVisible
 import androidx.fragment.app.activityViewModels
 import au.com.shiftyjelly.pocketcasts.player.databinding.FragmentLongPressOptionsBinding
 import au.com.shiftyjelly.pocketcasts.player.viewmodel.PlayerViewModel
-import au.com.shiftyjelly.pocketcasts.ui.helper.StatusBarColor
+import au.com.shiftyjelly.pocketcasts.ui.helper.StatusBarIconColor
 import au.com.shiftyjelly.pocketcasts.views.extensions.applyColor
 import au.com.shiftyjelly.pocketcasts.views.fragments.BaseDialogFragment
 import com.google.android.material.bottomsheet.BottomSheetBehavior
@@ -18,7 +18,7 @@ import dagger.hilt.android.AndroidEntryPoint
 @AndroidEntryPoint
 class LongPressOptionsFragment : BaseDialogFragment() {
 
-    override val statusBarColor: StatusBarColor? = null
+    override val statusBarIconColor: StatusBarIconColor? = null
 
     private val viewModel: PlayerViewModel by activityViewModels()
     private var binding: FragmentLongPressOptionsBinding? = null

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/PlayerContainerFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/PlayerContainerFragment.kt
@@ -36,9 +36,8 @@ import au.com.shiftyjelly.pocketcasts.player.viewmodel.ShelfSharedViewModel
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.repositories.playback.UpNextSource
 import au.com.shiftyjelly.pocketcasts.ui.helper.FragmentHostListener
-import au.com.shiftyjelly.pocketcasts.ui.helper.StatusBarColor
+import au.com.shiftyjelly.pocketcasts.ui.helper.StatusBarIconColor
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
-import au.com.shiftyjelly.pocketcasts.ui.theme.ThemeColor
 import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
 import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
 import au.com.shiftyjelly.pocketcasts.views.fragments.BaseFragment
@@ -134,7 +133,7 @@ class PlayerContainerFragment : BaseFragment(), HasBackstack {
 
                     activity?.let {
                         theme.setNavigationBarIconColor(window = it.window, isDark = true)
-                        theme.updateWindowStatusBarIcons(it.window, StatusBarColor.Custom(ThemeColor.secondaryUi01(overrideTheme), true), it)
+                        theme.updateWindowStatusBarIcons(it.window, StatusBarIconColor.Light)
                     }
 
                     upNextFragment.onExpanded()

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/SleepFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/SleepFragment.kt
@@ -17,7 +17,7 @@ import au.com.shiftyjelly.pocketcasts.settings.PlaybackSettingsFragment
 import au.com.shiftyjelly.pocketcasts.settings.PlaybackSettingsFragment.Companion.SCROLL_TO_SLEEP_TIMER
 import au.com.shiftyjelly.pocketcasts.settings.SettingsFragment
 import au.com.shiftyjelly.pocketcasts.ui.helper.FragmentHostListener
-import au.com.shiftyjelly.pocketcasts.ui.helper.StatusBarColor
+import au.com.shiftyjelly.pocketcasts.ui.helper.StatusBarIconColor
 import au.com.shiftyjelly.pocketcasts.utils.combineLatest
 import au.com.shiftyjelly.pocketcasts.utils.minutes
 import au.com.shiftyjelly.pocketcasts.views.extensions.applyColor
@@ -41,7 +41,7 @@ import au.com.shiftyjelly.pocketcasts.views.R as VR
 class SleepFragment : BaseDialogFragment() {
 
     @Inject lateinit var analyticsTracker: AnalyticsTracker
-    override val statusBarColor: StatusBarColor? = null
+    override val statusBarIconColor: StatusBarIconColor? = null
 
     private val viewModel: PlayerViewModel by activityViewModels()
     private var binding: FragmentSleepBinding? = null

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/UpNextFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/UpNextFragment.kt
@@ -34,7 +34,7 @@ import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
 import au.com.shiftyjelly.pocketcasts.repositories.playback.UpNextSource
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
 import au.com.shiftyjelly.pocketcasts.ui.helper.FragmentHostListener
-import au.com.shiftyjelly.pocketcasts.ui.helper.StatusBarColor
+import au.com.shiftyjelly.pocketcasts.ui.helper.StatusBarIconColor
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import au.com.shiftyjelly.pocketcasts.ui.theme.ThemeColor
 import au.com.shiftyjelly.pocketcasts.utils.extensions.hideShadow
@@ -250,11 +250,7 @@ class UpNextFragment : BaseFragment(), UpNextListener, UpNextTouchCallback.ItemT
     private fun updateStatusAndNavColors() {
         activity?.let {
             theme.setNavigationBarIconColor(window = it.window, isDark = true)
-            theme.updateWindowStatusBarIcons(
-                it.window,
-                StatusBarColor.Custom(ThemeColor.secondaryUi01(overrideTheme), overrideTheme.darkTheme),
-                it,
-            )
+            theme.updateWindowStatusBarIcons(window = it.window, statusBarIconColor = StatusBarIconColor.Theme)
         }
     }
 

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/bookmark/BookmarksContainerFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/bookmark/BookmarksContainerFragment.kt
@@ -1,7 +1,6 @@
 package au.com.shiftyjelly.pocketcasts.player.view.bookmark
 
 import android.content.res.Resources
-import android.graphics.Color
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
@@ -17,7 +16,7 @@ import au.com.shiftyjelly.pocketcasts.player.databinding.FragmentBookmarksContai
 import au.com.shiftyjelly.pocketcasts.player.viewmodel.BookmarksViewModel
 import au.com.shiftyjelly.pocketcasts.ui.extensions.getThemeColor
 import au.com.shiftyjelly.pocketcasts.ui.extensions.getThemeTintedDrawable
-import au.com.shiftyjelly.pocketcasts.ui.helper.StatusBarColor
+import au.com.shiftyjelly.pocketcasts.ui.helper.StatusBarIconColor
 import au.com.shiftyjelly.pocketcasts.views.extensions.setup
 import au.com.shiftyjelly.pocketcasts.views.fragments.BaseDialogFragment
 import au.com.shiftyjelly.pocketcasts.views.helper.NavigationIcon
@@ -50,15 +49,11 @@ class BookmarksContainerFragment :
     private val sourceView: SourceView
         get() = SourceView.fromString(arguments?.getString(ARG_SOURCE_VIEW))
 
-    override val statusBarColor: StatusBarColor
+    override val statusBarIconColor: StatusBarIconColor
         get() = if (sourceView == SourceView.PROFILE) {
-            StatusBarColor.Light
+            StatusBarIconColor.Theme
         } else {
-            StatusBarColor.Custom(
-                context?.getThemeColor(UR.attr.primary_ui_01)
-                    ?: Color.WHITE,
-                theme.isDarkTheme,
-            )
+            StatusBarIconColor.Dark
         }
 
     var binding: FragmentBookmarksContainerBinding? = null

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/episode/EpisodeContainerFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/episode/EpisodeContainerFragment.kt
@@ -3,7 +3,6 @@ package au.com.shiftyjelly.pocketcasts.podcasts.view.episode
 import android.app.Dialog
 import android.content.res.ColorStateList
 import android.content.res.Resources
-import android.graphics.Color
 import android.os.Bundle
 import android.view.ContextThemeWrapper
 import android.view.LayoutInflater
@@ -33,8 +32,7 @@ import au.com.shiftyjelly.pocketcasts.player.view.chapters.ChaptersViewModel.Mod
 import au.com.shiftyjelly.pocketcasts.player.viewmodel.BookmarksViewModel
 import au.com.shiftyjelly.pocketcasts.podcasts.databinding.FragmentEpisodeContainerBinding
 import au.com.shiftyjelly.pocketcasts.podcasts.view.episode.EpisodeFragment.EpisodeFragmentArgs
-import au.com.shiftyjelly.pocketcasts.ui.extensions.getThemeColor
-import au.com.shiftyjelly.pocketcasts.ui.helper.StatusBarColor
+import au.com.shiftyjelly.pocketcasts.ui.helper.StatusBarIconColor
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import au.com.shiftyjelly.pocketcasts.ui.theme.ThemeColor
 import au.com.shiftyjelly.pocketcasts.views.fragments.BaseDialogFragment
@@ -103,12 +101,8 @@ class EpisodeContainerFragment :
             bundle?.let { BundleCompat.getParcelable(it, NEW_INSTANCE_ARG, EpisodeFragmentArgs::class.java) }
     }
 
-    override val statusBarColor: StatusBarColor
-        get() = StatusBarColor.Custom(
-            context?.getThemeColor(UR.attr.primary_ui_01)
-                ?: Color.WHITE,
-            theme.isDarkTheme,
-        )
+    override val statusBarIconColor: StatusBarIconColor
+        get() = StatusBarIconColor.Light
 
     var binding: FragmentEpisodeContainerBinding? = null
 

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/episode/EpisodeFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/episode/EpisodeFragment.kt
@@ -42,7 +42,7 @@ import au.com.shiftyjelly.pocketcasts.ui.R
 import au.com.shiftyjelly.pocketcasts.ui.extensions.getThemeColor
 import au.com.shiftyjelly.pocketcasts.ui.extensions.themed
 import au.com.shiftyjelly.pocketcasts.ui.helper.FragmentHostListener
-import au.com.shiftyjelly.pocketcasts.ui.helper.StatusBarColor
+import au.com.shiftyjelly.pocketcasts.ui.helper.StatusBarIconColor
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import au.com.shiftyjelly.pocketcasts.ui.theme.ThemeColor
 import au.com.shiftyjelly.pocketcasts.utils.Network
@@ -114,7 +114,7 @@ class EpisodeFragment : BaseFragment() {
             bundle?.let { BundleCompat.getParcelable(it, NEW_INSTANCE_ARG, EpisodeFragmentArgs::class.java) }
     }
 
-    override lateinit var statusBarColor: StatusBarColor
+    override lateinit var statusBarIconColor: StatusBarIconColor
 
     @Inject lateinit var settings: Settings
 
@@ -177,9 +177,7 @@ class EpisodeFragment : BaseFragment() {
 
         showNotesFormatter = createShowNotesFormatter(contextThemeWrapper)
 
-        statusBarColor = StatusBarColor.Custom(
-            context?.getThemeColor(R.attr.primary_ui_01) ?: Color.WHITE, theme.isDarkTheme,
-        )
+        statusBarIconColor = StatusBarIconColor.Light
         return binding?.root
     }
 

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastAutoArchiveFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastAutoArchiveFragment.kt
@@ -38,7 +38,7 @@ import au.com.shiftyjelly.pocketcasts.compose.theme
 import au.com.shiftyjelly.pocketcasts.models.to.AutoArchiveAfterPlaying
 import au.com.shiftyjelly.pocketcasts.models.to.AutoArchiveInactive
 import au.com.shiftyjelly.pocketcasts.models.to.AutoArchiveLimit
-import au.com.shiftyjelly.pocketcasts.ui.helper.StatusBarColor
+import au.com.shiftyjelly.pocketcasts.ui.helper.StatusBarIconColor
 import au.com.shiftyjelly.pocketcasts.views.fragments.BaseFragment
 import au.com.shiftyjelly.pocketcasts.views.helper.ToolbarColors
 import dagger.hilt.android.AndroidEntryPoint
@@ -94,8 +94,7 @@ class PodcastAutoArchiveFragment : BaseFragment() {
     private fun tintToolbar(color: Int) {
         theme.updateWindowStatusBarIcons(
             window = requireActivity().window,
-            statusBarColor = StatusBarColor.Custom(color, isWhiteIcons = ColorUtils.calculateLuminance(color) < 0.5),
-            context = requireActivity(),
+            statusBarIconColor = if (ColorUtils.calculateLuminance(color) < 0.5) StatusBarIconColor.Light else StatusBarIconColor.Dark,
         )
     }
 

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastEffectsFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastEffectsFragment.kt
@@ -17,7 +17,7 @@ import au.com.shiftyjelly.pocketcasts.podcasts.viewmodel.PodcastEffectsViewModel
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
 import au.com.shiftyjelly.pocketcasts.ui.extensions.getThemeColor
 import au.com.shiftyjelly.pocketcasts.ui.extensions.getTintedDrawable
-import au.com.shiftyjelly.pocketcasts.ui.helper.StatusBarColor
+import au.com.shiftyjelly.pocketcasts.ui.helper.StatusBarIconColor
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import au.com.shiftyjelly.pocketcasts.views.extensions.includeStatusBarPadding
 import au.com.shiftyjelly.pocketcasts.views.extensions.setup
@@ -110,8 +110,7 @@ class PodcastEffectsFragment : PreferenceFragmentCompat() {
 
             theme.updateWindowStatusBarIcons(
                 window = requireActivity().window,
-                statusBarColor = StatusBarColor.Custom(colors.backgroundColor, isWhiteIcons = theme.activeTheme.defaultLightIcons),
-                context = context,
+                statusBarIconColor = StatusBarIconColor.Theme,
             )
 
             preferenceCustomForPodcast?.isChecked = podcast.overrideGlobalEffects

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastFragment.kt
@@ -64,7 +64,7 @@ import au.com.shiftyjelly.pocketcasts.sharing.SharingRequest
 import au.com.shiftyjelly.pocketcasts.ui.extensions.getThemeColor
 import au.com.shiftyjelly.pocketcasts.ui.extensions.openUrl
 import au.com.shiftyjelly.pocketcasts.ui.helper.FragmentHostListener
-import au.com.shiftyjelly.pocketcasts.ui.helper.StatusBarColor
+import au.com.shiftyjelly.pocketcasts.ui.helper.StatusBarIconColor
 import au.com.shiftyjelly.pocketcasts.ui.images.CoilManager
 import au.com.shiftyjelly.pocketcasts.ui.theme.ThemeColor
 import au.com.shiftyjelly.pocketcasts.utils.extensions.dpToPx
@@ -178,7 +178,7 @@ class PodcastFragment : BaseFragment(), Toolbar.OnMenuItemClickListener {
         }
     }
 
-    override var statusBarColor: StatusBarColor = StatusBarColor.Custom(color = 0xFF1E1F1E.toInt(), isWhiteIcons = true)
+    override var statusBarIconColor: StatusBarIconColor = StatusBarIconColor.Light
 
     private val onHeaderSummaryToggled: (
         expanded: Boolean,
@@ -605,7 +605,7 @@ class PodcastFragment : BaseFragment(), Toolbar.OnMenuItemClickListener {
         val headerColor = context.getThemeColor(UR.attr.support_09)
         binding.headerBackgroundPlaceholder.setBackgroundColor(headerColor)
         binding.toolbar.setBackgroundColor(headerColor)
-        statusBarColor = StatusBarColor.Custom(headerColor, true)
+        statusBarIconColor = StatusBarIconColor.Light
         updateStatusBar()
 
         loadData()
@@ -842,7 +842,7 @@ class PodcastFragment : BaseFragment(), Toolbar.OnMenuItemClickListener {
 
                 viewModel.archiveEpisodeLimit()
 
-                statusBarColor = StatusBarColor.Custom(backgroundColor, true)
+                statusBarIconColor = StatusBarIconColor.Light
                 updateStatusBar()
             },
         )

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastSettingsFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastSettingsFragment.kt
@@ -28,7 +28,7 @@ import au.com.shiftyjelly.pocketcasts.settings.AutoAddSettingsFragment
 import au.com.shiftyjelly.pocketcasts.ui.extensions.getThemeColor
 import au.com.shiftyjelly.pocketcasts.ui.extensions.getTintedDrawable
 import au.com.shiftyjelly.pocketcasts.ui.helper.FragmentHostListener
-import au.com.shiftyjelly.pocketcasts.ui.helper.StatusBarColor
+import au.com.shiftyjelly.pocketcasts.ui.helper.StatusBarIconColor
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import au.com.shiftyjelly.pocketcasts.utils.combineLatest
 import au.com.shiftyjelly.pocketcasts.views.dialog.ConfirmationDialog
@@ -165,8 +165,7 @@ class PodcastSettingsFragment : BasePreferenceFragment(), FilterSelectFragment.L
 
             theme.updateWindowStatusBarIcons(
                 window = requireActivity().window,
-                statusBarColor = StatusBarColor.Custom(colors.backgroundColor, isWhiteIcons = theme.activeTheme.defaultLightIcons),
-                context = context,
+                statusBarIconColor = StatusBarIconColor.Theme,
             )
 
             preferenceNotifications?.isChecked = podcast.isShowNotifications
@@ -420,7 +419,7 @@ class PodcastSettingsFragment : BasePreferenceFragment(), FilterSelectFragment.L
 
     private fun setupStatusBar() {
         activity?.let {
-            theme.updateWindowStatusBarIcons(window = it.window, statusBarColor = StatusBarColor.Light, context = it)
+            theme.updateWindowStatusBarIcons(window = it.window, statusBarIconColor = StatusBarIconColor.Theme)
         }
     }
 

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/ProfileFragment.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/ProfileFragment.kt
@@ -3,6 +3,7 @@ package au.com.shiftyjelly.pocketcasts.profile
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.ViewGroup
+import androidx.compose.foundation.layout.consumeWindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Modifier
@@ -116,6 +117,9 @@ class ProfileFragment : BaseFragment() {
             },
             modifier = Modifier.fillMaxSize(),
         )
+    }.apply {
+        // if we consume the insets on older versions of Android such as SDK 26 it will effect the layout of other areas of the app such as the What's New bottom sheet
+        consumeWindowInsets = false
     }
 
     override fun onResume() {

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/ProfilePage.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/ProfilePage.kt
@@ -190,9 +190,9 @@ private fun Toolbar(
         verticalAlignment = Alignment.CenterVertically,
         modifier = Modifier
             .fillMaxWidth()
+            .background(MaterialTheme.theme.colors.secondaryUi01)
             .windowInsetsPadding(AppBarDefaults.topAppBarWindowInsets)
             .height(56.dp)
-            .background(MaterialTheme.theme.colors.secondaryUi01)
             .padding(horizontal = horizontalPadding),
     ) {
         if (showReferralsIcon) {

--- a/modules/features/referrals/src/main/kotlin/au/com/shiftyjelly/pocketcasts/referrals/ReferralsGuestPassFragment.kt
+++ b/modules/features/referrals/src/main/kotlin/au/com/shiftyjelly/pocketcasts/referrals/ReferralsGuestPassFragment.kt
@@ -1,7 +1,6 @@
 package au.com.shiftyjelly.pocketcasts.referrals
 
 import android.app.Activity
-import android.graphics.Color
 import android.os.Bundle
 import android.os.Parcelable
 import android.view.LayoutInflater
@@ -20,7 +19,7 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
 import au.com.shiftyjelly.pocketcasts.ui.helper.FragmentHostListener
-import au.com.shiftyjelly.pocketcasts.ui.helper.StatusBarColor
+import au.com.shiftyjelly.pocketcasts.ui.helper.StatusBarIconColor
 import au.com.shiftyjelly.pocketcasts.utils.extensions.getActivity
 import au.com.shiftyjelly.pocketcasts.views.fragments.BaseFragment
 import au.com.shiftyjelly.pocketcasts.views.helper.UiUtil.setBackgroundColor
@@ -83,11 +82,7 @@ class ReferralsGuestPassFragment : BaseFragment() {
     private fun updateStatusAndNavColors() {
         activity?.let {
             theme.setNavigationBarIconColor(window = it.window, isDark = true)
-            theme.updateWindowStatusBarIcons(
-                it.window,
-                StatusBarColor.Custom(Color.BLACK, true),
-                it,
-            )
+            theme.updateWindowStatusBarIcons(window = it.window, statusBarIconColor = StatusBarIconColor.Dark)
         }
     }
 

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/developer/DeveloperFragment.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/developer/DeveloperFragment.kt
@@ -4,6 +4,7 @@ import android.content.Intent
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.ViewGroup
+import androidx.compose.foundation.layout.consumeWindowInsets
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 import androidx.fragment.app.viewModels
@@ -46,6 +47,8 @@ class DeveloperFragment : BaseFragment() {
                 onShowWhatsNewClick = ::onShowWhatsNewClick,
             )
         }
+    }.apply {
+        consumeWindowInsets = false
     }
 
     @Suppress("DEPRECATION")

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/developer/DeveloperFragment.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/developer/DeveloperFragment.kt
@@ -11,6 +11,8 @@ import androidx.fragment.compose.content
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import au.com.shiftyjelly.pocketcasts.compose.AppThemeWithBackground
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
+import au.com.shiftyjelly.pocketcasts.settings.whatsnew.WhatsNewFragment
+import au.com.shiftyjelly.pocketcasts.ui.helper.FragmentHostListener
 import au.com.shiftyjelly.pocketcasts.utils.extensions.pxToDp
 import au.com.shiftyjelly.pocketcasts.views.fragments.BaseFragment
 import com.airbnb.android.showkase.ui.ShowkaseBrowserActivity
@@ -41,6 +43,7 @@ class DeveloperFragment : BaseFragment() {
                 onTriggerResetEoYModalProfileBadge = viewModel::resetEoYModalProfileBadge,
                 bottomInset = bottomInset.value.pxToDp(LocalContext.current).dp,
                 onSendCrash = viewModel::onSendCrash,
+                onShowWhatsNewClick = ::onShowWhatsNewClick,
             )
         }
     }
@@ -55,5 +58,9 @@ class DeveloperFragment : BaseFragment() {
             putExtra("SHOWKASE_ROOT_MODULE", "au.com.shiftyjelly.pocketcasts.showkase.AppShowkaseRootModule")
         }
         startActivity(intent)
+    }
+
+    private fun onShowWhatsNewClick() {
+        (activity as? FragmentHostListener)?.showBottomSheet(fragment = WhatsNewFragment())
     }
 }

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/developer/DeveloperPage.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/developer/DeveloperPage.kt
@@ -23,6 +23,7 @@ import androidx.compose.material.icons.outlined.Delete
 import androidx.compose.material.icons.outlined.Downloading
 import androidx.compose.material.icons.outlined.EditCalendar
 import androidx.compose.material.icons.outlined.HomeRepairService
+import androidx.compose.material.icons.outlined.NewReleases
 import androidx.compose.material.icons.outlined.Notifications
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -57,6 +58,7 @@ fun DeveloperPage(
     onTriggerResetEoYModalProfileBadge: () -> Unit,
     bottomInset: Dp,
     onSendCrash: (String) -> Unit,
+    onShowWhatsNewClick: () -> Unit,
 ) {
     var openCrashMessageDialog by remember { mutableStateOf(false) }
     var crashMessage by remember { mutableStateOf("Test crash") }
@@ -94,6 +96,9 @@ fun DeveloperPage(
         }
         item {
             EndOfYear(onClick = onTriggerResetEoYModalProfileBadge)
+        }
+        item {
+            ShowWhatsNew(onClick = onShowWhatsNewClick)
         }
 
         if (openCrashMessageDialog) {
@@ -262,6 +267,19 @@ private fun EndOfYear(
     )
 }
 
+@Composable
+private fun ShowWhatsNew(
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    SettingRow(
+        primaryText = "Show What's New",
+        secondaryText = "Open the What's New page",
+        icon = rememberVectorPainter(Icons.Outlined.NewReleases),
+        modifier = modifier.clickable { onClick() },
+    )
+}
+
 @Preview(name = "Light")
 @Composable
 private fun DeveloperPageLightPreview() {
@@ -290,6 +308,7 @@ private fun DeveloperPagePreview() {
         onTriggerResetEoYModalProfileBadge = {},
         bottomInset = 0.dp,
         onSendCrash = {},
+        onShowWhatsNewClick = {},
     )
 }
 

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/whatsnew/WhatsNewFragment.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/whatsnew/WhatsNewFragment.kt
@@ -20,6 +20,7 @@ import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingLauncher
 import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingUpgradeSource
 import au.com.shiftyjelly.pocketcasts.settings.whatsnew.WhatsNewViewModel.NavigationState
 import au.com.shiftyjelly.pocketcasts.ui.helper.FragmentHostListener
+import au.com.shiftyjelly.pocketcasts.ui.helper.StatusBarIconColor
 import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
 import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
 import au.com.shiftyjelly.pocketcasts.views.fragments.BaseFragment
@@ -31,6 +32,8 @@ class WhatsNewFragment : BaseFragment() {
 
     @Inject
     lateinit var analyticsTracker: AnalyticsTracker
+
+    override var statusBarIconColor: StatusBarIconColor = StatusBarIconColor.ThemeNoToolbar
 
     override fun onCreateView(
         inflater: LayoutInflater,

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/whatsnew/WhatsNewFragment.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/whatsnew/WhatsNewFragment.kt
@@ -34,6 +34,7 @@ class WhatsNewFragment : BaseFragment() {
     lateinit var analyticsTracker: AnalyticsTracker
 
     override var statusBarIconColor: StatusBarIconColor = StatusBarIconColor.ThemeNoToolbar
+    override var backgroundTransparent: Boolean = true
 
     override fun onCreateView(
         inflater: LayoutInflater,

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/whatsnew/WhatsNewPage.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/whatsnew/WhatsNewPage.kt
@@ -19,7 +19,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
@@ -78,11 +77,6 @@ private fun WhatsNewPageLoaded(
     onConfirm: () -> Unit,
     onClose: () -> Unit,
 ) {
-    var closing by remember { mutableStateOf(false) }
-    val performClose = {
-        closing = true
-    }
-
     Box(
         contentAlignment = Alignment.Center,
         modifier = Modifier
@@ -93,7 +87,7 @@ private fun WhatsNewPageLoaded(
                     Modifier.clickable(
                         indication = null,
                         interactionSource = remember { MutableInteractionSource() },
-                        onClick = { performClose() },
+                        onClick = { onClose() },
                     )
                 } else {
                     Modifier
@@ -111,7 +105,7 @@ private fun WhatsNewPageLoaded(
             if (state.fullModel) {
                 ThemedTopAppBar(
                     navigationButton = NavigationButton.Close,
-                    onNavigationClick = performClose,
+                    onNavigationClick = onClose,
                     style = ThemedTopAppBar.Style.Immersive,
                 )
             }
@@ -159,7 +153,7 @@ private fun WhatsNewPageLoaded(
                 RowTextButton(
                     text = stringResource(it),
                     fontSize = 15.sp,
-                    onClick = performClose,
+                    onClick = onClose,
                 )
             }
 

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/whatsnew/WhatsNewPage.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/whatsnew/WhatsNewPage.kt
@@ -1,7 +1,6 @@
 package au.com.shiftyjelly.pocketcasts.settings.whatsnew
 
 import android.content.res.Configuration
-import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
@@ -12,7 +11,9 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.material.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -23,14 +24,14 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
-import au.com.shiftyjelly.pocketcasts.compose.bottomsheet.Pill
+import au.com.shiftyjelly.pocketcasts.compose.bars.NavigationButton
+import au.com.shiftyjelly.pocketcasts.compose.bars.ThemedTopAppBar
 import au.com.shiftyjelly.pocketcasts.compose.buttons.RowButton
 import au.com.shiftyjelly.pocketcasts.compose.buttons.RowTextButton
 import au.com.shiftyjelly.pocketcasts.compose.components.TextH10
@@ -38,7 +39,6 @@ import au.com.shiftyjelly.pocketcasts.compose.components.TextP40
 import au.com.shiftyjelly.pocketcasts.compose.theme
 import au.com.shiftyjelly.pocketcasts.settings.whatsnew.WhatsNewViewModel.UiState
 import au.com.shiftyjelly.pocketcasts.settings.whatsnew.WhatsNewViewModel.WhatsNewFeature
-import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 @Composable
 fun WhatsNewPage(
@@ -79,12 +79,6 @@ private fun WhatsNewPageLoaded(
     onClose: () -> Unit,
 ) {
     var closing by remember { mutableStateOf(false) }
-    val targetAlpha = if (closing) 0f else 0.66f
-    val scrimAlpha: Float by animateFloatAsState(
-        targetValue = targetAlpha,
-        finishedListener = { onClose() },
-    )
-
     val performClose = {
         closing = true
     }
@@ -92,7 +86,8 @@ private fun WhatsNewPageLoaded(
     Box(
         contentAlignment = Alignment.Center,
         modifier = Modifier
-            .background(Color.Black.copy(alpha = scrimAlpha))
+            .statusBarsPadding()
+            .navigationBarsPadding()
             .then(
                 if (!state.fullModel) {
                     Modifier.clickable(
@@ -114,21 +109,11 @@ private fun WhatsNewPageLoaded(
                 .then(if (state.fullModel) Modifier.fillMaxSize() else Modifier),
         ) {
             if (state.fullModel) {
-                Spacer(Modifier.height(8.dp))
-
-                Pill()
-
-                Box(
-                    modifier = Modifier.align(Alignment.Start),
-                ) {
-                    RowTextButton(
-                        text = stringResource(LR.string.cancel),
-                        fontSize = 15.sp,
-                        onClick = performClose,
-                        fullWidth = false,
-                        includePadding = false,
-                    )
-                }
+                ThemedTopAppBar(
+                    navigationButton = NavigationButton.Close,
+                    onNavigationClick = performClose,
+                    style = ThemedTopAppBar.Style.Immersive,
+                )
             }
 
             Column(

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/whatsnew/WhatsNewViewModel.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/whatsnew/WhatsNewViewModel.kt
@@ -26,7 +26,6 @@ class WhatsNewViewModel @Inject constructor() : ViewModel() {
     init {
         _state.value = UiState.Loaded(
             feature = WhatsNewFeature.Shuffle,
-            fullModel = true,
             tier = UserTier.Plus,
         )
     }
@@ -42,7 +41,6 @@ class WhatsNewViewModel @Inject constructor() : ViewModel() {
         data class Loaded(
             val feature: WhatsNewFeature,
             val tier: UserTier,
-            val fullModel: Boolean = false,
         ) : UiState()
     }
 

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/bars/ThemedTopAppBar.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/bars/ThemedTopAppBar.kt
@@ -32,14 +32,31 @@ sealed class NavigationButton(val image: ImageVector, val contentDescription: In
     object Close : NavigationButton(image = Icons.Default.Close, contentDescription = LR.string.close)
 }
 
+object ThemedTopAppBar {
+    sealed interface Style {
+        data object Solid : Style
+        data object Immersive : Style
+    }
+}
+
 @Composable
 fun ThemedTopAppBar(
     modifier: Modifier = Modifier,
     title: String? = null,
     navigationButton: NavigationButton = NavigationButton.Back,
-    iconColor: Color = MaterialTheme.theme.colors.secondaryIcon01,
-    textColor: Color = MaterialTheme.theme.colors.secondaryText01,
-    backgroundColor: Color = MaterialTheme.theme.colors.secondaryUi01,
+    style: ThemedTopAppBar.Style = ThemedTopAppBar.Style.Solid,
+    iconColor: Color = when (style) {
+        ThemedTopAppBar.Style.Solid -> MaterialTheme.theme.colors.secondaryIcon01
+        ThemedTopAppBar.Style.Immersive -> MaterialTheme.theme.colors.primaryIcon01
+    },
+    textColor: Color = when (style) {
+        ThemedTopAppBar.Style.Solid -> MaterialTheme.theme.colors.secondaryText01
+        ThemedTopAppBar.Style.Immersive -> MaterialTheme.theme.colors.primaryText01
+    },
+    backgroundColor: Color = when (style) {
+        ThemedTopAppBar.Style.Solid -> MaterialTheme.theme.colors.secondaryUi01
+        ThemedTopAppBar.Style.Immersive -> MaterialTheme.theme.colors.primaryUi01
+    },
     bottomShadow: Boolean = false,
     actions: @Composable RowScope.() -> Unit = {},
     onNavigationClick: () -> Unit,
@@ -100,6 +117,7 @@ private fun ThemedTopAppBarPreview(@PreviewParameter(ThemePreviewParameterProvid
         Column {
             ThemedTopAppBar(title = "Hello World", navigationButton = NavigationButton.Back, onNavigationClick = {})
             ThemedTopAppBar(title = "Hello World", navigationButton = NavigationButton.Close, onNavigationClick = {})
+            ThemedTopAppBar(title = "Hello World", navigationButton = NavigationButton.Back, style = ThemedTopAppBar.Style.Immersive, onNavigationClick = {})
         }
     }
 }

--- a/modules/services/ui/src/main/java/au/com/shiftyjelly/pocketcasts/ui/helper/StatusBarColor.kt
+++ b/modules/services/ui/src/main/java/au/com/shiftyjelly/pocketcasts/ui/helper/StatusBarColor.kt
@@ -1,7 +1,0 @@
-package au.com.shiftyjelly.pocketcasts.ui.helper
-
-sealed class StatusBarColor {
-    object Dark : StatusBarColor()
-    object Light : StatusBarColor()
-    data class Custom(val color: Int, val isWhiteIcons: Boolean) : StatusBarColor()
-}

--- a/modules/services/ui/src/main/java/au/com/shiftyjelly/pocketcasts/ui/helper/StatusBarIconColor.kt
+++ b/modules/services/ui/src/main/java/au/com/shiftyjelly/pocketcasts/ui/helper/StatusBarIconColor.kt
@@ -1,0 +1,15 @@
+package au.com.shiftyjelly.pocketcasts.ui.helper
+
+sealed interface StatusBarIconColor {
+    // Dark color for status bar icons.
+    data object Dark : StatusBarIconColor
+
+    // Light color for status bar icons.
+    data object Light : StatusBarIconColor
+
+    // The icon color is determined by the theme.
+    data object Theme : StatusBarIconColor
+
+    // The icon color is determined by the theme, but the page has no toolbar or a toolbar the same color as the background.
+    data object ThemeNoToolbar : StatusBarIconColor
+}

--- a/modules/services/ui/src/main/java/au/com/shiftyjelly/pocketcasts/ui/theme/Theme.kt
+++ b/modules/services/ui/src/main/java/au/com/shiftyjelly/pocketcasts/ui/theme/Theme.kt
@@ -21,7 +21,7 @@ import au.com.shiftyjelly.pocketcasts.preferences.model.ThemeSetting
 import au.com.shiftyjelly.pocketcasts.ui.BuildConfig
 import au.com.shiftyjelly.pocketcasts.ui.R
 import au.com.shiftyjelly.pocketcasts.ui.extensions.getThemeColor
-import au.com.shiftyjelly.pocketcasts.ui.helper.StatusBarColor
+import au.com.shiftyjelly.pocketcasts.ui.helper.StatusBarIconColor
 import au.com.shiftyjelly.pocketcasts.utils.Util
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -70,7 +70,8 @@ class Theme @Inject constructor(private val settings: Settings) {
         @StringRes val labelId: Int,
         @StyleRes val resourceId: Int,
         @DrawableRes val iconResourceId: Int,
-        val defaultLightIcons: Boolean,
+        val toolbarLightIcons: Boolean,
+        val backgroundLightIcons: Boolean,
         val darkTheme: Boolean,
         val isPlus: Boolean,
     ) {
@@ -79,7 +80,8 @@ class Theme @Inject constructor(private val settings: Settings) {
             labelId = LR.string.settings_theme_light,
             resourceId = R.style.ThemeLight,
             iconResourceId = IR.drawable.ic_apptheme0,
-            defaultLightIcons = false,
+            toolbarLightIcons = false,
+            backgroundLightIcons = false,
             darkTheme = false,
             isPlus = false,
         ),
@@ -88,7 +90,8 @@ class Theme @Inject constructor(private val settings: Settings) {
             labelId = LR.string.settings_theme_dark,
             resourceId = R.style.ThemeDark,
             iconResourceId = IR.drawable.ic_apptheme1,
-            defaultLightIcons = true,
+            toolbarLightIcons = true,
+            backgroundLightIcons = true,
             darkTheme = true,
             isPlus = false,
         ),
@@ -97,7 +100,8 @@ class Theme @Inject constructor(private val settings: Settings) {
             labelId = LR.string.settings_theme_rose,
             resourceId = R.style.Rose,
             iconResourceId = IR.drawable.ic_theme_rose,
-            defaultLightIcons = false,
+            toolbarLightIcons = false,
+            backgroundLightIcons = false,
             darkTheme = false,
             isPlus = false,
         ),
@@ -106,7 +110,8 @@ class Theme @Inject constructor(private val settings: Settings) {
             labelId = LR.string.settings_theme_indigo,
             resourceId = R.style.Indigo,
             iconResourceId = IR.drawable.ic_indigo,
-            defaultLightIcons = true,
+            toolbarLightIcons = true,
+            backgroundLightIcons = false,
             darkTheme = false,
             isPlus = false,
         ),
@@ -115,7 +120,8 @@ class Theme @Inject constructor(private val settings: Settings) {
             labelId = LR.string.settings_theme_extra_dark,
             resourceId = R.style.ExtraThemeDark,
             iconResourceId = IR.drawable.ic_apptheme2,
-            defaultLightIcons = true,
+            toolbarLightIcons = true,
+            backgroundLightIcons = true,
             darkTheme = true,
             isPlus = false,
         ),
@@ -124,7 +130,8 @@ class Theme @Inject constructor(private val settings: Settings) {
             labelId = LR.string.settings_theme_dark_contrast,
             resourceId = R.style.DarkContrast,
             iconResourceId = IR.drawable.ic_apptheme6,
-            defaultLightIcons = true,
+            toolbarLightIcons = true,
+            backgroundLightIcons = true,
             darkTheme = true,
             isPlus = false,
         ),
@@ -133,7 +140,8 @@ class Theme @Inject constructor(private val settings: Settings) {
             labelId = LR.string.settings_theme_light_contrast,
             resourceId = R.style.LightContrast,
             iconResourceId = IR.drawable.ic_apptheme7,
-            defaultLightIcons = false,
+            toolbarLightIcons = false,
+            backgroundLightIcons = false,
             darkTheme = false,
             isPlus = false,
         ),
@@ -142,7 +150,8 @@ class Theme @Inject constructor(private val settings: Settings) {
             labelId = LR.string.settings_theme_electricity,
             resourceId = R.style.Electric,
             iconResourceId = IR.drawable.ic_apptheme5,
-            defaultLightIcons = true,
+            toolbarLightIcons = true,
+            backgroundLightIcons = true,
             darkTheme = true,
             isPlus = true,
         ),
@@ -151,7 +160,8 @@ class Theme @Inject constructor(private val settings: Settings) {
             labelId = LR.string.settings_theme_classic, // "Classic Light"
             resourceId = R.style.ClassicLight,
             iconResourceId = IR.drawable.ic_apptheme3,
-            defaultLightIcons = true,
+            toolbarLightIcons = true,
+            backgroundLightIcons = false,
             darkTheme = false,
             isPlus = true,
         ),
@@ -160,7 +170,8 @@ class Theme @Inject constructor(private val settings: Settings) {
             labelId = LR.string.settings_theme_radioactivity,
             resourceId = R.style.Radioactive,
             iconResourceId = IR.drawable.ic_theme_radioactive,
-            defaultLightIcons = true,
+            toolbarLightIcons = true,
+            backgroundLightIcons = true,
             darkTheme = true,
             isPlus = true,
         ),
@@ -365,7 +376,7 @@ class Theme @Inject constructor(private val settings: Settings) {
      * StatusBarColor.Light means the background is light and the icons are black
      * StatusBarColor.Dark means the background is dark and the icons are white
      */
-    fun updateWindowStatusBarIcons(window: Window?, statusBarColor: StatusBarColor? = null, context: Context) {
+    fun updateWindowStatusBarIcons(window: Window?, statusBarIconColor: StatusBarIconColor? = null) {
         window ?: return
 
         // Fixes the issue where the window internal DecorView is null and causes a crash. https://console.firebase.google.com/project/singular-vector-91401/crashlytics/app/android:au.com.shiftyjelly.pocketcasts/issues/d44d873d36442ac43b59f56fe95e311b
@@ -373,28 +384,24 @@ class Theme @Inject constructor(private val settings: Settings) {
             return
         }
 
-        val color = statusBarColor ?: (if (isDarkTheme) StatusBarColor.Dark else StatusBarColor.Light)
-        when {
-            color is StatusBarColor.Custom -> {
-                if (color.isWhiteIcons) {
+        val color = statusBarIconColor ?: (if (isDarkTheme) StatusBarIconColor.Dark else StatusBarIconColor.Light)
+        when (color) {
+            StatusBarIconColor.Theme -> {
+                if (activeTheme.toolbarLightIcons) {
                     useLightStatusBarIcons(window)
                 } else {
                     useDarkStatusBarIcons(window)
                 }
             }
-            isDarkTheme -> {
-                useLightStatusBarIcons(window)
-            }
-            color is StatusBarColor.Dark -> {
-                useLightStatusBarIcons(window)
-            }
-            color is StatusBarColor.Light -> {
-                if (activeTheme.defaultLightIcons) {
+            StatusBarIconColor.ThemeNoToolbar -> {
+                if (activeTheme.backgroundLightIcons) {
                     useLightStatusBarIcons(window)
                 } else {
                     useDarkStatusBarIcons(window)
                 }
             }
+            StatusBarIconColor.Dark -> useDarkStatusBarIcons(window)
+            StatusBarIconColor.Light -> useLightStatusBarIcons(window)
         }
     }
 

--- a/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/fragments/BaseAppCompatDialogFragment.kt
+++ b/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/fragments/BaseAppCompatDialogFragment.kt
@@ -6,7 +6,7 @@ import android.view.View
 import androidx.appcompat.app.AppCompatDialogFragment
 import au.com.shiftyjelly.pocketcasts.ui.extensions.getThemeColor
 import au.com.shiftyjelly.pocketcasts.ui.helper.FragmentHostListener
-import au.com.shiftyjelly.pocketcasts.ui.helper.StatusBarColor
+import au.com.shiftyjelly.pocketcasts.ui.helper.StatusBarIconColor
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
@@ -18,7 +18,7 @@ import au.com.shiftyjelly.pocketcasts.ui.R as UR
 @AndroidEntryPoint
 open class BaseAppCompatDialogFragment : AppCompatDialogFragment(), CoroutineScope {
 
-    open val statusBarColor: StatusBarColor? = StatusBarColor.Light
+    open val statusBarIconColor: StatusBarIconColor? = StatusBarIconColor.Theme
 
     @Inject
     lateinit var theme: Theme
@@ -34,12 +34,11 @@ open class BaseAppCompatDialogFragment : AppCompatDialogFragment(), CoroutineSco
         view.isClickable = true
 
         val activity = activity
-        val statusBarColor = statusBarColor
-        if (activity != null && statusBarColor != null) {
+        val statusBarIconColor = statusBarIconColor
+        if (activity != null && statusBarIconColor != null) {
             theme.updateWindowStatusBarIcons(
                 window = activity.window,
-                statusBarColor = statusBarColor,
-                context = activity,
+                statusBarIconColor = statusBarIconColor,
             )
         }
     }

--- a/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/fragments/BaseDialogFragment.kt
+++ b/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/fragments/BaseDialogFragment.kt
@@ -13,7 +13,7 @@ import androidx.core.view.doOnLayout
 import androidx.navigation.NavHostController
 import au.com.shiftyjelly.pocketcasts.ui.extensions.getThemeColor
 import au.com.shiftyjelly.pocketcasts.ui.helper.FragmentHostListener
-import au.com.shiftyjelly.pocketcasts.ui.helper.StatusBarColor
+import au.com.shiftyjelly.pocketcasts.ui.helper.StatusBarIconColor
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.google.android.material.bottomsheet.BottomSheetDialog
@@ -28,7 +28,7 @@ import au.com.shiftyjelly.pocketcasts.ui.R as UR
 @AndroidEntryPoint
 open class BaseDialogFragment : BottomSheetDialogFragment(), CoroutineScope {
 
-    open val statusBarColor: StatusBarColor? = StatusBarColor.Light
+    open val statusBarIconColor: StatusBarIconColor? = StatusBarIconColor.Theme
 
     private var isBeingDragged = false
     private val dismissCallback = object : BottomSheetBehavior.BottomSheetCallback() {
@@ -52,9 +52,9 @@ open class BaseDialogFragment : BottomSheetDialogFragment(), CoroutineScope {
         view.isClickable = true
 
         val activity = activity
-        val statusBarColor = statusBarColor
-        if (activity != null && statusBarColor != null) {
-            theme.updateWindowStatusBarIcons(window = activity.window, statusBarColor = statusBarColor, context = activity)
+        val statusBarIconColor = statusBarIconColor
+        if (activity != null && statusBarIconColor != null) {
+            theme.updateWindowStatusBarIcons(window = activity.window, statusBarIconColor = statusBarIconColor)
         }
 
         view.doOnLayout {

--- a/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/fragments/BaseFragment.kt
+++ b/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/fragments/BaseFragment.kt
@@ -3,14 +3,13 @@ package au.com.shiftyjelly.pocketcasts.views.fragments
 import android.os.Bundle
 import android.view.Menu
 import android.view.View
-import androidx.annotation.ColorInt
 import androidx.annotation.MenuRes
 import androidx.appcompat.widget.Toolbar
 import androidx.fragment.app.Fragment
 import au.com.shiftyjelly.pocketcasts.repositories.chromecast.ChromeCastAnalytics
 import au.com.shiftyjelly.pocketcasts.ui.extensions.getThemeColor
 import au.com.shiftyjelly.pocketcasts.ui.helper.FragmentHostListener
-import au.com.shiftyjelly.pocketcasts.ui.helper.StatusBarColor
+import au.com.shiftyjelly.pocketcasts.ui.helper.StatusBarIconColor
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import au.com.shiftyjelly.pocketcasts.views.extensions.setup
 import au.com.shiftyjelly.pocketcasts.views.extensions.tintIcons
@@ -29,7 +28,7 @@ import au.com.shiftyjelly.pocketcasts.ui.R as UR
 @AndroidEntryPoint
 open class BaseFragment : Fragment(), CoroutineScope, HasBackstack {
 
-    open var statusBarColor: StatusBarColor = StatusBarColor.Light
+    open var statusBarIconColor: StatusBarIconColor = StatusBarIconColor.Theme
 
     @Inject lateinit var theme: Theme
 
@@ -63,13 +62,8 @@ open class BaseFragment : Fragment(), CoroutineScope, HasBackstack {
         if (activity is FragmentHostListener) {
             activity.updateStatusBar()
         } else {
-            theme.updateWindowStatusBarIcons(window = activity.window, statusBarColor = statusBarColor, context = activity)
+            theme.updateWindowStatusBarIcons(window = activity.window, statusBarIconColor = statusBarIconColor)
         }
-    }
-
-    fun updateStatusBarColor(@ColorInt color: Int) {
-        statusBarColor = StatusBarColor.Custom(color = color, isWhiteIcons = theme.activeTheme.defaultLightIcons)
-        updateStatusBar()
     }
 
     fun setupToolbarAndStatusBar(
@@ -92,7 +86,7 @@ open class BaseFragment : Fragment(), CoroutineScope, HasBackstack {
             toolbarColors = toolbarColors,
         )
         if (toolbarColors != null) {
-            updateStatusBarColor(toolbarColors.backgroundColor)
+            updateStatusBar()
         }
     }
 

--- a/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/fragments/BaseFragment.kt
+++ b/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/fragments/BaseFragment.kt
@@ -29,6 +29,7 @@ import au.com.shiftyjelly.pocketcasts.ui.R as UR
 open class BaseFragment : Fragment(), CoroutineScope, HasBackstack {
 
     open var statusBarIconColor: StatusBarIconColor = StatusBarIconColor.Theme
+    open var backgroundTransparent: Boolean = false
 
     @Inject lateinit var theme: Theme
 
@@ -39,7 +40,7 @@ open class BaseFragment : Fragment(), CoroutineScope, HasBackstack {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        if (view.background == null) {
+        if (view.background == null && !backgroundTransparent) {
             view.setBackgroundColor(view.context.getThemeColor(UR.attr.primary_ui_01))
         }
         view.isClickable = true


### PR DESCRIPTION
## Description

This change focuses on converting the Discover section to edge-to-edge for the Android 15 project. I could only find one page to fix, the region select page.

There will be multiple pull requests required to support Android 15 edge-to-edge but I'm going to break them down into smaller PRs. I will merge them all into a `task/android-15` branch, and after all the work is completed, raise a PR to merge into `main`.

## Testing Instructions

Go to the Discover tab and click through all the pages. Try testing:

- Older versions of Android versions
- Different themes
- Check content isn't under the system bars
- Check the end of pages / lists aren't under the bottom navigation or mini player

## Screenshots

Android 15, SDK 35

| Before | After |
| --- | --- |
| ![discover-after](https://github.com/user-attachments/assets/f93327bc-23b0-4547-a358-7b218f409bb9) | ![Screenshot_20241203_173836](https://github.com/user-attachments/assets/9626aa68-2580-4931-8520-02779660e6f0) |

Android 7, SDK 24

| Before | After |
| --- | --- |
| ![Screenshot_20241203_175150](https://github.com/user-attachments/assets/761fd2cc-4b45-40ad-93b0-419a2027a59d) | ![Screenshot_20241203_174653](https://github.com/user-attachments/assets/26e929de-67b6-4c3e-8300-af1f7f1aa058) |
| ![Screenshot_20241203_175156](https://github.com/user-attachments/assets/1c946ed8-f9ba-4cba-9586-1d63ef707a49) | ![Screenshot_20241203_174707](https://github.com/user-attachments/assets/efb5eae8-d462-48e6-b211-37bcef0bae38) |

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack
