### PR TITLE
Tracks Audit: Tweaks for tracking

### DIFF
--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/helper/ViewExtensions.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/helper/ViewExtensions.kt
@@ -7,10 +7,11 @@ import androidx.interpolator.view.animation.FastOutSlowInInterpolator
 import androidx.transition.ChangeBounds
 import androidx.transition.TransitionManager
 
-fun TextView.readMore(collapsedLines: Int) {
+fun TextView.readMore(collapsedLines: Int, onTextClicked: () -> Unit = {}) {
     maxLines = collapsedLines
     ellipsize = TextUtils.TruncateAt.END
     setOnClickListener {
+        onTextClicked()
         val transition = ChangeBounds().apply {
             duration = 200
             interpolator = FastOutSlowInInterpolator()

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastAdapter.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastAdapter.kt
@@ -135,6 +135,7 @@ class PodcastAdapter(
     private val onEpisodeRowLongPress: (PodcastEpisode) -> Unit,
     private val onBookmarkRowLongPress: (Bookmark) -> Unit,
     private val onFoldersClicked: () -> Unit,
+    private val onPodcastDescriptionClicked: () -> Unit,
     private val onNotificationsClicked: () -> Unit,
     private val onSettingsClicked: () -> Unit,
     private val playButtonListener: PlayButton.OnClickListener,
@@ -318,7 +319,9 @@ class PodcastAdapter(
                 podcast.podcastDescription
             }
         holder.binding.bottom.description.setLinkTextColor(tintColor)
-        holder.binding.bottom.description.readMore(3)
+        holder.binding.bottom.description.readMore(3) {
+            onPodcastDescriptionClicked()
+        }
         holder.binding.bottom.authorText.text = podcast.author
         holder.binding.bottom.authorText.isVisible = podcast.author.isNotBlank()
         holder.binding.bottom.authorImage.isVisible = podcast.author.isNotBlank()

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastFragment.kt
@@ -678,6 +678,9 @@ class PodcastFragment : BaseFragment(), Toolbar.OnMenuItemClickListener {
                     sortType = settings.podcastBookmarksSortType.flow.value,
                 ).asObservable(),
                 fragmentManager = parentFragmentManager,
+                onPodcastDescriptionClicked = {
+                    analyticsTracker.track(AnalyticsEvent.PODCAST_SCREEN_PODCAST_DESCRIPTION_TAPPED)
+                },
             )
         }
 

--- a/modules/features/reimagine/src/main/kotlin/au/com/shiftyjelly/pocketcasts/reimagine/clip/ShareClipFragment.kt
+++ b/modules/features/reimagine/src/main/kotlin/au/com/shiftyjelly/pocketcasts/reimagine/clip/ShareClipFragment.kt
@@ -120,6 +120,7 @@ class ShareClipFragment : BaseDialogFragment() {
             listener = listener,
             snackbarHostState = snackbarHostState,
             onNavigationButtonTapped = { analyticsTracker.track(AnalyticsEvent.SHARE_SCREEN_NAVIGATION_BUTTON_TAPPED) },
+            onEditTapped = { analyticsTracker.track(AnalyticsEvent.SHARE_SCREEN_EDIT_BUTTON_TAPPED) },
         )
 
         LaunchedEffect(Unit) {

--- a/modules/features/reimagine/src/main/kotlin/au/com/shiftyjelly/pocketcasts/reimagine/clip/ShareClipFragment.kt
+++ b/modules/features/reimagine/src/main/kotlin/au/com/shiftyjelly/pocketcasts/reimagine/clip/ShareClipFragment.kt
@@ -121,6 +121,7 @@ class ShareClipFragment : BaseDialogFragment() {
             snackbarHostState = snackbarHostState,
             onNavigationButtonTapped = { analyticsTracker.track(AnalyticsEvent.SHARE_SCREEN_NAVIGATION_BUTTON_TAPPED) },
             onEditTapped = { analyticsTracker.track(AnalyticsEvent.SHARE_SCREEN_EDIT_BUTTON_TAPPED) },
+            onCloseTapped = { analyticsTracker.track(AnalyticsEvent.SHARE_SCREEN_CLOSE_BUTTON_TAPPED) },
         )
 
         LaunchedEffect(Unit) {

--- a/modules/features/reimagine/src/main/kotlin/au/com/shiftyjelly/pocketcasts/reimagine/clip/ShareClipFragment.kt
+++ b/modules/features/reimagine/src/main/kotlin/au/com/shiftyjelly/pocketcasts/reimagine/clip/ShareClipFragment.kt
@@ -17,6 +17,8 @@ import androidx.core.os.BundleCompat
 import androidx.core.os.bundleOf
 import androidx.fragment.app.viewModels
 import androidx.fragment.compose.content
+import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
+import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTracker
 import au.com.shiftyjelly.pocketcasts.analytics.SourceView
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.reimagine.clip.ShareClipViewModel.SnackbarMessage
@@ -68,6 +70,9 @@ class ShareClipFragment : BaseDialogFragment() {
     lateinit var sharingClient: SharingClient
 
     @Inject
+    lateinit var analyticsTracker: AnalyticsTracker
+
+    @Inject
     lateinit var clipAnalyticsFactory: ClipAnalytics.Factory
 
     private lateinit var clipAnalytics: ClipAnalytics
@@ -114,6 +119,7 @@ class ShareClipFragment : BaseDialogFragment() {
             assetController = assetController,
             listener = listener,
             snackbarHostState = snackbarHostState,
+            onNavigationButtonTapped = { analyticsTracker.track(AnalyticsEvent.SHARE_SCREEN_NAVIGATION_BUTTON_TAPPED) },
         )
 
         LaunchedEffect(Unit) {

--- a/modules/features/reimagine/src/main/kotlin/au/com/shiftyjelly/pocketcasts/reimagine/clip/ShareClipPage.kt
+++ b/modules/features/reimagine/src/main/kotlin/au/com/shiftyjelly/pocketcasts/reimagine/clip/ShareClipPage.kt
@@ -130,6 +130,7 @@ internal fun ShareClipPage(
     useKeyboardInput: Boolean,
     assetController: BackgroundAssetController,
     onNavigationButtonTapped: () -> Unit,
+    onEditTapped: () -> Unit,
     listener: ShareClipPageListener,
     state: ClipPageState = rememberClipPageState(
         firstVisibleItemIndex = (clipRange.startInSeconds - 10).coerceAtLeast(0),
@@ -151,6 +152,7 @@ internal fun ShareClipPage(
             assetController = assetController,
             listener = listener,
             onNavigationButtonTapped = onNavigationButtonTapped,
+            onEditTapped = onEditTapped,
             state = state,
             snackbarHostState = snackbarHostState,
         )
@@ -168,6 +170,7 @@ internal fun ShareClipPage(
             assetController = assetController,
             listener = listener,
             onNavigationButtonTapped = onNavigationButtonTapped,
+            onEditTapped = onEditTapped,
             state = state,
             snackbarHostState = snackbarHostState,
         )
@@ -189,6 +192,7 @@ private fun VerticalClipPage(
     assetController: BackgroundAssetController,
     listener: ShareClipPageListener,
     onNavigationButtonTapped: () -> Unit,
+    onEditTapped: () -> Unit,
     state: ClipPageState,
     snackbarHostState: SnackbarHostState,
 ) {
@@ -215,6 +219,7 @@ private fun VerticalClipPage(
                         sharingState = sharingState,
                         shareColors = shareColors,
                         selectedCard = selectedCard,
+                        onEditTapped = onEditTapped,
                         listener = listener,
                         state = state,
                     )
@@ -277,6 +282,7 @@ private fun HorizontalClipPage(
     assetController: BackgroundAssetController,
     listener: ShareClipPageListener,
     onNavigationButtonTapped: () -> Unit,
+    onEditTapped: () -> Unit,
     state: ClipPageState,
     snackbarHostState: SnackbarHostState,
 ) {
@@ -293,6 +299,7 @@ private fun HorizontalClipPage(
                     sharingState = sharingState,
                     shareColors = shareColors,
                     selectedCard = CardType.Horizontal,
+                    onEditTapped = onEditTapped,
                     listener = listener,
                     state = state,
                 )
@@ -357,6 +364,7 @@ private fun DescriptionContent(
     sharingState: SharingState,
     shareColors: ShareColors,
     selectedCard: CardType,
+    onEditTapped: () -> Unit,
     listener: ShareClipPageListener,
     state: ClipPageState,
 ) {
@@ -425,7 +433,10 @@ private fun DescriptionContent(
                             indication = ripple(color = shareColors.accent),
                             onClickLabel = stringResource(LR.string.share_clip_edit_label),
                             role = Role.Button,
-                            onClick = listener::onShowClipSelection,
+                            onClick = {
+                                onEditTapped()
+                                listener.onShowClipSelection()
+                            },
                         )
                         .padding(vertical = 4.dp, horizontal = 16.dp),
                 )
@@ -837,6 +848,7 @@ internal fun ShareClipPagePreview(
         assetController = BackgroundAssetController.preview(),
         listener = ShareClipPageListener.Preview,
         onNavigationButtonTapped = {},
+        onEditTapped = {},
         state = rememberClipPageState(
             firstVisibleItemIndex = 0,
         ),

--- a/modules/features/reimagine/src/main/kotlin/au/com/shiftyjelly/pocketcasts/reimagine/clip/ShareClipPage.kt
+++ b/modules/features/reimagine/src/main/kotlin/au/com/shiftyjelly/pocketcasts/reimagine/clip/ShareClipPage.kt
@@ -131,6 +131,7 @@ internal fun ShareClipPage(
     assetController: BackgroundAssetController,
     onNavigationButtonTapped: () -> Unit,
     onEditTapped: () -> Unit,
+    onCloseTapped: () -> Unit,
     listener: ShareClipPageListener,
     state: ClipPageState = rememberClipPageState(
         firstVisibleItemIndex = (clipRange.startInSeconds - 10).coerceAtLeast(0),
@@ -153,6 +154,7 @@ internal fun ShareClipPage(
             listener = listener,
             onNavigationButtonTapped = onNavigationButtonTapped,
             onEditTapped = onEditTapped,
+            onCloseTapped = onCloseTapped,
             state = state,
             snackbarHostState = snackbarHostState,
         )
@@ -171,6 +173,7 @@ internal fun ShareClipPage(
             listener = listener,
             onNavigationButtonTapped = onNavigationButtonTapped,
             onEditTapped = onEditTapped,
+            onCloseTapped = onCloseTapped,
             state = state,
             snackbarHostState = snackbarHostState,
         )
@@ -193,6 +196,7 @@ private fun VerticalClipPage(
     listener: ShareClipPageListener,
     onNavigationButtonTapped: () -> Unit,
     onEditTapped: () -> Unit,
+    onCloseTapped: () -> Unit,
     state: ClipPageState,
     snackbarHostState: SnackbarHostState,
 ) {
@@ -254,7 +258,10 @@ private fun VerticalClipPage(
         }
         CloseButton(
             shareColors = shareColors,
-            onClick = listener::onClose,
+            onClick = {
+                onCloseTapped()
+                listener.onClose()
+            },
             modifier = Modifier
                 .padding(top = 12.dp, end = 12.dp)
                 .align(Alignment.TopEnd),
@@ -282,6 +289,7 @@ private fun HorizontalClipPage(
     assetController: BackgroundAssetController,
     listener: ShareClipPageListener,
     onNavigationButtonTapped: () -> Unit,
+    onCloseTapped: () -> Unit,
     onEditTapped: () -> Unit,
     state: ClipPageState,
     snackbarHostState: SnackbarHostState,
@@ -346,7 +354,10 @@ private fun HorizontalClipPage(
         }
         CloseButton(
             shareColors = shareColors,
-            onClick = listener::onClose,
+            onClick = {
+                onCloseTapped()
+                listener.onClose()
+            },
             modifier = Modifier
                 .padding(top = 12.dp, end = 12.dp)
                 .align(Alignment.TopEnd),
@@ -848,6 +859,7 @@ internal fun ShareClipPagePreview(
         assetController = BackgroundAssetController.preview(),
         listener = ShareClipPageListener.Preview,
         onNavigationButtonTapped = {},
+        onCloseTapped = {},
         onEditTapped = {},
         state = rememberClipPageState(
             firstVisibleItemIndex = 0,

--- a/modules/features/reimagine/src/main/kotlin/au/com/shiftyjelly/pocketcasts/reimagine/clip/ShareClipPage.kt
+++ b/modules/features/reimagine/src/main/kotlin/au/com/shiftyjelly/pocketcasts/reimagine/clip/ShareClipPage.kt
@@ -7,7 +7,6 @@ import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.animateIntOffsetAsState
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
-import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.ScrollState
 import androidx.compose.foundation.background
@@ -130,6 +129,7 @@ internal fun ShareClipPage(
     useEpisodeArtwork: Boolean,
     useKeyboardInput: Boolean,
     assetController: BackgroundAssetController,
+    onNavigationButtonTapped: () -> Unit,
     listener: ShareClipPageListener,
     state: ClipPageState = rememberClipPageState(
         firstVisibleItemIndex = (clipRange.startInSeconds - 10).coerceAtLeast(0),
@@ -150,6 +150,7 @@ internal fun ShareClipPage(
             useKeyboardInput = useKeyboardInput,
             assetController = assetController,
             listener = listener,
+            onNavigationButtonTapped = onNavigationButtonTapped,
             state = state,
             snackbarHostState = snackbarHostState,
         )
@@ -166,13 +167,13 @@ internal fun ShareClipPage(
             useKeyboardInput = useKeyboardInput,
             assetController = assetController,
             listener = listener,
+            onNavigationButtonTapped = onNavigationButtonTapped,
             state = state,
             snackbarHostState = snackbarHostState,
         )
     }
 }
 
-@OptIn(ExperimentalFoundationApi::class)
 @Composable
 private fun VerticalClipPage(
     episode: PodcastEpisode?,
@@ -187,6 +188,7 @@ private fun VerticalClipPage(
     useKeyboardInput: Boolean,
     assetController: BackgroundAssetController,
     listener: ShareClipPageListener,
+    onNavigationButtonTapped: () -> Unit,
     state: ClipPageState,
     snackbarHostState: SnackbarHostState,
 ) {
@@ -239,6 +241,7 @@ private fun VerticalClipPage(
                     shareColors = shareColors,
                     useKeyboardInput = useKeyboardInput,
                     selectedCard = selectedCard,
+                    onNavigationButtonTapped = onNavigationButtonTapped,
                     listener = listener,
                     state = state,
                 )
@@ -273,6 +276,7 @@ private fun HorizontalClipPage(
     useKeyboardInput: Boolean,
     assetController: BackgroundAssetController,
     listener: ShareClipPageListener,
+    onNavigationButtonTapped: () -> Unit,
     state: ClipPageState,
     snackbarHostState: SnackbarHostState,
 ) {
@@ -323,6 +327,7 @@ private fun HorizontalClipPage(
                         useKeyboardInput = useKeyboardInput,
                         selectedCard = CardType.Horizontal,
                         listener = listener,
+                        onNavigationButtonTapped = onNavigationButtonTapped,
                         state = state,
                         modifier = Modifier.weight(1f),
                     )
@@ -439,7 +444,6 @@ private fun DescriptionContent(
     }
 }
 
-@OptIn(ExperimentalFoundationApi::class)
 @Composable
 private fun PagingContent(
     episode: PodcastEpisode,
@@ -527,6 +531,7 @@ private fun PageControlsContent(
     useKeyboardInput: Boolean,
     selectedCard: CardType,
     listener: ShareClipPageListener,
+    onNavigationButtonTapped: () -> Unit,
     state: ClipPageState,
     modifier: Modifier = Modifier,
 ) {
@@ -547,6 +552,7 @@ private fun PageControlsContent(
                 useKeyboardInput = useKeyboardInput,
                 selectedCard = selectedCard,
                 listener = listener,
+                onNavigationButtonTapped = onNavigationButtonTapped,
                 state = state,
             )
             Step.PlatformSelection -> SharingControls(
@@ -574,6 +580,7 @@ private fun ClipControls(
     shareColors: ShareColors,
     useKeyboardInput: Boolean,
     selectedCard: CardType,
+    onNavigationButtonTapped: () -> Unit,
     listener: ShareClipPageListener,
     state: ClipPageState,
 ) {
@@ -598,6 +605,8 @@ private fun ClipControls(
         )
         BaseRowButton(
             onClick = {
+                onNavigationButtonTapped()
+
                 if (!sharingState.iSharing) {
                     when (selectedCard) {
                         CardType.Vertical, CardType.Horizontal, CardType.Square -> {
@@ -827,6 +836,7 @@ internal fun ShareClipPagePreview(
         useKeyboardInput = useKeyboardInput,
         assetController = BackgroundAssetController.preview(),
         listener = ShareClipPageListener.Preview,
+        onNavigationButtonTapped = {},
         state = rememberClipPageState(
             firstVisibleItemIndex = 0,
         ),

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/EpisodeArtworkConfigurationFragment.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/EpisodeArtworkConfigurationFragment.kt
@@ -136,7 +136,7 @@ class EpisodeArtworkConfigurationFragment : BaseFragment() {
             toggle = SettingRowToggle.Checkbox(checked = configuration.useEpisodeArtwork(element), enabled = configuration.useEpisodeArtwork),
             modifier = Modifier.toggleable(value = configuration.useEpisodeArtwork(element), role = Role.Checkbox) { newValue ->
                 if (configuration.useEpisodeArtwork) {
-                    analyticsTracker.track(AnalyticsEvent.SETTINGS_ADVANCED_EPISODE_ARTWORK_CUSTOMIZATION_ELEMENT_TOGGLED, mapOf("enabled" to newValue, "element" to element.name.lowercase()))
+                    analyticsTracker.track(AnalyticsEvent.SETTINGS_ADVANCED_EPISODE_ARTWORK_CUSTOMIZATION_ELEMENT_TOGGLED, mapOf("enabled" to newValue, "element" to element.analyticsValue))
                 }
                 onUpdateConfiguration(if (newValue) configuration.enable(element) else configuration.disable(element))
             },

--- a/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
+++ b/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
@@ -668,6 +668,7 @@ enum class AnalyticsEvent(val key: String) {
     SHARE_SCREEN_PAUSE_TAPPED("share_screen_pause_tapped"),
     SHARE_SCREEN_CLIP_SHARED("share_screen_clip_shared"),
     SHARE_SCREEN_NAVIGATION_BUTTON_TAPPED("share_screen_navigation_button_tapped"),
+    SHARE_SCREEN_EDIT_BUTTON_TAPPED("share_screen_edit_button_tapped"),
 
     /* Pocket Casts Champion */
     POCKET_CASTS_CHAMPION_DIALOG_SHOWN("pocket_casts_champion_dialog_shown"),

--- a/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
+++ b/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
@@ -214,6 +214,7 @@ enum class AnalyticsEvent(val key: String) {
     PODCAST_SCREEN_OPTIONS_TAPPED("podcast_screen_options_tapped"),
     PODCAST_SCREEN_TOGGLE_ARCHIVED("podcast_screen_toggle_archived"),
     PODCAST_SCREEN_TOGGLE_SUMMARY("podcast_screen_toggle_summary"),
+    PODCAST_SCREEN_PODCAST_DESCRIPTION_TAPPED("podcast_screen_podcast_description_tapped"),
     PODCAST_SCREEN_SHARE_TAPPED("podcast_screen_share_tapped"),
     PODCASTS_SCREEN_SORT_ORDER_CHANGED("podcasts_screen_sort_order_changed"),
     PODCASTS_SCREEN_EPISODE_GROUPING_CHANGED("podcasts_screen_episode_grouping_changed"),

--- a/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
+++ b/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
@@ -669,6 +669,7 @@ enum class AnalyticsEvent(val key: String) {
     SHARE_SCREEN_CLIP_SHARED("share_screen_clip_shared"),
     SHARE_SCREEN_NAVIGATION_BUTTON_TAPPED("share_screen_navigation_button_tapped"),
     SHARE_SCREEN_EDIT_BUTTON_TAPPED("share_screen_edit_button_tapped"),
+    SHARE_SCREEN_CLOSE_BUTTON_TAPPED("share_screen_close_button_tapped"),
 
     /* Pocket Casts Champion */
     POCKET_CASTS_CHAMPION_DIALOG_SHOWN("pocket_casts_champion_dialog_shown"),

--- a/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
+++ b/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
@@ -667,6 +667,7 @@ enum class AnalyticsEvent(val key: String) {
     SHARE_SCREEN_PLAY_TAPPED("share_screen_play_tapped"),
     SHARE_SCREEN_PAUSE_TAPPED("share_screen_pause_tapped"),
     SHARE_SCREEN_CLIP_SHARED("share_screen_clip_shared"),
+    SHARE_SCREEN_NAVIGATION_BUTTON_TAPPED("share_screen_navigation_button_tapped"),
 
     /* Pocket Casts Champion */
     POCKET_CASTS_CHAMPION_DIALOG_SHOWN("pocket_casts_champion_dialog_shown"),

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/model/ArtworkConfiguration.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/model/ArtworkConfiguration.kt
@@ -11,16 +11,17 @@ data class ArtworkConfiguration(
     fun disable(element: Element) = copy(enabledElements = enabledElements - element)
 
     enum class Element(
+        val analyticsValue: String,
         internal val key: String,
     ) {
-        Filters("filters"),
-        UpNext("up_next"),
-        Downloads("downloads"),
-        Files("files"),
-        Starred("starred"),
-        Bookmarks("bookmarks"),
-        ListeningHistory("listening_history"),
-        Podcasts("podcasts"),
+        Filters(key = "filters", analyticsValue = "filters"),
+        UpNext(key = "up_next", analyticsValue = "upnext"),
+        Downloads(key = "downloads", analyticsValue = "downloads"),
+        Files(key = "files", analyticsValue = "files"),
+        Starred(key = "starred", analyticsValue = "starred"),
+        Bookmarks(key = "bookmarks", analyticsValue = "bookmarks"),
+        ListeningHistory(key = "listening_history", analyticsValue = "listeninghistory"),
+        Podcasts(key = "podcasts", analyticsValue = "podcasts"),
         ;
 
         companion object {

--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/SystemBatteryRestrictions.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/SystemBatteryRestrictions.kt
@@ -13,11 +13,11 @@ import timber.log.Timber
 
 class SystemBatteryRestrictions @Inject constructor(@ApplicationContext private val context: Context) {
 
-    enum class Status {
-        Unrestricted,
-        Optimized,
-        Restricted,
-        Other,
+    enum class Status(val analyticsValue: String) {
+        Unrestricted("unrestricted"),
+        Optimized("optimized"),
+        Restricted("restricted"),
+        Other("other"),
         ;
         // "Other" occurs when battery use is unrestricted but background processing is restricted
         // The only way I know that users can get into this state is if the app is set to be restricted

--- a/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/fragments/BatteryRestrictionsSettingsFragment.kt
+++ b/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/fragments/BatteryRestrictionsSettingsFragment.kt
@@ -112,7 +112,7 @@ class BatteryRestrictionsSettingsFragment : BaseFragment() {
                     activity?.onBackPressed()
                 },
                 onClick = {
-                    analyticsTracker.track(AnalyticsEvent.BATTERY_RESTRICTIONS_TOGGLED, mapOf("current_status" to batteryRestrictions.status.name.lowercase()))
+                    analyticsTracker.track(AnalyticsEvent.BATTERY_RESTRICTIONS_TOGGLED, mapOf("current_status" to batteryRestrictions.status.analyticsValue))
                     batteryRestrictions.promptToUpdateBatteryRestriction(context)
                 },
                 openUrl = { url ->

--- a/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/fragments/PodcastSelectFragment.kt
+++ b/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/fragments/PodcastSelectFragment.kt
@@ -291,7 +291,7 @@ private class PodcastSelectAdapter(val list: List<SelectablePodcast>, @ColorInt 
 }
 
 private fun PodcastSelectFragmentSource?.toEventProperty(): Map<String, String> {
-    return this?.name?.let { mapOf("source" to it.lowercase()) } ?: emptyMap()
+    return this?.analyticsValue?.let { mapOf("source" to it) } ?: emptyMap()
 }
 
 @Parcelize
@@ -301,9 +301,9 @@ private data class PodcastSelectFragmentArgs(
     val source: PodcastSelectFragmentSource,
 ) : Parcelable
 
-enum class PodcastSelectFragmentSource {
-    AUTO_ADD,
-    DOWNLOADS,
-    NOTIFICATIONS,
-    FILTERS,
+enum class PodcastSelectFragmentSource(val analyticsValue: String) {
+    AUTO_ADD("auto_add"),
+    DOWNLOADS("downloads"),
+    NOTIFICATIONS("notifications"),
+    FILTERS("filters"),
 }


### PR DESCRIPTION
## Description
- This PR adds some minor changes. 
   - Creates `analyticsValue` for enum to avoid using `enum.name.lowercase()`
   - Tracks `share_screen_navigation_button_tapped`, `share_screen_edit_button_tapped` and `share_screen_close_button_tapped` for sharing clip
   - Tracks `podcast_screen_podcast_description_tapped` for when expands podcast description


## Testing Instructions

### Podcast's description
1. Open a podcast that has long description
2. Tap on podcast's description to expand
3. Ensure `🔵 Tracked: podcast_screen_podcast_description_tapped`

[Screen_recording_20250110_083044.webm](https://github.com/user-attachments/assets/a8c12701-03e9-467d-b272-f0e98036b17a)

### Clip Sharing
1. Play an episode
2. Tap to share episode -> Clip
4. Tap on Next button
5. Ensure `🔵 Tracked: share_screen_navigation_button_tapped`
6. Tap on Edit Clip
7. Ensure `🔵 Tracked: share_screen_edit_button_tapped,`
8. Tap on close button
9. Ensure `🔵 Tracked: share_screen_close_button_tapped`



## Checklist
- [ ] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] ~I have considered whether it makes sense to add tests for my changes~
- [ ] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [ ] ~Any jetpack compose components I added or changed are covered by compose previews~
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
