### PR TITLE
Converting user sync from Rx to Coroutines

### DIFF
--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/models/db/FolderDaoTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/models/db/FolderDaoTest.kt
@@ -103,7 +103,7 @@ class FolderDaoTest {
     @Test
     fun updateAllSyncedShouldUpdateTheSynModifiedFieldOfAllFolders() = runTest {
         folderDao.insert(fakeFolder)
-        folderDao.updateAllSyncedBlocking()
+        folderDao.updateAllSynced()
         val updatedFolder = folderDao.findFolders()
         assertTrue(updatedFolder.all { it.syncModified == 0L })
     }

--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/repositories/sync/PodcastSyncProcessTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/repositories/sync/PodcastSyncProcessTest.kt
@@ -91,7 +91,7 @@ class PodcastSyncProcessTest {
             whenever(playlistManager.findPlaylistsToSyncBlocking()).thenReturn(emptyList())
 
             val folderManager: FolderManager = mock()
-            whenever(folderManager.findFoldersToSync()).thenReturn(emptyList())
+            whenever(folderManager.findFoldersToSyncBlocking()).thenReturn(emptyList())
 
             val bookmarkManager = BookmarkManagerImpl(appDatabase = appDatabase, AnalyticsTracker.test())
             val bookmarkToUpdate = bookmarkManager.add(

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/PromoCodeViewModel.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/PromoCodeViewModel.kt
@@ -39,7 +39,7 @@ class PromoCodeViewModel @Inject constructor(
     fun setup(code: String, context: Context) {
         val signedInFlow = Single.defer<ViewState> { syncManager.redeemPromoCodeRxSingle(code).map { ViewState.Success(it) } }
             .flatMap { viewState ->
-                subscriptionManager.getSubscriptionStatus(allowCache = false).map { viewState } // Force reloading of the new subscription status
+                subscriptionManager.getSubscriptionStatusRxSingle(allowCache = false).map { viewState } // Force reloading of the new subscription status
             }
             .observeOn(AndroidSchedulers.mainThread())
             .onErrorReturn(errorHandler(isSignedIn = true, resources = context.resources))

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/EpisodeDao.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/EpisodeDao.kt
@@ -384,7 +384,7 @@ abstract class EpisodeDao {
     }
 
     @Query("UPDATE podcast_episodes SET starred_modified = NULL, archived_modified = NULL, duration_modified = NULL, played_up_to_modified = NULL, playing_status_modified = NULL WHERE uuid IN (:episodeUuids)")
-    abstract fun markAllSyncedBlocking(episodeUuids: List<String>)
+    abstract suspend fun markAllSynced(episodeUuids: List<String>)
 
     @Query("SELECT podcasts.uuid AS uuid, count(podcast_episodes.uuid) AS count FROM podcast_episodes, podcasts WHERE podcast_episodes.podcast_id = podcasts.uuid AND (podcast_episodes.playing_status = :playingStatusNotPlayed OR podcast_episodes.playing_status = :playingStatusInProgress) AND podcast_episodes.archived = 0 GROUP BY podcasts.uuid")
     protected abstract fun podcastToUnfinishedEpisodeCountRxFlowable(playingStatusNotPlayed: Int = EpisodePlayingStatus.NOT_PLAYED.ordinal, playingStatusInProgress: Int = EpisodePlayingStatus.IN_PROGRESS.ordinal): Flowable<List<UuidCount>>

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/FolderDao.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/FolderDao.kt
@@ -63,7 +63,7 @@ abstract class FolderDao {
     abstract suspend fun updateSortPosition(sortPosition: Int, uuid: String, syncModified: Long)
 
     @Query("UPDATE folders SET sync_modified = 0")
-    abstract fun updateAllSyncedBlocking()
+    abstract suspend fun updateAllSynced()
 
     @Transaction
     open suspend fun updateSortPositions(folders: List<Folder>, syncModified: Long) {
@@ -73,5 +73,5 @@ abstract class FolderDao {
     }
 
     @Query("SELECT COUNT(*) FROM folders WHERE deleted = 0")
-    abstract fun countBlocking(): Int
+    abstract suspend fun count(): Int
 }

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/PlaylistDao.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/PlaylistDao.kt
@@ -73,7 +73,7 @@ abstract class PlaylistDao {
     abstract fun updateSyncStatusBlocking(syncStatus: Int, uuid: String)
 
     @Query("UPDATE filters SET syncStatus = :syncStatus")
-    abstract fun updateAllSyncStatusBlocking(syncStatus: Int)
+    abstract suspend fun updateAllSyncStatus(syncStatus: Int)
 
     @Query("SELECT * FROM filters WHERE UPPER(title) = UPPER(:title)")
     abstract fun searchByTitleBlocking(title: String): Playlist?

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/PodcastDao.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/PodcastDao.kt
@@ -162,7 +162,7 @@ abstract class PodcastDao {
     }
 
     @Query("UPDATE podcasts SET sync_status = :syncStatus")
-    abstract fun updateAllSyncStatusBlocking(syncStatus: Int)
+    abstract suspend fun updateAllSyncStatus(syncStatus: Int)
 
     @Query("UPDATE podcasts SET sync_status = :syncStatus WHERE subscribed = 1")
     abstract suspend fun updateAllSubscribedSyncStatus(syncStatus: Int)

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManager.kt
@@ -43,7 +43,7 @@ interface EpisodeManager {
 
     fun findEpisodesToSyncBlocking(): List<PodcastEpisode>
     fun findEpisodesForHistorySyncBlocking(): List<PodcastEpisode>
-    fun markAllEpisodesSyncedBlocking(episodes: List<PodcastEpisode>)
+    suspend fun markAllEpisodesSynced(episodes: List<PodcastEpisode>)
 
     fun findEpisodesDownloadingBlocking(queued: Boolean = true, waitingForPower: Boolean = true, waitingForWifi: Boolean = true, downloading: Boolean = true): List<PodcastEpisode>
 

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManagerImpl.kt
@@ -879,10 +879,10 @@ class EpisodeManagerImpl @Inject constructor(
         return episodeDao.findEpisodesForHistorySyncBlocking()
     }
 
-    override fun markAllEpisodesSyncedBlocking(episodes: List<PodcastEpisode>) {
+    override suspend fun markAllEpisodesSynced(episodes: List<PodcastEpisode>) {
         val episodeUuids = episodes.map { it.uuid }
         episodeUuids.chunked(500).forEach { chunked ->
-            episodeDao.markAllSyncedBlocking(chunked)
+            episodeDao.markAllSynced(chunked)
         }
     }
 

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/FolderManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/FolderManager.kt
@@ -28,7 +28,7 @@ interface FolderManager {
     fun findFoldersSingle(): Single<List<Folder>>
     suspend fun updatePositions(folders: List<Folder>)
     suspend fun updateSortPosition(folderItems: List<FolderItem>)
-    fun findFoldersToSync(): List<Folder>
-    fun markAllSynced()
-    fun countFolders(): Int
+    fun findFoldersToSyncBlocking(): List<Folder>
+    suspend fun markAllSynced()
+    suspend fun countFolders(): Int
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/FolderManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/FolderManagerImpl.kt
@@ -151,12 +151,12 @@ class FolderManagerImpl @Inject constructor(
         updatePositions(folders)
     }
 
-    override fun findFoldersToSync(): List<Folder> {
+    override fun findFoldersToSyncBlocking(): List<Folder> {
         return folderDao.findNotSyncedBlocking()
     }
 
-    override fun markAllSynced() {
-        folderDao.updateAllSyncedBlocking()
+    override suspend fun markAllSynced() {
+        folderDao.updateAllSynced()
     }
 
     override suspend fun getHomeFolder(): List<FolderItem> {
@@ -165,7 +165,7 @@ class FolderManagerImpl @Inject constructor(
         val podcasts = if (sortType == EPISODE_DATE_NEWEST_TO_OLDEST) {
             podcastManager.findPodcastsOrderByLatestEpisode(orderAsc = false)
         } else {
-            podcastManager.findSubscribedBlocking()
+            podcastManager.findSubscribedNoOrder()
         }
         val folders = folderDao.findFolders()
         val folderItems = combineFoldersPodcasts(folders, podcasts)
@@ -208,5 +208,5 @@ class FolderManagerImpl @Inject constructor(
         return podcasts.sortedWith(folder.podcastsSortType.podcastComparator)
     }
 
-    override fun countFolders() = folderDao.countBlocking()
+    override suspend fun countFolders() = folderDao.count()
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PlaylistManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PlaylistManager.kt
@@ -48,7 +48,7 @@ interface PlaylistManager {
 
     fun getSystemDownloadsFilter(): Playlist
 
-    fun markAllSyncedBlocking()
+    suspend fun markAllSynced()
 
     fun updateAllBlocking(playlists: List<Playlist>)
     fun observeEpisodesPreviewBlocking(playlist: Playlist, episodeManager: EpisodeManager, playbackManager: PlaybackManager): Flowable<List<PodcastEpisode>>

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PlaylistManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PlaylistManagerImpl.kt
@@ -533,7 +533,7 @@ class PlaylistManagerImpl @Inject constructor(
         )
     }
 
-    override fun markAllSyncedBlocking() {
-        playlistDao.updateAllSyncStatusBlocking(Playlist.SYNC_STATUS_SYNCED)
+    override suspend fun markAllSynced() {
+        playlistDao.updateAllSyncStatus(Playlist.SYNC_STATUS_SYNCED)
     }
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PodcastManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PodcastManager.kt
@@ -94,7 +94,7 @@ interface PodcastManager {
     suspend fun updateFolderUuid(folderUuid: String?, podcastUuids: List<String>)
 
     fun markPodcastUuidAsNotSyncedBlocking(podcastUuid: String)
-    fun markAllPodcastsSyncedBlocking()
+    suspend fun markAllPodcastsSynced()
     suspend fun markAllPodcastsUnsynced()
 
     fun clearAllDownloadErrorsBlocking()

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PodcastManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PodcastManagerImpl.kt
@@ -383,8 +383,8 @@ class PodcastManagerImpl @Inject constructor(
         podcastDao.updateAllSubscribedSyncStatus(Podcast.SYNC_STATUS_NOT_SYNCED)
     }
 
-    override fun markAllPodcastsSyncedBlocking() {
-        podcastDao.updateAllSyncStatusBlocking(Podcast.SYNC_STATUS_SYNCED)
+    override suspend fun markAllPodcastsSynced() {
+        podcastDao.updateAllSyncStatus(Podcast.SYNC_STATUS_SYNCED)
     }
 
     override fun clearAllDownloadErrorsBlocking() {

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/subscription/SubscriptionManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/subscription/SubscriptionManager.kt
@@ -23,7 +23,8 @@ interface SubscriptionManager {
     fun observePurchaseEvents(): Flowable<PurchaseEvent>
     fun observeSubscriptionStatus(): Flowable<Optional<SubscriptionStatus>>
     fun subscriptionTier(): Flow<SubscriptionTier>
-    fun getSubscriptionStatus(allowCache: Boolean = true): Single<SubscriptionStatus>
+    fun getSubscriptionStatusRxSingle(allowCache: Boolean = true): Single<SubscriptionStatus>
+    suspend fun getSubscriptionStatus(allowCache: Boolean = true): SubscriptionStatus
     fun connectToGooglePlay(context: Context)
     fun loadProducts()
     fun onPurchasesUpdated(billingResult: BillingResult, purchases: MutableList<Purchase>?)

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/SyncManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/SyncManager.kt
@@ -83,6 +83,7 @@ interface SyncManager : NamedSettingsCaller {
 
     // Subscription
     fun subscriptionStatusRxSingle(): Single<SubscriptionStatusResponse>
+    suspend fun subscriptionStatus(): SubscriptionStatusResponse
     fun subscriptionPurchaseRxSingle(request: SubscriptionPurchaseRequest): Single<SubscriptionStatusResponse>
     fun redeemPromoCodeRxSingle(code: String): Single<PromoCodeResponse>
     fun validatePromoCodeRxSingle(code: String): Single<PromoCodeResponse>

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/SyncManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/SyncManagerImpl.kt
@@ -339,6 +339,11 @@ class SyncManagerImpl @Inject constructor(
 
     override fun subscriptionStatusRxSingle(): Single<SubscriptionStatusResponse> =
         getCacheTokenOrLoginRxSingle { token ->
+            syncServiceManager.subscriptionStatusRxSingle(token)
+        }
+
+    override suspend fun subscriptionStatus(): SubscriptionStatusResponse =
+        getCacheTokenOrLogin { token ->
             syncServiceManager.subscriptionStatus(token)
         }
 

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/user/UserManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/user/UserManager.kt
@@ -94,7 +94,7 @@ class UserManagerImpl @Inject constructor(
                             if (value != null) {
                                 Single.just(value)
                             } else {
-                                subscriptionManager.getSubscriptionStatus(allowCache = false)
+                                subscriptionManager.getSubscriptionStatusRxSingle(allowCache = false)
                             }
                         }
                         .combineLatest(syncManager.emailFlowable())

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/SyncService.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/SyncService.kt
@@ -104,7 +104,10 @@ interface SyncService {
     fun episodeProgressSync(@Header("Authorization") authorization: String, @Body request: EpisodeSyncRequest): Completable
 
     @GET("/subscription/status")
-    fun subscriptionStatus(@Header("Authorization") authorization: String): Single<SubscriptionStatusResponse>
+    fun subscriptionStatusRxSingle(@Header("Authorization") authorization: String): Single<SubscriptionStatusResponse>
+
+    @GET("/subscription/status")
+    suspend fun subscriptionStatus(@Header("Authorization") authorization: String): SubscriptionStatusResponse
 
     @POST("/subscription/purchase/android")
     fun subscriptionPurchase(@Header("Authorization") authorization: String, @Body request: SubscriptionPurchaseRequest): Single<SubscriptionStatusResponse>

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/SyncServiceManager.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/SyncServiceManager.kt
@@ -186,7 +186,10 @@ open class SyncServiceManager @Inject constructor(
     fun episodeSync(request: EpisodeSyncRequest, token: AccessToken): Completable =
         service.episodeProgressSync(addBearer(token), request)
 
-    fun subscriptionStatus(token: AccessToken): Single<SubscriptionStatusResponse> =
+    fun subscriptionStatusRxSingle(token: AccessToken): Single<SubscriptionStatusResponse> =
+        service.subscriptionStatusRxSingle(addBearer(token))
+
+    suspend fun subscriptionStatus(token: AccessToken): SubscriptionStatusResponse =
         service.subscriptionStatus(addBearer(token))
 
     fun subscriptionPurchase(


### PR DESCRIPTION
## Description

The aim is to slowly remove the Rx from the project, this change continues to switch parts of the user sync task to Coroutines.

## Testing Instructions
1. Install a fresh version of the app
2. Sign in with an account
3. ✅ Verify there aren't any new errors in logcat and the sync completes successfully. 

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack
