### PR TITLE
Tracks Audit: Add more eventos for Filters

### DIFF
--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/FiltersFragment.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/FiltersFragment.kt
@@ -130,6 +130,7 @@ class FiltersFragment : BaseFragment(), CoroutineScope, Toolbar.OnMenuItemClickL
     override fun onMenuItemClick(item: MenuItem): Boolean {
         return when (item.itemId) {
             R.id.filter_create -> {
+                viewModel.trackOnCreateFilterTap()
                 openCreate()
                 true
             }

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/FiltersFragmentViewModel.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/FiltersFragmentViewModel.kt
@@ -88,4 +88,8 @@ class FiltersFragmentViewModel @Inject constructor(
             onSuccess(playlist)
         }
     }
+
+    fun trackOnCreateFilterTap() {
+        analyticsTracker.track(AnalyticsEvent.FILTER_CREATE_BUTTON_TAPPED)
+    }
 }

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/PodcastOptionsFragment.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/PodcastOptionsFragment.kt
@@ -8,6 +8,9 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.core.view.isVisible
 import androidx.fragment.app.commit
+import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
+import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTracker
+import au.com.shiftyjelly.pocketcasts.analytics.SourceView
 import au.com.shiftyjelly.pocketcasts.filters.databinding.PodcastOptionsFragmentBinding
 import au.com.shiftyjelly.pocketcasts.models.entity.Playlist
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.PlaylistManager
@@ -54,6 +57,8 @@ class PodcastOptionsFragment : BaseFragment(), PodcastSelectFragment.Listener, C
 
     @Inject lateinit var playlistManager: PlaylistManager
 
+    @Inject lateinit var analyticsTracker: AnalyticsTracker
+
     var podcastSelection: List<String> = listOf()
     var playlist: Playlist? = null
     private var binding: PodcastOptionsFragmentBinding? = null
@@ -99,6 +104,7 @@ class PodcastOptionsFragment : BaseFragment(), PodcastSelectFragment.Listener, C
             }
 
             switchAllPodcasts.setOnCheckedChangeListener { _, isChecked ->
+                analyticsTracker.track(AnalyticsEvent.SETTINGS_SELECT_PODCASTS_SELECT_ALL_PODCASTS_TOGGLED, mapOf("source" to SourceView.FILTERS.analyticsValue, "enabled" to isChecked))
                 podcastSelectDisabled.isVisible = isChecked
                 if (!isChecked) {
                     podcastSelection = emptyList()

--- a/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
+++ b/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
@@ -272,6 +272,7 @@ enum class AnalyticsEvent(val key: String) {
     /* Filters */
     FILTER_AUTO_DOWNLOAD_LIMIT_UPDATED("filter_auto_download_limit_updated"),
     FILTER_AUTO_DOWNLOAD_UPDATED("filter_auto_download_updated"),
+    FILTER_CREATE_BUTTON_TAPPED("filter_create_button_tapped"),
     FILTER_CREATED("filter_created"),
     FILTER_DELETED("filter_deleted"),
     FILTER_EDIT_DISMISSED("filter_edit_dismissed"),

--- a/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
+++ b/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
@@ -518,6 +518,7 @@ enum class AnalyticsEvent(val key: String) {
     SETTINGS_SELECT_PODCASTS_SELECT_ALL_TAPPED("settings_select_podcasts_select_all_tapped"),
     SETTINGS_SELECT_PODCASTS_SELECT_NONE_TAPPED("settings_select_podcasts_select_none_tapped"),
     SETTINGS_SELECT_PODCASTS_PODCAST_TOGGLED("settings_select_podcasts_podcast_toggled"),
+    SETTINGS_SELECT_PODCASTS_SELECT_ALL_PODCASTS_TOGGLED("settings_select_podcasts_select_all_podcasts_toggled"),
 
     /* Settings - Files */
     SETTINGS_FILES_SHOWN("settings_files_shown"),


### PR DESCRIPTION
## Description
- Adds more events for filters feature

## Testing Instructions
1. Open Filters 
2. Tap on + button to create a filter
3. Ensure `🔵 Tracked: filter_create_button_tapped`
4. Tap on All Your Podcasts chip
5. Toggle All your podcasts
6. Ensure `🔵 Tracked: settings_select_podcasts_select_all_podcasts_toggled, Properties: {"source":"filters","enabled":false`

## Checklist
- [ ] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] ~I have considered whether it makes sense to add tests for my changes~
- [ ] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [ ] ~Any jetpack compose components I added or changed are covered by compose previews~
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
