### PR TITLE
Tech debt: Migrate import filters sync from RxJava to Coroutines

### DIFF
--- a/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
+++ b/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
@@ -586,15 +586,16 @@ class MainActivity :
             doRefresh()
         }
 
-        PocketCastsShortcuts.update(
-            playlistManager = playlistManager,
-            force = true,
-            coroutineScope = applicationScope,
-            context = this,
-            source = PocketCastsShortcuts.Source.REFRESH_APP,
-        )
+        lifecycleScope.launch {
+            PocketCastsShortcuts.update(
+                playlistManager = playlistManager,
+                force = true,
+                context = this@MainActivity,
+                source = PocketCastsShortcuts.Source.REFRESH_APP,
+            )
 
-        lifecycleScope.launch { subscriptionManager.refresh() }
+            subscriptionManager.refresh()
+        }
 
         // Schedule next refresh in the background
         RefreshPodcastsTask.scheduleOrCancel(this@MainActivity, settings)

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/PlaylistDao.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/PlaylistDao.kt
@@ -46,13 +46,22 @@ abstract class PlaylistDao {
     abstract fun findByUuidAsListRxFlowable(uuid: String): Flowable<List<Playlist>>
 
     @Query("SELECT COUNT(*) FROM filters")
+    abstract suspend fun count(): Int
+
+    @Query("SELECT COUNT(*) FROM filters")
     abstract fun countBlocking(): Int
+
+    @Update
+    abstract suspend fun update(playlist: Playlist)
 
     @Update
     abstract fun updateBlocking(playlist: Playlist)
 
     @Update
     abstract fun updateAllBlocking(playlists: List<Playlist>)
+
+    @Delete
+    abstract suspend fun delete(playlist: Playlist)
 
     @Delete
     abstract fun deleteBlocking(playlist: Playlist)
@@ -62,6 +71,9 @@ abstract class PlaylistDao {
 
     @Query("DELETE FROM filters WHERE deleted = 1")
     abstract fun deleteDeletedBlocking()
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    abstract suspend fun insert(playlist: Playlist): Long
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     abstract fun insertBlocking(playlist: Playlist): Long

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PlaylistManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PlaylistManager.kt
@@ -28,7 +28,8 @@ interface PlaylistManager {
 
     fun createPlaylistBlocking(name: String, iconId: Int, draft: Boolean): Playlist
 
-    fun createBlocking(playlist: Playlist): Long
+    suspend fun create(playlist: Playlist): Long
+    suspend fun update(playlist: Playlist, userPlaylistUpdate: UserPlaylistUpdate?, isCreatingFilter: Boolean = false)
     fun updateBlocking(playlist: Playlist, userPlaylistUpdate: UserPlaylistUpdate?, isCreatingFilter: Boolean = false)
 
     fun updateAutoDownloadStatus(playlist: Playlist, autoDownloadEnabled: Boolean, unmeteredOnly: Boolean, powerOnly: Boolean)
@@ -37,6 +38,7 @@ interface PlaylistManager {
     fun deleteBlocking(playlist: Playlist)
     suspend fun resetDb()
     fun deleteSyncedBlocking()
+    suspend fun deleteSynced(playlist: Playlist)
     fun deleteSyncedBlocking(playlist: Playlist)
 
     fun countEpisodesBlocking(id: Long?, episodeManager: EpisodeManager, playbackManager: PlaybackManager): Int

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/SyncManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/SyncManager.kt
@@ -104,7 +104,7 @@ interface SyncManager : NamedSettingsCaller {
 
     // Other
     suspend fun exchangeSonos(): ExchangeSonosResponse
-    fun getFiltersRxSingle(): Single<List<Playlist>>
+    suspend fun getFilters(): List<Playlist>
     suspend fun loadStats(): StatsBundle
     suspend fun upNextSync(request: UpNextSyncRequest): UpNextSyncResponse
     suspend fun getBookmarks(): List<Bookmark>

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/SyncManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/SyncManagerImpl.kt
@@ -413,8 +413,8 @@ class SyncManagerImpl @Inject constructor(
             syncServiceManager.exchangeSonos(token)
         }
 
-    override fun getFiltersRxSingle(): Single<List<Playlist>> =
-        getCacheTokenOrLoginRxSingle { token ->
+    override suspend fun getFilters(): List<Playlist> =
+        getCacheTokenOrLogin { token ->
             syncServiceManager.getFilters(token)
         }
 

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/SyncService.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/SyncService.kt
@@ -92,7 +92,7 @@ interface SyncService {
     suspend fun getPodcastList(@Header("Authorization") authorization: String, @Body request: UserPodcastListRequest): UserPodcastListResponse
 
     @POST("/user/playlist/list")
-    fun getFilterList(@Header("Authorization") authorization: String, @Body request: BasicRequest): Single<FilterListResponse>
+    suspend fun getFilterList(@Header("Authorization") authorization: String, @Body request: BasicRequest): FilterListResponse
 
     @POST("/history/sync")
     fun historySync(@Header("Authorization") authorization: String, @Body request: HistorySyncRequest): Single<HistorySyncResponse>

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/SyncServiceManager.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/SyncServiceManager.kt
@@ -162,9 +162,10 @@ open class SyncServiceManager @Inject constructor(
         return service.getPodcastEpisodes(addBearer(token), request)
     }
 
-    fun getFilters(token: AccessToken): Single<List<Playlist>> =
-        service.getFilterList(addBearer(token), buildBasicRequest())
-            .map { response -> response.filters?.mapNotNull { it.toFilter() } ?: emptyList() }
+    suspend fun getFilters(token: AccessToken): List<Playlist> {
+        val response = service.getFilterList(addBearer(token), buildBasicRequest())
+        return response.filters?.mapNotNull { it.toFilter() } ?: emptyList()
+    }
 
     suspend fun getBookmarks(token: AccessToken): List<Bookmark> {
         return service.getBookmarkList(addBearer(token), bookmarkRequest {}).bookmarksList.map { it.toBookmark() }


### PR DESCRIPTION
## Description

This small change removes some more RxJava from the sync task.

## Testing Instructions

1. Device 1: add a filter, remove another, and manually refresh.
2. Device 2: manually refresh.
3. ✅ Device 2: Verify one filter is added and one is removed.

## Screencast 

https://github.com/user-attachments/assets/801bd8ab-96cc-4d22-b08e-e5e37d4f2b98


## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack
