### PR TITLE
Handle multiple subscription during Winback flow

### DIFF
--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/winback/AvailablePlansPage.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/winback/AvailablePlansPage.kt
@@ -83,6 +83,7 @@ internal fun AvailablePlansPage(
                 TooManyPurchases, TooManyProducts -> TooManyPurchasesState(
                     onGoToSubscriptions = onGoToSubscriptions,
                 )
+
                 NoPurchases, NoProducts, NoOrderId, Default -> ErrorState(
                     onReload = onReload,
                 )
@@ -282,12 +283,7 @@ private fun SubscriptionRow(
         modifier = modifier
             .fillMaxWidth()
             .clip(RoundedCornerShape(8.dp))
-            .background(
-                color = when (MaterialTheme.theme.type) {
-                    ThemeType.INDIGO -> Color.White
-                    else -> MaterialTheme.theme.colors.primaryUi01
-                },
-            )
+            .background(MaterialTheme.theme.colors.primaryUi01Active)
             .then(
                 if (isSelected) {
                     Modifier.border(
@@ -386,7 +382,6 @@ private fun AvailablePlansPagePreview(
 ) {
     AppThemeWithBackground(
         themeType = theme,
-        backgroundColor = { MaterialTheme.theme.colors.primaryUi04 },
     ) {
         AvailablePlansPage(
             plansState = SubscriptionPlansState.Loaded(
@@ -440,7 +435,6 @@ private fun AvailablePlansPageFailureTooManyPreview(
 ) {
     AppThemeWithBackground(
         themeType = theme,
-        backgroundColor = { MaterialTheme.theme.colors.primaryUi04 },
     ) {
         AvailablePlansPage(
             plansState = SubscriptionPlansState.Failure(TooManyPurchases),
@@ -459,7 +453,6 @@ private fun AvailablePlansPageFailureDefaultPreview(
 ) {
     AppThemeWithBackground(
         themeType = theme,
-        backgroundColor = { MaterialTheme.theme.colors.primaryUi04 },
     ) {
         AvailablePlansPage(
             plansState = SubscriptionPlansState.Failure(Default),

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/winback/AvailablePlansPage.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/winback/AvailablePlansPage.kt
@@ -45,6 +45,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import au.com.shiftyjelly.pocketcasts.compose.AppThemeWithBackground
 import au.com.shiftyjelly.pocketcasts.compose.Devices
+import au.com.shiftyjelly.pocketcasts.compose.bars.BottomSheetAppBar
 import au.com.shiftyjelly.pocketcasts.compose.components.TextH30
 import au.com.shiftyjelly.pocketcasts.compose.components.TextH40
 import au.com.shiftyjelly.pocketcasts.compose.components.TextP40
@@ -72,28 +73,35 @@ internal fun AvailablePlansPage(
     onGoBack: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    AnimatedContent(
-        targetState = plansState,
-        modifier = modifier,
-    ) { state ->
-        when (state) {
-            is SubscriptionPlansState.Loading -> LoadingState()
+    Column(
+        modifier = Modifier.nestedScroll(rememberViewInteropNestedScrollConnection()),
+    ) {
+        BottomSheetAppBar(
+            onNavigationClick = onGoBack,
+        )
+        AnimatedContent(
+            targetState = plansState,
+            modifier = modifier,
+        ) { state ->
+            when (state) {
+                is SubscriptionPlansState.Loading -> LoadingState()
 
-            is SubscriptionPlansState.Failure -> when (state.reason) {
-                TooManyPurchases, TooManyProducts -> TooManyPurchasesState(
-                    onGoToSubscriptions = onGoToSubscriptions,
-                )
+                is SubscriptionPlansState.Failure -> when (state.reason) {
+                    TooManyPurchases, TooManyProducts -> TooManyPurchasesState(
+                        onGoToSubscriptions = onGoToSubscriptions,
+                    )
 
-                NoPurchases, NoProducts, NoOrderId, Default -> ErrorState(
-                    onReload = onReload,
+                    NoPurchases, NoProducts, NoOrderId, Default -> ErrorState(
+                        onReload = onReload,
+                    )
+                }
+
+                is SubscriptionPlansState.Loaded -> LoadedState(
+                    userPlanId = state.activePurchase.productId,
+                    plans = state.plans,
+                    onSelectPlan = onSelectPlan,
                 )
             }
-
-            is SubscriptionPlansState.Loaded -> LoadedState(
-                userPlanId = state.activePurchase.productId,
-                plans = state.plans,
-                onSelectPlan = onSelectPlan,
-            )
         }
     }
 }
@@ -109,7 +117,6 @@ private fun LoadedState(
         modifier = Modifier
             .fillMaxSize()
             .padding(horizontal = 20.dp)
-            .nestedScroll(rememberViewInteropNestedScrollConnection())
             .verticalScroll(rememberScrollState()),
     ) {
         Spacer(
@@ -157,7 +164,8 @@ private fun TooManyPurchasesState(
         horizontalAlignment = Alignment.CenterHorizontally,
         modifier = Modifier
             .fillMaxSize()
-            .padding(horizontal = 20.dp),
+            .padding(horizontal = 20.dp)
+            .verticalScroll(rememberScrollState()),
     ) {
         Spacer(
             modifier = Modifier.height(64.dp),
@@ -216,7 +224,8 @@ private fun ErrorState(
         horizontalAlignment = Alignment.CenterHorizontally,
         modifier = Modifier
             .fillMaxSize()
-            .padding(horizontal = 48.dp),
+            .padding(horizontal = 48.dp)
+            .verticalScroll(rememberScrollState()),
     ) {
         Spacer(
             modifier = Modifier.weight(3f),

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/winback/CancelConfirmationPage.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/winback/CancelConfirmationPage.kt
@@ -20,7 +20,7 @@ import androidx.compose.ui.unit.dp
 @Composable
 internal fun CancelConfirmationPage(
     onKeepSubscription: () -> Unit,
-    onCancelSubscription: () -> Unit,
+    onCancelSubscriptions: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Column(
@@ -63,7 +63,7 @@ internal fun CancelConfirmationPage(
                 .height(64.dp)
                 .fillMaxWidth()
                 .background(Color(0xFFEDDDD1))
-                .clickable(onClick = onCancelSubscription),
+                .clickable(onClick = onCancelSubscriptions),
         ) {
             Text(
                 text = "Cancel subscription",

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/winback/OfferClaimedPage.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/winback/OfferClaimedPage.kt
@@ -192,7 +192,6 @@ private fun WinbackOfferPagePreview(
 ) {
     AppThemeWithBackground(
         themeType = theme,
-        backgroundColor = { MaterialTheme.theme.colors.primaryUi04 },
     ) {
         OfferClaimedPage(
             theme = theme,

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/winback/WinbackFragment.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/winback/WinbackFragment.kt
@@ -36,7 +36,6 @@ import au.com.shiftyjelly.pocketcasts.settings.LogsPage
 import au.com.shiftyjelly.pocketcasts.settings.status.StatusPage
 import au.com.shiftyjelly.pocketcasts.views.fragments.BaseDialogFragment
 import dagger.hilt.android.AndroidEntryPoint
-import kotlinx.coroutines.launch
 
 @AndroidEntryPoint
 class WinbackFragment : BaseDialogFragment() {
@@ -51,7 +50,6 @@ class WinbackFragment : BaseDialogFragment() {
 
         AppThemeWithBackground(
             themeType = theme.activeTheme,
-            backgroundColor = { MaterialTheme.theme.colors.primaryUi04 },
         ) {
             val navController = rememberNavController()
 
@@ -129,29 +127,18 @@ class WinbackFragment : BaseDialogFragment() {
     private fun DialogTintEffect(
         navController: NavHostController,
     ) {
-        var isBackgroundStyled by remember { mutableStateOf(false) }
         var isNavBarWhite by remember { mutableStateOf(false) }
         LaunchedEffect(navController) {
             navController.currentBackStackEntryFlow.collect { entry ->
-                isBackgroundStyled = entry.destination.route in routesWithAppBar
                 isNavBarWhite = entry.destination.route == WinbackNavRoutes.HelpAndFeedback
             }
         }
-        val backgroundTint by animateColorAsState(
-            animationSpec = colorAnimationSpec,
-            targetValue = with(MaterialTheme.theme.colors) { if (isBackgroundStyled) secondaryUi01 else primaryUi04 },
-        )
         val navigationBarTint by animateColorAsState(
             animationSpec = colorAnimationSpec,
-            targetValue = with(MaterialTheme.theme.colors) { if (isNavBarWhite) Color.White else primaryUi04 },
+            targetValue = if (isNavBarWhite) Color.White else MaterialTheme.theme.colors.primaryUi01 ,
         )
         LaunchedEffect(Unit) {
-            launch {
-                snapshotFlow { backgroundTint }.collect { tint -> setBackgroundTint(tint.toArgb()) }
-            }
-            launch {
-                snapshotFlow { navigationBarTint }.collect { tint -> setNavigationBarTint(tint.toArgb()) }
-            }
+            snapshotFlow { navigationBarTint }.collect { tint -> setNavigationBarTint(tint.toArgb()) }
         }
     }
 }
@@ -165,12 +152,6 @@ private object WinbackNavRoutes {
     const val StatusCheck = "StatusCheck"
     const val CancelConfirmation = "CancelConfirmation"
 }
-
-private val routesWithAppBar = listOf(
-    WinbackNavRoutes.HelpAndFeedback,
-    WinbackNavRoutes.SupportLogs,
-    WinbackNavRoutes.StatusCheck,
-)
 
 private val colorAnimationSpec = tween<Color>(350)
 private val intOffsetAnimationSpec = tween<IntOffset>(350)

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/winback/WinbackFragment.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/winback/WinbackFragment.kt
@@ -90,6 +90,7 @@ class WinbackFragment : BaseDialogFragment() {
                     AvailablePlansPage(
                         plansState = state.subscriptionPlansState,
                         onSelectPlan = { },
+                        onGoToSubscriptions = { },
                         onReload = { viewModel.loadInitialPlans() },
                         onGoBack = { navController.popBackStack() },
                     )

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/winback/WinbackOfferPage.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/winback/WinbackOfferPage.kt
@@ -289,7 +289,6 @@ private fun WinbackOfferPagePreview(
 ) {
     AppThemeWithBackground(
         themeType = theme,
-        backgroundColor = { MaterialTheme.theme.colors.primaryUi04 },
     ) {
         WinbackOfferPage(
             onClaimOffer = {},

--- a/modules/features/profile/src/test/kotlin/au/com/shiftyjelly/pocketcasts/profile/winback/WinbackViewModelTest.kt
+++ b/modules/features/profile/src/test/kotlin/au/com/shiftyjelly/pocketcasts/profile/winback/WinbackViewModelTest.kt
@@ -15,7 +15,6 @@ import com.android.billingclient.api.Purchase
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
-import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
 import org.mockito.kotlin.doReturn
@@ -84,9 +83,9 @@ class WinbackViewModelTest {
         val viewModel = WinbackViewModel(subscriptionManager)
 
         viewModel.uiState.test {
-            val availablePlans = awaitItem().subscriptionPlansState
+            val availablePlans = awaitItem().subscriptionPlansState as SubscriptionPlansState.Failure
 
-            assertTrue(availablePlans is SubscriptionPlansState.Failure)
+            assertEquals(FailureReason.NoPurchases, availablePlans.reason)
         }
     }
 
@@ -100,9 +99,9 @@ class WinbackViewModelTest {
         val viewModel = WinbackViewModel(subscriptionManager)
 
         viewModel.uiState.test {
-            val availablePlans = awaitItem().subscriptionPlansState
+            val availablePlans = awaitItem().subscriptionPlansState as SubscriptionPlansState.Failure
 
-            assertTrue(availablePlans is SubscriptionPlansState.Failure)
+            assertEquals(FailureReason.NoOrderId, availablePlans.reason)
         }
     }
 
@@ -119,9 +118,9 @@ class WinbackViewModelTest {
         val viewModel = WinbackViewModel(subscriptionManager)
 
         viewModel.uiState.test {
-            val availablePlans = awaitItem().subscriptionPlansState
+            val availablePlans = awaitItem().subscriptionPlansState as SubscriptionPlansState.Failure
 
-            assertTrue(availablePlans is SubscriptionPlansState.Failure)
+            assertEquals(FailureReason.TooManyPurchases, availablePlans.reason)
         }
     }
 
@@ -142,9 +141,25 @@ class WinbackViewModelTest {
         val viewModel = WinbackViewModel(subscriptionManager)
 
         viewModel.uiState.test {
-            val availablePlans = awaitItem().subscriptionPlansState
+            val availablePlans = awaitItem().subscriptionPlansState as SubscriptionPlansState.Failure
 
-            assertTrue(availablePlans is SubscriptionPlansState.Failure)
+            assertEquals(FailureReason.TooManyProducts, availablePlans.reason)
+        }
+    }
+
+    @Test
+    fun `subscription plans for user with purchase with no products`() = runTest {
+        val purchases = listOf(createPurchase(productIds = emptyList()))
+
+        wheneverBlocking { subscriptionManager.loadProducts() } doReturn ProductDetailsState.Loaded(products)
+        wheneverBlocking { subscriptionManager.loadPurchases() } doReturn PurchasesState.Loaded(purchases)
+
+        val viewModel = WinbackViewModel(subscriptionManager)
+
+        viewModel.uiState.test {
+            val availablePlans = awaitItem().subscriptionPlansState as SubscriptionPlansState.Failure
+
+            assertEquals(FailureReason.NoProducts, availablePlans.reason)
         }
     }
 

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -2294,6 +2294,9 @@
     <string name="winback_claimed_offer_message_2">Thanks for choosing Pocket&#160;Casts. Billing starts after your free month ends.</string>
     <string name="winback_available_plans_title">Available Plans</string>
     <string name="winback_available_plans_billing_note">Your new plan will activate at the end of your current billing period.</string>
+    <string name="winback_too_many_subscritpions_title">Multiple subscriptions found</string>
+    <string name="winback_too_many_subscritpions_note">You have more than one active Pocket&#160;Casts subscription. Please manage your subscriptions in the Play&#160;Store to avoid duplicate charges.</string>
+    <string name="winback_too_many_subscritpions_button_label">Manage subscriptions in Play&#160;Store</string>
     <string name="winback_error_fetch_description">Sorry, but something went wrong fetching your plans.</string>
 
 </resources>


### PR DESCRIPTION
## Description

This PR handles a scenario when a user has multiple active subscriptions. Also some other minor changes:
- Added back button navigation. c4b9442281372ad5a2f66d14479ddf531285eb57
- Fixed inconsistent theming. e3068c615167f51f3efa37fa60ce7b3497063601

Designs: G22KfZwL1Gv5yyxdTheF9H-fi-1_776

## Testing Instructions

> [!note]
> Test this with the `release` variant of the app. You'll need to enable `WINBACK` feature flag in the code first.

1. Open the app.
2. Create an account.
3. Subscribe to any plan.
4. Go to Account Details page.
5. Sign out.
6. Create a new account.
7. Subscribe to any plan different from the plan from the 3rd step.
8. Go to Account Details page.
9. Tap on "Cancel subscription".
10. Tap on "Looking for a different plan?".
11. You should "Too many subscriptions screen".
12. Tap on "Manage subscriptions in Play Store".
13. You should see Pocket Casts subscriptions in Google Play.

## Screenshots or Screencast 

https://github.com/user-attachments/assets/a504dcd8-4f61-4d98-af7c-4fd16833ec70

<img width="1363" alt="Screenshot 2025-01-20 at 11 50 06" src="https://github.com/user-attachments/assets/ee9ee6f6-9017-49a0-a3ea-1e101123da45" />

## Checklist
- [ ] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [ ] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack