### PR TITLE
Fix multi-select with edge-to-edge

### DIFF
--- a/modules/features/podcasts/src/main/res/layout/fragment_profile_episode_list.xml
+++ b/modules/features/podcasts/src/main/res/layout/fragment_profile_episode_list.xml
@@ -15,16 +15,22 @@
         android:id="@+id/multiSelectToolbar"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:minHeight="?android:attr/actionBarSize"
         android:visibility="gone"
-        app:layout_constraintBottom_toBottomOf="@+id/toolbar" />
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <androidx.constraintlayout.widget.Barrier
+        android:id="@+id/toolbarBarrier"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        app:barrierDirection="bottom"
+        app:constraint_referenced_ids="toolbar,multiSelectToolbar" />
 
     <androidx.compose.ui.platform.ComposeView
         android:id="@+id/layoutSearch"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:background="?attr/secondary_ui_01"
-        app:layout_constraintTop_toBottomOf="@+id/toolbar" />
+        app:layout_constraintTop_toBottomOf="@+id/toolbarBarrier" />
 
     <androidx.compose.ui.platform.ComposeView
         android:id="@+id/manageDownloadsCard"

--- a/modules/services/ui/src/main/res/values/themes.xml
+++ b/modules/services/ui/src/main/res/values/themes.xml
@@ -412,8 +412,6 @@
         <item name="isDark">true</item>
         <item name="isImageTintEnabled">false</item>
         <item name="imageTintThemeCacheTag">dark</item>
-        <item name="enableEdgeToEdge">true</item>
-        <item name="android:navigationBarColor">@android:color/transparent</item>
 
         <!-- Default colours -->
         <item name="colorSearchBox">@color/searchBoxDark</item>

--- a/modules/services/ui/src/main/res/values/themes.xml
+++ b/modules/services/ui/src/main/res/values/themes.xml
@@ -412,6 +412,8 @@
         <item name="isDark">true</item>
         <item name="isImageTintEnabled">false</item>
         <item name="imageTintThemeCacheTag">dark</item>
+        <item name="enableEdgeToEdge">true</item>
+        <item name="android:navigationBarColor">@android:color/transparent</item>
 
         <!-- Default colours -->
         <item name="colorSearchBox">@color/searchBoxDark</item>

--- a/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/multiselect/MultiSelectToolbar.kt
+++ b/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/multiselect/MultiSelectToolbar.kt
@@ -16,6 +16,7 @@ import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTracker
 import au.com.shiftyjelly.pocketcasts.analytics.SourceView
 import au.com.shiftyjelly.pocketcasts.ui.extensions.getThemeColor
 import au.com.shiftyjelly.pocketcasts.views.R
+import au.com.shiftyjelly.pocketcasts.views.extensions.includeStatusBarPadding
 import au.com.shiftyjelly.pocketcasts.views.extensions.tintIcons
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
@@ -40,6 +41,7 @@ class MultiSelectToolbar @JvmOverloads constructor(
         multiSelectHelper: MultiSelectHelper<T>,
         @MenuRes menuRes: Int?,
         activity: FragmentActivity,
+        includeStatusBarPadding: Boolean = true,
     ) {
         setBackgroundColor(context.getThemeColor(UR.attr.support_01))
         if (menuRes != null) {
@@ -111,6 +113,10 @@ class MultiSelectToolbar @JvmOverloads constructor(
             multiSelectHelper.isMultiSelecting = false
         }
         navigationContentDescription = context.getString(LR.string.back)
+
+        if (includeStatusBarPadding) {
+            includeStatusBarPadding()
+        }
     }
 
     private fun showOverflowBottomSheet(


### PR DESCRIPTION
## Description

After moving to Android 15 the multi-select toolbar appeared under the status bar, this change fixes that.

## Testing Instructions

1. Go to the Podcasts tab
2. Open a podcast page
3. Long press on an episode row
4. ✅ Verify the multi-select toolbar doesn't appear under the status bar

Testing one of the pages that uses the multi-select toolbar should be enough but here are some more just in case.

5. Open the full screen player
6. Tap the Up Next icon
7. Tap the multi-select icon in the toolbar
8. ✅ Verify the multi-select toolbar doesn't appear under the status bar
9. Go to the Profile tab
10. Tap Files
11. Long press a file 
12. ✅ Verify the multi-select toolbar doesn't appear under the status bar

## Screenshots

| Before | After |
| --- | --- |
| ![multiselect-player-up-next-before](https://github.com/user-attachments/assets/590d7486-3c39-4f99-9d9a-3e5edb416825) | ![multiselect-player-up-next-after](https://github.com/user-attachments/assets/58cbe7ae-5e48-4d82-ba19-42c157a7e427) | 
| ![multiselect-files-before](https://github.com/user-attachments/assets/d92035a4-974f-4d75-87d2-2c1fa093e1ee) | ![multiselect-files-after](https://github.com/user-attachments/assets/cedf5e12-fc49-4785-a3f7-0ff4f765cb30) | 
| ![multiselect-podcast-before](https://github.com/user-attachments/assets/f8e7ad00-a1d3-465e-9cd6-a3f38c661972) | ![multiselect-podcast-after](https://github.com/user-attachments/assets/b7a58ef3-c8a0-40d0-bdd9-87f4497aa81c) | 

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack
