### PR TITLE
Fix padding in WebViewActivity

### DIFF
--- a/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/activity/WebViewActivity.kt
+++ b/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/activity/WebViewActivity.kt
@@ -16,6 +16,7 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.core.view.isVisible
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.views.databinding.ActivityWebViewBinding
+import au.com.shiftyjelly.pocketcasts.views.extensions.includeStatusBarPadding
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
 import kotlin.coroutines.CoroutineContext
@@ -61,6 +62,7 @@ class WebViewActivity : AppCompatActivity(), CoroutineScope {
         setContentView(binding.root)
 
         binding.toolbar.title = intent.extras?.getString(EXTRA_TITLE)
+        binding.toolbar.includeStatusBarPadding()
         setSupportActionBar(binding.toolbar)
         supportActionBar?.setDisplayHomeAsUpEnabled(true)
 


### PR DESCRIPTION
## Description

This PR adds missing padding to the toolbar in the `WebViewActivity`.

Fixes #3517

## Testing Instructions

Code review should be enough.

## Screenshots or Screencast 

| Before | After |
| - | - |
| ![b](https://github.com/user-attachments/assets/e486473f-4c0d-49ad-b521-c8abcdce2484) | ![a](https://github.com/user-attachments/assets/cea66ca5-4731-428d-807f-9ff162b09426) |

## Checklist
- [ ] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] ~I have considered whether it makes sense to add tests for my changes~
- [ ] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [ ] ~Any jetpack compose components I added or changed are covered by compose previews~
- [ ] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] ~with different themes~
- [x] with a landscape orientation
- [ ] ~with the device set to have a large display and font size~
- [ ] ~for accessibility with TalkBack~