### PR TITLE
Fix missing episodes with unfollowed podcasts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 7.83
 -----
-
+*   Bug Fixes
+    *   Fix missing episodes with unfollowed podcasts
+        ([#3546](https://github.com/Automattic/pocket-casts-android/pull/3546))
 
 7.82
 -----

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PodcastManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PodcastManagerImpl.kt
@@ -249,7 +249,7 @@ class PodcastManagerImpl @Inject constructor(
             // bulk delete or it takes 10 seconds on a large podcast
             deleteEpisodes.add(episode)
         }
-        // don't delete episodes or podcast if the latest playback interaction was less than a month ago,
+        // don't delete the episodes or podcast if the latest playback interaction happening in the last month
         val oneMonthAgoMs = System.currentTimeMillis() - 30.days.inWholeMilliseconds
         if (latestPlaybackInteraction > oneMonthAgoMs) {
             return false

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PodcastManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PodcastManagerImpl.kt
@@ -37,9 +37,9 @@ import io.reactivex.Flowable
 import io.reactivex.Maybe
 import io.reactivex.Single
 import io.reactivex.schedulers.Schedulers
-import java.util.concurrent.TimeUnit
 import javax.inject.Inject
 import kotlin.coroutines.CoroutineContext
+import kotlin.time.Duration.Companion.days
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
@@ -224,7 +224,7 @@ class PodcastManagerImpl @Inject constructor(
 
         // we don't delete podcasts added to the phone in the last week. This is to prevent stuff you just leave open in discover from being removed
         val addedDate = podcast.addedDate
-        val oneWeekAgoMs = System.currentTimeMillis() - TimeUnit.DAYS.toMillis(7)
+        val oneWeekAgoMs = System.currentTimeMillis() - 7.days.inWholeMilliseconds
         if (addedDate != null && addedDate.time > oneWeekAgoMs) {
             return false
         }
@@ -250,7 +250,7 @@ class PodcastManagerImpl @Inject constructor(
             deleteEpisodes.add(episode)
         }
         // don't delete episodes or podcast if the latest playback interaction was less than a month ago,
-        val oneMonthAgoMs = System.currentTimeMillis() - TimeUnit.DAYS.toMillis(30)
+        val oneMonthAgoMs = System.currentTimeMillis() - 30.days.inWholeMilliseconds
         if (latestPlaybackInteraction > oneMonthAgoMs) {
             return false
         }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PodcastManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PodcastManagerImpl.kt
@@ -241,6 +241,7 @@ class PodcastManagerImpl @Inject constructor(
                     latestPlaybackInteraction = interaction
                 }
             }
+            // don't delete the podcast if any of the episodes have been interacted with
             if (episodeManager.userHasInteractedWithEpisode(episode, playbackManager)) {
                 podcastHasChangedEpisodes = true
                 continue
@@ -248,7 +249,7 @@ class PodcastManagerImpl @Inject constructor(
             // bulk delete or it takes 10 seconds on a large podcast
             deleteEpisodes.add(episode)
         }
-        // don't remove episodes or the podcast if the latest playback interaction was less than a month ago,
+        // don't delete episodes or podcast if the latest playback interaction was less than a month ago,
         val oneMonthAgoMs = System.currentTimeMillis() - TimeUnit.DAYS.toMillis(30)
         if (latestPlaybackInteraction > oneMonthAgoMs) {
             return false

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/PodcastRefresherImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/PodcastRefresherImpl.kt
@@ -28,7 +28,7 @@ class PodcastRefresherImpl @Inject constructor(
     override suspend fun refreshPodcast(existingPodcast: Podcast, playbackManager: PlaybackManager) {
         try {
             val podcastResponse = cacheServiceManager.getPodcastResponse(existingPodcast.uuid)
-            // podcasts that aren't subscribed can have episodes removed, so always refresh them
+            // unsubscribed podcasts have episodes removed, so always refresh them
             if (existingPodcast.isSubscribed && (podcastResponse.wasCached() || podcastResponse.notModified())) {
                 LogBuffer.i(LogBuffer.TAG_BACKGROUND_TASKS, "Refreshing podcast ${existingPodcast.uuid} not required as cached")
                 return

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/PodcastRefresherImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/PodcastRefresherImpl.kt
@@ -28,7 +28,8 @@ class PodcastRefresherImpl @Inject constructor(
     override suspend fun refreshPodcast(existingPodcast: Podcast, playbackManager: PlaybackManager) {
         try {
             val podcastResponse = cacheServiceManager.getPodcastResponse(existingPodcast.uuid)
-            if (podcastResponse.wasCached() || podcastResponse.notModified()) {
+            // podcasts that aren't subscribed can have episodes removed, so always refresh them
+            if (existingPodcast.isSubscribed && (podcastResponse.wasCached() || podcastResponse.notModified())) {
                 LogBuffer.i(LogBuffer.TAG_BACKGROUND_TASKS, "Refreshing podcast ${existingPodcast.uuid} not required as cached")
                 return
             }


### PR DESCRIPTION
## Description

Internal reference p1738686765061199-slack-C02A333D8LQ

There's an issue that if: 
- You aren't following a podcast.
- It was added to the database (viewed in Discover) over 7 days ago.
- Have interacted with it, such as starred, archived, downloaded, completed, listened to, or have it in your Up Next.

It won’t delete the podcast from your database but will delete all the other episodes you haven’t interacted with. If the user goes back to the podcast page the episodes won't be added back to the podcast.

## Testing Instructions

To be able to repeat this issue you need to make the following code change as it only happens to podcasts added over a week ago.

1. Apply this [patch](https://github.com/user-attachments/files/18689492/testing.patch)
2. Be signed out
3. Tap the Discover tab
4. Subscribe to one podcast (so refresh runs later)
5. Go to the podcast page for a podcast you aren't following
6. Play and archive an episode
7. Tap the Profile tab
8. Manually refresh 
9. Go back to the podcast page
10. ✅ Verify all the episodes that haven't been interacted with are still available

## Screenshots 

Example of the issue:
| Before a clean up | The issue happening |
| --- | --- |
| ![Screenshot_20250206_224649](https://github.com/user-attachments/assets/4a3a7c2b-6c8f-4d8f-a920-eca7fcfdde34) | ![Screenshot_20250206_224709](https://github.com/user-attachments/assets/5e0ca81d-3061-438b-9dce-edea49508b9c) | 

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack