### PR TITLE
Position bookmark shelf item after podcast navigation item

### DIFF
--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/model/ShelfRowItem.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/model/ShelfRowItem.kt
@@ -78,6 +78,12 @@ enum class ShelfItem(
         iconId = { IR.drawable.ic_arrow_goto },
         analyticsValue = "go_to_podcast",
     ),
+    Bookmark(
+        id = "bookmark",
+        titleId = { LR.string.add_bookmark },
+        iconId = { IR.drawable.ic_bookmark },
+        analyticsValue = "add_bookmark",
+    ),
     Cast(
         id = "cast",
         titleId = { LR.string.chromecast },
@@ -89,12 +95,6 @@ enum class ShelfItem(
         titleId = { LR.string.mark_as_played },
         iconId = { IR.drawable.ic_markasplayed },
         analyticsValue = "mark_as_played",
-    ),
-    Bookmark(
-        id = "bookmark",
-        titleId = { LR.string.add_bookmark },
-        iconId = { IR.drawable.ic_bookmark },
-        analyticsValue = "add_bookmark",
     ),
     Archive(
         id = "archive",


### PR DESCRIPTION
## Description

This moves `Add bookmark` shelf item after the `Go to podcast` item to align with iOS. See: p1733730713364929-slack-C028JAG44VD

## Testing Instructions

1. Don't have a custom shelf items order.
2. Play a podcast episode.
3. Go to player.
4. Tap on the overflow menu on the shelf.
5. Notice that `Add bookmark` is positioned after `Go to podcast`

## Screenshots or Screencast 

| Before | After |
| - | - |
| ![before](https://github.com/user-attachments/assets/ffc17650-62cf-44a9-b75f-f8e98672d4af) | ![after](https://github.com/user-attachments/assets/1414758a-aab9-488e-ae4d-7bc9b705da4d) |

## Checklist
- [ ] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] ~I have considered whether it makes sense to add tests for my changes~
- [ ] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [ ] ~Any jetpack compose components I added or changed are covered by compose previews~
- [ ] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~