### PR TITLE
[Podcast Feed Update] Add Refresh Layout to Pull Down and Refresh Podcast List

### DIFF
--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastFragment.kt
@@ -384,7 +384,7 @@ class PodcastFragment : BaseFragment(), Toolbar.OnMenuItemClickListener {
             optionsDialog = optionsDialog.addTextOption(
                 titleId = LR.string.podcast_refresh_episodes,
                 imageId = IR.drawable.ic_refresh,
-                click = { viewModel.onRefreshPodcast() },
+                click = { viewModel.onRefreshPodcast(PodcastViewModel.RefreshType.REFRESH_BUTTON) },
             )
         }
 
@@ -713,7 +713,7 @@ class PodcastFragment : BaseFragment(), Toolbar.OnMenuItemClickListener {
         }
 
         binding.swipeRefreshLayout.setOnRefreshListener {
-            viewModel.onRefreshPodcast()
+            viewModel.onRefreshPodcast(PodcastViewModel.RefreshType.PULL_TO_REFRESH)
         }
 
         binding.episodesRecyclerView.requestFocus()
@@ -926,18 +926,23 @@ class PodcastFragment : BaseFragment(), Toolbar.OnMenuItemClickListener {
                 when (state) {
                     PodcastViewModel.RefreshState.Error -> {}
                     PodcastViewModel.RefreshState.NotStarted -> {}
-                    PodcastViewModel.RefreshState.Refreshed -> {
-                        binding?.swipeRefreshLayout?.isRefreshing = false
-                        (activity as? FragmentHostListener)?.snackBarView()?.let { snackBarView ->
-                            Snackbar.make(snackBarView, getString(LR.string.podcast_refresh_list_updated), Snackbar.LENGTH_LONG).show()
+                    is PodcastViewModel.RefreshState.Refreshed -> {
+                        if (state.type == PodcastViewModel.RefreshType.PULL_TO_REFRESH) {
+                            binding?.swipeRefreshLayout?.isRefreshing = false
+                        } else {
+                            (activity as? FragmentHostListener)?.snackBarView()?.let { snackBarView ->
+                                Snackbar.make(snackBarView, getString(LR.string.podcast_refresh_list_updated), Snackbar.LENGTH_LONG).show()
+                            }
                         }
                     }
 
-                    PodcastViewModel.RefreshState.Refreshing -> {
-                        // Setting isRefreshing to false because Snackbar handles refresh progress
-                        binding?.swipeRefreshLayout?.isRefreshing = false
-                        (activity as? FragmentHostListener)?.snackBarView()?.let { snackBarView ->
-                            Snackbar.make(snackBarView, getString(LR.string.podcast_refreshing_episode_list), Snackbar.LENGTH_INDEFINITE).show()
+                    is PodcastViewModel.RefreshState.Refreshing -> {
+                        if (state.type == PodcastViewModel.RefreshType.PULL_TO_REFRESH) {
+                            binding?.swipeRefreshLayout?.isRefreshing = true
+                        } else {
+                            (activity as? FragmentHostListener)?.snackBarView()?.let { snackBarView ->
+                                Snackbar.make(snackBarView, getString(LR.string.podcast_refreshing_episode_list), Snackbar.LENGTH_INDEFINITE).show()
+                            }
                         }
                     }
                 }

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastFragment.kt
@@ -712,6 +712,10 @@ class PodcastFragment : BaseFragment(), Toolbar.OnMenuItemClickListener {
             loadData()
         }
 
+        binding.swipeRefreshLayout.setOnRefreshListener {
+            viewModel.onRefreshPodcast()
+        }
+
         binding.episodesRecyclerView.requestFocus()
 
         return binding.root
@@ -923,12 +927,15 @@ class PodcastFragment : BaseFragment(), Toolbar.OnMenuItemClickListener {
                     PodcastViewModel.RefreshState.Error -> {}
                     PodcastViewModel.RefreshState.NotStarted -> {}
                     PodcastViewModel.RefreshState.Refreshed -> {
+                        binding?.swipeRefreshLayout?.isRefreshing = false
                         (activity as? FragmentHostListener)?.snackBarView()?.let { snackBarView ->
                             Snackbar.make(snackBarView, getString(LR.string.podcast_refresh_list_updated), Snackbar.LENGTH_LONG).show()
                         }
                     }
 
                     PodcastViewModel.RefreshState.Refreshing -> {
+                        // Setting isRefreshing to false because Snackbar handles refresh progress
+                        binding?.swipeRefreshLayout?.isRefreshing = false
                         (activity as? FragmentHostListener)?.snackBarView()?.let { snackBarView ->
                             Snackbar.make(snackBarView, getString(LR.string.podcast_refreshing_episode_list), Snackbar.LENGTH_INDEFINITE).show()
                         }

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/PodcastViewModel.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/PodcastViewModel.kt
@@ -577,15 +577,15 @@ class PodcastViewModel
         analyticsTracker.track(AnalyticsEvent.BOOKMARK_SHARE_TAPPED, mapOf("podcast_uuid" to podcastUuid, "episode_uuid" to episodeUuid, "source" to source.analyticsValue))
     }
 
-    fun onRefreshPodcast() {
+    fun onRefreshPodcast(refreshType: RefreshType) {
         val podcast = podcast.value ?: return
 
         analyticsTracker.track(AnalyticsEvent.PODCAST_SCREEN_REFRESH_EPISODE_LIST_TAPPED, mapOf("podcast_uuid" to podcast.uuid))
 
         launch {
-            _refreshState.emit(RefreshState.Refreshing)
+            _refreshState.emit(RefreshState.Refreshing(refreshType))
             delay(2.seconds)
-            _refreshState.emit(RefreshState.Refreshed)
+            _refreshState.emit(RefreshState.Refreshed(refreshType))
         }
     }
 
@@ -627,9 +627,14 @@ class PodcastViewModel
 
     sealed class RefreshState {
         data object NotStarted : RefreshState()
-        data object Refreshing : RefreshState()
-        data object Refreshed : RefreshState()
+        data class Refreshing(val type: RefreshType) : RefreshState()
+        data class Refreshed(val type: RefreshType) : RefreshState()
         data object Error : RefreshState()
+    }
+
+    enum class RefreshType {
+        PULL_TO_REFRESH,
+        REFRESH_BUTTON,
     }
 
     private object AnalyticsProp {

--- a/modules/features/podcasts/src/main/res/layout/fragment_podcast.xml
+++ b/modules/features/podcasts/src/main/res/layout/fragment_podcast.xml
@@ -38,55 +38,62 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent">
 
-        <FrameLayout
-            android:id="@+id/podcastContent"
+        <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
+            android:id="@+id/swipeRefreshLayout"
             android:layout_width="match_parent"
             android:layout_height="match_parent">
 
-            <View
-                android:id="@+id/headerBackgroundPlaceholder"
+            <FrameLayout
+                android:id="@+id/podcastContent"
                 android:layout_width="match_parent"
-                android:layout_height="@dimen/podcast_header_height" />
+                android:layout_height="match_parent">
 
-            <androidx.recyclerview.widget.RecyclerView
-                android:id="@+id/episodesRecyclerView"
-                android:layout_width="match_parent"
-                android:layout_height="match_parent"
-                android:clipToPadding="false"
-                android:scrollbars="vertical"
-                android:scrollbarStyle="outsideOverlay"
-                app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"/>
+                <View
+                    android:id="@+id/headerBackgroundPlaceholder"
+                    android:layout_width="match_parent"
+                    android:layout_height="@dimen/podcast_header_height" />
 
-            <ProgressBar
-                android:id="@+id/loading"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_gravity="center" />
+                <androidx.recyclerview.widget.RecyclerView
+                    android:id="@+id/episodesRecyclerView"
+                    android:layout_width="match_parent"
+                    android:layout_height="match_parent"
+                    android:clipToPadding="false"
+                    android:scrollbars="vertical"
+                    android:scrollbarStyle="outsideOverlay"
+                    app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"/>
 
-            <LinearLayout
-                android:id="@+id/errorContainer"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:orientation="vertical"
-                android:layout_gravity="center"
-                android:clipChildren="false"
-                android:clipToPadding="false"
-                android:padding="16dp">
-                <TextView
-                    android:id="@+id/errorMessage"
+                <ProgressBar
+                    android:id="@+id/loading"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:gravity="center"
-                    style="?attr/textBody1"
-                    android:layout_marginBottom="8dp"/>
-                <com.google.android.material.button.MaterialButton
-                    android:id="@+id/btnRetry"
+                    android:layout_gravity="center" />
+
+                <LinearLayout
+                    android:id="@+id/errorContainer"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
+                    android:orientation="vertical"
                     android:layout_gravity="center"
-                    android:text="@string/podcasts_download_retry"/>
-            </LinearLayout>
-        </FrameLayout>
+                    android:clipChildren="false"
+                    android:clipToPadding="false"
+                    android:padding="16dp">
+                    <TextView
+                        android:id="@+id/errorMessage"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:gravity="center"
+                        style="?attr/textBody1"
+                        android:layout_marginBottom="8dp"/>
+                    <com.google.android.material.button.MaterialButton
+                        android:id="@+id/btnRetry"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_gravity="center"
+                        android:text="@string/podcasts_download_retry"/>
+                </LinearLayout>
+            </FrameLayout>
+
+        </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
 
         <ImageView
             android:id="@+id/transitionArtwork"


### PR DESCRIPTION
## Description
- This PR adds the refresh layout to implement the pull down action
- I will update the tracks in another PR

Fixes #3485

## Testing Instructions

1. Open a podcast
2. Pull Down to refresh podcast
3. After 2 seconds you should see the snackbar with ok result

## Screenshots or Screencast 
[Screen_recording_20250124_111942.webm](https://github.com/user-attachments/assets/6cd3a3d4-d439-446f-af48-a6ccf385f168)


## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [ ] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
