### PR TITLE
Fix Help page overflow menu position

### DIFF
--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/HelpPage.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/HelpPage.kt
@@ -35,6 +35,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.material.AppBarDefaults
 import androidx.compose.material.CircularProgressIndicator
 import androidx.compose.material.Icon
@@ -218,6 +219,7 @@ private fun HelpPage(
         }
         AppBarActionsEffect(
             show = showActionPopup,
+            appBarInsets = appBarInsets,
             onShowLogs = onShowLogs,
             onShowStatusPage = onShowStatusPage,
             onExportDatabase = onExportDatabase,
@@ -253,6 +255,7 @@ private fun AppBar(
 @Composable
 private fun BoxScope.AppBarActionsEffect(
     show: Boolean,
+    appBarInsets: WindowInsets,
     onShowLogs: () -> Unit,
     onShowStatusPage: () -> Unit,
     onExportDatabase: () -> Unit,
@@ -277,6 +280,7 @@ private fun BoxScope.AppBarActionsEffect(
         exit = popupExitTranstion,
         modifier = Modifier
             .align(Alignment.TopEnd)
+            .windowInsetsPadding(appBarInsets)
             .offset(x = -16.dp, y = 16.dp)
             .shadow(elevation = 8.dp),
     ) {


### PR DESCRIPTION
## Description

This fixes missing padding in the overflow menu.

Fixes #3518

## Testing Instructions

1. Go to Help & feedback page.
2. Tap on the overflow menu.
3. It should be positioned correctly.

## Screenshots or Screencast 

| Before | After |
| - | - |
| ![before](https://github.com/user-attachments/assets/27caa2f4-3c40-45d2-bc14-e61125eeaa6a) | ![after](https://github.com/user-attachments/assets/7ce2181e-3033-47d0-ad3b-c2341a39559d) |

## Checklist
- [ ] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] ~I have considered whether it makes sense to add tests for my changes~
- [ ] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [ ] ~Any jetpack compose components I added or changed are covered by compose previews~
- [ ] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] ~with different themes~
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [ ] ~for accessibility with TalkBack~
