### PR TITLE
Add Android 15 upgrade to the changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@
 
 7.82
 -----
+*   New Features
+    *   Android 15 (SDK 35) upgrade 
+        ([#3392](https://github.com/Automattic/pocket-casts-android/pull/3392))
 *   Bug Fixes
     *   Fix status bar theming during onboarding.
         ([#3460](https://github.com/Automattic/pocket-casts-android/pull/3460))


### PR DESCRIPTION
## Description

The Android 15 upgrade wasn't in the changelog, so this includes an entry.

## Testing Instructions
You don't need to do any testing.

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 