### PR TITLE
Fix episode bottom sheet edge-to-edge

### DIFF
--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/episode/EpisodeContainerFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/episode/EpisodeContainerFragment.kt
@@ -253,6 +253,7 @@ class EpisodeContainerFragment :
             multiSelectHelper = bookmarksViewModel.multiSelectHelper,
             menuRes = null,
             activity = requireActivity(),
+            includeStatusBarPadding = false,
         )
     }
 

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/episode/EpisodeContainerFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/episode/EpisodeContainerFragment.kt
@@ -2,7 +2,6 @@ package au.com.shiftyjelly.pocketcasts.podcasts.view.episode
 
 import android.app.Dialog
 import android.content.res.ColorStateList
-import android.content.res.Resources
 import android.os.Bundle
 import android.view.ContextThemeWrapper
 import android.view.LayoutInflater
@@ -12,7 +11,6 @@ import androidx.activity.OnBackPressedCallback
 import androidx.annotation.StringRes
 import androidx.core.os.BundleCompat
 import androidx.core.view.isVisible
-import androidx.core.view.updateLayoutParams
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentManager
 import androidx.fragment.app.viewModels
@@ -32,7 +30,6 @@ import au.com.shiftyjelly.pocketcasts.player.view.chapters.ChaptersViewModel.Mod
 import au.com.shiftyjelly.pocketcasts.player.viewmodel.BookmarksViewModel
 import au.com.shiftyjelly.pocketcasts.podcasts.databinding.FragmentEpisodeContainerBinding
 import au.com.shiftyjelly.pocketcasts.podcasts.view.episode.EpisodeFragment.EpisodeFragmentArgs
-import au.com.shiftyjelly.pocketcasts.ui.helper.StatusBarIconColor
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import au.com.shiftyjelly.pocketcasts.ui.theme.ThemeColor
 import au.com.shiftyjelly.pocketcasts.views.fragments.BaseDialogFragment
@@ -101,8 +98,7 @@ class EpisodeContainerFragment :
             bundle?.let { BundleCompat.getParcelable(it, NEW_INSTANCE_ARG, EpisodeFragmentArgs::class.java) }
     }
 
-    override val statusBarIconColor: StatusBarIconColor
-        get() = StatusBarIconColor.Light
+    override val includeNavigationBarPadding: Boolean = false
 
     var binding: FragmentEpisodeContainerBinding? = null
 
@@ -185,14 +181,6 @@ class EpisodeContainerFragment :
             isFitToContents = false
             state = BottomSheetBehavior.STATE_EXPANDED
             skipCollapsed = true
-        }
-        // Ensure the dialog ends up the full height of the screen
-        // Bottom sheet dialogs get wrapped in a sheet that is WRAP_CONTENT so setting MATCH_PARENT on our
-        // root view is ignored.
-        bottomSheetDialog?.setOnShowListener {
-            view.updateLayoutParams<ViewGroup.LayoutParams> {
-                height = Resources.getSystem().displayMetrics.heightPixels
-            }
         }
 
         val binding = binding ?: return

--- a/modules/features/podcasts/src/main/res/layout/fragment_episode.xml
+++ b/modules/features/podcasts/src/main/res/layout/fragment_episode.xml
@@ -4,7 +4,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:paddingBottom="64dp"
+    android:paddingBottom="16dp"
     android:clipToPadding="false"
     android:background="?attr/primary_ui_01">
 
@@ -294,7 +294,7 @@
             android:paddingStart="@dimen/episode_card_edge_padding"
             android:paddingEnd="@dimen/episode_card_edge_padding"
             android:visibility="gone"
-            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintBottom_toTopOf="@+id/navigationBarSpacer"
             app:layout_constraintLeft_toLeftOf="parent"
             app:layout_constraintRight_toRightOf="parent"
             app:layout_constraintTop_toBottomOf="@+id/lblDate" />
@@ -324,11 +324,12 @@
             app:layout_constraintRight_toRightOf="parent"
             app:layout_constraintTop_toBottomOf="@+id/lblDate" />
 
-        <androidx.constraintlayout.widget.Guideline
-            android:id="@+id/center_vertical_guideline"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:orientation="vertical"
-            app:layout_constraintGuide_percent="0.5" />
+        <au.com.shiftyjelly.pocketcasts.views.component.NavigationBarSpacer
+            android:id="@+id/navigationBarSpacer"
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:layout_marginTop="16dp"
+            app:layout_constraintTop_toBottomOf="@+id/webViewShowNotes"
+            app:layout_constraintBottom_toBottomOf="parent"/>
     </androidx.constraintlayout.widget.ConstraintLayout>
 </androidx.core.widget.NestedScrollView>

--- a/modules/features/podcasts/src/main/res/layout/fragment_episode_container.xml
+++ b/modules/features/podcasts/src/main/res/layout/fragment_episode_container.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<au.com.shiftyjelly.pocketcasts.views.helper.MatchParentFrameLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:orientation="vertical">
+    android:layout_height="match_parent">
 
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
+        android:layout_height="match_parent"
         android:clickable="true"
         android:focusable="true"
         android:background="?attr/primary_ui_01">
@@ -73,11 +73,23 @@
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintTop_toTopOf="parent"/>
 
+        <androidx.constraintlayout.widget.Barrier
+            android:id="@+id/barrierTop"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            app:barrierDirection="bottom"
+            app:constraint_referenced_ids="btnClose,tabLayout,multiSelectToolbar" />
+
+        <androidx.viewpager2.widget.ViewPager2
+            android:id="@+id/viewPager"
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:orientation="horizontal"
+            app:layout_constraintTop_toBottomOf="@+id/barrierTop"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintBottom_toBottomOf="parent" />
+
     </androidx.constraintlayout.widget.ConstraintLayout>
 
-    <androidx.viewpager2.widget.ViewPager2
-        android:id="@+id/viewPager"
-        android:layout_width="match_parent"
-        android:layout_height="0dp"
-        android:layout_weight="1" />
-</LinearLayout>
+</au.com.shiftyjelly.pocketcasts.views.helper.MatchParentFrameLayout>

--- a/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/fragments/BaseDialogFragment.kt
+++ b/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/fragments/BaseDialogFragment.kt
@@ -30,6 +30,7 @@ open class BaseDialogFragment : BottomSheetDialogFragment(), CoroutineScope {
 
     open val statusBarIconColor: StatusBarIconColor = StatusBarIconColor.Theme
     open val navigationBarColor: NavigationBarColor = NavigationBarColor.Theme
+    open val includeNavigationBarPadding: Boolean = true
 
     private var isBeingDragged = false
     private val dismissCallback = object : BottomSheetBehavior.BottomSheetCallback() {
@@ -60,7 +61,9 @@ open class BaseDialogFragment : BottomSheetDialogFragment(), CoroutineScope {
         }
 
         // add padding to the bottom of the dialog for the navigation bar
-        view.setSystemWindowInsetToPadding(bottom = true)
+        if (includeNavigationBarPadding) {
+            view.setSystemWindowInsetToPadding(bottom = true)
+        }
 
         isBeingDragged = false
         addDismissCallback()

--- a/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/helper/MatchParentFrameLayout.kt
+++ b/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/helper/MatchParentFrameLayout.kt
@@ -1,0 +1,19 @@
+package au.com.shiftyjelly.pocketcasts.views.helper
+
+import android.content.Context
+import android.util.AttributeSet
+import android.widget.FrameLayout
+
+/**
+ * A FrameLayout that will always measure itself with the height of the parent.
+ * This fixes an issue with the episode bottom sheet not expanding to the full height of the screen.
+ */
+class MatchParentFrameLayout @JvmOverloads constructor(context: Context, attrs: AttributeSet? = null, defStyleAttr: Int = 0) : FrameLayout(context, attrs, defStyleAttr) {
+    override fun onMeasure(widthMeasureSpec: Int, heightMeasureSpec: Int) {
+        var newHeightMeasureSpec = heightMeasureSpec
+        if (MeasureSpec.getMode(heightMeasureSpec) == MeasureSpec.AT_MOST) {
+            newHeightMeasureSpec = MeasureSpec.makeMeasureSpec(MeasureSpec.getSize(heightMeasureSpec), MeasureSpec.EXACTLY)
+        }
+        super.onMeasure(widthMeasureSpec, newHeightMeasureSpec)
+    }
+}


### PR DESCRIPTION
## Description

This fixes the episode's bottom sheet. The status bar icons were the wrong colour, and the bottom padding was causing issues with the bottom of the page. 

## Testing Instructions

1. Tap on an episode row.
2. ✅ Check you can scroll to the bottom of the page and see all the show notes.

## Screenshots 

**Before**

<img width="1768" alt="Screenshot 2025-01-28 at 12 13 36 pm" src="https://github.com/user-attachments/assets/f70836ae-043e-4c4f-baad-859a2fc52d77" />

**After**

<img width="1768" alt="Screenshot 2025-01-28 at 3 56 09 pm" src="https://github.com/user-attachments/assets/a88bfb5b-f48f-4bf0-9de2-3c45cebbe520" />

<img width="1768" alt="Screenshot 2025-01-28 at 3 56 14 pm" src="https://github.com/user-attachments/assets/c8e6b410-9206-462e-ae1f-50579b344ccd" />

<img width="1768" alt="Screenshot 2025-01-28 at 3 54 19 pm" src="https://github.com/user-attachments/assets/ac1eb1fc-66df-4e18-89c4-da0f70a8d60f" />

<img width="1768" alt="Screenshot 2025-01-28 at 3 55 23 pm" src="https://github.com/user-attachments/assets/7a137a36-58db-49ca-91d2-2d621aae2c9a" />

The navigation bar icons aren't correct for API 24 but that is happening throughout the whole app.

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack
