### PR TITLE
Fix end of year translation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 *   Bug Fixes
     *   Fix global auto download setting was incorrectly overriding the podcast auto download setting
         ([#3342](https://github.com/Automattic/pocket-casts-android/pull/3342))
+    *   Fix end of year translation
+        ([#3387](https://github.com/Automattic/pocket-casts-android/pull/3387))
     *   Fix sleep timer was not stopping as expected
         ([#3377](https://github.com/Automattic/pocket-casts-android/pull/3377))
 

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/ui/PlusInterstitialStory.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/ui/PlusInterstitialStory.kt
@@ -94,7 +94,7 @@ private fun WaitText(
     textFactory: HumaneTextFactory,
 ) {
     ScrollingRow(
-        items = listOf("WAIT", "ATTENDEZ", "ESPERA", "ASPETTARE", "AGARDA"),
+        items = listOf("WAIT", "ATTENDEZ", "ESPERA", "ASPETTA", "AGARDA"),
         scrollDirection = scrollDirection,
     ) { text ->
         Row(


### PR DESCRIPTION
## Description

We received feedback that one of the transitions of "Thanks" on the second to last page of the 2024 Playback is incorrect. In Italian, "Aspettare" means "To wait", not "Wait". The correct translation is "Aspetta".

## Testing Instructions

As this is just a text change reviewing the code will be enough.

## Screenshots 

<img  width="300" src="https://github.com/user-attachments/assets/f0492152-acf7-436c-8179-1bf94a2c0881" /> 

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack
