### PR TITLE
Fix: Page becomes unresponsive after seeing an offer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
         ([#3546](https://github.com/Automattic/pocket-casts-android/pull/3546))
     *   Fix Media Notification artwork caching issues
         ([#3566](https://github.com/Automattic/pocket-casts-android/pull/3566))
+    *   Fix issue causing the Account Details page to become unresponsive after viewing an offer
+        ([#3574](https://github.com/Automattic/pocket-casts-android/pull/3574))
 *   Updates
     *   Filter out chapters that do not belong in table of contents. See [the specification](https://github.com/Podcastindex-org/podcast-namespace/blob/main/chapters/jsonChapters.md) for more details.
         ([#3556](https://github.com/Automattic/pocket-casts-android/pull/3556))

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeFlow.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeFlow.kt
@@ -101,6 +101,15 @@ fun OnboardingUpgradeFlow(
         }
     }
 
+    LaunchedEffect(sheetState.currentValue) {
+        // We need to check if the screen was initialized with the expanded state.
+        // Otherwise, the sheet will never be shown since the initial state is Hidden.
+        // This will trigger this event, and onBackPressed will be called.
+        if (sheetState.currentValue == ModalBottomSheetValue.Hidden && startSelectPaymentFrequencyInExpandedState) {
+            onBackPressed()
+        }
+    }
+
     BackHandler {
         if (sheetState.isVisible) {
             coroutineScope.launch { sheetState.hide() }


### PR DESCRIPTION
## Description
- Fix the unresponsive issue after seeing the upgrade modal bottom sheet

Fixes #3462

## Testing Instructions

See the issue's video here: https://github.com/Automattic/pocket-casts-android/issues/3462

### Issue

1. Log in with free account
2. Go to Profile -> Account
3. Tap on Subscribe button
4. See the upgrade modal bottom sheet
5. Tap out of the modal to close it
6. Ensure you can interact with the screen ✅
7. Open the modal again
8. Press device back button
9. Ensure you can interact with the screen ✅

### Smoke test
Smoke test the paywalls, open the paywalls from different sources and ensure they continue working as expected ✅

## Screenshots or Screencast 
[Screen_recording_20250210_143727.webm](https://github.com/user-attachments/assets/099d396a-7a70-4470-a0d7-63aee64f3c73)

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
