### PR TITLE
Add WinbackManager

### DIFF
--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/di/RepositoryModule.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/di/RepositoryModule.kt
@@ -63,6 +63,8 @@ import au.com.shiftyjelly.pocketcasts.repositories.user.UserManagerImpl
 import au.com.shiftyjelly.pocketcasts.repositories.user.UserSettingsCrashReportPermission
 import au.com.shiftyjelly.pocketcasts.repositories.widget.WidgetManager
 import au.com.shiftyjelly.pocketcasts.repositories.widget.WidgetManagerImpl
+import au.com.shiftyjelly.pocketcasts.repositories.winback.WinbackManager
+import au.com.shiftyjelly.pocketcasts.repositories.winback.WinbackManagerImpl
 import dagger.Binds
 import dagger.Module
 import dagger.hilt.InstallIn
@@ -192,4 +194,7 @@ abstract class RepositoryModule {
 
     @Binds
     abstract fun providePodcastRefresher(podcastRefresherImpl: PodcastRefresherImpl): PodcastRefresher
+
+    @Binds
+    abstract fun provideWinbackManager(manager: WinbackManagerImpl): WinbackManager
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/subscription/SubscriptionManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/subscription/SubscriptionManager.kt
@@ -1,5 +1,6 @@
 package au.com.shiftyjelly.pocketcasts.repositories.subscription
 
+import android.app.Activity
 import androidx.appcompat.app.AppCompatActivity
 import au.com.shiftyjelly.pocketcasts.models.to.SubscriptionStatus
 import au.com.shiftyjelly.pocketcasts.models.type.Subscription
@@ -7,6 +8,7 @@ import au.com.shiftyjelly.pocketcasts.models.type.SubscriptionFrequency
 import au.com.shiftyjelly.pocketcasts.models.type.SubscriptionTier
 import au.com.shiftyjelly.pocketcasts.utils.Optional
 import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
+import com.android.billingclient.api.BillingResult
 import com.android.billingclient.api.ProductDetails
 import com.android.billingclient.api.Purchase
 import io.reactivex.Flowable
@@ -38,8 +40,8 @@ interface SubscriptionManager {
         currentPurchaseProductId: String,
         newProduct: ProductDetails,
         newProductOfferToken: String,
-        activity: AppCompatActivity,
-    ): Boolean
+        activity: Activity,
+    ): BillingResult
 
     fun signOut()
 

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/subscription/SubscriptionManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/subscription/SubscriptionManagerImpl.kt
@@ -1,5 +1,6 @@
 package au.com.shiftyjelly.pocketcasts.repositories.subscription
 
+import android.app.Activity
 import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.lifecycleScope
 import au.com.shiftyjelly.pocketcasts.models.to.SubscriptionStatus
@@ -295,8 +296,8 @@ class SubscriptionManagerImpl @Inject constructor(
         currentPurchaseProductId: String,
         newProduct: ProductDetails,
         newProductOfferToken: String,
-        activity: AppCompatActivity,
-    ): Boolean {
+        activity: Activity,
+    ): BillingResult {
         val productDetailsParams = BillingFlowParams.ProductDetailsParams.newBuilder()
             .setProductDetails(newProduct)
             .setOfferToken(newProductOfferToken)
@@ -320,8 +321,7 @@ class SubscriptionManagerImpl @Inject constructor(
                 }
             }
             .build()
-        val result = billingClient.launchBillingFlow(activity, billingFlowParams)
-        return result.isOk()
+        return billingClient.launchBillingFlow(activity, billingFlowParams)
     }
 
     private suspend fun loadSubscriptionUpdateParamsMode(

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/winback/WinbackManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/winback/WinbackManager.kt
@@ -1,0 +1,22 @@
+package au.com.shiftyjelly.pocketcasts.repositories.winback
+
+import android.app.Activity
+import au.com.shiftyjelly.pocketcasts.repositories.subscription.ProductDetailsState
+import au.com.shiftyjelly.pocketcasts.repositories.subscription.PurchaseEvent
+import au.com.shiftyjelly.pocketcasts.repositories.subscription.PurchasesState
+import com.android.billingclient.api.ProductDetails
+import com.android.billingclient.api.Purchase
+
+interface WinbackManager {
+    suspend fun loadProducts(): ProductDetailsState
+
+    suspend fun loadPurchases(): PurchasesState
+
+    suspend fun changeProduct(
+        currentPurchase: Purchase,
+        currentPurchaseProductId: String,
+        newProduct: ProductDetails,
+        newProductOfferToken: String,
+        activity: Activity,
+    ): PurchaseEvent
+}

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/winback/WinbackManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/winback/WinbackManagerImpl.kt
@@ -1,0 +1,43 @@
+package au.com.shiftyjelly.pocketcasts.repositories.winback
+
+import android.app.Activity
+import au.com.shiftyjelly.pocketcasts.repositories.subscription.PurchaseEvent
+import au.com.shiftyjelly.pocketcasts.repositories.subscription.SubscriptionManager
+import au.com.shiftyjelly.pocketcasts.repositories.subscription.isOk
+import com.android.billingclient.api.ProductDetails
+import com.android.billingclient.api.Purchase
+import javax.inject.Inject
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.reactive.asFlow
+
+class WinbackManagerImpl @Inject constructor(
+    val subscriptionManager: SubscriptionManager,
+) : WinbackManager {
+    override suspend fun loadProducts() = subscriptionManager.loadProducts()
+
+    override suspend fun loadPurchases() = subscriptionManager.loadPurchases()
+
+    override suspend fun changeProduct(
+        currentPurchase: Purchase,
+        currentPurchaseProductId: String,
+        newProduct: ProductDetails,
+        newProductOfferToken: String,
+        activity: Activity,
+    ): PurchaseEvent {
+        val startResult = subscriptionManager.changeProduct(
+            currentPurchase = currentPurchase,
+            currentPurchaseProductId = currentPurchaseProductId,
+            newProduct = newProduct,
+            newProductOfferToken = newProductOfferToken,
+            activity = activity,
+        )
+        return if (startResult.isOk()) {
+            subscriptionManager.observePurchaseEvents().asFlow().first()
+        } else {
+            PurchaseEvent.Failure(
+                "Failed to start change product flow. ${startResult.debugMessage}",
+                startResult.responseCode,
+            )
+        }
+    }
+}


### PR DESCRIPTION
## Description

This PR wraps interactions with `SubscriptionManager` inside `WinbackViewModel` to use the new `WinbackManager` instead. 

`SubscriptionManager` is quite a bloated class, making it difficult to test without mocking. Having a specialized interface alleviates this problem. 

I made this change primarily because, while developing winback offer claiming, I had to add interactions with the referral manager, which made testing overly complicated. Now, I'll be able to encapsulate these 

## Testing Instructions

1. Install the `release` app variant.
2. Have an account with Google Play subscription.
3. Go to the profile details.
4. Smoke test cancellation—see if available plans are shown, if you can change them, and if you can cancel your subscription.

## Checklist
- [ ] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [ ] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [ ] ~Any jetpack compose components I added or changed are covered by compose previews~
- [ ] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~