### PR TITLE
[Dependency Cache] Use Custom Init Gradle Task to Download Dependencies

### DIFF
--- a/.buildkite/commands/save-cache.sh
+++ b/.buildkite/commands/save-cache.sh
@@ -2,33 +2,8 @@
 
 set -euo pipefail
 
-echo "--- :rubygems: Setting up Gems"
-install_gems
-
-echo "--- :closed_lock_with_key: Installing Secrets"
-bundle exec fastlane run configure_apply
-
-# .buildkite/pipeline.yml -> ./gradlew assembleRelease
-# .buildkite/commands/prototype-build.sh -> build_and_upload_prototype_build
-# -> prototype_build_type = 'debugProd'
-echo "--- 🛠 Download Mobile App Dependencies [Assemble Apps]"
-./gradlew assembleDebug
-echo ""
-
-# .buildkite/commands/lint.sh -> ./gradlew :app:lintRelease + ./gradlew :automotive:lintRelease :wear:lintRelease
-echo "--- 🧹 Download Lint Dependencies [Lint Apps]"
-./gradlew :app:lintDebug :automotive:lintDebug :wear:lintDebug
-echo ""
-
-# .buildkite/pipeline.yml -> ./gradlew testDebugUnitTest
-echo "--- 🧪 Download Unit Test Dependencies [Assemble Unit Tests]"
-./gradlew assembleDebugUnitTest
-echo ""
-
-# .buildkite/pipeline.yml -> build_and_instrumented_test
-# -> gradle(tasks: %w[assembleDebug assembleDebugAndroidTest])
-echo "--- 🧪 Download Android Test Dependencies [Assemble Android Tests]"
-./gradlew assembleDebugAndroidTest
+echo "--- 📦 Download Dependencies"
+./gradlew downloadDependencies
 echo ""
 
 echo "--- 💾 Save Cache"


### PR DESCRIPTION
Project Thread: paaHJt-7CE-p2

---

## Description
<!-- Please include a summary of what this PR is changing and why these changes are needed. -->

This PR uses the custom `init.gradle.kts` related file, defined within the Android AMI itself (see [buildkite-ci#585](https://github.com/Automattic/buildkite-ci/pull/585)), which now contains this custom `downloadDependencies` task.

With this change, instead of individually calling a number of `assemble/lint` related tasks to download as many dependencies as possible prior to saving the cache, any project can now utilize this globally defined `downloadDependencies` task to replace all this boilerplate and streamline the overall dependency cache process.

Notably, with this change, the dependency cache process:
1. Will no longer be broken on issues like [this](https://github.com/wordpress-mobile/WordPress-Android/pull/21627), making the process more robust.
2. Will no longer require an associated entry [save-cache.sh](https://github.com/Automattic/pocket-casts-android/blob/main/.buildkite/commands/save-cache.sh) entry ([example](https://github.com/Automattic/pocket-casts-android/blob/main/.buildkite/commands/save-cache.sh#L18-L21)) for newly defined jobs/commands, making the process more maintainable.
3. Will no longer have any missing dependencies that would require extra network activity, making the process faster (just a second or two, but faster nevertheless).
4. Will no longer take a significant amount of time to save the cache, as it will no longer run any `assemble/lint` tasks, just that single `downloadDependencies` task, making the build process faster (for scheduled builds).

---

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Tap on the Filters tab -->
<!-- 2. Tap on a filter -->
<!-- 3. etc. -->

Just verify the below:

1. Triggering [schedules/dependency-cache.yml](https://github.com/Automattic/pocket-casts-android/blob/main/.buildkite/schedules/dependency-cache.yml) manually via [this](https://buildkite.com/automattic/pocket-casts-android/builds/10301) build:
    - Starts [downloading the dependencies](https://buildkite.com/automattic/pocket-casts-android/builds/10301#0194b2aa-946b-4bd9-9edc-c5fcf12afd9e/6-79).
    - Caches [the dependencies successfully](https://buildkite.com/automattic/pocket-casts-android/builds/10301#0194b2aa-946b-4bd9-9edc-c5fcf12afd9e/24180-24181).
        - Duration: [42s](https://buildkite.com/automattic/pocket-casts-android/builds/10301#0194b2aa-946b-4bd9-9edc-c5fcf12afd9e/24180-24191)
        - Size: [588.04 MB](https://buildkite.com/automattic/pocket-casts-android/builds/10301#0194b2aa-946b-4bd9-9edc-c5fcf12afd9e/24180-24192)
    - Total time it takes for the `dependency cache` job to complete: [5m 36s](https://buildkite.com/automattic/pocket-casts-android/builds/10301#0194b2aa-946b-4bd9-9edc-c5fcf12afd9e)
2. [CI](https://buildkite.com/automattic/pocket-casts-android/builds/10302) is working as expected:
    - The cache is [restored successfully](https://buildkite.com/automattic/pocket-casts-android/builds/10302#0194b2b2-c8ca-4205-9864-17131a20eca2/179-180):
        - Duration: [18s](https://buildkite.com/automattic/pocket-casts-android/builds/10302#0194b2b2-c8ca-4205-9864-17131a20eca2/179-188)
        - SIze: [588.04 MB](https://buildkite.com/automattic/pocket-casts-android/builds/10302#0194b2b2-c8ca-4205-9864-17131a20eca2/179-189)
    - For that same job via its [build scan](https://buildkite.com/automattic/pocket-casts-android/builds/10302#0194b2b2-c8ca-4205-9864-17131a20eca2/235-1891), that no extra [network activity](https://scans.gradle.com/s/k66gel5ifduce/performance/network-activity) occurs during dependency resolution. Same should apply to all jobs that use [restore-cache.sh](https://github.com/Automattic/pocket-casts-android/blob/main/.buildkite/commands/restore-cache.sh).

> [!NOTE]
> The only drawback to this change, but an expected one, is that the size of the dependency cache is considerably bigger than before, `588.04 MB` now, `555.98 MB` before, which is more or less `50 MB` of a diff, and this makes the cache restoration a few seconds slower (`14s` before, `18s` now, ish). Having said that, we believe that the low cost of maintaining the cache saving process is worth the extra seconds ([context](https://github.com/woocommerce/woocommerce-android/pull/13387#pullrequestreview-2574871604)).

---

## Checklist `N/A`
 
#### I have tested any UI changes... `N/A`
<!-- If this PR does not contain UI changes, ignore these items -->