### PR TITLE
[Podcast Feed Update] Hide pull to refresh behind feature flag

### DIFF
--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastFragment.kt
@@ -627,6 +627,8 @@ class PodcastFragment : BaseFragment(), Toolbar.OnMenuItemClickListener {
 
         loadData()
 
+        binding.swipeRefreshLayout.isEnabled = FeatureFlag.isEnabled(Feature.PODCAST_FEED_UPDATE)
+
         binding.toolbar.let {
             it.inflateMenu(R.menu.podcast_menu)
             it.setOnMenuItemClickListener(this)


### PR DESCRIPTION
## Description
- This hides the swipe to refresh icon behind a feature flag. We were only hiding the refresh button. 
- I am disabling this for 7.82 and we will enable it in 7.83 instead

## Testing Instructions
1. Have `Podcast Feed Update` feature flag disabled
2. Go to Podcast page
3. Ensure you can't pull down to refresh
4. Open more options
5. Ensure you don't see the refresh episode list button
6. Have `Podcast Feed Update` feature flag enabled
2. Go to Podcast page
3. Ensure you can pull down to refresh
4. Open more options
5. Ensure you see the refresh episode list button


## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] ~I have considered whether it makes sense to add tests for my changes~
- [ ] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [ ] ~Any jetpack compose components I added or changed are covered by compose previews~
- [ ] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~
