### PR TITLE
[Tooling] Fix hiccups in hotfix process

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -136,7 +136,7 @@ platform :android do
       new_version: new_version,
       release_notes_file_path: RELEASE_NOTES_SOURCE_PATH
     )
-    push_to_git_remote(tags: false)
+    push_to_git_remote(set_upstream: true, tags: false)
 
     trigger_release_build(branch_to_build: "release/#{new_version}")
     create_backmerge_pr
@@ -272,6 +272,7 @@ platform :android do
       version_code: new_version_code
     )
     commit_version_bump
+    push_to_git_remote(set_upstream: true, tags: false)
     UI.success("Done! New Release Version: #{release_version_current}. New Build Code: #{build_code_current}")
   end
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -288,7 +288,13 @@ platform :android do
     UI.user_error!("Terminating as requested. Don't forget to run the remainder of this automation manually.") unless skip_confirm || UI.confirm('Do you want to continue?')
 
     trigger_release_build(branch_to_build: "release/#{version}")
+
     create_backmerge_pr
+    begin
+      close_milestone(repository: GITHUB_REPO, milestone: release_version_current)
+    rescue
+      UI.important("Could not find a GitHub milestone for hotfix #{release_version_current} to close.")
+    end
   end
 
   # Update the rollout of all 3 variants (app, automotive, wear) of the current version to the given value

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -292,8 +292,8 @@ platform :android do
     create_backmerge_pr
     begin
       close_milestone(repository: GITHUB_REPO, milestone: release_version_current)
-    rescue
-      UI.important("Could not find a GitHub milestone for hotfix #{release_version_current} to close.")
+    rescue StandardError => e
+      UI.important("Could not find a GitHub milestone for hotfix #{release_version_current} to close: #{e}")
     end
   end
 


### PR DESCRIPTION
_Note: [iOS companion PR here](https://github.com/Automattic/pocket-casts-ios/pull/2633)_

[Internal Refs]
 - Slack Thread about the hotfix process feedback: p1733831549430849/1733504114.702699-slack-C028JAG44VD
 - Related MC scenario PR: 170061-ghe-Automattic/wpcom

## Description

Addressing some feedback reported by devs / release managers on the process during the last time they did a hotfix

- Ensure the hotfix branch is pushed to upstream after it has been created
- Ensure we close the GitHub hotfix milestone at the end of the hotfix

## Testing Instructions

This won't really be testable until next time we do a hotfix, unfortunately, as testing those lanes would otherwise create side effects.