### PR TITLE
Hack Week: Up Next doesn't automatically play the next episode

### DIFF
--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/PlaybackSettingsFragment.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/PlaybackSettingsFragment.kt
@@ -392,6 +392,19 @@ class PlaybackSettingsFragment : BaseFragment() {
                             )
                         }
 
+                        SettingsItems.SETTINGS_PLAY_UP_NEXT_EPISODE_MANUALLY -> {
+                            PlayUpNextEpisodeManually(
+                                saved = settings.upNextEpisodeManually.flow.collectAsState().value,
+                                onSave = {
+                                    analyticsTracker.track(
+                                        AnalyticsEvent.SETTINGS_GENERAL_PLAY_UP_NEXT_EPISODE_MANUALLY_TOGGLED,
+                                        mapOf("enabled" to it),
+                                    )
+                                    settings.upNextEpisodeManually.set(it, updateModifiedAt = true)
+                                },
+                            )
+                        }
+
                         SettingsItems.SETTINGS_GENERAL_AUTOPLAY -> {
                             AutoPlayNextOnEmpty(
                                 saved = settings.autoPlayNextEpisodeOnEmpty.flow.collectAsState().value,
@@ -647,6 +660,16 @@ class PlaybackSettingsFragment : BaseFragment() {
         )
 
     @Composable
+    private fun PlayUpNextEpisodeManually(saved: Boolean, onSave: (Boolean) -> Unit) =
+        SettingRow(
+            primaryText = stringResource(LR.string.settings_up_next_episode_manually),
+            secondaryText = stringResource(LR.string.settings_up_next_episode_manually_summary),
+            toggle = SettingRowToggle.Switch(checked = saved),
+            modifier = Modifier.toggleable(value = saved, role = Role.Switch) { onSave(!saved) },
+            indent = false,
+        )
+
+    @Composable
     private fun ShakeToResetSleepTimer(saved: Boolean, onSave: (Boolean) -> Unit) =
         SettingRow(
             primaryText = stringResource(LR.string.settings_sleep_timer_shake_to_reset),
@@ -745,6 +768,7 @@ private enum class SettingsItems {
     SETTINGS_HEADER_UP_NEXT,
     SETTINGS_UP_NEXT_SWIPE,
     SETTINGS_PLAY_UP_NEXT_EPISODE,
+    SETTINGS_PLAY_UP_NEXT_EPISODE_MANUALLY,
 
     // The [scrollToAutoPlay] fragment argument handling depends on this item being last
     // in the list. If it's position is changed, make sure you update the handling when

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/PlaybackSettingsFragment.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/PlaybackSettingsFragment.kt
@@ -171,24 +171,6 @@ class PlaybackSettingsFragment : BaseFragment() {
                             )
                         }
 
-                        SettingsItems.SETTINGS_UP_NEXT_SWIPE -> {
-                            UpNextSwipe(
-                                saved = settings.upNextSwipe.flow.collectAsState().value,
-                                onSave = {
-                                    analyticsTracker.track(
-                                        AnalyticsEvent.SETTINGS_GENERAL_UP_NEXT_SWIPE_CHANGED,
-                                        mapOf(
-                                            "value" to when (it) {
-                                                Settings.UpNextAction.PLAY_NEXT -> "play_next"
-                                                Settings.UpNextAction.PLAY_LAST -> "play_last"
-                                            },
-                                        ),
-                                    )
-                                    settings.upNextSwipe.set(it, updateModifiedAt = true)
-                                },
-                            )
-                        }
-
                         SettingsItems.SETTINGS_EPISODE_GROUPING -> {
                             PodcastEpisodeGrouping(
                                 saved = settings.podcastGroupingDefault.flow.collectAsState().value,
@@ -320,19 +302,6 @@ class PlaybackSettingsFragment : BaseFragment() {
                             )
                         }
 
-                        SettingsItems.SETTINGS_PLAY_UP_NEXT_EPISODE -> {
-                            PlayUpNextOnTap(
-                                saved = settings.tapOnUpNextShouldPlay.flow.collectAsState().value,
-                                onSave = {
-                                    analyticsTracker.track(
-                                        AnalyticsEvent.SETTINGS_GENERAL_PLAY_UP_NEXT_ON_TAP_TOGGLED,
-                                        mapOf("enabled" to it),
-                                    )
-                                    settings.tapOnUpNextShouldPlay.set(it, updateModifiedAt = true)
-                                },
-                            )
-                        }
-
                         SettingsItems.SETTINGS_ADJUST_REMAINING_TIME -> {
                             UseRealTimeForPlaybackRemainingTime(
                                 saved = settings.useRealTimeForPlaybackRemaingTime.flow.collectAsState().value,
@@ -378,6 +347,47 @@ class PlaybackSettingsFragment : BaseFragment() {
                                         mapOf("enabled" to it),
                                     )
                                     settings.shakeToResetSleepTimer.set(it, updateModifiedAt = true)
+                                },
+                            )
+                        }
+
+                        SettingsItems.SETTINGS_HEADER_UP_NEXT -> {
+                            Column {
+                                Spacer(modifier = Modifier.height(SettingsSection.verticalPadding))
+                                SettingSectionHeader(
+                                    text = stringResource(LR.string.settings_general_up_next),
+                                    indent = false,
+                                )
+                            }
+                        }
+
+                        SettingsItems.SETTINGS_UP_NEXT_SWIPE -> {
+                            UpNextSwipe(
+                                saved = settings.upNextSwipe.flow.collectAsState().value,
+                                onSave = {
+                                    analyticsTracker.track(
+                                        AnalyticsEvent.SETTINGS_GENERAL_UP_NEXT_SWIPE_CHANGED,
+                                        mapOf(
+                                            "value" to when (it) {
+                                                Settings.UpNextAction.PLAY_NEXT -> "play_next"
+                                                Settings.UpNextAction.PLAY_LAST -> "play_last"
+                                            },
+                                        ),
+                                    )
+                                    settings.upNextSwipe.set(it, updateModifiedAt = true)
+                                },
+                            )
+                        }
+
+                        SettingsItems.SETTINGS_PLAY_UP_NEXT_EPISODE -> {
+                            PlayUpNextOnTap(
+                                saved = settings.tapOnUpNextShouldPlay.flow.collectAsState().value,
+                                onSave = {
+                                    analyticsTracker.track(
+                                        AnalyticsEvent.SETTINGS_GENERAL_PLAY_UP_NEXT_ON_TAP_TOGGLED,
+                                        mapOf("enabled" to it),
+                                    )
+                                    settings.tapOnUpNextShouldPlay.set(it, updateModifiedAt = true)
                                 },
                             )
                         }
@@ -719,7 +729,6 @@ class PlaybackSettingsFragment : BaseFragment() {
 private enum class SettingsItems {
     SETTINGS_HEADER_DEFAULTS,
     SETTINGS_ROW_ACTION,
-    SETTINGS_UP_NEXT_SWIPE,
     SETTINGS_EPISODE_GROUPING,
     SETTINGS_ARCHIVED_EPISODES,
     SETTINGS_MEDIA_NOTIFICATION_CONTROLS,
@@ -729,11 +738,13 @@ private enum class SettingsItems {
     SETTINGS_KEEP_SCREEN_AWAKE,
     SETTINGS_OPEN_PLAYER_AUTOMATICALLY,
     SETTINGS_INTELLIGENT_PLAYBACK,
-    SETTINGS_PLAY_UP_NEXT_EPISODE,
     SETTINGS_ADJUST_REMAINING_TIME,
     SETTINGS_HEADER_SLEEP_TIMER,
     SETTINGS_SLEEP_TIMER_RESTART,
     SETTINGS_SLEEP_TIMER_SHAKE,
+    SETTINGS_HEADER_UP_NEXT,
+    SETTINGS_UP_NEXT_SWIPE,
+    SETTINGS_PLAY_UP_NEXT_EPISODE,
 
     // The [scrollToAutoPlay] fragment argument handling depends on this item being last
     // in the list. If it's position is changed, make sure you update the handling when

--- a/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
+++ b/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
@@ -506,6 +506,7 @@ enum class AnalyticsEvent(val key: String) {
     SETTINGS_GENERAL_OPEN_PLAYER_AUTOMATICALLY_TOGGLED("settings_general_open_player_automatically_toggled"),
     SETTINGS_GENERAL_INTELLIGENT_PLAYBACK_TOGGLED("settings_general_intelligent_playback_toggled"),
     SETTINGS_GENERAL_PLAY_UP_NEXT_ON_TAP_TOGGLED("settings_general_play_up_next_on_tap_toggled"),
+    SETTINGS_GENERAL_PLAY_UP_NEXT_EPISODE_MANUALLY_TOGGLED("settings_general_play_up_next_episode_manually_toggled"),
     SETTINGS_GENERAL_SHAKE_TO_RESET_SLEEP_TIMER_TOGGLED("settings_general_shake_to_reset_sleep_timer_toggled"),
     SETTINGS_GENERAL_AUTO_SLEEP_TIMER_RESTART_TOGGLED("settings_general_auto_sleep_timer_restart_toggled"),
     SETTINGS_GENERAL_MEDIA_NOTIFICATION_CONTROLS_SHOWN("settings_general_media_notification_controls_shown"),

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -1237,6 +1237,7 @@
     <string name="settings_general_defaults">Defaults</string>
     <string name="settings_general_player">Player</string>
     <string name="settings_general_sleep_timer">Sleep Timer</string>
+    <string name="settings_general_up_next">Up Next</string>
     <string name="settings_get_plus_and_more">Get Pocket Casts Plus to unlock this feature and more!</string>
     <string name="settings_headphone_controls_action_next">Next action</string>
     <string name="settings_headphone_controls_action_previous">Previous action</string>

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -1417,6 +1417,8 @@
     <string name="settings_sleep_timer_shake_to_reset_summary">If on, the sleep timer will restart when you shake your phone.</string>
     <string name="settings_sleep_timer_auto_restart">Auto Restart Sleep Timer</string>
     <string name="settings_sleep_timer_auto_restart_summary">If on, the sleep timer will restart automatically if you play an episode within 5 minutes after the last pause.</string>
+    <string name="settings_up_next_episode_manually">Play Up Next Episode Manually</string>
+    <string name="settings_up_next_episode_manually_summary">Allows you to control playback by preventing the next episode in the Up Next queue from playing automatically</string>
     <string name="settings_up_next_tap">Play Up Next episode on tap</string>
     <string name="settings_up_next_tap_summary">If on, tapping on an item in your Up Next queue will play it. Long pressing will show the episode options.</string>
     <string name="settings_real_time_playback">Adjust remaining time</string>

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
@@ -390,6 +390,7 @@ interface Settings {
 
     val upNextSwipe: UserSetting<UpNextAction>
     val tapOnUpNextShouldPlay: UserSetting<Boolean>
+    val upNextEpisodeManually: UserSetting<Boolean>
 
     val headphoneControlsNextAction: UserSetting<HeadphoneAction>
     val headphoneControlsPreviousAction: UserSetting<HeadphoneAction>

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
@@ -1019,6 +1019,12 @@ class SettingsImpl @Inject constructor(
         sharedPrefs = sharedPreferences,
     )
 
+    override val upNextEpisodeManually = UserSetting.BoolPref(
+        sharedPrefKey = "up_next_episode_manually",
+        defaultValue = false,
+        sharedPrefs = sharedPreferences,
+    )
+
     override val cachedSubscriptionStatus = UserSetting.PrefFromString<SubscriptionStatus?>(
         sharedPrefKey = "accountstatus",
         defaultValue = null,

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
@@ -1358,6 +1358,13 @@ open class PlaybackManager @Inject constructor(
             }
         }
 
+        if (settings.upNextEpisodeManually.value) {
+            LogBuffer.i(LogBuffer.TAG_PLAYBACK, "Playback paused as 'Play Next Manually' setting is enabled")
+            stop()
+            shutdown()
+            return
+        }
+
         // Auto play if it had sleep time enabled for end of episodes and still has episodes set on sleep time
         // or if it did not have sleep time end of episode configured
         // and it was playing episode


### PR DESCRIPTION
## Description
- This is a Hack Week project. I propose adding a new Up Next setting to prevent automatic playback of the next episode if Up Next is not empty. This will give users the option to play only one episode from Up Next even if it still has episodes on queue.
- I also refactored the up next settings grouping them into a Up next section


## Testing Instructions
1. Go to Profile -> Settings -> General
2. Enable the new toggle `Play Up Next Episode Manually`
3. Have some episodes added to Up next
4. Start playing an episode
5. Scroll to almost the end of the episode
6. Once the current episode play finishes, ensure the playback stops.

## Screenshots or Screencast 
[demo.webm](https://github.com/user-attachments/assets/cd1b348f-15ba-4a51-8c0c-d581d185ecfb)


<img src="https://github.com/user-attachments/assets/ce5a29d6-cfd3-4430-a0ba-ee3941bcdbae" height=600 >





