### PR TITLE
Reload Winback offer after subscription plan changes

### DIFF
--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/winback/WinbackViewModel.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/winback/WinbackViewModel.kt
@@ -337,8 +337,10 @@ class WinbackViewModel @Inject constructor(
     }
 
     private fun UiState.applyWinbackResponse(response: WinbackResponse?): UiState {
+        val activePurchase = (subscriptionPlansState as? SubscriptionPlansState.Loaded)?.activePurchase
         return copy(
             winbackOfferState = response
+                ?.takeIf { activePurchase != null }
                 ?.toWinbackOffer(productsDetails)
                 ?.let(::WinbackOfferState),
         )

--- a/modules/features/profile/src/test/kotlin/au/com/shiftyjelly/pocketcasts/profile/winback/WinbackViewModelTest.kt
+++ b/modules/features/profile/src/test/kotlin/au/com/shiftyjelly/pocketcasts/profile/winback/WinbackViewModelTest.kt
@@ -348,10 +348,7 @@ class WinbackViewModelTest {
             assertNull(changedPlanState.winbackOfferState)
 
             winbackManager.addWinbackResponse(winbackResponse)
-            assertEquals(
-                "offer-token-${Subscription.PLUS_MONTHLY_PRODUCT_ID}",
-                awaitOfferState().offer.offerToken,
-            )
+            expectNoEvents()
         }
     }
 

--- a/modules/features/profile/src/test/kotlin/au/com/shiftyjelly/pocketcasts/profile/winback/WinbackViewModelTest.kt
+++ b/modules/features/profile/src/test/kotlin/au/com/shiftyjelly/pocketcasts/profile/winback/WinbackViewModelTest.kt
@@ -245,10 +245,18 @@ class WinbackViewModelTest {
             val newPurchase = createPurchase(orderId = "new-purchase")
             winbackManager.addPurchases(listOf(newPurchase))
             winbackManager.addPurchaseEvent(PurchaseEvent.Success)
-            val state = awaitLoadedState()
 
-            assertFalse(state.isChangingPlan)
-            assertEquals(state.activePurchase, ActivePurchase(newPurchase.orderId!!, newPurchase.products[0]))
+            val changedPlanState = awaitItem()
+            val plansState = changedPlanState.subscriptionPlansState as SubscriptionPlansState.Loaded
+            assertFalse(plansState.isChangingPlan)
+            assertEquals(plansState.activePurchase, ActivePurchase(newPurchase.orderId!!, newPurchase.products[0]))
+            assertNull(changedPlanState.winbackOfferState)
+
+            winbackManager.addWinbackResponse(winbackResponse)
+            assertEquals(
+                "offer-token-${Subscription.PLUS_MONTHLY_PRODUCT_ID}",
+                awaitOfferState().offer.offerToken,
+            )
         }
     }
 
@@ -335,8 +343,15 @@ class WinbackViewModelTest {
             winbackManager.addPurchases(emptyList())
             winbackManager.addPurchaseEvent(PurchaseEvent.Success)
 
-            val state = awaitItem().subscriptionPlansState
-            assertTrue(state is SubscriptionPlansState.Failure)
+            val changedPlanState = awaitItem()
+            assertTrue(changedPlanState.subscriptionPlansState is SubscriptionPlansState.Failure)
+            assertNull(changedPlanState.winbackOfferState)
+
+            winbackManager.addWinbackResponse(winbackResponse)
+            assertEquals(
+                "offer-token-${Subscription.PLUS_MONTHLY_PRODUCT_ID}",
+                awaitOfferState().offer.offerToken,
+            )
         }
     }
 
@@ -896,6 +911,7 @@ class WinbackViewModelTest {
         viewModel.changePlan(knownPlan, mock())
 
         winbackManager.addPurchase(createPurchase(productIds = listOf(Subscription.PLUS_MONTHLY_PRODUCT_ID)))
+        winbackManager.addWinbackResponse(null)
         winbackManager.addPurchaseEvent(PurchaseEvent.Success)
 
         assertEquals(


### PR DESCRIPTION
## Description

This PR adds Winback offer reloading when subscription plan changes. It is needed because we do not close the flow and different plans have different offers.

## Testing Instructions

1. Apply this [winback.patch](https://github.com/user-attachments/files/18671187/winback.patch).
2. Install the `debugProd` variant of the app.
3. Sign in with an account without a subscription.
4. If it is a new account wait for 3 minutes to make it old enough in the staging environment to make it eligible for the Winback offer.
5. Subscribe to any plan.
6. Go to the account details.
7. Tap on "Cancel subscription".
8. You should see a Winback offer. Remember its details.
9. Tap on the plan change row.
10. Change your subscription to any different plan. Preferably with a different billing cycle.
11. Go back to the main Winback offer screen.
12. You should see updated Winback offer.

## Checklist
- [ ] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [ ] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [ ] ~Any jetpack compose components I added or changed are covered by compose previews~
- [ ] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~