### PR TITLE
Fix: Sleep timer stops podcast  after given time

### DIFF
--- a/modules/services/repositories/src/main/AndroidManifest.xml
+++ b/modules/services/repositories/src/main/AndroidManifest.xml
@@ -5,6 +5,9 @@
 
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
 
+    <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM"
+        tools:ignore="ProtectedPermissions" />
+
     <application android:usesCleartextTraffic="true">
         <provider
             android:name="au.com.shiftyjelly.pocketcasts.repositories.playback.auto.AlbumArtContentProvider"


### PR DESCRIPTION
## Description
- We got some reports related to Sleep Timer not working as expected. Specially not respecting the time set
- The problem is that we were using the method `setAndAllowWhileIdle`, which might sets an inexact alarm. This method also might be affected by battery optimizations. See here for more details: https://developer.android.com/about/versions/14/changes/schedule-exact-alarms#use-cases
- But Android also provides another option to set exact alarm, which is `setExactAndAllowWhileIdle`. This one requires user's permission and the permission was introduced in Android 12 (`SCHEDULE_EXACT_ALARM`). See: https://developer.android.com/about/versions/14/changes/schedule-exact-alarms
- For devices with Android < 12 this permission request will not be necessary
- Also, users who already have granted the `ACTION_REQUEST_IGNORE_BATTERY_OPTIMIZATIONS ` permission our app won't need to request the `SCHEDULE_EXACT_ALARM` permission, which might cover a lot of our users since we request this for the battery restriction.

Fixes #3355
Fixes #2219


## Testing Instructions
- I have two devices but I was able to reproduce this issue https://github.com/Automattic/pocket-casts-android/issues/3355 only in one device. Something to note is that the device that I was able to reproduce this issue had low remaining battery.

### Android > 12
1. Have a fresh install
2. Play an episode
3. Do not grant the battery permission
4. Tap on sleep timer
5. You should see the new permission request for alarm
6. Grant PC permission
7. Tap on sleep timer again
8. Set 1 minute
9. Ensure you have a sleep timer more accurate ✅

### Android < 12
1. Have a fresh install
2. Play an episode
3. Do not grant the battery permission
4. Tap on sleep timer
5. Set 1 minute
6. Ensure you have a sleep timer more accurate ✅

### Android > 12 and migration
1. Instal the app from release/7.79
2. Play an episode
3. Grant the battery permission
4. Install the app from this branch
5. Play an episode
6. Tap on sleep timer
7. Set 1 minute
8. Ensure you have a sleep timer more accurate ✅

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] ~I have considered whether it makes sense to add tests for my changes~
- [ ] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [ ] ~Any jetpack compose components I added or changed are covered by compose previews~
- [ ] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~
