### PR TITLE
[Podcast Update Feed] Do not show tooltip for new installations 

### DIFF
--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastTooltip.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastTooltip.kt
@@ -25,7 +25,6 @@ import androidx.compose.ui.graphics.Path
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import androidx.compose.ui.window.Popup
 import au.com.shiftyjelly.pocketcasts.compose.CallOnce
 import au.com.shiftyjelly.pocketcasts.compose.components.TextH30
@@ -92,7 +91,6 @@ private fun TooltipContent(
 
                 TextP40(
                     text = subtitle,
-                    fontSize = 12.sp,
                     color = MaterialTheme.theme.colors.primaryText02,
                 )
             }

--- a/modules/features/shared/src/main/java/au/com/shiftyjelly/pocketcasts/shared/AppLifecycleObserver.kt
+++ b/modules/features/shared/src/main/java/au/com/shiftyjelly/pocketcasts/shared/AppLifecycleObserver.kt
@@ -103,6 +103,9 @@ class AppLifecycleObserver constructor(
             // new installs default to not forcing up next to use the dark theme
             settings.useDarkUpNextTheme.set(false, updateModifiedAt = false)
 
+            // new installations default to not displaying the tooltip
+            settings.showPodcastRefreshTooltip.set(false, updateModifiedAt = false)
+
             when (getAppPlatform()) {
                 // do nothing because this already defaults to true for all users on automotive
                 AppPlatform.Automotive -> {}

--- a/modules/features/shared/src/test/java/au/com/shiftyjelly/pocketcasts/shared/AppLifecycleObserverTest.kt
+++ b/modules/features/shared/src/test/java/au/com/shiftyjelly/pocketcasts/shared/AppLifecycleObserverTest.kt
@@ -41,6 +41,8 @@ class AppLifecycleObserverTest {
 
     @Mock private lateinit var useUpNextDarkThemeSetting: UserSetting<Boolean>
 
+    @Mock private lateinit var showPodcastRefreshTooltipSetting: UserSetting<Boolean>
+
     @Mock private lateinit var autoDownloadOnFollowPodcastSetting: UserSetting<Boolean>
 
     @Mock private lateinit var appLifecycleAnalytics: AppLifecycleAnalytics
@@ -64,6 +66,7 @@ class AppLifecycleObserverTest {
         whenever(settings.autoPlayNextEpisodeOnEmpty).thenReturn(autoPlayNextEpisodeSetting)
         whenever(settings.autoDownloadOnFollowPodcast).thenReturn(autoDownloadOnFollowPodcastSetting)
         whenever(settings.useDarkUpNextTheme).thenReturn(useUpNextDarkThemeSetting)
+        whenever(settings.showPodcastRefreshTooltip).thenReturn(showPodcastRefreshTooltipSetting)
 
         whenever(appLifecycleOwner.lifecycle).thenReturn(appLifecycle)
 


### PR DESCRIPTION
## Description
- See: p1739457691184399/1738908720.486589-slack-C088RDU8HAN
- This also addresses this minor request to update the font size: https://github.com/Automattic/pocket-casts-android/pull/3561/files/84b8428794c0395982232b44ebd17e924b606bd9#r1951700152

## Testing Instructions
1. Fresh install the app
2. Open a podcast
3. Ensure you don't see the tooltip ✅
4. Remove the app and install from `release/7.82` branch
5. Log in with an account
6. Close the app
7. Install from `update/tooltip-rule` branch
8. Open a podcast
9. Ensure you see the tooltip ✅

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.