### PR TITLE
[Podcast Feed Update] Add Refresh Button to Podcast Page 

### DIFF
--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastFragment.kt
@@ -379,6 +379,16 @@ class PodcastFragment : BaseFragment(), Toolbar.OnMenuItemClickListener {
     private val onEpisodesOptionsClicked: () -> Unit = {
         analyticsTracker.track(AnalyticsEvent.PODCAST_SCREEN_OPTIONS_TAPPED)
         var optionsDialog = OptionsDialog()
+
+        if (FeatureFlag.isEnabled(Feature.PODCAST_FEED_UPDATE)) {
+            optionsDialog = optionsDialog.addTextOption(
+                titleId = LR.string.podcast_refresh_episodes,
+                imageId = IR.drawable.ic_refresh,
+                click = {},
+            )
+        }
+
+        optionsDialog
             .addTextOption(
                 titleId = LR.string.podcast_sort_episodes,
                 imageId = IR.drawable.ic_sort,

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastFragment.kt
@@ -384,7 +384,7 @@ class PodcastFragment : BaseFragment(), Toolbar.OnMenuItemClickListener {
             optionsDialog = optionsDialog.addTextOption(
                 titleId = LR.string.podcast_refresh_episodes,
                 imageId = IR.drawable.ic_refresh,
-                click = {},
+                click = { viewModel.onRefreshPodcast() },
             )
         }
 
@@ -912,6 +912,28 @@ class PodcastFragment : BaseFragment(), Toolbar.OnMenuItemClickListener {
 
                     if (BuildConfig.DEBUG) {
                         UiUtil.displayAlertError(requireContext(), state.errorMessage, null)
+                    }
+                }
+            }
+        }
+
+        viewLifecycleOwner.lifecycleScope.launch {
+            viewModel.refreshState.collect { state ->
+                when (state) {
+                    PodcastViewModel.RefreshState.Error -> {}
+                    PodcastViewModel.RefreshState.NotStarted -> {}
+                    PodcastViewModel.RefreshState.Refreshed -> {
+                        binding?.loading?.visibility = View.GONE
+                        binding?.errorContainer?.visibility = View.GONE
+
+                        (activity as? FragmentHostListener)?.snackBarView()?.let { snackBarView ->
+                            Snackbar.make(snackBarView, getString(LR.string.podcast_refresh_list_updated), Snackbar.LENGTH_LONG).show()
+                        }
+                    }
+
+                    PodcastViewModel.RefreshState.Refreshing -> {
+                        binding?.loading?.visibility = View.VISIBLE
+                        binding?.errorContainer?.visibility = View.GONE
                     }
                 }
             }

--- a/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
+++ b/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
@@ -229,6 +229,7 @@ enum class AnalyticsEvent(val key: String) {
     PODCASTS_SCREEN_EPISODE_GROUPING_CHANGED("podcasts_screen_episode_grouping_changed"),
     PODCASTS_SCREEN_TAB_TAPPED("podcasts_screen_tab_tapped"),
     PODCAST_SCREEN_REPORT_TAPPED("podcast_screen_report_tapped"),
+    PODCAST_SCREEN_REFRESH_EPISODE_LIST_TAPPED("podcast_screen_refresh_episode_list_tapped"),
 
     /* Podcast Settings */
     PODCAST_SETTINGS_FEED_ERROR_TAPPED("podcast_settings_feed_error_tapped"),

--- a/modules/services/images/src/main/res/drawable/ic_refresh.xml
+++ b/modules/services/images/src/main/res/drawable/ic_refresh.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:pathData="M19,3C19.552,3 20,3.448 20,4V10H18H14C13.448,10 13,9.552 13,9C13,8.448 13.448,8 14,8H16.939C15.772,6.751 14.09,6 12.267,6C8.798,6 6,8.695 6,12C6,15.305 8.798,18 12.267,18C14.848,18 17.13,16.494 18.079,14.25C18.294,13.741 18.881,13.503 19.39,13.719C19.898,13.934 20.136,14.52 19.921,15.029C18.658,18.015 15.65,20 12.267,20C7.71,20 4,16.427 4,12C4,7.573 7.71,4 12.267,4C14.451,4 16.489,4.827 18,6.235V4C18,3.448 18.448,3 19,3Z"
+      android:fillColor="#03A9F4"
+      android:fillType="evenOdd"/>
+</vector>

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -627,6 +627,7 @@
     </plurals>
     <string name="podcast_show_archived" translatable="false">@string/show_archived</string>
     <string name="podcast_refresh_episodes">Refresh episode list</string>
+    <string name="podcast_refresh_list_updated">Episode list updated!</string>
     <string name="podcast_sort_episodes">Sort episodes</string>
     <string name="podcast_subscribed">Following</string>
     <string name="podcast_not_subscribed">Not Following</string>

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -626,6 +626,7 @@
         <item quantity="other">End clip handle: %d seconds</item>
     </plurals>
     <string name="podcast_show_archived" translatable="false">@string/show_archived</string>
+    <string name="podcast_refresh_episodes">Refresh episode list</string>
     <string name="podcast_sort_episodes">Sort episodes</string>
     <string name="podcast_subscribed">Following</string>
     <string name="podcast_not_subscribed">Not Following</string>

--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/Feature.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/Feature.kt
@@ -203,6 +203,14 @@ enum class Feature(
         hasFirebaseRemoteFlag = false,
         hasDevToggle = true,
     ),
+    PODCAST_FEED_UPDATE(
+        key = "podcast_feed_update",
+        title = "Podcast Feed Update",
+        defaultValue = BuildConfig.DEBUG,
+        tier = FeatureTier.Free,
+        hasFirebaseRemoteFlag = false,
+        hasDevToggle = true,
+    ),
     ;
 
     companion object {


### PR DESCRIPTION
## Description
- This PR adds the refresh button to the podcast and fake the refresh in order to show the snackbar with the result ok
- Note: We are still talking how the loading progress and how we are going to display this to our users. I will update in another PR. See this pdeCcb-8ui-p2 and this pdeCcb-8oU-p2#comment-6531
- This will be behind a local feature flag for now
- See: 3LuZimaaH5tGKxIkOpjYAZ-fi-956_15707


Fixes #3477

## Testing Instructions
1. Open a podcast
2. Tap on the 3 dots to open more options
3. See the new refresh button ✅
4. Tap to refresh
5. After 2 seconds you should see the snackbar with ok result

## Screenshots or Screencast 

https://github.com/user-attachments/assets/f01a531b-0a4f-4bf5-a4db-a1a7464c51d0



## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [ ] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack