### PR TITLE
Fix player actions pages

### DIFF
--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/ShelfBottomSheet.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/ShelfBottomSheet.kt
@@ -1,5 +1,6 @@
 package au.com.shiftyjelly.pocketcasts.player.view
 
+import android.graphics.Color
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.ViewGroup
@@ -14,6 +15,7 @@ import au.com.shiftyjelly.pocketcasts.player.viewmodel.ShelfSharedViewModel
 import au.com.shiftyjelly.pocketcasts.player.viewmodel.ShelfViewModel
 import au.com.shiftyjelly.pocketcasts.ui.helper.FragmentHostListener
 import au.com.shiftyjelly.pocketcasts.ui.helper.StatusBarIconColor
+import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import au.com.shiftyjelly.pocketcasts.views.fragments.BaseDialogFragment
 import dagger.hilt.android.AndroidEntryPoint
 import dagger.hilt.android.lifecycle.withCreationCallback
@@ -43,10 +45,12 @@ class ShelfBottomSheet : BaseDialogFragment() {
         container: ViewGroup?,
         savedInstanceState: Bundle?,
     ) = contentWithoutConsumedInsets {
+        // set the initial background color to black to stop the dialog from flashing white
+        setDialogTint(Color.BLACK)
         playerViewModel.playingEpisodeLive.observe(viewLifecycleOwner) { (_, backgroundColor) ->
             setDialogTint(backgroundColor)
         }
-        AppTheme(theme.activeTheme) {
+        AppTheme(Theme.ThemeType.DARK) {
             ShelfBottomSheetPage(
                 shelfViewModel = shelfViewModel,
                 shelfSharedViewModel = shelfSharedViewModel,

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/shelf/MenuShelfItems.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/shelf/MenuShelfItems.kt
@@ -1,6 +1,9 @@
 package au.com.shiftyjelly.pocketcasts.player.view.shelf
 
 import androidx.compose.animation.core.animateDpAsState
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material.Surface
@@ -32,6 +35,7 @@ fun MenuShelfItems(
     shelfViewModel: ShelfViewModel,
     normalBackgroundColor: Color = Color.Transparent,
     selectedBackgroundColor: Color = Color.Black,
+    navigationBarPadding: Boolean = false,
     onClick: ((ShelfItem, Boolean) -> Unit)? = null,
 ) {
     val uiState by shelfViewModel.uiState.collectAsStateWithLifecycle()
@@ -40,6 +44,7 @@ fun MenuShelfItems(
         selectedBackgroundColor = selectedBackgroundColor,
         normalBackgroundColor = normalBackgroundColor,
         onClick = onClick,
+        includeNavigationBarsPadding = navigationBarPadding,
         onMove = { from, to -> shelfViewModel.onShelfItemMove(from, to) },
     )
 }
@@ -49,6 +54,7 @@ private fun Content(
     state: UiState,
     selectedBackgroundColor: Color,
     normalBackgroundColor: Color,
+    includeNavigationBarsPadding: Boolean = true,
     onClick: ((ShelfItem, Boolean) -> Unit)? = null,
     onMove: (from: Int, to: Int) -> Unit,
 ) {
@@ -58,8 +64,10 @@ private fun Content(
         onMove(from.index, to.index)
     }
 
-    LazyColumn(state = lazyListState) {
-        items.forEachIndexed { index, listItem ->
+    LazyColumn(
+        state = lazyListState,
+    ) {
+        items.forEach { listItem ->
             when (listItem) {
                 is ShelfItem -> {
                     item(key = listItem.id) {
@@ -87,6 +95,14 @@ private fun Content(
                     }
                 }
             }
+        }
+        item {
+            Spacer(
+                modifier = Modifier
+                    // add the bottom padding in the list so the content is under the navigation bar but last item is above it
+                    .let { if (includeNavigationBarsPadding) it.navigationBarsPadding() else it }
+                    .height(8.dp),
+            )
         }
     }
 }

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/shelf/ShelfRearrangeActionsPage.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/shelf/ShelfRearrangeActionsPage.kt
@@ -2,7 +2,6 @@ package au.com.shiftyjelly.pocketcasts.player.view.shelf
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.material.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
@@ -24,7 +23,6 @@ import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import au.com.shiftyjelly.pocketcasts.ui.theme.ThemeColor
 import kotlinx.coroutines.flow.distinctUntilChangedBy
 import kotlinx.coroutines.flow.map
-import android.graphics.Color as AndroidColor
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 @Composable
@@ -35,9 +33,10 @@ fun ShelfRearrangeActionsPage(
     playerViewModel: PlayerViewModel,
     onBackPressed: () -> Unit,
 ) {
-    val iconColorInt = ThemeColor.playerContrast01(theme.activeTheme)
+    val iconColor = Color(ThemeColor.playerContrast01(theme.activeTheme))
     val backgroundColorInt = theme.playerBackground2Color(playerViewModel.podcast)
-    val toolbarColorInt = theme.playerBackgroundColor(playerViewModel.podcast)
+    val backgroundColor = Color(backgroundColorInt)
+    val toolbarColor = Color(theme.playerBackgroundColor(playerViewModel.podcast))
     val selectedColorInt = theme.playerHighlight7Color(playerViewModel.podcast)
     val selectedBackgroundInt = remember(backgroundColorInt, selectedColorInt) { ColorUtils.calculateCombinedColor(backgroundColorInt, selectedColorInt) }
 
@@ -49,15 +48,16 @@ fun ShelfRearrangeActionsPage(
     }.collectAsStateWithLifecycle(null)
 
     Content(
-        backgroundColorInt = backgroundColorInt,
-        toolbarColorInt = toolbarColorInt,
-        iconColorInt = iconColorInt,
+        backgroundColor = backgroundColor,
+        toolbarColor = toolbarColor,
+        iconColor = iconColor,
         onBackPressed = onBackPressed,
     ) {
         MenuShelfItems(
             shelfViewModel = shelfViewModel,
-            normalBackgroundColor = Color(AndroidColor.parseColor(ColorUtils.colorIntToHexString(backgroundColorInt))),
-            selectedBackgroundColor = Color(AndroidColor.parseColor(ColorUtils.colorIntToHexString(selectedBackgroundInt))),
+            navigationBarPadding = true,
+            normalBackgroundColor = Color(backgroundColorInt),
+            selectedBackgroundColor = Color(selectedBackgroundInt),
         )
     }
 
@@ -76,22 +76,18 @@ fun ShelfRearrangeActionsPage(
 
 @Composable
 private fun Content(
-    backgroundColorInt: Int,
-    toolbarColorInt: Int,
-    iconColorInt: Int,
+    backgroundColor: Color,
+    toolbarColor: Color,
+    iconColor: Color,
     onBackPressed: () -> Unit,
     menuShelfItems: @Composable () -> Unit,
 ) {
-    Column(
-        modifier = Modifier
-            .background(Color(AndroidColor.parseColor(ColorUtils.colorIntToHexString(backgroundColorInt))))
-            .navigationBarsPadding(),
-    ) {
+    Column(modifier = Modifier.background(backgroundColor)) {
         ThemedTopAppBar(
             title = stringResource(LR.string.rearrange_actions),
-            backgroundColor = Color(AndroidColor.parseColor(ColorUtils.colorIntToHexString(toolbarColorInt))),
+            backgroundColor = toolbarColor,
             textColor = MaterialTheme.theme.colors.playerContrast01,
-            iconColor = Color(AndroidColor.parseColor(ColorUtils.colorIntToHexString(iconColorInt))),
+            iconColor = iconColor,
             bottomShadow = true,
             onNavigationClick = { onBackPressed() },
         )


### PR DESCRIPTION
## Description

The end of the "Rearrange Actions" page list wasn't visible while scrolling under the navigation bar. Instead, the navigation bar was a solid colour. This change fixes this and some other minor issues such as the previous dialog flashing when opening.

## Testing Instructions
1. Open the full screen player
2. Tap the three dots in the action shelf
3. ✅ Verify the background of the dialog doesn't flash
4. Tap the edit pencil 
5. Scroll to the bottom of the list
6. ✅ Verify the list goes under the navigation bar and that the last actions don't stop under the navigation bar

## Screenshots

Before
<img width="1485" alt="Screenshot 2025-01-16 at 12 33 33 pm" src="https://github.com/user-attachments/assets/4a23c084-6c57-429b-986a-edbc4b7915e5" />

After
<img width="1486" alt="Screenshot 2025-01-16 at 1 28 12 pm" src="https://github.com/user-attachments/assets/1bdb784f-41c5-421f-ae58-d28492f5c8e8" />
<img width="1487" alt="Screenshot 2025-01-16 at 1 28 25 pm" src="https://github.com/user-attachments/assets/950b86d3-1107-469c-b106-780bba28fe72" />

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack
