### PR TITLE
[Tooling] Introduce publish_release lane

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -400,9 +400,9 @@ platform :android do
     # At this point, an intermediate branch has been created by creating a backmerge PR to a hotfix or the next version release branch.
     # This allows us to safely delete the `release/*` remote branch.
     remove_branch_protection(repository: GITHUB_REPO, branch: current_branch)
-    Fastlane::Helper::GitHelper::delete_remote_branch_if_exists!(current_branch)
-    Fastlane::Helper::GitHelper::checkout_and_pull(DEFAULT_BRANCH)
-    Fastlane::Helper::GitHelper::delete_local_branch_if_exists!(current_branch)
+    Fastlane::Helper::GitHelper.delete_remote_branch_if_exists!(current_branch)
+    Fastlane::Helper::GitHelper.checkout_and_pull(DEFAULT_BRANCH)
+    Fastlane::Helper::GitHelper.delete_local_branch_if_exists!(current_branch)
   end
 
   # @param branch_to_build [String] The branch to build. Defaults to the current git branch.


### PR DESCRIPTION
> [!NOTE]
> This is a re-opening of https://github.com/Automattic/pocket-casts-android/pull/3371 because the initial changes were accidentally commited to the wrong branch (`merge/release-7.79-into-main` instead of `tooling/publish_release`) when I initially worked on them (and I wasn't attentive enough to spot my mistake when I pushed them and opened the PR 😅 ).

## Description

Introduce a `publish_release` lane to automate:
 - The publication of the GitHub Release of the final build (once the version submitted to Google on Friday have been approved)
 - The creation of the final backmerge PR if needed(†)
 - The deletion of the release branch


<details><summary>(†) Note that in 95% of cases there won't be anything to backmerge—and the creation of that backmerge PR will be automatically skipped.</summary>

 - This is because there had already been a backmerge PR created during submission on Friday and no new commit should have been added to the `release/*` branch after submission.
  - But calling `create_release_backmerge_pull_request` anyway is more of safety net in case there would have been a new  commit on `release/*` anyway since, to make sure not lose it completely accidentally once we delete the `release/*` branch
  - Rare cases where this could happen is if a commit was added to change tooling-related files (`Fastlane`, `Gemfile.lock`, …) after the submission to fix issues encountered in the tooling, or update of the `CHANGELOG.md` file if one notice after having submitted the build that a PR was forgotten to be added to it, etc. Those seldom cases would not require a resubmission of the final build so that'd be ok for them to land even after the submission was done, and in those rare cases a backmerge PR would be created to propagate those properly instead of risking to lose those changes upon `release/*` branch deletion
</details>

This PR also:
 - Reorders lanes so that lanes called by Release Manager as part of release scenario steps are all grouped together at the top.
 - Renames `GH_REPOSITORY` constant to `GITHUB_REPO`, for consistency with our other repos

## Testing Instructions

Won't really be able to test those without doing a real final release publication as part of a Release Scenario, given this lane creates side-effects.

> [!IMPORTANT]
> I've made this PR target `release/7.79` so that we could use the occasion of the `7.79` publication to test that this lane works as expected if we want. Even if `7.79` won't be sent to Production track in Google Play this time around due to the EOY break (internal ref: pdeCcb-85s-p2), we will probably want to publish the GitHub Release and delete the `release/7.79` branch at the end of its scenario—which is what this `publish_release` branch is all about.
>
> That being said, if this PR is not ready to be merged by the time `release/7.79` is ready to be finalized, it's ok to make it target `7.80` instead.

## Next Steps

I will create the corresponding diff for the Release Scenario to replace the corresponding manual tasks during "Release" milestone to just call this new lane instead.