### PR TITLE
[Tooling] Fix `code_freeze` lane when run on CI

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -112,7 +112,6 @@ platform :android do
     # Create the release branch
     UI.message('Creating release branch...')
     Fastlane::Helper::GitHelper.create_branch("release/#{release_version_next}", from: DEFAULT_BRANCH)
-    ensure_git_branch(branch: '^release/') # Match branch names that begin with `release/`
     UI.success("Done! New release branch is: #{git_branch}")
 
     # Bump the version and build code
@@ -454,6 +453,7 @@ platform :android do
     is_beta = beta_version?(version)
     unless skip_prechecks
       # Match branch names that begin with `release/`
+      # Skip this check on CI because that action relies on CI env vars, but when this lane iscalled as part of `code_freeze` the branch changed since the CI build started, so that wouldn't work
       ensure_git_branch(branch: '^release/') unless is_ci
 
       UI.important("Building version #{version_name_current} (#{build_code_current}) for upload to Google Play Console")


### PR DESCRIPTION
Context: p1738584698791939/1738269556.705039-slack-C028JAG44VD

## Description

Removes the call to `ensure_git_branch` during `code_freeze`.

This is because `ensure_git_branch`'s default implementation relies on CI env vars to determine the git branch, instead of checking the current branch using git commands. But since, during `code_freeze`, we change the branch after the CI build started, the env var exposed by Buildkite (`BUILDKITE_BRANCH=main`) to the build would not match the current branch after `code_freeze` has just created the `release/*` branch, thus making the `ensure_git_branch` action mistakenly assume the current git branch was still `$BUILDKITE_BRANCH` aka `main`.

_Note: We could have bypassed this by using `ENV['FL_GIT_BRANCH_DONT_USE_ENV_VARS'] = 'true'` (see https://github.com/fastlane/fastlane/pull/21597), but in practice that check is not even needed at that stage of the lane, so we might as well just remove it._

## Testing Instructions

I have looked at all other calls to `ensure_git_branch` in the rest of the `Fastfile` and it seems to me that they are all happening in lanes that will already be triggered by ReleasesV2 on the right CI branch to begin with, as opposed to lanes that might switch git branches mid-process as `code_freeze` does when creating the new `release/*` branch. So I think we should be ok for all the other existing calls, even when run from CI.

@mebarbosa will test this fix as part of his Release Manager duties for `7.82`

