### PR TITLE
[Tooling] Fix `finalize_release` and the `release/*` branch checkout

### DIFF
--- a/.buildkite/commands/checkout-release-branch.sh
+++ b/.buildkite/commands/checkout-release-branch.sh
@@ -1,0 +1,19 @@
+#!/bin/bash -eu
+
+# Script to checkout a specific release branch
+# Usage: ./checkout-release-branch.sh <RELEASE_VERSION>
+
+# Buildkite, by default, checks out a specific commit, ending up in a detached HEAD state.
+# But in some cases, we need to ensure to be checked out on the `release/*` branch instead, namely:
+# - When a `release-pipelines/*.yml` will end up needing to do a `git push` to the `release/*` branch (for version bumps)
+# - When doing a new `release-build.sh` from a job that was `pipeline upload`'d by such a pipeline,
+#   to ensure that the job doing the build would include that recent extra commit before starting doing the build.
+
+echo "--- :git: Checkout Release Branch"
+
+RELEASE_VERSION="${1:?RELEASE_VERSION parameter missing}"
+BRANCH_NAME="release/${RELEASE_VERSION}"
+
+git fetch origin "$BRANCH_NAME"
+git checkout "$BRANCH_NAME"
+git pull

--- a/.buildkite/commands/release-build.sh
+++ b/.buildkite/commands/release-build.sh
@@ -1,15 +1,6 @@
 #!/bin/bash -eu
 
-echo "--- :git: Checkout Release Branch"
-# Buildkite, by default, checks out a specific commit. But given this step will be run on a CI build that will
-# first push a commit to do the version bump, before `pipeline upload`-ing the job calling this script, we need
-# to checkout the `release/` branch explicitly here, to ensure this job would include that extra commit
-# instead of running on the initial commit the whole CI build/pipeline was initially triggered on.
-RELEASE_VERSION="${1:?RELEASE_VERSION parameter missing}"
-BRANCH_NAME="release/${RELEASE_VERSION}"
-git fetch origin "$BRANCH_NAME"
-git checkout "$BRANCH_NAME"
-git pull
+"$(dirname "${BASH_SOURCE[0]}")/checkout-release-branch.sh" "$RELEASE_VERSION"
 
 echo "--- :rubygems: Setting up Gems"
 install_gems

--- a/.buildkite/release-pipelines/finalize-hotfix-release.yml
+++ b/.buildkite/release-pipelines/finalize-hotfix-release.yml
@@ -9,6 +9,8 @@ steps:
       echo '--- 🤖 Use bot for Git operations'
       source use-bot-for-git
 
+      .buildkite/commands/checkout-release-branch.sh "${RELEASE_VERSION}"
+
       echo '--- :ruby: Setup Ruby Tools'
       install_gems
 

--- a/.buildkite/release-pipelines/finalize-release.yml
+++ b/.buildkite/release-pipelines/finalize-release.yml
@@ -9,6 +9,8 @@ steps:
       echo '--- 🤖 Use bot for Git operations'
       source use-bot-for-git
 
+      .buildkite/commands/checkout-release-branch.sh "${RELEASE_VERSION}"
+
       echo '--- :ruby: Setup Ruby Tools'
       install_gems
 

--- a/.buildkite/release-pipelines/new-beta-release.yml
+++ b/.buildkite/release-pipelines/new-beta-release.yml
@@ -9,6 +9,8 @@ steps:
       echo '--- 🤖 Use bot for Git operations'
       source use-bot-for-git
 
+      .buildkite/commands/checkout-release-branch.sh "${RELEASE_VERSION}"
+
       echo '--- :ruby: Setup Ruby Tools'
       install_gems
 

--- a/.buildkite/release-pipelines/new-hotfix-release.yml
+++ b/.buildkite/release-pipelines/new-hotfix-release.yml
@@ -11,6 +11,8 @@ steps:
       echo '--- 🤖 Use bot for Git operations'
       source use-bot-for-git
 
+      .buildkite/commands/checkout-release-branch.sh "${RELEASE_VERSION}"
+
       echo '--- :ruby: Setup Ruby Tools'
       install_gems
 


### PR DESCRIPTION
# Why?

During release process we need the lanes invoked from the `release-pipelines/*.yml` and that will require to do a `git push` to the release branch to actually `git fetch` + `git checkout` those release branches explicitly, otherwise the `git push` will fail (e.g. unknown `refspec`)

# How

 - We still need to checkout the `release/*` branch before the compilation in `release-build.sh`, because we want to ensure that we include the latest commit that was just pushed by the `new_beta_release` / `finalize_release` lanes from previous job, instead of building the commit that the CI build was initially created on
 - But we **also** need to checkout the `release/*` in `release-pipelines/*.yml` before calling any of the lanes that would do a version bump and push the commit, otherwise it won't try to do the commit on the branch but on the detached HEAD.

# Links

Internal ref: p1739547154659529/1739543498.075849-slack-CC7L49W13
iOS Counterpart: https://github.com/Automattic/pocket-casts-ios/pull/2754