### PR TITLE
Fix Sleep Timer end of episode when skip last is set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@
         ([#3460](https://github.com/Automattic/pocket-casts-android/pull/3460))
     *   Fix issue with playback stopping when using Pixel Buds actions.
         ([#3493](https://github.com/Automattic/pocket-casts-android/pull/3493))
+    *   Fix issue with sleep timer end of episode when has skip last set
+        ([#3582](https://github.com/Automattic/pocket-casts-android/pull/3582))
 *   Updates
     *   Remove audio and video clip sharing
         ([#3481](https://github.com/Automattic/pocket-casts-android/pull/3481))

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
@@ -1458,8 +1458,8 @@ open class PlaybackManager @Inject constructor(
             val podcast = playbackStateRelay.blockingFirst().podcast
             if (podcast != null && podcast.skipLastSecs > 0) {
                 pause(sourceView = SourceView.AUTO_PAUSE)
+                onPlayerPaused()
             }
-            onPlayerPaused()
 
             // jump back 5 seconds from the current time so when the player opens it doesn't complete before giving the user a chance to skip back
             player?.let {
@@ -2206,6 +2206,7 @@ open class PlaybackManager @Inject constructor(
             if (timeRemaining < skipLast) {
                 if (isSleepAfterEpisodeEnabled()) {
                     sleepEndOfEpisode(episode)
+                    episodeManager.markAsPlayedBlocking(episode, this, podcastManager)
                 } else {
                     statsManager.addTimeSavedAutoSkipping(timeRemaining.toLong() * 1000L)
                     episodeManager.markAsPlayedBlocking(episode, this, podcastManager)


### PR DESCRIPTION
## Description
- This was reported here: p1739368346370609-slack-C02A333D8LQ
- Sleep timer end of episode was not marking the episode as played when it has skip last set. This was causing an issue that the episode was not finishing as the number of episode expected

## Testing Instructions
1. Open a podcast and set a skip last time for it
2. Add some episodes to Up next from this podcast you set skip last
3. Play the first up next episode
4. Set sleep timer end of episode
5. Ensure the episode finishes according to the skip last set ✅
6. Ensure the sleep timer end of episode updates the remaining end of episode counter ✅

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [ ] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.