### PR TITLE
[Tech Debt] Extract end of episode code out of PlaybackManager

### DIFF
--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
@@ -2268,6 +2268,8 @@ open class PlaybackManager @Inject constructor(
                     showToast(application.getString(LR.string.player_sleep_time_fired_end_of_chapter))
 
                     val podcast = playbackStateRelay.blockingFirst().podcast
+                    // When the "skip last" option is enabled, we need to pause the chapter at the time configured in "skip last."
+                    // Otherwise, this won't work with the sleep timer, as the sleep timer stops only when the chapter finishes
                     if (podcast != null && podcast.skipLastSecs > 0) {
                         pause(sourceView = SourceView.AUTO_PAUSE)
                     }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
@@ -2260,21 +2260,22 @@ open class PlaybackManager @Inject constructor(
     }
 
     private fun verifySleepTimeForEndOfChapter() {
-        val currentChapterUuid = getCurrentChapterUuid()
-        val currentEpisodeUui = getCurrentEpisode()?.uuid
-
         applicationScope.launch {
-            sleepTimer.verifySleepTimeForEndOfChapter(currentChapterUuid, currentEpisodeUui) {
-                showToast(application.getString(LR.string.player_sleep_time_fired_end_of_chapter))
+            sleepTimer.verifySleepTimeForEndOfChapter(
+                currentChapterUuid = getCurrentChapterUuid(),
+                currentEpisodeUuid = getCurrentEpisode()?.uuid,
+                onSleepEndOfChapter = {
+                    showToast(application.getString(LR.string.player_sleep_time_fired_end_of_chapter))
 
-                val podcast = playbackStateRelay.blockingFirst().podcast
-                if (podcast != null && podcast.skipLastSecs > 0) {
-                    pause(sourceView = SourceView.AUTO_PAUSE)
-                }
-                onPlayerPaused()
+                    val podcast = playbackStateRelay.blockingFirst().podcast
+                    if (podcast != null && podcast.skipLastSecs > 0) {
+                        pause(sourceView = SourceView.AUTO_PAUSE)
+                    }
+                    onPlayerPaused()
 
-                stop()
-            }
+                    stop()
+                },
+            )
         }
     }
 

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackState.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackState.kt
@@ -26,14 +26,7 @@ data class PlaybackState(
     val isVolumeBoosted: Boolean = false,
     // when transientLoss is true the foreground service won't be stopped
     val transientLoss: Boolean = false,
-    val lastListenedState: LastListenedState = LastListenedState(),
 ) {
-
-    data class LastListenedState(
-        val chapterUuid: String? = null,
-        val episodeUuid: String? = null,
-    )
-
     enum class State {
         EMPTY, PAUSED, PLAYING, STOPPED, ERROR
     }
@@ -84,7 +77,6 @@ data class PlaybackState(
                 trimMode = playbackEffects.trimMode,
                 isVolumeBoosted = playbackEffects.isVolumeBoosted,
                 lastChangeFrom = lastChangeFrom.value,
-                lastListenedState = previousPlaybackState?.lastListenedState ?: LastListenedState(),
             )
         }
     }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/SleepTimer.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/SleepTimer.kt
@@ -153,23 +153,6 @@ class SleepTimer @Inject constructor(
         onSleepEndOfEpisode()
     }
 
-    private suspend fun sleepEndOfChapter(onSleepEndOfChapter: suspend () -> Unit) {
-        if (state.isSleepEndOfChapterRunning) {
-            updateSleepTimer {
-                copy(numberOfChaptersLeft = state.numberOfChaptersLeft - 1)
-            }
-            setEndOfChapter()
-        }
-
-        if (state.isSleepEndOfChapterRunning) return
-
-        updateSleepTimerStatus(sleepTimeRunning = false)
-
-        LogBuffer.i(LogBuffer.TAG_PLAYBACK, "Sleeping playback for end of chapters")
-
-        onSleepEndOfChapter()
-    }
-
     fun cancelTimer() {
         LogBuffer.i(TAG, "Cleaning automatic sleep timer feature...")
         updateSleepTimerStatus(sleepTimeRunning = false, sleepAfterChapters = 0, sleepAfterEpisodes = 0)
@@ -201,6 +184,23 @@ class SleepTimer @Inject constructor(
             updateLastListenedState { copy(chapterUuid = currentChapterUuid, episodeUuid = currentEpisodeUuid) }
             sleepEndOfChapter { onSleepEndOfChapter() }
         }
+    }
+
+    private suspend fun sleepEndOfChapter(onSleepEndOfChapter: suspend () -> Unit) {
+        if (state.isSleepEndOfChapterRunning) {
+            updateSleepTimer {
+                copy(numberOfChaptersLeft = state.numberOfChaptersLeft - 1)
+            }
+            setEndOfChapter()
+        }
+
+        if (state.isSleepEndOfChapterRunning) return
+
+        updateSleepTimerStatus(sleepTimeRunning = false)
+
+        LogBuffer.i(LogBuffer.TAG_PLAYBACK, "Sleeping playback for end of chapters")
+
+        onSleepEndOfChapter()
     }
 
     private fun setEndOfEpisodeUuid(uuid: String) {

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/SleepTimerState.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/SleepTimerState.kt
@@ -35,3 +35,8 @@ sealed class SleepTimerHistory(
 
     data object None : SleepTimerHistory(lastFinishedTime = null)
 }
+
+data class LastListenedState(
+    val chapterUuid: String? = null,
+    val episodeUuid: String? = null,
+)

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/SleepTimerState.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/SleepTimerState.kt
@@ -35,8 +35,3 @@ sealed class SleepTimerHistory(
 
     data object None : SleepTimerHistory(lastFinishedTime = null)
 }
-
-data class LastListenedState(
-    val chapterUuid: String? = null,
-    val episodeUuid: String? = null,
-)


### PR DESCRIPTION
## Description
- This is the last part of the sleep timer refactor that started here: https://github.com/Automattic/pocket-casts-android/pull/3377
- The goal of this PR is to extract the End Of Chapter Logic out for PlaybackManager

Fixes #3384

## Testing Instructions

### End Of Chapter - Episodes that contains Chapters
1. Add episodes that contains chapters to Up next
2. Set end of chapter for Sleep timer
3. Switch from a chapter to another chapter
4. ✅ Ensure the end of chapter count decreases
5. Seek the scrabble, but make sure you don't switch the chapter
6. ✅ Ensure the end of chapter count does not change
7. Finish the current episode
8. ✅ Ensure the end of chapter count decreases

### End Of Chapter - Episodes that does not contain Chapters
1. Add episodes that does not contain chapters to Up next
2. Set end of chapter for Sleep timer
3. Finish the current episode
4. ✅ Ensure the end of chapter count decreases

### Smoke test
- Feel free to smoke test the sleep timer feature

## Checklist
- [ ] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [ ] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [ ] ~Any jetpack compose components I added or changed are covered by compose previews~
- [ ] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~