### PR TITLE
Handle subscription cancellation

### DIFF
--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/AccountDetailsFragment.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/AccountDetailsFragment.kt
@@ -111,6 +111,7 @@ class AccountDetailsFragment : BaseFragment() {
             upgradeBannerState = upgradeBannerState.collectAsState(null).value,
             sectionsState = accountViewModel.sectionsState.collectAsState().value,
         )
+
         AccountDetailsPage(
             state = state,
             theme = theme.activeTheme,
@@ -149,10 +150,12 @@ class AccountDetailsFragment : BaseFragment() {
                 val onboardingFlow = OnboardingFlow.PatronAccountUpgrade(source)
                 OnboardingLauncher.openOnboardingFlow(activity, onboardingFlow)
             },
-            onCancelSubscription = {
+            onCancelSubscription = { winbackParams ->
                 analyticsTracker.track(AnalyticsEvent.ACCOUNT_DETAILS_CANCEL_TAPPED)
                 if (FeatureFlag.isEnabled(Feature.WINBACK)) {
-                    WinbackFragment().show(childFragmentManager, "subscription_windback")
+                    WinbackFragment
+                        .create(winbackParams)
+                        .show(childFragmentManager, "subscription_windback")
                 } else {
                     CancelConfirmationFragment
                         .newInstance()

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/AccountDetailsPage.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/AccountDetailsPage.kt
@@ -33,6 +33,7 @@ import au.com.shiftyjelly.pocketcasts.compose.preview.ThemePreviewParameterProvi
 import au.com.shiftyjelly.pocketcasts.compose.theme
 import au.com.shiftyjelly.pocketcasts.models.type.SubscriptionFrequency
 import au.com.shiftyjelly.pocketcasts.models.type.SubscriptionTier
+import au.com.shiftyjelly.pocketcasts.profile.winback.WinbackInitParams
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import kotlin.time.Duration.Companion.days
 import au.com.shiftyjelly.pocketcasts.account.viewmodel.ProfileUpgradeBannerViewModel.State as UpgradeBannerState
@@ -50,7 +51,7 @@ internal fun AccountDetailsPage(
     onChangeEmail: () -> Unit,
     onChangePassword: () -> Unit,
     onUpgradeToPatron: () -> Unit,
-    onCancelSubscription: () -> Unit,
+    onCancelSubscription: (WinbackInitParams) -> Unit,
     onChangeNewsletterSubscription: (Boolean) -> Unit,
     onShowPrivacyPolicy: () -> Unit,
     onShowTermsOfUse: () -> Unit,
@@ -222,6 +223,7 @@ private fun AccountDetailsPageStub(
             sectionsState = AccountSectionsState(
                 isSubscribedToNewsLetter = false,
                 email = "noreplay@pocketcasts.com",
+                winbackInitParams = WinbackInitParams.Empty,
                 canChangeCredentials = true,
                 canUpgradeAccount = true,
                 canCancelSubscription = true,

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/AccountSections.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/AccountSections.kt
@@ -41,6 +41,7 @@ import au.com.shiftyjelly.pocketcasts.compose.components.TextH40
 import au.com.shiftyjelly.pocketcasts.compose.components.TextP50
 import au.com.shiftyjelly.pocketcasts.compose.patronPurple
 import au.com.shiftyjelly.pocketcasts.compose.theme
+import au.com.shiftyjelly.pocketcasts.profile.winback.WinbackInitParams
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import au.com.shiftyjelly.pocketcasts.images.R as IR
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
@@ -52,7 +53,7 @@ internal fun AccountSections(
     onChangeEmail: () -> Unit,
     onChangePassword: () -> Unit,
     onUpgradeToPatron: () -> Unit,
-    onCancelSubscription: () -> Unit,
+    onCancelSubscription: (WinbackInitParams) -> Unit,
     onChangeNewsletterSubscription: (Boolean) -> Unit,
     onShowPrivacyPolicy: () -> Unit,
     onShowTermsOfUse: () -> Unit,
@@ -96,7 +97,7 @@ internal fun AccountSections(
                     AccountSection.CancelSubscription -> ButtonSection(
                         section = section,
                         config = config,
-                        onClick = onCancelSubscription,
+                        onClick = { onCancelSubscription(state.winbackInitParams) },
                     )
                     AccountSection.Newsletter -> SwitchSection(
                         isToggled = state.isSubscribedToNewsLetter,
@@ -149,17 +150,20 @@ internal data class AccountSectionsConfig(
 internal data class AccountSectionsState(
     val isSubscribedToNewsLetter: Boolean,
     val email: String?,
+    val winbackInitParams: WinbackInitParams,
     val availableSections: List<AccountSection>,
 ) {
     constructor(
         isSubscribedToNewsLetter: Boolean,
         email: String?,
+        winbackInitParams: WinbackInitParams,
         canChangeCredentials: Boolean,
         canUpgradeAccount: Boolean,
         canCancelSubscription: Boolean,
     ) : this(
         isSubscribedToNewsLetter = isSubscribedToNewsLetter,
         email = email,
+        winbackInitParams = winbackInitParams,
         availableSections = buildList {
             addAll(AccountSection.entries)
             if (email == null) {
@@ -182,6 +186,7 @@ internal data class AccountSectionsState(
         fun empty() = AccountSectionsState(
             isSubscribedToNewsLetter = false,
             email = null,
+            winbackInitParams = WinbackInitParams.Empty,
             canChangeCredentials = false,
             canUpgradeAccount = false,
             canCancelSubscription = false,
@@ -390,6 +395,7 @@ private fun AccountSectionsPreview() {
                     isSubscribedToNewsLetter = false,
                     email = "",
                     availableSections = AccountSection.entries,
+                    winbackInitParams = WinbackInitParams.Empty,
                 ),
                 onChangeAvatar = { },
                 onChangeEmail = { },


### PR DESCRIPTION
## Description

This PR adds logic for handling subscription cancellation.

## Testing Instructions

> [!note]
> Enable `WINBACK` flag in the code and test this with the `release` variant.

### Paddle subscription

1. Sign in with this account: p1737624995796789-slack-C028JAG44VD
2. Go to Account Details.
3. Tap on `Cancel subscription`.
4. Tap on `Yes, Cancel my Subscription`.
5. You should see FAQ about how to cancel a subscription.

### Google subscription

1. Sign in with an account that has a Google subscription.
2. Go to Account Details.
3. Tap on `Cancel subscription`.
4. Tap on `Yes, Cancel my Subscription`.
5. You should see your subscription in the Play Store.

## Checklist
- [ ] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] ~I have considered whether it makes sense to add tests for my changes~
- [ ] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [ ] ~Any jetpack compose components I added or changed are covered by compose previews~
- [ ] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~