### PR TITLE
Add duration size property for Filter event

### DIFF
--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PlaylistUpdateAnalytics.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PlaylistUpdateAnalytics.kt
@@ -36,6 +36,10 @@ class PlaylistUpdateAnalytics @Inject constructor(
             put(Key.DOWNLOADED, playlist.downloaded)
             put(Key.NOT_DOWNLOADED, playlist.notDownloaded)
             put(Key.DURATION, playlist.filterDuration)
+            if (playlist.filterDuration) {
+                put(Key.DURATION_LONGER_THAN, playlist.longerThan)
+                put(Key.DURATION_SHORTER_THAN, playlist.shorterThan)
+            }
             put(Key.EPISODE_STATUS_IN_PROGRESS, playlist.partiallyPlayed)
             put(Key.EPISODE_STATUS_PLAYED, playlist.finished)
             put(Key.EPISODE_STATUS_UNPLAYED, playlist.unplayed)
@@ -158,6 +162,8 @@ class PlaylistUpdateAnalytics @Inject constructor(
             const val COLOR = "color"
             const val DOWNLOADED = "downloaded"
             const val DURATION = "duration"
+            const val DURATION_LONGER_THAN = "duration_longer_than"
+            const val DURATION_SHORTER_THAN = "duration_shorter_than"
             const val ENABLED = "enabled"
             const val GROUP = "group"
             const val ICON_NAME = "icon_name"


### PR DESCRIPTION
## Description
- This includes the `duration_longer_than` and `duration_shorter_than` when the user creates a filter and set a duration
- This is to improve the existing event `filter_created`
 
Fixes # <!-- issue number, if applicable -->

## Testing Instructions
1. Log with a plus account
2. Create a filter
3. Set a duration
4. ✅ Ensure you see the new properties

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [ ] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
