### PR TITLE
Change the Wear target SDK to 34

### DIFF
--- a/wear/build.gradle.kts
+++ b/wear/build.gradle.kts
@@ -13,6 +13,7 @@ android {
 
     defaultConfig {
         minSdk = project.property("minSdkVersionWear") as Int
+        targetSdk = 34
         applicationId = project.property("applicationId").toString()
     }
 


### PR DESCRIPTION
## Description

We get the following error when we try to upload the Wear OS app. So we need to reduce the target SDK to 34 (Android 14).

```
[2025-02-17T08:45:26Z] [08:45:26]: Preparing aab at path '.../pocket-casts-android/artifacts/wear-7.83-rc-1.aab' for upload...
[2025-02-17T08:45:50Z] [08:45:50]: Google Api Error: Invalid request - SDK version used by APK is too high. - Retrying...
```

## Testing Instructions

1. Build the Wear OS APK `./gradlew wear:assembleDebug`
2. Fresh install the app
```
adb uninstall au.com.shiftyjelly.pocketcasts.debug
adb install wear/build/outputs/apk/debug/wear-debug.apk
adb shell am start -n au.com.shiftyjelly.pocketcasts.debug/au.com.shiftyjelly.pocketcasts.wear.MainActivity
```
3. Sign into a Pocket Casts account
4. Try out some features such as playing an episode

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack
