### PR TITLE
Upgrade Automattic measure builds library

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -298,7 +298,7 @@ kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 kotlin-parcelize = { id = "org.jetbrains.kotlin.plugin.parcelize", version.ref = "kotlin" }
 ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
-measure-builds = "com.automattic.android.measure-builds:3.0.0"
+measure-builds = "com.automattic.android.measure-builds:3.1.1"
 protobuf = { id = "com.google.protobuf", version.ref = "protobuf-plugin" }
 sentry = { id = "io.sentry.android.gradle", version.ref = "sentry-plugin" }
 spotless = "com.diffplug.spotless:6.25.0"


### PR DESCRIPTION
## Description

I keep experiencing the following build issue:

```
* What went wrong:
lateinit property buildMetricsPreparedAction has not been initialized

* Try:
> Run with --info or --debug option to get more log output.
> Get more help at https://help.gradle.org.

* Exception is:
kotlin.UninitializedPropertyAccessException: lateinit property buildMetricsPreparedAction has not been initialized
	at com.automattic.android.measure.reporters.InMemoryMetricsReporter.getBuildMetricsPreparedAction(InMemoryMetricsReporter.kt:9)
	at com.automattic.android.measure.reporters.InMemoryMetricsReporter.report(InMemoryMetricsReporter.kt:21)
	at com.automattic.android.measure.lifecycle.BuildFinishedFlowAction.execute(BuildFinishedFlowAction.kt:69)
	at com.automattic.android.measure.lifecycle.BuildFinishedFlowAction.execute(BuildFinishedFlowAction.kt:18)
```

I noticed an upgrade to the library had the following change:

> Do not crash if buildMetricsPreparedAction null

https://github.com/Automattic/measure-builds-gradle-plugin/releases

## Testing Instructions

As this is a Gradle plugin, I recommend trying a full rebuild and checking the app runs.

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
