### PR TITLE
[Manage Download] Update manage download dismiss banner

### DIFF
--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/ProfileEpisodeListFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/ProfileEpisodeListFragment.kt
@@ -443,9 +443,8 @@ class ProfileEpisodeListFragment : BaseFragment(), Toolbar.OnMenuItemClickListen
                                     analyticsTracker.track(AnalyticsEvent.FREE_UP_SPACE_MANAGE_DOWNLOADS_TAPPED, mapOf("source" to SourceView.DOWNLOADS.analyticsValue))
                                     showFragment(ManualCleanupFragment.newInstance())
                                 },
-                                onMoreOptionsClick = {
-                                    analyticsTracker.track(AnalyticsEvent.FREE_UP_SPACE_MANAGE_DOWNLOADS_MORE_OPTIONS_TAPPED, mapOf("source" to SourceView.DOWNLOADS.analyticsValue))
-                                    onManageDownloadsMoreOptions()
+                                onDismissClick = {
+                                    onDismissManageDownloadTapped()
                                 },
                             )
                         }
@@ -453,13 +452,6 @@ class ProfileEpisodeListFragment : BaseFragment(), Toolbar.OnMenuItemClickListen
                 }
             }
         }
-    }
-
-    private fun onManageDownloadsMoreOptions() {
-        OptionsDialog()
-            .setTitle(resources.getString(LR.string.need_to_free_up_space))
-            .addTextOption(LR.string.dismiss_manage_download_banner, click = this::onDismissManageDownloadTapped)
-            .show(parentFragmentManager, "manage_downloads_more_options")
     }
 
     private fun onDismissManageDownloadTapped() {

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/ProfileManageDownloadsCard.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/ProfileManageDownloadsCard.kt
@@ -15,7 +15,7 @@ import androidx.compose.material.IconButton
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.TextButton
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.MoreVert
+import androidx.compose.material.icons.filled.Close
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
@@ -40,7 +40,7 @@ import au.com.shiftyjelly.pocketcasts.localization.R as LR
 fun ManageDownloadsCard(
     totalDownloadSize: Long,
     onManageDownloadsClick: () -> Unit,
-    onMoreOptionsClick: () -> Unit,
+    onDismissClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val formattedTotalDownloadSize = Util.formattedBytes(bytes = totalDownloadSize, context = LocalContext.current)
@@ -88,12 +88,12 @@ fun ManageDownloadsCard(
         }
 
         IconButton(
-            onClick = { onMoreOptionsClick.invoke() },
+            onClick = { onDismissClick.invoke() },
             modifier = Modifier.size(24.dp),
         ) {
             Icon(
-                imageVector = Icons.Default.MoreVert,
-                contentDescription = stringResource(LR.string.manage_download_more_options_content_description),
+                imageVector = Icons.Default.Close,
+                contentDescription = stringResource(LR.string.manage_download_dismiss_content_description),
                 tint = MaterialTheme.theme.colors.primaryIcon02,
             )
         }
@@ -106,6 +106,6 @@ fun ManageDownloadsCardPreview(
     @PreviewParameter(ThemePreviewParameterProvider::class) themeType: Theme.ThemeType,
 ) {
     AppThemeWithBackground(themeType) {
-        ManageDownloadsCard(totalDownloadSize = 15023232, onManageDownloadsClick = {}, onMoreOptionsClick = {})
+        ManageDownloadsCard(totalDownloadSize = 15023232, onManageDownloadsClick = {}, onDismissClick = {})
     }
 }

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -2265,7 +2265,7 @@
     <string name="manage_downloads">Manage downloads</string>
     <string name="maybe_later">Maybe Later</string>
     <string name="dismiss_manage_download_banner">Dismiss</string>
-    <string name="manage_download_more_options_content_description">Manage Download Banner More Options</string>
+    <string name="manage_download_dismiss_content_description">Manage Download Banner Dismiss</string>
 
     <!-- Up Next Shuffle -->
     <string name="up_next_shuffle_button_content_description">Up Next shuffle</string>


### PR DESCRIPTION
## Description
- This updates the manage download banner to use a X icon to dismiss the banner instead of opening a bottom sheet dialog
- See: p1735928599201419/1734454637.773259-slack-C07TL9YK9V1

Fixes #3404

## Testing Instructions
1. Apply [patch.patch](https://github.com/user-attachments/files/18201084/patch.patch)
2. Download an episode
3. Open downloads screen
4. See the low storage banner
5. Tap on the X button to dismiss the banner
6. Ensure the banner is hidden ✅
7. Wait more than 10 seconds (this is the mocked by the patch instead of 14 days)
8. Go to other screen
9. Back to Downloads screen
10. Ensure you see the banner back again ✅

## Screenshots or Screencast 
<img width="1415" alt="image" src="https://github.com/user-attachments/assets/3880592c-1035-4fa9-9fdf-1e3100a95383" />


## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack