### PR TITLE
Add Listening History Individual / Multiple Removal feature to `main` branch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 7.81
 -----
+*   New Features
+    *   Add support for removing individual episodes from listening history.
+        ([#3453](https://github.com/Automattic/pocket-casts-android/pull/3453))
 *   Bug Fixes
     *   Fix the cropping issue with the Add 5 Minutes sleep timer button.
         ([#3436](https://github.com/Automattic/pocket-casts-android/pull/3436))

--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/views/multiselect/MultiSelectEpisodeActionTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/views/multiselect/MultiSelectEpisodeActionTest.kt
@@ -10,7 +10,7 @@ class MultiSelectEpisodeActionTest {
 
     @Test
     fun testListFromIds() {
-        val ids = listOf("star", "play_last", "play_next", "download", "archive", "share", "mark_as_played")
+        val ids = listOf("star", "play_last", "play_next", "download", "archive", "share", "mark_as_played", "remove_listening_history")
         val result = MultiSelectEpisodeAction.listFromIds(ids)
         val expectedActions = listOf(
             MultiSelectEpisodeAction.Star,
@@ -20,6 +20,7 @@ class MultiSelectEpisodeActionTest {
             MultiSelectEpisodeAction.Archive,
             MultiSelectEpisodeAction.Share,
             MultiSelectEpisodeAction.MarkAsPlayed,
+            MultiSelectEpisodeAction.RemoveListeningHistory,
         )
         assertEquals(expectedActions, result)
     }

--- a/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
+++ b/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
@@ -390,6 +390,7 @@ enum class AnalyticsEvent(val key: String) {
     EPISODE_STARRED("episode_starred"),
     EPISODE_BULK_STARRED("episode_bulk_starred"),
     EPISODE_UNSTARRED("episode_unstarred"),
+    EPISODE_REMOVED_LISTENING_HISTORY("episode_removed_listening_history"),
     EPISODE_BULK_UNSTARRED("episode_bulk_unstarred"),
     EPISODE_ARCHIVED("episode_archived"),
     EPISODE_BULK_ARCHIVED("episode_bulk_archived"),

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -105,6 +105,7 @@
     <string name="sort_by">Sort by</string>
     <string name="star">Star</string>
     <string name="star_episode">Star episode</string>
+    <string name="clean_history">Remove from history</string>
     <string name="try_again">Try again</string>
     <string name="token_refresh_sign_in_error_title">Sign In Error</string>
     <string name="token_refresh_sign_in_error_description">There was a problem and you\'ve been signed out. Tap here to sign back in.</string>
@@ -242,6 +243,9 @@
     <string name="starred_episodes_plural">%1$d episodes starred</string>
     <string name="unstarred_episodes_singular">1 episode unstarred</string>
     <string name="unstarred_episodes_plural">%1$d episodes unstarred</string>
+
+    <string name="remove_listening_history_episodes_singular">Removed 1 episode from listening history</string>
+    <string name="remove_listening_history_episodes_plural">Removed %1$d episodes from listening history</string>
 
     <string name="download_warning_button">Download %1$d episodes</string>
     <string name="download_warning_title">Download All</string>

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/EpisodeDao.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/EpisodeDao.kt
@@ -366,6 +366,9 @@ abstract class EpisodeDao {
     @Query("UPDATE podcast_episodes SET last_playback_interaction_date = 0, last_playback_interaction_sync_status = 1")
     abstract suspend fun clearAllEpisodePlaybackInteractions()
 
+    @Query("UPDATE podcast_episodes SET last_playback_interaction_date = 0, last_playback_interaction_sync_status = 1 WHERE uuid IN (:episodeUuids)")
+    abstract suspend fun clearEpisodePlaybackInteractions(episodeUuids: List<String>)
+
     @Query("UPDATE podcast_episodes SET last_playback_interaction_sync_status = 1")
     abstract fun markPlaybackHistorySyncedBlocking()
 

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/EpisodeDao.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/EpisodeDao.kt
@@ -366,7 +366,7 @@ abstract class EpisodeDao {
     @Query("UPDATE podcast_episodes SET last_playback_interaction_date = 0, last_playback_interaction_sync_status = 1")
     abstract suspend fun clearAllEpisodePlaybackInteractions()
 
-    @Query("UPDATE podcast_episodes SET last_playback_interaction_date = 0, last_playback_interaction_sync_status = 1 WHERE uuid IN (:episodeUuids)")
+    @Query("UPDATE podcast_episodes SET last_playback_interaction_date = 0, last_playback_interaction_sync_status = 2 WHERE uuid IN (:episodeUuids)")
     abstract suspend fun clearEpisodePlaybackInteractions(episodeUuids: List<String>)
 
     @Query("UPDATE podcast_episodes SET last_playback_interaction_sync_status = 1")

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManager.kt
@@ -97,6 +97,7 @@ interface EpisodeManager {
     fun userHasInteractedWithEpisode(episode: PodcastEpisode, playbackManager: PlaybackManager): Boolean
     fun clearEpisodePlaybackInteractionDatesBeforeBlocking(lastCleared: Date)
     suspend fun clearAllEpisodeHistory()
+    suspend fun clearEpisodeHistory(episodes: List<PodcastEpisode>)
     fun markPlaybackHistorySyncedBlocking()
     fun stopDownloadAndCleanUp(episodeUuid: String, from: String)
     fun stopDownloadAndCleanUp(episode: PodcastEpisode, from: String)

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManagerImpl.kt
@@ -1010,6 +1010,10 @@ class EpisodeManagerImpl @Inject constructor(
         settings.setClearHistoryTimeNow()
     }
 
+    override suspend fun clearEpisodeHistory(episodes: List<PodcastEpisode>) {
+        episodeDao.clearEpisodePlaybackInteractions(episodes.map { it.uuid })
+    }
+
     override fun markPlaybackHistorySyncedBlocking() {
         return episodeDao.markPlaybackHistorySyncedBlocking()
     }

--- a/modules/services/ui/src/main/res/values/ids.xml
+++ b/modules/services/ui/src/main/res/values/ids.xml
@@ -11,4 +11,5 @@
     <item name="menu_undownload" type="id" />
     <item name="menu_unarchive" type="id" />
     <item name="menu_edit" type="id" />
+    <item name="menu_remove_listening_history" type="id" />
 </resources>

--- a/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/multiselect/MultiSelectAdapter.kt
+++ b/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/multiselect/MultiSelectAdapter.kt
@@ -39,7 +39,7 @@ private val MULTI_SELECT_ACTION_DIFF = object : DiffUtil.ItemCallback<Any>() {
     }
 }
 
-class MultiSelectAdapter(val editable: Boolean, val listener: ((MultiSelectAction) -> Unit)? = null, val dragListener: ((ItemViewHolder) -> Unit)?) : ListAdapter<Any, RecyclerView.ViewHolder>(MULTI_SELECT_ACTION_DIFF) {
+class MultiSelectAdapter(val editable: Boolean, val listener: ((MultiSelectAction) -> Unit)? = null, var shouldShowRemoveListeningHistory: Boolean = true, val dragListener: ((ItemViewHolder) -> Unit)?) : ListAdapter<Any, RecyclerView.ViewHolder>(MULTI_SELECT_ACTION_DIFF) {
     var episode: BaseEpisode? = null
         set(value) {
             field = value
@@ -101,6 +101,13 @@ class MultiSelectAdapter(val editable: Boolean, val listener: ((MultiSelectActio
     @SuppressLint("ClickableViewAccessibility")
     override fun onBindViewHolder(holder: RecyclerView.ViewHolder, position: Int) {
         val item = getItem(position)
+
+        if (item is MultiSelectEpisodeAction.RemoveListeningHistory && !shouldShowRemoveListeningHistory) {
+            holder.itemView.visibility = View.GONE
+            return
+        } else {
+            holder.itemView.visibility = View.VISIBLE
+        }
 
         if (item is MultiSelectAction && holder is ItemViewHolder) {
             holder.binding.lblTitle.setText(item.title)

--- a/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/multiselect/MultiSelectEpisodeAction.kt
+++ b/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/multiselect/MultiSelectEpisodeAction.kt
@@ -109,9 +109,16 @@ sealed class MultiSelectEpisodeAction(
         iconRes = IR.drawable.ic_star,
         analyticsValue = "star",
     )
+    object RemoveListeningHistory : MultiSelectEpisodeAction(
+        groupId = "listening_history",
+        actionId = UR.id.menu_remove_listening_history,
+        title = LR.string.clean_history,
+        iconRes = IR.drawable.ic_delete,
+        analyticsValue = "remove_listening_history",
+    )
 
     companion object {
-        private val STANDARD = listOf(Download, Archive, MarkAsPlayed, PlayNext, PlayLast, Star, Share)
+        private val STANDARD = listOf(Download, Archive, MarkAsPlayed, PlayNext, PlayLast, Star, Share, RemoveListeningHistory)
         private val ALL = STANDARD + listOf(DeleteDownload, DeleteUserEpisode, MarkAsUnplayed, Unstar, Unarchive)
         private val STANDARD_BY_GROUP_ID = STANDARD.associateBy { it.groupId }
         val ALL_BY_ACTION_ID = ALL.associateBy { it.actionId }
@@ -160,6 +167,14 @@ sealed class MultiSelectEpisodeAction(
                     }
 
                     return Unstar
+                }
+                RemoveListeningHistory.groupId -> {
+                    if (selected.any { it is UserEpisode }) return null
+
+                    val hasPlayedAnyEpisode = selected.any { episode ->
+                        episode is PodcastEpisode && (episode.lastPlaybackInteraction ?: 0L) > 0L
+                    }
+                    return if (hasPlayedAnyEpisode) RemoveListeningHistory else null
                 }
                 PlayNext.groupId -> return PlayNext
                 PlayLast.groupId -> return PlayLast

--- a/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/multiselect/MultiSelectEpisodesHelper.kt
+++ b/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/multiselect/MultiSelectEpisodesHelper.kt
@@ -144,6 +144,10 @@ class MultiSelectEpisodesHelper @Inject constructor(
                 unstar(resources = resources)
                 true
             }
+            UR.id.menu_remove_listening_history -> {
+                removeListeningHistory(resources = resources)
+                true
+            }
             else -> false
         }
     }
@@ -275,6 +279,24 @@ class MultiSelectEpisodesHelper @Inject constructor(
             episodeAnalytics.trackBulkEvent(AnalyticsEvent.EPISODE_BULK_UNSTARRED, source, list.size)
             withContext(Dispatchers.Main) {
                 val snackText = resources.getStringPlural(selectedList.size, LR.string.unstarred_episodes_singular, LR.string.unstarred_episodes_plural)
+                showSnackBar(snackText)
+                closeMultiSelect()
+            }
+        }
+    }
+
+    private fun removeListeningHistory(resources: Resources) {
+        if (selectedList.isEmpty()) {
+            closeMultiSelect()
+            return
+        }
+
+        launch {
+            val list = selectedList.filterIsInstance<PodcastEpisode>().toList()
+            episodeManager.clearEpisodeHistory(list)
+            episodeAnalytics.trackBulkEvent(AnalyticsEvent.EPISODE_REMOVED_LISTENING_HISTORY, source, list.size)
+            withContext(Dispatchers.Main) {
+                val snackText = resources.getStringPlural(selectedList.size, LR.string.remove_listening_history_episodes_singular, LR.string.remove_listening_history_episodes_plural)
                 showSnackBar(snackText)
                 closeMultiSelect()
             }

--- a/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/multiselect/MultiSelectFragment.kt
+++ b/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/multiselect/MultiSelectFragment.kt
@@ -31,10 +31,14 @@ class MultiSelectFragment : BaseFragment(), MultiSelectTouchCallback.ItemTouchHe
     @Inject lateinit var analyticsTracker: AnalyticsTracker
 
     @Inject lateinit var multiSelectEpisodesHelper: MultiSelectEpisodesHelper
+
     private val source: String
         get() = arguments?.getString(ARG_SOURCE) ?: SourceView.UNKNOWN.analyticsValue
 
-    private val adapter = MultiSelectAdapter(editable = true, listener = null, dragListener = this::onItemStartDrag)
+    private val shouldShowRemoveListeningHistory: Boolean
+        get() = arguments?.getBoolean(ARG_SHOULD_SHOW_REMOVE_LISTENING_HISTORY) ?: false
+
+    private val adapter = MultiSelectAdapter(editable = true, listener = null, shouldShowRemoveListeningHistory = shouldShowRemoveListeningHistory, dragListener = this::onItemStartDrag)
     private lateinit var itemTouchHelper: ItemTouchHelper
     private var items = emptyList<Any>()
     private val shortcutTitle = MultiSelectAdapter.Title(LR.string.multiselect_actions_shown)
@@ -86,6 +90,7 @@ class MultiSelectFragment : BaseFragment(), MultiSelectTouchCallback.ItemTouchHe
                 multiSelectActions.add(multiSelectEpisodesHelper.maxToolbarIcons + 1, overflowTitle)
 
                 items = multiSelectActions.toList()
+                adapter.shouldShowRemoveListeningHistory = shouldShowRemoveListeningHistory
                 adapter.submitList(multiSelectActions.toList())
             }
     }
@@ -186,9 +191,11 @@ class MultiSelectFragment : BaseFragment(), MultiSelectTouchCallback.ItemTouchHe
 
     companion object {
         private const val ARG_SOURCE = "source"
-        fun newInstance(source: SourceView) = MultiSelectFragment().apply {
+        private const val ARG_SHOULD_SHOW_REMOVE_LISTENING_HISTORY = "should_show_remove_listening_history"
+        fun newInstance(source: SourceView, shouldShowRemoveListeningHistory: Boolean) = MultiSelectFragment().apply {
             arguments = bundleOf(
                 ARG_SOURCE to source.analyticsValue,
+                ARG_SHOULD_SHOW_REMOVE_LISTENING_HISTORY to shouldShowRemoveListeningHistory,
             )
         }
     }


### PR DESCRIPTION
## Description
- This PR just adds the feature to the `main`. The feature was already reviewed in https://github.com/Automattic/pocket-casts-android/pull/3443 and https://github.com/Automattic/pocket-casts-android/pull/3452

Fixes #2814


## Screenshots or Screencast 
[Screen_recording_20250117_102646.webm](https://github.com/user-attachments/assets/89156160-7c8f-4a9d-bee9-8006ad2d3bda)


## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack
