### PR TITLE
Add Theme info to default track events properties

### DIFF
--- a/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/TracksAnalyticsTracker.kt
+++ b/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/TracksAnalyticsTracker.kt
@@ -83,6 +83,10 @@ class TracksAnalyticsTracker @Inject constructor(
             PredefinedEventProperty.PLUS_SUBSCRIPTION_TIER to subscriptionTier,
             PredefinedEventProperty.PLUS_SUBSCRIPTION_PLATFORM to subscriptionPlatform,
             PredefinedEventProperty.PLUS_SUBSCRIPTION_FREQUENCY to subscriptionFrequency,
+            PredefinedEventProperty.THEME_SELECTED to settings.theme.value.analyticsValue,
+            PredefinedEventProperty.THEME_DARK_PREFERENCE to settings.darkThemePreference.value.analyticsValue,
+            PredefinedEventProperty.THEME_LIGHT_PREFERENCE to settings.lightThemePreference.value.analyticsValue,
+            PredefinedEventProperty.THEME_USE_SYSTEM_SETTINGS to settings.useSystemTheme.value,
             PredefinedEventProperty.PLATFORM to when (Util.getAppPlatform(appContext)) {
                 AppPlatform.Automotive -> "automotive"
                 AppPlatform.Phone -> "phone"
@@ -129,6 +133,10 @@ class TracksAnalyticsTracker @Inject constructor(
         PLUS_SUBSCRIPTION_PLATFORM("plus_subscription_platform"),
         PLUS_SUBSCRIPTION_FREQUENCY("plus_subscription_frequency"),
         PLATFORM("platform"),
+        THEME_SELECTED("theme_selected"),
+        THEME_DARK_PREFERENCE("theme_dark_preference"),
+        THEME_LIGHT_PREFERENCE("theme_light_preference"),
+        THEME_USE_SYSTEM_SETTINGS("theme_use_system_settings"),
     }
 
     companion object {

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/model/ThemeSetting.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/model/ThemeSetting.kt
@@ -6,46 +6,57 @@ import au.com.shiftyjelly.pocketcasts.preferences.UserSetting
 enum class ThemeSetting(
     val id: String,
     val serverId: Int,
+    val analyticsValue: String,
 ) {
     LIGHT(
         id = "light",
         serverId = 0,
+        analyticsValue = "default_light",
     ),
     DARK(
         id = "dark",
         serverId = 1,
+        analyticsValue = "default_dark",
     ),
     ROSE(
         id = "rose",
         serverId = 3,
+        analyticsValue = "rose",
     ),
     INDIGO(
         id = "indigo",
         serverId = 4,
+        analyticsValue = "indigo",
     ),
     EXTRA_DARK(
         id = "extraDark",
         serverId = 2,
+        analyticsValue = "extra_dark",
     ),
     DARK_CONTRAST(
         id = "darkContrast",
         serverId = 5,
+        analyticsValue = "dark_contrast",
     ),
     LIGHT_CONTRAST(
         id = "lightContrast",
         serverId = 6,
+        analyticsValue = "light_contrast",
     ),
     ELECTRIC(
         id = "electric",
         serverId = 7,
+        analyticsValue = "electric",
     ),
     CLASSIC_LIGHT(
         id = "classicLight",
         serverId = 8,
+        analyticsValue = "classic",
     ),
     RADIOACTIVE(
         id = "radioactive",
         serverId = 9,
+        analyticsValue = "radioactive",
     ),
     ;
 


### PR DESCRIPTION
## Description
- See the request: p1737091811075529-slack-C088L7YF8BY

## Testing Instructions
- Play around the app and make sure the new properties were added to the events track

## Checklist
- [ ] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] ~I have considered whether it makes sense to add tests for my changes~
- [ ] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [ ] ~Any jetpack compose components I added or changed are covered by compose previews~
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.