### PR TITLE
Don't show the notification permission request as the first screen

### DIFF
--- a/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
+++ b/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
@@ -1580,6 +1580,7 @@ class MainActivity :
                 settings.setNotificationsDisabledMessageShown(true)
             },
             onPermissionGranted = onPermissionGranted,
+            onPermissionHandlingNotRequired = {},
         )
     }
 

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastFragment.kt
@@ -2,7 +2,6 @@ package au.com.shiftyjelly.pocketcasts.podcasts.view.podcast
 
 import android.content.Intent
 import android.net.Uri
-import android.os.Build
 import android.os.Bundle
 import android.os.Parcelable
 import android.view.LayoutInflater
@@ -500,31 +499,28 @@ class PodcastFragment : BaseFragment(), Toolbar.OnMenuItemClickListener {
 
     private val onNotificationsClicked: () -> Unit = {
         context?.let { context ->
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-                NotificationPermissionHelper.checkForNotificationPermission(
-                    requireActivity(),
-                    launcher = notificationPermissionLauncher,
-                    onShowRequestPermissionRationale = {
-                        (activity as? FragmentHostListener)?.snackBarView()?.let { snackBarView ->
-                            Snackbar.make(snackBarView, getString(LR.string.notifications_blocked_warning), Snackbar.LENGTH_LONG)
-                                .setAction(
-                                    getString(LR.string.notifications_blocked_warning_snackbar_action)
-                                        .uppercase(Locale.getDefault()),
-                                ) {
-                                    // Open app settings for the user to enable permissions
-                                    val intent = Intent(android.provider.Settings.ACTION_APPLICATION_DETAILS_SETTINGS)
-                                    intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-                                    val uri: Uri = Uri.fromParts("package", requireContext().packageName, null)
-                                    intent.data = uri
-                                    startActivity(intent)
-                                }.show()
-                        }
-                    },
-                    onPermissionGranted = { viewModel.toggleNotifications(context) },
-                )
-            } else {
-                viewModel.toggleNotifications(context)
-            }
+            NotificationPermissionHelper.checkForNotificationPermission(
+                requireActivity(),
+                launcher = notificationPermissionLauncher,
+                onShowRequestPermissionRationale = {
+                    (activity as? FragmentHostListener)?.snackBarView()?.let { snackBarView ->
+                        Snackbar.make(snackBarView, getString(LR.string.notifications_blocked_warning), Snackbar.LENGTH_LONG)
+                            .setAction(
+                                getString(LR.string.notifications_blocked_warning_snackbar_action)
+                                    .uppercase(Locale.getDefault()),
+                            ) {
+                                // Open app settings for the user to enable permissions
+                                val intent = Intent(android.provider.Settings.ACTION_APPLICATION_DETAILS_SETTINGS)
+                                intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                                val uri: Uri = Uri.fromParts("package", requireContext().packageName, null)
+                                intent.data = uri
+                                startActivity(intent)
+                            }.show()
+                    }
+                },
+                onPermissionGranted = { viewModel.toggleNotifications(context) },
+                onPermissionHandlingNotRequired = { viewModel.toggleNotifications(context) },
+            )
         }
     }
 

--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/NotificationPermissionHelper.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/NotificationPermissionHelper.kt
@@ -14,6 +14,7 @@ object NotificationPermissionHelper {
         launcher: ActivityResultLauncher<String>,
         onShowRequestPermissionRationale: () -> Unit = {},
         onPermissionGranted: () -> Unit = {},
+        onPermissionHandlingNotRequired: () -> Unit = {},
     ) {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
             when {
@@ -32,7 +33,7 @@ object NotificationPermissionHelper {
                 }
             }
         } else {
-            onPermissionGranted()
+            onPermissionHandlingNotRequired()
         }
     }
 }

--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/NotificationPermissionHelper.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/NotificationPermissionHelper.kt
@@ -2,6 +2,7 @@ package au.com.shiftyjelly.pocketcasts.utils
 
 import android.Manifest
 import android.app.Activity
+import android.content.Context
 import android.content.pm.PackageManager
 import android.os.Build
 import androidx.activity.result.ActivityResultLauncher
@@ -34,6 +35,17 @@ object NotificationPermissionHelper {
             }
         } else {
             onPermissionHandlingNotRequired()
+        }
+    }
+
+    fun hasNotificationPermissionGranted(context: Context): Boolean {
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            ContextCompat.checkSelfPermission(
+                context,
+                Manifest.permission.POST_NOTIFICATIONS,
+            ) == PackageManager.PERMISSION_GRANTED
+        } else {
+            true
         }
     }
 }

--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/NotificationPermissionHelper.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/NotificationPermissionHelper.kt
@@ -1,0 +1,38 @@
+package au.com.shiftyjelly.pocketcasts.utils
+
+import android.Manifest
+import android.app.Activity
+import android.content.pm.PackageManager
+import android.os.Build
+import androidx.activity.result.ActivityResultLauncher
+import androidx.core.content.ContextCompat
+
+object NotificationPermissionHelper {
+
+    fun checkForNotificationPermission(
+        activity: Activity,
+        launcher: ActivityResultLauncher<String>,
+        onShowRequestPermissionRationale: () -> Unit = {},
+        onPermissionGranted: () -> Unit = {},
+    ) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            when {
+                ContextCompat.checkSelfPermission(
+                    activity, Manifest.permission.POST_NOTIFICATIONS,
+                ) == PackageManager.PERMISSION_GRANTED -> {
+                    onPermissionGranted()
+                }
+
+                activity.shouldShowRequestPermissionRationale(Manifest.permission.POST_NOTIFICATIONS) -> {
+                    onShowRequestPermissionRationale()
+                }
+
+                else -> {
+                    launcher.launch(Manifest.permission.POST_NOTIFICATIONS)
+                }
+            }
+        } else {
+            onPermissionGranted()
+        }
+    }
+}


### PR DESCRIPTION
## Description
- This is the first PR to improve the notification permission request. Here, I am proposing to request the notification permission when is actually needed. This PR removes the notification permission request from the first screen and move it to when  the user tries to enable the notification for a podcast.
- I did not change the notification message the we already have in the app. 
- ⚠️ I am going to handle the `Warm before using data` notification in another PR

Fixes #3360

## Testing Instructions

### Android 15 - Notification ON
1. Have a fresh install 
2. Open the app and ensure you don't see the notification request in Log in page ✅
3. Go to some podcast
4. Follow this podcast 
5. Tap to enable the notification
6. Ensure you see the notification permission
7. **Allow it**
8. Ensure you see the toast with notification ON ✅

### Android 15 - Notification OFF
1. Have a fresh install 
2. Open the app and ensure you don't see the notification request in Log in page ✅
3. Go to some podcast
4. Follow this podcast 
5. Tap to enable the notification
6. Ensure you see the notification permission ✅
7. **Do not Allow it**
8. Ensure don't see the toast with notification on
9. Tap to enable the notification again
10. Ensure you see the warning about not having notification permission ✅

### Android 11 
1. Have a fresh install 
2. Go to some podcast
3. Follow this podcast 
4. Tap to enable the notification
5. Ensure you see the toast with notification ON ✅
6. Disable the podcast notification
7. Ensure you see the toast with notification OFF ✅


## Screenshots or Screencast 

### Android 15 - Notification On
[android 15 notification on.webm](https://github.com/user-attachments/assets/e755d74b-b436-4f0f-af8a-a0a136dac248)

### Android 15 - Notification Off
[android 15 notification off.webm](https://github.com/user-attachments/assets/b4743379-3ac9-4316-af5a-777e7ec02227)

### Android 11
[android 11.webm](https://github.com/user-attachments/assets/a7169749-b2c7-4d97-9738-0fb597648583)


## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] ~I have considered whether it makes sense to add tests for my changes~
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] ~Any jetpack compose components I added or changed are covered by compose previews~
- [ ] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] ~with different themes~
- [ ] ~with a landscape orientation~
- [ ] ~with the device set to have a large display and font size~
- [ ] ~for accessibility with TalkBack~
