### PR TITLE
Track Event Tweaks part 3

### DIFF
--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/ProfileFragment.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/ProfileFragment.kt
@@ -112,7 +112,7 @@ class ProfileFragment : BaseFragment() {
                 )
             },
             onCloseUpgradeProfileClick = {
-                profileViewModel.closeUpgradeProfile()
+                profileViewModel.closeUpgradeProfile(SourceView.PROFILE)
             },
             modifier = Modifier.fillMaxSize(),
         )

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/ProfileViewModel.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/ProfileViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTracker
+import au.com.shiftyjelly.pocketcasts.analytics.SourceView
 import au.com.shiftyjelly.pocketcasts.models.to.RefreshState
 import au.com.shiftyjelly.pocketcasts.models.to.SignInState
 import au.com.shiftyjelly.pocketcasts.models.type.SubscriptionTier
@@ -178,8 +179,8 @@ class ProfileViewModel @Inject constructor(
         }
     }
 
-    internal fun closeUpgradeProfile() {
-        tracker.track(AnalyticsEvent.PROFILE_REFRESH_UPGRADE_BANNER_DISMISSED)
+    internal fun closeUpgradeProfile(source: SourceView) {
+        tracker.track(AnalyticsEvent.UPGRADE_BANNER_DISMISSED, mapOf("source" to source.analyticsValue))
         settings.upgradeProfileClosed.set(true, updateModifiedAt = false)
     }
 }

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/cloud/AddFileActivity.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/cloud/AddFileActivity.kt
@@ -460,6 +460,7 @@ class AddFileActivity :
     override fun onMenuItemClick(item: MenuItem): Boolean {
         return when (item.itemId) {
             R.id.menu_save -> {
+                analyticsTracker.track(AnalyticsEvent.USER_FILE_EDIT_SAVE)
                 saveFile()
                 true
             }

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/cloud/AddFileActivity.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/cloud/AddFileActivity.kt
@@ -234,6 +234,7 @@ class AddFileActivity :
 
         val upgradeLayout = binding.upgradeLayout.root
         upgradeLayout.findViewById<View>(R.id.btnClose).setOnClickListener {
+            analyticsTracker.track(AnalyticsEvent.UPGRADE_BANNER_DISMISSED, mapOf("source" to OnboardingUpgradeSource.FILES.analyticsValue))
             settings.setUpgradeClosedAddFile(true)
             upgradeLayout.isVisible = false
         }

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/cloud/CloudSettingsFragment.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/cloud/CloudSettingsFragment.kt
@@ -9,6 +9,7 @@ import androidx.appcompat.content.res.AppCompatResources
 import androidx.core.content.ContextCompat
 import androidx.core.view.isVisible
 import androidx.fragment.app.viewModels
+import au.com.shiftyjelly.pocketcasts.analytics.SourceView
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.profile.R
 import au.com.shiftyjelly.pocketcasts.profile.databinding.FragmentCloudSettingsBinding
@@ -124,6 +125,7 @@ class CloudSettingsFragment : BaseFragment() {
         }
 
         binding.btnClose.setOnClickListener {
+            viewModel.onUpgradeBannerDismissed(SourceView.FILES_SETTINGS)
             settings.setUpgradeClosedCloudSettings(true)
             binding.upgradeLayout.isVisible = false
         }

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/cloud/CloudSettingsViewModel.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/cloud/CloudSettingsViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.toLiveData
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTracker
+import au.com.shiftyjelly.pocketcasts.analytics.SourceView
 import au.com.shiftyjelly.pocketcasts.models.to.SignInState
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.repositories.user.UserManager
@@ -78,5 +79,9 @@ class CloudSettingsViewModel @Inject constructor(
             AnalyticsEvent.SETTINGS_FILES_ONLY_ON_WIFI_TOGGLED,
             mapOf("enabled" to enabled),
         )
+    }
+
+    fun onUpgradeBannerDismissed(source: SourceView) {
+        analyticsTracker.track(AnalyticsEvent.UPGRADE_BANNER_DISMISSED, mapOf("source" to source.analyticsValue))
     }
 }

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/AppearanceSettingsFragment.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/AppearanceSettingsFragment.kt
@@ -16,6 +16,7 @@ import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
+import au.com.shiftyjelly.pocketcasts.analytics.SourceView
 import au.com.shiftyjelly.pocketcasts.models.type.SubscriptionTier
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.repositories.subscription.SubscriptionManager
@@ -234,6 +235,7 @@ class AppearanceSettingsFragment : BaseFragment() {
         }
 
         binding.btnCloseUpgrade.setOnClickListener {
+            viewModel.onUpgradeBannerDismissed(SourceView.APPEARANCE)
             settings.setUpgradeClosedAppearSettings(true)
             binding.upgradeGroup.isVisible = false
         }

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/AppearanceSettingsFragment.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/AppearanceSettingsFragment.kt
@@ -16,7 +16,6 @@ import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
-import au.com.shiftyjelly.pocketcasts.analytics.SourceView
 import au.com.shiftyjelly.pocketcasts.models.type.SubscriptionTier
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.repositories.subscription.SubscriptionManager
@@ -235,7 +234,7 @@ class AppearanceSettingsFragment : BaseFragment() {
         }
 
         binding.btnCloseUpgrade.setOnClickListener {
-            viewModel.onUpgradeBannerDismissed(SourceView.APPEARANCE)
+            viewModel.onUpgradeBannerDismissed(OnboardingUpgradeSource.APPEARANCE)
             settings.setUpgradeClosedAppearSettings(true)
             binding.upgradeGroup.isVisible = false
         }

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/viewmodel/SettingsAppearanceViewModel.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/viewmodel/SettingsAppearanceViewModel.kt
@@ -7,11 +7,11 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.toLiveData
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTracker
-import au.com.shiftyjelly.pocketcasts.analytics.SourceView
 import au.com.shiftyjelly.pocketcasts.models.to.SignInState
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.UserEpisodeManager
 import au.com.shiftyjelly.pocketcasts.repositories.user.UserManager
+import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingUpgradeSource
 import au.com.shiftyjelly.pocketcasts.ui.helper.AppIcon
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -157,7 +157,7 @@ class SettingsAppearanceViewModel @Inject constructor(
         )
     }
 
-    fun onUpgradeBannerDismissed(source: SourceView) {
+    fun onUpgradeBannerDismissed(source: OnboardingUpgradeSource) {
         analyticsTracker.track(AnalyticsEvent.UPGRADE_BANNER_DISMISSED, mapOf("source" to source.analyticsValue))
     }
 }

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/viewmodel/SettingsAppearanceViewModel.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/viewmodel/SettingsAppearanceViewModel.kt
@@ -7,6 +7,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.toLiveData
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTracker
+import au.com.shiftyjelly.pocketcasts.analytics.SourceView
 import au.com.shiftyjelly.pocketcasts.models.to.SignInState
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.UserEpisodeManager
@@ -154,6 +155,10 @@ class SettingsAppearanceViewModel @Inject constructor(
             AnalyticsEvent.SETTINGS_APPEARANCE_FOLLOW_SYSTEM_THEME_TOGGLED,
             mapOf("enabled" to use),
         )
+    }
+
+    fun onUpgradeBannerDismissed(source: SourceView) {
+        analyticsTracker.track(AnalyticsEvent.UPGRADE_BANNER_DISMISSED, mapOf("source" to source.analyticsValue))
     }
 }
 

--- a/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
+++ b/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
@@ -52,6 +52,7 @@ enum class AnalyticsEvent(val key: String) {
     PLUS_PROMOTION_SUBSCRIPTION_FREQUENCY_CHANGED("plus_promotion_subscription_frequency_changed"),
     PLUS_PROMOTION_PRIVACY_POLICY_TAPPED("plus_promotion_privacy_policy_tapped"),
     PLUS_PROMOTION_TERMS_AND_CONDITIONS_TAPPED("plus_promotion_terms_and_conditions_tapped"),
+    UPGRADE_BANNER_DISMISSED("upgrade_banner_dismissed"),
 
     /* Pull to refresh */
     PULLED_TO_REFRESH("pulled_to_refresh"),
@@ -125,7 +126,6 @@ enum class AnalyticsEvent(val key: String) {
     PROFILE_ACCOUNT_BUTTON_TAPPED("profile_account_button_tapped"),
     PROFILE_SETTINGS_BUTTON_TAPPED("profile_settings_button_tapped"),
     PROFILE_REFRESH_BUTTON_TAPPED("profile_refresh_button_tapped"),
-    PROFILE_REFRESH_UPGRADE_BANNER_DISMISSED("profile_refresh_upgrade_banner_dismissed"),
 
     /* Stats View */
     STATS_SHOWN("stats_shown"),

--- a/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
+++ b/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
@@ -171,6 +171,7 @@ enum class AnalyticsEvent(val key: String) {
     UPLOADED_FILES_ADD_FILE_TAPPED("uploaded_files_add_file_tapped"),
     UPLOADED_FILES_INVALID_FILE_ERROR("uploaded_files_invalid_file_error"),
     UPLOADED_FILES_UPLOAD_FAILED("uploaded_files_upload_failed"),
+    USER_FILE_EDIT_SAVE("user_file_edit_save"),
 
     /* User File Details View */
     USER_FILE_DETAIL_SHOWN("user_file_detail_shown"),

--- a/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/SourceView.kt
+++ b/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/SourceView.kt
@@ -52,6 +52,7 @@ enum class SourceView(val analyticsValue: String) {
     UP_NEXT("up_next"),
     WHATS_NEW("whats_new"),
     ABOUT("about"),
+    APPEARANCE("appearance_settings"),
     STORAGE_AND_DATA_USAGE("storage_and_data_usage"),
     WIDGET_PLAYER_LARGE("widget_player_large"),
     WIDGET_PLAYER_MEDIUM("widget_player_medium"),

--- a/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/SourceView.kt
+++ b/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/SourceView.kt
@@ -19,6 +19,7 @@ enum class SourceView(val analyticsValue: String) {
     EPISODE_DETAILS("episode_details"),
     EPISODE_SWIPE_ACTION("episode_swipe_action"),
     FILES("files"),
+    FILES_SETTINGS("files_settings"),
     FILTERS("filters"),
     FULL_SCREEN_VIDEO("full_screen_video"),
     LISTENING_HISTORY("listening_history"),

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
@@ -544,6 +544,7 @@ open class PlaybackManager @Inject constructor(
             SourceView.TASKER,
             SourceView.UNKNOWN,
             SourceView.UP_NEXT,
+            SourceView.FILES_SETTINGS,
             SourceView.STATS,
             SourceView.WHATS_NEW,
             SourceView.ABOUT,

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
@@ -547,6 +547,7 @@ open class PlaybackManager @Inject constructor(
             SourceView.STATS,
             SourceView.WHATS_NEW,
             SourceView.ABOUT,
+            SourceView.APPEARANCE,
             SourceView.STORAGE_AND_DATA_USAGE,
             SourceView.NOTIFICATION_BOOKMARK,
             SourceView.METERED_NETWORK_CHANGE,


### PR DESCRIPTION
## Description
- This updates the upgrade banner dismiss event to align with iOS and track in other missing areas. See: p1737040220122109/1736977627.026869-slack-C088L7YF8BY
- Track the save / edit button when uploading a file. See: p1737037979177609/1737034289.387959-slack-C088L7YF8BY

## Testing Instructions

### Upgrade banner dismiss

1. Log in with free account / No account to see the upgrade banner
2. Go to Profile and scroll down to see the upgrade banner
3. Dismiss this banner
4. Ensure `upgrade_banner_dismissed` event is tracked
5. Go to Appearance and dismiss the banner
6. Ensure `upgrade_banner_dismissed` event is tracked
7. Go to Files and try to upload a file
8. Dismiss the banner
9. Ensure `upgrade_banner_dismissed` event is tracked
10. Go to Files -> Files Settings
11. Dismiss the banner
12. Ensure `upgrade_banner_dismissed` event is tracked

### Upload file
1. Log in with a plus account
2. Go to Files and try to upload a file
3. When you tap on Save button
4. Ensure `user_file_edit_save` event is tracked


## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.