### PR TITLE
[Podcast feed update] Add tracks for refresh result

### DIFF
--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/PodcastViewModel.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/PodcastViewModel.kt
@@ -582,7 +582,14 @@ class PodcastViewModel
 
         _refreshState.emit(RefreshState.Refreshing(refreshType))
         val newEpisodeFound = podcastManager.refreshPodcastFeed(podcast = podcast)
-        _refreshState.emit(if (newEpisodeFound) RefreshState.NewEpisodeFound else RefreshState.NoEpisodesFound)
+
+        if (newEpisodeFound) {
+            analyticsTracker.track(AnalyticsEvent.PODCAST_SCREEN_REFRESH_NEW_EPISODE_FOUND, mapOf("podcast_uuid" to podcast.uuid, "action" to refreshType.analyticsValue))
+            _refreshState.emit(RefreshState.NewEpisodeFound)
+        } else {
+            analyticsTracker.track(AnalyticsEvent.PODCAST_SCREEN_REFRESH_NO_EPISODES_FOUND, mapOf("podcast_uuid" to podcast.uuid, "action" to refreshType.analyticsValue))
+            _refreshState.emit(RefreshState.NoEpisodesFound)
+        }
     }
 
     private fun trackEpisodeBulkEvent(event: AnalyticsEvent, count: Int) {

--- a/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
+++ b/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
@@ -230,6 +230,8 @@ enum class AnalyticsEvent(val key: String) {
     PODCASTS_SCREEN_TAB_TAPPED("podcasts_screen_tab_tapped"),
     PODCAST_SCREEN_REPORT_TAPPED("podcast_screen_report_tapped"),
     PODCAST_SCREEN_REFRESH_EPISODE_LIST("podcast_screen_refresh_episode_list"),
+    PODCAST_SCREEN_REFRESH_NEW_EPISODE_FOUND("podcast_screen_refresh_new_episode_found"),
+    PODCAST_SCREEN_REFRESH_NO_EPISODES_FOUND("podcast_screen_refresh_no_episodes_found"),
 
     /* Podcast Settings */
     PODCAST_SETTINGS_FEED_ERROR_TAPPED("podcast_settings_feed_error_tapped"),


### PR DESCRIPTION
## Description
- Adds two more events for when finding a new episode and when did not find a new episode
- See: p1738273764465099-slack-C088RDU8HAN

## Testing Instructions
code review should be fine

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.