### PR TITLE
Make sharing default 4th shelf action

### DIFF
--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/model/ShelfRowItem.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/model/ShelfRowItem.kt
@@ -37,12 +37,13 @@ enum class ShelfItem(
         showIf = { it is PodcastEpisode },
         analyticsValue = "star_episode",
     ),
-    Transcript(
-        id = "transcript",
-        titleId = { LR.string.transcript },
-        iconId = { IR.drawable.ic_transcript_24 },
+    Share(
+        id = "share",
+        titleId = { LR.string.podcast_share_episode },
+        subtitleId = { episode -> LR.string.player_actions_hidden_for_custom.takeIf { episode is UserEpisode } },
+        iconId = { IR.drawable.ic_share },
         showIf = { it is PodcastEpisode },
-        analyticsValue = "transcript",
+        analyticsValue = "share_episode",
     ),
     Download(
         id = "download",
@@ -64,13 +65,12 @@ enum class ShelfItem(
         showIf = { it is PodcastEpisode },
         analyticsValue = "download",
     ),
-    Share(
-        id = "share",
-        titleId = { LR.string.podcast_share_episode },
-        subtitleId = { episode -> LR.string.player_actions_hidden_for_custom.takeIf { episode is UserEpisode } },
-        iconId = { IR.drawable.ic_share },
+    Transcript(
+        id = "transcript",
+        titleId = { LR.string.transcript },
+        iconId = { IR.drawable.ic_transcript_24 },
         showIf = { it is PodcastEpisode },
-        analyticsValue = "share_episode",
+        analyticsValue = "transcript",
     ),
     Podcast(
         id = "podcast",


### PR DESCRIPTION
## Description
<!-- Please include a summary of what this PR is changing and why these changes are needed. -->

Fixes #3540

## Testing Instructions

1. Install the app from `main`.
2. Play something.
3. Change your shelf items order.
4. Install the app from `task/default-share` branch.
5. Go to the player. Notice that the order of shelf items has not changed.
6. Clear app data.
7. Start the app.
8. Play something.
9. Notice that sharing is the 4th item in the shelf.

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] ~I have considered whether it makes sense to add tests for my changes~
- [ ] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [ ] ~Any jetpack compose components I added or changed are covered by compose previews~
- [ ] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~