### PR TITLE
Add subscription plan change logic

### DIFF
--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/winback/AvailablePlansPage.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/winback/AvailablePlansPage.kt
@@ -46,6 +46,7 @@ import androidx.compose.ui.unit.sp
 import au.com.shiftyjelly.pocketcasts.compose.AppThemeWithBackground
 import au.com.shiftyjelly.pocketcasts.compose.Devices
 import au.com.shiftyjelly.pocketcasts.compose.bars.BottomSheetAppBar
+import au.com.shiftyjelly.pocketcasts.compose.components.ProgressDialog
 import au.com.shiftyjelly.pocketcasts.compose.components.TextH30
 import au.com.shiftyjelly.pocketcasts.compose.components.TextH40
 import au.com.shiftyjelly.pocketcasts.compose.components.TextP40
@@ -81,6 +82,7 @@ internal fun AvailablePlansPage(
         )
         AnimatedContent(
             targetState = plansState,
+            contentKey = { state -> state.javaClass },
             modifier = modifier,
         ) { state ->
             when (state) {
@@ -99,6 +101,7 @@ internal fun AvailablePlansPage(
                 is SubscriptionPlansState.Loaded -> LoadedState(
                     userPlanId = state.activePurchase.productId,
                     plans = state.plans,
+                    isChangingPlan = state.isChangingPlan,
                     onSelectPlan = onSelectPlan,
                 )
             }
@@ -110,49 +113,58 @@ internal fun AvailablePlansPage(
 private fun LoadedState(
     userPlanId: String?,
     plans: List<SubscriptionPlan>,
+    isChangingPlan: Boolean,
     onSelectPlan: (SubscriptionPlan) -> Unit,
 ) {
-    Column(
-        horizontalAlignment = Alignment.CenterHorizontally,
-        modifier = Modifier
-            .fillMaxSize()
-            .padding(horizontal = 20.dp)
-            .verticalScroll(rememberScrollState()),
-    ) {
-        Spacer(
-            modifier = Modifier.height(64.dp),
-        )
-        PocketCastsLogo()
-        Spacer(
-            modifier = Modifier.height(20.dp),
-        )
-        Text(
-            text = stringResource(LR.string.winback_available_plans_title),
-            fontSize = 28.sp,
-            fontWeight = FontWeight.Bold,
-            lineHeight = 38.5.sp,
-            color = MaterialTheme.theme.colors.primaryText01,
-            textAlign = TextAlign.Center,
-        )
-        Spacer(
-            modifier = Modifier.height(24.dp),
-        )
-        plans.forEach { plan ->
-            SubscriptionRow(
-                plan = plan,
-                isSelected = plan.productId == userPlanId,
-                onClick = { onSelectPlan(plan) },
+    Box {
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(horizontal = 20.dp)
+                .verticalScroll(rememberScrollState()),
+        ) {
+            Spacer(
+                modifier = Modifier.height(64.dp),
+            )
+            PocketCastsLogo()
+            Spacer(
+                modifier = Modifier.height(20.dp),
+            )
+            Text(
+                text = stringResource(LR.string.winback_available_plans_title),
+                fontSize = 28.sp,
+                fontWeight = FontWeight.Bold,
+                lineHeight = 38.5.sp,
+                color = MaterialTheme.theme.colors.primaryText01,
+                textAlign = TextAlign.Center,
             )
             Spacer(
-                modifier = Modifier.height(16.dp),
+                modifier = Modifier.height(24.dp),
+            )
+            plans.forEach { plan ->
+                SubscriptionRow(
+                    plan = plan,
+                    isSelected = plan.productId == userPlanId,
+                    onClick = { onSelectPlan(plan) },
+                )
+                Spacer(
+                    modifier = Modifier.height(16.dp),
+                )
+            }
+            TextP50(
+                text = stringResource(LR.string.winback_available_plans_billing_note),
+                color = MaterialTheme.theme.colors.primaryText02,
+                textAlign = TextAlign.Center,
+                modifier = Modifier.padding(horizontal = 36.dp),
             )
         }
-        TextP50(
-            text = stringResource(LR.string.winback_available_plans_billing_note),
-            color = MaterialTheme.theme.colors.primaryText02,
-            textAlign = TextAlign.Center,
-            modifier = Modifier.padding(horizontal = 36.dp),
-        )
+        if (isChangingPlan) {
+            ProgressDialog(
+                text = "Changing plan",
+                onDismiss = {},
+            )
+        }
     }
 }
 

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/winback/AvailablePlansPage.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/winback/AvailablePlansPage.kt
@@ -161,7 +161,7 @@ private fun LoadedState(
         }
         if (isChangingPlan) {
             ProgressDialog(
-                text = "Changing plan",
+                text = stringResource(LR.string.winback_changing_plan),
                 onDismiss = {},
             )
         }

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/winback/WinbackFragment.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/winback/WinbackFragment.kt
@@ -5,6 +5,7 @@ import android.net.Uri
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.ViewGroup
+import androidx.appcompat.app.AppCompatActivity
 import androidx.compose.animation.AnimatedContentTransitionScope
 import androidx.compose.animation.animateColorAsState
 import androidx.compose.animation.core.tween
@@ -99,11 +100,11 @@ class WinbackFragment : BaseDialogFragment() {
                     composable(WinbackNavRoutes.AvailablePlans) {
                         AvailablePlansPage(
                             plansState = state.subscriptionPlansState,
-                            onSelectPlan = { },
+                            onSelectPlan = { plan -> viewModel.changePlan(requireActivity() as AppCompatActivity, plan) },
                             onGoToSubscriptions = {
                                 if (!goToPlayStoreSubscriptions()) {
                                     scope.launch {
-                                        snackbarHostState.showSnackbar(getString(LR.string.error))
+                                        snackbarHostState.showSnackbar(getString(LR.string.error_generic_message))
                                     }
                                 }
                             },
@@ -137,7 +138,7 @@ class WinbackFragment : BaseDialogFragment() {
                             onCancelSubscriptions = {
                                 if (!goToPlayStoreSubscriptions()) {
                                     scope.launch {
-                                        snackbarHostState.showSnackbar(getString(LR.string.error))
+                                        snackbarHostState.showSnackbar(getString(LR.string.error_generic_message))
                                     }
                                 }
                             },
@@ -146,6 +147,13 @@ class WinbackFragment : BaseDialogFragment() {
                 }
 
                 DialogTintEffect(navController)
+
+                val hasPlanChangeFailed = (state.subscriptionPlansState as? SubscriptionPlansState.Loaded)?.hasPlanChangeFailed == true
+                if (hasPlanChangeFailed) {
+                    LaunchedEffect(Unit) {
+                        snackbarHostState.showSnackbar(getString(LR.string.error_generic_message))
+                    }
+                }
 
                 SnackbarHost(
                     hostState = snackbarHostState,

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -2297,5 +2297,6 @@
     <string name="winback_too_many_subscritpions_note">You have more than one active Pocket&#160;Casts subscription. Please manage your subscriptions in the Play&#160;Store to avoid duplicate charges.</string>
     <string name="winback_too_many_subscritpions_button_label">Manage subscriptions in Play&#160;Store</string>
     <string name="winback_error_fetch_description">Sorry, but something went wrong fetching your plans.</string>
+    <string name="winback_changing_plan">Changing plan</string>
 
 </resources>

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/subscription/SubscriptionManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/subscription/SubscriptionManager.kt
@@ -8,6 +8,7 @@ import au.com.shiftyjelly.pocketcasts.models.type.SubscriptionTier
 import au.com.shiftyjelly.pocketcasts.utils.Optional
 import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
 import com.android.billingclient.api.ProductDetails
+import com.android.billingclient.api.Purchase
 import io.reactivex.Flowable
 import io.reactivex.Single
 import kotlinx.coroutines.coroutineScope
@@ -31,6 +32,14 @@ interface SubscriptionManager {
     }
 
     fun launchBillingFlow(activity: AppCompatActivity, productDetails: ProductDetails, offerToken: String)
+
+    suspend fun changeProduct(
+        currentPurchase: Purchase,
+        currentPurchaseProductId: String,
+        newProduct: ProductDetails,
+        newProductOfferToken: String,
+        activity: AppCompatActivity,
+    ): Boolean
 
     fun signOut()
 


### PR DESCRIPTION
## Description

This PR adds logic for changing a subscription plan during the Winback flow. I had to clean up how we calculate the replacement mode to fit it into the flow. During my testing I discovered that using `DEFERRED` replacement mode is not suitable for us. Our backend treats such a subscription as a cancelled one. Also we can't effectively query it from the Billing API because it is not recurring yet.

## Testing Instructions

> [!note]
> Test this with the `release` variant of the app.

1. Have a device using a Google Play tester account with no Pocket Casts subscriptions.
2. Sign in into the app with an account without a subscription.
3. Purchase any subscription through Google Play.
4. Go to the Account Details page.
5. Tap on the `Cancel subscription` button.
6. Tap on `Looking for a different plan?` option.
7. Try switching a subscription and verify that it worked.

## Screenshots or Screencast 

### Demo

https://github.com/user-attachments/assets/7388673f-bab6-40c0-9b06-72a44088999d

### Clean transitions

A clean transition means that it is from a fresh subscription without any history. If there is history prices or dates might differ as pricing differences accumulate.

| Plus M -> Patron M | Plus M -> Plus Y | Plus M -> Patron Y |
| - | - | - |
| ![pat-m](https://github.com/user-attachments/assets/9aa161d8-0fc7-475e-af17-d736abdfdd1f) | ![plus-y](https://github.com/user-attachments/assets/c8d9c27f-1977-4858-83ba-a34cbf394956) | ![pat-y](https://github.com/user-attachments/assets/432b5476-08f6-44a2-9ed3-1c662a51b04a) |

| Patron M -> Plus M | Patron M -> Plus Y | Patron M -> Patron Y |
| - | - | - |
| ![plus-m](https://github.com/user-attachments/assets/596758dc-a4e1-4c78-a2d2-06007c47b889) | ![plus-y](https://github.com/user-attachments/assets/77e2dab2-dd9e-4cb7-bebe-b18734f0a0de) | ![pat-y](https://github.com/user-attachments/assets/fd8ef0a4-bc4a-47d0-af8b-1ccb89f2d1cb) |

| Plus Y -> Plus M | Plus Y -> Patron M | Plus M -> Patron Y |
| - | - | - |
| ![plus-m](https://github.com/user-attachments/assets/cb3f0a08-6e42-4743-87d5-22fe2ba33a96) | ![pat-m](https://github.com/user-attachments/assets/f24cae0f-f809-43be-9723-43e3627311a6) | ![pat-y](https://github.com/user-attachments/assets/9e71c222-e378-437d-8cf2-67718ee545b0) |

| Patron Y -> Plus M | Patron Y -> Patron M | Patron Y -> Plus Y |
| - | - | - |
| ![plus-m](https://github.com/user-attachments/assets/f412f626-6e03-4ba6-934f-ea3557edc0b0) | ![pat-m](https://github.com/user-attachments/assets/2d62db9b-ad73-4e45-9b25-1ade9395f945) | ![plus-y](https://github.com/user-attachments/assets/d6d994d8-b402-4551-b8f5-d43882c25ee3) |

## Checklist
- [ ] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] ~Any jetpack compose components I added or changed are covered by compose previews~
- [ ] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~