### PR TITLE
[Tooling] Update GitHub Actions

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -5,10 +5,10 @@ agents:
   queue: "android"
 
 steps:
-  - label: "Gradle Wrapper Validation"
-    command: |
-      validate_gradle_wrapper
-    plugins: [$CI_TOOLKIT]
+  - label: Gradle Wrapper Validation
+    command: validate_gradle_wrapper
+    agents:
+      queue: linter
 
   # Wait for Gradle Wrapper to be validated before running any other jobs
   - wait

--- a/.buildkite/release-builds.yml
+++ b/.buildkite/release-builds.yml
@@ -8,11 +8,13 @@ agents:
   queue: "android"
 
 steps:
-  - label: "Gradle Wrapper Validation"
-    command: |
-      validate_gradle_wrapper
+  # NOTE: once this pipeline is called inline from another pipeline via ReleasesV2,
+  # we may need to use another agent to checkout the release branch before the Gradle Wrapper Validation
+  - label: Gradle Wrapper Validation
+    command: validate_gradle_wrapper
     priority: 1
-    plugins: [$CI_TOOLKIT]
+    agents:
+      queue: linter
 
   # Wait for Gradle Wrapper to be validated before running any other jobs
   - wait

--- a/.github/workflows/gradle-wrapper-validation.yml
+++ b/.github/workflows/gradle-wrapper-validation.yml
@@ -7,4 +7,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: gradle/wrapper-validation-action@v2
+      - uses: gradle/actions/wrapper-validation@v4


### PR DESCRIPTION
Reference: p7H4VZ-59z-p2

PocketCasts Android doesn't use one of the GitHub Actions about to have its older versions deprecated as `actions/upload-artifact`, `actions/download-artifact` or `actions/cache`, but I used this opportunity to upgrade the Action `gradle/actions/wrapper-validation` and to move the Buildkite Gradle Wrapper Validation to the Linter queue.