### PR TITLE
Fix Suggested Folders Crash

### DIFF
--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcasts/PodcastsFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcasts/PodcastsFragment.kt
@@ -13,7 +13,9 @@ import androidx.core.os.bundleOf
 import androidx.core.view.updatePadding
 import androidx.fragment.app.activityViewModels
 import androidx.fragment.app.viewModels
+import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
 import androidx.recyclerview.widget.GridLayoutManager
 import androidx.recyclerview.widget.ItemTouchHelper
 import androidx.recyclerview.widget.LinearLayoutManager
@@ -232,15 +234,18 @@ class PodcastsFragment : BaseFragment(), FolderAdapter.ClickListener, PodcastTou
         }
 
         viewLifecycleOwner.lifecycleScope.launch {
-            viewModel.userSuggestedFoldersState.collect { (signInState, suggestedFoldersState) ->
-                when (suggestedFoldersState) {
-                    PodcastsViewModel.SuggestedFoldersState.Loaded -> {
-                        if (viewModel.showSuggestedFoldersPaywallOnOpen(signInState.isSignedInAsPlusOrPatron)) {
-                            SuggestedFoldersPaywallBottomSheet().show(parentFragmentManager, "suggested_folders_paywall")
+            viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
+                viewModel.userSuggestedFoldersState.collect { (signInState, suggestedFoldersState) ->
+                    when (suggestedFoldersState) {
+                        PodcastsViewModel.SuggestedFoldersState.Loaded -> {
+                            if (viewModel.showSuggestedFoldersPaywallOnOpen(signInState.isSignedInAsPlusOrPatron)) {
+                                SuggestedFoldersPaywallBottomSheet().show(parentFragmentManager, "suggested_folders_paywall")
+                            }
                         }
+
+                        PodcastsViewModel.SuggestedFoldersState.Fetching -> {}
+                        is PodcastsViewModel.SuggestedFoldersState.Error -> {}
                     }
-                    PodcastsViewModel.SuggestedFoldersState.Fetching -> {}
-                    is PodcastsViewModel.SuggestedFoldersState.Error -> {}
                 }
             }
         }


### PR DESCRIPTION
## Description
- See: p1739448836612389-slack-C07J5LNP4SF

## Testing Instructions
1. Go to Podcasts tab
2. Ensure you don't see any crash

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.