### PR TITLE
[Podcast Feed Update] Update Tracks

### DIFF
--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/PodcastViewModel.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/PodcastViewModel.kt
@@ -580,7 +580,7 @@ class PodcastViewModel
     fun onRefreshPodcast(refreshType: RefreshType) {
         val podcast = podcast.value ?: return
 
-        analyticsTracker.track(AnalyticsEvent.PODCAST_SCREEN_REFRESH_EPISODE_LIST_TAPPED, mapOf("podcast_uuid" to podcast.uuid))
+        analyticsTracker.track(AnalyticsEvent.PODCAST_SCREEN_REFRESH_EPISODE_LIST, mapOf("podcast_uuid" to podcast.uuid, "action" to refreshType.analyticsValue))
 
         launch {
             _refreshState.emit(RefreshState.Refreshing(refreshType))
@@ -632,9 +632,9 @@ class PodcastViewModel
         data object Error : RefreshState()
     }
 
-    enum class RefreshType {
-        PULL_TO_REFRESH,
-        REFRESH_BUTTON,
+    enum class RefreshType(val analyticsValue: String) {
+        PULL_TO_REFRESH("pull_to_refresh"),
+        REFRESH_BUTTON("refresh_button"),
     }
 
     private object AnalyticsProp {

--- a/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
+++ b/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
@@ -229,7 +229,7 @@ enum class AnalyticsEvent(val key: String) {
     PODCASTS_SCREEN_EPISODE_GROUPING_CHANGED("podcasts_screen_episode_grouping_changed"),
     PODCASTS_SCREEN_TAB_TAPPED("podcasts_screen_tab_tapped"),
     PODCAST_SCREEN_REPORT_TAPPED("podcast_screen_report_tapped"),
-    PODCAST_SCREEN_REFRESH_EPISODE_LIST_TAPPED("podcast_screen_refresh_episode_list_tapped"),
+    PODCAST_SCREEN_REFRESH_EPISODE_LIST("podcast_screen_refresh_episode_list"),
 
     /* Podcast Settings */
     PODCAST_SETTINGS_FEED_ERROR_TAPPED("podcast_settings_feed_error_tapped"),


### PR DESCRIPTION
## Description
- Updates the tracks

<img width="1217" alt="image" src="https://github.com/user-attachments/assets/39499bee-38f2-442f-9382-01f6ee6e0698" />


Fixes #3498 

## Testing Instructions
1. Open a podcast
2. Pull down to refresh
3. Ensure `Tracked: podcast_screen_refresh_episode_list, Properties: {"podcast_uuid":"uuid","action":"pull_to_refresh"`
4. Tap on 2 dots menu
5. Tap on Refresh episode list
6. Ensure `Tracked: podcast_screen_refresh_episode_list, Properties: {"podcast_uuid":"uuid","action":"refresh_button"`

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
