### PR TITLE
[Podcast Feed Update] Update New Episode Found message

### DIFF
--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastFragment.kt
@@ -928,16 +928,12 @@ class PodcastFragment : BaseFragment(), Toolbar.OnMenuItemClickListener {
                 when (state) {
                     PodcastViewModel.RefreshState.Error -> {}
                     PodcastViewModel.RefreshState.NotStarted -> {}
-                    is PodcastViewModel.RefreshState.Refreshed -> {
-                        if (state.type == PodcastViewModel.RefreshType.PULL_TO_REFRESH) {
-                            binding?.swipeRefreshLayout?.isRefreshing = false
-                        } else {
-                            (activity as? FragmentHostListener)?.snackBarView()?.let { snackBarView ->
-                                Snackbar.make(snackBarView, getString(LR.string.podcast_refresh_list_updated), Snackbar.LENGTH_LONG).show()
-                            }
+                    PodcastViewModel.RefreshState.NewEpisodeFound -> {
+                        binding?.swipeRefreshLayout?.isRefreshing = false
+                        (activity as? FragmentHostListener)?.snackBarView()?.let { snackBarView ->
+                            Snackbar.make(snackBarView, getString(LR.string.podcast_refresh_new_episode_found), Snackbar.LENGTH_LONG).show()
                         }
                     }
-
                     is PodcastViewModel.RefreshState.Refreshing -> {
                         if (state.type == PodcastViewModel.RefreshType.PULL_TO_REFRESH) {
                             binding?.swipeRefreshLayout?.isRefreshing = true

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/PodcastViewModel.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/PodcastViewModel.kt
@@ -585,7 +585,7 @@ class PodcastViewModel
         launch {
             _refreshState.emit(RefreshState.Refreshing(refreshType))
             delay(2.seconds)
-            _refreshState.emit(RefreshState.Refreshed(refreshType))
+            _refreshState.emit(RefreshState.NewEpisodeFound)
         }
     }
 
@@ -628,7 +628,7 @@ class PodcastViewModel
     sealed class RefreshState {
         data object NotStarted : RefreshState()
         data class Refreshing(val type: RefreshType) : RefreshState()
-        data class Refreshed(val type: RefreshType) : RefreshState()
+        data object NewEpisodeFound : RefreshState()
         data object Error : RefreshState()
     }
 

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -628,7 +628,7 @@
     <string name="podcast_show_archived" translatable="false">@string/show_archived</string>
     <string name="podcast_refresh_episodes">Refresh episode list</string>
     <string name="podcast_refreshing_episode_list">Refreshing episode list…</string>
-    <string name="podcast_refresh_list_updated">Episode list updated!</string>
+    <string name="podcast_refresh_new_episode_found">New episode found!</string>
     <string name="podcast_sort_episodes">Sort episodes</string>
     <string name="podcast_subscribed">Following</string>
     <string name="podcast_not_subscribed">Not Following</string>


### PR DESCRIPTION
## Description
- This updates the message when founds a new episode
- See: pdeCcb-8oU-p2

## Testing Instructions
1. Open a podcast
2. Pull down to refresh
3. See the `New Episode Found!` snackbar message after 2 seconds
4. Open more options (tap on 3 dots icon)
5. Tap on Refresh episode list
6. See the `New Episode Found!` snackbar message after 2 seconds

## Screenshots or Screencast 
[Screen_recording_20250128_085824.webm](https://github.com/user-attachments/assets/816df067-622b-4ec2-b283-2be193092d43)


## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.