### PR TITLE
Fix podcast ratings not loading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@
         ([#3294](https://github.com/Automattic/pocket-casts-android/pull/3294))
     *   Improve the Up Next clear all button
         ([#3334](https://github.com/Automattic/pocket-casts-android/pull/3334))
+*   Bug Fixes
+    *   Fix podcast ratings not loading
+        ([#3378](https://github.com/Automattic/pocket-casts-android/pull/3378))
 
 7.78
 -----

--- a/app/src/test/java/au/com/shiftyjelly/pocketcasts/ui/MainActivityViewModelTest.kt
+++ b/app/src/test/java/au/com/shiftyjelly/pocketcasts/ui/MainActivityViewModelTest.kt
@@ -225,7 +225,7 @@ class MainActivityViewModelTest {
             whenever(settings.getWhatsNewVersionCode()).thenReturn(Settings.WHATS_NEW_VERSION_CODE)
         }
 
-        whenever(userManager.getSignInStateFlowable()).thenReturn(
+        whenever(userManager.getSignInState()).thenReturn(
             Flowable.just(
                 SignInState.SignedIn(
                     email = "",

--- a/app/src/test/java/au/com/shiftyjelly/pocketcasts/ui/MainActivityViewModelTest.kt
+++ b/app/src/test/java/au/com/shiftyjelly/pocketcasts/ui/MainActivityViewModelTest.kt
@@ -225,7 +225,7 @@ class MainActivityViewModelTest {
             whenever(settings.getWhatsNewVersionCode()).thenReturn(Settings.WHATS_NEW_VERSION_CODE)
         }
 
-        whenever(userManager.getSignInState()).thenReturn(
+        whenever(userManager.getSignInStateFlowable()).thenReturn(
             Flowable.just(
                 SignInState.SignedIn(
                     email = "",

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/SyncAccountManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/SyncAccountManager.kt
@@ -6,6 +6,8 @@ import au.com.shiftyjelly.pocketcasts.preferences.AccountConstants
 import au.com.shiftyjelly.pocketcasts.preferences.RefreshToken
 import au.com.shiftyjelly.pocketcasts.servers.sync.LoginIdentity
 import au.com.shiftyjelly.pocketcasts.servers.sync.TokenHandler
+import au.com.shiftyjelly.pocketcasts.utils.Optional
+import io.reactivex.Flowable
 import kotlinx.coroutines.flow.Flow
 
 /**
@@ -17,7 +19,8 @@ interface SyncAccountManager : TokenHandler {
     fun addAccount(email: String, uuid: String, refreshToken: RefreshToken, accessToken: AccessToken, loginIdentity: LoginIdentity)
     fun getAccount(): Account?
     fun getEmail(): String?
-    fun observeEmail(): Flow<String?>
+    fun emailFlow(): Flow<String?>
+    fun emailFlowable(): Flowable<Optional<String>>
     fun getLoginIdentity(): LoginIdentity?
     fun getRefreshToken(account: Account? = null): RefreshToken?
     fun getSignInType(account: Account): AccountConstants.SignInType

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/SyncManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/SyncManager.kt
@@ -26,6 +26,7 @@ import au.com.shiftyjelly.pocketcasts.servers.sync.UserChangeResponse
 import au.com.shiftyjelly.pocketcasts.servers.sync.history.HistoryYearResponse
 import au.com.shiftyjelly.pocketcasts.servers.sync.login.ExchangeSonosResponse
 import au.com.shiftyjelly.pocketcasts.servers.sync.update.SyncUpdateResponse
+import au.com.shiftyjelly.pocketcasts.utils.Optional
 import com.jakewharton.rxrelay2.BehaviorRelay
 import com.pocketcasts.service.api.PodcastRatingResponse
 import com.pocketcasts.service.api.PodcastRatingsResponse
@@ -34,6 +35,7 @@ import com.pocketcasts.service.api.ReferralRedemptionResponse
 import com.pocketcasts.service.api.ReferralValidationResponse
 import com.pocketcasts.service.api.UserPodcastListResponse
 import io.reactivex.Completable
+import io.reactivex.Flowable
 import io.reactivex.Maybe
 import io.reactivex.Single
 import java.io.File
@@ -50,6 +52,7 @@ interface SyncManager : NamedSettingsCaller {
     fun getLoginIdentity(): LoginIdentity?
     fun getEmail(): String?
     fun emailFlow(): Flow<String?>
+    fun emailFlowable(): Flowable<Optional<String>>
     fun signOut(action: () -> Unit = {})
     suspend fun loginWithGoogle(idToken: String, signInSource: SignInSource): LoginResult
     suspend fun loginWithEmailAndPassword(email: String, password: String, signInSource: SignInSource): LoginResult

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/SyncManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/SyncManagerImpl.kt
@@ -42,6 +42,7 @@ import au.com.shiftyjelly.pocketcasts.servers.sync.login.ExchangeSonosResponse
 import au.com.shiftyjelly.pocketcasts.servers.sync.login.LoginTokenResponse
 import au.com.shiftyjelly.pocketcasts.servers.sync.parseErrorResponse
 import au.com.shiftyjelly.pocketcasts.servers.sync.update.SyncUpdateResponse
+import au.com.shiftyjelly.pocketcasts.utils.Optional
 import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
 import com.jakewharton.rxrelay2.BehaviorRelay
 import com.pocketcasts.service.api.PodcastRatingResponse
@@ -53,6 +54,7 @@ import com.pocketcasts.service.api.UserPodcastListResponse
 import com.squareup.moshi.Moshi
 import dagger.hilt.android.qualifiers.ApplicationContext
 import io.reactivex.Completable
+import io.reactivex.Flowable
 import io.reactivex.Maybe
 import io.reactivex.Single
 import java.io.File
@@ -130,7 +132,9 @@ class SyncManagerImpl @Inject constructor(
     override fun getEmail(): String? =
         syncAccountManager.getEmail()
 
-    override fun emailFlow() = syncAccountManager.observeEmail().distinctUntilChanged()
+    override fun emailFlow() = syncAccountManager.emailFlow().distinctUntilChanged()
+
+    override fun emailFlowable(): Flowable<Optional<String>> = syncAccountManager.emailFlowable().distinctUntilChanged()
 
     override suspend fun getAccessToken(account: Account): AccessToken =
         syncAccountManager.peekAccessToken(account)

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/user/UserManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/user/UserManager.kt
@@ -23,7 +23,6 @@ import au.com.shiftyjelly.pocketcasts.repositories.podcast.UserEpisodeManager
 import au.com.shiftyjelly.pocketcasts.repositories.searchhistory.SearchHistoryManager
 import au.com.shiftyjelly.pocketcasts.repositories.subscription.SubscriptionManager
 import au.com.shiftyjelly.pocketcasts.repositories.sync.SyncManager
-import au.com.shiftyjelly.pocketcasts.utils.Optional
 import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
 import com.automattic.android.tracks.crashlogging.CrashLogging
 import dagger.hilt.android.qualifiers.ApplicationContext
@@ -35,10 +34,8 @@ import javax.inject.Inject
 import kotlin.coroutines.CoroutineContext
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
-import kotlinx.coroutines.rx2.asFlowable
 import timber.log.Timber
 
 interface UserManager {
@@ -100,7 +97,7 @@ class UserManagerImpl @Inject constructor(
                                 subscriptionManager.getSubscriptionStatus(allowCache = false)
                             }
                         }
-                        .combineLatest(syncManager.emailFlow().map { Optional.of(it) }.asFlowable())
+                        .combineLatest(syncManager.emailFlowable())
                         .map { (status, maybeEmail) ->
                             analyticsTracker.refreshMetadata()
                             SignInState.SignedIn(email = maybeEmail.get() ?: "", subscriptionStatus = status)


### PR DESCRIPTION
## Description

This fixes an issue in beta, where the podcast rating page doesn't load. It seems to relate to the `UserManager.getSignInState` combining a Flowable and Flow. If I change the Coroutines dispatcher to IO it appears to fix the issue but until we switch the whole method to Flow, I have added a Flowable version that fixes the issue as well. Please let me know if you have any ideas why this code might cause the method to hang.

```
.combineLatest(syncManager.emailFlow().map { Optional.of(it) }.asFlowable())
```

I have also improved the ratings page to not use this as it only needs to know if the user is logged in and not the full sign in state.

## Testing Instructions
1. Don't be signed into an account
2. Open a podcast page
3. Expand the header
4. Tap on "Rate"
5. ✅ Verify you are asked to login
6. Sign into a Pocket Casts account
7. Open a podcast page
8. Tap on "Rate"
9. ✅ Verify you can rate a podcast

It would be good to check the `getSignInState` method still works.
1. Login or sign up with an email and password
2. Go to Profile -> Account
3. Tap "Change email address" and change the email
4. ✅ Verify the email address has updated on the account and profile pages

## Screencast 

After 

https://github.com/user-attachments/assets/ec370e23-754e-4311-92fd-373e8a6df650

Before

https://github.com/user-attachments/assets/34edaac0-3a81-4d08-9bda-54b61b219718

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack
