### PR TITLE
Adapt Winback for edge-to-edge

### DIFF
--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/winback/AvailablePlansPage.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/winback/AvailablePlansPage.kt
@@ -9,15 +9,18 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.AppBarDefaults
 import androidx.compose.material.Button
 import androidx.compose.material.ButtonDefaults
 import androidx.compose.material.CircularProgressIndicator
@@ -78,6 +81,7 @@ internal fun AvailablePlansPage(
         modifier = Modifier.nestedScroll(rememberViewInteropNestedScrollConnection()),
     ) {
         BottomSheetAppBar(
+            windowInsets = AppBarDefaults.topAppBarWindowInsets.only(WindowInsetsSides.Horizontal),
             onNavigationClick = onGoBack,
         )
         AnimatedContent(

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/winback/CancelConfirmationPage.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/winback/CancelConfirmationPage.kt
@@ -178,6 +178,8 @@ private fun Buttons(
             TextH30(
                 text = stringResource(LR.string.winback_cancel_subscription_stay_button_label),
                 color = MaterialTheme.theme.colors.primaryInteractive02,
+                textAlign = TextAlign.Center,
+                modifier = Modifier.fillMaxWidth(),
             )
         }
         Box(

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/winback/WinbackFragment.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/winback/WinbackFragment.kt
@@ -12,8 +12,11 @@ import androidx.compose.animation.AnimatedContentTransitionScope
 import androidx.compose.animation.animateColorAsState
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
+import androidx.compose.material.AppBarDefaults
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Snackbar
 import androidx.compose.material.SnackbarHost
@@ -149,6 +152,7 @@ class WinbackFragment : BaseDialogFragment() {
                     composable(WinbackNavRoutes.HelpAndFeedback) {
                         HelpPage(
                             activity = requireActivity(),
+                            appBarInsets = AppBarDefaults.topAppBarWindowInsets.only(WindowInsetsSides.Horizontal),
                             onShowLogs = { navController.navigate(WinbackNavRoutes.SupportLogs) },
                             onShowStatusPage = { navController.navigate(WinbackNavRoutes.StatusCheck) },
                             onGoBack = { navController.popBackStack() },
@@ -157,12 +161,14 @@ class WinbackFragment : BaseDialogFragment() {
                     composable(WinbackNavRoutes.SupportLogs) {
                         LogsPage(
                             bottomInset = 0.dp,
+                            appBarInsets = AppBarDefaults.topAppBarWindowInsets.only(WindowInsetsSides.Horizontal),
                             onBackPressed = { navController.popBackStack() },
                         )
                     }
                     composable(WinbackNavRoutes.StatusCheck) {
                         StatusPage(
                             bottomInset = 0.dp,
+                            appBarInsets = AppBarDefaults.topAppBarWindowInsets.only(WindowInsetsSides.Horizontal),
                             onBackPressed = { navController.popBackStack() },
                         )
                     }

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/HelpPage.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/HelpPage.kt
@@ -26,6 +26,7 @@ import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -34,6 +35,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.widthIn
+import androidx.compose.material.AppBarDefaults
 import androidx.compose.material.CircularProgressIndicator
 import androidx.compose.material.Icon
 import androidx.compose.material.IconButton
@@ -90,6 +92,7 @@ fun HelpPage(
     onShowStatusPage: () -> Unit,
     onGoBack: () -> Unit,
     modifier: Modifier = Modifier,
+    appBarInsets: WindowInsets = AppBarDefaults.topAppBarWindowInsets,
     viewModel: HelpViewModel = hiltViewModel(),
     onWebViewCreated: (WebView) -> Unit = {},
     onWebViewDisposed: (WebView) -> Unit = {},
@@ -102,6 +105,7 @@ fun HelpPage(
         modifier = modifier,
     ) {
         HelpPage(
+            appBarInsets = appBarInsets,
             onSendFeedbackEmail = {
                 scope.launch {
                     val intent = viewModel.getFeedbackIntent(activity)
@@ -173,7 +177,8 @@ fun HelpPage(
 }
 
 @Composable
-fun HelpPage(
+private fun HelpPage(
+    appBarInsets: WindowInsets,
     onSendFeedbackEmail: () -> Unit,
     onContactSupport: () -> Unit,
     onTapUri: (Uri) -> Unit,
@@ -193,6 +198,7 @@ fun HelpPage(
             AppBar(
                 onGoBack = onGoBack,
                 onShowActions = { showActionPopup = true },
+                windowInsets = appBarInsets,
                 modifier = Modifier
                     .fillMaxWidth()
                     // We use z-index to control the drawing order.
@@ -225,10 +231,12 @@ private fun AppBar(
     onGoBack: () -> Unit,
     onShowActions: () -> Unit,
     modifier: Modifier = Modifier,
+    windowInsets: WindowInsets,
 ) {
     ThemedTopAppBar(
         modifier = modifier.fillMaxWidth(),
         title = stringResource(LR.string.settings_title_help),
+        windowInsets = windowInsets,
         onNavigationClick = onGoBack,
         actions = { iconColor ->
             IconButton(onClick = onShowActions) {

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/LogsFragment.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/LogsFragment.kt
@@ -6,6 +6,7 @@ import android.view.ViewGroup
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -13,6 +14,7 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.text.selection.SelectionContainer
+import androidx.compose.material.AppBarDefaults
 import androidx.compose.material.Icon
 import androidx.compose.material.IconButton
 import androidx.compose.material.icons.Icons
@@ -84,6 +86,7 @@ class LogsFragment : BaseFragment() {
 @Composable
 fun LogsPage(
     bottomInset: Dp,
+    appBarInsets: WindowInsets = AppBarDefaults.topAppBarWindowInsets,
     onBackPressed: () -> Unit,
 ) {
     val viewModel = hiltViewModel<LogsViewModel>()
@@ -100,6 +103,7 @@ fun LogsPage(
         includeAppBar = !Util.isAutomotive(context),
         logLines = logLines,
         bottomInset = bottomInset,
+        appBarInsets = appBarInsets,
     )
 }
 
@@ -111,12 +115,15 @@ private fun LogsContent(
     logLines: List<String>,
     includeAppBar: Boolean,
     bottomInset: Dp,
+    appBarInsets: WindowInsets,
 ) {
     val logScrollState = rememberLazyListState()
     Column {
         if (includeAppBar) {
             val coroutineScope = rememberCoroutineScope()
             AppBarWithShare(
+                appBarInsets = appBarInsets,
+                logsAvailable = logLines.isNotEmpty(),
                 onBackPressed = onBackPressed,
                 onCopyToClipboard = onCopyToClipboard,
                 onShareLogs = onShareLogs,
@@ -134,7 +141,6 @@ private fun LogsContent(
                         }
                     }
                 },
-                logsAvailable = logLines.isNotEmpty(),
             )
         }
         Box(
@@ -183,10 +189,12 @@ private fun AppBarWithShare(
     onScrollToTop: () -> Unit,
     onScrollToBottom: () -> Unit,
     logsAvailable: Boolean,
+    appBarInsets: WindowInsets,
     modifier: Modifier = Modifier,
 ) {
     ThemedTopAppBar(
         title = stringResource(LR.string.settings_logs),
+        windowInsets = appBarInsets,
         onNavigationClick = onBackPressed,
         actions = {
             IconButton(
@@ -245,6 +253,7 @@ private fun LogsContentPreview(@PreviewParameter(ThemePreviewParameterProvider::
             ),
             includeAppBar = true,
             bottomInset = 0.dp,
+            appBarInsets = AppBarDefaults.topAppBarWindowInsets,
         )
     }
 }
@@ -260,6 +269,7 @@ private fun LogsContentLoadingPreview(@PreviewParameter(ThemePreviewParameterPro
             logLines = emptyList(),
             includeAppBar = true,
             bottomInset = 0.dp,
+            appBarInsets = AppBarDefaults.topAppBarWindowInsets,
         )
     }
 }

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/status/StatusFragment.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/status/StatusFragment.kt
@@ -9,11 +9,13 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material.AppBarDefaults
 import androidx.compose.material.Button
 import androidx.compose.material.CircularProgressIndicator
 import androidx.compose.material.Icon
@@ -79,15 +81,16 @@ class StatusFragment : BaseFragment() {
 fun StatusPage(
     bottomInset: Dp,
     onBackPressed: () -> Unit,
+    appBarInsets: WindowInsets = AppBarDefaults.topAppBarWindowInsets,
     viewModel: StatusViewModel = hiltViewModel(),
 ) {
     LazyColumn(
         contentPadding = PaddingValues(bottom = bottomInset),
-
     ) {
         item {
             ThemedTopAppBar(
                 title = stringResource(LR.string.settings_status_page),
+                windowInsets = appBarInsets,
                 onNavigationClick = onBackPressed,
             )
         }

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/bars/BottomSheetAppBar.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/bars/BottomSheetAppBar.kt
@@ -1,6 +1,8 @@
 package au.com.shiftyjelly.pocketcasts.compose.bars
 
 import androidx.compose.foundation.layout.RowScope
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.material.AppBarDefaults
 import androidx.compose.material.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.Color
@@ -17,6 +19,7 @@ import com.airbnb.android.showkase.annotation.ShowkaseComposable
 fun BottomSheetAppBar(
     title: String? = null,
     navigationButton: NavigationButton = NavigationButton.Back,
+    windowInsets: WindowInsets = AppBarDefaults.topAppBarWindowInsets,
     actions: @Composable RowScope.(Color) -> Unit = {},
     onNavigationClick: () -> Unit,
 ) {
@@ -25,6 +28,7 @@ fun BottomSheetAppBar(
         iconColor = MaterialTheme.theme.colors.primaryIcon01,
         textColor = MaterialTheme.theme.colors.primaryText01,
         backgroundColor = MaterialTheme.theme.colors.primaryUi01,
+        windowInsets = windowInsets,
         navigationButton = navigationButton,
         actions = actions,
         onNavigationClick = onNavigationClick,

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/bars/ThemedTopAppBar.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/bars/ThemedTopAppBar.kt
@@ -4,6 +4,7 @@ package au.com.shiftyjelly.pocketcasts.compose.bars
 
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.RowScope
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.material.AppBarDefaults
 import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.material.Icon
@@ -64,6 +65,7 @@ fun ThemedTopAppBar(
         ThemedTopAppBar.Style.Immersive -> MaterialTheme.theme.colors.primaryUi01
     },
     bottomShadow: Boolean = false,
+    windowInsets: WindowInsets = AppBarDefaults.topAppBarWindowInsets,
     actions: @Composable RowScope.(Color) -> Unit = {},
     onNavigationClick: () -> Unit,
 ) {
@@ -89,7 +91,7 @@ fun ThemedTopAppBar(
             actions = { actions(iconColor) },
             backgroundColor = backgroundColor,
             elevation = 0.dp,
-            windowInsets = AppBarDefaults.topAppBarWindowInsets,
+            windowInsets = windowInsets,
             modifier = if (bottomShadow) {
                 modifier
                     .zIndex(1f)


### PR DESCRIPTION
## Description

Some minor tweaks for edge-to-edge support.

## Testing Instructions

Code review should be enough.

## Screenshots or Screencast 

#### Before

| | | | |
| - | - | - | - |
| ![Screenshot_20250128-140751](https://github.com/user-attachments/assets/b56ea274-8223-49d6-8dd8-beaeaa3f20a1) | ![Screenshot_20250128-140756](https://github.com/user-attachments/assets/45299904-a82b-46a9-9dbc-a196c1361327) | ![Screenshot_20250128-140802](https://github.com/user-attachments/assets/2381e582-ed4d-4777-90e0-ad5620815f21) | ![Screenshot_20250128-140808](https://github.com/user-attachments/assets/c02ccaec-de6b-404e-b87d-b82fa5fde7a7) |

#### After

| | | | |
| - | - | - | - |
| ![1](https://github.com/user-attachments/assets/77ba89ec-3ffb-4dcd-9d2e-6f7fcd457c3b) | ![2](https://github.com/user-attachments/assets/e2309bc2-3927-47c3-8e2f-4d6d1140680a) | ![3](https://github.com/user-attachments/assets/275417d4-81a3-4b61-bedd-da3466896309) | ![4](https://github.com/user-attachments/assets/fe03f45d-b8b4-4f4f-9352-20ab1badeb9b) |

## Checklist
- [ ] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] ~I have considered whether it makes sense to add tests for my changes~
- [ ] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [ ] ~Any jetpack compose components I added or changed are covered by compose previews~
- [ ] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~