### PR TITLE
Filter out non-toc chapters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 *   Bug Fixes
     *   Fix missing episodes with unfollowed podcasts
         ([#3546](https://github.com/Automattic/pocket-casts-android/pull/3546))
+*   Updates
+    *   Filter out chapters that do not belong in table of contents. See [the specification](https://github.com/Podcastindex-org/podcast-namespace/blob/main/chapters/jsonChapters.md) for more details.
+        ([#3556](https://github.com/Automattic/pocket-casts-android/pull/3556))
 
 7.82
 -----

--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/models/db/AppDatabaseTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/models/db/AppDatabaseTest.kt
@@ -175,6 +175,7 @@ class AppDatabaseTest {
                 AppDatabase.MIGRATION_103_104,
                 AppDatabase.MIGRATION_104_105,
                 AppDatabase.MIGRATION_105_106,
+                AppDatabase.MIGRATION_106_107,
             )
             .build()
         // close the database and release any stream resources when the test finishes

--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/models/db/ChapterDaoTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/models/db/ChapterDaoTest.kt
@@ -38,6 +38,7 @@ class ChapterDaoTest {
     @Test
     fun insertSingleChapter() = runBlocking {
         val chapter = Chapter(
+            index = 0,
             episodeUuid = "episode-id",
             startTimeMs = 0L,
         )
@@ -51,6 +52,7 @@ class ChapterDaoTest {
     @Test
     fun doNotInsertTheSameChapterTwice() = runBlocking {
         val chapter = Chapter(
+            index = 0,
             episodeUuid = "episode-id",
             startTimeMs = 0L,
         )
@@ -65,6 +67,7 @@ class ChapterDaoTest {
     fun insertMultipleChapters() = runBlocking {
         val chapters = List(10) { index ->
             Chapter(
+                index = index,
                 episodeUuid = "episode-id",
                 startTimeMs = 0L + index,
             )
@@ -83,14 +86,17 @@ class ChapterDaoTest {
 
         val chapters = listOf(
             Chapter(
+                index = 0,
                 episodeUuid = id1,
                 startTimeMs = 0L,
             ),
             Chapter(
+                index = 1,
                 episodeUuid = id1,
                 startTimeMs = 1L,
             ),
             Chapter(
+                index = 0,
                 episodeUuid = id2,
                 startTimeMs = 0L,
             ),
@@ -106,6 +112,7 @@ class ChapterDaoTest {
     fun replaceAllEmbeddedChapters() = runBlocking {
         val chapters1 = List(10) { index ->
             Chapter(
+                index = index,
                 episodeUuid = "episode-id",
                 startTimeMs = 0L + index,
                 isEmbedded = true,
@@ -115,6 +122,7 @@ class ChapterDaoTest {
 
         val chapters2 = List(5) { index ->
             Chapter(
+                index = index,
                 episodeUuid = "episode-id",
                 startTimeMs = 0L + index,
                 isEmbedded = true,
@@ -130,6 +138,7 @@ class ChapterDaoTest {
     fun doNotReplaceEmptyEmbeddedChapters() = runBlocking {
         val chapters = List(10) { index ->
             Chapter(
+                index = index,
                 episodeUuid = "episode-id",
                 startTimeMs = 0L + index,
                 isEmbedded = true,
@@ -147,6 +156,7 @@ class ChapterDaoTest {
     fun replaceNotEmbeddedWithEmbeddedChapters() = runBlocking {
         val chapters1 = List(10) { index ->
             Chapter(
+                index = index,
                 episodeUuid = "episode-id",
                 startTimeMs = 0L + index,
                 isEmbedded = false,
@@ -156,6 +166,7 @@ class ChapterDaoTest {
 
         val chapters2 = List(5) { index ->
             Chapter(
+                index = index,
                 episodeUuid = "episode-id",
                 startTimeMs = 0L + index,
                 isEmbedded = true,
@@ -171,6 +182,7 @@ class ChapterDaoTest {
     fun doNotReplaceEmbeddedWithNotEmbeddedChapters() = runBlocking {
         val chapters1 = List(5) { index ->
             Chapter(
+                index = index,
                 episodeUuid = "episode-id",
                 startTimeMs = 0L + index,
                 isEmbedded = true,
@@ -180,6 +192,7 @@ class ChapterDaoTest {
 
         val chapters2 = List(10) { index ->
             Chapter(
+                index = index,
                 episodeUuid = "episode-id",
                 startTimeMs = 0L + index,
                 isEmbedded = false,
@@ -195,6 +208,7 @@ class ChapterDaoTest {
     fun replaceNotEmbeddedChaptersIfExistingCountIsSmaller() = runBlocking {
         val chapters1 = List(5) { index ->
             Chapter(
+                index = index,
                 title = "$index-0",
                 episodeUuid = "episode-id",
                 startTimeMs = 0L + index,
@@ -204,6 +218,7 @@ class ChapterDaoTest {
 
         val chapters2 = List(6) { index ->
             Chapter(
+                index = index,
                 title = "$index-1",
                 episodeUuid = "episode-id",
                 startTimeMs = 0L + index,
@@ -219,6 +234,7 @@ class ChapterDaoTest {
     fun replaceNotEmbeddedChaptersIfExistingCountIsEqual() = runBlocking {
         val chapters1 = List(5) { index ->
             Chapter(
+                index = index,
                 title = "$index-0",
                 episodeUuid = "episode-id",
                 startTimeMs = 0L + index,
@@ -228,6 +244,7 @@ class ChapterDaoTest {
 
         val chapters2 = List(5) { index ->
             Chapter(
+                index = index,
                 title = "$index-1",
                 episodeUuid = "episode-id",
                 startTimeMs = 0L + index,
@@ -243,6 +260,7 @@ class ChapterDaoTest {
     fun doNotReplaceNotEmbeddedChaptersIfExistingCountIsLarger() = runBlocking {
         val chapters1 = List(6) { index ->
             Chapter(
+                index = index,
                 title = "$index-0",
                 episodeUuid = "episode-id",
                 startTimeMs = 0L + index,
@@ -252,6 +270,7 @@ class ChapterDaoTest {
 
         val chapters2 = List(5) { index ->
             Chapter(
+                index = index,
                 title = "$index-1",
                 episodeUuid = "episode-id",
                 startTimeMs = 0L + index,
@@ -270,20 +289,24 @@ class ChapterDaoTest {
 
         val chapters1 = listOf(
             Chapter(
+                index = 0,
                 episodeUuid = id1,
                 startTimeMs = 0L,
             ),
             Chapter(
+                index = 1,
                 episodeUuid = id1,
                 startTimeMs = 1L,
             ),
         )
         val chapters2 = listOf(
             Chapter(
+                index = 0,
                 episodeUuid = id2,
                 startTimeMs = 0L,
             ),
             Chapter(
+                index = 1,
                 episodeUuid = id2,
                 startTimeMs = 1L,
             ),
@@ -305,6 +328,7 @@ class ChapterDaoTest {
 
             val chaptersEpisode1 = List(3) { index ->
                 Chapter(
+                    index = index,
                     episodeUuid = id1,
                     startTimeMs = 10L + index,
                 )
@@ -313,6 +337,7 @@ class ChapterDaoTest {
             assertEquals(chaptersEpisode1, awaitItem())
 
             val chapterEpisode2 = Chapter(
+                index = 0,
                 episodeUuid = id2,
                 startTimeMs = 0L,
             )
@@ -320,6 +345,7 @@ class ChapterDaoTest {
             expectNoEvents()
 
             val chapterEpisode1 = Chapter(
+                index = 3,
                 episodeUuid = id1,
                 startTimeMs = 0L,
             )

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/chapters/ChapterRow.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/chapters/ChapterRow.kt
@@ -102,7 +102,7 @@ fun ChapterRow(
                 Spacer(Modifier.width(8.dp))
             }
             TextH50(
-                text = (chapter.index + 1).toString(),
+                text = (chapter.uiIndex).toString(),
                 color = textColor,
                 modifier = Modifier
                     .padding(horizontal = 12.dp),
@@ -247,7 +247,8 @@ private fun ChapterRowPreview(theme: Theme.ThemeType) {
         endTime = 62.seconds,
         url = "https://pocketcasts.com".toHttpUrlOrNull(),
         imagePath = null,
-        index = 1,
+        index = 0,
+        uiIndex = 5,
     )
     AppThemeWithBackground(theme) {
         ChaptersTheme {

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/nowplaying/ArtworkSection.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/nowplaying/ArtworkSection.kt
@@ -215,6 +215,8 @@ private fun ArtworkSectionChapterPreview() {
                 startTime = 0.toDuration(DurationUnit.MINUTES),
                 imagePath = "",
                 url = "https://pocketcasts.com".toHttpUrlOrNull(),
+                index = 0,
+                uiIndex = 1,
             ),
             isChapterArtworkVisible = true,
         ),

--- a/modules/features/player/src/test/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/ChaptersViewModelTest.kt
+++ b/modules/features/player/src/test/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/ChaptersViewModelTest.kt
@@ -62,9 +62,9 @@ class ChaptersViewModelTest {
     private val episode = PodcastEpisode(uuid = "id", publishedDate = Date())
     private val chapters = Chapters(
         listOf(
-            Chapter("1", 0.milliseconds, 100.milliseconds, selected = true, index = 0),
-            Chapter("2", 101.milliseconds, 200.milliseconds, selected = true, index = 1),
-            Chapter("3", 201.milliseconds, 300.milliseconds, selected = true, index = 2),
+            Chapter("1", 0.milliseconds, 100.milliseconds, selected = true, index = 0, uiIndex = 1),
+            Chapter("2", 101.milliseconds, 200.milliseconds, selected = true, index = 1, uiIndex = 2),
+            Chapter("3", 201.milliseconds, 300.milliseconds, selected = true, index = 2, uiIndex = 3),
         ),
     )
 
@@ -267,7 +267,7 @@ class ChaptersViewModelTest {
         )
 
         val episode = PodcastEpisode(uuid = "id2", publishedDate = Date())
-        val chapter = Chapter("Chapter", startTime = 2.seconds, endTime = 3.seconds)
+        val chapter = Chapter("Chapter", startTime = 2.seconds, endTime = 3.seconds, index = 0, uiIndex = 1)
         whenever(episodeManager.findEpisodeByUuid("id2")).thenReturn(episode)
 
         chaptersViewModel.playChapter(chapter)

--- a/modules/services/model/schemas/au.com.shiftyjelly.pocketcasts.models.db.AppDatabase/107.json
+++ b/modules/services/model/schemas/au.com.shiftyjelly.pocketcasts.models.db.AppDatabase/107.json
@@ -1,0 +1,1876 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 107,
+    "identityHash": "3a6f5acf1f9def8186051ca708c30b54",
+    "entities": [
+      {
+        "tableName": "bump_stats",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`name` TEXT NOT NULL, `event_time` INTEGER NOT NULL, `custom_event_props` TEXT NOT NULL, PRIMARY KEY(`name`, `event_time`, `custom_event_props`))",
+        "fields": [
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "eventTime",
+            "columnName": "event_time",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "customEventProps",
+            "columnName": "custom_event_props",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "name",
+            "event_time",
+            "custom_event_props"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "bookmarks",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`uuid` TEXT NOT NULL, `podcast_uuid` TEXT NOT NULL, `episode_uuid` TEXT NOT NULL, `time` INTEGER NOT NULL, `created_at` INTEGER NOT NULL, `title` TEXT NOT NULL, `title_modified` INTEGER, `deleted` INTEGER NOT NULL, `deleted_modified` INTEGER, `sync_status` INTEGER NOT NULL, PRIMARY KEY(`uuid`))",
+        "fields": [
+          {
+            "fieldPath": "uuid",
+            "columnName": "uuid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "podcastUuid",
+            "columnName": "podcast_uuid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "episodeUuid",
+            "columnName": "episode_uuid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timeSecs",
+            "columnName": "time",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "titleModified",
+            "columnName": "title_modified",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "deleted",
+            "columnName": "deleted",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deletedModified",
+            "columnName": "deleted_modified",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "syncStatus",
+            "columnName": "sync_status",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "uuid"
+          ]
+        },
+        "indices": [
+          {
+            "name": "bookmarks_podcast_uuid",
+            "unique": false,
+            "columnNames": [
+              "podcast_uuid"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `bookmarks_podcast_uuid` ON `${TABLE_NAME}` (`podcast_uuid`)"
+          }
+        ],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "podcast_episodes",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`uuid` TEXT NOT NULL, `episode_description` TEXT NOT NULL, `published_date` INTEGER NOT NULL, `title` TEXT NOT NULL, `size_in_bytes` INTEGER NOT NULL, `episode_status` INTEGER NOT NULL, `file_type` TEXT, `duration` REAL NOT NULL, `download_url` TEXT, `downloaded_file_path` TEXT, `downloaded_error_details` TEXT, `play_error_details` TEXT, `played_up_to` REAL NOT NULL, `playing_status` INTEGER NOT NULL, `podcast_id` TEXT NOT NULL, `added_date` INTEGER NOT NULL, `auto_download_status` INTEGER NOT NULL, `starred` INTEGER NOT NULL, `thumbnail_status` INTEGER NOT NULL, `last_download_attempt_date` INTEGER, `playing_status_modified` INTEGER, `played_up_to_modified` INTEGER, `duration_modified` INTEGER, `starred_modified` INTEGER, `archived` INTEGER NOT NULL, `archived_modified` INTEGER, `season` INTEGER, `number` INTEGER, `type` TEXT, `cleanTitle` TEXT, `last_playback_interaction_date` INTEGER, `last_playback_interaction_sync_status` INTEGER NOT NULL, `exclude_from_episode_limit` INTEGER NOT NULL, `download_task_id` TEXT, `last_archive_interaction_date` INTEGER, `image_url` TEXT, `deselected_chapters` TEXT NOT NULL, `deselected_chapters_modified` INTEGER, PRIMARY KEY(`uuid`))",
+        "fields": [
+          {
+            "fieldPath": "uuid",
+            "columnName": "uuid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "episodeDescription",
+            "columnName": "episode_description",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "publishedDate",
+            "columnName": "published_date",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sizeInBytes",
+            "columnName": "size_in_bytes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "episodeStatus",
+            "columnName": "episode_status",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fileType",
+            "columnName": "file_type",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "duration",
+            "columnName": "duration",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "downloadUrl",
+            "columnName": "download_url",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "downloadedFilePath",
+            "columnName": "downloaded_file_path",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "downloadErrorDetails",
+            "columnName": "downloaded_error_details",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "playErrorDetails",
+            "columnName": "play_error_details",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "playedUpTo",
+            "columnName": "played_up_to",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playingStatus",
+            "columnName": "playing_status",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "podcastUuid",
+            "columnName": "podcast_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedDate",
+            "columnName": "added_date",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "autoDownloadStatus",
+            "columnName": "auto_download_status",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isStarred",
+            "columnName": "starred",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "thumbnailStatus",
+            "columnName": "thumbnail_status",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastDownloadAttemptDate",
+            "columnName": "last_download_attempt_date",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "playingStatusModified",
+            "columnName": "playing_status_modified",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "playedUpToModified",
+            "columnName": "played_up_to_modified",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "durationModified",
+            "columnName": "duration_modified",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "starredModified",
+            "columnName": "starred_modified",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "isArchived",
+            "columnName": "archived",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "archivedModified",
+            "columnName": "archived_modified",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "season",
+            "columnName": "season",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "number",
+            "columnName": "number",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "cleanTitle",
+            "columnName": "cleanTitle",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "lastPlaybackInteraction",
+            "columnName": "last_playback_interaction_date",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "lastPlaybackInteractionSyncStatus",
+            "columnName": "last_playback_interaction_sync_status",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "excludeFromEpisodeLimit",
+            "columnName": "exclude_from_episode_limit",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "downloadTaskId",
+            "columnName": "download_task_id",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "lastArchiveInteraction",
+            "columnName": "last_archive_interaction_date",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "imageUrl",
+            "columnName": "image_url",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "deselectedChapters",
+            "columnName": "deselected_chapters",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deselectedChaptersModified",
+            "columnName": "deselected_chapters_modified",
+            "affinity": "INTEGER",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "uuid"
+          ]
+        },
+        "indices": [
+          {
+            "name": "episode_last_download_attempt_date",
+            "unique": false,
+            "columnNames": [
+              "last_download_attempt_date"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `episode_last_download_attempt_date` ON `${TABLE_NAME}` (`last_download_attempt_date`)"
+          },
+          {
+            "name": "episode_podcast_id",
+            "unique": false,
+            "columnNames": [
+              "podcast_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `episode_podcast_id` ON `${TABLE_NAME}` (`podcast_id`)"
+          },
+          {
+            "name": "episode_published_date",
+            "unique": false,
+            "columnNames": [
+              "published_date"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `episode_published_date` ON `${TABLE_NAME}` (`published_date`)"
+          }
+        ],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "folders",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`uuid` TEXT NOT NULL, `name` TEXT NOT NULL, `color` INTEGER NOT NULL, `added_date` INTEGER NOT NULL, `sort_position` INTEGER NOT NULL, `podcasts_sort_type` INTEGER NOT NULL, `deleted` INTEGER NOT NULL, `sync_modified` INTEGER NOT NULL, PRIMARY KEY(`uuid`))",
+        "fields": [
+          {
+            "fieldPath": "uuid",
+            "columnName": "uuid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "color",
+            "columnName": "color",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedDate",
+            "columnName": "added_date",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sortPosition",
+            "columnName": "sort_position",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "podcastsSortType",
+            "columnName": "podcasts_sort_type",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deleted",
+            "columnName": "deleted",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "syncModified",
+            "columnName": "sync_modified",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "uuid"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "filters",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`_id` INTEGER, `uuid` TEXT NOT NULL, `title` TEXT NOT NULL, `sortPosition` INTEGER, `manual` INTEGER NOT NULL, `unplayed` INTEGER NOT NULL, `partiallyPlayed` INTEGER NOT NULL, `finished` INTEGER NOT NULL, `audioVideo` INTEGER NOT NULL, `allPodcasts` INTEGER NOT NULL, `podcastUuids` TEXT, `downloaded` INTEGER NOT NULL, `downloading` INTEGER NOT NULL, `notDownloaded` INTEGER NOT NULL, `autoDownload` INTEGER NOT NULL, `autoDownloadWifiOnly` INTEGER NOT NULL, `autoDownloadPowerOnly` INTEGER NOT NULL, `sortId` INTEGER NOT NULL, `iconId` INTEGER NOT NULL, `filterHours` INTEGER NOT NULL, `starred` INTEGER NOT NULL, `deleted` INTEGER NOT NULL, `syncStatus` INTEGER NOT NULL, `autoDownloadLimit` INTEGER NOT NULL, `filterDuration` INTEGER NOT NULL, `longerThan` INTEGER NOT NULL, `shorterThan` INTEGER NOT NULL, `draft` INTEGER NOT NULL, PRIMARY KEY(`_id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "_id",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "uuid",
+            "columnName": "uuid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sortPosition",
+            "columnName": "sortPosition",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "manual",
+            "columnName": "manual",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "unplayed",
+            "columnName": "unplayed",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "partiallyPlayed",
+            "columnName": "partiallyPlayed",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "finished",
+            "columnName": "finished",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "audioVideo",
+            "columnName": "audioVideo",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "allPodcasts",
+            "columnName": "allPodcasts",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "podcastUuids",
+            "columnName": "podcastUuids",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "downloaded",
+            "columnName": "downloaded",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "downloading",
+            "columnName": "downloading",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "notDownloaded",
+            "columnName": "notDownloaded",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "autoDownload",
+            "columnName": "autoDownload",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "autoDownloadUnmeteredOnly",
+            "columnName": "autoDownloadWifiOnly",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "autoDownloadPowerOnly",
+            "columnName": "autoDownloadPowerOnly",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sortId",
+            "columnName": "sortId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "iconId",
+            "columnName": "iconId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "filterHours",
+            "columnName": "filterHours",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "starred",
+            "columnName": "starred",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deleted",
+            "columnName": "deleted",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "syncStatus",
+            "columnName": "syncStatus",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "autodownloadLimit",
+            "columnName": "autoDownloadLimit",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "filterDuration",
+            "columnName": "filterDuration",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "longerThan",
+            "columnName": "longerThan",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "shorterThan",
+            "columnName": "shorterThan",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "draft",
+            "columnName": "draft",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "filters_uuid",
+            "unique": false,
+            "columnNames": [
+              "uuid"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `filters_uuid` ON `${TABLE_NAME}` (`uuid`)"
+          }
+        ],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "filter_episodes",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`_id` INTEGER PRIMARY KEY AUTOINCREMENT, `playlistId` INTEGER NOT NULL, `episodeUuid` TEXT NOT NULL, `position` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "_id",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "playlistId",
+            "columnName": "playlistId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "episodeUuid",
+            "columnName": "episodeUuid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "position",
+            "columnName": "position",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "filter_episodes_playlist_id",
+            "unique": false,
+            "columnNames": [
+              "playlistId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `filter_episodes_playlist_id` ON `${TABLE_NAME}` (`playlistId`)"
+          }
+        ],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "podcasts",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`uuid` TEXT NOT NULL, `added_date` INTEGER, `thumbnail_url` TEXT, `title` TEXT NOT NULL, `podcast_url` TEXT, `podcast_description` TEXT NOT NULL, `podcast_html_description` TEXT NOT NULL, `podcast_category` TEXT NOT NULL, `podcast_language` TEXT NOT NULL, `media_type` TEXT, `latest_episode_uuid` TEXT, `author` TEXT NOT NULL, `sort_order` INTEGER NOT NULL, `episodes_sort_order` INTEGER NOT NULL, `episodes_sort_order_modified` INTEGER, `latest_episode_date` INTEGER, `episodes_to_keep` INTEGER NOT NULL, `override_global_settings` INTEGER NOT NULL, `override_global_effects` INTEGER NOT NULL, `override_global_effects_modified` INTEGER, `start_from` INTEGER NOT NULL, `start_from_modified` INTEGER, `playback_speed` REAL NOT NULL, `playback_speed_modified` INTEGER, `volume_boosted` INTEGER NOT NULL, `volume_boosted_modified` INTEGER, `is_folder` INTEGER NOT NULL, `subscribed` INTEGER NOT NULL, `show_notifications` INTEGER NOT NULL, `show_notifications_modified` INTEGER, `auto_download_status` INTEGER NOT NULL, `auto_add_to_up_next` INTEGER NOT NULL, `auto_add_to_up_next_modified` INTEGER, `most_popular_color` INTEGER NOT NULL, `primary_color` INTEGER NOT NULL, `secondary_color` INTEGER NOT NULL, `light_overlay_color` INTEGER NOT NULL, `fab_for_light_bg` INTEGER NOT NULL, `link_for_dark_bg` INTEGER NOT NULL, `link_for_light_bg` INTEGER NOT NULL, `color_version` INTEGER NOT NULL, `color_last_downloaded` INTEGER NOT NULL, `sync_status` INTEGER NOT NULL, `exclude_from_auto_archive` INTEGER NOT NULL, `override_global_archive` INTEGER NOT NULL, `override_global_archive_modified` INTEGER, `auto_archive_played_after` INTEGER NOT NULL, `auto_archive_played_after_modified` INTEGER, `auto_archive_inactive_after` INTEGER NOT NULL, `auto_archive_inactive_after_modified` INTEGER, `auto_archive_episode_limit` INTEGER NOT NULL, `auto_archive_episode_limit_modified` INTEGER, `estimated_next_episode` INTEGER, `episode_frequency` TEXT, `grouping` INTEGER NOT NULL, `grouping_modified` INTEGER, `skip_last` INTEGER NOT NULL, `skip_last_modified` INTEGER, `show_archived` INTEGER NOT NULL, `show_archived_modified` INTEGER, `trim_silence_level` INTEGER NOT NULL, `trim_silence_level_modified` INTEGER, `refresh_available` INTEGER NOT NULL, `folder_uuid` TEXT, `licensing` INTEGER NOT NULL, `isPaid` INTEGER NOT NULL, `is_private` INTEGER NOT NULL, `bundleuuid` TEXT, `bundlebundleUrl` TEXT, `bundlepaymentUrl` TEXT, `bundledescription` TEXT, `bundlepodcastUuid` TEXT, `bundlepaidType` TEXT, PRIMARY KEY(`uuid`))",
+        "fields": [
+          {
+            "fieldPath": "uuid",
+            "columnName": "uuid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedDate",
+            "columnName": "added_date",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "thumbnailUrl",
+            "columnName": "thumbnail_url",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "podcastUrl",
+            "columnName": "podcast_url",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "podcastDescription",
+            "columnName": "podcast_description",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "podcastHtmlDescription",
+            "columnName": "podcast_html_description",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "podcastCategory",
+            "columnName": "podcast_category",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "podcastLanguage",
+            "columnName": "podcast_language",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mediaType",
+            "columnName": "media_type",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "latestEpisodeUuid",
+            "columnName": "latest_episode_uuid",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "author",
+            "columnName": "author",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sortPosition",
+            "columnName": "sort_order",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "episodesSortType",
+            "columnName": "episodes_sort_order",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "episodesSortTypeModified",
+            "columnName": "episodes_sort_order_modified",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "latestEpisodeDate",
+            "columnName": "latest_episode_date",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "episodesToKeep",
+            "columnName": "episodes_to_keep",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "overrideGlobalSettings",
+            "columnName": "override_global_settings",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "overrideGlobalEffects",
+            "columnName": "override_global_effects",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "overrideGlobalEffectsModified",
+            "columnName": "override_global_effects_modified",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "startFromSecs",
+            "columnName": "start_from",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startFromModified",
+            "columnName": "start_from_modified",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "playbackSpeed",
+            "columnName": "playback_speed",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playbackSpeedModified",
+            "columnName": "playback_speed_modified",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "isVolumeBoosted",
+            "columnName": "volume_boosted",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "volumeBoostedModified",
+            "columnName": "volume_boosted_modified",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "isFolder",
+            "columnName": "is_folder",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isSubscribed",
+            "columnName": "subscribed",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isShowNotifications",
+            "columnName": "show_notifications",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "showNotificationsModified",
+            "columnName": "show_notifications_modified",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "autoDownloadStatus",
+            "columnName": "auto_download_status",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "autoAddToUpNext",
+            "columnName": "auto_add_to_up_next",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "autoAddToUpNextModified",
+            "columnName": "auto_add_to_up_next_modified",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "backgroundColor",
+            "columnName": "most_popular_color",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tintColorForLightBg",
+            "columnName": "primary_color",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tintColorForDarkBg",
+            "columnName": "secondary_color",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fabColorForDarkBg",
+            "columnName": "light_overlay_color",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fabColorForLightBg",
+            "columnName": "fab_for_light_bg",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "linkColorForLightBg",
+            "columnName": "link_for_dark_bg",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "linkColorForDarkBg",
+            "columnName": "link_for_light_bg",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "colorVersion",
+            "columnName": "color_version",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "colorLastDownloaded",
+            "columnName": "color_last_downloaded",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "syncStatus",
+            "columnName": "sync_status",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "excludeFromAutoArchive",
+            "columnName": "exclude_from_auto_archive",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "overrideGlobalArchive",
+            "columnName": "override_global_archive",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "overrideGlobalArchiveModified",
+            "columnName": "override_global_archive_modified",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "rawAutoArchiveAfterPlaying",
+            "columnName": "auto_archive_played_after",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "autoArchiveAfterPlayingModified",
+            "columnName": "auto_archive_played_after_modified",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "rawAutoArchiveInactive",
+            "columnName": "auto_archive_inactive_after",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "autoArchiveInactiveModified",
+            "columnName": "auto_archive_inactive_after_modified",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "rawAutoArchiveEpisodeLimit",
+            "columnName": "auto_archive_episode_limit",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "autoArchiveEpisodeLimitModified",
+            "columnName": "auto_archive_episode_limit_modified",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "estimatedNextEpisode",
+            "columnName": "estimated_next_episode",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "episodeFrequency",
+            "columnName": "episode_frequency",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "grouping",
+            "columnName": "grouping",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "groupingModified",
+            "columnName": "grouping_modified",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "skipLastSecs",
+            "columnName": "skip_last",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "skipLastModified",
+            "columnName": "skip_last_modified",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "showArchived",
+            "columnName": "show_archived",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "showArchivedModified",
+            "columnName": "show_archived_modified",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "trimMode",
+            "columnName": "trim_silence_level",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "trimModeModified",
+            "columnName": "trim_silence_level_modified",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "refreshAvailable",
+            "columnName": "refresh_available",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "rawFolderUuid",
+            "columnName": "folder_uuid",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "licensing",
+            "columnName": "licensing",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isPaid",
+            "columnName": "isPaid",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isPrivate",
+            "columnName": "is_private",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "singleBundle.uuid",
+            "columnName": "bundleuuid",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "singleBundle.bundleUrl",
+            "columnName": "bundlebundleUrl",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "singleBundle.paymentUrl",
+            "columnName": "bundlepaymentUrl",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "singleBundle.description",
+            "columnName": "bundledescription",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "singleBundle.podcastUuid",
+            "columnName": "bundlepodcastUuid",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "singleBundle.paidType",
+            "columnName": "bundlepaidType",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "uuid"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "search_history",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`_id` INTEGER PRIMARY KEY AUTOINCREMENT, `modified` INTEGER NOT NULL, `term` TEXT, `podcast_uuid` TEXT, `podcast_title` TEXT, `podcast_author` TEXT, `folder_uuid` TEXT, `folder_title` TEXT, `folder_color` INTEGER, `folder_podcastIds` TEXT, `episode_uuid` TEXT, `episode_title` TEXT, `episode_duration` REAL, `episode_podcastUuid` TEXT, `episode_podcastTitle` TEXT, `episode_artworkUrl` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "_id",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "modified",
+            "columnName": "modified",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "term",
+            "columnName": "term",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "podcast.uuid",
+            "columnName": "podcast_uuid",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "podcast.title",
+            "columnName": "podcast_title",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "podcast.author",
+            "columnName": "podcast_author",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "folder.uuid",
+            "columnName": "folder_uuid",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "folder.title",
+            "columnName": "folder_title",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "folder.color",
+            "columnName": "folder_color",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "folder.podcastIds",
+            "columnName": "folder_podcastIds",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "episode.uuid",
+            "columnName": "episode_uuid",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "episode.title",
+            "columnName": "episode_title",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "episode.duration",
+            "columnName": "episode_duration",
+            "affinity": "REAL",
+            "notNull": false
+          },
+          {
+            "fieldPath": "episode.podcastUuid",
+            "columnName": "episode_podcastUuid",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "episode.podcastTitle",
+            "columnName": "episode_podcastTitle",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "episode.artworkUrl",
+            "columnName": "episode_artworkUrl",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_search_history_term",
+            "unique": true,
+            "columnNames": [
+              "term"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_search_history_term` ON `${TABLE_NAME}` (`term`)"
+          },
+          {
+            "name": "index_search_history_podcast_uuid",
+            "unique": true,
+            "columnNames": [
+              "podcast_uuid"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_search_history_podcast_uuid` ON `${TABLE_NAME}` (`podcast_uuid`)"
+          },
+          {
+            "name": "index_search_history_folder_uuid",
+            "unique": true,
+            "columnNames": [
+              "folder_uuid"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_search_history_folder_uuid` ON `${TABLE_NAME}` (`folder_uuid`)"
+          },
+          {
+            "name": "index_search_history_episode_uuid",
+            "unique": true,
+            "columnNames": [
+              "episode_uuid"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_search_history_episode_uuid` ON `${TABLE_NAME}` (`episode_uuid`)"
+          }
+        ],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "up_next_changes",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`_id` INTEGER PRIMARY KEY AUTOINCREMENT, `type` INTEGER NOT NULL, `uuid` TEXT, `uuids` TEXT, `modified` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "_id",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "uuid",
+            "columnName": "uuid",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "uuids",
+            "columnName": "uuids",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "modified",
+            "columnName": "modified",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "_id"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "up_next_episodes",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`_id` INTEGER PRIMARY KEY AUTOINCREMENT, `episodeUuid` TEXT NOT NULL, `position` INTEGER NOT NULL, `playlistId` INTEGER, `title` TEXT NOT NULL, `publishedDate` INTEGER, `downloadUrl` TEXT, `podcastUuid` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "_id",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "episodeUuid",
+            "columnName": "episodeUuid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "position",
+            "columnName": "position",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playlistId",
+            "columnName": "playlistId",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "publishedDate",
+            "columnName": "publishedDate",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "downloadUrl",
+            "columnName": "downloadUrl",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "podcastUuid",
+            "columnName": "podcastUuid",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "up_next_episode_episodeUuid",
+            "unique": false,
+            "columnNames": [
+              "episodeUuid"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `up_next_episode_episodeUuid` ON `${TABLE_NAME}` (`episodeUuid`)"
+          }
+        ],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "user_episodes",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`uuid` TEXT NOT NULL, `published_date` INTEGER NOT NULL, `episode_description` TEXT NOT NULL, `title` TEXT NOT NULL, `size_in_bytes` INTEGER NOT NULL, `episode_status` INTEGER NOT NULL, `file_type` TEXT, `duration` REAL NOT NULL, `download_url` TEXT, `played_up_to` REAL NOT NULL, `playing_status` INTEGER NOT NULL, `added_date` INTEGER NOT NULL, `auto_download_status` INTEGER NOT NULL, `last_download_attempt_date` INTEGER, `archived` INTEGER NOT NULL, `download_task_id` TEXT, `downloaded_file_path` TEXT, `playing_status_modified` INTEGER, `played_up_to_modified` INTEGER, `artwork_url` TEXT, `play_error_details` TEXT, `server_status` INTEGER NOT NULL, `upload_error_details` TEXT, `downloaded_error_details` TEXT, `tint_color_index` INTEGER NOT NULL, `has_custom_image` INTEGER NOT NULL, `upload_task_id` TEXT, `deselected_chapters` TEXT NOT NULL, `deselected_chapters_modified` INTEGER, PRIMARY KEY(`uuid`))",
+        "fields": [
+          {
+            "fieldPath": "uuid",
+            "columnName": "uuid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "publishedDate",
+            "columnName": "published_date",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "episodeDescription",
+            "columnName": "episode_description",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sizeInBytes",
+            "columnName": "size_in_bytes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "episodeStatus",
+            "columnName": "episode_status",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fileType",
+            "columnName": "file_type",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "duration",
+            "columnName": "duration",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "downloadUrl",
+            "columnName": "download_url",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "playedUpTo",
+            "columnName": "played_up_to",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playingStatus",
+            "columnName": "playing_status",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedDate",
+            "columnName": "added_date",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "autoDownloadStatus",
+            "columnName": "auto_download_status",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastDownloadAttemptDate",
+            "columnName": "last_download_attempt_date",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "isArchived",
+            "columnName": "archived",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "downloadTaskId",
+            "columnName": "download_task_id",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "downloadedFilePath",
+            "columnName": "downloaded_file_path",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "playingStatusModified",
+            "columnName": "playing_status_modified",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "playedUpToModified",
+            "columnName": "played_up_to_modified",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "artworkUrl",
+            "columnName": "artwork_url",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "playErrorDetails",
+            "columnName": "play_error_details",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "serverStatus",
+            "columnName": "server_status",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "uploadErrorDetails",
+            "columnName": "upload_error_details",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "downloadErrorDetails",
+            "columnName": "downloaded_error_details",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "tintColorIndex",
+            "columnName": "tint_color_index",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "hasCustomImage",
+            "columnName": "has_custom_image",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "uploadTaskId",
+            "columnName": "upload_task_id",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "deselectedChapters",
+            "columnName": "deselected_chapters",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deselectedChaptersModified",
+            "columnName": "deselected_chapters_modified",
+            "affinity": "INTEGER",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "uuid"
+          ]
+        },
+        "indices": [
+          {
+            "name": "user_episode_last_download_attempt_date",
+            "unique": false,
+            "columnNames": [
+              "last_download_attempt_date"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `user_episode_last_download_attempt_date` ON `${TABLE_NAME}` (`last_download_attempt_date`)"
+          },
+          {
+            "name": "user_episode_published_date",
+            "unique": false,
+            "columnNames": [
+              "published_date"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `user_episode_published_date` ON `${TABLE_NAME}` (`published_date`)"
+          }
+        ],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "podcast_ratings",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`podcast_uuid` TEXT NOT NULL, `average` REAL, `total` INTEGER, PRIMARY KEY(`podcast_uuid`))",
+        "fields": [
+          {
+            "fieldPath": "podcastUuid",
+            "columnName": "podcast_uuid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "average",
+            "columnName": "average",
+            "affinity": "REAL",
+            "notNull": false
+          },
+          {
+            "fieldPath": "total",
+            "columnName": "total",
+            "affinity": "INTEGER",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "podcast_uuid"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "episode_chapters",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`chapter_index` INTEGER NOT NULL, `episode_uuid` TEXT NOT NULL, `start_time` INTEGER NOT NULL, `end_time` INTEGER, `title` TEXT, `image_url` TEXT, `url` TEXT, `is_embedded` INTEGER NOT NULL, PRIMARY KEY(`episode_uuid`, `chapter_index`))",
+        "fields": [
+          {
+            "fieldPath": "index",
+            "columnName": "chapter_index",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "episodeUuid",
+            "columnName": "episode_uuid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startTimeMs",
+            "columnName": "start_time",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "endTimeMs",
+            "columnName": "end_time",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "imageUrl",
+            "columnName": "image_url",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "isEmbedded",
+            "columnName": "is_embedded",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "episode_uuid",
+            "chapter_index"
+          ]
+        },
+        "indices": [
+          {
+            "name": "chapter_episode_uuid_index",
+            "unique": false,
+            "columnNames": [
+              "episode_uuid"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `chapter_episode_uuid_index` ON `${TABLE_NAME}` (`episode_uuid`)"
+          }
+        ],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "curated_podcasts",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`list_id` TEXT NOT NULL, `list_title` TEXT NOT NULL, `podcast_id` TEXT NOT NULL, `podcast_title` TEXT NOT NULL, `podcast_description` TEXT, PRIMARY KEY(`list_id`, `podcast_id`))",
+        "fields": [
+          {
+            "fieldPath": "listId",
+            "columnName": "list_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "listTitle",
+            "columnName": "list_title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "podcastId",
+            "columnName": "podcast_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "podcastTitle",
+            "columnName": "podcast_title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "podcastDescription",
+            "columnName": "podcast_description",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "list_id",
+            "podcast_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "curated_podcasts_list_id_index",
+            "unique": false,
+            "columnNames": [
+              "list_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `curated_podcasts_list_id_index` ON `${TABLE_NAME}` (`list_id`)"
+          },
+          {
+            "name": "curated_podcasts_podcast_id_index",
+            "unique": false,
+            "columnNames": [
+              "podcast_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `curated_podcasts_podcast_id_index` ON `${TABLE_NAME}` (`podcast_id`)"
+          }
+        ],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "episode_transcript",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`episode_uuid` TEXT NOT NULL, `url` TEXT NOT NULL, `type` TEXT NOT NULL, `language` TEXT, PRIMARY KEY(`episode_uuid`, `url`))",
+        "fields": [
+          {
+            "fieldPath": "episodeUuid",
+            "columnName": "episode_uuid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "language",
+            "columnName": "language",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "episode_uuid",
+            "url"
+          ]
+        },
+        "indices": [
+          {
+            "name": "transcript_episode_uuid_index",
+            "unique": true,
+            "columnNames": [
+              "episode_uuid"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `transcript_episode_uuid_index` ON `${TABLE_NAME}` (`episode_uuid`)"
+          }
+        ],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "user_podcast_ratings",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`podcast_uuid` TEXT NOT NULL, `rating` INTEGER NOT NULL, `modified_at` INTEGER NOT NULL, PRIMARY KEY(`podcast_uuid`))",
+        "fields": [
+          {
+            "fieldPath": "podcastUuid",
+            "columnName": "podcast_uuid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "rating",
+            "columnName": "rating",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "modifiedAt",
+            "columnName": "modified_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "podcast_uuid"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      }
+    ],
+    "views": [],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '3a6f5acf1f9def8186051ca708c30b54')"
+    ]
+  }
+}

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/to/Chapter.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/to/Chapter.kt
@@ -8,9 +8,10 @@ data class Chapter(
     val title: String,
     val startTime: Duration,
     val endTime: Duration,
+    val index: Int,
+    val uiIndex: Int,
     val url: HttpUrl? = null,
     val imagePath: String? = null,
-    val index: Int = 0,
     val selected: Boolean = true,
 ) {
 

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/to/DbChapter.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/to/DbChapter.kt
@@ -6,17 +6,18 @@ import androidx.room.Index
 
 @Entity(
     tableName = "episode_chapters",
-    primaryKeys = ["episode_uuid", "start_time"],
+    primaryKeys = ["episode_uuid", "chapter_index"],
     indices = [
         Index(name = "chapter_episode_uuid_index", value = ["episode_uuid"]),
     ],
 )
 data class DbChapter(
+    @ColumnInfo(name = "chapter_index") val index: Int,
     @ColumnInfo(name = "episode_uuid") val episodeUuid: String,
     @ColumnInfo(name = "start_time") val startTimeMs: Long,
-    @ColumnInfo(name = "is_embedded", defaultValue = "0") val isEmbedded: Boolean = false,
     @ColumnInfo(name = "end_time") val endTimeMs: Long? = null,
     @ColumnInfo(name = "title") val title: String? = null,
     @ColumnInfo(name = "image_url") val imageUrl: String? = null,
     @ColumnInfo(name = "url") val url: String? = null,
+    @ColumnInfo(name = "is_embedded") val isEmbedded: Boolean = false,
 )

--- a/modules/services/model/src/test/java/au/com/shiftyjelly/pocketcasts/models/to/ChapterTest.kt
+++ b/modules/services/model/src/test/java/au/com/shiftyjelly/pocketcasts/models/to/ChapterTest.kt
@@ -12,6 +12,8 @@ class ChapterTest {
             title = "",
             startTime = 5.seconds,
             endTime = 10.seconds,
+            index = 0,
+            uiIndex = 1,
         )
 
         assertEquals(0f, chapter.calculateProgress(1.milliseconds), 0.001f)
@@ -27,6 +29,8 @@ class ChapterTest {
             title = "",
             startTime = 5.seconds,
             endTime = 70.seconds,
+            index = 0,
+            uiIndex = 1,
         )
 
         assertEquals("1m", chapter.remainingTime(5000.milliseconds, playbackSpeed = 1.0, adjustRemainingTimeDuration = false))
@@ -43,6 +47,8 @@ class ChapterTest {
             title = "",
             startTime = 0.seconds,
             endTime = 120.seconds,
+            index = 0,
+            uiIndex = 1,
         )
 
         assertEquals("4m", chapter.remainingTime(0.seconds, playbackSpeed = 0.5, adjustRemainingTimeDuration = true))
@@ -62,6 +68,8 @@ class ChapterTest {
             title = "",
             startTime = 0.seconds,
             endTime = 120.seconds,
+            index = 0,
+            uiIndex = 1,
         )
 
         assertEquals("2m", chapter.remainingTime(0.seconds, playbackSpeed = 0.5, adjustRemainingTimeDuration = false))

--- a/modules/services/model/src/test/java/au/com/shiftyjelly/pocketcasts/models/to/ChaptersTest.kt
+++ b/modules/services/model/src/test/java/au/com/shiftyjelly/pocketcasts/models/to/ChaptersTest.kt
@@ -74,11 +74,11 @@ class ChaptersTest {
     private fun initChapters(): Chapters {
         return Chapters(
             items = listOf(
-                Chapter("1", 0.milliseconds, 101.milliseconds, selected = true),
-                Chapter("2", 101.milliseconds, 201.milliseconds, selected = false),
-                Chapter("3", 201.milliseconds, 301.milliseconds, selected = false),
-                Chapter("4", 301.milliseconds, 401.milliseconds, selected = false),
-                Chapter("5", 401.milliseconds, 500.milliseconds, selected = true),
+                Chapter("1", 0.milliseconds, 101.milliseconds, selected = true, index = 0, uiIndex = 1),
+                Chapter("2", 101.milliseconds, 201.milliseconds, selected = false, index = 1, uiIndex = 2),
+                Chapter("3", 201.milliseconds, 301.milliseconds, selected = false, index = 2, uiIndex = 3),
+                Chapter("4", 301.milliseconds, 401.milliseconds, selected = false, index = 3, uiIndex = 4),
+                Chapter("5", 401.milliseconds, 500.milliseconds, selected = true, index = 4, uiIndex = 5),
             ),
         )
     }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/EpisodeFileMetadata.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/EpisodeFileMetadata.kt
@@ -75,7 +75,7 @@ class EpisodeFileMetadata(val filenamePrefix: String? = null) {
             }
             // sort the chapters by start time
             val indexedChapters = newChapters.sortedWith(START_TIME_COMPARATOR).mapIndexed { index, chapter ->
-                chapter.copy(index = index + 1)
+                chapter.copy(index = index, uiIndex = index + 1)
             }
             chapters = Chapters(indexedChapters)
         } catch (e: Exception) {
@@ -114,6 +114,9 @@ class EpisodeFileMetadata(val filenamePrefix: String? = null) {
             startTime = frame.startTimeMs.milliseconds,
             endTime = frame.endTimeMs.milliseconds,
             imagePath = imagePath,
+            // We set any values here as they are updated later after sorting
+            index = -1,
+            uiIndex = -1,
         )
     }
 

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
@@ -1535,9 +1535,9 @@ open class PlaybackManager @Inject constructor(
     private fun onMetadataAvailable(episodeMetadata: EpisodeFileMetadata) {
         playbackStateRelay.blockingFirst().let { playbackState ->
             launch {
-                val dbChapters = episodeMetadata.chapters.mapIndexed { index, chapter ->
+                val dbChapters = episodeMetadata.chapters.map { chapter ->
                     DbChapter(
-                        index = index,
+                        index = chapter.index,
                         episodeUuid = playbackState.episodeUuid,
                         startTimeMs = chapter.startTime.inWholeMilliseconds,
                         endTimeMs = chapter.endTime.inWholeMilliseconds,

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
@@ -1535,8 +1535,9 @@ open class PlaybackManager @Inject constructor(
     private fun onMetadataAvailable(episodeMetadata: EpisodeFileMetadata) {
         playbackStateRelay.blockingFirst().let { playbackState ->
             launch {
-                val dbChapters = episodeMetadata.chapters.map { chapter ->
+                val dbChapters = episodeMetadata.chapters.mapIndexed { index, chapter ->
                     DbChapter(
+                        index = index,
                         episodeUuid = playbackState.episodeUuid,
                         startTimeMs = chapter.startTime.inWholeMilliseconds,
                         endTimeMs = chapter.endTime.inWholeMilliseconds,

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/ChapterManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/ChapterManagerImpl.kt
@@ -30,35 +30,31 @@ class ChapterManagerImpl @Inject constructor(
     override fun observerChaptersForEpisode(episodeUuid: String) = combine(
         episodeManager.findEpisodeByUuidFlow(episodeUuid).distinctUntilChangedBy(BaseEpisode::deselectedChapters),
         chapterDao.observerChaptersForEpisode(episodeUuid),
-    ) { episode, dbChapters -> dbChapters.toChapters(episode) }
+    ) { episode, dbChapters -> Chapters(dbChapters.fixChapterTimestamps(episode)) }
 
-    private fun List<DbChapter>.toChapters(episode: BaseEpisode): Chapters {
-        val chaptersList = asSequence()
-            .fixChapterTimestamps(episode)
-            .filter { it.duration > Duration.ZERO }
-            .mapIndexed { index, chapter -> chapter.copy(index = index) }
-            .toList()
-        return Chapters(chaptersList)
-    }
+    private fun List<DbChapter>.fixChapterTimestamps(episode: BaseEpisode) = asSequence()
+        .withIndex()
+        .windowed(size = 2, partialWindows = true) { window ->
+            val sequenceIndex = window[0].index
+            val firstChapter = window[0].value
+            val secondChapter = window.getOrNull(1)?.value
 
-    private fun Sequence<DbChapter>.fixChapterTimestamps(episode: BaseEpisode) = withIndex().windowed(size = 2, partialWindows = true) { window ->
-        val index = window[0].index
-        val chapterIndex = window[0].index
-        val firstChapter = window[0].value
-        val secondChapter = window.getOrNull(1)?.value
+            val newStartTime = if (sequenceIndex == 0) Duration.ZERO else firstChapter.startTimeMs.milliseconds
+            val secondStartTime = secondChapter?.startTimeMs?.milliseconds ?: episode.durationMs.milliseconds
+            val newEndTime = firstChapter.endTimeMs?.milliseconds?.takeIf { it <= secondStartTime && it > newStartTime } ?: secondStartTime
 
-        val newStartTime = if (index == 0) Duration.ZERO else firstChapter.startTimeMs.milliseconds
-        val secondStartTime = secondChapter?.startTimeMs?.milliseconds ?: episode.durationMs.milliseconds
-        val newEndTime = firstChapter.endTimeMs?.milliseconds?.takeIf { it <= secondStartTime && it > newStartTime } ?: secondStartTime
-
-        Chapter(
-            title = firstChapter.title.orEmpty(),
-            startTime = newStartTime,
-            endTime = newEndTime,
-            url = firstChapter.url?.toHttpUrlOrNull(),
-            imagePath = firstChapter.imageUrl,
-            index = chapterIndex,
-            selected = chapterIndex !in episode.deselectedChapters,
-        )
-    }
+            Chapter(
+                title = firstChapter.title.orEmpty(),
+                startTime = newStartTime,
+                endTime = newEndTime,
+                url = firstChapter.url?.toHttpUrlOrNull(),
+                imagePath = firstChapter.imageUrl,
+                index = firstChapter.index,
+                uiIndex = -1, // We set any value here as it is updated later in the processing chain
+                selected = firstChapter.index !in episode.deselectedChapters,
+            )
+        }
+        .filter { it.duration > Duration.ZERO }
+        .mapIndexed { index, chapter -> chapter.copy(uiIndex = index + 1) }
+        .toList()
 }

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/ChapterManagerImplTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/ChapterManagerImplTest.kt
@@ -42,6 +42,7 @@ class ChapterManagerImplTest {
     fun `observe single chapter`() = runBlocking {
         val episode = PodcastEpisode("id", publishedDate = Date(), duration = 0.001)
         val dbChapter = DbChapter(
+            index = 0,
             episodeUuid = "id",
             startTimeMs = 0,
             endTimeMs = 1,
@@ -74,18 +75,21 @@ class ChapterManagerImplTest {
         val episode = PodcastEpisode("id", publishedDate = Date(), duration = 0.003)
         val dbChapters = listOf(
             DbChapter(
+                index = 0,
                 episodeUuid = "id",
                 startTimeMs = 0,
                 endTimeMs = 1,
                 title = "Title 1",
             ),
             DbChapter(
+                index = 1,
                 episodeUuid = "id",
                 startTimeMs = 1,
                 endTimeMs = 2,
                 title = "Title 2",
             ),
             DbChapter(
+                index = 3,
                 episodeUuid = "id",
                 startTimeMs = 2,
                 endTimeMs = 3,
@@ -130,6 +134,7 @@ class ChapterManagerImplTest {
     fun `observe chapter without title`() = runBlocking {
         val episode = PodcastEpisode("id", publishedDate = Date(), duration = 0.001)
         val dbChapter = DbChapter(
+            index = 0,
             episodeUuid = "id",
             startTimeMs = 0,
             endTimeMs = 1,
@@ -161,6 +166,7 @@ class ChapterManagerImplTest {
     fun `observe chapter without image URL`() = runBlocking {
         val episode = PodcastEpisode("id", publishedDate = Date(), duration = 0.001)
         val dbChapter = DbChapter(
+            index = 1,
             episodeUuid = "id",
             startTimeMs = 0,
             endTimeMs = 1,
@@ -192,6 +198,7 @@ class ChapterManagerImplTest {
     fun `observe chapter without URL`() = runBlocking {
         val episode = PodcastEpisode("id", publishedDate = Date(), duration = 0.001)
         val dbChapter = DbChapter(
+            index = 0,
             episodeUuid = "id",
             startTimeMs = 0,
             endTimeMs = 1,
@@ -223,6 +230,7 @@ class ChapterManagerImplTest {
     fun `observe chapter with invalid URL`() = runBlocking {
         val episode = PodcastEpisode("id", publishedDate = Date(), duration = 0.001)
         val dbChapter = DbChapter(
+            index = 0,
             episodeUuid = "id",
             startTimeMs = 0,
             endTimeMs = 1,
@@ -255,24 +263,28 @@ class ChapterManagerImplTest {
         val episode = PodcastEpisode("id", publishedDate = Date(), duration = 0.004, deselectedChapters = ChapterIndices(listOf(0, 3)))
         val dbChapters = listOf(
             DbChapter(
+                index = 0,
                 episodeUuid = "id",
                 startTimeMs = 0,
                 endTimeMs = 1,
                 title = "Title 1",
             ),
             DbChapter(
+                index = 1,
                 episodeUuid = "id",
                 startTimeMs = 1,
                 endTimeMs = 2,
                 title = "Title 2",
             ),
             DbChapter(
+                index = 2,
                 episodeUuid = "id",
                 startTimeMs = 2,
                 endTimeMs = 3,
                 title = "Title 3",
             ),
             DbChapter(
+                index = 3,
                 episodeUuid = "id",
                 startTimeMs = 3,
                 endTimeMs = 4,
@@ -325,18 +337,21 @@ class ChapterManagerImplTest {
         val episode = PodcastEpisode("id", publishedDate = Date(), duration = 0.003)
         val dbChapters = listOf(
             DbChapter(
+                index = 0,
                 episodeUuid = "id",
                 startTimeMs = 0,
                 endTimeMs = null,
                 title = "Title 1",
             ),
             DbChapter(
+                index = 1,
                 episodeUuid = "id",
                 startTimeMs = 1,
                 endTimeMs = 2,
                 title = "Title 2",
             ),
             DbChapter(
+                index = 2,
                 episodeUuid = "id",
                 startTimeMs = 2,
                 endTimeMs = null,
@@ -382,12 +397,14 @@ class ChapterManagerImplTest {
         val episode = PodcastEpisode("id", publishedDate = Date(), duration = 0.003)
         val dbChapters = listOf(
             DbChapter(
+                index = 0,
                 episodeUuid = "id",
                 startTimeMs = 0,
                 endTimeMs = 3, // end time is larger than next start time
                 title = "Title 1",
             ),
             DbChapter(
+                index = 1,
                 episodeUuid = "id",
                 startTimeMs = 2,
                 endTimeMs = 3,
@@ -426,6 +443,7 @@ class ChapterManagerImplTest {
         val episode = PodcastEpisode("id", publishedDate = Date(), duration = 0.001)
         val episodesFlow = MutableStateFlow(episode)
         val dbChapter = DbChapter(
+            index = 0,
             episodeUuid = "id",
             startTimeMs = 0,
             endTimeMs = 1,
@@ -459,12 +477,14 @@ class ChapterManagerImplTest {
         val episode = PodcastEpisode("id", publishedDate = Date(), duration = 0.003)
         val dbChapters = listOf(
             DbChapter(
+                index = 0,
                 episodeUuid = "id",
                 startTimeMs = 0,
                 endTimeMs = 0,
                 title = "Title 1",
             ),
             DbChapter(
+                index = 1,
                 episodeUuid = "id",
                 startTimeMs = 1,
                 endTimeMs = 1,
@@ -503,12 +523,14 @@ class ChapterManagerImplTest {
         val episode = PodcastEpisode("id", publishedDate = Date(), duration = 0.003)
         val dbChapters = listOf(
             DbChapter(
+                index = 0,
                 episodeUuid = "id",
                 startTimeMs = 0,
                 endTimeMs = -2,
                 title = "Title 1",
             ),
             DbChapter(
+                index = 1,
                 episodeUuid = "id",
                 startTimeMs = 1,
                 endTimeMs = 1,
@@ -547,30 +569,35 @@ class ChapterManagerImplTest {
         val episode = PodcastEpisode("id", publishedDate = Date(), duration = 0.003)
         val dbChapters = listOf(
             DbChapter(
+                index = 0,
                 episodeUuid = "id",
                 startTimeMs = 0,
                 endTimeMs = 0,
                 title = "Title 1",
             ),
             DbChapter(
+                index = 1,
                 episodeUuid = "id",
                 startTimeMs = 0,
                 endTimeMs = 0,
                 title = "Title 2",
             ),
             DbChapter(
+                index = 2,
                 episodeUuid = "id",
                 startTimeMs = 1,
                 endTimeMs = 1,
                 title = "Title 3",
             ),
             DbChapter(
+                index = 3,
                 episodeUuid = "id",
                 startTimeMs = 2,
                 endTimeMs = 2,
                 title = "Title 4",
             ),
             DbChapter(
+                index = 4,
                 episodeUuid = "id",
                 startTimeMs = 2,
                 endTimeMs = 2,

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/ChapterManagerImplTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/ChapterManagerImplTest.kt
@@ -57,6 +57,7 @@ class ChapterManagerImplTest {
         chapterManager.observerChaptersForEpisode("id").test {
             val expected = Chapter(
                 index = 0,
+                uiIndex = 1,
                 title = "Title",
                 startTime = 0.milliseconds,
                 endTime = 1.milliseconds,
@@ -104,6 +105,7 @@ class ChapterManagerImplTest {
             val expected = listOf(
                 Chapter(
                     index = 0,
+                    uiIndex = 1,
                     title = "Title 1",
                     startTime = 0.milliseconds,
                     endTime = 1.milliseconds,
@@ -111,13 +113,15 @@ class ChapterManagerImplTest {
                 ),
                 Chapter(
                     index = 1,
+                    uiIndex = 2,
                     title = "Title 2",
                     startTime = 1.milliseconds,
                     endTime = 2.milliseconds,
                     selected = true,
                 ),
                 Chapter(
-                    index = 2,
+                    index = 3,
+                    uiIndex = 3,
                     title = "Title 3",
                     startTime = 2.milliseconds,
                     endTime = 3.milliseconds,
@@ -149,6 +153,7 @@ class ChapterManagerImplTest {
         chapterManager.observerChaptersForEpisode("id").test {
             val expected = Chapter(
                 index = 0,
+                uiIndex = 1,
                 title = "",
                 startTime = 0.milliseconds,
                 endTime = 1.milliseconds,
@@ -166,7 +171,7 @@ class ChapterManagerImplTest {
     fun `observe chapter without image URL`() = runBlocking {
         val episode = PodcastEpisode("id", publishedDate = Date(), duration = 0.001)
         val dbChapter = DbChapter(
-            index = 1,
+            index = 0,
             episodeUuid = "id",
             startTimeMs = 0,
             endTimeMs = 1,
@@ -181,6 +186,7 @@ class ChapterManagerImplTest {
         chapterManager.observerChaptersForEpisode("id").test {
             val expected = Chapter(
                 index = 0,
+                uiIndex = 1,
                 title = "Title",
                 startTime = 0.milliseconds,
                 endTime = 1.milliseconds,
@@ -213,6 +219,7 @@ class ChapterManagerImplTest {
         chapterManager.observerChaptersForEpisode("id").test {
             val expected = Chapter(
                 index = 0,
+                uiIndex = 1,
                 title = "Title",
                 startTime = 0.milliseconds,
                 endTime = 1.milliseconds,
@@ -245,6 +252,7 @@ class ChapterManagerImplTest {
         chapterManager.observerChaptersForEpisode("id").test {
             val expected = Chapter(
                 index = 0,
+                uiIndex = 1,
                 title = "Title",
                 startTime = 0.milliseconds,
                 endTime = 1.milliseconds,
@@ -299,6 +307,7 @@ class ChapterManagerImplTest {
             val expected = listOf(
                 Chapter(
                     index = 0,
+                    uiIndex = 1,
                     title = "Title 1",
                     startTime = 0.milliseconds,
                     endTime = 1.milliseconds,
@@ -306,6 +315,7 @@ class ChapterManagerImplTest {
                 ),
                 Chapter(
                     index = 1,
+                    uiIndex = 2,
                     title = "Title 2",
                     startTime = 1.milliseconds,
                     endTime = 2.milliseconds,
@@ -313,6 +323,7 @@ class ChapterManagerImplTest {
                 ),
                 Chapter(
                     index = 2,
+                    uiIndex = 3,
                     title = "Title 3",
                     startTime = 2.milliseconds,
                     endTime = 3.milliseconds,
@@ -320,6 +331,7 @@ class ChapterManagerImplTest {
                 ),
                 Chapter(
                     index = 3,
+                    uiIndex = 4,
                     title = "Title 4",
                     startTime = 3.milliseconds,
                     endTime = 4.milliseconds,
@@ -366,6 +378,7 @@ class ChapterManagerImplTest {
             val expected = listOf(
                 Chapter(
                     index = 0,
+                    uiIndex = 1,
                     title = "Title 1",
                     startTime = 0.milliseconds,
                     endTime = 1.milliseconds,
@@ -373,6 +386,7 @@ class ChapterManagerImplTest {
                 ),
                 Chapter(
                     index = 1,
+                    uiIndex = 2,
                     title = "Title 2",
                     startTime = 1.milliseconds,
                     endTime = 2.milliseconds,
@@ -380,6 +394,7 @@ class ChapterManagerImplTest {
                 ),
                 Chapter(
                     index = 2,
+                    uiIndex = 3,
                     title = "Title 3",
                     startTime = 2.milliseconds,
                     endTime = 3.milliseconds,
@@ -419,6 +434,7 @@ class ChapterManagerImplTest {
             val expected = listOf(
                 Chapter(
                     index = 0,
+                    uiIndex = 1,
                     title = "Title 1",
                     startTime = 0.milliseconds,
                     endTime = 2.milliseconds,
@@ -426,6 +442,7 @@ class ChapterManagerImplTest {
                 ),
                 Chapter(
                     index = 1,
+                    uiIndex = 2,
                     title = "Title 2",
                     startTime = 2.milliseconds,
                     endTime = 3.milliseconds,
@@ -456,6 +473,7 @@ class ChapterManagerImplTest {
         chapterManager.observerChaptersForEpisode("id").test {
             val expectedSelected = Chapter(
                 index = 0,
+                uiIndex = 1,
                 title = "Title",
                 startTime = 0.milliseconds,
                 endTime = 1.milliseconds,
@@ -499,6 +517,7 @@ class ChapterManagerImplTest {
             val expected = listOf(
                 Chapter(
                     index = 0,
+                    uiIndex = 1,
                     title = "Title 1",
                     startTime = 0.milliseconds,
                     endTime = 1.milliseconds,
@@ -506,6 +525,7 @@ class ChapterManagerImplTest {
                 ),
                 Chapter(
                     index = 1,
+                    uiIndex = 2,
                     title = "Title 2",
                     startTime = 1.milliseconds,
                     endTime = 3.milliseconds,
@@ -545,6 +565,7 @@ class ChapterManagerImplTest {
             val expected = listOf(
                 Chapter(
                     index = 0,
+                    uiIndex = 1,
                     title = "Title 1",
                     startTime = 0.milliseconds,
                     endTime = 1.milliseconds,
@@ -552,6 +573,7 @@ class ChapterManagerImplTest {
                 ),
                 Chapter(
                     index = 1,
+                    uiIndex = 2,
                     title = "Title 2",
                     startTime = 1.milliseconds,
                     endTime = 3.milliseconds,
@@ -611,21 +633,24 @@ class ChapterManagerImplTest {
         chapterManager.observerChaptersForEpisode("id").test {
             val expected = listOf(
                 Chapter(
-                    index = 0,
+                    index = 1,
+                    uiIndex = 1,
                     title = "Title 2",
                     startTime = 0.milliseconds,
                     endTime = 1.milliseconds,
                     selected = true,
                 ),
                 Chapter(
-                    index = 1,
+                    index = 2,
+                    uiIndex = 2,
                     title = "Title 3",
                     startTime = 1.milliseconds,
                     endTime = 2.milliseconds,
                     selected = true,
                 ),
                 Chapter(
-                    index = 2,
+                    index = 4,
+                    uiIndex = 3,
                     title = "Title 5",
                     startTime = 2.milliseconds,
                     endTime = 3.milliseconds,

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/podcast/ShowNotesResponse.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/podcast/ShowNotesResponse.kt
@@ -40,6 +40,7 @@ data class ShowNotesChapter(
     @Json(name = "title") val title: String? = null,
     @Json(name = "img") val image: String? = null,
     @Json(name = "url") val url: String? = null,
+    @Json(name = "toc") val useInTableOfContents: Boolean? = null,
 )
 
 @JsonClass(generateAdapter = true)


### PR DESCRIPTION
## Description

This PR introduces filtering out chapters that should not be in the table of contents. See [the specification](https://github.com/Podcastindex-org/podcast-namespace/blob/main/chapters/jsonChapters.md) for more details.

The implementation relies on splitting real index and UI index. Real index is stored and is always used for syncing pre-selected chapters. While UI index is computed on-the-fly after we filter out all invalid chapters, etc.

In the database migration I had to delete all cached remote chapters as we don't have information whether such chapters should be displayed or not.

Fixes #3480

## Testing Instructions

1. Install the app from the `main` branch.
2. Subscribe to the [No Agenda](https://pca.st/noagenda) podcast.
3. Play the [1728 - "Hatchet Man" - No Agenda](https://pca.st/uxlj8oi0) episode.
4. See chapters.
5. Deselect a chapter like `X sats from Y`.
6. Close the app.
7. Install the app from `task/chaptes-toc` branch.
8. Go back to the chapters from the 4th step.
9. Verify that you don't see `X sats from Y` chapters and no chapters got de-selected.

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [ ] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [ ] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~