### PR TITLE
Fix: Do not close episode details when archiving an episode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 -----
 *   Bug Fixes
     *   Fix status bar theming during onboarding.
-        ([#3460](https://github.com/Automattic/pocket-casts-android/pull/3460)) 
+        ([#3460](https://github.com/Automattic/pocket-casts-android/pull/3460))
+    *   Fix do not close episode details when archiving an episode
+        ([#3473](https://github.com/Automattic/pocket-casts-android/pull/3473))
 
 7.81
 -----

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 *   Bug Fixes
     *   Fix status bar theming during onboarding.
         ([#3460](https://github.com/Automattic/pocket-casts-android/pull/3460))
-    *   Fix do not close episode details when archiving an episode
+*   Updates
+    *   Do not close episode details screen when archiving an episode
         ([#3473](https://github.com/Automattic/pocket-casts-android/pull/3473))
 
 7.81

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/episode/EpisodeFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/episode/EpisodeFragment.kt
@@ -420,9 +420,6 @@ class EpisodeFragment : BaseFragment() {
         binding?.btnArchive?.let { button ->
             button.onStateChange = {
                 viewModel.archiveClicked(button.isOn)
-                if (button.isOn) {
-                    (parentFragment as? BaseDialogFragment)?.dismiss()
-                }
             }
         }
 


### PR DESCRIPTION
## Description
- We should keep the screen opened instead of archiving an episode

Fixes #3442

## Testing Instructions
1. Open a podcast
2. Tap on Episode to open the episode detail
3. Tap on Archive button
4. The episode detail screen should not be closed ✅
5. The Archive button text should be updated to `Unarchive` ✅

## Screenshots or Screencast 
[Screen_recording_20250122_092743.webm](https://github.com/user-attachments/assets/4c4a229e-f662-4643-899e-ab7a1f82b8d8)


## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [ ] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [ ] ~Any jetpack compose components I added or changed are covered by compose previews~
- [ ] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~
