### PR TITLE
Update proguard-rules.pro

### DIFF
--- a/proguard-rules.pro
+++ b/proguard-rules.pro
@@ -31,7 +31,7 @@
 }
 
 # Do not optimize PlaybackService class.
-# It causes na issue where the media notification is not displayed in some cases.
+# It causes an issue where the media notification is not displayed in some cases.
 # https://github.com/shiftyjelly/pocketcasts-android/issues/1656
 # https://github.com/shiftyjelly/pocketcasts-android/pulls/2921
 -keep,allowobfuscation,allowshrinking class au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackService { *; }


### PR DESCRIPTION
fixed typo. 

## Description

Changes `na` to `an` in the comment

Fixes https://github.com/Automattic/pocket-casts-android/issues/3421

## Testing Instructions
 
N/A


## Checklist
- [na] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [na ] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [na] I have considered whether it makes sense to add tests for my changes
- [na] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [na] Any jetpack compose components I added or changed are covered by compose previews
- [na] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
