### PR TITLE
Tracks Audit: Add Advanced episode artwork settings events

### DIFF
--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/EpisodeArtworkConfigurationFragment.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/EpisodeArtworkConfigurationFragment.kt
@@ -20,7 +20,10 @@ import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
 import androidx.fragment.compose.content
+import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
+import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTracker
 import au.com.shiftyjelly.pocketcasts.compose.AppThemeWithBackground
+import au.com.shiftyjelly.pocketcasts.compose.CallOnce
 import au.com.shiftyjelly.pocketcasts.compose.bars.ThemedTopAppBar
 import au.com.shiftyjelly.pocketcasts.compose.components.SettingRow
 import au.com.shiftyjelly.pocketcasts.compose.components.SettingRowToggle
@@ -39,6 +42,9 @@ class EpisodeArtworkConfigurationFragment : BaseFragment() {
     @Inject
     lateinit var settings: Settings
 
+    @Inject
+    lateinit var analyticsTracker: AnalyticsTracker
+
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
@@ -48,10 +54,17 @@ class EpisodeArtworkConfigurationFragment : BaseFragment() {
         AppThemeWithBackground(theme.activeTheme) {
             val artworkConfiguration by settings.artworkConfiguration.flow.collectAsState()
 
+            CallOnce {
+                analyticsTracker.track(AnalyticsEvent.SETTINGS_ADVANCED_EPISODE_ARTWORK_SHOWN)
+            }
+
             EpisodeArtworkSettings(
                 artworkConfiguration = artworkConfiguration,
                 elements = sortedElements,
                 onUpdateConfiguration = { configuration ->
+                    if (artworkConfiguration.useEpisodeArtwork != configuration.useEpisodeArtwork) {
+                        analyticsTracker.track(AnalyticsEvent.SETTINGS_ADVANCED_EPISODE_ARTWORK_USE_EPISODE_ARTWORK_TOGGLED, mapOf("enabled" to configuration.useEpisodeArtwork))
+                    }
                     settings.artworkConfiguration.set(configuration, updateModifiedAt = true)
                 },
                 onBackPressed = {
@@ -122,6 +135,9 @@ class EpisodeArtworkConfigurationFragment : BaseFragment() {
             primaryText = stringResource(element.titleId),
             toggle = SettingRowToggle.Checkbox(checked = configuration.useEpisodeArtwork(element), enabled = configuration.useEpisodeArtwork),
             modifier = Modifier.toggleable(value = configuration.useEpisodeArtwork(element), role = Role.Checkbox) { newValue ->
+                if (configuration.useEpisodeArtwork) {
+                    analyticsTracker.track(AnalyticsEvent.SETTINGS_ADVANCED_EPISODE_ARTWORK_CUSTOMIZATION_ELEMENT_TOGGLED, mapOf("enabled" to newValue, "element" to element.name.lowercase()))
+                }
                 onUpdateConfiguration(if (newValue) configuration.enable(element) else configuration.disable(element))
             },
         )

--- a/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
+++ b/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
@@ -472,6 +472,11 @@ enum class AnalyticsEvent(val key: String) {
     SETTINGS_APPEARANCE_USE_DARK_UP_NEXT_TOGGLED("settings_appearance_use_dark_up_next_toggled"),
     SETTINGS_APPEARANCE_USE_DYNAMIC_COLORS_WIDGET_TOGGLED("settings_appearance_use_dynamic_colors_widget_toggled"),
 
+    /* Settings - Advanced Episode Artwork */
+    SETTINGS_ADVANCED_EPISODE_ARTWORK_SHOWN("settings_advanced_episode_artwork_shown"),
+    SETTINGS_ADVANCED_EPISODE_ARTWORK_USE_EPISODE_ARTWORK_TOGGLED("settings_advanced_episode_artwork_use_episode_artwork_toggled"),
+    SETTINGS_ADVANCED_EPISODE_ARTWORK_CUSTOMIZATION_ELEMENT_TOGGLED("settings_advanced_episode_artwork_customization_element_toggled"),
+
     /* Settings - Auto add */
     SETTINGS_AUTO_ADD_UP_NEXT_SHOWN("settings_auto_add_up_next_shown"),
     SETTINGS_AUTO_ADD_UP_NEXT_AUTO_ADD_LIMIT_CHANGED("settings_auto_add_up_next_auto_add_limit_changed"),


### PR DESCRIPTION
## Description
- Add events for this screen

## Testing Instructions
1. Go to Settings -> Appearance
2. Tap on Advanced episode artwork settings
3. Ensure `🔵 Tracked: settings_advanced_episode_artwork_shown` is tracked
4. Disable Use Episode Artwork toggle
5. Ensure `🔵 Tracked: settings_advanced_episode_artwork_use_episode_artwork_toggled, Properties: {"enabled":false` is tracked
6. Enable it again
7. Uncheck Up Next element
8. Ensure `🔵 Tracked: settings_advanced_episode_artwork_customization_element_toggled, Properties: {"enabled":false,"element":"upnext",` is tracked

## Screenshots or Screencast 

<img src="https://github.com/user-attachments/assets/c77d475f-29a6-45bc-8b56-d38a5f435b32" alt="Episode Artwork" width="300">


## Checklist
- [ ] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] ~I have considered whether it makes sense to add tests for my changes~
- [ ] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [ ] ~Any jetpack compose components I added or changed are covered by compose previews~
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
