### PR TITLE
[Suggested Folders] Populate paywall with suggested folders

### DIFF
--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/folders/Folder.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/folders/Folder.kt
@@ -1,7 +1,11 @@
 package au.com.shiftyjelly.pocketcasts.podcasts.view.folders
 
+import android.os.Parcelable
+import kotlinx.parcelize.Parcelize
+
+@Parcelize
 data class Folder(
     val name: String,
     val podcasts: List<String>,
     val color: Int,
-)
+) : Parcelable

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/folders/SuggestedFoldersMapper.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/folders/SuggestedFoldersMapper.kt
@@ -1,6 +1,7 @@
 package au.com.shiftyjelly.pocketcasts.podcasts.view.folders
 
 import au.com.shiftyjelly.pocketcasts.models.entity.SuggestedFolder
+import kotlin.random.Random
 import au.com.shiftyjelly.pocketcasts.podcasts.view.folders.Folder as SuggestedFolderModel
 
 fun List<SuggestedFolder>.toFolders(): List<SuggestedFolderModel> {
@@ -10,7 +11,7 @@ fun List<SuggestedFolder>.toFolders(): List<SuggestedFolderModel> {
         SuggestedFolderModel(
             name = folderName,
             podcasts = folderItems.map { it.podcastUuid },
-            color = 1,
+            color = Random.nextInt(0, 12),
         )
     }
 }

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/folders/SuggestedFoldersMapper.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/folders/SuggestedFoldersMapper.kt
@@ -1,0 +1,16 @@
+package au.com.shiftyjelly.pocketcasts.podcasts.view.folders
+
+import au.com.shiftyjelly.pocketcasts.models.entity.SuggestedFolder
+import au.com.shiftyjelly.pocketcasts.podcasts.view.folders.Folder as SuggestedFolderModel
+
+fun List<SuggestedFolder>.toFolders(): List<SuggestedFolderModel> {
+    val grouped = this.groupBy { it.name }
+
+    return grouped.map { (folderName, folderItems) ->
+        SuggestedFolderModel(
+            name = folderName,
+            podcasts = folderItems.map { it.podcastUuid },
+            color = 1,
+        )
+    }
+}

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/folders/SuggestedFoldersPaywall.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/folders/SuggestedFoldersPaywall.kt
@@ -134,8 +134,8 @@ private fun Folders(folders: List<Folder>, modifier: Modifier = Modifier) {
     val episodeImageWidthDp = UiUtil.getGridImageWidthPx(smallArtwork = false, context = LocalContext.current).pxToDp(LocalContext.current).toInt()
 
     LazyRow(
-        horizontalArrangement = Arrangement.spacedBy(6.dp),
-        modifier = modifier,
+        horizontalArrangement = Arrangement.spacedBy(6.dp, Alignment.CenterHorizontally),
+        modifier = modifier.fillMaxWidth(),
     ) {
         items(
             count = folders.take(3).size,

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/folders/SuggestedFoldersPaywall.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/folders/SuggestedFoldersPaywall.kt
@@ -142,7 +142,8 @@ private fun Folders(folders: List<Folder>, modifier: Modifier = Modifier) {
             key = { index -> index },
         ) { index ->
             val folder = folders[index]
-            FolderItem(folder.name, Color.Yellow, folder.podcasts, Modifier.size(episodeImageWidthDp.dp))
+            val backgroundColor = MaterialTheme.theme.colors.getFolderColor(folder.color)
+            FolderItem(folder.name, backgroundColor, folder.podcasts, Modifier.size(episodeImageWidthDp.dp))
         }
     }
 }

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/folders/SuggestedFoldersPaywall.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/folders/SuggestedFoldersPaywall.kt
@@ -50,6 +50,7 @@ import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 @Composable
 fun SuggestedFoldersPaywall(
+    folders: List<Folder>,
     onShown: () -> Unit,
     onUseTheseFolders: () -> Unit,
     onMaybeLater: () -> Unit,
@@ -82,7 +83,7 @@ fun SuggestedFoldersPaywall(
 
         AnimatedVisibility(isPortrait) {
             Folders(
-                podcastUuids = mockedPodcastsUuids,
+                folders = folders,
                 modifier = Modifier
                     .fillMaxWidth()
                     .padding(vertical = animatedPadding),
@@ -129,7 +130,7 @@ fun SuggestedFoldersPaywall(
 }
 
 @Composable
-private fun Folders(podcastUuids: List<String>, modifier: Modifier = Modifier) {
+private fun Folders(folders: List<Folder>, modifier: Modifier = Modifier) {
     val episodeImageWidthDp = UiUtil.getGridImageWidthPx(smallArtwork = false, context = LocalContext.current).pxToDp(LocalContext.current).toInt()
 
     LazyRow(
@@ -137,10 +138,11 @@ private fun Folders(podcastUuids: List<String>, modifier: Modifier = Modifier) {
         modifier = modifier,
     ) {
         items(
-            count = 3,
+            count = folders.take(3).size,
             key = { index -> index },
         ) { index ->
-            FolderItem("Test", Color.Yellow, podcastUuids, Modifier.size(episodeImageWidthDp.dp))
+            val folder = folders[index]
+            FolderItem(folder.name, Color.Yellow, folder.podcasts, Modifier.size(episodeImageWidthDp.dp))
         }
     }
 }
@@ -150,15 +152,13 @@ private fun Folders(podcastUuids: List<String>, modifier: Modifier = Modifier) {
 private fun SuggestedFoldersPagePreview(@PreviewParameter(ThemePreviewParameterProvider::class) themeType: Theme.ThemeType) {
     AppTheme(themeType) {
         SuggestedFoldersPaywall(
+            folders = listOf(
+                Folder("Folder 1", listOf("2e61ba20-50a9-0135-902b-63f4b61a9224", "2e61ba20-50a9-0135-902b-63f4b61a9224"), 1),
+                Folder("Folder 2", listOf("2e61ba20-50a9-0135-902b-63f4b61a9224", "2e61ba20-50a9-0135-902b-63f4b61a9224"), 2),
+            ),
             onUseTheseFolders = {},
             onMaybeLater = {},
             onShown = {},
         )
     }
 }
-
-private val mockedPodcastsUuids = listOf(
-    "5d308950-1fe3-012e-02b0-00163e1b201c",
-    "f086f200-4f32-0139-3396-0acc26574db2",
-    "2e61ba20-50a9-0135-902b-63f4b61a9224",
-)

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/folders/SuggestedFoldersPaywallBottomSheet.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/folders/SuggestedFoldersPaywallBottomSheet.kt
@@ -6,6 +6,7 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.FrameLayout
 import androidx.compose.runtime.collectAsState
+import androidx.core.os.BundleCompat
 import androidx.core.view.doOnLayout
 import androidx.fragment.app.viewModels
 import androidx.fragment.compose.content
@@ -23,10 +24,25 @@ import javax.inject.Inject
 @AndroidEntryPoint
 class SuggestedFoldersPaywallBottomSheet : BottomSheetDialogFragment() {
 
+    companion object {
+        private const val FOLDERS_KEY = "folders_key"
+
+        fun newInstance(folders: List<Folder>): SuggestedFoldersPaywallBottomSheet {
+            return SuggestedFoldersPaywallBottomSheet().apply {
+                arguments = Bundle().apply {
+                    putParcelableArrayList(FOLDERS_KEY, ArrayList(folders))
+                }
+            }
+        }
+    }
+
     @Inject
     lateinit var theme: Theme
 
     private val viewModel: SuggestedFoldersPaywallViewModel by viewModels<SuggestedFoldersPaywallViewModel>()
+
+    val suggestedFolders: ArrayList<Folder>
+        get() = arguments?.let { (BundleCompat.getParcelableArrayList(it, FOLDERS_KEY, Folder::class.java)) } ?: ArrayList()
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -37,6 +53,7 @@ class SuggestedFoldersPaywallBottomSheet : BottomSheetDialogFragment() {
             val signInState = viewModel.signInState.collectAsState(null)
 
             SuggestedFoldersPaywall(
+                folders = suggestedFolders,
                 onShown = {
                     viewModel.onShown()
                 },

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcasts/PodcastsFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcasts/PodcastsFragment.kt
@@ -241,7 +241,7 @@ class PodcastsFragment : BaseFragment(), FolderAdapter.ClickListener, PodcastTou
                     if (state is PodcastsViewModel.SuggestedFoldersState.Loaded) {
                         val existingModal = parentFragmentManager.findFragmentByTag("suggested_folders_paywall")
                         if (viewModel.showSuggestedFoldersPaywallOnOpen(signInState.isSignedInAsPlusOrPatron) && existingModal == null) {
-                            SuggestedFoldersPaywallBottomSheet().show(parentFragmentManager, "suggested_folders_paywall")
+                            SuggestedFoldersPaywallBottomSheet.newInstance(state.folders()).show(parentFragmentManager, "suggested_folders_paywall")
                         }
                     }
                 }

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcasts/PodcastsFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcasts/PodcastsFragment.kt
@@ -201,8 +201,9 @@ class PodcastsFragment : BaseFragment(), FolderAdapter.ClickListener, PodcastTou
         toolbar.setOnMenuItemClickListener(this)
 
         toolbar.menu.findItem(R.id.folders_locked).setOnMenuItemClickListener {
-            if (FeatureFlag.isEnabled(Feature.SUGGESTED_FOLDERS)) {
-                SuggestedFoldersPaywallBottomSheet().show(childFragmentManager, "suggested_folders_paywall")
+            val state = viewModel.suggestedFoldersState
+            if (FeatureFlag.isEnabled(Feature.SUGGESTED_FOLDERS) && state is PodcastsViewModel.SuggestedFoldersState.Loaded) {
+                SuggestedFoldersPaywallBottomSheet.newInstance(state.folders()).show(childFragmentManager, "suggested_folders_paywall")
             } else {
                 OnboardingLauncher.openOnboardingFlow(activity, OnboardingFlow.Upsell(OnboardingUpgradeSource.FOLDERS))
             }

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/PodcastsViewModel.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/PodcastsViewModel.kt
@@ -35,7 +35,7 @@ import kotlin.coroutines.CoroutineContext
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.take
 import kotlinx.coroutines.launch
@@ -135,7 +135,9 @@ class PodcastsViewModel
     val folder: Folder?
         get() = folderState.value?.folder
 
-    private val _suggestedFoldersState = MutableSharedFlow<SuggestedFoldersState>()
+    private val _suggestedFoldersState = MutableStateFlow<SuggestedFoldersState>(SuggestedFoldersState.Idle)
+    val suggestedFoldersState: SuggestedFoldersState
+        get() = _suggestedFoldersState.value
 
     val userSuggestedFoldersState: Flow<Pair<SignInState, SuggestedFoldersState>> = userManager.getSignInState().asFlow()
         .combine(_suggestedFoldersState) { signIn, suggestedFolders ->
@@ -321,6 +323,7 @@ class PodcastsViewModel
         FeatureFlag.isEnabled(Feature.SUGGESTED_FOLDERS) && !isSignedInAsPlusOrPatron && settings.suggestedFolderPaywallDismissTime.value == 0L
 
     sealed class SuggestedFoldersState {
+        data object Idle : SuggestedFoldersState()
         data object Loading : SuggestedFoldersState()
         data class Loaded(private val folders: List<SuggestedFolder>) : SuggestedFoldersState() {
             private val convertedFolders: List<SuggestedFolderModel> by lazy {


### PR DESCRIPTION
## Description
- Populates the suggested folders paywall with data fetched
- Applies random color for folders

> [!IMPORTANT]  
> There is an issue with the current podcast follow list. If you follow or unfollow a podcast, it will not be automatically updated in the Podcast tab for suggested folders. To get the updated list of followed podcasts sent to the suggested folders API, you will need to navigate away from the Podcast tab, go to another screen, and then return to the Podcast tab. This was already addressed in https://github.com/Automattic/pocket-casts-android/pull/3606

> [!NOTE]  
> I am going to check with the server team if it's possible to get empty list in success response because currently I ignore if I get empty response since I am getting 400 error code, but this is leading a weird behavior: If I unfollow all podcasts I still get suggested folders. I will address this in another PR

## Testing Instructions
1. Run the app in `debug` with free user
2. Follow some podcasts
3. Go to Podcast tab to fetch data (you have to go to other screen and then go back to Podcast tab due the issue I mentioned above)
4. You should see the suggested folders paywall with suggested folders from API ✅

## Screenshots or Screencast 
[Screen_recording_20250217_205754.webm](https://github.com/user-attachments/assets/00926eb4-3a4b-4c9c-8da4-6157afbf6c76)


## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.

