### PR TITLE
[CI] Fix Incorrect Duration of Buildkite Groups

### DIFF
--- a/.buildkite/shared-pipeline-vars
+++ b/.buildkite/shared-pipeline-vars
@@ -3,4 +3,4 @@
 # This file is `source`'d before calling `buildkite-agent pipeline upload`, and can be used
 # to set up some variables that will be interpolated in the `.yml` pipeline before uploading it.
 
-export CI_TOOLKIT="automattic/a8c-ci-toolkit#3.9.1"
+export CI_TOOLKIT="automattic/a8c-ci-toolkit#3.10.1"


### PR DESCRIPTION
## Description
<!-- Please include a summary of what this PR is changing and why these changes are needed. -->

This change fixes incorrect duration of buildkite groups by updating `a8c-ci-toolkit` to [3.10.1](https://github.com/Automattic/a8c-ci-toolkit-buildkite-plugin/releases/tag/3.10.1).

For more info see: [Do not echo three dashes at the end of restore cache script #146](https://github.com/Automattic/a8c-ci-toolkit-buildkite-plugin/pull/146)

---

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Tap on the Filters tab -->
<!-- 2. Tap on a filter -->
<!-- 3. etc. -->

- Verify that all the CI checks are successful.
- Verify that the duration of Buildkite groups is now correct.

---

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes... `N/A`
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
