### PR TITLE
Fix: Casting not working correctly to Google Devices

### DIFF
--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/MediaSessionManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/MediaSessionManager.kt
@@ -687,12 +687,6 @@ class MediaSessionManager(
                 .subscribeBy(onError = { Timber.e(it) })
         }
 
-        // note: the stop event is called from cars when they only want to pause, this is less destructive and doesn't cause issues if they try to play again
-        override fun onStop() {
-            logEvent("stop")
-            enqueueCommand("stop") { playbackManager.pauseSuspend(sourceView = source) }
-        }
-
         override fun onSkipToPrevious() {
             onRewind()
         }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/MediaSessionManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/MediaSessionManager.kt
@@ -687,6 +687,15 @@ class MediaSessionManager(
                 .subscribeBy(onError = { Timber.e(it) })
         }
 
+        // note: the stop event is called from cars when they only want to pause, this is less destructive and doesn't cause issues if they try to play again
+        override fun onStop() {
+            // This event is causing issues during casting, so as a temporary solution, we are going to ignore it for now
+            if (playbackManager.player !is CastPlayer) {
+                logEvent("stop")
+                enqueueCommand("stop") { playbackManager.pauseSuspend(sourceView = source) }
+            }
+        }
+
         override fun onSkipToPrevious() {
             onRewind()
         }


### PR DESCRIPTION
## Description
- This is an attempt to fix the reported chromecast issues: 
> Pocket Cast pauses less than a second into playing a podcast through Chromecast. Hit play, and it starts for a half second again and immediately pauses

- In my investigations, I noticed that we are receiving the stop command from MediaSession when casting an episode, and this is causing the episode to stop. We are overriding the `stop` method in `MediaSessionManager.kt`, which stops the episode when this command is received. However, upon reviewing the code, I noticed that this overridden `stop` method is being called only when attempting to cast an episode. It is not being triggered for the `App`, `Wear`, or `Automotive` platforms, as suggested by the comments in the stop method. All platforms call the `pause` method instead
- If I remove this method, the Chromecast issue is resolved, and all platforms continue to work as expected. I performed a smoke test on the app by interacting with playback through various sources, such as the notification media center, the now playing screen, Wear OS, and automotive, and confirmed that everything functions correctly, so my propose is to remove this method. 
- ⚠️ I was not able to reproduce the same reported scenario the users are reporting because I don't have a Google Nest. What I used to cast was my Tv and the behavior I got was this one:

1. Have some episode playing
2. Open Now Playing
3. Tap on the 3 dots
4. Chromecast
5. Select the device to cast 
6. In my case, the episode was paused here like the users reported
7. So I pressed play again and I was able to play the episode as expected. What our users are reporting is that this step don't work for them

- I opened this thread so we can discuss about this @Automattic/pocket-casts-android : p1735230022595629-slack-C07J5LNP4SF

Fixes #3321

## Testing Instructions
1. Have some episode playing
2. Open Now Playing
3. Tap on the 3 dots
4. Chromecast
5. Select the device to cast 
6. The episode should continue playing in the selected device ✅

## Screenshots or Screencast 
<!-- if applicable -->

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] ~I have considered whether it makes sense to add tests for my changes~
- [ ] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [ ] ~Any jetpack compose components I added or changed are covered by compose previews~
- [ ] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~