### PR TITLE
[Auto Downloading] Add auto download on follow toggle to support file

### DIFF
--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/support/Support.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/support/Support.kt
@@ -292,6 +292,7 @@ class Support @Inject constructor(
             output.append("Auto downloads").append(eol)
             output.append("  Any podcast? ").append(yesNoString(autoDownloadOn[0])).append(eol)
             output.append("  New Episodes? ").append(yesNoString(settings.autoDownloadNewEpisodes.value == AUTO_DOWNLOAD_NEW_EPISODES)).append(eol)
+            output.append("  On Follow? ").append(yesNoString(settings.autoDownloadOnFollowPodcast.value)).append(eol)
             output.append("  Limit Downloads ").append(settings.autoDownloadLimit.value).append(eol)
             output.append("  Up Next? ").append(yesNoString(settings.autoDownloadUpNext.value)).append(eol)
             output.append("  Only on unmetered WiFi? ").append(yesNoString(settings.autoDownloadUnmeteredOnly.value)).append(eol)


### PR DESCRIPTION
## Description
- Add auto download on follow toggle to support file

## Testing Instructions
1. Go to Profile -> Auto download screen
2. Enable On Follow toggle
3. Go to Profile -> Help & feedback
4. Tap the three dots in the toolbar
5. Tap Log
6. See that you have On Follow toggle enabled

## Screenshots or Screencast 
<img width="185" alt="image" src="https://github.com/user-attachments/assets/516e207c-93c8-457c-8bb9-eabbf85416b7">


## Checklist
- [ ] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] ~I have considered whether it makes sense to add tests for my changes~
- [ ] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [ ] ~Any jetpack compose components I added or changed are covered by compose previews~
- [ ] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~

