### PR TITLE
Add Pixel Watch skip buttons setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 *   Bug Fixes
     *   Fix the Galaxy Watch skip buttons not working.
         ([#3455](https://github.com/Automattic/pocket-casts-android/pull/3455)) 
+    *   Add Pixel Watch skip buttons setting.
+        ([#3474](https://github.com/Automattic/pocket-casts-android/pull/3474))
     *   Fix the cropping issue with the Add 5 Minutes sleep timer button.
         ([#3436](https://github.com/Automattic/pocket-casts-android/pull/3436))
 

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/notification/MediaActionsFragment.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/notification/MediaActionsFragment.kt
@@ -43,6 +43,7 @@ class MediaActionsFragment : BaseFragment() {
             MediaActionsPage(
                 state = state,
                 onShowCustomActionsChanged = viewModel::setShowCustomActionsChanged,
+                onNextPreviousTrackSkipButtonsChanged = viewModel::setNextPreviousTrackSkipButtonsChanged,
                 onActionsOrderChanged = viewModel::onActionsOrderChanged,
                 onActionMoved = viewModel::onActionMoved,
                 onBackClick = ::onBackClick,

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/notification/MediaActionsPage.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/notification/MediaActionsPage.kt
@@ -37,6 +37,7 @@ fun MediaActionsPage(
     state: State,
     onBackClick: () -> Unit,
     onShowCustomActionsChanged: (Boolean) -> Unit,
+    onNextPreviousTrackSkipButtonsChanged: (Boolean) -> Unit,
     onActionsOrderChanged: (List<MenuAction>) -> Unit,
     modifier: Modifier = Modifier,
     onActionMoved: (fromIndex: Int, toIndex: Int, action: MenuAction) -> Unit = { _, _, _ -> },
@@ -52,6 +53,8 @@ fun MediaActionsPage(
                 PageHeader(
                     customActionsVisibility = state.customActionsVisibility,
                     onShowCustomActionsChanged = onShowCustomActionsChanged,
+                    nextPreviousTrackSkipButtons = state.nextPreviousTrackSkipButtons,
+                    onNextPreviousTrackSkipButtonsChanged = onNextPreviousTrackSkipButtonsChanged,
                 )
             },
             menuActions = state.actions,
@@ -69,12 +72,18 @@ fun MediaActionsPage(
 private fun PageHeader(
     customActionsVisibility: Boolean,
     onShowCustomActionsChanged: (Boolean) -> Unit,
+    nextPreviousTrackSkipButtons: Boolean,
+    onNextPreviousTrackSkipButtonsChanged: (Boolean) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Column(modifier = modifier) {
         ShowCustomActionsSettings(
             customActionsVisibility = customActionsVisibility,
             onShowCustomActionsChanged = onShowCustomActionsChanged,
+        )
+        PixelWatchSKipButtonsSetting(
+            nextPreviousTrackSkipButtons = nextPreviousTrackSkipButtons,
+            onNextPreviousTrackSkipButtonsChanged = onNextPreviousTrackSkipButtonsChanged,
         )
         Spacer(Modifier.height(16.dp))
         SettingRow(
@@ -111,6 +120,28 @@ private fun ShowCustomActionsSettings(
     )
 }
 
+@Composable
+private fun PixelWatchSKipButtonsSetting(
+    nextPreviousTrackSkipButtons: Boolean,
+    onNextPreviousTrackSkipButtonsChanged: (Boolean) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    SettingRow(
+        primaryText = stringResource(LR.string.settings_pixel_watch_title),
+        secondaryText = stringResource(LR.string.settings_pixel_watch_subtitle),
+        toggle = SettingRowToggle.Switch(checked = nextPreviousTrackSkipButtons),
+        indent = false,
+        modifier = modifier
+            .padding(top = 8.dp)
+            .toggleable(
+                value = nextPreviousTrackSkipButtons,
+                role = Role.Switch,
+            ) {
+                onNextPreviousTrackSkipButtonsChanged(it)
+            },
+    )
+}
+
 @Preview
 @Composable
 fun MediaActionsPagePreview(@PreviewParameter(ThemePreviewParameterProvider::class) themeType: Theme.ThemeType) {
@@ -129,6 +160,7 @@ fun MediaActionsPagePreview(@PreviewParameter(ThemePreviewParameterProvider::cla
             ),
             onBackClick = {},
             onShowCustomActionsChanged = {},
+            onNextPreviousTrackSkipButtonsChanged = {},
             onActionsOrderChanged = {},
         )
     }

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/notification/MediaActionsViewModel.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/notification/MediaActionsViewModel.kt
@@ -25,6 +25,7 @@ class MediaActionsViewModel @Inject constructor(
 
     data class State(
         val customActionsVisibility: Boolean = false,
+        val nextPreviousTrackSkipButtons: Boolean = false,
         val actions: List<MenuAction> = emptyList(),
     )
 
@@ -36,9 +37,11 @@ class MediaActionsViewModel @Inject constructor(
             combine(
                 settings.mediaControlItems.flow,
                 settings.customMediaActionsVisibility.flow,
-            ) { items, visibility ->
+                settings.nextPreviousTrackSkipButtons.flow,
+            ) { items, visibility, skipButtons ->
                 State(
                     customActionsVisibility = visibility,
+                    nextPreviousTrackSkipButtons = skipButtons,
                     actions = items.map { MenuAction(key = it.key, name = it.controlName, icon = it.iconRes) },
                 )
             }
@@ -52,6 +55,14 @@ class MediaActionsViewModel @Inject constructor(
         analyticsTracker.track(
             AnalyticsEvent.SETTINGS_GENERAL_MEDIA_NOTIFICATION_CONTROLS_SHOW_CUSTOM_TOGGLED,
             mapOf("enabled" to visibility),
+        )
+    }
+
+    fun setNextPreviousTrackSkipButtonsChanged(enabled: Boolean) {
+        settings.nextPreviousTrackSkipButtons.set(enabled, updateModifiedAt = true)
+        analyticsTracker.track(
+            AnalyticsEvent.SETTINGS_GENERAL_MEDIA_NOTIFICATION_NEXT_PREVIOUS_TRACK_SKIP_BUTTONS_TOGGLED,
+            mapOf("enabled" to enabled),
         )
     }
 

--- a/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
+++ b/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
@@ -554,6 +554,7 @@ enum class AnalyticsEvent(val key: String) {
     SETTINGS_GENERAL_AUTO_SLEEP_TIMER_RESTART_TOGGLED("settings_general_auto_sleep_timer_restart_toggled"),
     SETTINGS_GENERAL_MEDIA_NOTIFICATION_CONTROLS_SHOWN("settings_general_media_notification_controls_shown"),
     SETTINGS_GENERAL_MEDIA_NOTIFICATION_CONTROLS_SHOW_CUSTOM_TOGGLED("settings_general_media_notification_controls_show_custom_toggled"),
+    SETTINGS_GENERAL_MEDIA_NOTIFICATION_NEXT_PREVIOUS_TRACK_SKIP_BUTTONS_TOGGLED("settings_general_media_notification_next_previous_track_skip_buttons_toggled"),
     SETTINGS_GENERAL_MEDIA_NOTIFICATION_CONTROLS_ORDER_CHANGED("settings_general_media_notification_controls_order_changed"),
     SETTINGS_GENERAL_AUTOPLAY_TOGGLED("settings_general_autoplay_toggled"),
     SETTINGS_GENERAL_USE_REAL_TIME_FOR_PLAYBACK_REMAINING_TIME("settings_use_real_time_for_playback_remaining_time"),

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -1310,6 +1310,8 @@
     <string name="settings_media_actions_customise">Customize media actions</string>
     <string name="settings_media_actions_show_title">Show custom media actions</string>
     <string name="settings_media_actions_show_subtitle">Show custom media actions in Android 13+ media notifications and Android Auto.</string>
+    <string name="settings_pixel_watch_title">Pixel Watch skip buttons</string>
+    <string name="settings_pixel_watch_subtitle">Replace the custom skip buttons with standard next/previous track buttons that function as skip buttons, allowing compatibility with more devices.</string>
     <string name="settings_media_notification_controls">Media notification controls</string>
     <string name="settings_media_notification_controls_title_archive" translatable="false">@string/archive</string>
     <string name="settings_media_notification_controls_title_mark_as_played" translatable="false">@string/mark_as_played</string>

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
@@ -489,6 +489,7 @@ interface Settings {
     fun setHasDoneInitialOnboarding()
 
     val customMediaActionsVisibility: UserSetting<Boolean>
+    val nextPreviousTrackSkipButtons: UserSetting<Boolean>
 
     fun isNotificationsDisabledMessageShown(): Boolean
     fun setNotificationsDisabledMessageShown(value: Boolean)

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
@@ -1357,6 +1357,12 @@ class SettingsImpl @Inject constructor(
         sharedPrefs = sharedPreferences,
     )
 
+    override val nextPreviousTrackSkipButtons = UserSetting.BoolPref(
+        sharedPrefKey = "NextPreviousTrackSkipButtonsKey",
+        defaultValue = false,
+        sharedPrefs = sharedPreferences,
+    )
+
     override fun isNotificationsDisabledMessageShown() =
         getBoolean(NOTIFICATIONS_DISABLED_MESSAGE_SHOWN, false)
 

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/MediaSessionManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/MediaSessionManager.kt
@@ -287,12 +287,12 @@ class MediaSessionManager(
                 PlaybackStateCompat.ACTION_REWIND or
                 prepareActions
 
-            return if (shouldHideCustomSkipButtons()) {
+            return if (useCustomSkipButtons()) {
+                actions
+            } else {
                 PlaybackStateCompat.ACTION_SKIP_TO_PREVIOUS or
                     PlaybackStateCompat.ACTION_SKIP_TO_NEXT or
                     actions
-            } else {
-                actions
             }
         }
     }
@@ -428,7 +428,7 @@ class MediaSessionManager(
     }
 
     private fun addCustomActions(stateBuilder: PlaybackStateCompat.Builder, currentEpisode: BaseEpisode, playbackState: PlaybackState) {
-        if (!shouldHideCustomSkipButtons()) {
+        if (useCustomSkipButtons()) {
             addCustomAction(stateBuilder, APP_ACTION_SKIP_BACK, "Skip back", IR.drawable.media_skipback)
             addCustomAction(stateBuilder, APP_ACTION_SKIP_FWD, "Skip forward", IR.drawable.media_skipforward)
         }
@@ -960,8 +960,9 @@ class MediaSessionManager(
         playbackManager.playNow(episode = latestEpisode, sourceView = sourceView)
     }
 
-    private fun shouldHideCustomSkipButtons(): Boolean {
-        return MANUFACTURERS_TO_HIDE_CUSTOM_SKIP_BUTTONS.contains(Build.MANUFACTURER.lowercase())
+    private fun useCustomSkipButtons(): Boolean {
+        return !MANUFACTURERS_TO_HIDE_CUSTOM_SKIP_BUTTONS.contains(Build.MANUFACTURER.lowercase()) &&
+            !settings.nextPreviousTrackSkipButtons.value
     }
 }
 


### PR DESCRIPTION
## Description

As part of fixing the Samsung Galaxy Watch skip buttons the Pixel Watch skip buttons no longer work. There is an issue with the watch media controller app, it doesn't support custom actions. Unfortunately, there isn't a good fix for both Samsung and Google watches. 

This change adds a new setting under General -> Customise media actions -> Pixel Watch skip buttons. It explains that to support skip we need to use the next/previous track buttons.

## Testing Instructions

1. Play an episode on your phone
2. On your Pixel watch home screen tap the media controller icon at the bottom of the page
3. ✅ Verify that the skip buttons don't work
4. On your phone pause the episode
5. Go to settings -> General -> Customise media actions
6. Turn on "Pixel Watch skip buttons"
7. Tap play
8. ✅ Verify the skip buttons on the watch now work

## Screenshots 

| Phone | Watch |
| --- | --- |
| ![Screenshot_20250123_123835_Pocket Debug](https://github.com/user-attachments/assets/cc087b8b-855e-423f-af7c-7c5512238d50) | ![screenshot-2025-01-23-12-37-57](https://github.com/user-attachments/assets/98bb4a96-e509-44d2-b1b4-2156d4f139ab) Pixel Watch | 
| ![Screenshot_20250123-124043](https://github.com/user-attachments/assets/ac8b3de8-bbc3-4ce5-aa1f-8daca3e54b54) | ![Screenshot_20250123_124054_Media Controller](https://github.com/user-attachments/assets/d7353374-58ae-4a8b-b7bc-8c478b4821b9) Galaxy Watch |

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack
