### PR TITLE
Add Winback analytics

### DIFF
--- a/modules/features/profile/src/test/kotlin/au/com/shiftyjelly/pocketcasts/profile/winback/WinbackViewModelTest.kt
+++ b/modules/features/profile/src/test/kotlin/au/com/shiftyjelly/pocketcasts/profile/winback/WinbackViewModelTest.kt
@@ -2,6 +2,9 @@ package au.com.shiftyjelly.pocketcasts.profile.winback
 
 import app.cash.turbine.TurbineTestContext
 import app.cash.turbine.test
+import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
+import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTracker
+import au.com.shiftyjelly.pocketcasts.analytics.Tracker
 import au.com.shiftyjelly.pocketcasts.models.to.SubscriptionStatus
 import au.com.shiftyjelly.pocketcasts.models.type.Subscription
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
@@ -43,6 +46,8 @@ class WinbackViewModelTest {
     private val purchaseEventsFlowable = purchaseEvents.asFlowable()
 
     private val settings = mock<Settings>()
+
+    private val tracker = FakeTracker()
 
     @Before
     fun setUp() {
@@ -409,9 +414,289 @@ class WinbackViewModelTest {
         }
     }
 
+    @Test
+    fun `track screen shown`() = runTest {
+        val purchases = listOf(createPurchase())
+        wheneverBlocking { subscriptionManager.loadProducts() } doReturn ProductDetailsState.Loaded(products)
+        wheneverBlocking { subscriptionManager.loadPurchases() } doReturn PurchasesState.Loaded(purchases)
+
+        val viewModel = createViewModel()
+        viewModel.trackScreenShown("screen_key")
+
+        val event = tracker.events.single()
+        assertEquals(
+            TrackEvent(
+                AnalyticsEvent.WINBACK_SCREEN_SHOWN,
+                mapOf("screen" to "screen_key"),
+            ),
+            event,
+        )
+    }
+
+    @Test
+    fun `track screen dismissed`() = runTest {
+        val purchases = listOf(createPurchase())
+        wheneverBlocking { subscriptionManager.loadProducts() } doReturn ProductDetailsState.Loaded(products)
+        wheneverBlocking { subscriptionManager.loadPurchases() } doReturn PurchasesState.Loaded(purchases)
+
+        val viewModel = createViewModel()
+        viewModel.trackScreenDismissed("screen_key")
+
+        val event = tracker.events.single()
+        assertEquals(
+            TrackEvent(
+                AnalyticsEvent.WINBACK_SCREEN_DISMISSED,
+                mapOf("screen" to "screen_key"),
+            ),
+            event,
+        )
+    }
+
+    @Test
+    fun `track continue cancellation tapped`() = runTest {
+        val purchases = listOf(createPurchase())
+        wheneverBlocking { subscriptionManager.loadProducts() } doReturn ProductDetailsState.Loaded(products)
+        wheneverBlocking { subscriptionManager.loadPurchases() } doReturn PurchasesState.Loaded(purchases)
+
+        val viewModel = createViewModel()
+        viewModel.trackContinueCancellationTapped()
+
+        val event = tracker.events.single()
+        assertEquals(
+            TrackEvent(AnalyticsEvent.WINBACK_CONTINUE_BUTTON_TAP, emptyMap()),
+            event,
+        )
+    }
+
+    @Test
+    fun `track claim plus monthly offer tapped`() = runTest {
+        val purchases = listOf(createPurchase(productIds = listOf(Subscription.PLUS_MONTHLY_PRODUCT_ID)))
+        wheneverBlocking { subscriptionManager.loadProducts() } doReturn ProductDetailsState.Loaded(products)
+        wheneverBlocking { subscriptionManager.loadPurchases() } doReturn PurchasesState.Loaded(purchases)
+
+        val viewModel = createViewModel()
+        viewModel.trackClaimOfferTapped()
+
+        val event = tracker.events.single()
+        assertEquals(
+            TrackEvent(
+                AnalyticsEvent.WINBACK_MAIN_SCREEN_ROW_TAP,
+                mapOf(
+                    "row" to "claim_offer",
+                    "tier" to "plus",
+                    "frequency" to "monthly",
+                ),
+            ),
+            event,
+        )
+    }
+
+    @Test
+    fun `track claim plus yearly offer tapped`() = runTest {
+        val purchases = listOf(createPurchase(productIds = listOf(Subscription.PLUS_YEARLY_PRODUCT_ID)))
+        wheneverBlocking { subscriptionManager.loadProducts() } doReturn ProductDetailsState.Loaded(products)
+        wheneverBlocking { subscriptionManager.loadPurchases() } doReturn PurchasesState.Loaded(purchases)
+
+        val viewModel = createViewModel()
+        viewModel.trackClaimOfferTapped()
+
+        val event = tracker.events.single()
+        assertEquals(
+            TrackEvent(
+                AnalyticsEvent.WINBACK_MAIN_SCREEN_ROW_TAP,
+                mapOf(
+                    "row" to "claim_offer",
+                    "tier" to "plus",
+                    "frequency" to "yearly",
+                ),
+            ),
+            event,
+        )
+    }
+
+    @Test
+    fun `track claim patron monthly offer tapped`() = runTest {
+        val purchases = listOf(createPurchase(productIds = listOf(Subscription.PATRON_MONTHLY_PRODUCT_ID)))
+        wheneverBlocking { subscriptionManager.loadProducts() } doReturn ProductDetailsState.Loaded(products)
+        wheneverBlocking { subscriptionManager.loadPurchases() } doReturn PurchasesState.Loaded(purchases)
+
+        val viewModel = createViewModel()
+        viewModel.trackClaimOfferTapped()
+
+        val event = tracker.events.single()
+        assertEquals(
+            TrackEvent(
+                AnalyticsEvent.WINBACK_MAIN_SCREEN_ROW_TAP,
+                mapOf(
+                    "row" to "claim_offer",
+                    "tier" to "patron",
+                    "frequency" to "monthly",
+                ),
+            ),
+            event,
+        )
+    }
+
+    @Test
+    fun `track claim patron yearly offer tapped`() = runTest {
+        val purchases = listOf(createPurchase(productIds = listOf(Subscription.PATRON_YEARLY_PRODUCT_ID)))
+        wheneverBlocking { subscriptionManager.loadProducts() } doReturn ProductDetailsState.Loaded(products)
+        wheneverBlocking { subscriptionManager.loadPurchases() } doReturn PurchasesState.Loaded(purchases)
+
+        val viewModel = createViewModel()
+        viewModel.trackClaimOfferTapped()
+
+        val event = tracker.events.single()
+        assertEquals(
+            TrackEvent(
+                AnalyticsEvent.WINBACK_MAIN_SCREEN_ROW_TAP,
+                mapOf(
+                    "row" to "claim_offer",
+                    "tier" to "patron",
+                    "frequency" to "yearly",
+                ),
+            ),
+            event,
+        )
+    }
+
+    @Test
+    fun `track available plans tapped`() = runTest {
+        val purchases = listOf(createPurchase())
+        wheneverBlocking { subscriptionManager.loadProducts() } doReturn ProductDetailsState.Loaded(products)
+        wheneverBlocking { subscriptionManager.loadPurchases() } doReturn PurchasesState.Loaded(purchases)
+
+        val viewModel = createViewModel()
+        viewModel.trackAvailablePlansTapped()
+
+        val event = tracker.events.single()
+        assertEquals(
+            TrackEvent(
+                AnalyticsEvent.WINBACK_MAIN_SCREEN_ROW_TAP,
+                mapOf("row" to "available_plans"),
+            ),
+            event,
+        )
+    }
+
+    @Test
+    fun `track help and feedback tapped`() = runTest {
+        val purchases = listOf(createPurchase())
+        wheneverBlocking { subscriptionManager.loadProducts() } doReturn ProductDetailsState.Loaded(products)
+        wheneverBlocking { subscriptionManager.loadPurchases() } doReturn PurchasesState.Loaded(purchases)
+
+        val viewModel = createViewModel()
+        viewModel.trackHelpAndFeedbackTapped()
+
+        val event = tracker.events.single()
+        assertEquals(
+            TrackEvent(
+                AnalyticsEvent.WINBACK_MAIN_SCREEN_ROW_TAP,
+                mapOf("row" to "help_and_feedback"),
+            ),
+            event,
+        )
+    }
+
+    @Test
+    fun `track offer claimed confirmation tapped`() = runTest {
+        val purchases = listOf(createPurchase())
+        wheneverBlocking { subscriptionManager.loadProducts() } doReturn ProductDetailsState.Loaded(products)
+        wheneverBlocking { subscriptionManager.loadPurchases() } doReturn PurchasesState.Loaded(purchases)
+
+        val viewModel = createViewModel()
+        viewModel.trackOfferClaimedConfirmationTapped()
+
+        val event = tracker.events.single()
+        assertEquals(
+            TrackEvent(AnalyticsEvent.WINBACK_OFFER_CLAIMED_DONE_BUTTON_TAPPED, emptyMap()),
+            event,
+        )
+    }
+
+    @Test
+    fun `track plans back button tapped`() = runTest {
+        val purchases = listOf(createPurchase())
+        wheneverBlocking { subscriptionManager.loadProducts() } doReturn ProductDetailsState.Loaded(products)
+        wheneverBlocking { subscriptionManager.loadPurchases() } doReturn PurchasesState.Loaded(purchases)
+
+        val viewModel = createViewModel()
+        viewModel.trackPlansBackButtonTapped()
+
+        val event = tracker.events.single()
+        assertEquals(
+            TrackEvent(AnalyticsEvent.WINBACK_AVAILABLE_PLANS_BACK_BUTTON_TAPPED, emptyMap()),
+            event,
+        )
+    }
+
+    @Test
+    fun `track plan change`() = runTest {
+        val purchases = listOf(createPurchase(productIds = listOf(Subscription.PLUS_MONTHLY_PRODUCT_ID)))
+        wheneverBlocking { subscriptionManager.loadProducts() } doReturn ProductDetailsState.Loaded(products)
+        wheneverBlocking { subscriptionManager.loadPurchases() } doReturn PurchasesState.Loaded(purchases)
+        wheneverBlocking { subscriptionManager.changeProduct(any(), any(), any(), any(), any()) } doReturn true
+
+        val viewModel = createViewModel()
+        viewModel.changePlan(mock(), knownPlan)
+        purchaseEvents.emit(PurchaseEvent.Success)
+
+        assertEquals(
+            listOf(
+                TrackEvent(
+                    AnalyticsEvent.WINBACK_AVAILABLE_PLANS_SELECT_PLAN,
+                    mapOf(
+                        "product" to knownPlan.productId,
+                    ),
+                ),
+                TrackEvent(
+                    AnalyticsEvent.WINBACK_AVAILABLE_PLANS_NEW_PLAN_PURCHASE_SUCCESSFUL,
+                    mapOf(
+                        "current_product" to Subscription.PLUS_MONTHLY_PRODUCT_ID,
+                        "new_product" to knownPlan.productId,
+                    ),
+                ),
+            ),
+            tracker.events,
+        )
+    }
+
+    @Test
+    fun `track keep subscription tapped`() = runTest {
+        val purchases = listOf(createPurchase())
+        wheneverBlocking { subscriptionManager.loadProducts() } doReturn ProductDetailsState.Loaded(products)
+        wheneverBlocking { subscriptionManager.loadPurchases() } doReturn PurchasesState.Loaded(purchases)
+
+        val viewModel = createViewModel()
+        viewModel.trackKeepSubscriptionTapped()
+
+        val event = tracker.events.single()
+        assertEquals(
+            TrackEvent(AnalyticsEvent.WINBACK_CANCEL_CONFIRMATION_STAY_BUTTON_TAPPED, emptyMap()),
+            event,
+        )
+    }
+
+    @Test
+    fun `track cancel subscription tapped`() = runTest {
+        val purchases = listOf(createPurchase())
+        wheneverBlocking { subscriptionManager.loadProducts() } doReturn ProductDetailsState.Loaded(products)
+        wheneverBlocking { subscriptionManager.loadPurchases() } doReturn PurchasesState.Loaded(purchases)
+
+        val viewModel = createViewModel()
+        viewModel.trackCancelSubscriptionTapped()
+
+        val event = tracker.events.single()
+        assertEquals(
+            TrackEvent(AnalyticsEvent.WINBACK_CANCEL_CONFIRMATION_CANCEL_BUTTON_TAPPED, emptyMap()),
+            event,
+        )
+    }
+
     private fun createViewModel() = WinbackViewModel(
         subscriptionManager,
         settings,
+        AnalyticsTracker.test(tracker, isEnabled = true),
     )
 }
 
@@ -496,3 +781,24 @@ private val BillingPeriod.value
         BillingPeriod.Monthly -> "P1M"
         BillingPeriod.Yearly -> "P1Y"
     }
+
+class FakeTracker : Tracker {
+    private val _events = mutableListOf<TrackEvent>()
+
+    val events get() = _events.toList()
+
+    override fun track(event: AnalyticsEvent, properties: Map<String, Any>) {
+        _events += TrackEvent(event, properties)
+    }
+
+    override fun refreshMetadata() = Unit
+
+    override fun flush() = Unit
+
+    override fun clearAllData() = Unit
+}
+
+data class TrackEvent(
+    val type: AnalyticsEvent,
+    val properties: Map<String, Any>,
+)

--- a/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
+++ b/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
@@ -723,4 +723,16 @@ enum class AnalyticsEvent(val key: String) {
     /* Battery Restrictions */
     BATTERY_RESTRICTIONS_SHOWN("battery_restrictions_shown"),
     BATTERY_RESTRICTIONS_TOGGLED("battery_restrictions_toggled"),
+
+    /* Winback */
+    WINBACK_SCREEN_SHOWN("winback_screen_shown"),
+    WINBACK_SCREEN_DISMISSED("winback_screen_dismissed"),
+    WINBACK_CONTINUE_BUTTON_TAP("winback_continue_button_tap"),
+    WINBACK_MAIN_SCREEN_ROW_TAP("winback_main_screen_row_tap"),
+    WINBACK_OFFER_CLAIMED_DONE_BUTTON_TAPPED("winback_offer_claimed_done_button_tapped"),
+    WINBACK_AVAILABLE_PLANS_BACK_BUTTON_TAPPED("winback_available_plans_back_button_tapped"),
+    WINBACK_AVAILABLE_PLANS_SELECT_PLAN("winback_available_plans_select_plan"),
+    WINBACK_AVAILABLE_PLANS_NEW_PLAN_PURCHASE_SUCCESSFUL("winback_available_plans_new_plan_purchase_successful"),
+    WINBACK_CANCEL_CONFIRMATION_STAY_BUTTON_TAPPED("winback_cancel_confirmation_stay_button_tapped"),
+    WINBACK_CANCEL_CONFIRMATION_CANCEL_BUTTON_TAPPED("winback_cancel_confirmation_cancel_button_tapped"),
 }

--- a/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/TracksAnalyticsTracker.kt
+++ b/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/TracksAnalyticsTracker.kt
@@ -55,9 +55,9 @@ class TracksAnalyticsTracker @Inject constructor(
 
             tracksClient.track(EVENTS_PREFIX + eventKey, propertiesToJSON, user, userType)
             if (propertiesToJSON.length() > 0) {
-                Timber.i("\uD83D\uDD35 Tracked: $eventKey, Properties: $propertiesToJSON")
+                Timber.tag("Tracks").i("\uD83D\uDD35 Tracked: $eventKey, Properties: $propertiesToJSON")
             } else {
-                Timber.i("\uD83D\uDD35 Tracked: $eventKey")
+                Timber.tag("Tracks").i("\uD83D\uDD35 Tracked: $eventKey")
             }
         }
     }


### PR DESCRIPTION
## Description

This PR adds Tracks events to the Winback flow.

<img width="1012" alt="Screenshot 2025-01-24 at 09 06 20" src="https://github.com/user-attachments/assets/1f952a59-1296-4a1a-a2d2-7c1bb6b36f47" />


## Testing Instructions

1. Apply [this patch](https://github.com/user-attachments/files/18521218/winback.patch) to be able to enter Winback flow and see the logs.
2. Build and install the `debugProd` variant.
3. Verify the Tracks events.

I recommend applying this filter to the Logcat output: `package:mine tag:Tracks message:winback`

## Checklist
- [ ] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [ ] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [ ] ~Any jetpack compose components I added or changed are covered by compose previews~
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.