### PR TITLE
Share Playback Stories in 9:16 aspect ratio

### DIFF
--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/StoryCaptureController.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/StoryCaptureController.kt
@@ -12,10 +12,12 @@ import androidx.compose.ui.graphics.asAndroidBitmap
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.platform.LocalContext
 import androidx.core.graphics.applyCanvas
+import androidx.core.graphics.createBitmap
 import androidx.core.graphics.drawable.toBitmap
 import androidx.core.graphics.scale
 import au.com.shiftyjelly.pocketcasts.endofyear.ui.backgroundColor
 import au.com.shiftyjelly.pocketcasts.models.to.Story
+import au.com.shiftyjelly.pocketcasts.utils.fitToAspectRatio
 import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
 import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer.TAG_CRASH
 import dev.shreyaspatil.capturable.controller.CaptureController
@@ -77,7 +79,7 @@ internal fun rememberStoryCaptureController(): StoryCaptureController {
                 delay(50) // A small delay to settle stories animations before capturing a screenshot
                 val controller = captureController(story)
                 val file = runCatching {
-                    val bitmap: Bitmap = withContext(Dispatchers.Default) {
+                    val bitmap = withContext(Dispatchers.Default) {
                         val background = controller.captureAsync().await()
                             .asAndroidBitmap()
                             .copy(Bitmap.Config.ARGB_8888, false)
@@ -88,7 +90,7 @@ internal fun rememberStoryCaptureController(): StoryCaptureController {
                             .toBitmap()
                             .scale(width = logoWidth, height = logoHeight)
 
-                        Bitmap.createBitmap(background.width, background.height, Bitmap.Config.ARGB_8888).applyCanvas {
+                        createBitmap(background.width, background.height).applyCanvas {
                             // Draw captured bitmap
                             drawBitmap(background, 0f, 0f, null)
                             // Hide bottom button behind an empty rect
@@ -110,7 +112,7 @@ internal fun rememberStoryCaptureController(): StoryCaptureController {
                                 (height - buttonHeightPx + (buttonHeightPx - pcLogo.height) / 2).toFloat(),
                                 null,
                             )
-                        }
+                        }.fitToAspectRatio(9f / 16)
                     }
                     withContext(Dispatchers.IO) {
                         val file = File(context.cacheDir, "pocket-casts-playback-screenshot.png")

--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/BitmapUtil.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/BitmapUtil.kt
@@ -1,0 +1,43 @@
+package au.com.shiftyjelly.pocketcasts.utils
+
+import android.graphics.Bitmap
+import android.graphics.Color
+import android.graphics.Paint
+import androidx.annotation.ColorInt
+import androidx.core.graphics.applyCanvas
+import kotlin.math.abs
+import kotlin.math.roundToInt
+
+fun Bitmap.fitToAspectRatio(
+    aspectRatio: Float,
+    @ColorInt backgroundColor: Int = Color.BLACK,
+    bitmapConfig: Bitmap.Config = Bitmap.Config.ARGB_8888,
+): Bitmap {
+    val (newWidth, newHeight) = calculateNearestSize(width, height, aspectRatio)
+    return Bitmap.createBitmap(newWidth, newHeight, bitmapConfig).applyCanvas {
+        val paint = Paint().apply {
+            isDither = true
+            color = backgroundColor
+        }
+        drawRect(0f, 0f, width.toFloat(), height.toFloat(), paint)
+        drawBitmap(
+            this@fitToAspectRatio,
+            abs(width - this@fitToAspectRatio.width).toFloat() / 2,
+            abs(height - this@fitToAspectRatio.height).toFloat() / 2,
+            null,
+        )
+    }
+}
+
+internal fun calculateNearestSize(
+    width: Int,
+    height: Int,
+    aspectRatio: Float,
+): Pair<Int, Int> {
+    check(aspectRatio > 0) { "Aspect ratio must be a positive number: $aspectRatio" }
+    return when (width.toFloat() / height) {
+        aspectRatio -> width to height
+        in 0f..aspectRatio -> (height * aspectRatio).roundToInt() to height
+        else -> width to (width / aspectRatio).roundToInt()
+    }
+}

--- a/modules/services/utils/src/test/java/au/com/shiftyjelly/pocketcasts/utils/BitmapUtilTest.kt
+++ b/modules/services/utils/src/test/java/au/com/shiftyjelly/pocketcasts/utils/BitmapUtilTest.kt
@@ -1,0 +1,38 @@
+package au.com.shiftyjelly.pocketcasts.utils
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class BitmapUtilTest {
+    @Test
+    fun `fail for zero aspect ratio`() {
+        try {
+            calculateNearestSize(0, 0, aspectRatio = 0f)
+        } catch (e: IllegalStateException) {
+            assertEquals("Aspect ratio must be a positive number: 0.0", e.message)
+        }
+    }
+
+    @Test
+    fun `fail for negative aspect ratio`() {
+        try {
+            calculateNearestSize(0, 0, aspectRatio = -1f)
+        } catch (e: IllegalStateException) {
+            assertEquals("Aspect ratio must be a positive number: -1.0", e.message)
+        }
+    }
+
+    @Test
+    fun `calculate to fit horizontally`() {
+        val size = calculateNearestSize(width = 100, height = 200, aspectRatio = 9f / 16)
+
+        assertEquals(113 to 200, size)
+    }
+
+    @Test
+    fun `calculate to fit vertically`() {
+        val size = calculateNearestSize(width = 200, height = 100, aspectRatio = 9f / 16)
+
+        assertEquals(200 to 356, size)
+    }
+}


### PR DESCRIPTION
## Description

Instagram has an expectation of `9:16` aspect ratio when sharing content to it but different devices have different screen sizes. This PR ensures that a captured Playback Story conforms to IG requirements by adding black padding strips to edges.

Previously, sharing a story to IG caused our images to be cropped and users had to manually zoom it out.

https://github.com/user-attachments/assets/0c60453a-c7ff-45be-915e-485cd8f68e6d

## Testing Instructions

1. Start PB24.
2. Share a story to Instagram.
3. It should not be cropped and should fit the screen.

## Screenshots or Screencast 

| Before | After |
| - | - |
| ![regular-before](https://github.com/user-attachments/assets/29382c13-35e1-4960-b33c-ec11ece16d54) | ![regular-after](https://github.com/user-attachments/assets/bf923f75-756b-41c7-b297-f05f3c8e2a5b) |

## Checklist
- [ ] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [ ] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [ ] ~Any jetpack compose components I added or changed are covered by compose previews~
- [ ] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~