### PR TITLE
Fix a typo `s/iscalled/is called`

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -453,7 +453,7 @@ platform :android do
     is_beta = beta_version?(version)
     unless skip_prechecks
       # Match branch names that begin with `release/`
-      # Skip this check on CI because that action relies on CI env vars, but when this lane iscalled as part of `code_freeze` the branch changed since the CI build started, so that wouldn't work
+      # Skip this check on CI because that action relies on CI env vars, but when this lane is called as part of `code_freeze` the branch changed since the CI build started, so that wouldn't work
       ensure_git_branch(branch: '^release/') unless is_ci
 
       UI.important("Building version #{version_name_current} (#{build_code_current}) for upload to Google Play Console")


### PR DESCRIPTION
Noticed when looking at https://github.com/Automattic/pocket-casts-android/pull/3537 but it was too late to suggest an edit.

_I removed the rest of the PR description template because this is just a typo fix in a comment._