### PR TITLE
Improve user log sharing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 7.79
 -----
 *   Updates
+    *   Improve log sharing
+        ([#3336](https://github.com/Automattic/pocket-casts-android/pull/3336))
     *   Update account details header UI
         ([#3294](https://github.com/Automattic/pocket-casts-android/pull/3294))
 

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/viewmodel/LogsViewModel.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/viewmodel/LogsViewModel.kt
@@ -11,7 +11,6 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
-import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 @HiltViewModel
 class LogsViewModel @Inject constructor(
@@ -37,9 +36,9 @@ class LogsViewModel @Inject constructor(
     fun shareLogs(context: Context) {
         viewModelScope.launch(Dispatchers.IO) {
             val intent = support.shareLogs(
-                subject = context.getString(LR.string.settings_logs),
-                intro = "",
-                emailSupport = false,
+                subject = "Android logs.",
+                intro = "Please find my logs attached.",
+                emailSupport = true,
                 context = context,
             )
             context.startActivity(intent)

--- a/modules/features/settings/src/main/res/menu/menu_help.xml
+++ b/modules/features/settings/src/main/res/menu/menu_help.xml
@@ -4,11 +4,11 @@
     <item android:id="@+id/menu_logs"
         android:title="@string/settings_logs"
         android:icon="@drawable/baseline_view_list_24"
-        app:showAsAction="always" />
+        app:showAsAction="never" />
     <item android:id="@+id/menu_status_page"
         android:title="@string/settings_status_page"
         android:icon="@drawable/ic_status_page"
-        app:showAsAction="always" />
+        app:showAsAction="never" />
     <item android:id="@+id/menu_export_database"
         android:title="@string/settings_export_database"
         android:icon="@drawable/ic_external"


### PR DESCRIPTION
## Description

Requesting a user's log is difficult, so this change aims to help improve this.

- When sharing a log it prefills the support email to make it easier for users.
- The logs toolbar action has been moved into the overflow menu to make it easier to explain rather than saying to tap the hamburger.

Slack discussion: p1733458200619619/1733441524.933739-slack-C029BMW150R

## Testing Instructions
1. Tap Profile
2. Tap Help & feedback
3. Tap the three dots in the toolbar
4. Tap Logs
5. Tap Share
6. ✅ Verify the support email add been added

## Screencast 

| |  |
| --- | --- |
| <img width="510" alt="Screenshot 2024-12-08 at 8 03 31 am" src="https://github.com/user-attachments/assets/783476ce-fee9-475e-82ee-b4fc11822990"> | <img width="510" alt="Screenshot 2024-12-08 at 8 03 56 am" src="https://github.com/user-attachments/assets/2cf1895f-ed0e-4ae6-9888-65cfd54dc811"> | 

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack