### PR TITLE
Tracks Audit: Add Podcast Episode Grouping change event

### DIFF
--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/PlaybackSettingsFragment.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/PlaybackSettingsFragment.kt
@@ -692,7 +692,11 @@ class PlaybackSettingsFragment : BaseFragment() {
                 ),
             )
             .setIconId(R.drawable.ic_podcasts)
+            .setOnSecondary {
+                analyticsTracker.track(AnalyticsEvent.SETTINGS_GENERAL_EPISODE_GROUPING_NO_APPLYING_TO_EXISTING)
+            }
             .setOnConfirm {
+                analyticsTracker.track(AnalyticsEvent.SETTINGS_GENERAL_EPISODE_GROUPING_APPLYING_TO_EXISTING)
                 applicationScope.launch {
                     podcastManager.updateGroupingForAllBlocking(grouping)
                 }

--- a/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
+++ b/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
@@ -500,6 +500,8 @@ enum class AnalyticsEvent(val key: String) {
     SETTINGS_GENERAL_SHOWN("settings_general_shown"),
     SETTINGS_GENERAL_ROW_ACTION_CHANGED("settings_general_row_action_changed"),
     SETTINGS_GENERAL_EPISODE_GROUPING_CHANGED("settings_general_episode_grouping_changed"),
+    SETTINGS_GENERAL_EPISODE_GROUPING_APPLYING_TO_EXISTING("settings_general_episode_grouping_applying_to_existing"),
+    SETTINGS_GENERAL_EPISODE_GROUPING_NO_APPLYING_TO_EXISTING("settings_general_episode_grouping_no_applying_to_existing"),
     SETTINGS_GENERAL_ARCHIVED_EPISODES_CHANGED("settings_general_archived_episodes_changed"),
     SETTINGS_GENERAL_UP_NEXT_SWIPE_CHANGED("settings_general_up_next_swipe_changed"),
     SETTINGS_GENERAL_SKIP_FORWARD_CHANGED("settings_general_skip_forward_changed"),


### PR DESCRIPTION
## Description
- This adds the episode grouping change. The goal is to track the dialog of this setting row

## Testing Instructions
1. Go to settings
2. General
3. Change the Podcast episode grouping
4. Tap on Applying to existing
5. Ensure `🔵 Tracked: settings_general_episode_grouping_applying_to_existing` is tracked
6. Repeat the steps and tap on `No thanks`
7. Ensure `🔵 Tracked: settings_general_episode_grouping_no_applying_to_existing` is tracked

## Checklist
- [ ] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] ~I have considered whether it makes sense to add tests for my changes~
- [ ] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [ ] ~Any jetpack compose components I added or changed are covered by compose previews~
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
