### PR TITLE
[Suggested Folders] Add Tracks

### DIFF
--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/folders/FolderCreateFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/folders/FolderCreateFragment.kt
@@ -6,6 +6,7 @@ import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.compose.material.MaterialTheme
 import androidx.compose.ui.graphics.toArgb
+import androidx.core.os.bundleOf
 import androidx.fragment.app.activityViewModels
 import androidx.fragment.app.viewModels
 import androidx.navigation.NavHostController
@@ -14,6 +15,7 @@ import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
 import au.com.shiftyjelly.pocketcasts.compose.AppThemeWithBackground
+import au.com.shiftyjelly.pocketcasts.compose.CallOnce
 import au.com.shiftyjelly.pocketcasts.compose.extensions.contentWithoutConsumedInsets
 import au.com.shiftyjelly.pocketcasts.compose.theme
 import au.com.shiftyjelly.pocketcasts.podcasts.view.folders.FolderEditViewModel.Companion.COLOR_KEY
@@ -31,11 +33,26 @@ class FolderCreateFragment : BaseDialogFragment() {
     private val sharedViewModel: FolderCreateSharedViewModel by activityViewModels()
     private var navHostController: NavHostController? = null
 
+    companion object {
+        const val ARG_SOURCE = "ARG_SOURCE"
+
+        fun newInstance(source: String): FolderCreateFragment {
+            return FolderCreateFragment().apply {
+                arguments = bundleOf(
+                    ARG_SOURCE to source,
+                )
+            }
+        }
+    }
+
     private object NavRoutes {
         const val podcasts = "folder_podcasts"
         const val name = "folder_name"
         const val color = "folder_color"
     }
+
+    private val source: String
+        get() = arguments?.getString(ARG_SOURCE) ?: ""
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -43,6 +60,10 @@ class FolderCreateFragment : BaseDialogFragment() {
         savedInstanceState: Bundle?,
     ) = contentWithoutConsumedInsets {
         AppThemeWithBackground(theme.activeTheme) {
+            CallOnce {
+                viewModel.trackShown(source)
+            }
+
             navHostController = rememberNavController()
             val navController = navHostController ?: return@AppThemeWithBackground
             NavHost(navController = navController, startDestination = NavRoutes.podcasts) {

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/folders/FolderEditViewModel.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/folders/FolderEditViewModel.kt
@@ -314,6 +314,10 @@ class FolderEditViewModel
         }
     }
 
+    fun trackShown(source: String) {
+        analyticsTracker.track(AnalyticsEvent.FOLDER_CREATE_SHOWN, mapOf("source" to source))
+    }
+
     companion object {
         private const val SORT_ORDER_KEY = "sort_order"
         private const val NUMBER_OF_PODCASTS_KEY = "number_of_podcasts"

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/folders/SuggestedFolders.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/folders/SuggestedFolders.kt
@@ -14,7 +14,8 @@ import javax.inject.Inject
 @AndroidEntryPoint
 class SuggestedFolders : BaseDialogFragment() {
 
-    @Inject lateinit var analyticsTracker: AnalyticsTracker
+    @Inject
+    lateinit var analyticsTracker: AnalyticsTracker
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -23,11 +24,18 @@ class SuggestedFolders : BaseDialogFragment() {
     ) = contentWithoutConsumedInsets {
         AppThemeWithBackground(theme.activeTheme) {
             SuggestedFoldersPage(
+                onShown = {
+                    analyticsTracker.track(AnalyticsEvent.SUGGESTED_FOLDERS_MODAL_SHOWN)
+                },
                 onDismiss = {
+                    analyticsTracker.track(AnalyticsEvent.SUGGESTED_FOLDERS_MODAL_DISMISSED)
                     dismiss()
                 },
-                onUseTheseFolders = {},
+                onUseTheseFolders = {
+                    analyticsTracker.track(AnalyticsEvent.SUGGESTED_FOLDERS_MODAL_USE_THESE_FOLDERS_TAPPED)
+                },
                 onCreateCustomFolders = {
+                    analyticsTracker.track(AnalyticsEvent.SUGGESTED_FOLDERS_MODAL_CREATE_CUSTOM_FOLDERS_TAPPED)
                     analyticsTracker.track(AnalyticsEvent.FOLDER_CREATE_SHOWN, mapOf("source" to "suggested_folders"))
                     FolderCreateFragment().show(parentFragmentManager, "create_folder_card")
                     dismiss()

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/folders/SuggestedFolders.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/folders/SuggestedFolders.kt
@@ -36,8 +36,7 @@ class SuggestedFolders : BaseDialogFragment() {
                 },
                 onCreateCustomFolders = {
                     analyticsTracker.track(AnalyticsEvent.SUGGESTED_FOLDERS_MODAL_CREATE_CUSTOM_FOLDERS_TAPPED)
-                    analyticsTracker.track(AnalyticsEvent.FOLDER_CREATE_SHOWN, mapOf("source" to "suggested_folders"))
-                    FolderCreateFragment().show(parentFragmentManager, "create_folder_card")
+                    FolderCreateFragment.newInstance(source = "suggested_folders").show(parentFragmentManager, "create_folder_card")
                     dismiss()
                 },
             )

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/folders/SuggestedFolders.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/folders/SuggestedFolders.kt
@@ -3,19 +3,16 @@ package au.com.shiftyjelly.pocketcasts.podcasts.view.folders
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.ViewGroup
-import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
-import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTracker
+import androidx.fragment.app.viewModels
 import au.com.shiftyjelly.pocketcasts.compose.AppThemeWithBackground
 import au.com.shiftyjelly.pocketcasts.compose.extensions.contentWithoutConsumedInsets
 import au.com.shiftyjelly.pocketcasts.views.fragments.BaseDialogFragment
 import dagger.hilt.android.AndroidEntryPoint
-import javax.inject.Inject
 
 @AndroidEntryPoint
 class SuggestedFolders : BaseDialogFragment() {
 
-    @Inject
-    lateinit var analyticsTracker: AnalyticsTracker
+    private val viewModel: SuggestedFoldersViewModel by viewModels<SuggestedFoldersViewModel>()
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -25,17 +22,17 @@ class SuggestedFolders : BaseDialogFragment() {
         AppThemeWithBackground(theme.activeTheme) {
             SuggestedFoldersPage(
                 onShown = {
-                    analyticsTracker.track(AnalyticsEvent.SUGGESTED_FOLDERS_MODAL_SHOWN)
+                    viewModel.onShown()
                 },
                 onDismiss = {
-                    analyticsTracker.track(AnalyticsEvent.SUGGESTED_FOLDERS_MODAL_DISMISSED)
+                    viewModel.onDismissed()
                     dismiss()
                 },
                 onUseTheseFolders = {
-                    analyticsTracker.track(AnalyticsEvent.SUGGESTED_FOLDERS_MODAL_USE_THESE_FOLDERS_TAPPED)
+                    viewModel.onUseTheseFolders()
                 },
                 onCreateCustomFolders = {
-                    analyticsTracker.track(AnalyticsEvent.SUGGESTED_FOLDERS_MODAL_CREATE_CUSTOM_FOLDERS_TAPPED)
+                    viewModel.onCreateCustomFolders()
                     FolderCreateFragment.newInstance(source = "suggested_folders").show(parentFragmentManager, "create_folder_card")
                     dismiss()
                 },

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/folders/SuggestedFoldersPage.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/folders/SuggestedFoldersPage.kt
@@ -29,6 +29,7 @@ import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import au.com.shiftyjelly.pocketcasts.compose.AppTheme
+import au.com.shiftyjelly.pocketcasts.compose.CallOnce
 import au.com.shiftyjelly.pocketcasts.compose.buttons.RowButton
 import au.com.shiftyjelly.pocketcasts.compose.buttons.RowOutlinedButton
 import au.com.shiftyjelly.pocketcasts.compose.components.TextH10
@@ -42,11 +43,15 @@ import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 @Composable
 fun SuggestedFoldersPage(
+    onShown: () -> Unit,
     onDismiss: () -> Unit,
     onUseTheseFolders: () -> Unit,
     onCreateCustomFolders: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
+    CallOnce {
+        onShown.invoke()
+    }
     Column(
         modifier = modifier
             .fillMaxSize()
@@ -146,6 +151,7 @@ private fun SuggestedFoldersPagePreview(@PreviewParameter(ThemePreviewParameterP
             onDismiss = {},
             onUseTheseFolders = {},
             onCreateCustomFolders = {},
+            onShown = {},
         )
     }
 }

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/folders/SuggestedFoldersPaywall.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/folders/SuggestedFoldersPaywall.kt
@@ -35,6 +35,7 @@ import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import au.com.shiftyjelly.pocketcasts.compose.AppTheme
+import au.com.shiftyjelly.pocketcasts.compose.CallOnce
 import au.com.shiftyjelly.pocketcasts.compose.buttons.RowButton
 import au.com.shiftyjelly.pocketcasts.compose.buttons.RowOutlinedButton
 import au.com.shiftyjelly.pocketcasts.compose.components.TextH30
@@ -49,10 +50,15 @@ import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 @Composable
 fun SuggestedFoldersPaywall(
+    onShown: () -> Unit,
     onUseTheseFolders: () -> Unit,
     onMaybeLater: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
+    CallOnce {
+        onShown.invoke()
+    }
+
     Column(
         modifier = modifier
             .windowInsetsPadding(WindowInsets.safeDrawing.only(WindowInsetsSides.Horizontal))
@@ -146,6 +152,7 @@ private fun SuggestedFoldersPagePreview(@PreviewParameter(ThemePreviewParameterP
         SuggestedFoldersPaywall(
             onUseTheseFolders = {},
             onMaybeLater = {},
+            onShown = {},
         )
     }
 }

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/folders/SuggestedFoldersPaywallBottomSheet.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/folders/SuggestedFoldersPaywallBottomSheet.kt
@@ -34,13 +34,17 @@ class SuggestedFoldersPaywallBottomSheet : BottomSheetDialogFragment() {
     ) = content {
         AppTheme(theme.activeTheme) {
             SuggestedFoldersPaywall(
+                onShown = {
+                    viewModel.onShown()
+                },
                 onUseTheseFolders = {
+                    viewModel.onUseTheseFolders()
                     dismiss()
                     val onboardingFlow = OnboardingFlow.PlusAccountUpgrade(OnboardingUpgradeSource.FOLDERS)
                     OnboardingLauncher.openOnboardingFlow(activity, onboardingFlow)
                 },
                 onMaybeLater = {
-                    viewModel.dismissModal()
+                    viewModel.onMaybeLater()
                     dismiss()
                 },
             )

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/folders/SuggestedFoldersPaywallViewModel.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/folders/SuggestedFoldersPaywallViewModel.kt
@@ -1,6 +1,8 @@
 package au.com.shiftyjelly.pocketcasts.podcasts.view.folders
 
 import androidx.lifecycle.ViewModel
+import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
+import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTracker
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
@@ -8,9 +10,19 @@ import javax.inject.Inject
 @HiltViewModel
 class SuggestedFoldersPaywallViewModel @Inject constructor(
     private val settings: Settings,
+    private val analyticsTracker: AnalyticsTracker,
 ) : ViewModel() {
 
-    fun dismissModal() {
+    fun onMaybeLater() {
+        analyticsTracker.track(AnalyticsEvent.SUGGESTED_FOLDERS_PAYWALL_MODAL_MAYBE_LATER_TAPPED)
         settings.suggestedFolderPaywallDismissTime.set(System.currentTimeMillis(), updateModifiedAt = false)
+    }
+
+    fun onShown() {
+        analyticsTracker.track(AnalyticsEvent.SUGGESTED_FOLDERS_PAYWALL_MODAL_SHOWN)
+    }
+
+    fun onUseTheseFolders() {
+        analyticsTracker.track(AnalyticsEvent.SUGGESTED_FOLDERS_PAYWALL_MODAL_USE_THESE_FOLDERS_TAPPED)
     }
 }

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/folders/SuggestedFoldersViewModel.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/folders/SuggestedFoldersViewModel.kt
@@ -1,0 +1,29 @@
+package au.com.shiftyjelly.pocketcasts.podcasts.view.folders
+
+import androidx.lifecycle.ViewModel
+import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
+import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTracker
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+
+@HiltViewModel
+class SuggestedFoldersViewModel @Inject constructor(
+    private val analyticsTracker: AnalyticsTracker,
+) : ViewModel() {
+
+    fun onShown() {
+        analyticsTracker.track(AnalyticsEvent.SUGGESTED_FOLDERS_MODAL_SHOWN)
+    }
+
+    fun onDismissed() {
+        analyticsTracker.track(AnalyticsEvent.SUGGESTED_FOLDERS_MODAL_DISMISSED)
+    }
+
+    fun onUseTheseFolders() {
+        analyticsTracker.track(AnalyticsEvent.SUGGESTED_FOLDERS_MODAL_USE_THESE_FOLDERS_TAPPED)
+    }
+
+    fun onCreateCustomFolders() {
+        analyticsTracker.track(AnalyticsEvent.SUGGESTED_FOLDERS_MODAL_CREATE_CUSTOM_FOLDERS_TAPPED)
+    }
+}

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcasts/PodcastsFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcasts/PodcastsFragment.kt
@@ -316,8 +316,7 @@ class PodcastsFragment : BaseFragment(), FolderAdapter.ClickListener, PodcastTou
         if (FeatureFlag.isEnabled(Feature.SUGGESTED_FOLDERS)) {
             SuggestedFolders().show(parentFragmentManager, "suggested_folders")
         } else {
-            analyticsTracker.track(AnalyticsEvent.FOLDER_CREATE_SHOWN, mapOf(SOURCE_KEY to PODCASTS_LIST))
-            FolderCreateFragment().show(parentFragmentManager, "create_folder_card")
+            FolderCreateFragment.newInstance(PODCASTS_LIST).show(parentFragmentManager, "create_folder_card")
         }
     }
 

--- a/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
+++ b/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
@@ -739,4 +739,10 @@ enum class AnalyticsEvent(val key: String) {
     WINBACK_AVAILABLE_PLANS_NEW_PLAN_PURCHASE_SUCCESSFUL("winback_available_plans_new_plan_purchase_successful"),
     WINBACK_CANCEL_CONFIRMATION_STAY_BUTTON_TAPPED("winback_cancel_confirmation_stay_button_tapped"),
     WINBACK_CANCEL_CONFIRMATION_CANCEL_BUTTON_TAPPED("winback_cancel_confirmation_cancel_button_tapped"),
+
+    /* Suggested Folders */
+    SUGGESTED_FOLDERS_MODAL_SHOWN("suggested_folders_modal_shown"),
+    SUGGESTED_FOLDERS_MODAL_DISMISSED("suggested_folders_modal_dismissed"),
+    SUGGESTED_FOLDERS_MODAL_USE_THESE_FOLDERS_TAPPED("suggested_folders_modal_use_these_folders_tapped"),
+    SUGGESTED_FOLDERS_MODAL_CREATE_CUSTOM_FOLDERS_TAPPED("suggested_folders_modal_create_custom_folders_tapped"),
 }

--- a/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
+++ b/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
@@ -745,4 +745,7 @@ enum class AnalyticsEvent(val key: String) {
     SUGGESTED_FOLDERS_MODAL_DISMISSED("suggested_folders_modal_dismissed"),
     SUGGESTED_FOLDERS_MODAL_USE_THESE_FOLDERS_TAPPED("suggested_folders_modal_use_these_folders_tapped"),
     SUGGESTED_FOLDERS_MODAL_CREATE_CUSTOM_FOLDERS_TAPPED("suggested_folders_modal_create_custom_folders_tapped"),
+    SUGGESTED_FOLDERS_PAYWALL_MODAL_SHOWN("suggested_folders_paywall_modal_shown"),
+    SUGGESTED_FOLDERS_PAYWALL_MODAL_USE_THESE_FOLDERS_TAPPED("suggested_folders_paywall_modal_use_these_folders_tapped"),
+    SUGGESTED_FOLDERS_PAYWALL_MODAL_MAYBE_LATER_TAPPED("suggested_folders_paywall_modal_maybe_later_tapped"),
 }


### PR DESCRIPTION
## Description
- Adds tracks to suggested folders feature


## Testing Instructions
Verify events

### Free user
1. Log with free account
2. Open Podcasts tap 
3. See the suggested folder paywall and check the paywall events

### Paid user
1. Log with paid account
2. Open Podcasts tap 
3. Tap to create a folder
4. Check the suggested folders modal events

<img width="871" alt="image" src="https://github.com/user-attachments/assets/742ea0c6-9b76-4429-a9f9-d2cee809dadb" />

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
