### PR TITLE
Fix the About page edge-to-edge status bar issue

### DIFF
--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/about/AboutFragment.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/about/AboutFragment.kt
@@ -212,136 +212,137 @@ private fun AboutPage(
     openFragment: (Fragment) -> Unit,
 ) {
     val context = LocalContext.current
-    LazyColumn(
-        horizontalAlignment = Alignment.CenterHorizontally,
+    Column(
         modifier = Modifier
             .background(MaterialTheme.theme.colors.primaryUi02),
-        contentPadding = PaddingValues(bottom = bottomInset),
     ) {
-        item {
-            ThemedTopAppBar(
-                title = stringResource(LR.string.settings_title_about),
-                onNavigationClick = onBackPressed,
-            )
-        }
-        item {
-            Image(
-                painter = painterResource(context.getThemeDrawable(UR.attr.logo_title_vertical)),
-                contentDescription = stringResource(LR.string.settings_app_icon),
-                modifier = Modifier.padding(top = 56.dp),
-            )
-        }
-        item {
-            Text(
-                text = stringResource(LR.string.settings_version, BuildConfig.VERSION_NAME, BuildConfig.VERSION_CODE.toString()),
-                style = MaterialTheme.typography.body1,
-                modifier = Modifier.padding(top = 8.dp),
-                textAlign = TextAlign.Center,
-                color = MaterialTheme.theme.colors.primaryText02,
-            )
-        }
-        item {
-            HorizontalDivider(
-                modifier = Modifier.padding(top = 56.dp, bottom = 8.dp),
-            )
-        }
-        item {
-            RowTextButton(
-                text = stringResource(LR.string.settings_about_rate_us),
-                onClick = {
-                    onRateUsTapped()
-                    rateUs(context)
-                },
-            )
-        }
-        item {
-            RowTextButton(
-                text = stringResource(LR.string.settings_about_share_with_friends),
-                onClick = {
-                    onShareWithFriendsTapped()
-                    shareWithFriends(context)
-                },
-            )
-        }
-        item {
-            HorizontalDivider(modifier = Modifier.padding(vertical = 8.dp))
-        }
-        item {
-            RowTextButton(
-                text = stringResource(LR.string.settings_about_website),
-                secondaryText = "pocketcasts.com",
-                onClick = {
-                    onWebsiteTapped()
-                    openUrl("https://www.pocketcasts.com", context)
-                },
-            )
-        }
-        item {
-            RowTextButton(
-                text = stringResource(LR.string.settings_about_instagram),
-                secondaryText = "@pocketcasts",
-                onClick = {
-                    onInstagramTapped()
-                    openUrl("https://www.instagram.com/pocketcasts/", context)
-                },
-            )
-        }
-        item {
-            RowTextButton(
-                text = stringResource(LR.string.settings_about_x),
-                secondaryText = "@pocketcasts",
-                onClick = {
-                    onXTapped()
-                    openUrl("https://x.com/pocketcasts", context)
-                },
-            )
-        }
-        item {
-            HorizontalDivider(modifier = Modifier.padding(vertical = 8.dp))
-        }
-        item {
-            AutomatticFamilyRow(onAutomatticFamilyTapped = onAutomatticFamilyTapped)
-        }
-        item {
-            HorizontalDivider(modifier = Modifier.padding(bottom = 8.dp))
-        }
-        item {
-            LegalAndMoreRow(onTermsOfServiceTapped, onPrivacyPolicyTapped, openFragment)
-        }
-        item {
-            HorizontalDivider(modifier = Modifier.padding(vertical = 8.dp))
-        }
-        item {
-            Column(
-                modifier = Modifier
-                    .clickable {
-                        onWorkWithUsTapped()
-                        openUrl("https://automattic.com/work-with-us/", context)
-                    }
-                    .fillMaxWidth()
-                    .padding(all = 14.dp),
-            ) {
-                Text(
-                    text = stringResource(LR.string.settings_about_work_with_us),
-                    fontSize = 17.sp,
-                    color = MaterialTheme.theme.colors.primaryText01,
+        ThemedTopAppBar(
+            title = stringResource(LR.string.settings_title_about),
+            onNavigationClick = onBackPressed,
+        )
+        LazyColumn(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            contentPadding = PaddingValues(bottom = bottomInset),
+        ) {
+            item {
+                Image(
+                    painter = painterResource(context.getThemeDrawable(UR.attr.logo_title_vertical)),
+                    contentDescription = stringResource(LR.string.settings_app_icon),
+                    modifier = Modifier.padding(top = 56.dp),
                 )
+            }
+            item {
                 Text(
-                    text = stringResource(LR.string.settings_about_work_from_anywhere),
-                    fontSize = 14.sp,
+                    text = stringResource(LR.string.settings_version, BuildConfig.VERSION_NAME, BuildConfig.VERSION_CODE.toString()),
                     style = MaterialTheme.typography.body1,
+                    modifier = Modifier.padding(top = 8.dp),
+                    textAlign = TextAlign.Center,
                     color = MaterialTheme.theme.colors.primaryText02,
                 )
             }
-        }
-        item {
-            Spacer(modifier = Modifier.height(24.dp))
-        }
-        item {
-            AutomatticLogo(onAutomatticFamilyTapped = onAutomatticFamilyTapped)
-        }
-        item {
-            Spacer(modifier = Modifier.height(24.dp))
+            item {
+                HorizontalDivider(
+                    modifier = Modifier.padding(top = 56.dp, bottom = 8.dp),
+                )
+            }
+            item {
+                RowTextButton(
+                    text = stringResource(LR.string.settings_about_rate_us),
+                    onClick = {
+                        onRateUsTapped()
+                        rateUs(context)
+                    },
+                )
+            }
+            item {
+                RowTextButton(
+                    text = stringResource(LR.string.settings_about_share_with_friends),
+                    onClick = {
+                        onShareWithFriendsTapped()
+                        shareWithFriends(context)
+                    },
+                )
+            }
+            item {
+                HorizontalDivider(modifier = Modifier.padding(vertical = 8.dp))
+            }
+            item {
+                RowTextButton(
+                    text = stringResource(LR.string.settings_about_website),
+                    secondaryText = "pocketcasts.com",
+                    onClick = {
+                        onWebsiteTapped()
+                        openUrl("https://www.pocketcasts.com", context)
+                    },
+                )
+            }
+            item {
+                RowTextButton(
+                    text = stringResource(LR.string.settings_about_instagram),
+                    secondaryText = "@pocketcasts",
+                    onClick = {
+                        onInstagramTapped()
+                        openUrl("https://www.instagram.com/pocketcasts/", context)
+                    },
+                )
+            }
+            item {
+                RowTextButton(
+                    text = stringResource(LR.string.settings_about_x),
+                    secondaryText = "@pocketcasts",
+                    onClick = {
+                        onXTapped()
+                        openUrl("https://x.com/pocketcasts", context)
+                    },
+                )
+            }
+            item {
+                HorizontalDivider(modifier = Modifier.padding(vertical = 8.dp))
+            }
+            item {
+                AutomatticFamilyRow(onAutomatticFamilyTapped = onAutomatticFamilyTapped)
+            }
+            item {
+                HorizontalDivider(modifier = Modifier.padding(bottom = 8.dp))
+            }
+            item {
+                LegalAndMoreRow(onTermsOfServiceTapped, onPrivacyPolicyTapped, openFragment)
+            }
+            item {
+                HorizontalDivider(modifier = Modifier.padding(vertical = 8.dp))
+            }
+            item {
+                Column(
+                    modifier = Modifier
+                        .clickable {
+                            onWorkWithUsTapped()
+                            openUrl("https://automattic.com/work-with-us/", context)
+                        }
+                        .fillMaxWidth()
+                        .padding(all = 14.dp),
+                ) {
+                    Text(
+                        text = stringResource(LR.string.settings_about_work_with_us),
+                        fontSize = 17.sp,
+                        color = MaterialTheme.theme.colors.primaryText01,
+                    )
+                    Text(
+                        text = stringResource(LR.string.settings_about_work_from_anywhere),
+                        fontSize = 14.sp,
+                        style = MaterialTheme.typography.body1,
+                        color = MaterialTheme.theme.colors.primaryText02,
+                    )
+                }
+            }
+            item {
+                Spacer(modifier = Modifier.height(24.dp))
+            }
+            item {
+                AutomatticLogo(onAutomatticFamilyTapped = onAutomatticFamilyTapped)
+            }
+            item {
+                Spacer(modifier = Modifier.height(24.dp))
+            }
         }
     }
 }


### PR DESCRIPTION
## Description

This change stops the About page from going under the status bar. When we have upgraded to Material 3 it would be good to change the toolbar scroll behaviour so the toolbar disappears on scroll when you go down the page but comes straight back when you scroll up, similar to how apps like Gmail do it.

Fixes https://github.com/Automattic/pocket-casts-android/issues/3516

## Testing Instructions
1. Tap the Profile tab
2. Tap the settings cog 
3. Tap About
4. ✅ Verify the page content doesn't go under the status bar

## Screenshots

| Top | Bottom |
| --- | --- |
| ![Screenshot_20250203_153519](https://github.com/user-attachments/assets/ca0ea7a8-9008-4af7-aa89-d6d1a0c6e621) | ![Screenshot_20250203_153525](https://github.com/user-attachments/assets/2b026aca-90c4-4a6b-b60f-6fb34cae52db) | 
| ![Screenshot_20250203_153439](https://github.com/user-attachments/assets/226bcb92-826a-448f-afdb-7ac9cd9b6f9f) | ![Screenshot_20250203_153452](https://github.com/user-attachments/assets/366ec7f7-47b1-4849-a314-235c35a81530) | 

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack
