### PR TITLE
Fix App version in About screen for large fonts

### DIFF
--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/about/AboutFragment.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/about/AboutFragment.kt
@@ -44,6 +44,7 @@ import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
@@ -235,6 +236,7 @@ private fun AboutPage(
                 text = stringResource(LR.string.settings_version, BuildConfig.VERSION_NAME, BuildConfig.VERSION_CODE.toString()),
                 style = MaterialTheme.typography.body1,
                 modifier = Modifier.padding(top = 8.dp),
+                textAlign = TextAlign.Center,
                 color = MaterialTheme.theme.colors.primaryText02,
             )
         }


### PR DESCRIPTION
## Description
- Center version name in About screen

## Testing Instructions
Check if the version name is aligned (center) for large fonts

## Screenshots or Screencast 
| Before | After |
|--------|--------|
| ![before](https://github.com/user-attachments/assets/676103c4-8cde-47f8-ab4a-5b178c5ed9c9) | ![after](https://github.com/user-attachments/assets/33497e7c-c958-4bd0-b715-89efaa485307) | 

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
