### PR TITLE
Sync Listening History Individual / Multiple Removal

### DIFF
--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/EpisodeDao.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/EpisodeDao.kt
@@ -366,7 +366,7 @@ abstract class EpisodeDao {
     @Query("UPDATE podcast_episodes SET last_playback_interaction_date = 0, last_playback_interaction_sync_status = 1")
     abstract suspend fun clearAllEpisodePlaybackInteractions()
 
-    @Query("UPDATE podcast_episodes SET last_playback_interaction_date = 0, last_playback_interaction_sync_status = 1 WHERE uuid IN (:episodeUuids)")
+    @Query("UPDATE podcast_episodes SET last_playback_interaction_date = 0, last_playback_interaction_sync_status = 2 WHERE uuid IN (:episodeUuids)")
     abstract suspend fun clearEpisodePlaybackInteractions(episodeUuids: List<String>)
 
     @Query("UPDATE podcast_episodes SET last_playback_interaction_sync_status = 1")


### PR DESCRIPTION
## Description
- This PR fixes the sync status to be DELETE action instead of CLEAN in order to sync the multiple removal

## Testing Instructions
1. Log in with an account
2. Play some episodes to have the listening history
3. Go to Profile and tap on `Refresh Now` to have your account synced
4. Go to Listening History screen
5. Long press some episodes
6. Tap on the 3 dots
7. Remove from history
8. Go to Profile and sync your account again
9. Back to Listening History screen
10. ✅ Ensure the episodes you had removed in step 7 is not showing in the list

## Screenshots or Screencast 
[Screen_recording_20250117_102646.webm](https://github.com/user-attachments/assets/586ee500-fdd9-4612-83e5-6d0afb2f6499)


## Checklist
- [ ] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [ ] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] ~I have considered whether it makes sense to add tests for my changes~
- [ ] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [ ] ~Any jetpack compose components I added or changed are covered by compose previews~
- [ ] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~
