### PR TITLE
Remove the option to share bookmarks for user files

### DIFF
--- a/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/multiselect/MultiSelectBookmarksHelper.kt
+++ b/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/multiselect/MultiSelectBookmarksHelper.kt
@@ -4,13 +4,16 @@ import android.content.res.Resources
 import androidx.fragment.app.FragmentActivity
 import androidx.fragment.app.FragmentManager
 import androidx.lifecycle.LiveData
-import androidx.lifecycle.map
+import androidx.lifecycle.asFlow
+import androidx.lifecycle.liveData
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTracker
 import au.com.shiftyjelly.pocketcasts.analytics.SourceView
 import au.com.shiftyjelly.pocketcasts.localization.extensions.getStringPlural
 import au.com.shiftyjelly.pocketcasts.models.entity.Bookmark
+import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.repositories.bookmark.BookmarkManager
+import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
 import au.com.shiftyjelly.pocketcasts.views.R
 import au.com.shiftyjelly.pocketcasts.views.dialog.ConfirmationDialog
 import javax.inject.Inject
@@ -26,6 +29,7 @@ import au.com.shiftyjelly.pocketcasts.ui.R as UR
 class MultiSelectBookmarksHelper @Inject constructor(
     private val bookmarkManager: BookmarkManager,
     private val analyticsTracker: AnalyticsTracker,
+    var episodeManager: EpisodeManager,
 ) : MultiSelectHelper<Bookmark>() {
     override val maxToolbarIcons = 3
 
@@ -34,19 +38,22 @@ class MultiSelectBookmarksHelper @Inject constructor(
 
     override var source by bookmarkManager::sourceView
 
-    override val toolbarActions: LiveData<List<MultiSelectAction>> = _selectedListLive
-        .map {
-            Timber.d("MultiSelectBookmarksHelper toolbarActions updated, ${it.size} bookmarks from $source")
-            listOf(
+    override val toolbarActions: LiveData<List<MultiSelectAction>> = liveData {
+        _selectedListLive.asFlow().collect { selectedList ->
+            Timber.d("MultiSelectBookmarksHelper toolbarActions updated, ${selectedList.size} bookmarks from $source")
+
+            val actions = listOf(
                 MultiSelectBookmarkAction.ShareBookmark(
-                    isVisible = source != SourceView.FILES &&
-                        it.count() == 1,
+                    isVisible = source != SourceView.FILES && selectedList.count() == 1 && isEligibleToShare(),
                 ),
-                MultiSelectBookmarkAction.EditBookmark(isVisible = it.count() == 1),
+                MultiSelectBookmarkAction.EditBookmark(isVisible = selectedList.count() == 1),
                 MultiSelectBookmarkAction.DeleteBookmark,
                 MultiSelectAction.SelectAll,
             )
+
+            emit(actions)
         }
+    }
 
     override fun isSelected(multiSelectable: Bookmark) =
         selectedList.count { it.uuid == multiSelectable.uuid } > 0
@@ -163,6 +170,13 @@ class MultiSelectBookmarksHelper @Inject constructor(
                 closeMultiSelect()
             }
             .show(fragmentManager, "delete_bookmarks_warning")
+    }
+
+    private suspend fun isEligibleToShare(): Boolean {
+        val bookmark = selectedList.first()
+
+        val episode = episodeManager.findEpisodeByUuid(bookmark.episodeUuid)
+        return episode is PodcastEpisode
     }
 
     sealed class NavigationState {


### PR DESCRIPTION
## Description
- This is to align the same behavior that iOS fixed: https://github.com/Automattic/pocket-casts-ios/pull/2661/files

[Screen_recording_20250121_120555.webm](https://github.com/user-attachments/assets/0fca08a2-1db6-424f-9dff-39d15439794b)

## Testing Instructions

1. Start the app
2. Open the Profile tab
3. Tap on Files and ensure you upload at least one file
4. Tap on one of the files
5. Tap on bookmark
6. Select one of the bookmarks
7. Ensure you don't see the share option ✅
8. Play an public episode
9. Bookmark something
10. and try to share the bookmark
11. Ensure you see the share option ✅


## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
