### PR TITLE
Fix Discover Subtitle List for Large Font Sizes

### DIFF
--- a/modules/features/discover/src/main/res/layout/row_podcast.xml
+++ b/modules/features/discover/src/main/res/layout/row_podcast.xml
@@ -21,7 +21,7 @@
 
     <LinearLayout
         android:layout_width="0dp"
-        android:layout_height="match_parent"
+        android:layout_height="wrap_content"
         android:layout_weight="1"
         android:orientation="vertical"
         android:gravity="center">

--- a/modules/features/discover/src/main/res/layout/row_podcast.xml
+++ b/modules/features/discover/src/main/res/layout/row_podcast.xml
@@ -11,7 +11,8 @@
         android:layout_height="56dp"
         android:elevation="2dp"
         app:cardCornerRadius="4dp"
-        android:layout_marginRight="8dp">
+        android:layout_marginRight="8dp"
+        android:layout_gravity="center_vertical">
         <ImageView
             android:id="@+id/imageView"
             android:layout_width="56dp"


### PR DESCRIPTION
## Description
- This fixes the discover subtitle list items for large font sizes

## Testing Instructions
1. Increase device font size
2. Check the small list in discover page

## Screenshots or Screencast 

| Before | After |
|--------|--------|
| ![before](https://github.com/user-attachments/assets/a955f6a3-b59e-4d1e-8619-f23defd62e79) | ![after](https://github.com/user-attachments/assets/6e7858b4-1781-4dca-a08b-35882d6a1882) | 

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack
