### PR TITLE
Tracks Audit: Add new subscriptions events

### DIFF
--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeBottomSheet.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeBottomSheet.kt
@@ -60,6 +60,8 @@ private const val UNKNOWN_TIER = "unknown_tier"
 @Composable
 fun OnboardingUpgradeBottomSheet(
     onClickSubscribe: () -> Unit,
+    onPrivacyPolicyClick: () -> Unit = {},
+    onTermsAndConditionsClick: () -> Unit = {},
 ) {
     // The keyboard sometimes gets opened when returning from the Google payment flow.
     // This is keeps it closed while on this screen.
@@ -219,6 +221,8 @@ fun OnboardingUpgradeBottomSheet(
         OnboardingUpgradeHelper.PrivacyPolicy(
             color = Color.White,
             textAlign = TextAlign.Center,
+            onPrivacyPolicyClick = onPrivacyPolicyClick,
+            onTermsAndConditionsClick = onTermsAndConditionsClick,
         )
 
         Spacer(Modifier.height(16.dp))

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeFeaturesPage.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeFeaturesPage.kt
@@ -3,7 +3,6 @@ package au.com.shiftyjelly.pocketcasts.account.onboarding.upgrade
 import androidx.activity.SystemBarStyle
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.tween
-import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.ScrollState
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
@@ -154,6 +153,8 @@ internal fun OnboardingUpgradeFeaturesPage(
                         onFeatureCardChanged = { viewModel.onFeatureCardChanged(loadedState.featureCardsState.featureCards[it]) },
                         onClickSubscribe = { onClickSubscribe(false) },
                         canUpgrade = canUpgrade,
+                        onPrivacyPolicyClick = { viewModel.onPrivacyPolicyPressed() },
+                        onTermsAndConditionsClick = { viewModel.onTermsAndConditionsPressed() },
                     )
                 }
             }
@@ -178,6 +179,8 @@ private fun UpgradeLayoutOriginal(
     onSubscriptionFrequencyChanged: (SubscriptionFrequency) -> Unit,
     onFeatureCardChanged: (Int) -> Unit,
     onClickSubscribe: () -> Unit,
+    onPrivacyPolicyClick: () -> Unit = {},
+    onTermsAndConditionsClick: () -> Unit = {},
     canUpgrade: Boolean,
     modifier: Modifier = Modifier,
 ) {
@@ -275,6 +278,8 @@ private fun UpgradeLayoutOriginal(
                             state = state,
                             upgradeButton = state.currentUpgradeButton,
                             onFeatureCardChanged = onFeatureCardChanged,
+                            onPrivacyPolicyClick = onPrivacyPolicyClick,
+                            onTermsAndConditionsClick = onTermsAndConditionsClick,
                         )
                     }
 
@@ -292,12 +297,13 @@ private fun UpgradeLayoutOriginal(
     }
 }
 
-@OptIn(ExperimentalFoundationApi::class)
 @Composable
 fun FeatureCards(
     state: OnboardingUpgradeFeaturesState.Loaded,
     upgradeButton: UpgradeButton,
     onFeatureCardChanged: (Int) -> Unit,
+    onPrivacyPolicyClick: () -> Unit = {},
+    onTermsAndConditionsClick: () -> Unit = {},
 ) {
     val featureCardsState = state.featureCardsState
     val currentSubscriptionFrequency = state.currentSubscriptionFrequency
@@ -314,6 +320,8 @@ fun FeatureCards(
             card = featureCardsState.featureCards[index],
             subscriptionFrequency = currentSubscriptionFrequency,
             upgradeButton = upgradeButton,
+            onPrivacyPolicyClick = onPrivacyPolicyClick,
+            onTermsAndConditionsClick = onTermsAndConditionsClick,
             modifier = if (pagerHeight > 0) {
                 Modifier.height(pagerHeight.pxToDp(LocalContext.current).dp)
             } else {
@@ -330,6 +338,8 @@ private fun FeatureCard(
     subscription: Subscription,
     subscriptionFrequency: SubscriptionFrequency,
     modifier: Modifier = Modifier,
+    onPrivacyPolicyClick: () -> Unit = {},
+    onTermsAndConditionsClick: () -> Unit = {},
 ) {
     Card(
         shape = RoundedCornerShape(24.dp),
@@ -416,6 +426,8 @@ private fun FeatureCard(
                     color = Color.Black.copy(alpha = .5f),
                     textAlign = TextAlign.Start,
                     lineHeight = 18.sp,
+                    onPrivacyPolicyClick = onPrivacyPolicyClick,
+                    onTermsAndConditionsClick = onTermsAndConditionsClick,
                 )
             }
         }

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeFeaturesPage.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeFeaturesPage.kt
@@ -139,6 +139,7 @@ internal fun OnboardingUpgradeFeaturesPage(
                         state = loadedState,
                         onNotNowPressed = onNotNowPressed,
                         onClickSubscribe = { onClickSubscribe(true) },
+                        onRateUsPressed = { viewModel.onRateUsPressed() },
                         canUpgrade = canUpgrade,
                     )
                 }

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeFlow.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeFlow.kt
@@ -163,6 +163,12 @@ fun OnboardingUpgradeFlow(
                         LogBuffer.e(LogBuffer.TAG_SUBSCRIPTIONS, NULL_ACTIVITY_ERROR)
                     }
                 },
+                onPrivacyPolicyClick = {
+                    mainSheetViewModel.onPrivacyPolicyPressed()
+                },
+                onTermsAndConditionsClick = {
+                    mainSheetViewModel.onTermsAndConditionsPressed()
+                },
             )
         },
     )

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeHelper.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeHelper.kt
@@ -384,6 +384,8 @@ object OnboardingUpgradeHelper {
         textAlign: TextAlign,
         modifier: Modifier = Modifier,
         lineHeight: TextUnit = 16.sp,
+        onPrivacyPolicyClick: () -> Unit = {},
+        onTermsAndConditionsClick: () -> Unit = {},
     ) {
         val privacyPolicyText = stringResource(LR.string.onboarding_plus_privacy_policy)
         val termsAndConditionsText = stringResource(LR.string.onboarding_plus_terms_and_conditions)
@@ -402,12 +404,14 @@ object OnboardingUpgradeHelper {
                 Clickable(
                     text = privacyPolicyText,
                     onClick = {
+                        onPrivacyPolicyClick()
                         uriHandler.openUri(Settings.INFO_PRIVACY_URL)
                     },
                 ),
                 Clickable(
                     text = termsAndConditionsText,
                     onClick = {
+                        onTermsAndConditionsClick()
                         uriHandler.openUri(Settings.INFO_TOS_URL)
                     },
                 ),

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/paywallreviews/UpgradeLayoutReviews.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/paywallreviews/UpgradeLayoutReviews.kt
@@ -61,6 +61,7 @@ fun UpgradeLayoutReviews(
     state: OnboardingUpgradeFeaturesState.Loaded,
     onNotNowPressed: () -> Unit,
     onClickSubscribe: () -> Unit,
+    onRateUsPressed: () -> Unit,
     canUpgrade: Boolean,
     modifier: Modifier = Modifier,
     data: List<ReviewData> = reviews,
@@ -153,6 +154,7 @@ fun UpgradeLayoutReviews(
                 item {
                     Button(
                         onClick = {
+                            onRateUsPressed()
                             rateUs(context)
                         },
                         colors = ButtonDefaults.buttonColors(

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/OnboardingUpgradeFeaturesViewModel.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/OnboardingUpgradeFeaturesViewModel.kt
@@ -177,6 +177,7 @@ class OnboardingUpgradeFeaturesViewModel @Inject constructor(
                     frequency = frequency,
                 )
             settings.setLastSelectedSubscriptionFrequency(frequency)
+            analyticsTracker.track(AnalyticsEvent.PLUS_PROMOTION_SUBSCRIPTION_FREQUENCY_CHANGED, mapOf("value" to frequency.name.lowercase()))
             currentSubscription?.let {
                 _state.update {
                     loadedState.copy(
@@ -196,6 +197,7 @@ class OnboardingUpgradeFeaturesViewModel @Inject constructor(
                     tier = upgradeFeatureCard.subscriptionTier,
                     frequency = loadedState.currentSubscriptionFrequency,
                 )
+            analyticsTracker.track(AnalyticsEvent.PLUS_PROMOTION_SUBSCRIPTION_TIER_CHANGED, mapOf("value" to upgradeFeatureCard.subscriptionTier.name.lowercase()))
             settings.setLastSelectedSubscriptionTier(upgradeFeatureCard.subscriptionTier)
             currentSubscription?.let {
                 _state.update {

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/OnboardingUpgradeFeaturesViewModel.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/OnboardingUpgradeFeaturesViewModel.kt
@@ -276,6 +276,18 @@ class OnboardingUpgradeFeaturesViewModel @Inject constructor(
         }
     }
 
+    fun onRateUsPressed() {
+        analyticsTracker.track(AnalyticsEvent.RATE_US_TAPPED, mapOf("source" to OnboardingUpgradeSource.PLUS_DETAILS.analyticsValue))
+    }
+
+    fun onPrivacyPolicyPressed() {
+        analyticsTracker.track(AnalyticsEvent.PLUS_PROMOTION_PRIVACY_POLICY_TAPPED)
+    }
+
+    fun onTermsAndConditionsPressed() {
+        analyticsTracker.track(AnalyticsEvent.PLUS_PROMOTION_TERMS_AND_CONDITIONS_TAPPED)
+    }
+
     companion object {
         private fun analyticsProps(flow: OnboardingFlow, source: OnboardingUpgradeSource) =
             mapOf("flow" to flow.analyticsValue, "source" to source.analyticsValue)

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/AccountDetailsFragment.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/AccountDetailsFragment.kt
@@ -127,6 +127,7 @@ class AccountDetailsFragment : BaseFragment() {
                 OnboardingLauncher.openOnboardingFlow(activity, onboardingFlow)
             },
             onFeatureCardChanged = { featureCard ->
+                analyticsTracker.track(AnalyticsEvent.PLUS_PROMOTION_SUBSCRIPTION_TIER_CHANGED, mapOf("value" to featureCard.subscriptionTier.name.lowercase()))
                 upgradeBannerViewModel.onFeatureCardChanged(featureCard)
             },
             onChangeAvatar = { email ->

--- a/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
+++ b/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
@@ -621,6 +621,7 @@ enum class AnalyticsEvent(val key: String) {
 
     /* App Store Review */
     APP_STORE_REVIEW_REQUESTED("app_store_review_requested"),
+    RATE_US_TAPPED("rate_us_tapped"),
 
     /* Deselect Chapters */
     DESELECT_CHAPTERS_TOGGLED_ON("deselect_chapters_toggled_on"),

--- a/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
+++ b/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
@@ -40,6 +40,8 @@ enum class AnalyticsEvent(val key: String) {
     PLUS_PROMOTION_DISMISSED("plus_promotion_dismissed"),
     PLUS_PROMOTION_NOT_NOW_BUTTON_TAPPED("plus_promotion_not_now_button_tapped"),
     PLUS_PROMOTION_UPGRADE_BUTTON_TAPPED("plus_promotion_upgrade_button_tapped"),
+    PLUS_PROMOTION_SUBSCRIPTION_TIER_CHANGED("plus_promotion_subscription_tier_changed"),
+    PLUS_PROMOTION_SUBSCRIPTION_FREQUENCY_CHANGED("plus_promotion_subscription_frequency_changed"),
 
     /* Pull to refresh */
     PULLED_TO_REFRESH("pulled_to_refresh"),

--- a/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
+++ b/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
@@ -42,6 +42,8 @@ enum class AnalyticsEvent(val key: String) {
     PLUS_PROMOTION_UPGRADE_BUTTON_TAPPED("plus_promotion_upgrade_button_tapped"),
     PLUS_PROMOTION_SUBSCRIPTION_TIER_CHANGED("plus_promotion_subscription_tier_changed"),
     PLUS_PROMOTION_SUBSCRIPTION_FREQUENCY_CHANGED("plus_promotion_subscription_frequency_changed"),
+    PLUS_PROMOTION_PRIVACY_POLICY_TAPPED("plus_promotion_privacy_policy_tapped"),
+    PLUS_PROMOTION_TERMS_AND_CONDITIONS_TAPPED("plus_promotion_terms_and_conditions_tapped"),
 
     /* Pull to refresh */
     PULLED_TO_REFRESH("pulled_to_refresh"),


### PR DESCRIPTION
## Description
- This adds more events that were not listened in out Tracks sheet related to subscriptions 
- I also added `rate_us_tapped` because I was already working near by since we can rate the app from the new paywall reviews that has a button to open the store. I am going to track this new events for others cases in another PR

## Testing Instructions

### Paywall original
1. Open the paywall
2. Ensure the `🔵 Tracked: plus_promotion_subscription_tier_changed, Properties: {"value":"plus"` is tracked
3. Swipe to patron
4. Ensure the `🔵 Tracked: plus_promotion_subscription_tier_changed, Properties: {"value":"patron"` is tracked
5. Set Monthly 
6. Ensure the `🔵 Tracked: plus_promotion_subscription_frequency_changed, Properties: {"value":"monthly"` is tracked
7. On the cards, tap on Privacy and Policy link
8. Ensure `🔵 Tracked: plus_promotion_privacy_policy_tapped` is tracked
9. Back to paywall
10. Tap on Terms and conditions link
11. Ensure `plus_promotion_terms_and_conditions_tapped`

### Paywall Reviews
1. [paywall-reviews.patch](https://github.com/user-attachments/files/18335643/paywall-reviews.patch)
2. Open the paywall reviews
3. Scroll to the bottom
4. Tap on `See all reviews in the play store`
5. Ensure `🔵 Tracked: rate_us_tapped` is tapped


## Checklist
- [ ] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] ~I have considered whether it makes sense to add tests for my changes~
- [ ] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [ ] ~Any jetpack compose components I added or changed are covered by compose previews~
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
