### PR TITLE
Tracks Audit: Add missing bookmark events

### DIFF
--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/bookmark/BookmarkFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/bookmark/BookmarkFragment.kt
@@ -13,6 +13,7 @@ import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import androidx.fragment.compose.content
 import au.com.shiftyjelly.pocketcasts.compose.AppThemeWithBackground
+import au.com.shiftyjelly.pocketcasts.compose.CallOnce
 import au.com.shiftyjelly.pocketcasts.models.entity.Bookmark
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import dagger.hilt.android.AndroidEntryPoint
@@ -30,6 +31,11 @@ class BookmarkFragment : Fragment() {
         LaunchedEffect(Unit) { viewModel.load(BookmarkArguments.createFromArguments(arguments)) }
         AppThemeWithBackground(Theme.ThemeType.DARK) {
             val uiState: BookmarkViewModel.UiState by viewModel.uiState.collectAsState()
+
+            CallOnce {
+                viewModel.onShown()
+            }
+
             BookmarkPage(
                 isNewBookmark = uiState.isNewBookmark,
                 title = uiState.title,
@@ -44,6 +50,7 @@ class BookmarkFragment : Fragment() {
     }
 
     private fun saveBookmark() {
+        viewModel.onSubmitBookmark()
         viewModel.saveBookmark(onSaved = { bookmark, isExisting ->
             bookmarkSaved(bookmark, isExisting)
         })
@@ -63,6 +70,7 @@ class BookmarkFragment : Fragment() {
     }
 
     private fun close() {
+        viewModel.onClose()
         requireActivity().run {
             setResult(Activity.RESULT_CANCELED)
             finish()

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/bookmark/BookmarkViewModel.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/bookmark/BookmarkViewModel.kt
@@ -5,6 +5,8 @@ import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
+import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTracker
 import au.com.shiftyjelly.pocketcasts.models.entity.Bookmark
 import au.com.shiftyjelly.pocketcasts.repositories.bookmark.BookmarkManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
@@ -25,6 +27,7 @@ class BookmarkViewModel
     private val episodeManager: EpisodeManager,
     private val userEpisodeManager: UserEpisodeManager,
     private val bookmarkManager: BookmarkManager,
+    private val analyticsTracker: AnalyticsTracker,
 ) : ViewModel(), CoroutineScope {
 
     private lateinit var arguments: BookmarkArguments
@@ -113,5 +116,17 @@ class BookmarkViewModel
                 Timber.e(e)
             }
         }
+    }
+
+    fun onShown() {
+        analyticsTracker.track(AnalyticsEvent.BOOKMARK_EDIT_FORM_SHOWN)
+    }
+
+    fun onClose() {
+        analyticsTracker.track(AnalyticsEvent.BOOKMARK_EDIT_FORM_DISMISSED)
+    }
+
+    fun onSubmitBookmark() {
+        analyticsTracker.track(AnalyticsEvent.BOOKMARK_EDIT_FORM_SUBMITTED)
     }
 }

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/bookmark/BookmarksFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/bookmark/BookmarksFragment.kt
@@ -146,6 +146,9 @@ class BookmarksFragment : BaseFragment() {
                             addFragment(fragment)
                         }
                     },
+                    onClearSearchTapped = {
+                        bookmarksViewModel.clearSearchTapped()
+                    },
                     bottomInset = if (sourceView == SourceView.PROFILE) {
                         0.dp + bottomInset.value.pxToDp(LocalContext.current).dp
                     } else {

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/bookmark/BookmarksFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/bookmark/BookmarksFragment.kt
@@ -149,6 +149,9 @@ class BookmarksFragment : BaseFragment() {
                     onClearSearchTapped = {
                         bookmarksViewModel.clearSearchTapped()
                     },
+                    onSearchBarClearButtonTapped = {
+                        bookmarksViewModel.searchBarClearButtonTapped()
+                    },
                     bottomInset = if (sourceView == SourceView.PROFILE) {
                         0.dp + bottomInset.value.pxToDp(LocalContext.current).dp
                     } else {

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/bookmark/BookmarksFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/bookmark/BookmarksFragment.kt
@@ -8,7 +8,6 @@ import androidx.compose.material.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.State
 import androidx.compose.runtime.collectAsState
-import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -218,6 +217,7 @@ class BookmarksFragment : BaseFragment() {
     private fun onShareBookmarkClick() {
         lifecycleScope.launch {
             val (podcast, episode, bookmark) = bookmarksViewModel.getSharedBookmark() ?: return@launch
+            bookmarksViewModel.onShare(podcast.uuid, episode.uuid, sourceView)
             val timestamp = bookmark.timeSecs.seconds
             if (FeatureFlag.isEnabled(Feature.REIMAGINE_SHARING)) {
                 ShareEpisodeTimestampFragment

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/bookmark/BookmarksPage.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/bookmark/BookmarksPage.kt
@@ -68,6 +68,7 @@ fun BookmarksPage(
     showOptionsDialog: (Int) -> Unit,
     openFragment: (Fragment) -> Unit,
     onClearSearchTapped: () -> Unit,
+    onSearchBarClearButtonTapped: () -> Unit,
     bottomInset: Dp,
 ) {
     val context = LocalContext.current
@@ -88,6 +89,7 @@ fun BookmarksPage(
         openFragment = openFragment,
         bottomInset = bottomInset,
         onClearSearchTapped = onClearSearchTapped,
+        onSearchBarClearButtonTapped = onSearchBarClearButtonTapped,
     )
     LaunchedEffect(episodeUuid) {
         bookmarksViewModel.loadBookmarks(
@@ -135,6 +137,7 @@ private fun Content(
     onUpgradeClicked: () -> Unit,
     openFragment: (Fragment) -> Unit,
     onClearSearchTapped: () -> Unit,
+    onSearchBarClearButtonTapped: () -> Unit,
     bottomInset: Dp,
 ) {
     Box(
@@ -153,6 +156,7 @@ private fun Content(
                 onSearchTextChanged = onSearchTextChanged,
                 bottomInset = bottomInset,
                 onClearSearchTapped = onClearSearchTapped,
+                onSearchBarClearButtonTapped = onSearchBarClearButtonTapped,
             )
 
             is UiState.Empty -> NoBookmarksView(
@@ -184,6 +188,7 @@ private fun BookmarksView(
     onPlayClick: (Bookmark) -> Unit,
     onSearchTextChanged: (String) -> Unit,
     onClearSearchTapped: () -> Unit,
+    onSearchBarClearButtonTapped: () -> Unit,
     bottomInset: Dp,
 ) {
     val focusRequester = remember { FocusRequester() }
@@ -198,6 +203,7 @@ private fun BookmarksView(
                     text = state.searchText,
                     placeholder = stringResource(LR.string.search),
                     onTextChanged = onSearchTextChanged,
+                    onClearButtonTapped = onSearchBarClearButtonTapped,
                     modifier = Modifier
                         .fillMaxWidth()
                         .padding(horizontal = 16.dp)
@@ -307,6 +313,7 @@ private fun BookmarksPreview(
             onUpgradeClicked = {},
             openFragment = {},
             onClearSearchTapped = {},
+            onSearchBarClearButtonTapped = {},
             bottomInset = 0.dp,
         )
     }

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/bookmark/BookmarksPage.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/bookmark/BookmarksPage.kt
@@ -67,6 +67,7 @@ fun BookmarksPage(
     onUpgradeClicked: () -> Unit,
     showOptionsDialog: (Int) -> Unit,
     openFragment: (Fragment) -> Unit,
+    onClearSearchTapped: () -> Unit,
     bottomInset: Dp,
 ) {
     val context = LocalContext.current
@@ -86,6 +87,7 @@ fun BookmarksPage(
         onUpgradeClicked = onUpgradeClicked,
         openFragment = openFragment,
         bottomInset = bottomInset,
+        onClearSearchTapped = onClearSearchTapped,
     )
     LaunchedEffect(episodeUuid) {
         bookmarksViewModel.loadBookmarks(
@@ -132,6 +134,7 @@ private fun Content(
     onSearchTextChanged: (String) -> Unit,
     onUpgradeClicked: () -> Unit,
     openFragment: (Fragment) -> Unit,
+    onClearSearchTapped: () -> Unit,
     bottomInset: Dp,
 ) {
     Box(
@@ -149,6 +152,7 @@ private fun Content(
                 onPlayClick = onPlayClick,
                 onSearchTextChanged = onSearchTextChanged,
                 bottomInset = bottomInset,
+                onClearSearchTapped = onClearSearchTapped,
             )
 
             is UiState.Empty -> NoBookmarksView(
@@ -179,6 +183,7 @@ private fun BookmarksView(
     onOptionsMenuClicked: () -> Unit,
     onPlayClick: (Bookmark) -> Unit,
     onSearchTextChanged: (String) -> Unit,
+    onClearSearchTapped: () -> Unit,
     bottomInset: Dp,
 ) {
     val focusRequester = remember { FocusRequester() }
@@ -205,7 +210,14 @@ private fun BookmarksView(
             state.searchText.isNotEmpty() &&
             state.bookmarks.isEmpty()
         ) {
-            item { NoBookmarksInSearchView(onActionClick = { onSearchTextChanged("") }) }
+            item {
+                NoBookmarksInSearchView(
+                    onActionClick = {
+                        onClearSearchTapped()
+                        onSearchTextChanged("")
+                    },
+                )
+            }
         } else {
             item {
                 val title = stringResource(
@@ -294,6 +306,7 @@ private fun BookmarksPreview(
             onSearchTextChanged = {},
             onUpgradeClicked = {},
             openFragment = {},
+            onClearSearchTapped = {},
             bottomInset = 0.dp,
         )
     }

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/BookmarksViewModel.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/BookmarksViewModel.kt
@@ -352,6 +352,10 @@ class BookmarksViewModel
         return sortType as UserSetting<BookmarksSortType>
     }
 
+    fun clearSearchTapped() {
+        analyticsTracker.track(AnalyticsEvent.BOOKMARKS_CLEAR_SEARCH_TAPPED)
+    }
+
     sealed class UiState {
         data class Empty(val sourceView: SourceView) : UiState() {
             val colors: NoBookmarksViewColors

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/BookmarksViewModel.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/BookmarksViewModel.kt
@@ -356,6 +356,10 @@ class BookmarksViewModel
         analyticsTracker.track(AnalyticsEvent.BOOKMARKS_CLEAR_SEARCH_TAPPED)
     }
 
+    fun searchBarClearButtonTapped() {
+        analyticsTracker.track(AnalyticsEvent.BOOKMARKS_SEARCHBAR_CLEAR_BUTTON_TAPPED)
+    }
+
     sealed class UiState {
         data class Empty(val sourceView: SourceView) : UiState() {
             val colors: NoBookmarksViewColors

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/BookmarksViewModel.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/BookmarksViewModel.kt
@@ -360,6 +360,10 @@ class BookmarksViewModel
         analyticsTracker.track(AnalyticsEvent.BOOKMARKS_SEARCHBAR_CLEAR_BUTTON_TAPPED)
     }
 
+    fun onShare(podcastUuid: String, episodeUuid: String, source: SourceView) {
+        analyticsTracker.track(AnalyticsEvent.BOOKMARK_SHARE_TAPPED, mapOf("podcast_uuid" to podcastUuid, "episode_uuid" to episodeUuid, "source" to source.analyticsValue))
+    }
+
     sealed class UiState {
         data class Empty(val sourceView: SourceView) : UiState() {
             val colors: NoBookmarksViewColors

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastFragment.kt
@@ -723,6 +723,7 @@ class PodcastFragment : BaseFragment(), Toolbar.OnMenuItemClickListener {
     private fun onShareBookmarkClick() {
         lifecycleScope.launch {
             val (podcast, episode, bookmark) = viewModel.getSharedBookmark() ?: return@launch
+            viewModel.onBookmarkShare(podcast.uuid, episode.uuid, sourceView)
             val timestamp = bookmark.timeSecs.seconds
             if (FeatureFlag.isEnabled(Feature.REIMAGINE_SHARING)) {
                 ShareEpisodeTimestampFragment

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/PodcastViewModel.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/PodcastViewModel.kt
@@ -566,6 +566,10 @@ class PodcastViewModel
         }
     }
 
+    fun onBookmarkShare(podcastUuid: String, episodeUuid: String, source: SourceView) {
+        analyticsTracker.track(AnalyticsEvent.BOOKMARK_SHARE_TAPPED, mapOf("podcast_uuid" to podcastUuid, "episode_uuid" to episodeUuid, "source" to source.analyticsValue))
+    }
+
     private fun trackEpisodeBulkEvent(event: AnalyticsEvent, count: Int) {
         episodeAnalytics.trackBulkEvent(
             event,

--- a/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
+++ b/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
@@ -17,6 +17,7 @@ enum class AnalyticsEvent(val key: String) {
     BOOKMARKS_SORT_BY_CHANGED("bookmarks_sort_by_changed"),
     BOOKMARK_DELETED("bookmark_deleted"),
     BOOKMARKS_CLEAR_SEARCH_TAPPED("bookmarks_clear_search_tapped"),
+    BOOKMARKS_SEARCHBAR_CLEAR_BUTTON_TAPPED("bookmarks_searchbar_clear_button_tapped"),
     PROFILE_BOOKMARKS_SHOWN("profile_bookmarks_shown"),
 
     /* User lifecycle events */

--- a/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
+++ b/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
@@ -23,6 +23,7 @@ enum class AnalyticsEvent(val key: String) {
     BOOKMARK_EDIT_FORM_SHOWN("bookmark_edit_form_shown"),
     BOOKMARK_EDIT_FORM_DISMISSED("bookmark_edit_form_dismissed"),
     BOOKMARK_EDIT_FORM_SUBMITTED("bookmark_edit_form_submitted"),
+    BOOKMARK_SHARE_TAPPED("bookmark_share_tapped"),
     PROFILE_BOOKMARKS_SHOWN("profile_bookmarks_shown"),
 
     /* User lifecycle events */

--- a/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
+++ b/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
@@ -16,6 +16,7 @@ enum class AnalyticsEvent(val key: String) {
     BOOKMARK_PLAY_TAPPED("bookmark_play_tapped"),
     BOOKMARKS_SORT_BY_CHANGED("bookmarks_sort_by_changed"),
     BOOKMARK_DELETED("bookmark_deleted"),
+    BOOKMARKS_CLEAR_SEARCH_TAPPED("bookmarks_clear_search_tapped"),
     PROFILE_BOOKMARKS_SHOWN("profile_bookmarks_shown"),
 
     /* User lifecycle events */

--- a/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
+++ b/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
@@ -18,6 +18,9 @@ enum class AnalyticsEvent(val key: String) {
     BOOKMARK_DELETED("bookmark_deleted"),
     BOOKMARKS_CLEAR_SEARCH_TAPPED("bookmarks_clear_search_tapped"),
     BOOKMARKS_SEARCHBAR_CLEAR_BUTTON_TAPPED("bookmarks_searchbar_clear_button_tapped"),
+    BOOKMARK_EDIT_FORM_SHOWN("bookmark_edit_form_shown"),
+    BOOKMARK_EDIT_FORM_DISMISSED("bookmark_edit_form_dismissed"),
+    BOOKMARK_EDIT_FORM_SUBMITTED("bookmark_edit_form_submitted"),
     PROFILE_BOOKMARKS_SHOWN("profile_bookmarks_shown"),
 
     /* User lifecycle events */

--- a/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
+++ b/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
@@ -17,6 +17,8 @@ enum class AnalyticsEvent(val key: String) {
     BOOKMARKS_SORT_BY_CHANGED("bookmarks_sort_by_changed"),
     BOOKMARK_DELETED("bookmark_deleted"),
     BOOKMARKS_CLEAR_SEARCH_TAPPED("bookmarks_clear_search_tapped"),
+    BOOKMARK_DELETE_FORM_SHOWN("bookmark_delete_form_shown"),
+    BOOKMARK_DELETE_FORM_SUBMITTED("bookmark_delete_form_submitted"),
     BOOKMARKS_SEARCHBAR_CLEAR_BUTTON_TAPPED("bookmarks_searchbar_clear_button_tapped"),
     BOOKMARK_EDIT_FORM_SHOWN("bookmark_edit_form_shown"),
     BOOKMARK_EDIT_FORM_DISMISSED("bookmark_edit_form_dismissed"),

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/SearchBar.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/SearchBar.kt
@@ -90,6 +90,7 @@ object SearchBarDefaults {
 fun SearchBar(
     text: String,
     onTextChanged: (String) -> Unit,
+    onClearButtonTapped: () -> Unit = {},
     modifier: Modifier = Modifier,
     leadingIcon: @Composable (() -> Unit)? = null,
     trailingIcon: @Composable (() -> Unit)? = null,
@@ -163,6 +164,7 @@ fun SearchBar(
                     if (text.isNotEmpty()) {
                         IconButton(
                             onClick = {
+                                onClearButtonTapped()
                                 onTextChanged("")
                                 focusManager.clearFocus()
                             },

--- a/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/multiselect/MultiSelectBookmarksHelper.kt
+++ b/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/multiselect/MultiSelectBookmarksHelper.kt
@@ -109,6 +109,11 @@ class MultiSelectBookmarksHelper @Inject constructor(
             return
         }
 
+        analyticsTracker.track(
+            AnalyticsEvent.BOOKMARK_DELETE_FORM_SHOWN,
+            mapOf("source" to source.analyticsValue),
+        )
+
         val count = bookmarks.size
         ConfirmationDialog()
             .setForceDarkTheme(source == SourceView.PLAYER)
@@ -133,6 +138,11 @@ class MultiSelectBookmarksHelper @Inject constructor(
             .setIconTint(UR.attr.support_05)
             .setOnConfirm {
                 launch {
+                    analyticsTracker.track(
+                        AnalyticsEvent.BOOKMARK_DELETE_FORM_SUBMITTED,
+                        mapOf("source" to source.analyticsValue),
+                    )
+
                     bookmarks.forEach {
                         bookmarkManager.deleteToSync(it.uuid)
                         analyticsTracker.track(


### PR DESCRIPTION
## Description
- This adds some missing events for Bookmark

## Testing Instructions

### Bookmark - Episode view

1. Log with plus / patron account
2. Go to a podcast, follow and play an episode
3. Open shelf and tap on Bookmark
4. Ensure `🔵 Tracked: bookmark_edit_form_shown` 
5. Dismiss this form
6. Ensure `🔵 Tracked: bookmark_edit_form_dismissed,` 
7. Back to the screen and tap to save the bookmark
8. Ensure `🔵 Tracked: bookmark_edit_form_submitted`
9. In Now Playing screen, switch to bookmark tab
10. Long press the bookmark
11. Tap to share
12. Ensure `🔵 Tracked: bookmark_share_tapped` 
13. Close the screen
14. Tap to dele the bookmark
15. Ensure `🔵 Tracked: bookmark_delete_form_shown`
16. Delete
17. Ensure `🔵 Tracked: bookmark_delete_form_submitted`

### Bookmark - Profile
1. Have some bookmarks
2. Go to Profile -> Bookmarks
3. Search something like "sdfsdf" to see the `no bookmarks found` view
4. Tap on Clear Search
5. Ensure `🔵 Tracked: bookmarks_clear_search_tapped`
6. Search something again
7. Tap on X searchbar clear button
8. Ensure `🔵 Tracked: bookmarks_searchbar_clear_button_tapped`
9. Long press the bookmark
10. Tap to share
11. Ensure `🔵 Tracked: bookmark_share_tapped` 
12. Close the screen
13. Tap to dele the bookmark
14. Ensure `🔵 Tracked: bookmark_delete_form_shown`
15. Delete
16. Ensure `🔵 Tracked: bookmark_delete_form_submitted`

## Checklist
- [ ] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] ~I have considered whether it makes sense to add tests for my changes~
- [ ] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [ ] ~Any jetpack compose components I added or changed are covered by compose previews~
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
