### PR TITLE
Fix create folder edge-to-edge padding

### DIFF
--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/winback/AvailablePlansPage.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/winback/AvailablePlansPage.kt
@@ -9,18 +9,15 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material.AppBarDefaults
 import androidx.compose.material.Button
 import androidx.compose.material.ButtonDefaults
 import androidx.compose.material.CircularProgressIndicator
@@ -81,7 +78,6 @@ internal fun AvailablePlansPage(
         modifier = Modifier.nestedScroll(rememberViewInteropNestedScrollConnection()),
     ) {
         BottomSheetAppBar(
-            windowInsets = AppBarDefaults.topAppBarWindowInsets.only(WindowInsetsSides.Horizontal),
             onNavigationClick = onGoBack,
         )
         AnimatedContent(

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/bars/BottomSheetAppBar.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/bars/BottomSheetAppBar.kt
@@ -2,6 +2,8 @@ package au.com.shiftyjelly.pocketcasts.compose.bars
 
 import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.WindowInsetsSides
+import androidx.compose.foundation.layout.only
 import androidx.compose.material.AppBarDefaults
 import androidx.compose.material.MaterialTheme
 import androidx.compose.runtime.Composable
@@ -19,7 +21,7 @@ import com.airbnb.android.showkase.annotation.ShowkaseComposable
 fun BottomSheetAppBar(
     title: String? = null,
     navigationButton: NavigationButton = NavigationButton.Back,
-    windowInsets: WindowInsets = AppBarDefaults.topAppBarWindowInsets,
+    windowInsets: WindowInsets = AppBarDefaults.topAppBarWindowInsets.only(WindowInsetsSides.Horizontal),
     actions: @Composable RowScope.(Color) -> Unit = {},
     onNavigationClick: () -> Unit,
 ) {


### PR DESCRIPTION
## Description

The bottom sheet is having issues with the top inset. This removes the top padding for all the pages using BottomSheetAppBar.

Fixes https://github.com/Automattic/pocket-casts-android/issues/3515

## Testing Instructions
1. Login with a Plus account
2. Tap the Podcasts tab
3. Tap on the create folder icon in the toolbar
4. ✅ Check the top padding is correct for the create folder pages

## Screenshots 

| Before | After |
| --- | --- |
| ![Screenshot_20250203_165401](https://github.com/user-attachments/assets/a7faf97e-ab10-416b-8a17-6bbebdece685) | ![Screenshot_20250203_165208](https://github.com/user-attachments/assets/aee76662-c3d8-440c-b641-7366ce678820) | 
| ![Screenshot_20250203_165418](https://github.com/user-attachments/assets/00c85ee5-7dba-442d-adc5-8a9cfeae6c2e) | ![Screenshot_20250203_165239](https://github.com/user-attachments/assets/06b67ab8-a12f-4ad0-bc49-f067317ccb50) | 
| ![Screenshot_20250203_165425](https://github.com/user-attachments/assets/9a602ef2-2be2-4fa3-9bad-8f3b312dff6c) | ![Screenshot_20250203_165248](https://github.com/user-attachments/assets/c9641ab3-902b-4b79-90bf-086017e0355e) | 
| ![Screenshot_20250203_165435](https://github.com/user-attachments/assets/833eb910-901f-40a7-af75-838a1bb19bfc) | ![Screenshot_20250203_165305](https://github.com/user-attachments/assets/c5b81d12-19a3-4f06-b514-6cd46a99d2ef) | 
| ![Screenshot_20250203_164248](https://github.com/user-attachments/assets/9100f7d6-75d3-4420-b564-1303b0556a60) | ![Screenshot_20250203_165114](https://github.com/user-attachments/assets/32f8d797-ef4d-4d92-8901-3f404d913225) | 

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack
