### PR TITLE
[Tooling] Fix incorrect call to `copy_branch_protection`

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -139,7 +139,7 @@ platform :android do
     trigger_release_build(branch_to_build: "release/#{new_version}")
     create_backmerge_pr
 
-    copy_branch_protection(repository: GITHUB_REPO, branch: "release/#{new_version}", from_branch: DEFAULT_BRANCH)
+    copy_branch_protection(repository: GITHUB_REPO, from_branch: DEFAULT_BRANCH, to_branch: "release/#{new_version}")
 
     begin
       # Move PRs to next milestone


### PR DESCRIPTION
Fix syntax error in the PR https://github.com/Automattic/pocket-casts-android/pull/3562 I just landed.

I shouldn't have trusted Cursor's autocomplete suggestion… 🤦 