### PR TITLE
[Tooling] Allow `update_rollouts` to specify the track to update

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -303,7 +303,7 @@ platform :android do
   # @param track [String] The Google Play track for which to update the rollout of. Must be either `beta` or `production`.
   #
   lane :update_rollouts do |percent:, track:|
-    UI.user_error!('percent parameter must be between 0.0 and 1.0') if percent.to_f < 0 || percent.to_f > 1
+    UI.user_error!('percent parameter must be between 0.0 and 1.0') if percent.to_f.negative? || percent.to_f > 1
     UI.user_error!('track parameter must be either `beta` or `production`') unless %w[beta production].include?(track)
 
     is_beta = track == 'beta'

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -297,31 +297,23 @@ platform :android do
     end
   end
 
-  # Update the rollout of all 3 variants (app, automotive, wear) of the current version to the given value
+  # Update the rollout of all 3 variants/form-factors (app, automotive, wear) of the latest builds of the given Google Play track to the given % value
   #
   # @param percent [Float] The rollout percentage, between 0 and 1
-  # @param track [String]
-  #        If `beta`, will update the rollout of the latest build in all 3 Beta tracks.
-  #        If `production`, will update the rollout of the latest build in all 3 Production tracks.
-  #        If `nil`, will derive the track based on if the `version_name_current` contains `-rc-` or not.
+  # @param track [String] The Google Play track for which to update the rollout of. Must be either `beta` or `production`.
   #
-  lane :update_rollouts do |percent:, track: nil|
-    if track.nil?
-      # Derive values from current version in `version.properties`
-      is_beta = beta_version?(version_name_current)
-      base_version_code = build_code_current
-    else
-      # Use Google Play API to find the latest versionCode for the requested track
-      UI.user_error!('track parameter must be either `beta` or `production`') unless %w[beta production].include?(track)
+  lane :update_rollouts do |percent:, track:|
+    UI.user_error!('percent parameter must be between 0.0 and 1.0') if percent.to_f < 0 || percent.to_f > 1
+    UI.user_error!('track parameter must be either `beta` or `production`') unless %w[beta production].include?(track)
 
-      is_beta = track == 'beta'
-      prod_version_codes = google_play_track_version_codes(
-        package_name: APP_PACKAGE_NAME,
-        track: track,
-        json_key: UPLOAD_TO_PLAY_STORE_JSON_KEY
-      )
-      base_version_code = prod_version_codes.max # Use the latest (as there's likely to be 2: the previous one already at 100%, and the latest one with partial rollout)
-    end
+    is_beta = track == 'beta'
+    # Use Google Play API to find the latest versionCode for the requested track
+    prod_version_codes = google_play_track_version_codes(
+      package_name: APP_PACKAGE_NAME,
+      track: track,
+      json_key: UPLOAD_TO_PLAY_STORE_JSON_KEY
+    )
+    base_version_code = prod_version_codes.max # Use the latest (as there's likely to be 2: the previous one already at 100%, and the latest one with partial rollout)
 
     not_found_variants = []
     APPS.each do |app|

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -300,16 +300,31 @@ platform :android do
   # Update the rollout of all 3 variants (app, automotive, wear) of the current version to the given value
   #
   # @param percent [Float] The rollout percentage, between 0 and 1
+  # @param production_track [Boolean]
+  #        If `true`, will update the rollout of the latest build in Production tracks.
+  #        If `false`, will update the rollout of the latest build in Beta tracks.
+  #        If `nil`, will derive the track based on if the `version_name_current` contains `-rc-` or not.
   #
-  lane :update_rollouts do |percent:|
-    version = version_name_current
-    build_code = build_code_current
-    is_beta = beta_version?(version)
+  lane :update_rollouts do |percent:, production_track: nil|
+    if production_track.nil?
+      # Derive values from current version in `version.properties`
+      is_beta = beta_version?(version_name_current)
+      base_version_code = build_code_current
+    else
+      # Use Google Play API to find the latest versionCode for the requested track
+      is_beta = !production_track
+      prod_version_codes = google_play_track_version_codes(
+        package_name: APP_PACKAGE_NAME,
+        track: production_track ? 'production' : 'beta', # Use the mobile app's track (not wear or automotive), to get the base_version_code
+        json_key: UPLOAD_TO_PLAY_STORE_JSON_KEY
+      )
+      base_version_code = prod_version_codes.max # Use the latest (as there's likely to be 2: the previous one already at 100%, and the latest one with partial rollout)
+    end
 
     not_found_variants = []
     APPS.each do |app|
       track = play_store_track(app: app, is_beta: is_beta)
-      version_code = version_code_for_app(app: app, version_code: build_code)
+      version_code = version_code_for_app(app: app, version_code: base_version_code)
       upload_to_play_store(
         **UPLOAD_TO_PLAY_STORE_COMMON_OPTIONS,
         skip_upload_aab: true,
@@ -321,11 +336,11 @@ platform :android do
     rescue FastlaneCore::Interface::FastlaneError => e
       raise unless e.message =~ /Unable to find the requested release on track/
 
-      not_found_variants << app
+      not_found_variants << "'#{app}' variant with version code `#{version_code}` was not found in `#{track}` track in Google Play Console"
     end
 
-    not_found_variants.each do |app|
-      UI.important("'#{app}' variant for `#{version}` was not found in Google Play Console")
+    not_found_variants.each do |message|
+      UI.important(message)
     end
     UI.user_error!('None of the 3 app variants were found in Google Play Console. We expected at least one') if not_found_variants.count == APPS.count
   end

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -300,22 +300,24 @@ platform :android do
   # Update the rollout of all 3 variants (app, automotive, wear) of the current version to the given value
   #
   # @param percent [Float] The rollout percentage, between 0 and 1
-  # @param production_track [Boolean]
-  #        If `true`, will update the rollout of the latest build in Production tracks.
-  #        If `false`, will update the rollout of the latest build in Beta tracks.
+  # @param track [String]
+  #        If `beta`, will update the rollout of the latest build in all 3 Beta tracks.
+  #        If `production`, will update the rollout of the latest build in all 3 Production tracks.
   #        If `nil`, will derive the track based on if the `version_name_current` contains `-rc-` or not.
   #
-  lane :update_rollouts do |percent:, production_track: nil|
-    if production_track.nil?
+  lane :update_rollouts do |percent:, track: nil|
+    if track.nil?
       # Derive values from current version in `version.properties`
       is_beta = beta_version?(version_name_current)
       base_version_code = build_code_current
     else
       # Use Google Play API to find the latest versionCode for the requested track
-      is_beta = !production_track
+      UI.user_error!('track parameter must be either `beta` or `production`') unless %w[beta production].include?(track)
+
+      is_beta = track == 'beta'
       prod_version_codes = google_play_track_version_codes(
         package_name: APP_PACKAGE_NAME,
-        track: production_track ? 'production' : 'beta', # Use the mobile app's track (not wear or automotive), to get the base_version_code
+        track: track,
         json_key: UPLOAD_TO_PLAY_STORE_JSON_KEY
       )
       base_version_code = prod_version_codes.max # Use the latest (as there's likely to be 2: the previous one already at 100%, and the latest one with partial rollout)
@@ -323,20 +325,20 @@ platform :android do
 
     not_found_variants = []
     APPS.each do |app|
-      track = play_store_track(app: app, is_beta: is_beta)
-      version_code = version_code_for_app(app: app, version_code: base_version_code)
+      variant_track = play_store_track(app: app, is_beta: is_beta)
+      variant_version_code = version_code_for_app(app: app, version_code: base_version_code)
       upload_to_play_store(
         **UPLOAD_TO_PLAY_STORE_COMMON_OPTIONS,
         skip_upload_aab: true,
-        track: track,
-        version_code: version_code,
+        track: variant_track,
+        version_code: variant_version_code,
         release_status: percent.to_f < 1.0 ? 'inProgress' : 'completed',
         rollout: percent.to_s
       )
     rescue FastlaneCore::Interface::FastlaneError => e
       raise unless e.message =~ /Unable to find the requested release on track/
 
-      not_found_variants << "'#{app}' variant with version code `#{version_code}` was not found in `#{track}` track in Google Play Console"
+      not_found_variants << "'#{app}' variant with version code `#{variant_version_code}` was not found in `#{variant_track}` track in Google Play Console"
     end
 
     not_found_variants.each do |message|


### PR DESCRIPTION
## Why / Context

During his last run of the release scenario, @geekygecko noticed that, by the time the release manager is supposed to run `update_rollouts percent:1` to roll out the production build to 100% after it has been approved by Google, that command updates the rollout of the wrong build / track. [Internal ref: p1737528474331869-slack-CC7L49W13]

The reason this happens is because, so far, `update_rollouts` was always using the version stored in the `version.properties` file of the current branch to figure out which version name and code to update the rollout of.

But, by the time one wants to update the rollout of version `x.y` in production track to 100%, the `release/x.y` branch for that version has already been deleted (by the release manager running the `publish_release` lane earlier in the process, namely as soon as Google as approved the production release over the weekend and we started the rollout to production).

This means the release manager would not be able to run that `update_rollouts` lane from the `release/x.y` branch to update the rolllout of `x.y` in Production to 100%. And running that same lane from the `main` branch instead would end up updating the rollout of the latest beta that has been done after code-freeze of `x.y+1`, instead of updating the rollout of the production build for `x.y`

## How / The Fix

This PR updates the logic of `update_rollouts` so that one can now pass an explicit `track:production` to force the code to fetch the latest `versionCode` of the production track using the GooglePlay API, rather than relying on the value extracted from the `version.properties` of the current branch.

This should allow to update the rollout of the latest build in production track even if the `release/*` branch of that build version has been deleted since and the `version.properties` as already been bumped to a next beta version.

## Testing Instructions

 - Manually modify the `version.properties` files locally to set fake/invalid version name and code in it (save, but no need to commit)
 - Run `bundle exec fastlane update_rollouts percent:0.21 track:beta`
 - Observe from the logs that it fetches the `versionCode` of the beta track from the API (as opposed to relying on the value from `version.properties`) during the `Step: google_play_track_version_codes`
 - Validate that the latest Beta build in GooglePlay Console had its current rollout updated from 20% to 21%. (You can re-run the same lane with `percent:0.20` right after that test if you want to revert the rollout back to 20%)

Note: At the time this PR is created, the build currently in `production` track is already at 100%, so it won't be possible to run a similar test with `track:production`, since it's already at max rollout %.

## Internal References

171055-ghe-Automattic/wpcom
p1737528474331869-slack-CC7L49W13