### PR TITLE
Fix issue where Champion information was not considered in the UI

### DIFF
--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/AccountDetailsViewModel.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/AccountDetailsViewModel.kt
@@ -97,11 +97,13 @@ class AccountDetailsViewModel
                                 SubscriptionHeaderState.SupporterRenew(
                                     tier = activeSubscription.tier,
                                     expiresIn = activeSubscription.expiryDate?.toDurationFromNow(),
+                                    isChampion = status.isPocketCastsChampion,
                                 )
                             } else {
                                 SubscriptionHeaderState.SupporterCancel(
                                     tier = activeSubscription.tier,
                                     expiresIn = activeSubscription.expiryDate?.toDurationFromNow(),
+                                    isChampion = status.isPocketCastsChampion,
                                 )
                             }
                         }

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/AccountHeader.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/AccountHeader.kt
@@ -164,105 +164,103 @@ internal sealed interface SubscriptionHeaderState {
     data class SupporterRenew(
         override val tier: SubscriptionTier,
         override val expiresIn: Duration?,
-    ) : SubscriptionHeaderState {
-        override val isChampion = false
-    }
+        override val isChampion: Boolean,
+    ) : SubscriptionHeaderState
 
     data class SupporterCancel(
         override val tier: SubscriptionTier,
         override val expiresIn: Duration?,
-    ) : SubscriptionHeaderState {
-        override val isChampion = false
-    }
+        override val isChampion: Boolean,
+    ) : SubscriptionHeaderState
 }
 
 @Composable
 private fun SubscriptionHeaderState.labels(): Labels {
     val context = LocalContext.current
     return remember(this) {
-        when (this) {
-            is SubscriptionHeaderState.Free -> {
-                Labels(
-                    start = Label(
-                        text = context.getString(LR.string.profile_free_account),
-                    ),
-                )
-            }
+        if (isChampion) {
+            Labels(
+                start = Label(
+                    text = context.getString(LR.string.plus_thanks_for_your_support_bang),
+                ),
+                end = Label(
+                    text = context.getString(LR.string.pocket_casts_champion),
+                    color = { support02 },
+                ),
+            )
+        } else {
+            when (this) {
+                is SubscriptionHeaderState.Free -> {
+                    Labels(
+                        start = Label(
+                            text = context.getString(LR.string.profile_free_account),
+                        ),
+                    )
+                }
 
-            is SubscriptionHeaderState.PaidRenew -> {
-                val expiryDate = Date(Date().time + expiresIn.inWholeMilliseconds)
-                Labels(
-                    start = Label(
-                        text = context.getString(LR.string.profile_next_payment, expiryDate.toLocalizedFormatLongStyle()),
-                    ),
-                    end = Label(
-                        text = when (frequency) {
-                            SubscriptionFrequency.MONTHLY -> context.getString(LR.string.profile_monthly)
-                            SubscriptionFrequency.YEARLY -> context.getString(LR.string.profile_yearly)
-                            SubscriptionFrequency.NONE -> ""
-                        },
-                    ),
-                )
-            }
+                is SubscriptionHeaderState.PaidRenew -> {
+                    val expiryDate = Date(Date().time + expiresIn.inWholeMilliseconds)
+                    Labels(
+                        start = Label(
+                            text = context.getString(LR.string.profile_next_payment, expiryDate.toLocalizedFormatLongStyle()),
+                        ),
+                        end = Label(
+                            text = when (frequency) {
+                                SubscriptionFrequency.MONTHLY -> context.getString(LR.string.profile_monthly)
+                                SubscriptionFrequency.YEARLY -> context.getString(LR.string.profile_yearly)
+                                SubscriptionFrequency.NONE -> ""
+                            },
+                        ),
+                    )
+                }
 
-            is SubscriptionHeaderState.PaidCancel -> {
-                Labels(
-                    start = Label(
-                        text = when {
-                            isChampion -> {
-                                context.getString(LR.string.plus_thanks_for_your_support_bang)
-                            }
-                            platform == SubscriptionPlatform.GIFT -> {
-                                val daysString = context.resources.getStringPluralDaysMonthsOrYears(giftDaysLeft)
-                                context.getString(LR.string.profile_time_free, daysString)
-                            }
-                            else -> {
-                                context.getString(LR.string.profile_payment_cancelled)
-                            }
-                        },
-                    ),
-                    end = Label(
-                        text = if (isChampion) {
-                            context.getString(LR.string.pocket_casts_champion)
-                        } else {
-                            val expiryDate = Date(Date().time + expiresIn.inWholeMilliseconds)
-                            context.getString(LR.string.profile_plus_expires, expiryDate.toLocalizedFormatLongStyle())
-                        },
-                        color = {
-                            if (isChampion) {
-                                support02
-                            } else {
-                                primaryText02
-                            }
-                        },
-                    ),
-                )
-            }
+                is SubscriptionHeaderState.PaidCancel -> {
+                    Labels(
+                        start = Label(
+                            text = when {
+                                platform == SubscriptionPlatform.GIFT -> {
+                                    val daysString = context.resources.getStringPluralDaysMonthsOrYears(giftDaysLeft)
+                                    context.getString(LR.string.profile_time_free, daysString)
+                                }
+                                else -> {
+                                    context.getString(LR.string.profile_payment_cancelled)
+                                }
+                            },
+                        ),
+                        end = Label(
+                            text = run {
+                                val expiryDate = Date(Date().time + expiresIn.inWholeMilliseconds)
+                                context.getString(LR.string.profile_plus_expires, expiryDate.toLocalizedFormatLongStyle())
+                            },
+                        ),
+                    )
+                }
 
-            is SubscriptionHeaderState.SupporterRenew -> {
-                Labels(
-                    start = Label(
-                        text = context.getString(LR.string.supporter),
-                        color = { support02 },
-                    ),
-                    end = Label(
-                        text = context.getString(LR.string.supporter_check_contributions),
-                    ),
-                )
-            }
+                is SubscriptionHeaderState.SupporterRenew -> {
+                    Labels(
+                        start = Label(
+                            text = context.getString(LR.string.supporter),
+                            color = { support02 },
+                        ),
+                        end = Label(
+                            text = context.getString(LR.string.supporter_check_contributions),
+                        ),
+                    )
+                }
 
-            is SubscriptionHeaderState.SupporterCancel -> {
-                val expiryDate = expiresIn?.inWholeMilliseconds?.let { Date(Date().time + it) }
-                val expiryString = expiryDate?.toLocalizedFormatLongStyle() ?: context.getString(LR.string.profile_expiry_date_unknown)
-                Labels(
-                    start = Label(
-                        text = context.getString(LR.string.supporter_payment_cancelled),
-                        color = { support05 },
-                    ),
-                    end = Label(
-                        text = context.getString(LR.string.supporter_subscription_ends, expiryString),
-                    ),
-                )
+                is SubscriptionHeaderState.SupporterCancel -> {
+                    val expiryDate = expiresIn?.inWholeMilliseconds?.let { Date(Date().time + it) }
+                    val expiryString = expiryDate?.toLocalizedFormatLongStyle() ?: context.getString(LR.string.profile_expiry_date_unknown)
+                    Labels(
+                        start = Label(
+                            text = context.getString(LR.string.supporter_payment_cancelled),
+                            color = { support05 },
+                        ),
+                        end = Label(
+                            text = context.getString(LR.string.supporter_subscription_ends, expiryString),
+                        ),
+                    )
+                }
             }
         }
     }
@@ -431,6 +429,16 @@ private class AccountHeaderStateParameterProvider : PreviewParameterProvider<Acc
             subscription = SubscriptionHeaderState.SupporterRenew(
                 tier = SubscriptionTier.PLUS,
                 expiresIn = null,
+                isChampion = false,
+            ),
+        ),
+        AccountHeaderState(
+            email = "noreply@pocketcasts.com",
+            imageUrl = null,
+            subscription = SubscriptionHeaderState.SupporterRenew(
+                tier = SubscriptionTier.PLUS,
+                expiresIn = null,
+                isChampion = true,
             ),
         ),
         AccountHeaderState(
@@ -439,6 +447,16 @@ private class AccountHeaderStateParameterProvider : PreviewParameterProvider<Acc
             subscription = SubscriptionHeaderState.SupporterCancel(
                 tier = SubscriptionTier.PLUS,
                 expiresIn = 10.days,
+                isChampion = false,
+            ),
+        ),
+        AccountHeaderState(
+            email = "noreply@pocketcasts.com",
+            imageUrl = null,
+            subscription = SubscriptionHeaderState.SupporterCancel(
+                tier = SubscriptionTier.PLUS,
+                expiresIn = 10.days,
+                isChampion = true,
             ),
         ),
         AccountHeaderState(
@@ -447,6 +465,7 @@ private class AccountHeaderStateParameterProvider : PreviewParameterProvider<Acc
             subscription = SubscriptionHeaderState.SupporterCancel(
                 tier = SubscriptionTier.PLUS,
                 expiresIn = null,
+                isChampion = false,
             ),
         ),
     )


### PR DESCRIPTION
## Description

Champion users navigating to the account details would see incorrect information about their account. This happened during account details migration to Compose UI where I made a mistake of considering Champion status only for paid accounts and not supporter accounts. Now the Champion status is applied correctly across all subscriptions.

Reported here: https://pocketcastsbeta.slack.com/archives/C013F9S9C2W/p1733998102685089

I also went ahead and informed the community: https://www.reddit.com/r/pocketcasts/comments/1hcis87/pocket_casts_champion_ui_bug_in_779_beta/

## Testing Instructions

Hard to test it without a real Champion account and not one created through the Admin tool. But code review should be enough as the change is covered by previews. The old logic applying champion status looked like this:

https://github.com/Automattic/pocket-casts-android/blob/f56cac105002765d17fd27868a8c3e0535aa6c2a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/UserView.kt#L244-L278

You can see that the `isPocketCastsChampion` was always applied at the end instead of selectively when `autoRenew` was false.

## Checklist
- [ ] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [ ] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [ ] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~