### PR TITLE
Fix media session controls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 *   Bug Fixes
     *   Fix status bar theming during onboarding.
         ([#3460](https://github.com/Automattic/pocket-casts-android/pull/3460))
+    *   Fix issue with playback stopping when using Pixel Buds actions.
+        ([#3493](https://github.com/Automattic/pocket-casts-android/pull/3493))
 *   Updates
     *   Remove audio and video clip sharing
         ([#3481](https://github.com/Automattic/pocket-casts-android/pull/3481))

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/MediaEventQueue.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/MediaEventQueue.kt
@@ -13,7 +13,7 @@ internal class MediaEventQueue(
 
     suspend fun consumeEvent(event: MediaEvent) = when (event) {
         MediaEvent.SingleTap -> handleSingleTapEvent()
-        MediaEvent.DoubleTap, MediaEvent.TrippleTap -> handleMultiTapEvent(event)
+        MediaEvent.DoubleTap, MediaEvent.TripleTap -> handleMultiTapEvent(event)
     }
 
     private suspend fun handleSingleTapEvent(): MediaEvent? {
@@ -65,7 +65,7 @@ internal class MediaEventQueue(
         fun event() = when (counter) {
             1 -> MediaEvent.SingleTap
             2 -> MediaEvent.DoubleTap
-            else -> MediaEvent.TrippleTap
+            else -> MediaEvent.TripleTap
         }
     }
 }
@@ -73,5 +73,5 @@ internal class MediaEventQueue(
 internal enum class MediaEvent {
     SingleTap,
     DoubleTap,
-    TrippleTap,
+    TripleTap,
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/MediaEventQueue.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/MediaEventQueue.kt
@@ -1,0 +1,77 @@
+package au.com.shiftyjelly.pocketcasts.repositories.playback
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+
+internal class MediaEventQueue(
+    private val scope: CoroutineScope,
+) {
+    private var singleTapJob: SingleTapJob? = null
+    private var multiTapJob: Job? = null
+
+    suspend fun consumeEvent(event: MediaEvent) = when (event) {
+        MediaEvent.SingleTap -> handleSingleTapEvent()
+        MediaEvent.DoubleTap, MediaEvent.TrippleTap -> handleMultiTapEvent(event)
+    }
+
+    private suspend fun handleSingleTapEvent(): MediaEvent? {
+        val currentSingleTapJob = singleTapJob
+        return when {
+            // Pixel Buds (and possibly other headphones) trigger KEYCODE_MEDIA_PLAY
+            // after KEYCODE_MEDIA_NEXT or KEYCODE_MEDIA_PREVIOUS.
+            // We need to ignore it so the single tap action isn't triggered in such cases.
+            multiTapJob?.isActive == true -> {
+                null
+            }
+
+            currentSingleTapJob?.isActive == true -> {
+                currentSingleTapJob.incrementTaps()
+                null
+            }
+
+            else -> {
+                val newSingleTapJob = SingleTapJob(scope)
+                singleTapJob = newSingleTapJob
+                newSingleTapJob.await()
+                newSingleTapJob.event()
+            }
+        }
+    }
+
+    private fun handleMultiTapEvent(event: MediaEvent): MediaEvent {
+        val currentJob = multiTapJob
+        multiTapJob = scope.launch { delay(250) }
+        currentJob?.cancel()
+        return event
+    }
+
+    private class SingleTapJob(
+        private val scope: CoroutineScope,
+    ) {
+        private var counter: Int = 1
+
+        private val job = scope.launch { delay(600) }
+
+        val isActive get() = job.isActive
+
+        suspend fun await() = job.join()
+
+        fun incrementTaps() {
+            counter++
+        }
+
+        fun event() = when (counter) {
+            1 -> MediaEvent.SingleTap
+            2 -> MediaEvent.DoubleTap
+            else -> MediaEvent.TrippleTap
+        }
+    }
+}
+
+internal enum class MediaEvent {
+    SingleTap,
+    DoubleTap,
+    TrippleTap,
+}

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/MediaSessionManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/MediaSessionManager.kt
@@ -538,7 +538,7 @@ class MediaSessionManager(
                          */
                         KeyEvent.KEYCODE_MEDIA_PLAY, KeyEvent.KEYCODE_MEDIA_PLAY_PAUSE, KeyEvent.KEYCODE_HEADSETHOOK -> MediaEvent.SingleTap
                         KeyEvent.KEYCODE_MEDIA_NEXT -> MediaEvent.DoubleTap
-                        KeyEvent.KEYCODE_MEDIA_PREVIOUS -> MediaEvent.TrippleTap
+                        KeyEvent.KEYCODE_MEDIA_PREVIOUS -> MediaEvent.TripleTap
                         else -> null
                     }
 
@@ -548,7 +548,7 @@ class MediaSessionManager(
                             when (outputEvent) {
                                 MediaEvent.SingleTap -> handleMediaButtonSingleTap()
                                 MediaEvent.DoubleTap -> handleMediaButtonDoubleTap()
-                                MediaEvent.TrippleTap -> handleMediaButtonTripleTap()
+                                MediaEvent.TripleTap -> handleMediaButtonTripleTap()
                                 null -> Unit
                             }
                         }

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/playback/MediaEventQueueTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/playback/MediaEventQueueTest.kt
@@ -28,7 +28,7 @@ class MediaEventQueueTest {
     }
 
     @Test
-    fun `tripple tap event`() = runTest {
+    fun `triple tap event`() = runTest {
         val handler = MediaEventQueue(this)
 
         val event = handler.consumeEvent(MediaEvent.TripleTap)
@@ -49,7 +49,7 @@ class MediaEventQueueTest {
     }
 
     @Test
-    fun `map single tap events to tripple tap event`() = runTest {
+    fun `map single tap events to triple tap event`() = runTest {
         val handler = MediaEventQueue(this)
 
         val firstEvent = async { handler.consumeEvent(MediaEvent.SingleTap) }
@@ -62,7 +62,7 @@ class MediaEventQueueTest {
     }
 
     @Test
-    fun `map single tap events to tripple tap event when event count is higher`() = runTest {
+    fun `map single tap events to triple tap event when event count is higher`() = runTest {
         val handler = MediaEventQueue(this)
 
         val firstEvent = async { handler.consumeEvent(MediaEvent.SingleTap) }
@@ -137,7 +137,7 @@ class MediaEventQueueTest {
     }
 
     @Test
-    fun `ignore single tap events while tripple tap window is active`() = runTest {
+    fun `ignore single tap events while triple tap window is active`() = runTest {
         val handler = MediaEventQueue(this)
 
         handler.consumeEvent(MediaEvent.TripleTap)

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/playback/MediaEventQueueTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/playback/MediaEventQueueTest.kt
@@ -1,0 +1,152 @@
+package au.com.shiftyjelly.pocketcasts.repositories.playback
+
+import kotlinx.coroutines.async
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.yield
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class MediaEventQueueTest {
+    @Test
+    fun `single tap event`() = runTest {
+        val handler = MediaEventQueue(this)
+
+        val event = handler.consumeEvent(MediaEvent.SingleTap)
+
+        assertEquals(MediaEvent.SingleTap, event)
+    }
+
+    @Test
+    fun `double tap event`() = runTest {
+        val handler = MediaEventQueue(this)
+
+        val event = handler.consumeEvent(MediaEvent.DoubleTap)
+
+        assertEquals(MediaEvent.DoubleTap, event)
+    }
+
+    @Test
+    fun `tripple tap event`() = runTest {
+        val handler = MediaEventQueue(this)
+
+        val event = handler.consumeEvent(MediaEvent.TrippleTap)
+
+        assertEquals(MediaEvent.TrippleTap, event)
+    }
+
+    @Test
+    fun `map single tap events to double tap event`() = runTest {
+        val handler = MediaEventQueue(this)
+
+        val firstEvent = async { handler.consumeEvent(MediaEvent.SingleTap) }
+
+        yield()
+        assertNull(handler.consumeEvent(MediaEvent.SingleTap))
+
+        assertEquals(MediaEvent.DoubleTap, firstEvent.await())
+    }
+
+    @Test
+    fun `map single tap events to tripple tap event`() = runTest {
+        val handler = MediaEventQueue(this)
+
+        val firstEvent = async { handler.consumeEvent(MediaEvent.SingleTap) }
+
+        yield()
+        assertNull(handler.consumeEvent(MediaEvent.SingleTap))
+        assertNull(handler.consumeEvent(MediaEvent.SingleTap))
+
+        assertEquals(MediaEvent.TrippleTap, firstEvent.await())
+    }
+
+    @Test
+    fun `map single tap events to tripple tap event when event count is higher`() = runTest {
+        val handler = MediaEventQueue(this)
+
+        val firstEvent = async { handler.consumeEvent(MediaEvent.SingleTap) }
+
+        yield()
+        repeat(100) {
+            assertNull(handler.consumeEvent(MediaEvent.SingleTap))
+        }
+
+        assertEquals(MediaEvent.TrippleTap, firstEvent.await())
+    }
+
+    @Test
+    fun `map single tap events to multi tap event in time window`() = runTest {
+        val handler = MediaEventQueue(this)
+
+        val firstEvent = async { handler.consumeEvent(MediaEvent.SingleTap) }
+
+        delay(600)
+        assertNull(handler.consumeEvent(MediaEvent.SingleTap))
+
+        assertEquals(MediaEvent.DoubleTap, firstEvent.await())
+    }
+
+    @Test
+    fun `map single tap events to single tap events outside of time window`() = runTest {
+        val handler = MediaEventQueue(this)
+
+        val firstEvent = async { handler.consumeEvent(MediaEvent.SingleTap) }
+
+        delay(601)
+        val secondEvent = handler.consumeEvent(MediaEvent.SingleTap)
+        assertEquals(MediaEvent.SingleTap, secondEvent)
+
+        assertEquals(MediaEvent.SingleTap, firstEvent.await())
+    }
+
+    @Test
+    fun `do not reset single tap time window with each new event`() = runTest {
+        val handler = MediaEventQueue(this)
+
+        val firstEvent = async { handler.consumeEvent(MediaEvent.SingleTap) }
+
+        delay(250)
+        assertNull(handler.consumeEvent(MediaEvent.SingleTap))
+
+        delay(250)
+        assertNull(handler.consumeEvent(MediaEvent.SingleTap))
+
+        delay(250)
+        val secondEvent = async { handler.consumeEvent(MediaEvent.SingleTap) }
+
+        yield()
+        assertNull(handler.consumeEvent(MediaEvent.SingleTap))
+
+        assertEquals(MediaEvent.TrippleTap, firstEvent.await())
+        assertEquals(MediaEvent.DoubleTap, secondEvent.await())
+    }
+
+    @Test
+    fun `ignore single tap events while double tap window is active`() = runTest {
+        val handler = MediaEventQueue(this)
+
+        handler.consumeEvent(MediaEvent.DoubleTap)
+
+        delay(250)
+        assertNull(handler.consumeEvent(MediaEvent.SingleTap))
+
+        delay(1)
+        val event = handler.consumeEvent(MediaEvent.SingleTap)
+        assertEquals(MediaEvent.SingleTap, event)
+    }
+
+    @Test
+    fun `ignore single tap events while tripple tap window is active`() = runTest {
+        val handler = MediaEventQueue(this)
+
+        handler.consumeEvent(MediaEvent.TrippleTap)
+
+        delay(250)
+        assertNull(handler.consumeEvent(MediaEvent.SingleTap))
+
+        delay(1)
+        val event = handler.consumeEvent(MediaEvent.SingleTap)
+        assertEquals(MediaEvent.SingleTap, event)
+    }
+}

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/playback/MediaEventQueueTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/playback/MediaEventQueueTest.kt
@@ -31,9 +31,9 @@ class MediaEventQueueTest {
     fun `tripple tap event`() = runTest {
         val handler = MediaEventQueue(this)
 
-        val event = handler.consumeEvent(MediaEvent.TrippleTap)
+        val event = handler.consumeEvent(MediaEvent.TripleTap)
 
-        assertEquals(MediaEvent.TrippleTap, event)
+        assertEquals(MediaEvent.TripleTap, event)
     }
 
     @Test
@@ -58,7 +58,7 @@ class MediaEventQueueTest {
         assertNull(handler.consumeEvent(MediaEvent.SingleTap))
         assertNull(handler.consumeEvent(MediaEvent.SingleTap))
 
-        assertEquals(MediaEvent.TrippleTap, firstEvent.await())
+        assertEquals(MediaEvent.TripleTap, firstEvent.await())
     }
 
     @Test
@@ -72,7 +72,7 @@ class MediaEventQueueTest {
             assertNull(handler.consumeEvent(MediaEvent.SingleTap))
         }
 
-        assertEquals(MediaEvent.TrippleTap, firstEvent.await())
+        assertEquals(MediaEvent.TripleTap, firstEvent.await())
     }
 
     @Test
@@ -118,7 +118,7 @@ class MediaEventQueueTest {
         yield()
         assertNull(handler.consumeEvent(MediaEvent.SingleTap))
 
-        assertEquals(MediaEvent.TrippleTap, firstEvent.await())
+        assertEquals(MediaEvent.TripleTap, firstEvent.await())
         assertEquals(MediaEvent.DoubleTap, secondEvent.await())
     }
 
@@ -140,7 +140,7 @@ class MediaEventQueueTest {
     fun `ignore single tap events while tripple tap window is active`() = runTest {
         val handler = MediaEventQueue(this)
 
-        handler.consumeEvent(MediaEvent.TrippleTap)
+        handler.consumeEvent(MediaEvent.TripleTap)
 
         delay(250)
         assertNull(handler.consumeEvent(MediaEvent.SingleTap))


### PR DESCRIPTION
## Description

This PR changes processing of media session events to use coroutines. I did this in order to have comprehensive tests for handling it and fix the reported bug introduced by #3297. This was happening because `KEYCODE_MEDIA_NEXT` is followed by `KEYCODE_MEDIA_PLAY` event when using Pixel Buds. I don't know if other brands experience it.

Fixes #3487

## Testing Instructions

1. Listen to an episode with Pixel Buds Pro 2.
2. Double tap a bud to advance by 30 seconds, or triple tap to rewind 10 seconds.
3. Playback should not pause.

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [ ] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [ ] ~Any jetpack compose components I added or changed are covered by compose previews~
- [ ] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~