### PR TITLE
[Suggested Folder] Create suggested folder screen UI

### DIFF
--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/folders/SuggestedFoldersPage.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/folders/SuggestedFoldersPage.kt
@@ -124,7 +124,7 @@ fun SuggestedFoldersPage(
 }
 
 @Composable
-private fun FolderItem(folderName: String, folderColor: Color, podcastUuids: List<String>, modifier: Modifier = Modifier) {
+fun FolderItem(folderName: String, folderColor: Color, podcastUuids: List<String>, modifier: Modifier = Modifier) {
     val stringResource = stringResource(LR.string.folder_content_description, folderName)
 
     FolderImage(

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/folders/SuggestedFoldersPaywall.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/folders/SuggestedFoldersPaywall.kt
@@ -27,7 +27,6 @@ import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.clearAndSetSemantics
-import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
@@ -39,7 +38,6 @@ import au.com.shiftyjelly.pocketcasts.compose.buttons.RowButton
 import au.com.shiftyjelly.pocketcasts.compose.buttons.RowOutlinedButton
 import au.com.shiftyjelly.pocketcasts.compose.components.TextH30
 import au.com.shiftyjelly.pocketcasts.compose.components.TextH50
-import au.com.shiftyjelly.pocketcasts.compose.folder.FolderImage
 import au.com.shiftyjelly.pocketcasts.compose.preview.ThemePreviewParameterProvider
 import au.com.shiftyjelly.pocketcasts.compose.theme
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
@@ -138,21 +136,6 @@ private fun Folders(podcastUuids: List<String>, modifier: Modifier = Modifier) {
             FolderItem("Test", Color.Yellow, podcastUuids)
         }
     }
-}
-
-@Composable
-private fun FolderItem(folderName: String, folderColor: Color, podcastUuids: List<String>, modifier: Modifier = Modifier) {
-    val stringResource = stringResource(LR.string.folder_content_description, folderName)
-
-    FolderImage(
-        name = folderName,
-        color = folderColor,
-        podcastUuids = podcastUuids,
-        textSpacing = true,
-        modifier = modifier.clearAndSetSemantics {
-            contentDescription = stringResource
-        },
-    )
 }
 
 @Preview(showBackground = true)

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/folders/SuggestedFoldersPaywall.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/folders/SuggestedFoldersPaywall.kt
@@ -11,10 +11,10 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.safeDrawing
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.layout.wrapContentSize
-import androidx.compose.foundation.lazy.grid.GridCells
-import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.material.ButtonDefaults
 import androidx.compose.material.Icon
 import androidx.compose.material.MaterialTheme
@@ -24,6 +24,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.clearAndSetSemantics
@@ -41,6 +42,8 @@ import au.com.shiftyjelly.pocketcasts.compose.components.TextH50
 import au.com.shiftyjelly.pocketcasts.compose.preview.ThemePreviewParameterProvider
 import au.com.shiftyjelly.pocketcasts.compose.theme
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
+import au.com.shiftyjelly.pocketcasts.utils.extensions.pxToDp
+import au.com.shiftyjelly.pocketcasts.views.helper.UiUtil
 import au.com.shiftyjelly.pocketcasts.images.R as IR
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
@@ -76,8 +79,7 @@ fun SuggestedFoldersPaywall(
                 podcastUuids = mockedPodcastsUuids,
                 modifier = Modifier
                     .fillMaxWidth()
-                    .padding(vertical = animatedPadding)
-                    .align(Alignment.CenterHorizontally),
+                    .padding(vertical = animatedPadding),
             )
         }
 
@@ -122,18 +124,17 @@ fun SuggestedFoldersPaywall(
 
 @Composable
 private fun Folders(podcastUuids: List<String>, modifier: Modifier = Modifier) {
-    val folders = 3
+    val episodeImageWidthDp = UiUtil.getGridImageWidthPx(smallArtwork = false, context = LocalContext.current).pxToDp(LocalContext.current).toInt()
 
-    LazyVerticalGrid(
-        columns = GridCells.Fixed(3),
+    LazyRow(
         horizontalArrangement = Arrangement.spacedBy(6.dp),
         modifier = modifier,
     ) {
         items(
-            count = folders,
+            count = 3,
             key = { index -> index },
         ) { index ->
-            FolderItem("Test", Color.Yellow, podcastUuids)
+            FolderItem("Test", Color.Yellow, podcastUuids, Modifier.size(episodeImageWidthDp.dp))
         }
     }
 }

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/folders/SuggestedFoldersPaywall.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/folders/SuggestedFoldersPaywall.kt
@@ -21,6 +21,8 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.clearAndSetSemantics
+import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
@@ -44,7 +46,8 @@ fun SuggestedFoldersPaywall(modifier: Modifier = Modifier) {
     Column(
         modifier = modifier
             .wrapContentSize()
-            .padding(16.dp),
+            .padding(horizontal = 16.dp)
+            .padding(top = 8.dp, bottom = 16.dp),
         horizontalAlignment = Alignment.CenterHorizontally,
     ) {
         val isPortrait = LocalConfiguration.current.orientation == Configuration.ORIENTATION_PORTRAIT
@@ -57,6 +60,7 @@ fun SuggestedFoldersPaywall(modifier: Modifier = Modifier) {
             painter = painterResource(IR.drawable.ic_swipe),
             contentDescription = null,
             tint = MaterialTheme.theme.colors.primaryUi05,
+            modifier = Modifier.clearAndSetSemantics {},
         )
 
         AnimatedVisibility(isPortrait) {
@@ -128,12 +132,16 @@ private fun Folders(podcastUuids: List<String>, modifier: Modifier = Modifier) {
 
 @Composable
 private fun FolderItem(folderName: String, folderColor: Color, podcastUuids: List<String>, modifier: Modifier = Modifier) {
+    val stringResource = stringResource(LR.string.folder_content_description, folderName)
+
     FolderImage(
         name = folderName,
         color = folderColor,
         podcastUuids = podcastUuids,
         textSpacing = true,
-        modifier = modifier,
+        modifier = modifier.clearAndSetSemantics {
+            contentDescription = stringResource
+        },
     )
 }
 

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/folders/SuggestedFoldersPaywall.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/folders/SuggestedFoldersPaywall.kt
@@ -1,0 +1,143 @@
+package au.com.shiftyjelly.pocketcasts.podcasts.view.folders
+
+import android.content.res.Configuration
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.animateDpAsState
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.wrapContentSize
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.material.ButtonDefaults
+import androidx.compose.material.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewParameter
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import au.com.shiftyjelly.pocketcasts.compose.AppTheme
+import au.com.shiftyjelly.pocketcasts.compose.buttons.RowButton
+import au.com.shiftyjelly.pocketcasts.compose.buttons.RowOutlinedButton
+import au.com.shiftyjelly.pocketcasts.compose.components.TextH30
+import au.com.shiftyjelly.pocketcasts.compose.components.TextH50
+import au.com.shiftyjelly.pocketcasts.compose.folder.FolderImage
+import au.com.shiftyjelly.pocketcasts.compose.preview.ThemePreviewParameterProvider
+import au.com.shiftyjelly.pocketcasts.compose.theme
+import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
+import au.com.shiftyjelly.pocketcasts.localization.R as LR
+
+@Composable
+fun SuggestedFoldersPaywall(modifier: Modifier = Modifier) {
+    Column(
+        modifier = modifier
+            .wrapContentSize()
+            .padding(16.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        val isPortrait = LocalConfiguration.current.orientation == Configuration.ORIENTATION_PORTRAIT
+
+        val animatedPadding by animateDpAsState(
+            targetValue = if (isPortrait) 32.dp else 8.dp,
+        )
+
+        AnimatedVisibility(isPortrait) {
+            Folders(
+                podcastUuids = mockedPodcastsUuids,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(vertical = animatedPadding)
+                    .align(Alignment.CenterHorizontally),
+            )
+        }
+
+        TextH30(
+            text = stringResource(LR.string.suggested_folders_paywall_tittle),
+            fontWeight = FontWeight.W600,
+            textAlign = TextAlign.Center,
+            modifier = Modifier.padding(bottom = 12.dp),
+        )
+
+        TextH50(
+            text = stringResource(LR.string.suggested_folders_paywall_subtitle),
+            color = MaterialTheme.theme.colors.primaryText02,
+            textAlign = TextAlign.Center,
+            modifier = Modifier.padding(bottom = 12.dp),
+        )
+
+        RowButton(
+            text = stringResource(LR.string.suggested_folders_use_these_folders_button),
+            modifier = Modifier.padding(bottom = 16.dp),
+            textColor = MaterialTheme.theme.colors.primaryInteractive02,
+            fontSize = 18.sp,
+            fontWeight = FontWeight.W600,
+            colors = ButtonDefaults.buttonColors(
+                backgroundColor = MaterialTheme.theme.colors.primaryInteractive01,
+            ),
+            includePadding = false,
+            onClick = { },
+        )
+
+        RowOutlinedButton(
+            text = stringResource(id = LR.string.maybe_later),
+            modifier = Modifier.padding(bottom = 16.dp),
+            onClick = {},
+            includePadding = false,
+            colors = ButtonDefaults.outlinedButtonColors(contentColor = MaterialTheme.theme.colors.primaryIcon01, backgroundColor = Color.Transparent),
+            fontSize = 18.sp,
+            fontWeight = FontWeight.W600,
+        )
+    }
+}
+
+@Composable
+private fun Folders(podcastUuids: List<String>, modifier: Modifier = Modifier) {
+    val folders = 3
+
+    LazyVerticalGrid(
+        columns = GridCells.Fixed(3),
+        horizontalArrangement = Arrangement.spacedBy(6.dp),
+        modifier = modifier,
+    ) {
+        items(
+            count = folders,
+            key = { index -> index },
+        ) { index ->
+            FolderItem("Test", Color.Yellow, podcastUuids)
+        }
+    }
+}
+
+@Composable
+private fun FolderItem(folderName: String, folderColor: Color, podcastUuids: List<String>, modifier: Modifier = Modifier) {
+    FolderImage(
+        name = folderName,
+        color = folderColor,
+        podcastUuids = podcastUuids,
+        textSpacing = true,
+        modifier = modifier,
+    )
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun SuggestedFoldersPagePreview(@PreviewParameter(ThemePreviewParameterProvider::class) themeType: Theme.ThemeType) {
+    AppTheme(themeType) {
+        SuggestedFoldersPaywall()
+    }
+}
+
+private val mockedPodcastsUuids = listOf(
+    "5d308950-1fe3-012e-02b0-00163e1b201c",
+    "f086f200-4f32-0139-3396-0acc26574db2",
+    "2e61ba20-50a9-0135-902b-63f4b61a9224",
+)

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/folders/SuggestedFoldersPaywall.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/folders/SuggestedFoldersPaywall.kt
@@ -5,8 +5,13 @@ import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.safeDrawing
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
@@ -49,6 +54,7 @@ fun SuggestedFoldersPaywall(
 ) {
     Column(
         modifier = modifier
+            .windowInsetsPadding(WindowInsets.safeDrawing.only(WindowInsetsSides.Horizontal))
             .wrapContentSize()
             .padding(horizontal = 16.dp)
             .padding(top = 8.dp, bottom = 16.dp),

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/folders/SuggestedFoldersPaywall.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/folders/SuggestedFoldersPaywall.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.material.ButtonDefaults
+import androidx.compose.material.Icon
 import androidx.compose.material.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -18,6 +19,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
@@ -34,6 +36,7 @@ import au.com.shiftyjelly.pocketcasts.compose.folder.FolderImage
 import au.com.shiftyjelly.pocketcasts.compose.preview.ThemePreviewParameterProvider
 import au.com.shiftyjelly.pocketcasts.compose.theme
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
+import au.com.shiftyjelly.pocketcasts.images.R as IR
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 @Composable
@@ -48,6 +51,12 @@ fun SuggestedFoldersPaywall(modifier: Modifier = Modifier) {
 
         val animatedPadding by animateDpAsState(
             targetValue = if (isPortrait) 32.dp else 8.dp,
+        )
+
+        Icon(
+            painter = painterResource(IR.drawable.ic_swipe),
+            contentDescription = null,
+            tint = MaterialTheme.theme.colors.primaryUi05,
         )
 
         AnimatedVisibility(isPortrait) {

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/folders/SuggestedFoldersPaywall.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/folders/SuggestedFoldersPaywall.kt
@@ -42,7 +42,11 @@ import au.com.shiftyjelly.pocketcasts.images.R as IR
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 @Composable
-fun SuggestedFoldersPaywall(modifier: Modifier = Modifier) {
+fun SuggestedFoldersPaywall(
+    onUseTheseFolders: () -> Unit,
+    onMaybeLater: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
     Column(
         modifier = modifier
             .wrapContentSize()
@@ -97,13 +101,13 @@ fun SuggestedFoldersPaywall(modifier: Modifier = Modifier) {
                 backgroundColor = MaterialTheme.theme.colors.primaryInteractive01,
             ),
             includePadding = false,
-            onClick = { },
+            onClick = onUseTheseFolders,
         )
 
         RowOutlinedButton(
             text = stringResource(id = LR.string.maybe_later),
             modifier = Modifier.padding(bottom = 16.dp),
-            onClick = {},
+            onClick = onMaybeLater,
             includePadding = false,
             colors = ButtonDefaults.outlinedButtonColors(contentColor = MaterialTheme.theme.colors.primaryIcon01, backgroundColor = Color.Transparent),
             fontSize = 18.sp,
@@ -149,7 +153,10 @@ private fun FolderItem(folderName: String, folderColor: Color, podcastUuids: Lis
 @Composable
 private fun SuggestedFoldersPagePreview(@PreviewParameter(ThemePreviewParameterProvider::class) themeType: Theme.ThemeType) {
     AppTheme(themeType) {
-        SuggestedFoldersPaywall()
+        SuggestedFoldersPaywall(
+            onUseTheseFolders = {},
+            onMaybeLater = {},
+        )
     }
 }
 

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/folders/SuggestedFoldersPaywallBottomSheet.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/folders/SuggestedFoldersPaywallBottomSheet.kt
@@ -6,12 +6,13 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.FrameLayout
 import androidx.core.view.doOnLayout
+import androidx.fragment.compose.content
 import au.com.shiftyjelly.pocketcasts.compose.AppTheme
-import au.com.shiftyjelly.pocketcasts.compose.extensions.contentWithoutConsumedInsets
 import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingFlow
 import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingLauncher
 import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingUpgradeSource
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
+import au.com.shiftyjelly.pocketcasts.views.extensions.setSystemWindowInsetToPadding
 import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.google.android.material.bottomsheet.BottomSheetDialog
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
@@ -28,7 +29,7 @@ class SuggestedFoldersPaywallBottomSheet : BottomSheetDialogFragment() {
         inflater: LayoutInflater,
         container: ViewGroup?,
         savedInstanceState: Bundle?,
-    ) = contentWithoutConsumedInsets {
+    ) = content {
         AppTheme(theme.activeTheme) {
             SuggestedFoldersPaywall(
                 onUseTheseFolders = {
@@ -58,5 +59,6 @@ class SuggestedFoldersPaywallBottomSheet : BottomSheetDialogFragment() {
                 }
             }
         }
+        view.setSystemWindowInsetToPadding(right = true, left = true)
     }
 }

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/folders/SuggestedFoldersPaywallBottomSheet.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/folders/SuggestedFoldersPaywallBottomSheet.kt
@@ -12,7 +12,6 @@ import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingFlow
 import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingLauncher
 import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingUpgradeSource
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
-import au.com.shiftyjelly.pocketcasts.views.extensions.setSystemWindowInsetToPadding
 import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.google.android.material.bottomsheet.BottomSheetDialog
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
@@ -59,6 +58,5 @@ class SuggestedFoldersPaywallBottomSheet : BottomSheetDialogFragment() {
                 }
             }
         }
-        view.setSystemWindowInsetToPadding(right = true, left = true)
     }
 }

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/folders/SuggestedFoldersPaywallBottomSheet.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/folders/SuggestedFoldersPaywallBottomSheet.kt
@@ -1,0 +1,49 @@
+package au.com.shiftyjelly.pocketcasts.podcasts.view.folders
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.FrameLayout
+import androidx.core.view.doOnLayout
+import au.com.shiftyjelly.pocketcasts.compose.AppTheme
+import au.com.shiftyjelly.pocketcasts.compose.extensions.contentWithoutConsumedInsets
+import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
+import com.google.android.material.bottomsheet.BottomSheetBehavior
+import com.google.android.material.bottomsheet.BottomSheetDialog
+import com.google.android.material.bottomsheet.BottomSheetDialogFragment
+import dagger.hilt.android.AndroidEntryPoint
+import javax.inject.Inject
+
+@AndroidEntryPoint
+class SuggestedFoldersPaywallBottomSheet : BottomSheetDialogFragment() {
+
+    @Inject
+    lateinit var theme: Theme
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?,
+    ) = contentWithoutConsumedInsets {
+        AppTheme(theme.activeTheme) {
+            SuggestedFoldersPaywall()
+        }
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        view.doOnLayout {
+            val dialog = dialog as BottomSheetDialog
+            val bottomSheet = dialog.findViewById<View>(com.google.android.material.R.id.design_bottom_sheet) as FrameLayout?
+            if (bottomSheet != null) {
+                BottomSheetBehavior.from(bottomSheet).run {
+                    state = BottomSheetBehavior.STATE_EXPANDED
+                    peekHeight = 0
+                    skipCollapsed = true
+                }
+            }
+        }
+    }
+}

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/folders/SuggestedFoldersPaywallBottomSheet.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/folders/SuggestedFoldersPaywallBottomSheet.kt
@@ -8,6 +8,9 @@ import android.widget.FrameLayout
 import androidx.core.view.doOnLayout
 import au.com.shiftyjelly.pocketcasts.compose.AppTheme
 import au.com.shiftyjelly.pocketcasts.compose.extensions.contentWithoutConsumedInsets
+import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingFlow
+import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingLauncher
+import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingUpgradeSource
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.google.android.material.bottomsheet.BottomSheetDialog
@@ -27,7 +30,17 @@ class SuggestedFoldersPaywallBottomSheet : BottomSheetDialogFragment() {
         savedInstanceState: Bundle?,
     ) = contentWithoutConsumedInsets {
         AppTheme(theme.activeTheme) {
-            SuggestedFoldersPaywall()
+            SuggestedFoldersPaywall(
+                onUseTheseFolders = {
+                    dismiss()
+                    val source = OnboardingUpgradeSource.PROFILE
+                    val onboardingFlow = OnboardingFlow.PlusAccountUpgrade(source)
+                    OnboardingLauncher.openOnboardingFlow(activity, onboardingFlow)
+                },
+                onMaybeLater = {
+                    dismiss()
+                },
+            )
         }
     }
 

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcasts/PodcastsFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcasts/PodcastsFragment.kt
@@ -30,8 +30,8 @@ import au.com.shiftyjelly.pocketcasts.podcasts.view.folders.FolderCreateFragment
 import au.com.shiftyjelly.pocketcasts.podcasts.view.folders.FolderCreateSharedViewModel
 import au.com.shiftyjelly.pocketcasts.podcasts.view.folders.FolderEditFragment
 import au.com.shiftyjelly.pocketcasts.podcasts.view.folders.FolderEditPodcastsFragment
-import au.com.shiftyjelly.pocketcasts.podcasts.view.folders.SuggestedFoldersPaywallBottomSheet
 import au.com.shiftyjelly.pocketcasts.podcasts.view.folders.SuggestedFolders
+import au.com.shiftyjelly.pocketcasts.podcasts.view.folders.SuggestedFoldersPaywallBottomSheet
 import au.com.shiftyjelly.pocketcasts.podcasts.view.podcast.PodcastFragment
 import au.com.shiftyjelly.pocketcasts.podcasts.viewmodel.PodcastsViewModel
 import au.com.shiftyjelly.pocketcasts.preferences.Settings

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcasts/PodcastsFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcasts/PodcastsFragment.kt
@@ -30,6 +30,7 @@ import au.com.shiftyjelly.pocketcasts.podcasts.view.folders.FolderCreateFragment
 import au.com.shiftyjelly.pocketcasts.podcasts.view.folders.FolderCreateSharedViewModel
 import au.com.shiftyjelly.pocketcasts.podcasts.view.folders.FolderEditFragment
 import au.com.shiftyjelly.pocketcasts.podcasts.view.folders.FolderEditPodcastsFragment
+import au.com.shiftyjelly.pocketcasts.podcasts.view.folders.SuggestedFoldersPaywallBottomSheet
 import au.com.shiftyjelly.pocketcasts.podcasts.view.folders.SuggestedFolders
 import au.com.shiftyjelly.pocketcasts.podcasts.view.podcast.PodcastFragment
 import au.com.shiftyjelly.pocketcasts.podcasts.viewmodel.PodcastsViewModel
@@ -198,7 +199,11 @@ class PodcastsFragment : BaseFragment(), FolderAdapter.ClickListener, PodcastTou
         toolbar.setOnMenuItemClickListener(this)
 
         toolbar.menu.findItem(R.id.folders_locked).setOnMenuItemClickListener {
-            OnboardingLauncher.openOnboardingFlow(activity, OnboardingFlow.Upsell(OnboardingUpgradeSource.FOLDERS))
+            if (FeatureFlag.isEnabled(Feature.SUGGESTED_FOLDERS)) {
+                SuggestedFoldersPaywallBottomSheet().show(childFragmentManager, "suggested_folders_paywall")
+            } else {
+                OnboardingLauncher.openOnboardingFlow(activity, OnboardingFlow.Upsell(OnboardingUpgradeSource.FOLDERS))
+            }
             true
         }
 

--- a/modules/services/images/src/main/res/drawable/ic_swipe.xml
+++ b/modules/services/images/src/main/res/drawable/ic_swipe.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="55dp"
+    android:height="5dp"
+    android:viewportWidth="55"
+    android:viewportHeight="5">
+  <path
+      android:pathData="M2.782,0.616L52.34,0.616A1.906,1.906 0,0 1,54.246 2.522L54.246,2.522A1.906,1.906 0,0 1,52.34 4.428L2.782,4.428A1.906,1.906 0,0 1,0.875 2.522L0.875,2.522A1.906,1.906 0,0 1,2.782 0.616z"
+      android:fillColor="#E4E4E4"/>
+</vector>

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -2327,10 +2327,5 @@
     <string name="folder_content_description">Folder %s</string>
     <string name="suggested_folders_paywall_tittle">Your podcasts, automatically organized</string>
     <string name="suggested_folders_paywall_subtitle">We\'ve pre-made folders for your podcasts. Unlock this and features like bookmarks, transcripts, and more with Pocket Casts Plus.</string>
-<<<<<<< HEAD
-=======
-    <string name="suggested_folders_use_these_folders_button">Use these folders</string>
-    <string name="folder_content_description">Folder %s</string>
->>>>>>> 7bc169f6e (improve accessibility)
 
 </resources>

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -2325,5 +2325,7 @@
     <string name="suggested_folders_use_these_folders_button">Use these folders</string>
     <string name="suggested_folders_use_create_custom_folders_button">Create custom folders</string>
     <string name="folder_content_description">Folder %s</string>
+    <string name="suggested_folders_paywall_tittle">Your podcasts, automatically organized</string>
+    <string name="suggested_folders_paywall_subtitle">We\'ve pre-made folders for your podcasts. Unlock this and features like bookmarks, transcripts, and more with Pocket Casts Plus.</string>
 
 </resources>

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -2327,5 +2327,10 @@
     <string name="folder_content_description">Folder %s</string>
     <string name="suggested_folders_paywall_tittle">Your podcasts, automatically organized</string>
     <string name="suggested_folders_paywall_subtitle">We\'ve pre-made folders for your podcasts. Unlock this and features like bookmarks, transcripts, and more with Pocket Casts Plus.</string>
+<<<<<<< HEAD
+=======
+    <string name="suggested_folders_use_these_folders_button">Use these folders</string>
+    <string name="folder_content_description">Folder %s</string>
+>>>>>>> 7bc169f6e (improve accessibility)
 
 </resources>


### PR DESCRIPTION
## Description
- Add the suggested folder paywall. For now, we will display if the feature flag is ON, but in the next PRs this will depend if we get suggested folder from server
- I faced an issue that I think is related to this reported one #3462, so once we see the offer we can't interact with the screen anymore. I will have to fix this in another PR

Fixes #3553

## Testing Instructions
1. Have the feature flag ON
2. Open the app with free account
3. Go to Podcasts tab
4. Tap to create a folder
5. You should see the suggested folders paywall bottom sheet ✅
6. Maybe later button should dismiss ✅
7. Use these folders button should open the paywall with plans ✅

## Screenshots or Screencast 
[Screen_recording_20250205_151647.webm](https://github.com/user-attachments/assets/0f297c98-6894-41b3-9828-49c7ed0c3e43)

| Theme | Theme | Theme | Theme |
|--------|--------|--------|--------|
| ![Screenshot_20250205_151605](https://github.com/user-attachments/assets/867cd021-2841-47ca-b2cf-e20d319d1177) | ![Screenshot_20250205_151617](https://github.com/user-attachments/assets/a9810a39-8223-4431-9e98-f01d283f7684) | ![Screenshot_20250205_151628](https://github.com/user-attachments/assets/9a5b878a-7f21-4fcf-a0a3-dc4ea618ff0c) | ![Screenshot_20250205_151548](https://github.com/user-attachments/assets/c0e1fd22-ec3c-4062-b16b-43cfceec08a9) | 


| Larger Font Size | Landscape |
|--------|--------|
| ![big](https://github.com/user-attachments/assets/dbf5dcb0-f943-4a4e-8497-6f48cc166754) | ![land](https://github.com/user-attachments/assets/120bd39b-bafd-42b5-8f17-0be36c14a7c9) | 


## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack
