### PR TITLE
Disable End of Year feature flags

### DIFF
--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/Feature.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/Feature.kt
@@ -14,7 +14,7 @@ enum class Feature(
     SYNC_EOY_DATA_ON_STARTUP(
         key = "sync_eoy_data_on_startup",
         title = "Whether the End of Year data should be synced on startup",
-        defaultValue = BuildConfig.DEBUG,
+        defaultValue = false,
         tier = FeatureTier.Free,
         hasFirebaseRemoteFlag = true,
         hasDevToggle = false,
@@ -22,7 +22,7 @@ enum class Feature(
     END_OF_YEAR_2024(
         key = "end_of_year_2024",
         title = "End of Year 2024",
-        defaultValue = BuildConfig.DEBUG,
+        defaultValue = false,
         tier = FeatureTier.Free,
         hasFirebaseRemoteFlag = true,
         hasDevToggle = false,


### PR DESCRIPTION
## Description

This disables End of Year feature flags for debug builds. They're already disabled in the Remote Config so it's just to have the same behavior during development.

## Testing Instructions

1. Go to the Profile tab.
2. PB24 shouldn't be present.

## Checklist
- [ ] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] ~I have considered whether it makes sense to add tests for my changes~
- [ ] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [ ] ~Any jetpack compose components I added or changed are covered by compose previews~
- [ ] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~