### PR TITLE
Fix: Disabled global Auto download new episodes setting overrides podcast specifc one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 7.80
 -----
-
+*   Bug Fixes
+    *   Fix global auto download setting was incorrectly overriding the podcast auto download setting
+        ([#3342](https://github.com/Automattic/pocket-casts-android/pull/3342))
 
 7.79
 -----

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/AutoDownloadSettingsFragment.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/AutoDownloadSettingsFragment.kt
@@ -46,11 +46,8 @@ import au.com.shiftyjelly.pocketcasts.views.fragments.PodcastSelectFragmentSourc
 import au.com.shiftyjelly.pocketcasts.views.helper.HasBackstack
 import au.com.shiftyjelly.pocketcasts.views.helper.NavigationIcon.BackArrow
 import dagger.hilt.android.AndroidEntryPoint
-import io.reactivex.Single
-import io.reactivex.android.schedulers.AndroidSchedulers
 import io.reactivex.rxkotlin.subscribeBy
 import io.reactivex.rxkotlin.zipWith
-import io.reactivex.schedulers.Schedulers
 import javax.inject.Inject
 import kotlin.coroutines.CoroutineContext
 import kotlinx.coroutines.CoroutineScope
@@ -399,21 +396,9 @@ class AutoDownloadSettingsFragment :
         }
     }
 
-    private fun countPodcastsAutoDownloading(): Single<Int> {
-        return podcastManager.countDownloadStatusRxSingle(Podcast.AUTO_DOWNLOAD_NEW_EPISODES)
-            .subscribeOn(Schedulers.io())
-            .observeOn(AndroidSchedulers.mainThread())
-    }
-
-    private fun countPodcasts(): Single<Int> {
-        return podcastManager.countSubscribedRxSingle()
-            .observeOn(AndroidSchedulers.mainThread())
-            .subscribeOn(Schedulers.io())
-    }
-
     @SuppressLint("CheckResult")
     private fun updatePodcastsSummary() {
-        countPodcastsAutoDownloading().zipWith(countPodcasts())
+        viewModel.countPodcastsAutoDownloading().zipWith(viewModel.countPodcasts())
             .subscribeBy(
                 onError = { Timber.e(it) },
                 onSuccess = { (autoDownloadingCount, allCount) ->
@@ -431,7 +416,7 @@ class AutoDownloadSettingsFragment :
 
     @SuppressLint("CheckResult")
     private fun setupNewEpisodesToggleStatusCheck() {
-        countPodcastsAutoDownloading()
+        viewModel.countPodcastsAutoDownloading()
             .map { it > 0 }
             .subscribeBy(
                 onError = { Timber.e(it) },

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/viewmodel/AutoDownloadSettingsViewModel.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/viewmodel/AutoDownloadSettingsViewModel.kt
@@ -1,7 +1,6 @@
 package au.com.shiftyjelly.pocketcasts.settings.viewmodel
 
 import androidx.lifecycle.ViewModel
-import androidx.lifecycle.viewModelScope
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTracker
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
@@ -16,8 +15,6 @@ import io.reactivex.schedulers.Schedulers
 import javax.inject.Inject
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
 
 @HiltViewModel
@@ -31,14 +28,7 @@ class AutoDownloadSettingsViewModel @Inject constructor(
     override val coroutineContext = Dispatchers.Default
     private var isFragmentChangingConfigurations: Boolean = false
 
-    private var _hasEpisodesWithAutoDownloadEnabled: MutableStateFlow<Boolean> = MutableStateFlow(false)
-    val hasEpisodesWithAutoDownloadEnabled: StateFlow<Boolean> = _hasEpisodesWithAutoDownloadEnabled
-
-    init {
-        viewModelScope.launch(Dispatchers.IO) {
-            _hasEpisodesWithAutoDownloadEnabled.value = podcastManager.hasEpisodesWithAutoDownloadStatus(Podcast.AUTO_DOWNLOAD_NEW_EPISODES)
-        }
-    }
+    suspend fun hasEpisodesWithAutoDownloadEnabled() = podcastManager.hasEpisodesWithAutoDownloadStatus(Podcast.AUTO_DOWNLOAD_NEW_EPISODES)
 
     fun onShown() {
         if (!isFragmentChangingConfigurations) {

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/viewmodel/AutoDownloadSettingsViewModel.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/viewmodel/AutoDownloadSettingsViewModel.kt
@@ -10,6 +10,9 @@ import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.repositories.download.DownloadManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
 import dagger.hilt.android.lifecycle.HiltViewModel
+import io.reactivex.Single
+import io.reactivex.android.schedulers.AndroidSchedulers
+import io.reactivex.schedulers.Schedulers
 import javax.inject.Inject
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -123,6 +126,13 @@ class AutoDownloadSettingsViewModel @Inject constructor(
     suspend fun updateAllAutoDownloadStatus(status: Int) {
         podcastManager.updateAllAutoDownloadStatus(status)
     }
+
+    fun countPodcastsAutoDownloading(): Single<Int> = podcastManager.countDownloadStatusRxSingle(Podcast.AUTO_DOWNLOAD_NEW_EPISODES)
+        .subscribeOn(Schedulers.io())
+
+    fun countPodcasts(): Single<Int> = podcastManager.countSubscribedRxSingle()
+        .observeOn(AndroidSchedulers.mainThread())
+        .subscribeOn(Schedulers.io())
 }
 
 fun Boolean.toAutoDownloadStatus(): Int = when (this) {

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/viewmodel/AutoDownloadSettingsViewModel.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/viewmodel/AutoDownloadSettingsViewModel.kt
@@ -57,8 +57,6 @@ class AutoDownloadSettingsViewModel @Inject constructor(
 
     fun getAutoDownloadUpNext() = settings.autoDownloadUpNext.value
 
-    fun getAutoDownloadNewEpisodes() = settings.autoDownloadNewEpisodes.value
-
     fun getLimitDownload() = settings.autoDownloadLimit.value
 
     fun isAutoDownloadOnFollowPodcastEnabled() = settings.autoDownloadOnFollowPodcast.value


### PR DESCRIPTION
## Description
- Auto download screen was updating podcast auto download setting when this screen was opened

Fixes #3338

## Testing Instructions
- Follow the steps from https://github.com/Automattic/pocket-casts-android/issues/3338 to make sure the issue was fixed

## Screenshots or Screencast 
[Screen_recording_20241209_130121.webm](https://github.com/user-attachments/assets/b6b802ff-1b32-4336-a6ff-da5ffc66c530)


## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] ~I have considered whether it makes sense to add tests for my changes~
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] ~Any jetpack compose components I added or changed are covered by compose previews~
- [ ] ~ I have updated (or requested that someone edit) [the spreadsheet]~(https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.

