### PR TITLE
Request permission before enabling Notify Me

### DIFF
--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/NotificationPermissionHelper.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/NotificationPermissionHelper.kt
@@ -2,6 +2,7 @@ package au.com.shiftyjelly.pocketcasts.utils
 
 import android.Manifest
 import android.app.Activity
+import android.content.Context
 import android.content.pm.PackageManager
 import android.os.Build
 import androidx.activity.result.ActivityResultLauncher
@@ -34,6 +35,17 @@ object NotificationPermissionHelper {
             }
         } else {
             onPermissionHandlingNotRequired()
+        }
+    }
+
+    fun hasNotificationPermissionGranted(context: Context): Boolean {
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            ContextCompat.checkSelfPermission(
+                context,
+                Manifest.permission.POST_NOTIFICATIONS,
+            ) == PackageManager.PERMISSION_GRANTED
+        } else {
+            true
         }
     }
 }


### PR DESCRIPTION
## Description
- This is part of https://github.com/Automattic/pocket-casts-android/pull/3350 whether we are removing the notification permission request from the first screen in order to request when is actual needed.
- This PR, requests the notification permission when the user tries to enable the `Notify me` toggle from Notification screen.
- Here, I am proposing to disable the `Notify Me` toggle when the user had this one previous enabled, but removed the notification permission after that because does not make sense to let the user with the Notify me enabled when this one removed the notification permission

Fixes: #3358

## Testing Instructions

### Android 15 - Notification ON
1. Have a fresh install
2. Go to Profile -> Settings -> Notification
3. Enable Notify me toggle
4. ✅ Ensure you see the notification request permission
5. Allow it
6. ✅ Have Notify me toggle enabled

[notification on.webm](https://github.com/user-attachments/assets/e5436b3d-1143-47c8-923e-6cf327bc74bc)

### Android 15 - Notification OFF
1. Have a fresh install
2. Go to Profile -> Settings -> Notification
3. Enable Notify me toggle
4. ✅ Ensure you see the notification request permission
5. Do not allow it
6. ✅ Have Notify me toggle disabled
7. Tap to enable this toggle again
8. ✅ See the snackbar message about having blocked notifications

[notification off.webm](https://github.com/user-attachments/assets/ea83ae29-4e32-4733-94eb-93769d03d308)


### Android 15 - Notification ON and then remove permission
1. Have a fresh install
2. Go to Profile -> Settings -> Notification
3. Enable Notify me toggle
4. Go to system notification management and remove Pocket Casts App notification permission
5. Go back to Notification screen
6. ✅ Ensure you have Notify me disabled

### Android 11
- Smoke test: You should be able to enable and disable the toggle

## Checklist
- [ ] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [ ] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] ~I have considered whether it makes sense to add tests for my changes~
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] ~Any jetpack compose components I added or changed are covered by compose previews~
- [ ] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~

