### PR TITLE
Rename Free Up Space Event

### DIFF
--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/ProfileEpisodeListFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/ProfileEpisodeListFragment.kt
@@ -456,7 +456,7 @@ class ProfileEpisodeListFragment : BaseFragment(), Toolbar.OnMenuItemClickListen
 
     private fun onDismissManageDownloadTapped() {
         analyticsTracker.track(
-            AnalyticsEvent.FREE_UP_SPACE_MANAGE_DOWNLOADS_MORE_OPTIONS_DISMISS_TAPPED,
+            AnalyticsEvent.FREE_UP_SPACE_MAYBE_LATER_TAPPED,
             mapOf("source" to SourceView.DOWNLOADS.analyticsValue),
         )
         settings.setDismissLowStorageBannerTime(System.currentTimeMillis())

--- a/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
+++ b/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
@@ -716,8 +716,6 @@ enum class AnalyticsEvent(val key: String) {
     FREE_UP_SPACE_BANNER_SHOWN("free_up_space_banner_shown"),
     FREE_UP_SPACE_MODAL_SHOWN("free_up_space_modal_shown"),
     FREE_UP_SPACE_MANAGE_DOWNLOADS_TAPPED("free_up_space_manage_downloads_tapped"),
-    FREE_UP_SPACE_MANAGE_DOWNLOADS_MORE_OPTIONS_TAPPED("free_up_space_manage_downloads_more_options_tapped"),
-    FREE_UP_SPACE_MANAGE_DOWNLOADS_MORE_OPTIONS_DISMISS_TAPPED("free_up_space_manage_downloads_more_options_dismiss_tapped"),
     FREE_UP_SPACE_MAYBE_LATER_TAPPED("free_up_space_maybe_later_tapped"),
 
     /* Battery Restrictions */


### PR DESCRIPTION
## Description
- This is to align the same free up space events with iOS
- I am deleting the unused `free_up_space_manage_downloads_more_options_tapped` event
- I use `free_up_space_maybe_later_tapped` event to hide the banner in Downloads screen instead of `free_up_space_manage_downloads_more_options_tapped` to align with iOS
- See context: 

## Testing Instructions
Code review should be fine, but if you want to track the event you can:

1. Modify the code to return true https://github.com/Automattic/pocket-casts-android/blob/ab6bb0c3f9cec6e52c7f74b8ee3c321a28ab758c/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/DeviceStorageUtil.kt#L10
2. Build the App
3. Download an episode
4. Go to Downloads screen
5. See the free up space banner
6. Dismiss the banner
7. Ensure `free_up_space_maybe_later_tapped` is tracked


## Checklist
- [ ] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] ~I have considered whether it makes sense to add tests for my changes~
- [ ] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [ ] ~Any jetpack compose components I added or changed are covered by compose previews~
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
