### PR TITLE
Tracks Audit: Battery restrictions events

### DIFF
--- a/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
+++ b/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
@@ -672,4 +672,8 @@ enum class AnalyticsEvent(val key: String) {
     FREE_UP_SPACE_MANAGE_DOWNLOADS_MORE_OPTIONS_TAPPED("free_up_space_manage_downloads_more_options_tapped"),
     FREE_UP_SPACE_MANAGE_DOWNLOADS_MORE_OPTIONS_DISMISS_TAPPED("free_up_space_manage_downloads_more_options_dismiss_tapped"),
     FREE_UP_SPACE_MAYBE_LATER_TAPPED("free_up_space_maybe_later_tapped"),
+
+    /* Battery Restrictions */
+    BATTERY_RESTRICTIONS_SHOWN("battery_restrictions_shown"),
+    BATTERY_RESTRICTIONS_TOGGLED("battery_restrictions_toggled"),
 }


### PR DESCRIPTION
## Description
- Add the missing events for battery restrictions

## Testing Instructions
1. Have a fresh install
2. Play an episode to see the battery restrictions warning (if you see the warning, tap to open the settings) or go to settings and open the battery screen
3. ✅ Ensure the new event `battery_restrictions_shown` is tracked when see the battery restriction screen
4. Toggle the restriction
5. ✅ Ensure the event `Tracked: battery_restrictions_toggled, Properties: {"current_status":"optimized"` is tracked

## Checklist
- [ ] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] ~I have considered whether it makes sense to add tests for my changes~
- [ ] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [ ] ~Any jetpack compose components I added or changed are covered by compose previews~
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
