### PR TITLE
[Podcast feed update] Cancel refresh if switch screen

### DIFF
--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastFragment.kt
@@ -168,6 +168,8 @@ class PodcastFragment : BaseFragment(), Toolbar.OnMenuItemClickListener {
 
     private var listState: Parcelable? = null
 
+    private var currentSnackBar: Snackbar? = null
+
     private val onScrollListener = object : RecyclerView.OnScrollListener() {
         override fun onScrolled(recyclerView: RecyclerView, dx: Int, dy: Int) {}
 
@@ -385,7 +387,11 @@ class PodcastFragment : BaseFragment(), Toolbar.OnMenuItemClickListener {
             optionsDialog = optionsDialog.addTextOption(
                 titleId = LR.string.podcast_refresh_episodes,
                 imageId = IR.drawable.ic_refresh,
-                click = { viewModel.onRefreshPodcast(PodcastViewModel.RefreshType.REFRESH_BUTTON) },
+                click = {
+                    viewLifecycleOwner.lifecycleScope.launch {
+                        viewModel.onRefreshPodcast(PodcastViewModel.RefreshType.REFRESH_BUTTON)
+                    }
+                },
             )
         }
 
@@ -715,7 +721,9 @@ class PodcastFragment : BaseFragment(), Toolbar.OnMenuItemClickListener {
         }
 
         binding.swipeRefreshLayout.setOnRefreshListener {
-            viewModel.onRefreshPodcast(PodcastViewModel.RefreshType.PULL_TO_REFRESH)
+            viewLifecycleOwner.lifecycleScope.launch {
+                viewModel.onRefreshPodcast(PodcastViewModel.RefreshType.PULL_TO_REFRESH)
+            }
         }
 
         binding.episodesRecyclerView.requestFocus()
@@ -993,6 +1001,8 @@ class PodcastFragment : BaseFragment(), Toolbar.OnMenuItemClickListener {
         binding?.episodesRecyclerView?.removeOnScrollListener(onScrollListener)
         binding?.episodesRecyclerView?.adapter = null
         binding = null
+        currentSnackBar?.dismiss()
+        currentSnackBar = null
     }
 
     private fun archiveAllPlayed() {
@@ -1053,7 +1063,9 @@ class PodcastFragment : BaseFragment(), Toolbar.OnMenuItemClickListener {
 
     private fun showSnackBar(message: String, duration: Int = Snackbar.LENGTH_LONG) {
         (activity as? FragmentHostListener)?.snackBarView()?.let { snackBarView ->
-            Snackbar.make(snackBarView, message, duration).show()
+            currentSnackBar = Snackbar.make(snackBarView, message, duration).apply {
+                show()
+            }
         }
     }
 

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/PodcastViewModel.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/PodcastViewModel.kt
@@ -575,16 +575,14 @@ class PodcastViewModel
         analyticsTracker.track(AnalyticsEvent.BOOKMARK_SHARE_TAPPED, mapOf("podcast_uuid" to podcastUuid, "episode_uuid" to episodeUuid, "source" to source.analyticsValue))
     }
 
-    fun onRefreshPodcast(refreshType: RefreshType) {
+    suspend fun onRefreshPodcast(refreshType: RefreshType) {
         val podcast = podcast.value ?: return
 
         analyticsTracker.track(AnalyticsEvent.PODCAST_SCREEN_REFRESH_EPISODE_LIST, mapOf("podcast_uuid" to podcast.uuid, "action" to refreshType.analyticsValue))
 
-        viewModelScope.launch {
-            _refreshState.emit(RefreshState.Refreshing(refreshType))
-            val newEpisodeFound = podcastManager.refreshPodcastFeed(podcast = podcast)
-            _refreshState.emit(if (newEpisodeFound) RefreshState.NewEpisodeFound else RefreshState.NoEpisodesFound)
-        }
+        _refreshState.emit(RefreshState.Refreshing(refreshType))
+        val newEpisodeFound = podcastManager.refreshPodcastFeed(podcast = podcast)
+        _refreshState.emit(if (newEpisodeFound) RefreshState.NewEpisodeFound else RefreshState.NoEpisodesFound)
     }
 
     private fun trackEpisodeBulkEvent(event: AnalyticsEvent, count: Int) {


### PR DESCRIPTION
## Description
- This PR cancels the refreshing and also hide the snackbar if there is a refreshing in progress and the user switched to another screen
- See: p1738161669692569-slack-C088RDU8HAN

## Testing Instructions
1. Run the app in `debug`
2. Open a podcast
3. Open more options and tap on refresh episode list button
4. You will see the snackbar with in progress state
5. Switch to another screen
6. ✅ The snackbar should be hidden

## Screenshots or Screencast 
[Screen_recording_20250130_131519.webm](https://github.com/user-attachments/assets/87ea79bc-f304-406e-bbe2-c6e5bf33a4d6)


## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.