### PR TITLE
Add Winback view model

### DIFF
--- a/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
+++ b/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
@@ -585,9 +585,8 @@ class MainActivity :
             source = PocketCastsShortcuts.Source.REFRESH_APP,
         )
 
-        lifecycleScope.launch {
-            subscriptionManager.refreshPurchases()
-        }
+        lifecycleScope.launch { subscriptionManager.refreshProducts() }
+        lifecycleScope.launch { subscriptionManager.refreshPurchases() }
 
         // Schedule next refresh in the background
         RefreshPodcastsTask.scheduleOrCancel(this@MainActivity, settings)

--- a/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
+++ b/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
@@ -585,8 +585,7 @@ class MainActivity :
             source = PocketCastsShortcuts.Source.REFRESH_APP,
         )
 
-        lifecycleScope.launch { subscriptionManager.refreshProducts() }
-        lifecycleScope.launch { subscriptionManager.refreshPurchases() }
+        lifecycleScope.launch { subscriptionManager.refresh() }
 
         // Schedule next refresh in the background
         RefreshPodcastsTask.scheduleOrCancel(this@MainActivity, settings)

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/OnboardingUpgradeBottomSheetViewModel.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/OnboardingUpgradeBottomSheetViewModel.kt
@@ -62,7 +62,7 @@ class OnboardingUpgradeBottomSheetViewModel @Inject constructor(
                 .stateIn(viewModelScope)
                 .collect { productDetails ->
                     val subscriptions = when (productDetails) {
-                        is ProductDetailsState.Loading, ProductDetailsState.Failure -> null
+                        is ProductDetailsState.Failure -> null
                         is ProductDetailsState.Loaded -> productDetails.productDetails.mapNotNull { productDetailsState ->
                             subscriptionMapper.mapFromProductDetails(
                                 productDetails = productDetailsState,

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/OnboardingUpgradeBottomSheetViewModel.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/OnboardingUpgradeBottomSheetViewModel.kt
@@ -62,7 +62,7 @@ class OnboardingUpgradeBottomSheetViewModel @Inject constructor(
                 .stateIn(viewModelScope)
                 .collect { productDetails ->
                     val subscriptions = when (productDetails) {
-                        is ProductDetailsState.Error -> null
+                        is ProductDetailsState.Loading, ProductDetailsState.Failure -> null
                         is ProductDetailsState.Loaded -> productDetails.productDetails.mapNotNull { productDetailsState ->
                             subscriptionMapper.mapFromProductDetails(
                                 productDetails = productDetailsState,

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/OnboardingUpgradeFeaturesViewModel.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/OnboardingUpgradeFeaturesViewModel.kt
@@ -65,7 +65,7 @@ class OnboardingUpgradeFeaturesViewModel @Inject constructor(
                 .stateIn(viewModelScope)
                 .collect { productDetails ->
                     val subscriptions = when (productDetails) {
-                        is ProductDetailsState.Loading, ProductDetailsState.Failure -> emptyList()
+                        is ProductDetailsState.Failure -> emptyList()
                         is ProductDetailsState.Loaded -> productDetails.productDetails.mapNotNull { productDetailsState ->
                             subscriptionMapper.mapFromProductDetails(
                                 productDetails = productDetailsState,

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/OnboardingUpgradeFeaturesViewModel.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/OnboardingUpgradeFeaturesViewModel.kt
@@ -65,7 +65,7 @@ class OnboardingUpgradeFeaturesViewModel @Inject constructor(
                 .stateIn(viewModelScope)
                 .collect { productDetails ->
                     val subscriptions = when (productDetails) {
-                        is ProductDetailsState.Error -> emptyList()
+                        is ProductDetailsState.Loading, ProductDetailsState.Failure -> emptyList()
                         is ProductDetailsState.Loaded -> productDetails.productDetails.mapNotNull { productDetailsState ->
                             subscriptionMapper.mapFromProductDetails(
                                 productDetails = productDetailsState,

--- a/modules/features/profile/build.gradle.kts
+++ b/modules/features/profile/build.gradle.kts
@@ -81,4 +81,6 @@ dependencies {
     testImplementation(libs.mockito.core)
     testImplementation(libs.mockito.kotlin)
     testImplementation(libs.turbine)
+
+    testImplementation(projects.modules.services.sharedtest)
 }

--- a/modules/features/profile/build.gradle.kts
+++ b/modules/features/profile/build.gradle.kts
@@ -75,4 +75,10 @@ dependencies {
     implementation(projects.modules.services.images)
     implementation(projects.modules.services.localization)
     implementation(projects.modules.services.utils)
+
+    testImplementation(libs.coroutines.test)
+    testImplementation(libs.junit)
+    testImplementation(libs.mockito.core)
+    testImplementation(libs.mockito.kotlin)
+    testImplementation(libs.turbine)
 }

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/winback/WinbackOfferPage.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/winback/WinbackOfferPage.kt
@@ -56,7 +56,6 @@ internal fun WinbackOfferPage(
     modifier: Modifier = Modifier,
 ) {
     Column(
-        verticalArrangement = Arrangement.spacedBy(16.dp),
         modifier = modifier
             .fillMaxSize()
             .nestedScroll(rememberNestedScrollInteropConnection())

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/winback/WinbackViewModel.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/winback/WinbackViewModel.kt
@@ -64,7 +64,7 @@ class WinbackViewModel @Inject constructor(
 
 internal data class SubscriptionPlan(
     val productId: String,
-    val offetToken: String,
+    val offerToken: String,
     val name: String,
     val formattedPrice: String,
     val billingPeriod: BillingPeriod,
@@ -111,7 +111,7 @@ private fun createAvailablePlans(
 
 private fun Subscription.Simple.toPlan() = SubscriptionPlan(
     productId = productDetails.productId,
-    offetToken = offerToken,
+    offerToken = offerToken,
     name = shortTitle,
     formattedPrice = recurringPricingPhase.formattedPrice,
     billingPeriod = when (recurringPricingPhase) {

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/winback/WinbackViewModel.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/winback/WinbackViewModel.kt
@@ -2,72 +2,123 @@ package au.com.shiftyjelly.pocketcasts.profile.winback
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import au.com.shiftyjelly.pocketcasts.models.to.SignInState
-import au.com.shiftyjelly.pocketcasts.models.to.SubscriptionStatus
 import au.com.shiftyjelly.pocketcasts.models.type.Subscription
 import au.com.shiftyjelly.pocketcasts.models.type.SubscriptionMapper
 import au.com.shiftyjelly.pocketcasts.models.type.SubscriptionPricingPhase
 import au.com.shiftyjelly.pocketcasts.repositories.subscription.ProductDetailsState
+import au.com.shiftyjelly.pocketcasts.repositories.subscription.PurchasesState
 import au.com.shiftyjelly.pocketcasts.repositories.subscription.SubscriptionManager
-import au.com.shiftyjelly.pocketcasts.repositories.user.UserManager
 import com.android.billingclient.api.ProductDetails
+import com.android.billingclient.api.Purchase
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
-import kotlinx.coroutines.flow.SharingStarted
-import kotlinx.coroutines.flow.combine
-import kotlinx.coroutines.flow.stateIn
-import kotlinx.coroutines.reactive.asFlow
+import kotlinx.coroutines.async
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
 
 @HiltViewModel
 class WinbackViewModel @Inject constructor(
-    val userManager: UserManager,
     val subscriptionManager: SubscriptionManager,
 ) : ViewModel() {
-    private val signInState = userManager.getSignInState().asFlow()
+    private val subscriptionMapper = SubscriptionMapper()
 
-    private val productDetails = subscriptionManager.observeProductDetails().asFlow()
+    private val _uiState = MutableStateFlow(UiState.Empty)
+    internal val uiState = _uiState.asStateFlow()
 
-    internal val uiState = combine(
-        signInState,
-        productDetails,
-    ) { signInState, productsState ->
-        val primarySubscription = signInState.findPrimarySubscription()
-        UiState(
-            userSubscriptionId = primarySubscription?.plan,
-            googleBillingProducts = when (productsState) {
-                is ProductDetailsState.Failure, ProductDetailsState.Loading -> emptyList()
-                is ProductDetailsState.Loaded -> productsState.productDetails
-            },
-            availablePlans = if (primarySubscription != null) {
-                createAvailablePlans(productsState)
-            } else {
-                AvailablePlans.Failure
-            },
+    init {
+        loadInitialPlans()
+    }
 
-        )
-    }.stateIn(viewModelScope, SharingStarted.Eagerly, UiState.Empty)
+    private fun loadInitialPlans() {
+        _uiState.value = _uiState.value.copy(subscriptionPlansState = SubscriptionPlansState.Loading)
+        viewModelScope.launch {
+            val plansDeferred = async { loadPlans() }
+            val activePurchaseDeferred = async { loadActivePurchase() }
+
+            val plansResult = plansDeferred.await()
+            val activePurchaseResult = activePurchaseDeferred.await()
+
+            val productsDetails = plansResult?.first.orEmpty()
+            val plans = plansResult?.second
+            val purchases = activePurchaseResult?.first.orEmpty()
+            val activePurchase = activePurchaseResult?.second
+
+            _uiState.value = _uiState.value.copy(
+                productsDetails = productsDetails,
+                purchases = purchases,
+                subscriptionPlansState = if (plans == null || activePurchase == null) {
+                    SubscriptionPlansState.Failure
+                } else {
+                    SubscriptionPlansState.Loaded(activePurchase, plans)
+                },
+            )
+        }
+    }
+
+    private suspend fun loadPlans() = when (val state = subscriptionManager.loadProducts()) {
+        is ProductDetailsState.Loaded -> state.productDetails to state.productDetails.toSubscriptionPlans()
+        is ProductDetailsState.Failure -> null
+    }
+
+    private suspend fun loadActivePurchase() = when (val state = subscriptionManager.loadPurchases()) {
+        is PurchasesState.Loaded -> state.purchases to state.purchases.findActivePurchase()
+        is PurchasesState.Failure -> null
+    }
+
+    private fun List<ProductDetails>.toSubscriptionPlans() = map(subscriptionMapper::mapFromProductDetails)
+        .filterIsInstance<Subscription.Simple>()
+        .map(Subscription.Simple::toPlan)
+        .sortedWith(PlanComparator)
+
+    private fun List<Purchase>.findActivePurchase(): ActivePurchase? {
+        val purchase = filter(Purchase::isAcknowledged).singleOrNull()
+        val orderId = purchase?.orderId
+        val productId = purchase?.products?.singleOrNull()
+        return if (orderId != null && productId != null) {
+            ActivePurchase(orderId, productId)
+        } else {
+            null
+        }
+    }
 
     internal data class UiState(
-        val userSubscriptionId: String?,
-        val googleBillingProducts: List<ProductDetails>,
-        val availablePlans: AvailablePlans,
+        val productsDetails: List<ProductDetails>,
+        val purchases: List<Purchase>,
+        val subscriptionPlansState: SubscriptionPlansState,
     ) {
         companion object {
             val Empty = UiState(
-                userSubscriptionId = null,
-                googleBillingProducts = emptyList(),
-                availablePlans = AvailablePlans.Loading,
+                purchases = emptyList(),
+                productsDetails = emptyList(),
+                subscriptionPlansState = SubscriptionPlansState.Loading,
             )
         }
     }
 }
 
+internal sealed interface SubscriptionPlansState {
+    data object Loading : SubscriptionPlansState
+
+    data object Failure : SubscriptionPlansState
+
+    data class Loaded(
+        val activePurchase: ActivePurchase,
+        val plans: List<SubscriptionPlan>,
+    ) : SubscriptionPlansState
+}
+
 internal data class SubscriptionPlan(
     val productId: String,
     val offerToken: String,
-    val name: String,
+    val title: String,
     val formattedPrice: String,
     val billingPeriod: BillingPeriod,
+)
+
+internal data class ActivePurchase(
+    val orderId: String,
+    val productId: String,
 )
 
 internal enum class BillingPeriod {
@@ -75,44 +126,10 @@ internal enum class BillingPeriod {
     Yearly,
 }
 
-internal sealed interface AvailablePlans {
-    data object Loading : AvailablePlans
-
-    data object Failure : AvailablePlans
-
-    data class Loaded(
-        val plans: List<SubscriptionPlan>,
-    ) : AvailablePlans
-}
-
-private fun SignInState.findPrimarySubscription() = when (this) {
-    is SignInState.SignedOut -> null
-    is SignInState.SignedIn -> when (val subscriptionStatus = subscriptionStatus) {
-        is SubscriptionStatus.Free -> null
-        is SubscriptionStatus.Paid -> subscriptionStatus.subscriptions.find { it.isPrimarySubscription }
-    }
-}
-
-private fun createAvailablePlans(
-    productDetailsState: ProductDetailsState,
-) = when (productDetailsState) {
-    is ProductDetailsState.Loading -> AvailablePlans.Loading
-    is ProductDetailsState.Failure -> AvailablePlans.Failure
-    is ProductDetailsState.Loaded -> {
-        val mapper = SubscriptionMapper()
-        val plans = productDetailsState.productDetails
-            .map(mapper::mapFromProductDetails)
-            .filterIsInstance<Subscription.Simple>()
-            .map(Subscription.Simple::toPlan)
-            .sortedWith(PlanComparator)
-        AvailablePlans.Loaded(plans)
-    }
-}
-
 private fun Subscription.Simple.toPlan() = SubscriptionPlan(
     productId = productDetails.productId,
     offerToken = offerToken,
-    name = shortTitle,
+    title = shortTitle,
     formattedPrice = recurringPricingPhase.formattedPrice,
     billingPeriod = when (recurringPricingPhase) {
         is SubscriptionPricingPhase.Months -> BillingPeriod.Monthly
@@ -135,7 +152,7 @@ private object PlanComparator : Comparator<SubscriptionPlan> {
             priority1 != null && priority2 != null -> priority1 - priority2
             priority1 != null && priority2 == null -> -1
             priority1 == null && priority2 != null -> 1
-            else -> o1.name.compareTo(o2.name)
+            else -> o1.title.compareTo(o2.title)
         }
     }
 }

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/winback/WinbackViewModel.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/winback/WinbackViewModel.kt
@@ -1,0 +1,88 @@
+package au.com.shiftyjelly.pocketcasts.profile.winback
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import au.com.shiftyjelly.pocketcasts.models.to.SignInState
+import au.com.shiftyjelly.pocketcasts.models.to.SubscriptionStatus
+import au.com.shiftyjelly.pocketcasts.models.type.Subscription
+import au.com.shiftyjelly.pocketcasts.models.type.SubscriptionMapper
+import au.com.shiftyjelly.pocketcasts.repositories.subscription.ProductDetailsState
+import au.com.shiftyjelly.pocketcasts.repositories.subscription.SubscriptionManager
+import au.com.shiftyjelly.pocketcasts.repositories.user.UserManager
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.reactive.asFlow
+
+@HiltViewModel
+class WinbackViewModel @Inject constructor(
+    val userManager: UserManager,
+    val subscriptionManager: SubscriptionManager,
+) : ViewModel() {
+    private val signInState = userManager.getSignInState().asFlow()
+
+    private val productDetails = subscriptionManager.observeProductDetails().asFlow()
+
+    internal val uiState = combine(
+        signInState,
+        productDetails,
+    ) { signInState, productDetails ->
+        UiState(
+            subscriptionsState = createAvailablePlans(signInState, productDetails),
+        )
+    }.stateIn(viewModelScope, SharingStarted.Eagerly, UiState.Empty)
+
+    internal data class UiState(
+        val subscriptionsState: SubscriptionsState,
+    ) {
+        companion object {
+            val Empty = UiState(
+                subscriptionsState = SubscriptionsState.Loading,
+            )
+        }
+    }
+}
+
+internal sealed interface SubscriptionsState {
+    data object Loading : SubscriptionsState
+
+    data object Failure : SubscriptionsState
+
+    data class Loaded(
+        val userSubscription: Subscription.Simple?,
+        val subscriptions: List<Subscription.Simple>,
+    ) : SubscriptionsState
+}
+
+private fun createAvailablePlans(
+    signInState: SignInState,
+    productDetailsState: ProductDetailsState,
+): SubscriptionsState {
+    val primarySubscription = signInState.findPrimarySubscription()
+    if (primarySubscription == null) {
+        return SubscriptionsState.Failure
+    }
+
+    return when (productDetailsState) {
+        is ProductDetailsState.Loading -> SubscriptionsState.Loading
+        is ProductDetailsState.Failure -> SubscriptionsState.Failure
+        is ProductDetailsState.Loaded -> {
+            val mapper = SubscriptionMapper()
+            val subscriptions = productDetailsState.productDetails
+                .map(mapper::mapFromProductDetails)
+                .filterIsInstance<Subscription.Simple>()
+            val matchingSubscription = subscriptions.find { it.productDetails.productId == primarySubscription.plan }
+            SubscriptionsState.Loaded(matchingSubscription, subscriptions)
+        }
+    }
+}
+
+private fun SignInState.findPrimarySubscription() = when (this) {
+    is SignInState.SignedOut -> null
+    is SignInState.SignedIn -> when (val subscriptionStatus = subscriptionStatus) {
+        is SubscriptionStatus.Free -> null
+        is SubscriptionStatus.Paid -> subscriptionStatus.subscriptions.find { it.isPrimarySubscription }
+    }
+}

--- a/modules/features/profile/src/test/kotlin/au/com/shiftyjelly/pocketcasts/profile/winback/WinbackViewModelTest.kt
+++ b/modules/features/profile/src/test/kotlin/au/com/shiftyjelly/pocketcasts/profile/winback/WinbackViewModelTest.kt
@@ -163,7 +163,7 @@ class WinbackViewModelTest {
             val availablePlans = awaitItem().availablePlans as AvailablePlans.Loaded
 
             val plan = availablePlans[Subscription.PLUS_MONTHLY_PRODUCT_ID]
-            assertEquals(Subscription.PLUS_MONTHLY_PRODUCT_ID, plan?.offetToken)
+            assertEquals(Subscription.PLUS_MONTHLY_PRODUCT_ID, plan?.offerToken)
         }
     }
 

--- a/modules/features/profile/src/test/kotlin/au/com/shiftyjelly/pocketcasts/profile/winback/WinbackViewModelTest.kt
+++ b/modules/features/profile/src/test/kotlin/au/com/shiftyjelly/pocketcasts/profile/winback/WinbackViewModelTest.kt
@@ -1,0 +1,286 @@
+package au.com.shiftyjelly.pocketcasts.profile.winback
+
+import app.cash.turbine.test
+import au.com.shiftyjelly.pocketcasts.models.to.SignInState
+import au.com.shiftyjelly.pocketcasts.models.to.SubscriptionStatus
+import au.com.shiftyjelly.pocketcasts.models.type.Subscription
+import au.com.shiftyjelly.pocketcasts.models.type.SubscriptionFrequency
+import au.com.shiftyjelly.pocketcasts.models.type.SubscriptionPlatform
+import au.com.shiftyjelly.pocketcasts.models.type.SubscriptionTier
+import au.com.shiftyjelly.pocketcasts.repositories.subscription.ProductDetailsState
+import au.com.shiftyjelly.pocketcasts.repositories.subscription.SubscriptionManager
+import au.com.shiftyjelly.pocketcasts.repositories.user.UserManager
+import com.android.billingclient.api.ProductDetails
+import com.android.billingclient.api.ProductDetails.PricingPhase
+import com.android.billingclient.api.ProductDetails.PricingPhases
+import com.android.billingclient.api.ProductDetails.RecurrenceMode
+import com.android.billingclient.api.ProductDetails.SubscriptionOfferDetails
+import java.util.Date
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.rx2.asFlowable
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Test
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+
+class WinbackViewModelTest {
+    private val signInStateFlow = MutableSharedFlow<SignInState>()
+    private val productDetailsFlow = MutableSharedFlow<ProductDetailsState>()
+
+    private lateinit var viewModel: WinbackViewModel
+
+    @Before
+    fun setUp() {
+        val userManager = mock<UserManager> {
+            on { getSignInState() } doReturn signInStateFlow.asFlowable()
+        }
+        val subscriptionManager = mock<SubscriptionManager> {
+            on { observeProductDetails() } doReturn productDetailsFlow.asFlowable()
+        }
+        viewModel = WinbackViewModel(userManager, subscriptionManager)
+    }
+
+    @Test
+    fun `initial state`() = runTest {
+        viewModel.uiState.test {
+            assertEquals(WinbackViewModel.UiState.Empty, awaitItem())
+        }
+    }
+
+    @Test
+    fun `subscriptions state for paid user with known subscription`() = runTest {
+        viewModel.uiState.test {
+            skipItems(1)
+
+            signInStateFlow.emit(createPaidUser(SubscriptionView(plan = Subscription.PLUS_MONTHLY_PRODUCT_ID, isPrimary = true)))
+            productDetailsFlow.emit(ProductDetailsState.Loaded(availableSubscriptions))
+            val state = awaitItem().subscriptionsState as SubscriptionsState.Loaded
+
+            val plusMonthly = state[Subscription.PLUS_MONTHLY_PRODUCT_ID]
+            val patronMonthly = state[Subscription.PATRON_MONTHLY_PRODUCT_ID]
+            val plusYearly = state[Subscription.PLUS_YEARLY_PRODUCT_ID]
+            val patronYearly = state[Subscription.PATRON_YEARLY_PRODUCT_ID]
+
+            assertNotNull(plusMonthly?.offerToken)
+            assertNotNull(patronMonthly?.offerToken)
+            assertNotNull(plusYearly?.offerToken)
+            assertNotNull(patronYearly?.offerToken)
+
+            assertEquals(state.userSubscription, plusMonthly)
+        }
+    }
+
+    @Test
+    fun `subscriptions state for paid user with unknown subscription`() = runTest {
+        viewModel.uiState.test {
+            skipItems(1)
+
+            signInStateFlow.emit(createPaidUser(SubscriptionView(plan = "no.plan", isPrimary = true)))
+            productDetailsFlow.emit(ProductDetailsState.Loaded(availableSubscriptions))
+            val state = awaitItem().subscriptionsState as SubscriptionsState.Loaded
+
+            assertNull(state.userSubscription)
+        }
+    }
+
+    @Test
+    fun `subscriptions state for paid user without any plan`() = runTest {
+        viewModel.uiState.test {
+            skipItems(1)
+
+            signInStateFlow.emit(createPaidUser(SubscriptionView(plan = null, isPrimary = true)))
+            productDetailsFlow.emit(ProductDetailsState.Loaded(availableSubscriptions))
+            val state = awaitItem().subscriptionsState as SubscriptionsState.Loaded
+
+            assertNull(state.userSubscription)
+        }
+    }
+
+    @Test
+    fun `subscriptions state for signed out user`() = runTest {
+        viewModel.uiState.test {
+            skipItems(1)
+
+            signInStateFlow.emit(SignInState.SignedOut)
+            productDetailsFlow.emit(ProductDetailsState.Loaded(availableSubscriptions))
+            val state = awaitItem().subscriptionsState
+
+            assertEquals(SubscriptionsState.Failure, state)
+        }
+    }
+
+    @Test
+    fun `subscriptions state for free user`() = runTest {
+        viewModel.uiState.test {
+            skipItems(1)
+
+            signInStateFlow.emit(SignInState.SignedOut)
+            productDetailsFlow.emit(ProductDetailsState.Loaded(availableSubscriptions))
+            val state = awaitItem().subscriptionsState
+
+            assertEquals(SubscriptionsState.Failure, state)
+        }
+    }
+
+    @Test
+    fun `subscriptions state for paid user without primary subscription`() = runTest {
+        viewModel.uiState.test {
+            skipItems(1)
+
+            signInStateFlow.emit(createPaidUser(SubscriptionView(plan = "no.plan", isPrimary = false)))
+            productDetailsFlow.emit(ProductDetailsState.Loaded(availableSubscriptions))
+            val state = awaitItem().subscriptionsState
+
+            assertEquals(SubscriptionsState.Failure, state)
+        }
+    }
+
+    @Test
+    fun `subscritpions state ignores subscription offers`() = runTest {
+        viewModel.uiState.test {
+            skipItems(1)
+
+            signInStateFlow.emit(createPaidUser(SubscriptionView(plan = "", isPrimary = true)))
+            productDetailsFlow.emit(
+                ProductDetailsState.Loaded(
+                    listOf(
+                        createProductDetails(
+                            id = Subscription.PLUS_MONTHLY_PRODUCT_ID,
+                            period = BillingPeriod.Monthly,
+                            offer = Offer(
+                                id = "offer-id",
+                                billingPeriod = BillingPeriod.Monthly,
+                            ),
+                        ),
+                    ),
+                ),
+            )
+            val state = awaitItem().subscriptionsState as SubscriptionsState.Loaded
+
+            val subscritpion = state[Subscription.PLUS_MONTHLY_PRODUCT_ID]
+            assertEquals(Subscription.PLUS_MONTHLY_PRODUCT_ID, subscritpion?.offerToken)
+        }
+    }
+
+    private val availableSubscriptions = listOf(
+        createProductDetails(
+            id = Subscription.PLUS_MONTHLY_PRODUCT_ID,
+            period = BillingPeriod.Monthly,
+        ),
+        createProductDetails(
+            id = Subscription.PATRON_MONTHLY_PRODUCT_ID,
+            period = BillingPeriod.Monthly,
+        ),
+        createProductDetails(
+            id = Subscription.PLUS_YEARLY_PRODUCT_ID,
+            period = BillingPeriod.Yearly,
+        ),
+        createProductDetails(
+            id = Subscription.PATRON_YEARLY_PRODUCT_ID,
+            period = BillingPeriod.Yearly,
+        ),
+    )
+}
+
+private operator fun SubscriptionsState.Loaded.get(offerToken: String) = subscriptions.singleOrNull { it.offerToken == offerToken }
+
+private class SubscriptionView(
+    val plan: String?,
+    val isPrimary: Boolean,
+)
+
+private class Offer(
+    val id: String,
+    val billingPeriod: BillingPeriod,
+)
+
+private enum class BillingPeriod(
+    val value: String,
+) {
+    Monthly("P1M"),
+    Yearly("P1Y"),
+}
+
+private fun createPaidUser(
+    vararg subscriptions: SubscriptionView,
+) = SignInState.SignedIn(
+    email = "noreplay@pocketcasts.com",
+    subscriptionStatus = createPaidSubscritpion(*subscriptions),
+)
+
+private fun createPaidSubscritpion(
+    vararg subscriptions: SubscriptionView,
+) = SubscriptionStatus.Paid(
+    expiryDate = Date(),
+    autoRenew = true,
+    giftDays = 0,
+    frequency = SubscriptionFrequency.NONE,
+    platform = SubscriptionPlatform.ANDROID,
+    tier = SubscriptionTier.PLUS,
+    index = 0,
+    subscriptions = subscriptions.map {
+        SubscriptionStatus.Subscription(
+            plan = it.plan,
+            isPrimarySubscription = it.isPrimary,
+            tier = SubscriptionTier.PLUS,
+            frequency = SubscriptionFrequency.YEARLY,
+            autoRenewing = true,
+            expiryDate = Date(),
+            updateUrl = "",
+        )
+    },
+)
+
+private fun createProductDetails(
+    id: String,
+    period: BillingPeriod,
+    offer: Offer? = null,
+) = mock<ProductDetails> {
+    check(id != offer?.id) { "ID and offer ID must be different" }
+
+    val basePricingPhase = mock<PricingPhase> {
+        on { billingPeriod } doReturn period.value
+        on { recurrenceMode } doReturn RecurrenceMode.INFINITE_RECURRING
+    }
+    val offerPricingPhase = offer?.let {
+        mock<PricingPhase> {
+            on { billingPeriod } doReturn offer.billingPeriod.value
+            on { recurrenceMode } doReturn RecurrenceMode.INFINITE_RECURRING
+        }
+    }
+    val basePricingPhases = mock<PricingPhases> {
+        on { pricingPhaseList } doReturn listOf(basePricingPhase)
+    }
+    val offserPricingPhases = offerPricingPhase?.let {
+        mock<PricingPhases> {
+            on { pricingPhaseList } doReturn listOf(
+                offerPricingPhase,
+                basePricingPhase,
+            )
+        }
+    }
+    val offerDetails = buildList {
+        if (offserPricingPhases != null) {
+            add(
+                mock<SubscriptionOfferDetails> {
+                    on { offerId } doReturn offer.id
+                    on { offerToken } doReturn offer.id
+                    on { pricingPhases } doReturn offserPricingPhases
+                },
+            )
+        }
+        add(
+            mock<SubscriptionOfferDetails> {
+                on { offerToken } doReturn id
+                on { pricingPhases } doReturn basePricingPhases
+            },
+        )
+    }
+
+    on { productId } doReturn id
+    on { subscriptionOfferDetails } doReturn offerDetails
+}

--- a/modules/features/profile/src/test/kotlin/au/com/shiftyjelly/pocketcasts/profile/winback/WinbackViewModelTest.kt
+++ b/modules/features/profile/src/test/kotlin/au/com/shiftyjelly/pocketcasts/profile/winback/WinbackViewModelTest.kt
@@ -166,6 +166,26 @@ class WinbackViewModelTest {
         }
     }
 
+    @Test
+    fun `subscritpions are sorted`() = runTest {
+        viewModel.uiState.test {
+            skipItems(1)
+
+            signInStateFlow.emit(createPaidUser(SubscriptionView(plan = "", isPrimary = true)))
+            productDetailsFlow.emit(ProductDetailsState.Loaded(availableSubscriptions.reversed()))
+            val state = awaitItem().subscriptionsState as SubscriptionsState.Loaded
+
+            val tokens = state.subscriptions.map(Subscription::offerToken)
+            val expected = listOf(
+                Subscription.PLUS_MONTHLY_PRODUCT_ID,
+                Subscription.PATRON_MONTHLY_PRODUCT_ID,
+                Subscription.PLUS_YEARLY_PRODUCT_ID,
+                Subscription.PATRON_YEARLY_PRODUCT_ID,
+            )
+            assertEquals(expected, tokens)
+        }
+    }
+
     private val availableSubscriptions = listOf(
         createProductDetails(
             id = Subscription.PLUS_MONTHLY_PRODUCT_ID,

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/type/SubscriptionMapper.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/type/SubscriptionMapper.kt
@@ -30,13 +30,12 @@ class SubscriptionMapper @Inject constructor() {
         val relevantSubscriptionOfferDetails = if ((FeatureFlag.isEnabled(Feature.REFERRALS_CLAIM) || FeatureFlag.isEnabled(Feature.REFERRALS_SEND)) && referralProductDetails != null) {
             matchingSubscriptionOfferDetails.find { it.offerId == referralProductDetails.offerId }
         } else {
-            val matchingSubscriptionOfferDetailsWithoutReferralOffer = matchingSubscriptionOfferDetails
+            matchingSubscriptionOfferDetails
                 .filter { !it.offerTags.contains(REFERRAL_OFFER_TAG) }
-            // TODO handle multiple matching SubscriptionOfferDetails
-            if (matchingSubscriptionOfferDetailsWithoutReferralOffer.size > 1) {
-                LogBuffer.w(LogBuffer.TAG_SUBSCRIPTIONS, "Multiple matching SubscriptionOfferDetails found. Only using the first.")
-            }
-            matchingSubscriptionOfferDetailsWithoutReferralOffer.firstOrNull()
+                // This assumes that base plan has lowest number of pricing phases,
+                // and if something else has the same number of phases,
+                // base plan will be the first one
+                .minByOrNull { offerDetails -> offerDetails.pricingPhases.pricingPhaseList.size }
         }
 
         return relevantSubscriptionOfferDetails

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/subscription/SubscriptionManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/subscription/SubscriptionManager.kt
@@ -15,7 +15,9 @@ import timber.log.Timber
 
 interface SubscriptionManager {
     suspend fun initializeBillingConnection(): Nothing
+    suspend fun refreshProducts()
     suspend fun refreshPurchases()
+
     fun launchBillingFlow(activity: AppCompatActivity, productDetails: ProductDetails, offerToken: String)
 
     fun signOut()

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/subscription/SubscriptionManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/subscription/SubscriptionManager.kt
@@ -10,13 +10,25 @@ import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
 import com.android.billingclient.api.ProductDetails
 import io.reactivex.Flowable
 import io.reactivex.Single
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.launch
 import timber.log.Timber
 
 interface SubscriptionManager {
     suspend fun initializeBillingConnection(): Nothing
-    suspend fun refreshProducts()
-    suspend fun refreshPurchases()
+
+    suspend fun loadProducts(): ProductDetailsState
+
+    suspend fun loadPurchases(): PurchasesState
+
+    suspend fun loadPurchaseHistory(): PurchaseHistoryState
+
+    suspend fun refresh() = coroutineScope {
+        launch { loadProducts() }
+        launch { loadPurchases() }
+        launch { loadPurchaseHistory() }
+    }
 
     fun launchBillingFlow(activity: AppCompatActivity, productDetails: ProductDetails, offerToken: String)
 

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/referrals/ReferralOfferInfoProviderTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/referrals/ReferralOfferInfoProviderTest.kt
@@ -76,7 +76,7 @@ class ReferralOfferInfoProviderTest {
 
     @Test
     fun `referralOfferInfo returns null subscription when product details state is error`() = runTest {
-        val productDetailsState = ProductDetailsState.Error("error")
+        val productDetailsState = ProductDetailsState.Failure
         whenever(subscriptionManager.observeProductDetails()).thenReturn(Flowable.just(productDetailsState))
 
         val result = referralOfferInfoProvider.referralOfferInfo()

--- a/modules/services/sharedtest/src/main/java/au/com/shiftyjelly/pocketcasts/sharedtest/MainCoroutineRule.kt
+++ b/modules/services/sharedtest/src/main/java/au/com/shiftyjelly/pocketcasts/sharedtest/MainCoroutineRule.kt
@@ -15,7 +15,7 @@ import kotlinx.coroutines.test.setMain
 import org.junit.rules.TestWatcher
 import org.junit.runner.Description
 
-@ExperimentalCoroutinesApi
+@OptIn(ExperimentalCoroutinesApi::class)
 class MainCoroutineRule(
     val testDispatcher: TestDispatcher = UnconfinedTestDispatcher(),
 ) : TestWatcher() {


### PR DESCRIPTION
## Description

This PR adds Winback VM with logic for fetching available plans and matching user's subscription with them. It makes a lot of assumptions about the subscriptions:
* Only a single acknowledged purchase is allowed.
* Purchase must have an order ID.
* Purchase cannot have multiple products.

This matches iOS behavior and is done this way because there's no UI to handle different cases. Also, in practice, it should be the only viable option as Google Play prevents users from having multiple subscriptions and we don't have single-purchase products.

## Testing Instructions

There's nothing to test here manually.

## Checklist
- [ ] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [ ] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [ ] ~Any jetpack compose components I added or changed are covered by compose previews~
- [ ] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~