### PR TITLE
[Suggested Folder] Create suggested folder screen UI

### DIFF
--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/folders/SuggestedFolders.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/folders/SuggestedFolders.kt
@@ -3,13 +3,18 @@ package au.com.shiftyjelly.pocketcasts.podcasts.view.folders
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.ViewGroup
+import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
+import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTracker
 import au.com.shiftyjelly.pocketcasts.compose.AppThemeWithBackground
 import au.com.shiftyjelly.pocketcasts.compose.extensions.contentWithoutConsumedInsets
 import au.com.shiftyjelly.pocketcasts.views.fragments.BaseDialogFragment
 import dagger.hilt.android.AndroidEntryPoint
+import javax.inject.Inject
 
 @AndroidEntryPoint
 class SuggestedFolders : BaseDialogFragment() {
+
+    @Inject lateinit var analyticsTracker: AnalyticsTracker
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -23,6 +28,7 @@ class SuggestedFolders : BaseDialogFragment() {
                 },
                 onUseTheseFolders = {},
                 onCreateCustomFolders = {
+                    analyticsTracker.track(AnalyticsEvent.FOLDER_CREATE_SHOWN, mapOf("source" to "suggested_folders"))
                     FolderCreateFragment().show(parentFragmentManager, "create_folder_card")
                 },
             )

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/folders/SuggestedFolders.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/folders/SuggestedFolders.kt
@@ -30,6 +30,7 @@ class SuggestedFolders : BaseDialogFragment() {
                 onCreateCustomFolders = {
                     analyticsTracker.track(AnalyticsEvent.FOLDER_CREATE_SHOWN, mapOf("source" to "suggested_folders"))
                     FolderCreateFragment().show(parentFragmentManager, "create_folder_card")
+                    dismiss()
                 },
             )
         }

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/folders/SuggestedFolders.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/folders/SuggestedFolders.kt
@@ -1,0 +1,31 @@
+package au.com.shiftyjelly.pocketcasts.podcasts.view.folders
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import au.com.shiftyjelly.pocketcasts.compose.AppThemeWithBackground
+import au.com.shiftyjelly.pocketcasts.compose.extensions.contentWithoutConsumedInsets
+import au.com.shiftyjelly.pocketcasts.views.fragments.BaseDialogFragment
+import dagger.hilt.android.AndroidEntryPoint
+
+@AndroidEntryPoint
+class SuggestedFolders : BaseDialogFragment() {
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?,
+    ) = contentWithoutConsumedInsets {
+        AppThemeWithBackground(theme.activeTheme) {
+            SuggestedFoldersPage(
+                onDismiss = {
+                    dismiss()
+                },
+                onUseTheseFolders = {},
+                onCreateCustomFolders = {
+                    FolderCreateFragment().show(parentFragmentManager, "create_folder_card")
+                },
+            )
+        }
+    }
+}

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/folders/SuggestedFoldersPage.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/folders/SuggestedFoldersPage.kt
@@ -1,0 +1,120 @@
+package au.com.shiftyjelly.pocketcasts.podcasts.view.folders
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.ButtonDefaults
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.ripple
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewParameter
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import au.com.shiftyjelly.pocketcasts.compose.AppTheme
+import au.com.shiftyjelly.pocketcasts.compose.buttons.RowButton
+import au.com.shiftyjelly.pocketcasts.compose.buttons.RowOutlinedButton
+import au.com.shiftyjelly.pocketcasts.compose.components.TextH10
+import au.com.shiftyjelly.pocketcasts.compose.components.TextP40
+import au.com.shiftyjelly.pocketcasts.compose.preview.ThemePreviewParameterProvider
+import au.com.shiftyjelly.pocketcasts.compose.theme
+import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
+import au.com.shiftyjelly.pocketcasts.images.R as IR
+import au.com.shiftyjelly.pocketcasts.localization.R as LR
+
+@Composable
+fun SuggestedFoldersPage(
+    onDismiss: () -> Unit,
+    onUseTheseFolders: () -> Unit,
+    onCreateCustomFolders: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .padding(horizontal = 16.dp)
+            .padding(bottom = 16.dp),
+    ) {
+        Spacer(
+            modifier = Modifier.height(16.dp),
+        )
+
+        Image(
+            painter = painterResource(IR.drawable.ic_close),
+            contentDescription = stringResource(LR.string.close),
+            colorFilter = ColorFilter.tint(MaterialTheme.theme.colors.primaryInteractive01),
+            modifier = Modifier
+                .padding(bottom = 16.dp)
+                .size(24.dp)
+                .clickable(
+                    interactionSource = remember(::MutableInteractionSource),
+                    indication = ripple(color = Color.Black, bounded = false),
+                    onClickLabel = stringResource(LR.string.close),
+                    role = Role.Button,
+                    onClick = onDismiss,
+                ),
+        )
+
+        TextH10(
+            text = stringResource(LR.string.suggested_folders),
+            lineHeight = 36.sp,
+            modifier = Modifier.padding(bottom = 8.dp),
+        )
+
+        TextP40(
+            text = stringResource(LR.string.suggested_folders_subtitle),
+            color = MaterialTheme.theme.colors.primaryText02,
+            modifier = Modifier.padding(bottom = 16.dp),
+        )
+
+        Spacer(modifier = Modifier.weight(1f))
+
+        RowButton(
+            text = stringResource(LR.string.suggested_folders_use_these_folders_button),
+            modifier = Modifier.padding(bottom = 16.dp),
+            textColor = MaterialTheme.theme.colors.primaryInteractive02,
+            fontSize = 18.sp,
+            fontWeight = FontWeight.W600,
+            colors = ButtonDefaults.buttonColors(
+                backgroundColor = MaterialTheme.theme.colors.primaryInteractive01,
+            ),
+            includePadding = false,
+            onClick = onUseTheseFolders,
+        )
+
+        RowOutlinedButton(
+            text = stringResource(id = LR.string.suggested_folders_use_create_custom_folders_button),
+            onClick = onCreateCustomFolders,
+            includePadding = false,
+            colors = ButtonDefaults.outlinedButtonColors(contentColor = MaterialTheme.theme.colors.primaryIcon01, backgroundColor = Color.Transparent),
+            fontSize = 18.sp,
+            fontWeight = FontWeight.W600,
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun SuggestedFoldersPagePreview(@PreviewParameter(ThemePreviewParameterProvider::class) themeType: Theme.ThemeType) {
+    AppTheme(themeType) {
+        SuggestedFoldersPage(
+            onDismiss = {},
+            onUseTheseFolders = {},
+            onCreateCustomFolders = {},
+        )
+    }
+}

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/folders/SuggestedFoldersPage.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/folders/SuggestedFoldersPage.kt
@@ -1,25 +1,18 @@
 package au.com.shiftyjelly.pocketcasts.podcasts.view.folders
 
-import androidx.compose.foundation.Image
-import androidx.compose.foundation.clickable
-import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.material.ButtonDefaults
+import androidx.compose.material.Icon
+import androidx.compose.material.IconButton
 import androidx.compose.material.MaterialTheme
-import androidx.compose.material.ripple
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
@@ -44,66 +37,60 @@ fun SuggestedFoldersPage(
     modifier: Modifier = Modifier,
 ) {
     Column(
-        modifier = modifier
-            .fillMaxSize()
-            .padding(horizontal = 16.dp)
-            .padding(bottom = 16.dp),
+        modifier = modifier.fillMaxSize(),
     ) {
-        Spacer(
-            modifier = Modifier.height(16.dp),
-        )
+        IconButton(
+            onClick = onDismiss,
+        ) {
+            Icon(
+                painter = painterResource(IR.drawable.ic_close),
+                contentDescription = stringResource(LR.string.close),
+                tint = MaterialTheme.theme.colors.primaryInteractive01,
+                modifier = Modifier.padding(16.dp),
+            )
+        }
 
-        Image(
-            painter = painterResource(IR.drawable.ic_close),
-            contentDescription = stringResource(LR.string.close),
-            colorFilter = ColorFilter.tint(MaterialTheme.theme.colors.primaryInteractive01),
+        Column(
             modifier = Modifier
-                .padding(bottom = 16.dp)
-                .size(24.dp)
-                .clickable(
-                    interactionSource = remember(::MutableInteractionSource),
-                    indication = ripple(color = Color.Black, bounded = false),
-                    onClickLabel = stringResource(LR.string.close),
-                    role = Role.Button,
-                    onClick = onDismiss,
+                .padding(horizontal = 16.dp)
+                .padding(bottom = 16.dp),
+        ) {
+            TextH10(
+                text = stringResource(LR.string.suggested_folders),
+                lineHeight = 36.sp,
+                modifier = Modifier.padding(bottom = 8.dp),
+            )
+
+            TextP40(
+                text = stringResource(LR.string.suggested_folders_subtitle),
+                color = MaterialTheme.theme.colors.primaryText02,
+                modifier = Modifier.padding(bottom = 16.dp),
+            )
+
+            Spacer(modifier = Modifier.weight(1f))
+
+            RowButton(
+                text = stringResource(LR.string.suggested_folders_use_these_folders_button),
+                modifier = Modifier.padding(bottom = 16.dp),
+                textColor = MaterialTheme.theme.colors.primaryInteractive02,
+                fontSize = 18.sp,
+                fontWeight = FontWeight.W600,
+                colors = ButtonDefaults.buttonColors(
+                    backgroundColor = MaterialTheme.theme.colors.primaryInteractive01,
                 ),
-        )
+                includePadding = false,
+                onClick = onUseTheseFolders,
+            )
 
-        TextH10(
-            text = stringResource(LR.string.suggested_folders),
-            lineHeight = 36.sp,
-            modifier = Modifier.padding(bottom = 8.dp),
-        )
-
-        TextP40(
-            text = stringResource(LR.string.suggested_folders_subtitle),
-            color = MaterialTheme.theme.colors.primaryText02,
-            modifier = Modifier.padding(bottom = 16.dp),
-        )
-
-        Spacer(modifier = Modifier.weight(1f))
-
-        RowButton(
-            text = stringResource(LR.string.suggested_folders_use_these_folders_button),
-            modifier = Modifier.padding(bottom = 16.dp),
-            textColor = MaterialTheme.theme.colors.primaryInteractive02,
-            fontSize = 18.sp,
-            fontWeight = FontWeight.W600,
-            colors = ButtonDefaults.buttonColors(
-                backgroundColor = MaterialTheme.theme.colors.primaryInteractive01,
-            ),
-            includePadding = false,
-            onClick = onUseTheseFolders,
-        )
-
-        RowOutlinedButton(
-            text = stringResource(id = LR.string.suggested_folders_use_create_custom_folders_button),
-            onClick = onCreateCustomFolders,
-            includePadding = false,
-            colors = ButtonDefaults.outlinedButtonColors(contentColor = MaterialTheme.theme.colors.primaryIcon01, backgroundColor = Color.Transparent),
-            fontSize = 18.sp,
-            fontWeight = FontWeight.W600,
-        )
+            RowOutlinedButton(
+                text = stringResource(id = LR.string.suggested_folders_use_create_custom_folders_button),
+                onClick = onCreateCustomFolders,
+                includePadding = false,
+                colors = ButtonDefaults.outlinedButtonColors(contentColor = MaterialTheme.theme.colors.primaryIcon01, backgroundColor = Color.Transparent),
+                fontSize = 18.sp,
+                fontWeight = FontWeight.W600,
+            )
+        }
     }
 }
 

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/folders/SuggestedFoldersPage.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/folders/SuggestedFoldersPage.kt
@@ -2,8 +2,13 @@ package au.com.shiftyjelly.pocketcasts.podcasts.view.folders
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.safeDrawing
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.material.ButtonDefaults
@@ -42,7 +47,9 @@ fun SuggestedFoldersPage(
     modifier: Modifier = Modifier,
 ) {
     Column(
-        modifier = modifier.fillMaxSize(),
+        modifier = modifier
+            .fillMaxSize()
+            .windowInsetsPadding(WindowInsets.safeDrawing.only(WindowInsetsSides.Horizontal)),
     ) {
         IconButton(
             onClick = onDismiss,

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/folders/SuggestedFoldersPage.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/folders/SuggestedFoldersPage.kt
@@ -1,9 +1,11 @@
 package au.com.shiftyjelly.pocketcasts.podcasts.view.folders
 
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.material.ButtonDefaults
 import androidx.compose.material.Icon
 import androidx.compose.material.IconButton
@@ -23,6 +25,7 @@ import au.com.shiftyjelly.pocketcasts.compose.buttons.RowButton
 import au.com.shiftyjelly.pocketcasts.compose.buttons.RowOutlinedButton
 import au.com.shiftyjelly.pocketcasts.compose.components.TextH10
 import au.com.shiftyjelly.pocketcasts.compose.components.TextP40
+import au.com.shiftyjelly.pocketcasts.compose.folder.FolderImage
 import au.com.shiftyjelly.pocketcasts.compose.preview.ThemePreviewParameterProvider
 import au.com.shiftyjelly.pocketcasts.compose.theme
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
@@ -67,7 +70,7 @@ fun SuggestedFoldersPage(
                 modifier = Modifier.padding(bottom = 16.dp),
             )
 
-            Spacer(modifier = Modifier.weight(1f))
+            Folders(podcastUuids = mockedPodcastsUuids, Modifier.padding(bottom = 8.dp).weight(1f))
 
             RowButton(
                 text = stringResource(LR.string.suggested_folders_use_these_folders_button),
@@ -94,6 +97,36 @@ fun SuggestedFoldersPage(
     }
 }
 
+@Composable
+private fun Folders(podcastUuids: List<String>, modifier: Modifier = Modifier) {
+    val folders = 25
+
+    LazyVerticalGrid(
+        columns = GridCells.Adaptive(110.dp),
+        horizontalArrangement = Arrangement.spacedBy(6.dp),
+        verticalArrangement = Arrangement.spacedBy(6.dp),
+        modifier = modifier,
+    ) {
+        items(
+            count = folders,
+            key = { index -> index },
+        ) { index ->
+            FolderItem("Test", Color.Yellow, podcastUuids)
+        }
+    }
+}
+
+@Composable
+private fun FolderItem(folderName: String, folderColor: Color, podcastUuids: List<String>, modifier: Modifier = Modifier) {
+    FolderImage(
+        name = folderName,
+        color = folderColor,
+        podcastUuids = podcastUuids,
+        textSpacing = true,
+        modifier = modifier,
+    )
+}
+
 @Preview(showBackground = true)
 @Composable
 private fun SuggestedFoldersPagePreview(@PreviewParameter(ThemePreviewParameterProvider::class) themeType: Theme.ThemeType) {
@@ -105,3 +138,12 @@ private fun SuggestedFoldersPagePreview(@PreviewParameter(ThemePreviewParameterP
         )
     }
 }
+
+private val mockedPodcastsUuids = listOf(
+    "5d308950-1fe3-012e-02b0-00163e1b201c",
+    "f086f200-4f32-0139-3396-0acc26574db2",
+    "2e61ba20-50a9-0135-902b-63f4b61a9224",
+    "f98ce900-79da-0139-347d-0acc26574db2",
+    "39844640-7cb5-013b-f2a7-0acc26574db2",
+    "2d721350-e0d4-0137-b6c9-0acc26574db2",
+)

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/folders/SuggestedFoldersPage.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/folders/SuggestedFoldersPage.kt
@@ -15,6 +15,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.clearAndSetSemantics
+import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
@@ -70,7 +72,12 @@ fun SuggestedFoldersPage(
                 modifier = Modifier.padding(bottom = 16.dp),
             )
 
-            Folders(podcastUuids = mockedPodcastsUuids, Modifier.padding(bottom = 8.dp).weight(1f))
+            Folders(
+                podcastUuids = mockedPodcastsUuids,
+                Modifier
+                    .padding(bottom = 8.dp)
+                    .weight(1f),
+            )
 
             RowButton(
                 text = stringResource(LR.string.suggested_folders_use_these_folders_button),
@@ -99,7 +106,7 @@ fun SuggestedFoldersPage(
 
 @Composable
 private fun Folders(podcastUuids: List<String>, modifier: Modifier = Modifier) {
-    val folders = 25
+    val folders = 4
 
     LazyVerticalGrid(
         columns = GridCells.Adaptive(110.dp),
@@ -118,12 +125,16 @@ private fun Folders(podcastUuids: List<String>, modifier: Modifier = Modifier) {
 
 @Composable
 private fun FolderItem(folderName: String, folderColor: Color, podcastUuids: List<String>, modifier: Modifier = Modifier) {
+    val stringResource = stringResource(LR.string.folder_content_description, folderName)
+
     FolderImage(
         name = folderName,
         color = folderColor,
         podcastUuids = podcastUuids,
         textSpacing = true,
-        modifier = modifier,
+        modifier = modifier.clearAndSetSemantics {
+            contentDescription = stringResource
+        },
     )
 }
 

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/folders/SuggestedFoldersPage.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/folders/SuggestedFoldersPage.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.GridItemSpan
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.material.ButtonDefaults
 import androidx.compose.material.Icon
@@ -62,71 +63,63 @@ fun SuggestedFoldersPage(
             )
         }
 
-        Column(
+        LazyVerticalGrid(
+            columns = GridCells.Adaptive(110.dp),
+            horizontalArrangement = Arrangement.spacedBy(6.dp),
+            verticalArrangement = Arrangement.spacedBy(6.dp),
             modifier = Modifier
+                .padding(bottom = 8.dp)
                 .padding(horizontal = 16.dp)
-                .padding(bottom = 16.dp),
+                .weight(1f),
         ) {
-            TextH10(
-                text = stringResource(LR.string.suggested_folders),
-                lineHeight = 36.sp,
-                modifier = Modifier.padding(bottom = 8.dp),
-            )
-
-            TextP40(
-                text = stringResource(LR.string.suggested_folders_subtitle),
-                color = MaterialTheme.theme.colors.primaryText02,
-                modifier = Modifier.padding(bottom = 16.dp),
-            )
-
-            Folders(
-                podcastUuids = mockedPodcastsUuids,
-                Modifier
-                    .padding(bottom = 8.dp)
-                    .weight(1f),
-            )
-
-            RowButton(
-                text = stringResource(LR.string.suggested_folders_use_these_folders_button),
-                modifier = Modifier.padding(bottom = 16.dp),
-                textColor = MaterialTheme.theme.colors.primaryInteractive02,
-                fontSize = 18.sp,
-                fontWeight = FontWeight.W600,
-                colors = ButtonDefaults.buttonColors(
-                    backgroundColor = MaterialTheme.theme.colors.primaryInteractive01,
-                ),
-                includePadding = false,
-                onClick = onUseTheseFolders,
-            )
-
-            RowOutlinedButton(
-                text = stringResource(id = LR.string.suggested_folders_use_create_custom_folders_button),
-                onClick = onCreateCustomFolders,
-                includePadding = false,
-                colors = ButtonDefaults.outlinedButtonColors(contentColor = MaterialTheme.theme.colors.primaryIcon01, backgroundColor = Color.Transparent),
-                fontSize = 18.sp,
-                fontWeight = FontWeight.W600,
-            )
+            item(span = { GridItemSpan(maxLineSpan) }) {
+                TextH10(
+                    text = stringResource(LR.string.suggested_folders),
+                    lineHeight = 36.sp,
+                    modifier = Modifier.padding(bottom = 2.dp),
+                )
+            }
+            item(span = { GridItemSpan(maxLineSpan) }) {
+                TextP40(
+                    text = stringResource(LR.string.suggested_folders_subtitle),
+                    color = MaterialTheme.theme.colors.primaryText02,
+                    modifier = Modifier.padding(bottom = 10.dp),
+                )
+            }
+            items(
+                count = 4,
+                key = { index -> index },
+            ) { index ->
+                FolderItem("Test", Color.Yellow, podcastUuids = mockedPodcastsUuids)
+            }
         }
-    }
-}
 
-@Composable
-private fun Folders(podcastUuids: List<String>, modifier: Modifier = Modifier) {
-    val folders = 4
+        RowButton(
+            text = stringResource(LR.string.suggested_folders_use_these_folders_button),
+            modifier = Modifier
+                .padding(bottom = 16.dp)
+                .padding(horizontal = 16.dp),
+            textColor = MaterialTheme.theme.colors.primaryInteractive02,
+            fontSize = 18.sp,
+            fontWeight = FontWeight.W600,
+            colors = ButtonDefaults.buttonColors(
+                backgroundColor = MaterialTheme.theme.colors.primaryInteractive01,
+            ),
+            includePadding = false,
+            onClick = onUseTheseFolders,
+        )
 
-    LazyVerticalGrid(
-        columns = GridCells.Adaptive(110.dp),
-        horizontalArrangement = Arrangement.spacedBy(6.dp),
-        verticalArrangement = Arrangement.spacedBy(6.dp),
-        modifier = modifier,
-    ) {
-        items(
-            count = folders,
-            key = { index -> index },
-        ) { index ->
-            FolderItem("Test", Color.Yellow, podcastUuids)
-        }
+        RowOutlinedButton(
+            text = stringResource(id = LR.string.suggested_folders_use_create_custom_folders_button),
+            onClick = onCreateCustomFolders,
+            includePadding = false,
+            colors = ButtonDefaults.outlinedButtonColors(contentColor = MaterialTheme.theme.colors.primaryIcon01, backgroundColor = Color.Transparent),
+            fontSize = 18.sp,
+            fontWeight = FontWeight.W600,
+            modifier = Modifier
+                .padding(bottom = 16.dp)
+                .padding(horizontal = 16.dp),
+        )
     }
 }
 

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcasts/PodcastsFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcasts/PodcastsFragment.kt
@@ -43,6 +43,8 @@ import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingUpgradeSourc
 import au.com.shiftyjelly.pocketcasts.ui.extensions.getColor
 import au.com.shiftyjelly.pocketcasts.ui.helper.FragmentHostListener
 import au.com.shiftyjelly.pocketcasts.utils.extensions.hideShadow
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
 import au.com.shiftyjelly.pocketcasts.views.adapter.PodcastTouchCallback
 import au.com.shiftyjelly.pocketcasts.views.extensions.showIf
 import au.com.shiftyjelly.pocketcasts.views.fragments.BaseFragment
@@ -67,7 +69,6 @@ class PodcastsFragment : BaseFragment(), FolderAdapter.ClickListener, PodcastTou
         private const val OPTION_KEY = "option"
         private const val SORT_BY = "sort_by"
         private const val EDIT_FOLDER = "edit_folder"
-        private const val REQUIRED_SUBSCRIPTIONS_FOR_SUGGESTED_FOLDERS = 8
         const val ARG_FOLDER_UUID = "ARG_FOLDER_UUID"
 
         fun newInstance(folderUuid: String): PodcastsFragment {
@@ -285,8 +286,7 @@ class PodcastsFragment : BaseFragment(), FolderAdapter.ClickListener, PodcastTou
     }
 
     private fun createFolder() {
-        val podcastListSize = adapter?.currentList?.size ?: 0
-        if (podcastListSize > REQUIRED_SUBSCRIPTIONS_FOR_SUGGESTED_FOLDERS) {
+        if (FeatureFlag.isEnabled(Feature.SUGGESTED_FOLDERS)) {
             SuggestedFolders().show(parentFragmentManager, "suggested_folders")
         } else {
             analyticsTracker.track(AnalyticsEvent.FOLDER_CREATE_SHOWN, mapOf(SOURCE_KEY to PODCASTS_LIST))

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcasts/PodcastsFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcasts/PodcastsFragment.kt
@@ -30,6 +30,7 @@ import au.com.shiftyjelly.pocketcasts.podcasts.view.folders.FolderCreateFragment
 import au.com.shiftyjelly.pocketcasts.podcasts.view.folders.FolderCreateSharedViewModel
 import au.com.shiftyjelly.pocketcasts.podcasts.view.folders.FolderEditFragment
 import au.com.shiftyjelly.pocketcasts.podcasts.view.folders.FolderEditPodcastsFragment
+import au.com.shiftyjelly.pocketcasts.podcasts.view.folders.SuggestedFolders
 import au.com.shiftyjelly.pocketcasts.podcasts.view.podcast.PodcastFragment
 import au.com.shiftyjelly.pocketcasts.podcasts.viewmodel.PodcastsViewModel
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
@@ -66,6 +67,7 @@ class PodcastsFragment : BaseFragment(), FolderAdapter.ClickListener, PodcastTou
         private const val OPTION_KEY = "option"
         private const val SORT_BY = "sort_by"
         private const val EDIT_FOLDER = "edit_folder"
+        private const val REQUIRED_SUBSCRIPTIONS_FOR_SUGGESTED_FOLDERS = 8
         const val ARG_FOLDER_UUID = "ARG_FOLDER_UUID"
 
         fun newInstance(folderUuid: String): PodcastsFragment {
@@ -283,8 +285,13 @@ class PodcastsFragment : BaseFragment(), FolderAdapter.ClickListener, PodcastTou
     }
 
     private fun createFolder() {
-        analyticsTracker.track(AnalyticsEvent.FOLDER_CREATE_SHOWN, mapOf(SOURCE_KEY to PODCASTS_LIST))
-        FolderCreateFragment().show(parentFragmentManager, "create_folder_card")
+        val podcastListSize = adapter?.currentList?.size ?: 0
+        if (podcastListSize > REQUIRED_SUBSCRIPTIONS_FOR_SUGGESTED_FOLDERS) {
+            SuggestedFolders().show(parentFragmentManager, "suggested_folders")
+        } else {
+            analyticsTracker.track(AnalyticsEvent.FOLDER_CREATE_SHOWN, mapOf(SOURCE_KEY to PODCASTS_LIST))
+            FolderCreateFragment().show(parentFragmentManager, "create_folder_card")
+        }
     }
 
     override fun onPause() {

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -2320,5 +2320,6 @@
     <string name="suggested_folders_subtitle">We’ve organized your podcasts for you. Save or customize them to fit your style.</string>
     <string name="suggested_folders_use_these_folders_button">Use these folders</string>
     <string name="suggested_folders_use_create_custom_folders_button">Create custom folders</string>
+    <string name="folder_content_description">Folder %s</string>
 
 </resources>

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -2315,4 +2315,10 @@
     <string name="winback_cancel_subscription_stay_button_label">Actually, I want to stay</string>
     <string name="winback_cancel_subscription_cancel_button_label">Yes, Cancel my Subscription</string>
 
+    <!-- Suggested Folders -->
+    <string name="suggested_folders">Suggested Folders</string>
+    <string name="suggested_folders_subtitle">We’ve organized your podcasts for you. Save or customize them to fit your style.</string>
+    <string name="suggested_folders_use_these_folders_button">Use these folders</string>
+    <string name="suggested_folders_use_create_custom_folders_button">Create custom folders</string>
+
 </resources>

--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/Feature.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/Feature.kt
@@ -211,6 +211,14 @@ enum class Feature(
         hasFirebaseRemoteFlag = false,
         hasDevToggle = true,
     ),
+    SUGGESTED_FOLDERS(
+        key = "suggested_folders",
+        title = "Suggested Folders",
+        defaultValue = BuildConfig.DEBUG,
+        tier = FeatureTier.Free,
+        hasFirebaseRemoteFlag = false,
+        hasDevToggle = true,
+    ),
     ;
 
     companion object {


### PR DESCRIPTION
## Description
- This PR creates the suggested folder UI with folders mocks, so for this PR you can ignore the folder part
- I will be using the same Folder component that we use in Podcasts screen to keep the consistency 
- This feature will be behind a feature flag
- See: QmqtGNKfPivyq5BrVRPpyV-fi-41_7024

Fixes #3549

## Testing Instructions
1. Ensure the suggested folder feature flag is enabled
2. Log with a Pus / Patron account
3. Go to Podcasts tab
4. Tap to create a Folder
5. See the new screen and check the layout
6. Tap on Create custom folders
7. Ensure you see the create folder screen

## Screenshots or Screencast 
[Screen_recording_20250205_093219.webm](https://github.com/user-attachments/assets/e0239f5b-f2e2-4e1a-ac95-e28d86f8bcd8)


| Theme 1 | Theme 2 | Theme 3 | Theme 4 |
|--------|--------|--------|--------|
| ![Screenshot_20250204_170640](https://github.com/user-attachments/assets/6f45ad63-852d-4ab8-8860-2716db931e02) | ![Screenshot_20250204_170705](https://github.com/user-attachments/assets/64537351-ce3d-4f87-a96e-7a018ed2f2e1) | ![Screenshot_20250204_170718](https://github.com/user-attachments/assets/c90ea6c3-87d9-4db2-81ca-b9700ea41827) | ![Screenshot_20250205_094218](https://github.com/user-attachments/assets/40fce31f-e713-4dcc-824c-538a70e4031e) | 

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack