### PR TITLE
Fix add user file edge-to-edge

### DIFF
--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/AccountDetailsPage.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/AccountDetailsPage.kt
@@ -8,8 +8,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.verticalScroll
+import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material.Divider
 import androidx.compose.material.MaterialTheme
 import androidx.compose.runtime.Composable
@@ -104,11 +103,9 @@ internal fun AccountDetailsPage(
     }
     AppTheme(theme) {
         Column(
-            verticalArrangement = Arrangement.spacedBy(16.dp),
             modifier = modifier
                 .fillMaxSize()
-                .background(MaterialTheme.theme.colors.primaryUi02)
-                .verticalScroll(rememberScrollState()),
+                .background(MaterialTheme.theme.colors.primaryUi02),
         ) {
             if (!state.isAutomotive) {
                 ThemedTopAppBar(
@@ -116,43 +113,57 @@ internal fun AccountDetailsPage(
                     onNavigationClick = onNavigateBack,
                 )
             }
-            AccountHeader(
-                state = state.headerState,
-                config = headerConfig,
-                onClick = onClickHeader,
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(horizontal = 16.dp)
-                    .then(if (state.isAutomotive) Modifier.padding(top = 32.dp) else Modifier),
-            )
-            if (bannerState is UpgradeBannerState.Loaded) {
-                Divider()
-                ProfileUpgradeBanner(
-                    state = bannerState,
-                    onClick = onClickUpgradeBanner,
-                    onFeatureCardChanged = onFeatureCardChanged,
-                    modifier = Modifier.fillMaxWidth(),
-                )
-            }
-            Column {
-                AccountSections(
-                    state = sectionsState,
-                    config = sectionsConfig,
-                    onChangeAvatar = onChangeAvatar,
-                    onChangeEmail = onChangeEmail,
-                    onChangePassword = onChangePassword,
-                    onUpgradeToPatron = onUpgradeToPatron,
-                    onCancelSubscription = onCancelSubscription,
-                    onChangeNewsletterSubscription = onChangeNewsletterSubscription,
-                    onShowPrivacyPolicy = onShowPrivacyPolicy,
-                    onShowTermsOfUse = onShowTermsOfUse,
-                    onSignOut = onSignOut,
-                    onDeleteAccount = onDeleteAccount,
-                    modifier = Modifier.fillMaxWidth(),
-                )
-                Spacer(
-                    modifier = Modifier.height(state.miniPlayerPadding),
-                )
+            LazyColumn(
+                verticalArrangement = Arrangement.spacedBy(16.dp),
+                modifier = modifier.fillMaxSize(),
+            ) {
+                item {
+                    Spacer(Modifier.height(16.dp))
+                }
+                item {
+                    AccountHeader(
+                        state = state.headerState,
+                        config = headerConfig,
+                        onClick = onClickHeader,
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(horizontal = 16.dp)
+                            .then(if (state.isAutomotive) Modifier.padding(top = 32.dp) else Modifier),
+                    )
+                }
+                if (bannerState is UpgradeBannerState.Loaded) {
+                    item {
+                        Divider()
+                    }
+                    item {
+                        ProfileUpgradeBanner(
+                            state = bannerState,
+                            onClick = onClickUpgradeBanner,
+                            onFeatureCardChanged = onFeatureCardChanged,
+                            modifier = Modifier.fillMaxWidth(),
+                        )
+                    }
+                }
+                item {
+                    AccountSections(
+                        state = sectionsState,
+                        config = sectionsConfig,
+                        onChangeAvatar = onChangeAvatar,
+                        onChangeEmail = onChangeEmail,
+                        onChangePassword = onChangePassword,
+                        onUpgradeToPatron = onUpgradeToPatron,
+                        onCancelSubscription = onCancelSubscription,
+                        onChangeNewsletterSubscription = onChangeNewsletterSubscription,
+                        onShowPrivacyPolicy = onShowPrivacyPolicy,
+                        onShowTermsOfUse = onShowTermsOfUse,
+                        onSignOut = onSignOut,
+                        onDeleteAccount = onDeleteAccount,
+                        modifier = Modifier.fillMaxWidth(),
+                    )
+                }
+                item {
+                    Spacer(Modifier.height(state.miniPlayerPadding))
+                }
             }
         }
     }

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/ProfilePage.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/ProfilePage.kt
@@ -5,7 +5,6 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -14,8 +13,8 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.windowInsetsPadding
-import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.verticalScroll
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyListScope
 import androidx.compose.material.AppBarDefaults
 import androidx.compose.material.Icon
 import androidx.compose.material.IconButton
@@ -73,12 +72,12 @@ internal fun ProfilePage(
     onCloseUpgradeProfileClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
+    val isPortrait = LocalConfiguration.current.orientation != Configuration.ORIENTATION_LANDSCAPE
     AppTheme(themeType) {
         Column(
             modifier = modifier
                 .fillMaxSize()
-                .background(MaterialTheme.theme.colors.primaryUi02)
-                .verticalScroll(rememberScrollState()),
+                .background(MaterialTheme.theme.colors.primaryUi02),
         ) {
             Toolbar(
                 showReferralsIcon = state.isSendReferralsEnabled,
@@ -88,68 +87,99 @@ internal fun ProfilePage(
                 onReferralsTooltipShown = onReferralsTooltipShown,
                 onSettingsClick = onSettingsClick,
             )
-            VerticalSpacer()
-            HeaderWithStats(
-                headerState = state.headerState,
-                statsState = state.statsState,
-                onHeaderClick = onHeaderClick,
-            )
-            VerticalSpacer()
-            if (state.isPlaybackEnabled) {
-                EndOfYearPromptCard(
-                    onClick = onPlaybackClick,
-                    modifier = Modifier.padding(horizontal = horizontalPadding),
-                )
-                VerticalSpacer()
-            }
-            if (state.isClaimReferralsEnabled) {
-                ReferralsClaimGuestPassBannerCard(
-                    state = state.referralsState,
-                    onClick = onClaimReferralsClick,
-                    onHideBannerClick = onHideReferralsCardClick,
-                    onBannerShown = onReferralsCardShown,
-                    onShowReferralsSheet = onShowReferralsSheet,
-                    modifier = Modifier.padding(horizontal = horizontalPadding),
-                )
-                if ((state.referralsState as? ReferralsViewModel.UiState.Loaded)?.showProfileBanner == true) {
+            LazyColumn(
+                modifier = modifier.fillMaxSize(),
+            ) {
+                item {
                     VerticalSpacer()
                 }
+                HeaderWithStats(
+                    headerState = state.headerState,
+                    statsState = state.statsState,
+                    onHeaderClick = onHeaderClick,
+                    isPortrait = isPortrait,
+                )
+                item {
+                    VerticalSpacer()
+                }
+                if (state.isPlaybackEnabled) {
+                    item {
+                        EndOfYearPromptCard(
+                            onClick = onPlaybackClick,
+                            modifier = Modifier.padding(horizontal = horizontalPadding),
+                        )
+                    }
+                    item {
+                        VerticalSpacer()
+                    }
+                }
+                if (state.isClaimReferralsEnabled) {
+                    item {
+                        ReferralsClaimGuestPassBannerCard(
+                            state = state.referralsState,
+                            onClick = onClaimReferralsClick,
+                            onHideBannerClick = onHideReferralsCardClick,
+                            onBannerShown = onReferralsCardShown,
+                            onShowReferralsSheet = onShowReferralsSheet,
+                            modifier = Modifier.padding(horizontal = horizontalPadding),
+                        )
+                    }
+                    if ((state.referralsState as? ReferralsViewModel.UiState.Loaded)?.showProfileBanner == true) {
+                        item {
+                            VerticalSpacer()
+                        }
+                    }
+                }
+                item {
+                    HorizontalDivider()
+                }
+                item {
+                    ProfileSections(
+                        sections = ProfileSection.entries,
+                        onClick = onSectionClick,
+                        modifier = Modifier.fillMaxWidth(),
+                    )
+                }
+                item {
+                    VerticalSpacer()
+                }
+                item {
+                    var localRefreshState by remember(state.refreshState) { mutableStateOf(state.refreshState) }
+                    RefreshSection(
+                        refreshState = localRefreshState,
+                        onClick = {
+                            localRefreshState = RefreshState.Refreshing
+                            onRefreshClick()
+                        },
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(horizontal = horizontalPadding),
+                    )
+                }
+                item {
+                    VerticalSpacer()
+                }
+                item {
+                    ProfileUpgradeSection(
+                        isVisible = state.isUpgradeBannerVisible,
+                        contentPadding = PaddingValues(
+                            horizontal = 64.dp,
+                            vertical = verticalSpacing,
+                        ),
+                        onClick = onUpgradeProfileClick,
+                        onCloseClick = onCloseUpgradeProfileClick,
+                        modifier = Modifier
+                            .background(MaterialTheme.colors.background)
+                            .fillMaxWidth(),
+                    )
+                }
+                item {
+                    MiniPlayerPadding(
+                        padding = state.miniPlayerPadding,
+                        isUpgradeBannerVisible = state.isUpgradeBannerVisible,
+                    )
+                }
             }
-            HorizontalDivider()
-            ProfileSections(
-                sections = ProfileSection.entries,
-                onClick = onSectionClick,
-                modifier = Modifier.fillMaxWidth(),
-            )
-            VerticalSpacer()
-            var localRefreshState by remember(state.refreshState) { mutableStateOf(state.refreshState) }
-            RefreshSection(
-                refreshState = localRefreshState,
-                onClick = {
-                    localRefreshState = RefreshState.Refreshing
-                    onRefreshClick()
-                },
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(horizontal = horizontalPadding),
-            )
-            VerticalSpacer()
-            ProfileUpgradeSection(
-                isVisible = state.isUpgradeBannerVisible,
-                contentPadding = PaddingValues(
-                    horizontal = 64.dp,
-                    vertical = verticalSpacing,
-                ),
-                onClick = onUpgradeProfileClick,
-                onCloseClick = onCloseUpgradeProfileClick,
-                modifier = Modifier
-                    .background(MaterialTheme.colors.background)
-                    .fillMaxWidth(),
-            )
-            MiniPlayerPadding(
-                padding = state.miniPlayerPadding,
-                isUpgradeBannerVisible = state.isUpgradeBannerVisible,
-            )
         }
     }
 }
@@ -220,46 +250,58 @@ private fun Toolbar(
     }
 }
 
-@Composable
-private fun ColumnScope.HeaderWithStats(
+private fun LazyListScope.HeaderWithStats(
     headerState: ProfileHeaderState,
     statsState: ProfileStatsState,
     onHeaderClick: () -> Unit,
+    isPortrait: Boolean,
 ) {
-    if (LocalConfiguration.current.orientation != Configuration.ORIENTATION_LANDSCAPE) {
-        ProfileHeader(
-            state = headerState,
-            onClick = onHeaderClick,
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(horizontal = horizontalPadding),
-        )
-        VerticalSpacer()
-        ProfileStats(
-            state = statsState,
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(horizontal = horizontalPadding),
-        )
-        VerticalSpacer()
-    } else {
-        Row(
-            verticalAlignment = Alignment.CenterVertically,
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(horizontal = horizontalPadding),
-        ) {
+    if (isPortrait) {
+        item {
             ProfileHeader(
                 state = headerState,
                 onClick = onHeaderClick,
-                modifier = Modifier.weight(1f),
-            )
-            ProfileStats(
-                state = statsState,
-                modifier = Modifier.weight(1f),
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = horizontalPadding),
             )
         }
-        VerticalSpacer()
+        item {
+            VerticalSpacer()
+        }
+        item {
+            ProfileStats(
+                state = statsState,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = horizontalPadding),
+            )
+        }
+        item {
+            VerticalSpacer()
+        }
+    } else {
+        item {
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = horizontalPadding),
+            ) {
+                ProfileHeader(
+                    state = headerState,
+                    onClick = onHeaderClick,
+                    modifier = Modifier.weight(1f),
+                )
+                ProfileStats(
+                    state = statsState,
+                    modifier = Modifier.weight(1f),
+                )
+            }
+        }
+        item {
+            VerticalSpacer()
+        }
     }
 }
 

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/cloud/AddFileActivity.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/cloud/AddFileActivity.kt
@@ -14,6 +14,7 @@ import android.provider.OpenableColumns
 import android.view.MenuItem
 import android.view.View
 import android.widget.Toast
+import androidx.activity.enableEdgeToEdge
 import androidx.activity.viewModels
 import androidx.annotation.StringRes
 import androidx.appcompat.app.AlertDialog
@@ -58,6 +59,7 @@ import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingUpgradeSourc
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import au.com.shiftyjelly.pocketcasts.ui.theme.ThemeColor
 import au.com.shiftyjelly.pocketcasts.utils.Util
+import au.com.shiftyjelly.pocketcasts.views.extensions.setSystemWindowInsetToPadding
 import au.com.shiftyjelly.pocketcasts.views.extensions.setup
 import au.com.shiftyjelly.pocketcasts.views.helper.NavigationIcon
 import au.com.shiftyjelly.pocketcasts.views.helper.UiUtil
@@ -199,9 +201,12 @@ class AddFileActivity :
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         theme.setupThemeForConfig(this, resources.configuration)
+        enableEdgeToEdge(navigationBarStyle = theme.getNavigationBarStyle(this))
+        theme.updateWindowStatusBarIcons(window = window)
 
         binding = ActivityAddFileBinding.inflate(layoutInflater)
         val view = binding.root
+        view.setSystemWindowInsetToPadding(right = true, left = true)
         setContentView(view)
 
         colorAdapter = AddFileColourAdapter(
@@ -260,6 +265,8 @@ class AddFileActivity :
         if (launchedFileChooser) {
             // do nothing as we are returning from the file chooser
         } else if (existingUuid == null) {
+            setupToolbar(title = LR.string.profile_cloud_add_file)
+
             if (isFileChooserMode) {
                 launchFileChooser()
                 return
@@ -272,14 +279,14 @@ class AddFileActivity :
             }
             setupForNewFile(dataUri)
         } else {
+            setupToolbar(title = LR.string.profile_cloud_edit_file)
+
             launch {
                 val userEpisode = getUserEpisode(existingUuid)
                 if (userEpisode == null) {
                     finish()
                     return@launch
                 }
-
-                setupToolbar(title = LR.string.profile_cloud_edit_file)
 
                 binding.lblFilename.text = ""
                 binding.lblFilesize.text = Util.formattedBytes(bytes = userEpisode.sizeInBytes, context = binding.lblFilesize.context)

--- a/modules/features/profile/src/main/res/layout/activity_add_file.xml
+++ b/modules/features/profile/src/main/res/layout/activity_add_file.xml
@@ -1,36 +1,28 @@
 <?xml version="1.0" encoding="utf-8"?>
-<FrameLayout
+<LinearLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/container"
-    android:background="?attr/primary_ui_03"
+    android:background="?attr/primary_ui_01"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    android:orientation="vertical">
 
-    <com.google.android.material.appbar.AppBarLayout
-        android:id="@+id/toolbarLayout"
+    <androidx.appcompat.widget.Toolbar
+        android:id="@+id/toolbar"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content">
-
-        <androidx.appcompat.widget.Toolbar
-            android:id="@+id/toolbar"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:background="?attr/secondary_ui_01"
-            android:minHeight="?android:attr/actionBarSize"
-            android:paddingLeft="0dp"
-            android:paddingStart="0dp"
-            android:paddingRight="20dp"
-            android:paddingEnd="20dp"/>
-    </com.google.android.material.appbar.AppBarLayout>
+        android:layout_height="wrap_content"
+        android:background="?attr/secondary_ui_01"
+        android:paddingLeft="0dp"
+        android:paddingStart="0dp"
+        android:paddingRight="20dp"
+        android:paddingEnd="20dp"/>
 
     <ScrollView
         android:id="@+id/mainScrollView"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:layout_marginTop="?android:actionBarSize"
-        android:background="?attr/primary_ui_03"
         android:fillViewport="true"
         tools:ignore="UnusedIds">
 
@@ -99,7 +91,6 @@
                 android:id="@+id/containerImage"
                 android:layout_width="match_parent"
                 android:layout_height="330dp"
-                android:background="?attr/primary_ui_03"
                 android:layout_marginTop="16dp"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
@@ -197,6 +188,12 @@
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toBottomOf="@+id/recyclerColor" />
 
+            <au.com.shiftyjelly.pocketcasts.views.component.NavigationBarSpacer
+                android:layout_width="match_parent"
+                android:layout_height="0dp"
+                app:layout_constraintTop_toBottomOf="@+id/upgradeLayout"
+                app:layout_constraintBottom_toBottomOf="parent" />
+
         </androidx.constraintlayout.widget.ConstraintLayout>
     </ScrollView>
 
@@ -204,7 +201,6 @@
         android:id="@+id/layoutLoading"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:background="#aa000000"
         android:visibility="gone">
         <ProgressBar
             android:layout_width="wrap_content"
@@ -212,4 +208,4 @@
             android:layout_gravity="center"/>
     </FrameLayout>
 
-</FrameLayout>
+</LinearLayout>

--- a/modules/features/referrals/src/main/kotlin/au/com/shiftyjelly/pocketcasts/referrals/ReferralsClaimGuestPassPage.kt
+++ b/modules/features/referrals/src/main/kotlin/au/com/shiftyjelly/pocketcasts/referrals/ReferralsClaimGuestPassPage.kt
@@ -9,8 +9,10 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.foundation.rememberScrollState
@@ -250,7 +252,9 @@ private fun ClaimGuestPassContent(
         horizontalAlignment = Alignment.CenterHorizontally,
         modifier = Modifier
             .verticalScroll(rememberScrollState())
-            .padding(16.dp),
+            .padding(horizontal = 16.dp, vertical = 8.dp)
+            .statusBarsPadding()
+            .navigationBarsPadding(),
     ) {
         val language = Locale.current.language
         val titleTextResId = if (language == "en") {

--- a/modules/features/referrals/src/main/kotlin/au/com/shiftyjelly/pocketcasts/referrals/ReferralsGuestPassError.kt
+++ b/modules/features/referrals/src/main/kotlin/au/com/shiftyjelly/pocketcasts/referrals/ReferralsGuestPassError.kt
@@ -4,7 +4,9 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Button
 import androidx.compose.material.ButtonDefaults
@@ -38,7 +40,9 @@ fun ReferralsGuestPassError(
         horizontalAlignment = Alignment.CenterHorizontally,
         modifier = Modifier
             .fillMaxSize()
-            .padding(16.dp),
+            .padding(horizontal = 16.dp, vertical = 8.dp)
+            .statusBarsPadding()
+            .navigationBarsPadding(),
     ) {
         CloseButton(
             modifier = Modifier

--- a/modules/features/referrals/src/main/kotlin/au/com/shiftyjelly/pocketcasts/referrals/ReferralsGuestPassFragment.kt
+++ b/modules/features/referrals/src/main/kotlin/au/com/shiftyjelly/pocketcasts/referrals/ReferralsGuestPassFragment.kt
@@ -37,6 +37,8 @@ class ReferralsGuestPassFragment : BaseFragment() {
     private val args get() = requireNotNull(arguments?.let { BundleCompat.getParcelable(it, NEW_INSTANCE_ARG, Args::class.java) })
     private val pageType get() = args.pageType
 
+    override var statusBarIconColor: StatusBarIconColor = StatusBarIconColor.Light
+
     @OptIn(ExperimentalMaterial3WindowSizeClassApi::class)
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -87,7 +89,7 @@ class ReferralsGuestPassFragment : BaseFragment() {
     private fun updateStatusAndNavColors() {
         activity?.let {
             theme.updateWindowNavigationBarColor(window = it.window, navigationBarColor = NavigationBarColor.Color(color = Color.BLACK, lightIcons = true))
-            theme.updateWindowStatusBarIcons(window = it.window, statusBarIconColor = StatusBarIconColor.Dark)
+            theme.updateWindowStatusBarIcons(window = it.window, statusBarIconColor = StatusBarIconColor.Light)
         }
     }
 

--- a/modules/features/referrals/src/main/kotlin/au/com/shiftyjelly/pocketcasts/referrals/ReferralsInvalidOfferPage.kt
+++ b/modules/features/referrals/src/main/kotlin/au/com/shiftyjelly/pocketcasts/referrals/ReferralsInvalidOfferPage.kt
@@ -9,7 +9,9 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.foundation.rememberScrollState
@@ -106,7 +108,9 @@ private fun ReferralsInvalidOfferPageContent(
                 horizontalAlignment = Alignment.CenterHorizontally,
                 modifier = Modifier
                     .verticalScroll(rememberScrollState())
-                    .padding(16.dp),
+                    .padding(16.dp)
+                    .statusBarsPadding()
+                    .navigationBarsPadding(),
             ) {
                 Spacer(modifier = Modifier.height(48.dp))
 

--- a/modules/features/referrals/src/main/kotlin/au/com/shiftyjelly/pocketcasts/referrals/ReferralsSendGuestPassPage.kt
+++ b/modules/features/referrals/src/main/kotlin/au/com/shiftyjelly/pocketcasts/referrals/ReferralsSendGuestPassPage.kt
@@ -9,9 +9,11 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.foundation.rememberScrollState
@@ -175,7 +177,9 @@ private fun SendGuestPassContent(
         horizontalAlignment = Alignment.CenterHorizontally,
         modifier = Modifier
             .verticalScroll(rememberScrollState())
-            .padding(16.dp),
+            .padding(horizontal = 16.dp, vertical = 8.dp)
+            .statusBarsPadding()
+            .navigationBarsPadding(),
     ) {
         CloseButton(
             modifier = Modifier

--- a/modules/services/ui/src/main/java/au/com/shiftyjelly/pocketcasts/ui/theme/Theme.kt
+++ b/modules/services/ui/src/main/java/au/com/shiftyjelly/pocketcasts/ui/theme/Theme.kt
@@ -402,7 +402,7 @@ class Theme @Inject constructor(private val settings: Settings) {
             return
         }
 
-        val color = statusBarIconColor ?: (if (isDarkTheme) StatusBarIconColor.Dark else StatusBarIconColor.Light)
+        val color = statusBarIconColor ?: StatusBarIconColor.Theme
         when (color) {
             StatusBarIconColor.Theme -> {
                 if (activeTheme.toolbarLightIcons) {

--- a/modules/services/ui/src/main/res/values/themes.xml
+++ b/modules/services/ui/src/main/res/values/themes.xml
@@ -412,8 +412,6 @@
         <item name="isDark">true</item>
         <item name="isImageTintEnabled">false</item>
         <item name="imageTintThemeCacheTag">dark</item>
-        <item name="enableEdgeToEdge">true</item>
-        <item name="android:navigationBarColor">@android:color/transparent</item>
 
         <!-- Default colours -->
         <item name="colorSearchBox">@color/searchBoxDark</item>

--- a/modules/services/ui/src/main/res/values/themes.xml
+++ b/modules/services/ui/src/main/res/values/themes.xml
@@ -412,6 +412,8 @@
         <item name="isDark">true</item>
         <item name="isImageTintEnabled">false</item>
         <item name="imageTintThemeCacheTag">dark</item>
+        <item name="enableEdgeToEdge">true</item>
+        <item name="android:navigationBarColor">@android:color/transparent</item>
 
         <!-- Default colours -->
         <item name="colorSearchBox">@color/searchBoxDark</item>

--- a/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/multiselect/MultiSelectToolbar.kt
+++ b/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/multiselect/MultiSelectToolbar.kt
@@ -16,6 +16,7 @@ import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTracker
 import au.com.shiftyjelly.pocketcasts.analytics.SourceView
 import au.com.shiftyjelly.pocketcasts.ui.extensions.getThemeColor
 import au.com.shiftyjelly.pocketcasts.views.R
+import au.com.shiftyjelly.pocketcasts.views.extensions.includeStatusBarPadding
 import au.com.shiftyjelly.pocketcasts.views.extensions.tintIcons
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
@@ -40,6 +41,7 @@ class MultiSelectToolbar @JvmOverloads constructor(
         multiSelectHelper: MultiSelectHelper<T>,
         @MenuRes menuRes: Int?,
         activity: FragmentActivity,
+        includeStatusBarPadding: Boolean = true,
     ) {
         setBackgroundColor(context.getThemeColor(UR.attr.support_01))
         if (menuRes != null) {
@@ -111,6 +113,10 @@ class MultiSelectToolbar @JvmOverloads constructor(
             multiSelectHelper.isMultiSelecting = false
         }
         navigationContentDescription = context.getString(LR.string.back)
+
+        if (includeStatusBarPadding) {
+            includeStatusBarPadding()
+        }
     }
 
     private fun showOverflowBottomSheet(

--- a/modules/services/views/src/main/res/layout/layout_plus_callout.xml
+++ b/modules/services/views/src/main/res/layout/layout_plus_callout.xml
@@ -6,7 +6,6 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:layout_marginTop="16dp"
-    android:background="?attr/primary_ui_03"
     tools:layout_height="200dp">
 
     <View
@@ -90,7 +89,8 @@
 
     <Space
         android:layout_width="wrap_content"
-        android:layout_height="64dp"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="16dp"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@id/lblFindMore" />


### PR DESCRIPTION
## Description

Upgrading to Android 15 edge-to-edge caused the adding of a user file toolbar to be under the status bar, this change fixes that and cleans up the page.

## Testing Instructions

1. Go to the Profile tab
2. Tap Files
3. Tap the Plus + FAB 
4. Pick a media file
5. ✅ Verify the Add File page looks correct and no page content if hidden under the status or navigation bar.

## Screenshots

<img width="1487" alt="Screenshot 2025-01-13 at 4 28 31 pm" src="https://github.com/user-attachments/assets/f935ac66-8cb3-469e-a39d-1e1d6e1b4ab5" />

<img width="1484" alt="Screenshot 2025-01-13 at 4 46 23 pm" src="https://github.com/user-attachments/assets/dd9d070d-d334-4494-93a2-54b6d20a01d3" />

![Screenshot_20250113_164701](https://github.com/user-attachments/assets/b82f1872-858c-4dbc-b937-d0e8faa308f2)

![Screenshot_20250113_164735](https://github.com/user-attachments/assets/20e6650e-8c11-4a23-bf40-0d1e6903aeb4)

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack
