### PR TITLE
 [Suggested Folders] Update flow for free users

### DIFF
--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/folders/SuggestedFoldersPaywallBottomSheet.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/folders/SuggestedFoldersPaywallBottomSheet.kt
@@ -6,6 +6,7 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.FrameLayout
 import androidx.core.view.doOnLayout
+import androidx.fragment.app.viewModels
 import androidx.fragment.compose.content
 import au.com.shiftyjelly.pocketcasts.compose.AppTheme
 import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingFlow
@@ -24,6 +25,8 @@ class SuggestedFoldersPaywallBottomSheet : BottomSheetDialogFragment() {
     @Inject
     lateinit var theme: Theme
 
+    private val viewModel: SuggestedFoldersPaywallViewModel by viewModels<SuggestedFoldersPaywallViewModel>()
+
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
@@ -38,6 +41,7 @@ class SuggestedFoldersPaywallBottomSheet : BottomSheetDialogFragment() {
                     OnboardingLauncher.openOnboardingFlow(activity, onboardingFlow)
                 },
                 onMaybeLater = {
+                    viewModel.dismissModal()
                     dismiss()
                 },
             )

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/folders/SuggestedFoldersPaywallViewModel.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/folders/SuggestedFoldersPaywallViewModel.kt
@@ -1,0 +1,16 @@
+package au.com.shiftyjelly.pocketcasts.podcasts.view.folders
+
+import androidx.lifecycle.ViewModel
+import au.com.shiftyjelly.pocketcasts.preferences.Settings
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+
+@HiltViewModel
+class SuggestedFoldersPaywallViewModel @Inject constructor(
+    private val settings: Settings,
+) : ViewModel() {
+
+    fun dismissModal() {
+        settings.suggestedFolderPaywallDismissTime.set(System.currentTimeMillis(), updateModifiedAt = false)
+    }
+}

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcasts/PodcastsFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcasts/PodcastsFragment.kt
@@ -224,6 +224,28 @@ class PodcastsFragment : BaseFragment(), FolderAdapter.ClickListener, PodcastTou
         return binding.root
     }
 
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        viewLifecycleOwner.lifecycleScope.launch {
+            viewModel.fetchSuggestedFolders()
+        }
+
+        viewLifecycleOwner.lifecycleScope.launch {
+            viewModel.userSuggestedFoldersState.collect { (signInState, suggestedFoldersState) ->
+                when (suggestedFoldersState) {
+                    PodcastsViewModel.SuggestedFoldersState.Loaded -> {
+                        if (viewModel.showSuggestedFoldersPaywallOnOpen(signInState.isSignedInAsPlusOrPatron)) {
+                            SuggestedFoldersPaywallBottomSheet().show(parentFragmentManager, "suggested_folders_paywall")
+                        }
+                    }
+                    PodcastsViewModel.SuggestedFoldersState.Fetching -> {}
+                    is PodcastsViewModel.SuggestedFoldersState.Error -> {}
+                }
+            }
+        }
+    }
+
     override fun onDestroyView() {
         listState = binding.recyclerView.layoutManager?.onSaveInstanceState()
         binding.recyclerView.adapter = null

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/PodcastsViewModel.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/PodcastsViewModel.kt
@@ -226,7 +226,7 @@ class PodcastsViewModel
                 }
             }
         } catch (ex: IndexOutOfBoundsException) {
-            Timber.e("Move folder item failed.", ex)
+            Timber.e("Move folder item failed: $ex")
         }
 
         return adapterState.toList()
@@ -305,7 +305,7 @@ class PodcastsViewModel
     }
 
     fun showSuggestedFoldersPaywallOnOpen(isSignedInAsPlusOrPatron: Boolean) =
-        FeatureFlag.isEnabled(Feature.SUGGESTED_FOLDERS) && !isSignedInAsPlusOrPatron
+        FeatureFlag.isEnabled(Feature.SUGGESTED_FOLDERS) && !isSignedInAsPlusOrPatron && settings.suggestedFolderPaywallDismissTime.value == 0L
 
     sealed class SuggestedFoldersState {
         data object Fetching : SuggestedFoldersState()

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
@@ -335,6 +335,8 @@ interface Settings {
 
     val hideNotificationOnPause: UserSetting<Boolean>
 
+    val suggestedFolderPaywallDismissTime: UserSetting<Long>
+
     val streamingMode: UserSetting<Boolean>
     val keepScreenAwake: UserSetting<Boolean>
     val openPlayerAutomatically: UserSetting<Boolean>

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
@@ -555,6 +555,12 @@ class SettingsImpl @Inject constructor(
         sharedPrefs = sharedPreferences,
     )
 
+    override val suggestedFolderPaywallDismissTime = UserSetting.LongPref(
+        sharedPrefKey = "globalAutoDownloadNewEpisodes",
+        defaultValue = 0L,
+        sharedPrefs = sharedPreferences,
+    )
+
     override val streamingMode: UserSetting<Boolean> = UserSetting.BoolPref(
         sharedPrefKey = Settings.PREFERENCE_GLOBAL_STREAMING_MODE,
         defaultValue = true,

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
@@ -556,7 +556,7 @@ class SettingsImpl @Inject constructor(
     )
 
     override val suggestedFolderPaywallDismissTime = UserSetting.LongPref(
-        sharedPrefKey = "globalAutoDownloadNewEpisodes",
+        sharedPrefKey = "suggestedFolderPaywallDismissTime",
         defaultValue = 0L,
         sharedPrefs = sharedPreferences,
     )


### PR DESCRIPTION
## Description
- This PR displays the modal for free and logged-out users when opening the podcasts screen. Since we are not fetching the suggested folders from server yet, I am mocking 2 seconds of fetching and then display the modal.
- I am ignoring if the user follows any podcasts for now, so they can see the modal even if does not follow a podcast. I will update this later
- See: pdeCcb-8AH-p2

Fixes #3572

## Testing Instructions

### Free and Logged-Out Users
1. Have the feature flag ON
2. Go to Podcasts tab
3. Wait for 2 seconds (mock)
4. Ensure you **see** the Suggested Folder Paywall modal ✅
5. Tap on Maybe Later Button
6. Go to another screen
7. Back to Podcasts tab again
8. Ensure you **don't see** the Suggested Folder Paywall modal anymore ✅
9. Tap to create a folder in folder toolbar icon
10. Ensure you **see** the Suggested Folder Paywall modal ✅
11. Repeat he test above with the feature flag OFF and ensure you don't see the modal

### Paid Users
1. Have the feature flag ON
2. Log with a paid account
3. Go to Podcasts tab
4. Wait for 2 seconds (mock)
5. Ensure you **don't see** the Suggested Folder Paywall modal ✅
6. Tap to create a folder in folder toolbar icon
7. Ensure you see the screen with suggested folders ✅


## Screenshots or Screencast 
<!-- if applicable -->

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.