### PR TITLE
[Tooling] Danger GitHub Actions configuration update

### DIFF
--- a/.github/workflows/run-danger.yml
+++ b/.github/workflows/run-danger.yml
@@ -7,11 +7,11 @@ on:
 jobs:
   dangermattic:
     if: ${{ (github.event.pull_request.draft == false) }}
-    uses: Automattic/dangermattic/.github/workflows/reusable-retry-buildkite-step-on-events.yml@1.2.2
+    uses: Automattic/dangermattic/.github/workflows/reusable-retry-buildkite-step-on-events.yml@v1
     with:
-      org-slug: "automattic"
-      pipeline-slug: "pocket-casts-android"
-      retry-step-key: "danger"
-      build-commit-sha: "${{ github.event.pull_request.head.sha }}"
+      org-slug: automattic
+      pipeline-slug: pocket-casts-android
+      retry-step-key: danger
+      build-commit-sha: ${{ github.event.pull_request.head.sha }}
     secrets:
       buildkite-api-token: ${{ secrets.TRIGGER_BK_BUILD_TOKEN }}

--- a/.github/workflows/run-danger.yml
+++ b/.github/workflows/run-danger.yml
@@ -2,7 +2,7 @@ name: ☢️ Trigger Danger On Buildkite
 
 on:
   pull_request:
-    types: [labeled, unlabeled, milestoned, demilestoned]
+    types: [labeled, unlabeled, milestoned, demilestoned, ready_for_review, edited]
 
 jobs:
   dangermattic:


### PR DESCRIPTION
## Description
Reference: p1734116587744489-slack-C02KLTL3MKM

Changes in this PR:
- Run Danger when a PR is Ready for Review (previously, this was triggered by CI but we updated to avoid the extra full build).
- Run Danger when a PR has been edited (this is required by the ViewChecker Danger plugin)
- Uses Dangermattic GHA workflow latest `v1` version instead of an specific version
- Some workflow file clean-up

## Testing Instructions
CI should be 🟢 

I've also confirmed Danger ran properly when the PR moved from Draft to Ready For Review, as well as when editing the description.