### PR TITLE
Tracks Audit: Add About Track event

### DIFF
--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/about/AboutFragment.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/about/AboutFragment.kt
@@ -53,6 +53,7 @@ import androidx.fragment.compose.content
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTracker
+import au.com.shiftyjelly.pocketcasts.analytics.SourceView
 import au.com.shiftyjelly.pocketcasts.compose.AppThemeWithBackground
 import au.com.shiftyjelly.pocketcasts.compose.CallOnce
 import au.com.shiftyjelly.pocketcasts.compose.bars.ThemedTopAppBar
@@ -99,6 +100,9 @@ class AboutFragment : BaseFragment() {
                 },
                 onBackPressed = { closeFragment() },
                 bottomInset = bottomInset.value.pxToDp(LocalContext.current).dp,
+                onRateUsTapped = {
+                    analyticsTracker.track(AnalyticsEvent.RATE_US_TAPPED, mapOf("source" to SourceView.ABOUT.analyticsValue))
+                },
             )
         }
     }
@@ -177,6 +181,7 @@ private val icons = listOf(
 @Composable
 private fun AboutPage(
     onBackPressed: () -> Unit,
+    onRateUsTapped: () -> Unit,
     bottomInset: Dp,
     openFragment: (Fragment) -> Unit,
 ) {
@@ -216,7 +221,10 @@ private fun AboutPage(
         item {
             RowTextButton(
                 text = stringResource(LR.string.settings_about_rate_us),
-                onClick = { rateUs(context) },
+                onClick = {
+                    onRateUsTapped()
+                    rateUs(context)
+                },
             )
         }
         item {
@@ -421,5 +429,6 @@ private fun AboutPagePreview() {
         onBackPressed = {},
         bottomInset = 0.dp,
         openFragment = {},
+        onRateUsTapped = {},
     )
 }

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/about/AboutFragment.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/about/AboutFragment.kt
@@ -103,6 +103,9 @@ class AboutFragment : BaseFragment() {
                 onRateUsTapped = {
                     analyticsTracker.track(AnalyticsEvent.RATE_US_TAPPED, mapOf("source" to SourceView.ABOUT.analyticsValue))
                 },
+                onShareWithFriendsTapped = {
+                    analyticsTracker.track(AnalyticsEvent.SETTINGS_ABOUT_SHARE_WITH_FRIENDS_TAPPED)
+                },
             )
         }
     }
@@ -182,6 +185,7 @@ private val icons = listOf(
 private fun AboutPage(
     onBackPressed: () -> Unit,
     onRateUsTapped: () -> Unit,
+    onShareWithFriendsTapped: () -> Unit,
     bottomInset: Dp,
     openFragment: (Fragment) -> Unit,
 ) {
@@ -230,7 +234,10 @@ private fun AboutPage(
         item {
             RowTextButton(
                 text = stringResource(LR.string.settings_about_share_with_friends),
-                onClick = { shareWithFriends(context) },
+                onClick = {
+                    onShareWithFriendsTapped()
+                    shareWithFriends(context)
+                },
             )
         }
         item {
@@ -430,5 +437,6 @@ private fun AboutPagePreview() {
         bottomInset = 0.dp,
         openFragment = {},
         onRateUsTapped = {},
+        onShareWithFriendsTapped = {},
     )
 }

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/about/AboutFragment.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/about/AboutFragment.kt
@@ -106,6 +106,9 @@ class AboutFragment : BaseFragment() {
                 onShareWithFriendsTapped = {
                     analyticsTracker.track(AnalyticsEvent.SETTINGS_ABOUT_SHARE_WITH_FRIENDS_TAPPED)
                 },
+                onWebsiteTapped = {
+                    analyticsTracker.track(AnalyticsEvent.SETTINGS_ABOUT_WEBSITE_TAPPED)
+                },
             )
         }
     }
@@ -186,6 +189,7 @@ private fun AboutPage(
     onBackPressed: () -> Unit,
     onRateUsTapped: () -> Unit,
     onShareWithFriendsTapped: () -> Unit,
+    onWebsiteTapped: () -> Unit,
     bottomInset: Dp,
     openFragment: (Fragment) -> Unit,
 ) {
@@ -247,7 +251,10 @@ private fun AboutPage(
             RowTextButton(
                 text = stringResource(LR.string.settings_about_website),
                 secondaryText = "pocketcasts.com",
-                onClick = { openUrl("https://www.pocketcasts.com", context) },
+                onClick = {
+                    onWebsiteTapped()
+                    openUrl("https://www.pocketcasts.com", context)
+                },
             )
         }
         item {
@@ -438,5 +445,6 @@ private fun AboutPagePreview() {
         openFragment = {},
         onRateUsTapped = {},
         onShareWithFriendsTapped = {},
+        onWebsiteTapped = {},
     )
 }

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/about/AboutFragment.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/about/AboutFragment.kt
@@ -96,6 +96,7 @@ class AboutFragment : BaseFragment() {
         AppThemeWithBackground(theme.activeTheme) {
             AboutPage(
                 openFragment = { fragment ->
+                    analyticsTracker.track(AnalyticsEvent.SETTINGS_ABOUT_LEGAL_AND_MORE_TAPPED, mapOf("row" to "acknowledgements"))
                     (activity as? FragmentHostListener)?.addFragment(fragment)
                 },
                 onBackPressed = { closeFragment() },
@@ -108,6 +109,24 @@ class AboutFragment : BaseFragment() {
                 },
                 onWebsiteTapped = {
                     analyticsTracker.track(AnalyticsEvent.SETTINGS_ABOUT_WEBSITE_TAPPED)
+                },
+                onInstagramTapped = {
+                    analyticsTracker.track(AnalyticsEvent.SETTINGS_ABOUT_INSTAGRAM_TAPPED)
+                },
+                onTwitterTapped = {
+                    analyticsTracker.track(AnalyticsEvent.SETTINGS_ABOUT_TWITTER_TAPPED)
+                },
+                onAutomatticFamilyTapped = {
+                    analyticsTracker.track(AnalyticsEvent.SETTINGS_ABOUT_AUTOMATTIC_FAMILY_TAPPED)
+                },
+                onWorkWithUsTapped = {
+                    analyticsTracker.track(AnalyticsEvent.SETTINGS_ABOUT_WORK_WITH_US_TAPPED)
+                },
+                onTermsOfServiceTapped = {
+                    analyticsTracker.track(AnalyticsEvent.SETTINGS_ABOUT_LEGAL_AND_MORE_TAPPED, mapOf("row" to "terms_of_service"))
+                },
+                onPrivacyPolicyTapped = {
+                    analyticsTracker.track(AnalyticsEvent.SETTINGS_ABOUT_LEGAL_AND_MORE_TAPPED, mapOf("row" to "privacy_policy"))
                 },
             )
         }
@@ -190,6 +209,12 @@ private fun AboutPage(
     onRateUsTapped: () -> Unit,
     onShareWithFriendsTapped: () -> Unit,
     onWebsiteTapped: () -> Unit,
+    onInstagramTapped: () -> Unit,
+    onTwitterTapped: () -> Unit,
+    onAutomatticFamilyTapped: () -> Unit = {},
+    onWorkWithUsTapped: () -> Unit = {},
+    onTermsOfServiceTapped: () -> Unit = {},
+    onPrivacyPolicyTapped: () -> Unit = {},
     bottomInset: Dp,
     openFragment: (Fragment) -> Unit,
 ) {
@@ -261,27 +286,33 @@ private fun AboutPage(
             RowTextButton(
                 text = stringResource(LR.string.settings_about_instagram),
                 secondaryText = "@pocketcasts",
-                onClick = { openUrl("https://www.instagram.com/pocketcasts/", context) },
+                onClick = {
+                    onInstagramTapped()
+                    openUrl("https://www.instagram.com/pocketcasts/", context)
+                },
             )
         }
         item {
             RowTextButton(
                 text = stringResource(LR.string.settings_about_twitter),
                 secondaryText = "@pocketcasts",
-                onClick = { openUrl("https://twitter.com/pocketcasts", context) },
+                onClick = {
+                    onTwitterTapped()
+                    openUrl("https://twitter.com/pocketcasts", context)
+                },
             )
         }
         item {
             HorizontalDivider(modifier = Modifier.padding(vertical = 8.dp))
         }
         item {
-            AutomatticFamilyRow()
+            AutomatticFamilyRow(onAutomatticFamilyTapped = onAutomatticFamilyTapped)
         }
         item {
             HorizontalDivider(modifier = Modifier.padding(bottom = 8.dp))
         }
         item {
-            LegalAndMoreRow(openFragment)
+            LegalAndMoreRow(onTermsOfServiceTapped, onPrivacyPolicyTapped, openFragment)
         }
         item {
             HorizontalDivider(modifier = Modifier.padding(vertical = 8.dp))
@@ -289,7 +320,10 @@ private fun AboutPage(
         item {
             Column(
                 modifier = Modifier
-                    .clickable { openUrl("https://automattic.com/work-with-us/", context) }
+                    .clickable {
+                        onWorkWithUsTapped()
+                        openUrl("https://automattic.com/work-with-us/", context)
+                    }
                     .fillMaxWidth()
                     .padding(all = 14.dp),
             ) {
@@ -313,7 +347,9 @@ private fun AboutPage(
 }
 
 @Composable
-fun AutomatticFamilyRow() {
+fun AutomatticFamilyRow(
+    onAutomatticFamilyTapped: () -> Unit = {},
+) {
     val context = LocalContext.current
     val configuration = LocalConfiguration.current
     var appIconViewWidth = configuration.screenWidthDp
@@ -322,7 +358,10 @@ fun AutomatticFamilyRow() {
     }
     Box(
         modifier = Modifier
-            .clickable { openUrl("https://automattic.com", context) }
+            .clickable {
+                onAutomatticFamilyTapped()
+                openUrl("https://automattic.com", context)
+            }
             .height(192.dp)
             .fillMaxWidth(),
         contentAlignment = Alignment.TopStart,
@@ -353,7 +392,11 @@ fun AutomatticFamilyRow() {
 }
 
 @Composable
-fun LegalAndMoreRow(openFragment: (Fragment) -> Unit) {
+fun LegalAndMoreRow(
+    termsOfService: () -> Unit,
+    privacyPolicy: () -> Unit,
+    openFragment: (Fragment) -> Unit,
+) {
     val context = LocalContext.current
     var legalExpanded by rememberSaveable { mutableStateOf(false) }
     val target = if (legalExpanded) 360f else 180f
@@ -381,11 +424,17 @@ fun LegalAndMoreRow(openFragment: (Fragment) -> Unit) {
         Column {
             RowTextButton(
                 text = stringResource(LR.string.settings_about_terms_of_serivce),
-                onClick = { openUrl(Settings.INFO_TOS_URL, context) },
+                onClick = {
+                    termsOfService()
+                    openUrl(Settings.INFO_TOS_URL, context)
+                },
             )
             RowTextButton(
                 text = stringResource(LR.string.settings_about_privacy_policy),
-                onClick = { openUrl(Settings.INFO_PRIVACY_URL, context) },
+                onClick = {
+                    privacyPolicy()
+                    openUrl(Settings.INFO_PRIVACY_URL, context)
+                },
             )
             RowTextButton(
                 text = stringResource(LR.string.settings_about_acknowledgements),
@@ -446,5 +495,9 @@ private fun AboutPagePreview() {
         onRateUsTapped = {},
         onShareWithFriendsTapped = {},
         onWebsiteTapped = {},
+        onInstagramTapped = {},
+        onTwitterTapped = {},
+        onAutomatticFamilyTapped = {},
+        onWorkWithUsTapped = {},
     )
 }

--- a/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
+++ b/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
@@ -449,6 +449,7 @@ enum class AnalyticsEvent(val key: String) {
 
     /* Settings - About */
     SETTINGS_ABOUT_SHOWN("settings_about_shown"),
+    SETTINGS_ABOUT_SHARE_WITH_FRIENDS_TAPPED("settings_about_share_with_friends_tapped"),
 
     /* Settings - Appearance */
     SETTINGS_APPEARANCE_SHOWN("settings_appearance_shown"),

--- a/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
+++ b/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
@@ -451,6 +451,11 @@ enum class AnalyticsEvent(val key: String) {
     SETTINGS_ABOUT_SHOWN("settings_about_shown"),
     SETTINGS_ABOUT_SHARE_WITH_FRIENDS_TAPPED("settings_about_share_with_friends_tapped"),
     SETTINGS_ABOUT_WEBSITE_TAPPED("settings_about_website_tapped"),
+    SETTINGS_ABOUT_INSTAGRAM_TAPPED("settings_about_instagram_tapped"),
+    SETTINGS_ABOUT_TWITTER_TAPPED("settings_about_twitter_tapped"),
+    SETTINGS_ABOUT_AUTOMATTIC_FAMILY_TAPPED("settings_about_automattic_family_tapped"),
+    SETTINGS_ABOUT_LEGAL_AND_MORE_TAPPED("settings_about_legal_and_more_tapped"),
+    SETTINGS_ABOUT_WORK_WITH_US_TAPPED("settings_about_work_with_us_tapped"),
 
     /* Settings - Appearance */
     SETTINGS_APPEARANCE_SHOWN("settings_appearance_shown"),

--- a/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
+++ b/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
@@ -619,6 +619,7 @@ enum class AnalyticsEvent(val key: String) {
 
     /* App Store Review */
     APP_STORE_REVIEW_REQUESTED("app_store_review_requested"),
+    RATE_US_TAPPED("rate_us_tapped"),
 
     /* Deselect Chapters */
     DESELECT_CHAPTERS_TOGGLED_ON("deselect_chapters_toggled_on"),

--- a/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
+++ b/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
@@ -450,6 +450,7 @@ enum class AnalyticsEvent(val key: String) {
     /* Settings - About */
     SETTINGS_ABOUT_SHOWN("settings_about_shown"),
     SETTINGS_ABOUT_SHARE_WITH_FRIENDS_TAPPED("settings_about_share_with_friends_tapped"),
+    SETTINGS_ABOUT_WEBSITE_TAPPED("settings_about_website_tapped"),
 
     /* Settings - Appearance */
     SETTINGS_APPEARANCE_SHOWN("settings_appearance_shown"),

--- a/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/SourceView.kt
+++ b/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/SourceView.kt
@@ -51,6 +51,7 @@ enum class SourceView(val analyticsValue: String) {
     UNKNOWN("unknown"),
     UP_NEXT("up_next"),
     WHATS_NEW("whats_new"),
+    ABOUT("about"),
     STORAGE_AND_DATA_USAGE("storage_and_data_usage"),
     WIDGET_PLAYER_LARGE("widget_player_large"),
     WIDGET_PLAYER_MEDIUM("widget_player_medium"),

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
@@ -546,6 +546,7 @@ open class PlaybackManager @Inject constructor(
             SourceView.UP_NEXT,
             SourceView.STATS,
             SourceView.WHATS_NEW,
+            SourceView.ABOUT,
             SourceView.STORAGE_AND_DATA_USAGE,
             SourceView.NOTIFICATION_BOOKMARK,
             SourceView.METERED_NETWORK_CHANGE,


### PR DESCRIPTION
## Description
- This adds track events for all row's click in About page

<img width="1454" height="180" alt="image" src="https://github.com/user-attachments/assets/d7f279b6-62a6-419c-b947-0408c46aa3f9" />

## Testing Instructions
1. Go to About screen
2. Verify the all row items track event

## Checklist
- [ ] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] ~I have considered whether it makes sense to add tests for my changes~
- [ ] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [ ] ~Any jetpack compose components I added or changed are covered by compose previews~
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
