### PR TITLE
Make Chapters implement List

### DIFF
--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/chapters/ChaptersViewModel.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/chapters/ChaptersViewModel.kt
@@ -182,7 +182,7 @@ class ChaptersViewModel @AssistedInject constructor(
     }.milliseconds
 
     private fun Chapters.toChapterStates(playbackPosition: Duration): List<ChapterState> {
-        return getList().map { chapter ->
+        return map { chapter ->
             when {
                 playbackPosition in chapter -> ChapterState.Playing(chapter.calculateProgress(playbackPosition), chapter)
                 playbackPosition > chapter.startTime -> ChapterState.Played(chapter)

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/PlayerViewModel.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/PlayerViewModel.kt
@@ -125,7 +125,7 @@ class PlayerViewModel @Inject constructor(
         val isStarred = (episode as? PodcastEpisode)?.isStarred == true
         val isUserEpisode = episode is UserEpisode
 
-        val isChaptersPresent: Boolean = !chapters.isEmpty
+        val isChaptersPresent: Boolean = chapters.isNotEmpty()
         val chapter: Chapter? = chapters.getChapter(positionMs.milliseconds)
         val chapterProgress: Float = chapter?.calculateProgress(positionMs.milliseconds) ?: 0f
         val chapterTimeRemaining: String = chapter?.remainingTime(
@@ -375,7 +375,7 @@ class PlayerViewModel @Inject constructor(
                 chapters = playbackState.chapters,
                 backgroundColor = playerBackground,
                 iconTintColor = iconTintColor,
-                podcastTitle = if (playbackState.chapters.isEmpty) podcast?.title else null,
+                podcastTitle = if (playbackState.chapters.isEmpty()) podcast?.title else null,
                 skipBackwardInSecs = skipBackwardInSecs,
                 skipForwardInSecs = skipForwardInSecs,
                 isSleepRunning = sleepTimerState.isSleepTimerRunning,

--- a/modules/features/player/src/test/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/ChaptersViewModelTest.kt
+++ b/modules/features/player/src/test/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/ChaptersViewModelTest.kt
@@ -146,9 +146,9 @@ class ChaptersViewModelTest {
         chaptersViewModel.uiState.test {
             val state = awaitItem()
 
-            assertEquals(ChaptersViewModel.ChapterState.Played(chapters.getList()[0]), state.chapters[0])
-            assertEquals(ChaptersViewModel.ChapterState.Playing(progress = 0.4949495f, chapters.getList()[1]), state.chapters[1])
-            assertEquals(ChaptersViewModel.ChapterState.NotPlayed(chapters.getList()[2]), state.chapters[2])
+            assertEquals(ChaptersViewModel.ChapterState.Played(chapters[0]), state.chapters[0])
+            assertEquals(ChaptersViewModel.ChapterState.Playing(progress = 0.4949495f, chapters[1]), state.chapters[1])
+            assertEquals(ChaptersViewModel.ChapterState.NotPlayed(chapters[2]), state.chapters[2])
         }
     }
 
@@ -206,14 +206,14 @@ class ChaptersViewModelTest {
 
     @Test
     fun `select chapter`() = runTest {
-        chaptersViewModel.selectChapter(true, chapters.getList()[1])
+        chaptersViewModel.selectChapter(true, chapters[1])
 
         verifyBlocking(chapterManager, times(1)) { selectChapter("id", chapterIndex = 1, true) }
     }
 
     @Test
     fun `deselect chapter`() = runTest {
-        chaptersViewModel.selectChapter(false, chapters.getList()[0])
+        chaptersViewModel.selectChapter(false, chapters[0])
 
         verifyBlocking(chapterManager, times(1)) { selectChapter("id", chapterIndex = 0, false) }
     }
@@ -223,14 +223,14 @@ class ChaptersViewModelTest {
         chaptersViewModel.scrollToChapter.test {
             expectNoEvents()
 
-            chaptersViewModel.scrollToChapter(chapters.getList()[0])
-            assertEquals(chapters.getList()[0], awaitItem())
+            chaptersViewModel.scrollToChapter(chapters[0])
+            assertEquals(chapters[0], awaitItem())
 
-            chaptersViewModel.scrollToChapter(chapters.getList()[0])
-            assertEquals(chapters.getList()[0], awaitItem())
+            chaptersViewModel.scrollToChapter(chapters[0])
+            assertEquals(chapters[0], awaitItem())
 
-            chaptersViewModel.scrollToChapter(chapters.getList()[1])
-            assertEquals(chapters.getList()[1], awaitItem())
+            chaptersViewModel.scrollToChapter(chapters[1])
+            assertEquals(chapters[1], awaitItem())
         }
     }
 
@@ -238,9 +238,9 @@ class ChaptersViewModelTest {
     fun `skip to chapter from current episode while playing`() = runTest {
         playbackStateFlow.update { it.copy(state = PlaybackState.State.PLAYING) }
 
-        chaptersViewModel.playChapter(chapters.getList()[2])
+        chaptersViewModel.playChapter(chapters[2])
 
-        verify(playbackManager, times(1)).skipToChapter(chapters.getList()[2])
+        verify(playbackManager, times(1)).skipToChapter(chapters[2])
         verifyBlocking(playbackManager, never()) { playNowSuspend("id") }
     }
 
@@ -248,9 +248,9 @@ class ChaptersViewModelTest {
     fun `skip to and play chapter from current episode while not playing`() = runTest {
         playbackStateFlow.update { it.copy(state = PlaybackState.State.STOPPED) }
 
-        chaptersViewModel.playChapter(chapters.getList()[2])
+        chaptersViewModel.playChapter(chapters[2])
 
-        verify(playbackManager, times(1)).skipToChapter(chapters.getList()[2])
+        verify(playbackManager, times(1)).skipToChapter(chapters[2])
         verifyBlocking(playbackManager, times(1)) { playNowSuspend("id") }
     }
 
@@ -281,10 +281,10 @@ class ChaptersViewModelTest {
         chaptersViewModel.showPlayer.test {
             expectNoEvents()
 
-            chaptersViewModel.playChapter(chapters.getList()[0])
+            chaptersViewModel.playChapter(chapters[0])
             assertEquals(Unit, awaitItem())
 
-            chaptersViewModel.playChapter(chapters.getList()[0])
+            chaptersViewModel.playChapter(chapters[0])
             assertEquals(Unit, awaitItem())
         }
     }

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/to/Chapters.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/to/Chapters.kt
@@ -6,19 +6,9 @@ import kotlin.time.Duration
 
 data class Chapters(
     private val items: List<Chapter> = emptyList(),
-) {
-
-    val isEmpty: Boolean
-        get() = items.isEmpty()
-
-    val size: Int
-        get() = items.size
-
+) : List<Chapter> by items {
     private val selectedItems: List<Chapter>
-        get() = items.filter { it.selected }
-
-    val lastChapter: Chapter?
-        get() = items.getOrNull(items.size - 1)
+        get() = filter { it.selected }
 
     fun getNextSelectedChapter(time: Duration): Chapter? {
         val currentTimeFinal = time.coerceAtLeast(Duration.ZERO)
@@ -32,7 +22,7 @@ data class Chapters(
     }
 
     fun getPreviousSelectedChapter(time: Duration): Chapter? {
-        if (items.isEmpty()) {
+        if (isEmpty()) {
             return null
         }
         var foundChapter: Chapter? = null
@@ -55,22 +45,17 @@ data class Chapters(
 
     fun getChapter(time: Duration): Chapter? {
         val finalTime = time.coerceAtLeast(Duration.ZERO)
-        return items.firstOrNull { chapter -> finalTime in chapter }
+        return firstOrNull { chapter -> finalTime in chapter }
     }
 
     fun getChapterIndex(time: Duration): Int {
         val finalTime = time.coerceAtLeast(Duration.ZERO)
-        return items.indexOfFirst { chapter -> finalTime in chapter }
-    }
-
-    fun getList(): List<Chapter> {
-        return items
+        return indexOfFirst { chapter -> finalTime in chapter }
     }
 
     fun getChapterSummary(time: Duration): ChapterSummaryData {
-        val chapterSize = items.size
         val chapterIndex = getChapterIndex(time)
-        return ChapterSummaryData(chapterIndex + 1, chapterSize)
+        return ChapterSummaryData(chapterIndex + 1, size)
     }
 
     fun isFirstChapter(time: Duration): Boolean {
@@ -78,7 +63,7 @@ data class Chapters(
     }
 
     fun isLastChapter(time: Duration): Boolean {
-        return getChapterIndex(time) == items.size - 1
+        return getChapterIndex(time) == size - 1
     }
 
     fun skippedChaptersDuration(time: Duration): Duration {
@@ -95,21 +80,6 @@ data class Chapters(
         } else {
             Duration.ZERO
         }
-    }
-
-    fun toDbChapters(
-        episodeId: String,
-        isEmbedded: Boolean,
-    ) = items.map { chapter ->
-        DbChapter(
-            episodeUuid = episodeId,
-            startTimeMs = chapter.startTime.inWholeMilliseconds,
-            endTimeMs = chapter.endTime.inWholeMilliseconds,
-            title = chapter.title,
-            imageUrl = chapter.imagePath,
-            url = chapter.url?.toString(),
-            isEmbedded = isEmbedded,
-        )
     }
 }
 


### PR DESCRIPTION
## Description

This PR adds makes `Chapters` implement `List<Chapter>` interface and removes all now redundant methods.

## Testing Instructions

Smoke test chapters interactions with podcasts that use chapters like [Upgrade](https://pca.st/upgrade) or [The Changelog](https://pca.st/changelog).

## Checklist
- [ ] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] ~I have considered whether it makes sense to add tests for my changes~
- [ ] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [ ] ~Any jetpack compose components I added or changed are covered by compose previews~
- [ ] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~