### PR TITLE
Handle claiming winback offer

### DIFF
--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -2307,6 +2307,7 @@
     <string name="winback_too_many_subscritpions_button_label">Manage subscriptions in Play&#160;Store</string>
     <string name="winback_error_fetch_description">Sorry, but something went wrong fetching your plans.</string>
     <string name="winback_changing_plan">Changing plan</string>
+    <string name="winback_claiming_offer">Claiming offer</string>
     <string name="winback_cancel_subscription_header_title">Changing plan</string>
     <string name="winback_cancel_subscription_header_description">This will change your plan to a free account.</string>
     <string name="winback_cancel_subscription_perk_active_with_date">Your current subscription will remain active until %1$s.</string>

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/subscription/SubscriptionManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/subscription/SubscriptionManager.kt
@@ -43,6 +43,13 @@ interface SubscriptionManager {
         activity: Activity,
     ): BillingResult
 
+    suspend fun claimWinbackOffer(
+        currentPurchase: Purchase,
+        winbackProduct: ProductDetails,
+        winbackOfferToken: String,
+        activity: Activity,
+    ): BillingResult
+
     fun signOut()
 
     fun observeProductDetails(): Flowable<ProductDetailsState>

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/subscription/SubscriptionManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/subscription/SubscriptionManagerImpl.kt
@@ -324,6 +324,30 @@ class SubscriptionManagerImpl @Inject constructor(
         return billingClient.launchBillingFlow(activity, billingFlowParams)
     }
 
+    override suspend fun claimWinbackOffer(
+        currentPurchase: Purchase,
+        winbackProduct: ProductDetails,
+        winbackOfferToken: String,
+        activity: Activity,
+    ): BillingResult {
+        val productDetailsParams = BillingFlowParams.ProductDetailsParams.newBuilder()
+            .setProductDetails(winbackProduct)
+            .setOfferToken(winbackOfferToken)
+            .build()
+
+        val updateParams = BillingFlowParams.SubscriptionUpdateParams.newBuilder()
+            .setOldPurchaseToken(currentPurchase.purchaseToken)
+            .setSubscriptionReplacementMode(BillingFlowParams.SubscriptionUpdateParams.ReplacementMode.CHARGE_FULL_PRICE)
+            .build()
+
+        val billingFlowParams = BillingFlowParams.newBuilder()
+            .setProductDetailsParamsList(listOf(productDetailsParams))
+            .setSubscriptionUpdateParams(updateParams)
+            .build()
+
+        return billingClient.launchBillingFlow(activity, billingFlowParams)
+    }
+
     private suspend fun loadSubscriptionUpdateParamsMode(
         productDetails: ProductDetails,
     ): Pair<BillingResult, BillingFlowParams.SubscriptionUpdateParams?> {

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/winback/WinbackManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/winback/WinbackManager.kt
@@ -22,4 +22,12 @@ interface WinbackManager {
     ): PurchaseEvent
 
     suspend fun getWinbackOffer(): WinbackResponse?
+
+    suspend fun claimWinbackOffer(
+        currentPurchase: Purchase,
+        winbackProduct: ProductDetails,
+        winbackOfferToken: String,
+        winbackClaimCode: String,
+        activity: Activity,
+    ): PurchaseEvent
 }


### PR DESCRIPTION
## Description

This PR adds claiming Winback offer Right now it is available only in staging due to Winback codes being available only there.

## Testing Instructions

1. Apply this [winback.patch](https://github.com/user-attachments/files/18671187/winback.patch).
2. Install the `debugProd` variant of the app.
3. Sign in with an account without a subscription.
4. If it is a new account wait for 3 minutes to make it old enough in the staging environment to make it eligible for the Winback offer.
5. Subscribe to any plan.
6. Go to the account details.
7. Tap on "Cancel subscription".
8. You should see a Winback offer.
9. Tap on the Claim button.
10. Play Store sheet should appear.
11. Close the sheet without making a purchase.
12. There should no loading dialog on top of UI.
13. Claim the offer again.
14. Finish the flow.
15. You should see the confirmation screen.

## Checklist
- [ ] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] ~Any jetpack compose components I added or changed are covered by compose previews~
- [ ] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack