### PR TITLE
Load media notification images using Coil

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 *   Bug Fixes
     *   Fix missing episodes with unfollowed podcasts
         ([#3546](https://github.com/Automattic/pocket-casts-android/pull/3546))
+    *   Fix Media Notification artwork caching issues
+        ([#3566](https://github.com/Automattic/pocket-casts-android/pull/3566))
 *   Updates
     *   Filter out chapters that do not belong in table of contents. See [the specification](https://github.com/Podcastindex-org/podcast-namespace/blob/main/chapters/jsonChapters.md) for more details.
         ([#3556](https://github.com/Automattic/pocket-casts-android/pull/3556))


### PR DESCRIPTION
## Description

This PR changes the source of files for the Media Notification. Previously, we were using two separate sources:

1. `Coil` for general-purpose use of artwork inside the app.
2. `OkHttp` to fetch images inside the Content Provider when the Media Notification requested images.

I removed the direct usage of `OkHttp` and ensured that `Coil` is always the source of truth. This has two main benefits:

- **Fewer network HTTP requests** due to a shared cache.
- **Consistent podcast artwork.** Previously, multiple caches could get out of sync, causing issues like #3564. For example, when we performed artwork cleanup from the Appearance settings, the `OkHttp` cache wasn’t cleared. It wasn’t even easy to do so since we didn’t use a custom directory for it.

Fixes #1529  
Fixes #3564  

## Testing Instructions

### General Behavior

Smoke test the general artwork behavior. Pay special attention to the Media Notification and the lock screen.

### Cache Update

1. Subscribe to [my testing podcast](https://anchor.fm/s/f68090c0/podcast/rss).
2. Play any episode.
3. Pause in the middle of it.
4. In [Nodeweb](https://nodeweb.pocketcasts.com/admin/podcasts/5283175), set a manual override for the podcast artwork.
5. Refresh the Nodeweb page and ensure that the updated artwork is displayed.
6. Return to the Android app.
7. Go to `Settings > Appearance > Refresh all podcast artwork`.
8. Wait a bit.
9. Resume the episode.
10. Verify that the Media Notification and the lock screen display the updated artwork.  
    **Note:** The mini player artwork doesn’t refresh automatically, as the image is cached for the episode. If you play another episode, it should update there as well.
11. Reset the artwork in Nodeweb.

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] ~I have considered whether it makes sense to add tests for my changes~
- [ ] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [ ] ~Any jetpack compose components I added or changed are covered by compose previews~
- [ ] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~