### PR TITLE
Tracks Audit: Add events for podcast screen selection

### DIFF
--- a/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
+++ b/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
@@ -487,6 +487,12 @@ enum class AnalyticsEvent(val key: String) {
     SETTINGS_AUTO_DOWNLOAD_STOP_ALL_DOWNLOADS("settings_auto_download_stop_all_downloads"),
     SETTINGS_AUTO_DOWNLOAD_CLEAR_DOWNLOAD_ERRORS("settings_auto_download_clear_download_errors"),
 
+    /* Settings - Select Podcasts */
+    SETTINGS_SELECT_PODCASTS_SHOWN("settings_select_podcasts_shown"),
+    SETTINGS_SELECT_PODCASTS_SELECT_ALL_TAPPED("settings_select_podcasts_select_all_tapped"),
+    SETTINGS_SELECT_PODCASTS_SELECT_NONE_TAPPED("settings_select_podcasts_select_none_tapped"),
+    SETTINGS_SELECT_PODCASTS_PODCAST_TOGGLED("settings_select_podcasts_podcast_toggled"),
+
     /* Settings - Files */
     SETTINGS_FILES_SHOWN("settings_files_shown"),
     SETTINGS_FILES_AUTO_ADD_UP_NEXT_TOGGLED("settings_files_auto_add_up_next_toggled"),

--- a/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/fragments/PodcastSelectFragment.kt
+++ b/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/fragments/PodcastSelectFragment.kt
@@ -105,6 +105,8 @@ class PodcastSelectFragment : BaseFragment() {
 
         source = args.source
 
+        analyticsTracker.track(AnalyticsEvent.SETTINGS_SELECT_PODCASTS_SHOWN, source.toEventProperty())
+
         val imageRequestFactory = PocketCastsImageRequestFactory(requireContext()).themed()
         binding.toolbarLayout.isVisible = args.showToolbar
         if (binding.toolbarLayout.isVisible) {
@@ -127,13 +129,21 @@ class PodcastSelectFragment : BaseFragment() {
             .subscribeBy(
                 onError = { Timber.e(it) },
                 onSuccess = {
-                    val adapter = PodcastSelectAdapter(it, args.tintColor, imageRequestFactory) {
-                        val selectedList = it.map { it.uuid }
-                        binding.lblPodcastsChosen.text =
-                            resources.getStringPluralPodcastsSelected(selectedList.size)
-                        listener.podcastSelectFragmentSelectionChanged(selectedList)
-                        userChanged = true
-                    }
+                    val adapter = PodcastSelectAdapter(
+                        it,
+                        args.tintColor,
+                        imageRequestFactory,
+                        onPodcastToggled = { podcastUuid, enabled ->
+                            analyticsTracker.track(AnalyticsEvent.SETTINGS_SELECT_PODCASTS_PODCAST_TOGGLED, source.toEventProperty() + mapOf("uuid" to podcastUuid, "enabled" to enabled))
+                        },
+                        onSelectionChanged = {
+                            val selectedList = it.map { it.uuid }
+                            binding.lblPodcastsChosen.text =
+                                resources.getStringPluralPodcastsSelected(selectedList.size)
+                            listener.podcastSelectFragmentSelectionChanged(selectedList)
+                            userChanged = true
+                        },
+                    )
 
                     val selected = it.filter { it.selected }
                     binding.lblPodcastsChosen.text =
@@ -144,8 +154,10 @@ class PodcastSelectFragment : BaseFragment() {
                     updateSelectButtonText(adapter.selectedPodcasts.size, adapter.list.size)
                     binding.btnSelect.setOnClickListener {
                         if (adapter.selectedPodcasts.size == adapter.list.size) { // Everything is selected
+                            analyticsTracker.track(AnalyticsEvent.SETTINGS_SELECT_PODCASTS_SELECT_NONE_TAPPED, source.toEventProperty())
                             adapter.deselectAll()
                         } else {
+                            analyticsTracker.track(AnalyticsEvent.SETTINGS_SELECT_PODCASTS_SELECT_ALL_TAPPED, source.toEventProperty())
                             adapter.selectAll()
                         }
 
@@ -220,7 +232,7 @@ class PodcastSelectFragment : BaseFragment() {
 }
 
 private data class SelectablePodcast(val podcast: Podcast, var selected: Boolean)
-private class PodcastSelectAdapter(val list: List<SelectablePodcast>, @ColorInt val tintColor: Int?, imageRequestFactory: PocketCastsImageRequestFactory, val onSelectionChanged: (selected: List<Podcast>) -> Unit) : RecyclerView.Adapter<PodcastSelectAdapter.PodcastViewHolder>() {
+private class PodcastSelectAdapter(val list: List<SelectablePodcast>, @ColorInt val tintColor: Int?, imageRequestFactory: PocketCastsImageRequestFactory, val onPodcastToggled: (uuid: String, enabled: Boolean) -> Unit, val onSelectionChanged: (selected: List<Podcast>) -> Unit) : RecyclerView.Adapter<PodcastSelectAdapter.PodcastViewHolder>() {
     val imageRequestFactory = imageRequestFactory.smallSize()
 
     class PodcastViewHolder(val binding: SettingsRowPodcastBinding) : RecyclerView.ViewHolder(binding.root)
@@ -251,6 +263,7 @@ private class PodcastSelectAdapter(val list: List<SelectablePodcast>, @ColorInt 
         }
         holder.binding.checkbox.setOnCheckedChangeListener { _, isChecked ->
             item.selected = isChecked
+            onPodcastToggled(item.podcast.uuid, isChecked)
             onSelectionChanged(selectedPodcasts)
         }
 
@@ -275,6 +288,10 @@ private class PodcastSelectAdapter(val list: List<SelectablePodcast>, @ColorInt 
         notifyDataSetChanged()
         onSelectionChanged(selectedPodcasts)
     }
+}
+
+private fun PodcastSelectFragmentSource?.toEventProperty(): Map<String, String> {
+    return this?.name?.let { mapOf("source" to it.lowercase()) } ?: emptyMap()
 }
 
 @Parcelize


### PR DESCRIPTION
## Description
- This adds events for podcast screen selection

## Testing Instructions
This screen can be opened from different screens, so we are going to use the same event name, but changing the source property

1. Follow some podcasts
2. Go to Settings -> Notifications
3. Enable Notify me
4. Tap on Choose podcasts
5. Ensure `🔵 Tracked: settings_select_podcasts_shown, Properties: {"source":"notifications"` is tracked
6. Tap on Select none
7. Ensure `🔵 Tracked: settings_select_podcasts_select_none_tapped, Properties: {"source":"notifications"` is tracked
8. Tap on select all
9. Ensure `🔵 Tracked: settings_select_podcasts_select_all_tapped, Properties: {"source":"notifications"` is tracked
10. Uncheck one podcast
11. Ensure `🔵 Tracked: settings_select_podcasts_podcast_toggled, Properties: {"source":"notifications","uuid":"5a1697a0-5339-012e-1e7a-00163e1b201c","enabled":false` is tracked

## Screenshots or Screencast 
<img width="274" alt="image" src="https://github.com/user-attachments/assets/c1ae2598-5a28-40e7-b9f1-d90f56f71107" />


## Checklist
- [ ] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] ~I have considered whether it makes sense to add tests for my changes~
- [ ] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [ ] ~Any jetpack compose components I added or changed are covered by compose previews~
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
