### PR TITLE
[Suggested Folders] Open suggested folders only if has pre cached them

### DIFF
--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/folders/SuggestedFoldersPaywallBottomSheet.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/folders/SuggestedFoldersPaywallBottomSheet.kt
@@ -41,8 +41,10 @@ class SuggestedFoldersPaywallBottomSheet : BottomSheetDialogFragment() {
 
     private val viewModel: SuggestedFoldersPaywallViewModel by viewModels<SuggestedFoldersPaywallViewModel>()
 
-    val suggestedFolders: ArrayList<Folder>
-        get() = arguments?.let { (BundleCompat.getParcelableArrayList(it, FOLDERS_KEY, Folder::class.java)) } ?: ArrayList()
+    private val suggestedFolders
+        get() = requireNotNull(BundleCompat.getParcelableArrayList(requireArguments(), FOLDERS_KEY, Folder::class.java)) {
+            "Missing input parameters"
+        }
 
     override fun onCreateView(
         inflater: LayoutInflater,

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcasts/PodcastsFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcasts/PodcastsFragment.kt
@@ -233,7 +233,9 @@ class PodcastsFragment : BaseFragment(), FolderAdapter.ClickListener, PodcastTou
         super.onViewCreated(view, savedInstanceState)
 
         viewLifecycleOwner.lifecycleScope.launch {
-            viewModel.loadSuggestedFolders()
+            viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
+                viewModel.loadSuggestedFolders()
+            }
         }
 
         viewLifecycleOwner.lifecycleScope.launch {

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcasts/PodcastsFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcasts/PodcastsFragment.kt
@@ -317,7 +317,8 @@ class PodcastsFragment : BaseFragment(), FolderAdapter.ClickListener, PodcastTou
     }
 
     private fun createFolder() {
-        if (FeatureFlag.isEnabled(Feature.SUGGESTED_FOLDERS)) {
+        val state = viewModel.suggestedFoldersState
+        if (FeatureFlag.isEnabled(Feature.SUGGESTED_FOLDERS) && state is PodcastsViewModel.SuggestedFoldersState.Loaded) {
             SuggestedFolders().show(parentFragmentManager, "suggested_folders")
         } else {
             FolderCreateFragment.newInstance(PODCASTS_LIST).show(parentFragmentManager, "create_folder_card")

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/PodcastsViewModel.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/PodcastsViewModel.kt
@@ -303,9 +303,10 @@ class PodcastsViewModel
     suspend fun loadSuggestedFolders() {
         if (FeatureFlag.isEnabled(Feature.SUGGESTED_FOLDERS)) {
             _suggestedFoldersState.emit(SuggestedFoldersState.Loading)
-            val folders = suggestedFoldersManager.getSuggestedFolders()
-            if (!folders.isEmpty()) {
-                _suggestedFoldersState.emit(SuggestedFoldersState.Loaded(folders))
+            suggestedFoldersManager.getSuggestedFolders().collect { folders ->
+                if (!folders.isEmpty()) {
+                    _suggestedFoldersState.emit(SuggestedFoldersState.Loaded(folders))
+                }
             }
         }
     }

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/SuggestedFoldersDao.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/SuggestedFoldersDao.kt
@@ -6,6 +6,7 @@ import androidx.room.OnConflictStrategy
 import androidx.room.Query
 import androidx.room.Transaction
 import au.com.shiftyjelly.pocketcasts.models.entity.SuggestedFolder
+import kotlinx.coroutines.flow.Flow
 
 @Dao
 abstract class SuggestedFoldersDao {
@@ -20,7 +21,7 @@ abstract class SuggestedFoldersDao {
     abstract suspend fun findAllFolderPodcasts(folderName: String): List<SuggestedFolder>
 
     @Query("SELECT * FROM suggested_folders")
-    abstract suspend fun findAll(): List<SuggestedFolder>
+    abstract fun findAll(): Flow<List<SuggestedFolder>>
 
     @Query("DELETE FROM suggested_folders")
     protected abstract suspend fun deleteAll()

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/SuggestedFoldersManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/SuggestedFoldersManager.kt
@@ -6,6 +6,7 @@ import au.com.shiftyjelly.pocketcasts.models.entity.SuggestedFolder
 import au.com.shiftyjelly.pocketcasts.servers.podcast.PodcastCacheServiceManager
 import au.com.shiftyjelly.pocketcasts.servers.podcast.SuggestedFoldersRequest
 import jakarta.inject.Inject
+import kotlinx.coroutines.flow.Flow
 import timber.log.Timber
 
 class SuggestedFoldersManager @Inject constructor(
@@ -15,7 +16,7 @@ class SuggestedFoldersManager @Inject constructor(
 
     private val suggestedFoldersDao: SuggestedFoldersDao = appDatabase.suggestedFoldersDao()
 
-    suspend fun getSuggestedFolders(): List<SuggestedFolder> = suggestedFoldersDao.findAll()
+    fun getSuggestedFolders(): Flow<List<SuggestedFolder>> = suggestedFoldersDao.findAll()
 
     suspend fun refreshSuggestedFolders(podcastUuids: List<String>) {
         try {

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/SuggestedFoldersManagerTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/SuggestedFoldersManagerTest.kt
@@ -5,6 +5,8 @@ import au.com.shiftyjelly.pocketcasts.models.db.dao.SuggestedFoldersDao
 import au.com.shiftyjelly.pocketcasts.models.entity.SuggestedFolder
 import au.com.shiftyjelly.pocketcasts.servers.podcast.PodcastCacheServiceManager
 import junit.framework.TestCase.assertEquals
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.runBlocking
 import org.junit.Before
 import org.junit.Test
@@ -37,9 +39,9 @@ class SuggestedFoldersManagerTest {
             SuggestedFolder("uuid2", "Folder2"),
         )
 
-        whenever(mockSuggestedFoldersDao.findAll()).thenReturn(folders)
+        whenever(mockSuggestedFoldersDao.findAll()).thenReturn(flowOf(folders))
 
-        val result = suggestedFoldersManager.getSuggestedFolders()
+        val result = suggestedFoldersManager.getSuggestedFolders().first()
 
         assertEquals(folders, result)
     }


### PR DESCRIPTION
## Description
- This opens the suggested folders screen when tapping on create folder button only if has pre cached for paid users
- Opens the suggested folders paywall for free users only if has pre cached them


## Testing Instructions
- Run the app in `debug`

#### Free user
1. Open the app
2. Do not follow any podcast
3. Go to Podcasts tab and ensure you don't follow any podcast
4. Ensure you don't see the suggested folders paywall ✅
5. Try to create a folder
6. Ensure you see the regular upgrade account screen ✅
7. Follow some podcasts
8. Go to podcasts tab again
9. Wait a few seconds
10. Ensure you see the suggested folders paywall ✅
11. Try to create a folder
12. Ensure you see the suggested folders paywall ✅

### Paid user
1. Open the app
2. Do not follow any podcast
3. Go to Podcasts tab and ensure you don't follow any podcast
4. Try to create a folder
5. Ensure you see the existing Create Folder screen ✅
6. Follow some podcasts
7. Go to podcasts tab again
8. Wait a few seconds
9. Try to create a folder
10. Ensure you see the suggested folder screen ✅

## Screenshots or Screencast 

#### Paid User
[paid.webm](https://github.com/user-attachments/assets/56c7ba6c-ec95-41ec-b1ea-9dbdbd42828a)

#### Free User
[free.webm](https://github.com/user-attachments/assets/2db058d3-f3e7-493e-ab8e-337f4a0827e9)


## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.

