### PR TITLE
Rename Twitter to X

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
         ([#3481](https://github.com/Automattic/pocket-casts-android/pull/3481))
     *   Do not close episode details screen when archiving an episode
         ([#3473](https://github.com/Automattic/pocket-casts-android/pull/3473))
+    *   Rename Twitter to X
+        ([#3489](https://github.com/Automattic/pocket-casts-android/pull/3489))
 
 7.81
 -----

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/about/AboutFragment.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/about/AboutFragment.kt
@@ -114,8 +114,8 @@ class AboutFragment : BaseFragment() {
                 onInstagramTapped = {
                     analyticsTracker.track(AnalyticsEvent.SETTINGS_ABOUT_INSTAGRAM_TAPPED)
                 },
-                onTwitterTapped = {
-                    analyticsTracker.track(AnalyticsEvent.SETTINGS_ABOUT_TWITTER_TAPPED)
+                onXTapped = {
+                    analyticsTracker.track(AnalyticsEvent.SETTINGS_ABOUT_X_TAPPED)
                 },
                 onAutomatticFamilyTapped = {
                     analyticsTracker.track(AnalyticsEvent.SETTINGS_ABOUT_AUTOMATTIC_FAMILY_TAPPED)
@@ -202,7 +202,7 @@ private fun AboutPage(
     onShareWithFriendsTapped: () -> Unit,
     onWebsiteTapped: () -> Unit,
     onInstagramTapped: () -> Unit,
-    onTwitterTapped: () -> Unit,
+    onXTapped: () -> Unit,
     onAutomatticFamilyTapped: () -> Unit = {},
     onWorkWithUsTapped: () -> Unit = {},
     onTermsOfServiceTapped: () -> Unit = {},
@@ -286,11 +286,11 @@ private fun AboutPage(
         }
         item {
             RowTextButton(
-                text = stringResource(LR.string.settings_about_twitter),
+                text = stringResource(LR.string.settings_about_x),
                 secondaryText = "@pocketcasts",
                 onClick = {
-                    onTwitterTapped()
-                    openUrl("https://twitter.com/pocketcasts", context)
+                    onXTapped()
+                    openUrl("https://x.com/pocketcasts", context)
                 },
             )
         }
@@ -518,7 +518,7 @@ private fun AboutPagePreview() {
         onShareWithFriendsTapped = {},
         onWebsiteTapped = {},
         onInstagramTapped = {},
-        onTwitterTapped = {},
+        onXTapped = {},
         onAutomatticFamilyTapped = {},
         onWorkWithUsTapped = {},
     )

--- a/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
+++ b/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
@@ -471,7 +471,7 @@ enum class AnalyticsEvent(val key: String) {
     SETTINGS_ABOUT_SHARE_WITH_FRIENDS_TAPPED("settings_about_share_with_friends_tapped"),
     SETTINGS_ABOUT_WEBSITE_TAPPED("settings_about_website_tapped"),
     SETTINGS_ABOUT_INSTAGRAM_TAPPED("settings_about_instagram_tapped"),
-    SETTINGS_ABOUT_TWITTER_TAPPED("settings_about_twitter_tapped"),
+    SETTINGS_ABOUT_X_TAPPED("settings_about_twitter_tapped"),
     SETTINGS_ABOUT_AUTOMATTIC_FAMILY_TAPPED("settings_about_automattic_family_tapped"),
     SETTINGS_ABOUT_LEGAL_AND_MORE_TAPPED("settings_about_legal_and_more_tapped"),
     SETTINGS_ABOUT_WORK_WITH_US_TAPPED("settings_about_work_with_us_tapped"),

--- a/modules/services/localization/src/main/res/values-ar/strings.xml
+++ b/modules/services/localization/src/main/res/values-ar/strings.xml
@@ -435,7 +435,6 @@ Language: ar
     <string name="settings_about_work_from_anywhere">العمل من أي مكان</string>
     <string name="settings_about_legal">الشؤون القانونية وغيرها</string>
     <string name="settings_about_work_with_us">العمل معنا</string>
-    <string name="settings_about_twitter">تويتر</string>
     <string name="settings_about_instagram">إنستغرام</string>
     <string name="settings_about_rate_us">تقييمنا</string>
     <string name="settings_about_share_with_friends_message">مرحبًا! فيما يأتي رابط لتنزيل تطبيق Pocket Casts. إنني استمتع به حقًا واعتقد أنك قد تستمتع به كذلك. \nhttps://www.pocketcasts.com</string>

--- a/modules/services/localization/src/main/res/values-ca/strings.xml
+++ b/modules/services/localization/src/main/res/values-ca/strings.xml
@@ -798,7 +798,6 @@ Language: ca
     <string name="settings_about_work_from_anywhere">Treballa des de qualsevol lloc</string>
     <string name="settings_about_legal">Legal i altres</string>
     <string name="settings_about_work_with_us">Treballa amb nosaltres</string>
-    <string name="settings_about_twitter">Twitter</string>
     <string name="settings_about_instagram">Instagram</string>
     <string name="settings_about_rate_us">Puntua\'ns</string>
     <string name="settings_about_share_with_friends_message">Ei! Aquí tens un enllaç per descarregar l\'app Pocket Casts. Realment m\'està agradant i he pensat que a tu també et podria agradar. \nhttps://www.pocketcasts.com</string>

--- a/modules/services/localization/src/main/res/values-de/strings.xml
+++ b/modules/services/localization/src/main/res/values-de/strings.xml
@@ -807,7 +807,6 @@ Language: de
     <string name="settings_about_work_from_anywhere">Arbeite mit, egal wo du bist!</string>
     <string name="settings_about_legal">Rechtliches und mehr</string>
     <string name="settings_about_work_with_us">Arbeite für uns</string>
-    <string name="settings_about_twitter">Twitter</string>
     <string name="settings_about_instagram">Instagram</string>
     <string name="settings_about_rate_us">Bewerte uns</string>
     <string name="settings_about_share_with_friends_message">Hallo! Hier ist ein Link zum Herunterladen der Pocket Casts-App. Mir gefällt sie sehr gut und ich dachte, sie könnte dir auch gefallen.\nhttps://www.pocketcasts.com</string>

--- a/modules/services/localization/src/main/res/values-en-rGB/strings.xml
+++ b/modules/services/localization/src/main/res/values-en-rGB/strings.xml
@@ -445,7 +445,6 @@ Language: en_GB
     <string name="settings_about_work_from_anywhere">Work from Anywhere</string>
     <string name="settings_about_legal">Legal and more</string>
     <string name="settings_about_work_with_us">Work with us</string>
-    <string name="settings_about_twitter">Twitter</string>
     <string name="settings_about_instagram">Instagram</string>
     <string name="settings_about_rate_us">Rate us</string>
     <string name="settings_about_share_with_friends_message">Hi! Here\'s a link to download the Pocket Casts app. I\'m really enjoying it and thought you might too. \nhttps://www.pocketcasts.com</string>

--- a/modules/services/localization/src/main/res/values-es-rMX/strings.xml
+++ b/modules/services/localization/src/main/res/values-es-rMX/strings.xml
@@ -807,7 +807,6 @@ Language: es
     <string name="settings_about_work_from_anywhere">Trabaja desde cualquier lugar</string>
     <string name="settings_about_legal">Legal y otros</string>
     <string name="settings_about_work_with_us">Trabaja con nosotros</string>
-    <string name="settings_about_twitter">Twitter</string>
     <string name="settings_about_instagram">Instagram</string>
     <string name="settings_about_rate_us">Puntúanos</string>
     <string name="settings_about_share_with_friends_message">¡Hola! A continuación, encontrarás un enlace para descargar Pocket Casts. Esta aplicación me está gustando mucho y creo que a ti también te puede interesar. \nhttps://www.pocketcasts.com</string>

--- a/modules/services/localization/src/main/res/values-es/strings.xml
+++ b/modules/services/localization/src/main/res/values-es/strings.xml
@@ -807,7 +807,6 @@ Language: es
     <string name="settings_about_work_from_anywhere">Trabaja desde cualquier lugar</string>
     <string name="settings_about_legal">Legal y otros</string>
     <string name="settings_about_work_with_us">Trabaja con nosotros</string>
-    <string name="settings_about_twitter">Twitter</string>
     <string name="settings_about_instagram">Instagram</string>
     <string name="settings_about_rate_us">Puntúanos</string>
     <string name="settings_about_share_with_friends_message">¡Hola! A continuación, encontrarás un enlace para descargar Pocket Casts. Esta aplicación me está gustando mucho y creo que a ti también te puede interesar. \nhttps://www.pocketcasts.com</string>

--- a/modules/services/localization/src/main/res/values-fr-rCA/strings.xml
+++ b/modules/services/localization/src/main/res/values-fr-rCA/strings.xml
@@ -807,7 +807,6 @@ Language: fr
     <string name="settings_about_work_from_anywhere">Travaillez de n’importe où</string>
     <string name="settings_about_legal">Droit et divers</string>
     <string name="settings_about_work_with_us">Rejoignez-nous</string>
-    <string name="settings_about_twitter">Twitter</string>
     <string name="settings_about_instagram">Instagram</string>
     <string name="settings_about_rate_us">Donnez-nous votre avis</string>
     <string name="settings_about_share_with_friends_message">Salut, Voici un lien pour télécharger l’application Pocket Casts. Je la trouve super et je me suis dit qu’elle pourrait aussi te plaire. \nhttps://www.pocketcasts.com</string>

--- a/modules/services/localization/src/main/res/values-fr/strings.xml
+++ b/modules/services/localization/src/main/res/values-fr/strings.xml
@@ -807,7 +807,6 @@ Language: fr
     <string name="settings_about_work_from_anywhere">Travaillez de n’importe où</string>
     <string name="settings_about_legal">Droit et divers</string>
     <string name="settings_about_work_with_us">Rejoignez-nous</string>
-    <string name="settings_about_twitter">Twitter</string>
     <string name="settings_about_instagram">Instagram</string>
     <string name="settings_about_rate_us">Donnez-nous votre avis</string>
     <string name="settings_about_share_with_friends_message">Salut, Voici un lien pour télécharger l’application Pocket Casts. Je la trouve super et je me suis dit qu’elle pourrait aussi te plaire. \nhttps://www.pocketcasts.com</string>

--- a/modules/services/localization/src/main/res/values-it/strings.xml
+++ b/modules/services/localization/src/main/res/values-it/strings.xml
@@ -807,7 +807,6 @@ Language: it
     <string name="settings_about_work_from_anywhere">Lavora in remoto, ovunque tu sia</string>
     <string name="settings_about_legal">Accordi legali e altro</string>
     <string name="settings_about_work_with_us">Lavora con noi</string>
-    <string name="settings_about_twitter">Twitter</string>
     <string name="settings_about_instagram">Instagram</string>
     <string name="settings_about_rate_us">Valuta l\'app</string>
     <string name="settings_about_share_with_friends_message">Ciao! Ecco un link da cui scaricare l\'app Pocket Casts. Mi sto davvero divertendo e penso possa farlo anche tu. \nhttps://www.pocketcasts.com</string>

--- a/modules/services/localization/src/main/res/values-ja/strings.xml
+++ b/modules/services/localization/src/main/res/values-ja/strings.xml
@@ -807,7 +807,6 @@ Language: ja_JP
     <string name="settings_about_work_from_anywhere">どこでも作業可能</string>
     <string name="settings_about_legal">法的情報およびその他</string>
     <string name="settings_about_work_with_us">求人情報</string>
-    <string name="settings_about_twitter">Twitter</string>
     <string name="settings_about_instagram">Instagram</string>
     <string name="settings_about_rate_us">評価してください</string>
     <string name="settings_about_share_with_friends_message">注目! このリンクから Pocket Casts アプリをダウンロードできます。とても楽しく、どなたにも気に入ってもらえると思います。\nhttps://www.pocketcasts.com</string>

--- a/modules/services/localization/src/main/res/values-ko/strings.xml
+++ b/modules/services/localization/src/main/res/values-ko/strings.xml
@@ -807,7 +807,6 @@ Language: ko_KR
     <string name="settings_about_work_from_anywhere">어디에서나 근무</string>
     <string name="settings_about_legal">법적 고지 사항 및 기타</string>
     <string name="settings_about_work_with_us">채용 공고</string>
-    <string name="settings_about_twitter">Twitter</string>
     <string name="settings_about_instagram">Instagram</string>
     <string name="settings_about_rate_us">평가하기</string>
     <string name="settings_about_share_with_friends_message">안녕하세요! Pocket Casts 앱을 다운로드하는 링크가 있습니다. 정말 즐겁게 사용하고 있는데 여러분도 그럴 것입니다. \nhttps://www.pocketcasts.com</string>

--- a/modules/services/localization/src/main/res/values-nb/strings.xml
+++ b/modules/services/localization/src/main/res/values-nb/strings.xml
@@ -431,7 +431,6 @@ Language: nb_NO
     <string name="settings_about_work_from_anywhere">Arbeid hvor som helst</string>
     <string name="settings_about_legal">Juridisk og mer</string>
     <string name="settings_about_work_with_us">Arbeid med oss</string>
-    <string name="settings_about_twitter">Twitter</string>
     <string name="settings_about_instagram">Instagram</string>
     <string name="settings_about_rate_us">Gi oss en rangering</string>
     <string name="settings_about_share_with_friends_message">Hei! Her er en lenke for å laste ned Pocket Casts-appen. Jeg liker den svært godt, og det tror jeg du også vil gjøre. \nhttps://www.pocketcasts.com</string>

--- a/modules/services/localization/src/main/res/values-nl/strings.xml
+++ b/modules/services/localization/src/main/res/values-nl/strings.xml
@@ -807,7 +807,6 @@ Language: nl
     <string name="settings_about_work_from_anywhere">Werken vanaf elke locatie</string>
     <string name="settings_about_legal">Juridisch en meer</string>
     <string name="settings_about_work_with_us">Met ons samenwerken</string>
-    <string name="settings_about_twitter">Twitter</string>
     <string name="settings_about_instagram">Instagram</string>
     <string name="settings_about_rate_us">Beoordeel ons</string>
     <string name="settings_about_share_with_friends_message">Hallo! Alsjeblieft, een downloadlink voor de Pocket Casts-app. Ik vind hem geweldig en ik dacht, jij vast ook. \nhttps://www.pocketcasts.com</string>

--- a/modules/services/localization/src/main/res/values-pt-rBR/strings.xml
+++ b/modules/services/localization/src/main/res/values-pt-rBR/strings.xml
@@ -807,7 +807,6 @@ Language: pt_BR
     <string name="settings_about_work_from_anywhere">Trabalhe de qualquer lugar</string>
     <string name="settings_about_legal">Jurídico e mais</string>
     <string name="settings_about_work_with_us">Trabalhe conosco</string>
-    <string name="settings_about_twitter">Twitter</string>
     <string name="settings_about_instagram">Instagram</string>
     <string name="settings_about_rate_us">Classifique-nos</string>
     <string name="settings_about_share_with_friends_message">Oi! Este é um link para fazer download do aplicativo do Pocket Casts. Eu estou gostando muito de usá-lo e acho que talvez você goste também. \nhttps://www.pocketcasts.com</string>

--- a/modules/services/localization/src/main/res/values-ru/strings.xml
+++ b/modules/services/localization/src/main/res/values-ru/strings.xml
@@ -807,7 +807,6 @@ Language: ru
     <string name="settings_about_work_from_anywhere">Работайте откуда угодно</string>
     <string name="settings_about_legal">Юридическая информация и прочее</string>
     <string name="settings_about_work_with_us">Вакансии</string>
-    <string name="settings_about_twitter">Twitter</string>
     <string name="settings_about_instagram">Instagram</string>
     <string name="settings_about_rate_us">Оцените нас</string>
     <string name="settings_about_share_with_friends_message">Привет! Вот ссылка для загрузки приложения Pocket Casts. Мне оно нравится, рекомендую. \nhttps://www.pocketcasts.com</string>

--- a/modules/services/localization/src/main/res/values-sv/strings.xml
+++ b/modules/services/localization/src/main/res/values-sv/strings.xml
@@ -807,7 +807,6 @@ Language: sv_SE
     <string name="settings_about_work_from_anywhere">Jobba var du än är</string>
     <string name="settings_about_legal">Juridisk information med mera</string>
     <string name="settings_about_work_with_us">Jobba med oss</string>
-    <string name="settings_about_twitter">Twitter</string>
     <string name="settings_about_instagram">Instagram</string>
     <string name="settings_about_rate_us">Betygsätt oss</string>
     <string name="settings_about_share_with_friends_message">Hej! Här är en länk för att ladda ner Pocket Casts-appen. Jag tycker att den är jättebra och tänkte att du också skulle gilla den. \nhttps://www.pocketcasts.com</string>

--- a/modules/services/localization/src/main/res/values-zh-rTW/strings.xml
+++ b/modules/services/localization/src/main/res/values-zh-rTW/strings.xml
@@ -807,7 +807,6 @@ Language: zh_TW
     <string name="settings_about_work_from_anywhere">遠端工作，不限地點</string>
     <string name="settings_about_legal">法律與其他</string>
     <string name="settings_about_work_with_us">工作機會</string>
-    <string name="settings_about_twitter">Twitter</string>
     <string name="settings_about_instagram">Instagram</string>
     <string name="settings_about_rate_us">幫我們評分</string>
     <string name="settings_about_share_with_friends_message">嗨！分享 Pocket Casts 的下載連結。我很喜歡這個 App，相信你也會喜歡它。 \nhttps://www.pocketcasts.com</string>

--- a/modules/services/localization/src/main/res/values-zh/strings.xml
+++ b/modules/services/localization/src/main/res/values-zh/strings.xml
@@ -807,7 +807,6 @@ Language: zh_CN
     <string name="settings_about_work_from_anywhere">随时随地工作</string>
     <string name="settings_about_legal">法律及更多信息</string>
     <string name="settings_about_work_with_us">加入我们</string>
-    <string name="settings_about_twitter">Twitter</string>
     <string name="settings_about_instagram">Instagram</string>
     <string name="settings_about_rate_us">给我们评分</string>
     <string name="settings_about_share_with_friends_message">嘿！ 这是下载 Pocket Casts 应用的链接。我非常喜欢这个应用，希望您也喜欢。 \nhttps://www.pocketcasts.com</string>

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -1576,7 +1576,7 @@
     <string name="settings_about_share_with_friends_message">Hey! Here is a link to download the Pocket Casts app. I\'m really enjoying it and thought you might too. \nhttps://www.pocketcasts.com</string>
     <string name="settings_about_rate_us">Rate us</string>
     <string name="settings_about_instagram">Instagram</string>
-    <string name="settings_about_twitter">Twitter</string>
+    <string name="settings_about_x" translatable="false">X</string>
     <string name="settings_about_work_with_us">Work with us</string>
     <string name="settings_about_legal">Legal and more</string>
     <string name="settings_about_work_from_anywhere">Work from Anywhere</string>


### PR DESCRIPTION
## Description

Internal reference: pbMoDN-4vZ-p2#comment-7289 

This change renames Twitter to X and updates the URL.

## Testing Instructions

1. Go to the about page
2. ✅ Verify the label has changed to X and tapping opens our x.com page.

## Screenshots

| Before | After |
| --- | --- |
| ![Screenshot_20250126_092251](https://github.com/user-attachments/assets/e3302c13-ab0d-43ed-b113-58b7c45da1d5) | ![Screenshot_20250126_092853](https://github.com/user-attachments/assets/64ef9407-3b85-407e-aa03-aa64a7fb6b31) | 

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack