### PR TITLE
Tracks Audit: Track upgrade banner dismiss action

### DIFF
--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/ProfileViewModel.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/ProfileViewModel.kt
@@ -179,6 +179,7 @@ class ProfileViewModel @Inject constructor(
     }
 
     internal fun closeUpgradeProfile() {
+        tracker.track(AnalyticsEvent.PROFILE_REFRESH_UPGRADE_BANNER_DISMISSED)
         settings.upgradeProfileClosed.set(true, updateModifiedAt = false)
     }
 }

--- a/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
+++ b/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
@@ -117,6 +117,7 @@ enum class AnalyticsEvent(val key: String) {
     PROFILE_ACCOUNT_BUTTON_TAPPED("profile_account_button_tapped"),
     PROFILE_SETTINGS_BUTTON_TAPPED("profile_settings_button_tapped"),
     PROFILE_REFRESH_BUTTON_TAPPED("profile_refresh_button_tapped"),
+    PROFILE_REFRESH_UPGRADE_BANNER_DISMISSED("profile_refresh_upgrade_banner_dismissed"),
 
     /* Stats View */
     STATS_SHOWN("stats_shown"),


### PR DESCRIPTION
## Description
- This tracks the action when the user dismiss the upgrade banner from profile screen

## Testing Instructions
1. Fresh install
2. Go to profile
3. Dismiss upgrade banner
4. Ensure `🔵 Tracked: profile_refresh_upgrade_banner_dismissed` is tracked

<img width="224" alt="image" src="https://github.com/user-attachments/assets/c5687757-0eec-4017-86c8-e967f2588aed" />


## Checklist
- [ ] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] ~I have considered whether it makes sense to add tests for my changes~
- [ ] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [ ] ~Any jetpack compose components I added or changed are covered by compose previews~
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
