### PR TITLE
Do not scroll episode artwork settings app bar

### DIFF
--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/EpisodeArtworkConfigurationFragment.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/EpisodeArtworkConfigurationFragment.kt
@@ -16,9 +16,11 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.res.dimensionResource
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.unit.Dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTracker
 import au.com.shiftyjelly.pocketcasts.compose.AppThemeWithBackground
@@ -35,7 +37,6 @@ import au.com.shiftyjelly.pocketcasts.views.fragments.BaseFragment
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
-import au.com.shiftyjelly.pocketcasts.ui.R as UR
 
 @AndroidEntryPoint
 class EpisodeArtworkConfigurationFragment : BaseFragment() {
@@ -51,6 +52,8 @@ class EpisodeArtworkConfigurationFragment : BaseFragment() {
         savedInstanceState: Bundle?,
     ) = contentWithoutConsumedInsets {
         val sortedElements = remember { ArtworkConfiguration.Element.entries.sortedBy { getString(it.titleId) } }
+        val bottomInset by settings.bottomInset.collectAsStateWithLifecycle(initialValue = 0)
+
         AppThemeWithBackground(theme.activeTheme) {
             val artworkConfiguration by settings.artworkConfiguration.flow.collectAsState()
 
@@ -61,6 +64,7 @@ class EpisodeArtworkConfigurationFragment : BaseFragment() {
             EpisodeArtworkSettings(
                 artworkConfiguration = artworkConfiguration,
                 elements = sortedElements,
+                bottomInset = LocalDensity.current.run { bottomInset.toDp() },
                 onUpdateConfiguration = { configuration ->
                     if (artworkConfiguration.useEpisodeArtwork != configuration.useEpisodeArtwork) {
                         analyticsTracker.track(AnalyticsEvent.SETTINGS_ADVANCED_EPISODE_ARTWORK_USE_EPISODE_ARTWORK_TOGGLED, mapOf("enabled" to configuration.useEpisodeArtwork))
@@ -79,6 +83,7 @@ class EpisodeArtworkConfigurationFragment : BaseFragment() {
     private fun EpisodeArtworkSettings(
         artworkConfiguration: ArtworkConfiguration,
         elements: List<ArtworkConfiguration.Element>,
+        bottomInset: Dp,
         onUpdateConfiguration: (ArtworkConfiguration) -> Unit,
         onBackPressed: () -> Unit,
     ) {
@@ -106,7 +111,7 @@ class EpisodeArtworkConfigurationFragment : BaseFragment() {
                     }
                 }
                 Spacer(
-                    modifier = Modifier.height(dimensionResource(UR.dimen.mini_player_height)),
+                    modifier = Modifier.height(bottomInset),
                 )
             }
         }

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/EpisodeArtworkConfigurationFragment.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/EpisodeArtworkConfigurationFragment.kt
@@ -83,30 +83,32 @@ class EpisodeArtworkConfigurationFragment : BaseFragment() {
         onBackPressed: () -> Unit,
     ) {
         Column(
-            modifier = Modifier
-                .background(MaterialTheme.theme.colors.primaryUi02)
-                .verticalScroll(rememberScrollState()),
+            modifier = Modifier.background(MaterialTheme.theme.colors.primaryUi02),
         ) {
             ThemedTopAppBar(
                 title = stringResource(LR.string.settings_use_episode_artwork_title),
                 onNavigationClick = onBackPressed,
                 bottomShadow = true,
             )
-            SettingSection {
-                UseEpisodeArtwork(artworkConfiguration, onUpdateConfiguration)
-            }
-            SettingSection(
-                heading = stringResource(LR.string.settings_use_episode_artwork_customization_section),
-                subHeading = stringResource(LR.string.settings_use_episode_artwork_customization_description),
-                showDivider = false,
+            Column(
+                modifier = Modifier.verticalScroll(rememberScrollState()),
             ) {
-                elements.forEach { element ->
-                    ArtworkElement(artworkConfiguration, element, onUpdateConfiguration)
+                SettingSection {
+                    UseEpisodeArtwork(artworkConfiguration, onUpdateConfiguration)
                 }
+                SettingSection(
+                    heading = stringResource(LR.string.settings_use_episode_artwork_customization_section),
+                    subHeading = stringResource(LR.string.settings_use_episode_artwork_customization_description),
+                    showDivider = false,
+                ) {
+                    elements.forEach { element ->
+                        ArtworkElement(artworkConfiguration, element, onUpdateConfiguration)
+                    }
+                }
+                Spacer(
+                    modifier = Modifier.height(dimensionResource(UR.dimen.mini_player_height)),
+                )
             }
-            Spacer(
-                modifier = Modifier.height(dimensionResource(UR.dimen.mini_player_height)),
-            )
         }
     }
 


### PR DESCRIPTION
## Description

Episode Artwork settings app bar was scrollable making it inaccessible when scrolled up and hidden behind notification status bar.

Fixes #3567

## Testing Instructions

1. Increase font size so that Episode Artwork screen doesn't fit in a single screen.
2. Go to the settings.
3. Go to the Appearance page.
4. Go to the Advanced episode artwork.
5. Scroll content.
6. Notice that the the app bar does not scroll with the content.

## Checklist
- [ ] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] ~I have considered whether it makes sense to add tests for my changes~
- [ ] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [ ] ~Any jetpack compose components I added or changed are covered by compose previews~
- [ ] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [ ] ~for accessibility with TalkBack~
