### PR TITLE
[Up Next Shuffle] - Add snackbar confirmation for when enabling shuffle

### DIFF
--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -14,15 +14,7 @@
             android:id="@+id/mainFragment"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            android:paddingBottom="@dimen/design_bottom_navigation_height"
             android:clipToPadding="false" />
-
-        <!-- Hack: the only way to get the Snackbar in front of the bottom navigation view -->
-        <androidx.coordinatorlayout.widget.CoordinatorLayout
-            android:id="@+id/snackbarFragment"
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:paddingBottom="56dp"/>
 
         <au.com.shiftyjelly.pocketcasts.player.view.PlayerBottomSheet
             android:id="@+id/playerBottomSheet"
@@ -58,8 +50,7 @@
             android:elevation="8dp"
             app:behavior_peekHeight="0dp"
             app:layout_behavior="au.com.shiftyjelly.pocketcasts.view.LockableBottomSheetBehavior"
-            android:clickable="true"
-            android:translationZ="200dp"/>
+            android:translationZ="200dp" />
 
         <FrameLayout
             android:id="@+id/modalBottomSheet"
@@ -68,6 +59,12 @@
             android:translationZ="200dp"/>
 
     </androidx.coordinatorlayout.widget.CoordinatorLayout>
+
+    <!-- Hack: the only way to get the Snackbar in front of the bottom navigation view -->
+    <androidx.coordinatorlayout.widget.CoordinatorLayout
+        android:id="@+id/snackbarFragment"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent" />
 
     <au.com.shiftyjelly.pocketcasts.views.component.RadioactiveLineView
         android:id="@+id/radioactiveLineView"

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/UpNextAdapter.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/UpNextAdapter.kt
@@ -37,6 +37,7 @@ import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingFlow
 import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingLauncher
 import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingUpgradeSource
 import au.com.shiftyjelly.pocketcasts.ui.extensions.themed
+import au.com.shiftyjelly.pocketcasts.ui.helper.FragmentHostListener
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import au.com.shiftyjelly.pocketcasts.ui.theme.ThemeColor
 import au.com.shiftyjelly.pocketcasts.utils.extensions.dpToPx
@@ -51,6 +52,7 @@ import com.airbnb.lottie.LottieProperty
 import com.airbnb.lottie.SimpleColorFilter
 import com.airbnb.lottie.model.KeyPath
 import com.airbnb.lottie.value.LottieValueCallback
+import com.google.android.material.snackbar.Snackbar
 import timber.log.Timber
 import au.com.shiftyjelly.pocketcasts.images.R as IR
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
@@ -192,6 +194,12 @@ class UpNextAdapter(
                     if (isSignedInAsPaidUser) {
                         val newValue = !settings.upNextShuffle.value
                         analyticsTracker.track(AnalyticsEvent.UP_NEXT_SHUFFLE_ENABLED, mapOf("value" to newValue, SOURCE_KEY to upNextSource.analyticsValue))
+
+                        if (newValue) {
+                            (root.context.getActivity() as? FragmentHostListener)?.snackBarView()?.let { snackBarView ->
+                                Snackbar.make(snackBarView, root.resources.getString(LR.string.up_next_shuffle_enable_confirmation_message), Snackbar.LENGTH_LONG).show()
+                            }
+                        }
 
                         settings.upNextShuffle.set(newValue, updateModifiedAt = false)
                     } else {

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -2256,5 +2256,6 @@
     <!-- Up Next Shuffle -->
     <string name="up_next_shuffle_button_content_description">Up next shuffle</string>
     <string name="up_next_shuffle_disable_button_content_description">Up next shuffle disable</string>
+    <string name="up_next_shuffle_enable_confirmation_message">Shuffle is on. Episodes will play in random order.</string>
 
 </resources>


### PR DESCRIPTION
## Description
- Displays snackbar when toggling shuffle on
- Cherry-picked https://github.com/Automattic/pocket-casts-android/pull/3272/commits/0d2cc39fb279bef5118013bccb7d2679f45ab83a and copied some changes from `task/android-15` to fix snackbar position
- I noticed that our current Snackbar experience does not work well with TalkBack. After the Snackbar is displayed, TalkBack does not have enough time to read it before it disappears

Fixes #3327

## Testing Instructions
1. Log with a plus account
2. Add some episodes to Up next
3. Toggle shuffle on
4. See the snackbar ✅
5. Toggle the shuffle off
6. You should not see the snackbar ✅

## Screenshots or Screencast 

<img src="https://github.com/user-attachments/assets/3aaf044d-18d3-4cb3-902b-20e5785132c9" height=600 >


## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
