### PR TITLE
Improving the Up Next clear all button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 *   Updates
     *   Update account details header UI
         ([#3294](https://github.com/Automattic/pocket-casts-android/pull/3294))
+    *   Improve the Up Next clear all button
+        ([#3334](https://github.com/Automattic/pocket-casts-android/pull/3334))
 
 7.78
 -----

--- a/modules/features/player/src/main/res/menu/upnext.xml
+++ b/modules/features/player/src/main/res/menu/upnext.xml
@@ -5,7 +5,7 @@
     <item
         android:id="@+id/clear_up_next"
         android:title="@string/player_up_next_clear_queue"
-        android:icon="@drawable/ic_delete"
+        android:icon="@drawable/ic_upnext_remove"
         app:showAsAction="ifRoom" />
 
     <item

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -2266,8 +2266,8 @@
     <string name="maybe_later">Maybe Later</string>
 
     <!-- Up Next Shuffle -->
-    <string name="up_next_shuffle_button_content_description">Up next shuffle</string>
-    <string name="up_next_shuffle_disable_button_content_description">Up next shuffle disable</string>
+    <string name="up_next_shuffle_button_content_description">Up Next shuffle</string>
+    <string name="up_next_shuffle_disable_button_content_description">Up Next shuffle disable</string>
     <string name="up_next_shuffle_enable_confirmation_message">Shuffle is on. Episodes will play in random order.</string>
 
 </resources>


### PR DESCRIPTION
## Description

After user feedback we have changed the Up Next clear all button.

Fixes https://github.com/Automattic/pocket-casts-android/issues/3313#issuecomment-2521170083

## Testing Instructions
1. Add some episodes to the Up Next
2. Open the Up Next
3. ✅ Verify the clear all button has change.

## Screenshots 

| Before | After |
| --- | --- |
| ![Screenshot_20241206_150716](https://github.com/user-attachments/assets/96180928-3176-49c6-bd95-084399bd63bd) | ![Screenshot_20241206_150438](https://github.com/user-attachments/assets/ee63cf46-5ffc-4264-903d-c8b5951c793a) | 

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack
