### PR TITLE
[Podcast Update Feed] Add Tooltip

### DIFF
--- a/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
+++ b/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
@@ -996,6 +996,10 @@ class MainActivity :
         return binding.snackbarFragment
     }
 
+    override fun setFullScreenDarkOverlayViewVisibility(visible: Boolean) {
+        binding.fullScreenDarkOverlayView.isVisible = visible
+    }
+
     override fun onMiniPlayerHidden() {
         updateSnackbarPosition(miniPlayerOpen = false)
         settings.updateBottomInset(0)

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -66,7 +66,7 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent" />
 
-    <androidx.coordinatorlayout.widget.CoordinatorLayout
+    <View
         android:id="@+id/fullScreenDarkOverlayView"
         android:layout_width="match_parent"
         android:layout_height="match_parent"

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -66,6 +66,13 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent" />
 
+    <androidx.coordinatorlayout.widget.CoordinatorLayout
+        android:id="@+id/fullScreenDarkOverlayView"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:background="#80000000"
+        android:visibility="gone" />
+
     <au.com.shiftyjelly.pocketcasts.views.component.RadioactiveLineView
         android:id="@+id/radioactiveLineView"
         android:layout_width="match_parent"

--- a/automotive/src/main/java/au/com/shiftyjelly/pocketcasts/AutomotiveSettingsActivity.kt
+++ b/automotive/src/main/java/au/com/shiftyjelly/pocketcasts/AutomotiveSettingsActivity.kt
@@ -116,6 +116,9 @@ class AutomotiveSettingsActivity : AppCompatActivity(), FragmentHostListener {
         return findViewById(android.R.id.content)
     }
 
+    override fun setFullScreenDarkOverlayViewVisibility(visible: Boolean) {
+    }
+
     override fun showAccountUpgradeNow(autoSelectPlus: Boolean) {
     }
 

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastAdapter.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastAdapter.kt
@@ -446,10 +446,10 @@ class PodcastAdapter(
         }
     }
 
-    fun setPodcast(podcast: Podcast) {
+    fun setPodcast(podcast: Podcast, forceHeaderExpanded: Boolean? = null) {
         // expand the podcast description and details if the user hasn't subscribed
         if (this.podcast.uuid != podcast.uuid) {
-            headerExpanded = !podcast.isSubscribed
+            headerExpanded = forceHeaderExpanded ?: !podcast.isSubscribed
             ratingsViewModel.loadRatings(podcast.uuid)
             ratingsViewModel.refreshPodcastRatings(podcast.uuid)
             onHeaderSummaryToggled(headerExpanded, false)

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastFragment.kt
@@ -751,7 +751,7 @@ class PodcastFragment : BaseFragment(), Toolbar.OnMenuItemClickListener {
         binding?.composeTooltipHost?.setContent {
             AppTheme(theme.activeTheme) {
                 val shouldShow by viewModel.shouldShowPodcastTooltip.collectAsState()
-                AnimatedVisibility(visible = shouldShow && tooltipEnabled) {
+                AnimatedVisibility(visible = shouldShow && tooltipEnabled && FeatureFlag.isEnabled(Feature.PODCAST_FEED_UPDATE)) {
                     PodcastTooltip(
                         title = stringResource(LR.string.podcast_feed_update_tooltip_title),
                         subtitle = stringResource(LR.string.podcast_feed_update_tooltip_subtitle),
@@ -784,7 +784,7 @@ class PodcastFragment : BaseFragment(), Toolbar.OnMenuItemClickListener {
 
     private fun configureTooltip() {
         lifecycleScope.launch {
-            delay(500)
+            delay(1.seconds) // Delay to wait the recyclerview to be configured
 
             val headerPositionInList = 2 // See: au.com.shiftyjelly.pocketcasts.podcasts.view.podcast.PodcastAdapter.setEpisodes
 

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastFragment.kt
@@ -756,8 +756,12 @@ class PodcastFragment : BaseFragment(), Toolbar.OnMenuItemClickListener {
                         title = stringResource(LR.string.podcast_feed_update_tooltip_title),
                         subtitle = stringResource(LR.string.podcast_feed_update_tooltip_subtitle),
                         offset = tooltipOffset,
+                        onTooltipShown = {
+                            analyticsTracker.track(AnalyticsEvent.PODCAST_REFRESH_EPISODE_TOOLTIP_SHOWN)
+                        },
                         onDismissRequest = {},
                         onCloseButtonClick = {
+                            analyticsTracker.track(AnalyticsEvent.PODCAST_REFRESH_EPISODE_TOOLTIP_DISMISSED)
                             viewModel.hidePodcastRefreshTooltip()
                         },
                     )

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastFragment.kt
@@ -769,6 +769,7 @@ class PodcastFragment : BaseFragment(), Toolbar.OnMenuItemClickListener {
                         },
                         onDismissRequest = {
                             (activity as? FragmentHostListener)?.setFullScreenDarkOverlayViewVisibility(false)
+                            viewModel.hidePodcastRefreshTooltip()
                             canShowTooltip = false
                         },
                         onCloseButtonClick = {

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastFragment.kt
@@ -8,7 +8,6 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.widget.Toolbar
-import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -751,16 +750,21 @@ class PodcastFragment : BaseFragment(), Toolbar.OnMenuItemClickListener {
         binding?.composeTooltipHost?.setContent {
             AppTheme(theme.activeTheme) {
                 val shouldShow by viewModel.shouldShowPodcastTooltip.collectAsState()
-                AnimatedVisibility(visible = shouldShow && tooltipEnabled && FeatureFlag.isEnabled(Feature.PODCAST_FEED_UPDATE)) {
+                if (shouldShow && tooltipEnabled && FeatureFlag.isEnabled(Feature.PODCAST_FEED_UPDATE)) {
                     PodcastTooltip(
                         title = stringResource(LR.string.podcast_feed_update_tooltip_title),
                         subtitle = stringResource(LR.string.podcast_feed_update_tooltip_subtitle),
                         offset = tooltipOffset,
                         onTooltipShown = {
+                            (activity as? FragmentHostListener)?.setFullScreenDarkOverlayViewVisibility(true)
                             analyticsTracker.track(AnalyticsEvent.PODCAST_REFRESH_EPISODE_TOOLTIP_SHOWN)
                         },
-                        onDismissRequest = {},
+                        onDismissRequest = {
+                            (activity as? FragmentHostListener)?.setFullScreenDarkOverlayViewVisibility(false)
+                            tooltipEnabled = false
+                        },
                         onCloseButtonClick = {
+                            (activity as? FragmentHostListener)?.setFullScreenDarkOverlayViewVisibility(false)
                             analyticsTracker.track(AnalyticsEvent.PODCAST_REFRESH_EPISODE_TOOLTIP_DISMISSED)
                             viewModel.hidePodcastRefreshTooltip()
                         },

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastFragment.kt
@@ -814,7 +814,7 @@ class PodcastFragment : BaseFragment(), Toolbar.OnMenuItemClickListener {
         tooltipComposeView.getLocationOnScreen(composeLocation)
 
         val anchorX = anchorLocation[0] - composeLocation[0] + (view.width / 2)
-        var anchorY = anchorLocation[1] - composeLocation[1] - 350
+        var anchorY = anchorLocation[1] - composeLocation[1] - 360
 
         if (anchorY < 0) {
             anchorY = 0

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastTooltip.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastTooltip.kt
@@ -26,6 +26,7 @@ import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.window.Popup
+import au.com.shiftyjelly.pocketcasts.compose.CallOnce
 import au.com.shiftyjelly.pocketcasts.compose.components.TextH40
 import au.com.shiftyjelly.pocketcasts.compose.components.TextH70
 import au.com.shiftyjelly.pocketcasts.compose.theme
@@ -36,11 +37,16 @@ fun PodcastTooltip(
     title: String,
     subtitle: String,
     offset: IntOffset,
+    onTooltipShown: () -> Unit,
     onDismissRequest: () -> Unit,
     onCloseButtonClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val tooltipColor = MaterialTheme.theme.colors.primaryUi01
+
+    CallOnce {
+        onTooltipShown.invoke()
+    }
 
     Popup(
         alignment = Alignment.TopStart,

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastTooltip.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastTooltip.kt
@@ -1,0 +1,128 @@
+package au.com.shiftyjelly.pocketcasts.podcasts.view.podcast
+
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxScope
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.Card
+import androidx.compose.material.Icon
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.compose.ui.window.Popup
+import au.com.shiftyjelly.pocketcasts.compose.components.TextH40
+import au.com.shiftyjelly.pocketcasts.compose.components.TextH70
+import au.com.shiftyjelly.pocketcasts.compose.theme
+import au.com.shiftyjelly.pocketcasts.localization.R as LR
+
+@Composable
+fun PodcastTooltip(
+    title: String,
+    subtitle: String,
+    offset: IntOffset,
+    onDismissRequest: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val tooltipColor = MaterialTheme.theme.colors.primaryUi01
+
+    Popup(
+        alignment = Alignment.TopStart,
+        offset = offset,
+        onDismissRequest = onDismissRequest,
+    ) {
+        Box(
+            modifier = modifier.padding(24.dp).widthIn(max = 400.dp),
+        ) {
+            TooltipContent(tooltipColor, title, subtitle, onDismissRequest)
+
+            TooltipArrow(tooltipColor)
+        }
+    }
+}
+
+@Composable
+private fun TooltipContent(
+    tooltipColor: Color,
+    title: String,
+    subtitle: String,
+    onDismissRequest: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Card(
+        backgroundColor = tooltipColor,
+        elevation = 8.dp,
+        shape = RoundedCornerShape(8.dp),
+        modifier = modifier,
+    ) {
+        Row(
+            modifier = Modifier.padding(16.dp),
+            verticalAlignment = Alignment.Top,
+        ) {
+            Column(
+                modifier = Modifier.weight(1f),
+            ) {
+                TextH40(
+                    text = title,
+                    modifier = Modifier.padding(bottom = 4.dp),
+                )
+
+                TextH70(
+                    text = subtitle,
+                    fontSize = 12.sp,
+                    color = MaterialTheme.theme.colors.primaryText02,
+                )
+            }
+
+            Spacer(modifier = Modifier.width(12.dp))
+
+            Icon(
+                imageVector = Icons.Default.Close,
+                contentDescription = stringResource(LR.string.close),
+                tint = MaterialTheme.theme.colors.primaryIcon02,
+                modifier = Modifier
+                    .align(Alignment.Top)
+                    .width(24.dp)
+                    .clickable {
+                        onDismissRequest.invoke()
+                    },
+            )
+        }
+    }
+}
+
+@Composable
+private fun BoxScope.TooltipArrow(tooltipColor: Color) {
+    Canvas(
+        modifier = Modifier
+            .align(Alignment.BottomEnd)
+            .padding(end = 28.dp),
+    ) {
+        val triangleSize = 12.dp.toPx()
+
+        drawPath(
+            path = Path().apply {
+                moveTo(0f, -2f)
+                lineTo(triangleSize, 0f)
+                lineTo(triangleSize / 2f, triangleSize)
+                close()
+            },
+            color = tooltipColor,
+        )
+    }
+}

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastTooltip.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastTooltip.kt
@@ -1,6 +1,7 @@
 package au.com.shiftyjelly.pocketcasts.podcasts.view.podcast
 
 import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxScope
@@ -27,8 +28,8 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.window.Popup
 import au.com.shiftyjelly.pocketcasts.compose.CallOnce
-import au.com.shiftyjelly.pocketcasts.compose.components.TextH40
-import au.com.shiftyjelly.pocketcasts.compose.components.TextH70
+import au.com.shiftyjelly.pocketcasts.compose.components.TextH30
+import au.com.shiftyjelly.pocketcasts.compose.components.TextP40
 import au.com.shiftyjelly.pocketcasts.compose.theme
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
@@ -54,7 +55,7 @@ fun PodcastTooltip(
         onDismissRequest = onDismissRequest,
     ) {
         Box(
-            modifier = modifier.padding(24.dp).widthIn(max = 400.dp),
+            modifier = modifier.background(Color.Transparent).padding(16.dp).widthIn(max = 400.dp),
         ) {
             TooltipContent(tooltipColor, title, subtitle, onCloseButtonClick)
 
@@ -73,23 +74,23 @@ private fun TooltipContent(
 ) {
     Card(
         backgroundColor = tooltipColor,
-        elevation = 8.dp,
         shape = RoundedCornerShape(8.dp),
+        elevation = 0.dp,
         modifier = modifier,
     ) {
         Row(
-            modifier = Modifier.padding(16.dp),
+            modifier = Modifier.background(tooltipColor).padding(16.dp),
             verticalAlignment = Alignment.Top,
         ) {
             Column(
                 modifier = Modifier.weight(1f),
             ) {
-                TextH40(
+                TextH30(
                     text = title,
                     modifier = Modifier.padding(bottom = 4.dp),
                 )
 
-                TextH70(
+                TextP40(
                     text = subtitle,
                     fontSize = 12.sp,
                     color = MaterialTheme.theme.colors.primaryText02,

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastTooltip.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastTooltip.kt
@@ -37,6 +37,7 @@ fun PodcastTooltip(
     subtitle: String,
     offset: IntOffset,
     onDismissRequest: () -> Unit,
+    onCloseButtonClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val tooltipColor = MaterialTheme.theme.colors.primaryUi01
@@ -49,7 +50,7 @@ fun PodcastTooltip(
         Box(
             modifier = modifier.padding(24.dp).widthIn(max = 400.dp),
         ) {
-            TooltipContent(tooltipColor, title, subtitle, onDismissRequest)
+            TooltipContent(tooltipColor, title, subtitle, onCloseButtonClick)
 
             TooltipArrow(tooltipColor)
         }
@@ -61,7 +62,7 @@ private fun TooltipContent(
     tooltipColor: Color,
     title: String,
     subtitle: String,
-    onDismissRequest: () -> Unit,
+    onCloseButtonClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Card(
@@ -99,7 +100,7 @@ private fun TooltipContent(
                     .align(Alignment.Top)
                     .width(24.dp)
                     .clickable {
-                        onDismissRequest.invoke()
+                        onCloseButtonClick.invoke()
                     },
             )
         }

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/PodcastViewModel.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/PodcastViewModel.kt
@@ -60,6 +60,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.launch
@@ -101,6 +102,8 @@ class PodcastViewModel
 
     private val _refreshState = MutableSharedFlow<RefreshState>()
     val refreshState = _refreshState.asSharedFlow()
+
+    val shouldShowPodcastTooltip = MutableStateFlow(settings.showPodcastRefreshTooltip.value)
 
     val groupedEpisodes: MutableLiveData<List<List<PodcastEpisode>>> = MutableLiveData()
     val signInState = userManager.getSignInState().toLiveData()
@@ -590,6 +593,11 @@ class PodcastViewModel
             analyticsTracker.track(AnalyticsEvent.PODCAST_SCREEN_REFRESH_NO_EPISODES_FOUND, mapOf("podcast_uuid" to podcast.uuid, "action" to refreshType.analyticsValue))
             _refreshState.emit(RefreshState.NoEpisodesFound)
         }
+    }
+
+    fun hidePodcastRefreshTooltip() {
+        settings.showPodcastRefreshTooltip.set(false, updateModifiedAt = false)
+        shouldShowPodcastTooltip.value = false
     }
 
     private fun trackEpisodeBulkEvent(event: AnalyticsEvent, count: Int) {

--- a/modules/features/podcasts/src/main/res/layout/fragment_podcast.xml
+++ b/modules/features/podcasts/src/main/res/layout/fragment_podcast.xml
@@ -105,6 +105,12 @@
             android:scaleType="centerCrop"
             tools:src="@tools:sample/avatars" />
 
+        <androidx.compose.ui.platform.ComposeView
+            android:id="@+id/composeTooltipHost"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            />
+
     </FrameLayout>
 
 </LinearLayout>

--- a/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
+++ b/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
@@ -232,6 +232,8 @@ enum class AnalyticsEvent(val key: String) {
     PODCAST_SCREEN_REFRESH_EPISODE_LIST("podcast_screen_refresh_episode_list"),
     PODCAST_SCREEN_REFRESH_NEW_EPISODE_FOUND("podcast_screen_refresh_new_episode_found"),
     PODCAST_SCREEN_REFRESH_NO_EPISODES_FOUND("podcast_screen_refresh_no_episodes_found"),
+    PODCAST_REFRESH_EPISODE_TOOLTIP_SHOWN("podcast_refresh_episode_tooltip_shown"),
+    PODCAST_REFRESH_EPISODE_TOOLTIP_DISMISSED("podcast_refresh_episode_tooltip_dismissed"),
 
     /* Podcast Settings */
     PODCAST_SETTINGS_FEED_ERROR_TAPPED("podcast_settings_feed_error_tapped"),

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -566,6 +566,8 @@
     <string name="podcast_group_unplayed" translatable="false">@string/unplayed</string>
     <string name="podcast_hide_archived">Hide archived</string>
     <string name="podcast_load_error">There was an error loading the podcast.</string>
+    <string name="podcast_feed_update_tooltip_title">Fresh episodes, coming right up!</string>
+    <string name="podcast_feed_update_tooltip_subtitle">Pull down or use this menu to see if there\'s something new.</string>
     <string name="podcast_loading">Loading your podcasts</string>
     <string name="podcast_next_episode_any_day_now">Next episode any day now</string>
     <string name="podcast_next_episode_today">Next episode today</string>

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
@@ -119,6 +119,8 @@ interface Settings {
         const val AUTOMOTIVE_CONNECTED_TO_MEDIA_SESSION = "automotive_connected_to_media_session"
 
         const val SHOW_REFERRALS_TOOLTIP = "show_referrals_tooltip"
+
+        const val SHOW_PODCAST_REFRESH_TOOLTIP = "show_podcast_refresh_tooltip"
     }
 
     enum class NotificationChannel(val id: String) {
@@ -555,6 +557,8 @@ interface Settings {
     fun setAutomotiveConnectedToMediaSession(isLoaded: Boolean)
 
     val showReferralsTooltip: UserSetting<Boolean>
+
+    val showPodcastRefreshTooltip: UserSetting<Boolean>
 
     val playerOrUpNextBottomSheetState: Flow<Int>
     fun updatePlayerOrUpNextBottomSheetState(state: Int)

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
@@ -1536,6 +1536,12 @@ class SettingsImpl @Inject constructor(
         sharedPrefs = sharedPreferences,
     )
 
+    override val showPodcastRefreshTooltip: UserSetting<Boolean> = UserSetting.BoolPref(
+        sharedPrefKey = Settings.SHOW_PODCAST_REFRESH_TOOLTIP,
+        defaultValue = true,
+        sharedPrefs = sharedPreferences,
+    )
+
     override val referralClaimCode = UserSetting.StringPref(
         sharedPrefKey = "referralCode",
         defaultValue = "",

--- a/modules/services/ui/src/main/java/au/com/shiftyjelly/pocketcasts/ui/helper/FragmentHostListener.kt
+++ b/modules/services/ui/src/main/java/au/com/shiftyjelly/pocketcasts/ui/helper/FragmentHostListener.kt
@@ -21,6 +21,7 @@ interface FragmentHostListener {
     fun openPodcastPage(uuid: String, sourceView: String? = null)
     fun openCloudFiles()
     fun snackBarView(): View
+    fun setFullScreenDarkOverlayViewVisibility(visible: Boolean)
     fun showAccountUpgradeNow(autoSelectPlus: Boolean)
     fun updateStatusBar()
     fun getPlayerBottomSheetState(): Int


### PR DESCRIPTION
## Description
- This adds the tooltip for podcast update feed
- While I was testing I noticed that the tooltip is not being displayed in a very specific scenario:
   1. Small device
   2. The user did not dismiss the tooltip yet
   3. and open a podcast that does not follow
- This is happening because we are aligning the tooltip with the more options button, which is not visible. I asked David about this here: p1738863222122779/1738285496.288959-slack-C088RDU8HAN
- See: p1738782693924129/1738285496.288959-slack-C088RDU8HAN

## Testing Instructions

### Feature flag disabled
1. Have the podcast update feed feature flag disabled
2. Open an podcast
3. You should not see the tooltip

### Feature flag enabled
1. Have the podcast update feed feature flag enabled
5. Open an podcast
6. If the more options button is visible, you should see the tooltip
7. Tap out of the tooltip
8. The tooltip should be closed
9. Go to Discover
10. Back to this podcast you have just opened
11. You should see the tooltip again
12. Dismiss the tooltip by tapping on close button
13. Go to Discover
14. Open the podcast again
15. You should not see the tooltip

## Screenshots or Screencast 
[Screen_recording_20250206_150940.webm](https://github.com/user-attachments/assets/82fa9691-93bd-47f9-9b3d-fad3350453ab)


## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack