### PR TITLE
Update Remove Listening History Button

### DIFF
--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/ProfileEpisodeListFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/ProfileEpisodeListFragment.kt
@@ -395,7 +395,14 @@ class ProfileEpisodeListFragment : BaseFragment(), Toolbar.OnMenuItemClickListen
             }
         }
         multiSelectHelper.coordinatorLayout = (activity as FragmentHostListener).snackBarView()
-        binding?.multiSelectToolbar?.setup(viewLifecycleOwner, multiSelectHelper, menuRes = null, activity = requireActivity())
+
+        val sourceView = when (mode) {
+            Mode.Downloaded -> SourceView.DOWNLOADS
+            Mode.History -> SourceView.LISTENING_HISTORY
+            Mode.Starred -> SourceView.STARRED
+        }
+
+        binding?.multiSelectToolbar?.setup(viewLifecycleOwner, multiSelectHelper, menuRes = null, activity = requireActivity(), sourceView = sourceView)
 
         viewLifecycleOwner.lifecycleScope.launch {
             viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {

--- a/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/multiselect/MultiSelectAdapter.kt
+++ b/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/multiselect/MultiSelectAdapter.kt
@@ -39,7 +39,7 @@ private val MULTI_SELECT_ACTION_DIFF = object : DiffUtil.ItemCallback<Any>() {
     }
 }
 
-class MultiSelectAdapter(val editable: Boolean, val listener: ((MultiSelectAction) -> Unit)? = null, val dragListener: ((ItemViewHolder) -> Unit)?) : ListAdapter<Any, RecyclerView.ViewHolder>(MULTI_SELECT_ACTION_DIFF) {
+class MultiSelectAdapter(val editable: Boolean, val listener: ((MultiSelectAction) -> Unit)? = null, var shouldShowRemoveListeningHistory: Boolean = true, val dragListener: ((ItemViewHolder) -> Unit)?) : ListAdapter<Any, RecyclerView.ViewHolder>(MULTI_SELECT_ACTION_DIFF) {
     var episode: BaseEpisode? = null
         set(value) {
             field = value
@@ -101,6 +101,13 @@ class MultiSelectAdapter(val editable: Boolean, val listener: ((MultiSelectActio
     @SuppressLint("ClickableViewAccessibility")
     override fun onBindViewHolder(holder: RecyclerView.ViewHolder, position: Int) {
         val item = getItem(position)
+
+        if (item is MultiSelectEpisodeAction.RemoveListeningHistory && !shouldShowRemoveListeningHistory) {
+            holder.itemView.visibility = View.GONE
+            return
+        } else {
+            holder.itemView.visibility = View.VISIBLE
+        }
 
         if (item is MultiSelectAction && holder is ItemViewHolder) {
             holder.binding.lblTitle.setText(item.title)

--- a/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/multiselect/MultiSelectAdapter.kt
+++ b/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/multiselect/MultiSelectAdapter.kt
@@ -39,7 +39,7 @@ private val MULTI_SELECT_ACTION_DIFF = object : DiffUtil.ItemCallback<Any>() {
     }
 }
 
-class MultiSelectAdapter(val editable: Boolean, val listener: ((MultiSelectAction) -> Unit)? = null, var shouldShowRemoveListeningHistory: Boolean = true, val dragListener: ((ItemViewHolder) -> Unit)?) : ListAdapter<Any, RecyclerView.ViewHolder>(MULTI_SELECT_ACTION_DIFF) {
+class MultiSelectAdapter(val editable: Boolean, val listener: ((MultiSelectAction) -> Unit)? = null, val dragListener: ((ItemViewHolder) -> Unit)?) : ListAdapter<Any, RecyclerView.ViewHolder>(MULTI_SELECT_ACTION_DIFF) {
     var episode: BaseEpisode? = null
         set(value) {
             field = value
@@ -101,13 +101,6 @@ class MultiSelectAdapter(val editable: Boolean, val listener: ((MultiSelectActio
     @SuppressLint("ClickableViewAccessibility")
     override fun onBindViewHolder(holder: RecyclerView.ViewHolder, position: Int) {
         val item = getItem(position)
-
-        if (item is MultiSelectEpisodeAction.RemoveListeningHistory && !shouldShowRemoveListeningHistory) {
-            holder.itemView.visibility = View.GONE
-            return
-        } else {
-            holder.itemView.visibility = View.VISIBLE
-        }
 
         if (item is MultiSelectAction && holder is ItemViewHolder) {
             holder.binding.lblTitle.setText(item.title)

--- a/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/multiselect/MultiSelectFragment.kt
+++ b/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/multiselect/MultiSelectFragment.kt
@@ -38,7 +38,7 @@ class MultiSelectFragment : BaseFragment(), MultiSelectTouchCallback.ItemTouchHe
     private val shouldShowRemoveListeningHistory: Boolean
         get() = arguments?.getBoolean(ARG_SHOULD_SHOW_REMOVE_LISTENING_HISTORY) ?: false
 
-    private val adapter = MultiSelectAdapter(editable = true, listener = null, dragListener = this::onItemStartDrag)
+    private val adapter = MultiSelectAdapter(editable = true, listener = null, shouldShowRemoveListeningHistory = shouldShowRemoveListeningHistory, dragListener = this::onItemStartDrag)
     private lateinit var itemTouchHelper: ItemTouchHelper
     private var items = emptyList<Any>()
     private val shortcutTitle = MultiSelectAdapter.Title(LR.string.multiselect_actions_shown)
@@ -86,16 +86,11 @@ class MultiSelectFragment : BaseFragment(), MultiSelectTouchCallback.ItemTouchHe
             .observe(viewLifecycleOwner) {
                 val multiSelectActions: MutableList<Any> = MultiSelectEpisodeAction.listFromIds(it).toMutableList()
 
-                if (!shouldShowRemoveListeningHistory) {
-                    multiSelectActions.removeAll { action ->
-                        action is MultiSelectEpisodeAction.RemoveListeningHistory
-                    }
-                }
-
                 multiSelectActions.add(0, shortcutTitle)
                 multiSelectActions.add(multiSelectEpisodesHelper.maxToolbarIcons + 1, overflowTitle)
 
                 items = multiSelectActions.toList()
+                adapter.shouldShowRemoveListeningHistory = shouldShowRemoveListeningHistory
                 adapter.submitList(multiSelectActions.toList())
             }
     }

--- a/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/multiselect/MultiSelectFragment.kt
+++ b/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/multiselect/MultiSelectFragment.kt
@@ -38,7 +38,7 @@ class MultiSelectFragment : BaseFragment(), MultiSelectTouchCallback.ItemTouchHe
     private val shouldShowRemoveListeningHistory: Boolean
         get() = arguments?.getBoolean(ARG_SHOULD_SHOW_REMOVE_LISTENING_HISTORY) ?: false
 
-    private val adapter = MultiSelectAdapter(editable = true, listener = null, shouldShowRemoveListeningHistory = shouldShowRemoveListeningHistory, dragListener = this::onItemStartDrag)
+    private val adapter = MultiSelectAdapter(editable = true, listener = null, dragListener = this::onItemStartDrag)
     private lateinit var itemTouchHelper: ItemTouchHelper
     private var items = emptyList<Any>()
     private val shortcutTitle = MultiSelectAdapter.Title(LR.string.multiselect_actions_shown)
@@ -86,11 +86,16 @@ class MultiSelectFragment : BaseFragment(), MultiSelectTouchCallback.ItemTouchHe
             .observe(viewLifecycleOwner) {
                 val multiSelectActions: MutableList<Any> = MultiSelectEpisodeAction.listFromIds(it).toMutableList()
 
+                if (!shouldShowRemoveListeningHistory) {
+                    multiSelectActions.removeAll { action ->
+                        action is MultiSelectEpisodeAction.RemoveListeningHistory
+                    }
+                }
+
                 multiSelectActions.add(0, shortcutTitle)
                 multiSelectActions.add(multiSelectEpisodesHelper.maxToolbarIcons + 1, overflowTitle)
 
                 items = multiSelectActions.toList()
-                adapter.shouldShowRemoveListeningHistory = shouldShowRemoveListeningHistory
                 adapter.submitList(multiSelectActions.toList())
             }
     }

--- a/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/multiselect/MultiSelectToolbar.kt
+++ b/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/multiselect/MultiSelectToolbar.kt
@@ -40,6 +40,7 @@ class MultiSelectToolbar @JvmOverloads constructor(
         multiSelectHelper: MultiSelectHelper<T>,
         @MenuRes menuRes: Int?,
         activity: FragmentActivity,
+        sourceView: SourceView? = null,
     ) {
         setBackgroundColor(context.getThemeColor(UR.attr.support_01))
         if (menuRes != null) {
@@ -56,7 +57,8 @@ class MultiSelectToolbar @JvmOverloads constructor(
                     val item = menu.add(Menu.NONE, action.actionId, 0, action.title)
                     item.setIcon(action.iconRes)
                     item.setShowAsAction(MenuItem.SHOW_AS_ACTION_ALWAYS)
-                    item.isVisible = action.isVisible
+                    item.isVisible =
+                        if (action is MultiSelectEpisodeAction.RemoveListeningHistory && sourceView != SourceView.LISTENING_HISTORY) false else action.isVisible
                 }
 
                 overflowItems = it.subList(maxIcons, it.size)
@@ -95,7 +97,7 @@ class MultiSelectToolbar @JvmOverloads constructor(
                         AnalyticsEvent.MULTI_SELECT_VIEW_OVERFLOW_MENU_SHOWN,
                         AnalyticsProp.sourceMap(multiSelectHelper.source),
                     )
-                    showOverflowBottomSheet(activity.supportFragmentManager, multiSelectHelper)
+                    showOverflowBottomSheet(activity.supportFragmentManager, multiSelectHelper, sourceView)
                 }
                 true
             } else {
@@ -116,9 +118,10 @@ class MultiSelectToolbar @JvmOverloads constructor(
     private fun showOverflowBottomSheet(
         fragmentManager: FragmentManager?,
         multiSelectHelper: MultiSelectEpisodesHelper,
+        sourceView: SourceView?,
     ) {
         if (fragmentManager == null) return
-        val overflowSheet = MultiSelectBottomSheet.newInstance(overflowItems.map { it.actionId })
+        val overflowSheet = MultiSelectBottomSheet.newInstance(overflowItems.map { it.actionId }, shouldShowRemoveListeningHistory = sourceView == SourceView.LISTENING_HISTORY)
         overflowSheet.multiSelectHelper = multiSelectHelper
         overflowSheet.show(fragmentManager, "multiselectbottomsheet")
     }

--- a/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/multiselect/MultiSelectToolbar.kt
+++ b/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/multiselect/MultiSelectToolbar.kt
@@ -53,15 +53,22 @@ class MultiSelectToolbar @JvmOverloads constructor(
                 menu.clear()
 
                 val maxIcons = multiSelectHelper.maxToolbarIcons
-                it.subList(0, maxIcons).forEachIndexed { _, action ->
+
+                val visibleIcons = it.filter { action ->
+                    if (action is MultiSelectEpisodeAction.RemoveListeningHistory) {
+                        sourceView == SourceView.LISTENING_HISTORY
+                    } else {
+                        action.isVisible
+                    }
+                }.take(maxIcons)
+
+                visibleIcons.forEachIndexed { _, action ->
                     val item = menu.add(Menu.NONE, action.actionId, 0, action.title)
                     item.setIcon(action.iconRes)
                     item.setShowAsAction(MenuItem.SHOW_AS_ACTION_ALWAYS)
-                    item.isVisible =
-                        if (action is MultiSelectEpisodeAction.RemoveListeningHistory && sourceView != SourceView.LISTENING_HISTORY) false else action.isVisible
                 }
 
-                overflowItems = it.subList(maxIcons, it.size)
+                overflowItems = it - visibleIcons
 
                 when (multiSelectHelper) {
                     is MultiSelectBookmarksHelper -> {


### PR DESCRIPTION
## Description
- This removes the button instead of hide to avoid this issue https://github.com/Automattic/pocket-casts-android/pull/3453#issuecomment-2605485990

## Testing Instructions
- Smoke test the remove individual listening history
- ✅ Ensure this button displays only for when the user played the episode
- ✅ Ensure this button is not available for when the user favorited / downloaded an episode without playing it


## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
