### PR TITLE
[Suggested Folders] Open upgrade screen instead of bottom sheet modal

### DIFF
--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/OnboardingFlowComposable.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/OnboardingFlowComposable.kt
@@ -226,6 +226,7 @@ private fun Content(
                 OnboardingUpgradeSource.END_OF_YEAR,
                 OnboardingUpgradeSource.FILES,
                 OnboardingUpgradeSource.FOLDERS,
+                OnboardingUpgradeSource.SUGGESTED_FOLDERS,
                 OnboardingUpgradeSource.FOLDERS_PODCAST_SCREEN,
                 OnboardingUpgradeSource.HEADPHONE_CONTROLS_SETTINGS,
                 OnboardingUpgradeSource.LOGIN,

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/UpgradeFeatureCard.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/UpgradeFeatureCard.kt
@@ -57,6 +57,8 @@ sealed class UpgradeFeatureCard(
 
             source == OnboardingUpgradeSource.FILES -> LR.string.files_plus_prompt
 
+            source == OnboardingUpgradeSource.SUGGESTED_FOLDERS -> LR.string.suggested_folders_plus_prompt
+
             else -> LR.string.onboarding_plus_features_title
         }
     }

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/folders/SuggestedFoldersPaywallBottomSheet.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/folders/SuggestedFoldersPaywallBottomSheet.kt
@@ -5,6 +5,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.FrameLayout
+import androidx.compose.runtime.collectAsState
 import androidx.core.view.doOnLayout
 import androidx.fragment.app.viewModels
 import androidx.fragment.compose.content
@@ -33,15 +34,19 @@ class SuggestedFoldersPaywallBottomSheet : BottomSheetDialogFragment() {
         savedInstanceState: Bundle?,
     ) = content {
         AppTheme(theme.activeTheme) {
+            val signInState = viewModel.signInState.collectAsState(null)
+
             SuggestedFoldersPaywall(
                 onShown = {
                     viewModel.onShown()
                 },
                 onUseTheseFolders = {
-                    viewModel.onUseTheseFolders()
-                    dismiss()
-                    val onboardingFlow = OnboardingFlow.PlusAccountUpgrade(OnboardingUpgradeSource.FOLDERS)
-                    OnboardingLauncher.openOnboardingFlow(activity, onboardingFlow)
+                    if (signInState.value?.isSignedInAsPlusOrPatron == true) {
+                        dismiss()
+                        SuggestedFolders().show(parentFragmentManager, "suggested_folders")
+                    } else {
+                        OnboardingLauncher.openOnboardingFlow(activity, OnboardingFlow.Upsell(OnboardingUpgradeSource.SUGGESTED_FOLDERS))
+                    }
                 },
                 onMaybeLater = {
                     viewModel.onMaybeLater()

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/folders/SuggestedFoldersPaywallViewModel.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/folders/SuggestedFoldersPaywallViewModel.kt
@@ -4,14 +4,19 @@ import androidx.lifecycle.ViewModel
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTracker
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
+import au.com.shiftyjelly.pocketcasts.repositories.user.UserManager
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
+import kotlinx.coroutines.reactive.asFlow
 
 @HiltViewModel
 class SuggestedFoldersPaywallViewModel @Inject constructor(
+    userManager: UserManager,
     private val settings: Settings,
     private val analyticsTracker: AnalyticsTracker,
 ) : ViewModel() {
+
+    val signInState = userManager.getSignInState().asFlow()
 
     fun onMaybeLater() {
         analyticsTracker.track(AnalyticsEvent.SUGGESTED_FOLDERS_PAYWALL_MODAL_MAYBE_LATER_TAPPED)

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcasts/PodcastsFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcasts/PodcastsFragment.kt
@@ -238,13 +238,11 @@ class PodcastsFragment : BaseFragment(), FolderAdapter.ClickListener, PodcastTou
         viewLifecycleOwner.lifecycleScope.launch {
             viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
                 viewModel.userSuggestedFoldersState.collect { (signInState, state) ->
-                    when (state) {
-                        is PodcastsViewModel.SuggestedFoldersState.Loaded -> {
-                            if (viewModel.showSuggestedFoldersPaywallOnOpen(signInState.isSignedInAsPlusOrPatron)) {
-                                SuggestedFoldersPaywallBottomSheet().show(parentFragmentManager, "suggested_folders_paywall")
-                            }
+                    if (state is PodcastsViewModel.SuggestedFoldersState.Loaded) {
+                        val existingModal = parentFragmentManager.findFragmentByTag("suggested_folders_paywall")
+                        if (viewModel.showSuggestedFoldersPaywallOnOpen(signInState.isSignedInAsPlusOrPatron) && existingModal == null) {
+                            SuggestedFoldersPaywallBottomSheet().show(parentFragmentManager, "suggested_folders_paywall")
                         }
-                        PodcastsViewModel.SuggestedFoldersState.Loading -> {}
                     }
                 }
             }

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/onboarding/OnboardingUpgradeSource.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/onboarding/OnboardingUpgradeSource.kt
@@ -10,6 +10,7 @@ enum class OnboardingUpgradeSource(val analyticsValue: String) {
     END_OF_YEAR("end_of_year"),
     FILES("files"),
     FOLDERS("folders"),
+    SUGGESTED_FOLDERS("suggested_folders"),
     FOLDERS_PODCAST_SCREEN("folders_podcast_screen"),
     HEADPHONE_CONTROLS_SETTINGS("headphone_controls_settings"),
     LOGIN("login"), // for login from within upsell screen

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -2238,6 +2238,7 @@
     <string name="themes_plus_prompt">Get exclusive themes with Pocket&#160;Casts&#160;Plus, and more</string>
     <string name="icons_plus_prompt">Get exclusive app icons with Pocket&#160;Casts&#160;Plus, and more</string>
     <string name="files_plus_prompt">Upload your files with Pocket&#160;Casts&#160;Plus, and more</string>
+    <string name="suggested_folders_plus_prompt">Organize your shows, with Pocket&#160;Casts&#160;Plus, and more</string>
     <string name="up_next_shuffle_plus_prompt">Shuffle your episodes with Pocket&#160;Casts&#160;Plus, and more</string>
 
     <!-- Engage SDK -->


### PR DESCRIPTION
## Description
- This updates the free user flow to open the upgrade screen when a free user tries to use this paid feature instead of opening the upgrade bottom sheet.
- See: p1739510234779639/1739475147.971979-slack-C08BRS7N9UL


## Testing Instructions
1. Apply [suggested-folders.patch](https://github.com/user-attachments/files/18803575/suggested-folders.patch)
2. Run in `debugProd`
3. You don't need to follow any podcast since we are mocking here, so go to Podcast tab
4. See the suggested folders bottom sheet
5. Tap on `Use these folders`
6. See the upgrade bottom sheet
7. Subscribe to any plan
8. You will see the suggested folders bottom sheet
9. Tap on `Use these folders`
10. You should see the Suggested Folders screen ✅


## Screenshots or Screencast 
[Screen_recording_20250214_154552.webm](https://github.com/user-attachments/assets/f56d24aa-8ddc-4c78-a67a-d44bb35b54ad)


## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.