### PR TITLE
Do not use deprecated startActivity function

### DIFF
--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastAdapter.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastAdapter.kt
@@ -679,7 +679,7 @@ class PodcastAdapter(
         podcast.podcastUrl?.let { url ->
             if (url.isNotBlank()) {
                 try {
-                    startActivity(context, webUrlToIntent(url), null)
+                    context.startActivity(webUrlToIntent(url), null)
                 } catch (e: Exception) {
                     Timber.e(e, "Failed to open podcast web page.")
                 }

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/share/ShareListCreateViewModel.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/share/ShareListCreateViewModel.kt
@@ -99,7 +99,7 @@ class ShareListCreateViewModel @Inject constructor(
                     type = "text/plain"
                     putExtra(Intent.EXTRA_TEXT, url)
                 }
-                startActivity(context, Intent.createChooser(intent, label), null)
+                context.startActivity(Intent.createChooser(intent, label), null)
                 trackShareEvent(
                     AnalyticsEvent.SHARE_PODCASTS_LIST_PUBLISH_SUCCEEDED,
                     AnalyticsProp.countMap(selectedPodcasts.size),


### PR DESCRIPTION
## Description

There was unintended interaction between #3507 and #3513 where `startActivity` import got removed and it started failing builds. This PR fixes it by removing usage of the deprecated function.

## Testing Instructions

🟢 CI is enough