### PR TITLE
Add event to track Podcasts list discover button tap

### DIFF
--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcasts/PodcastsFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcasts/PodcastsFragment.kt
@@ -204,10 +204,7 @@ class PodcastsFragment : BaseFragment(), FolderAdapter.ClickListener, PodcastTou
         }
 
         binding.btnDiscover.setOnClickListener {
-            (activity as FragmentHostListener).openTab(VR.id.navigation_discover)
-        }
-
-        binding.btnDiscover.setOnClickListener {
+            analyticsTracker.track(AnalyticsEvent.PODCASTS_LIST_DISCOVER_BUTTON_TAPPED)
             (activity as FragmentHostListener).openTab(VR.id.navigation_discover)
         }
 

--- a/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
+++ b/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
@@ -96,6 +96,7 @@ enum class AnalyticsEvent(val key: String) {
     PODCASTS_LIST_SORT_ORDER_CHANGED("podcasts_list_sort_order_changed"),
     PODCASTS_LIST_LAYOUT_CHANGED("podcasts_list_layout_changed"),
     PODCASTS_LIST_BADGES_CHANGED("podcasts_list_badges_changed"),
+    PODCASTS_LIST_DISCOVER_BUTTON_TAPPED("podcasts_list_discover_button_tapped"),
 
     /* Tab bar items */
     PODCASTS_TAB_OPENED("podcasts_tab_opened"),


### PR DESCRIPTION
## Description
- Just adds the missing event track for `Discover Podcasts` button
- Context: p1734591702871389-slack-C029BMLUGRX

## Testing Instructions
1. Start the app from scratch
2. Go to Podcasts tab
3. You should screen the screen above
4. Tap on the Discover Podcasts
5. ✅ Ensure the `podcasts_list_discover_button_tapped` event is tracked

## Screenshots or Screencast 

<img src="https://github.com/user-attachments/assets/39ad6bb6-9745-4d41-9af8-491e0182cead" alt="Screenshot" width="300">


## Checklist
- [ ] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] ~I have considered whether it makes sense to add tests for my changes~
- [ ] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [ ] ~Any jetpack compose components I added or changed are covered by compose previews~
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 