### PR TITLE
Add Podcast View Changes feature flag

### DIFF
--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastAdapter.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastAdapter.kt
@@ -17,9 +17,16 @@ import android.view.View
 import android.view.ViewGroup
 import android.view.animation.AccelerateDecelerateInterpolator
 import android.widget.TextView
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.ComposeView
+import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.unit.dp
 import androidx.constraintlayout.widget.ConstraintSet
@@ -120,6 +127,7 @@ private val differ: DiffUtil.ItemCallback<Any> = object : DiffUtil.ItemCallback<
 
 class PodcastAdapter(
     var fromListUuid: String?,
+    private val isHeaderRedesigned: Boolean,
     private val context: Context,
     private val downloadManager: DownloadManager,
     private val playbackManager: PlaybackManager,
@@ -220,7 +228,11 @@ class PodcastAdapter(
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): RecyclerView.ViewHolder {
         val inflater = LayoutInflater.from(parent.context)
         return when (viewType) {
-            VIEW_TYPE_PODCAST_HEADER -> PodcastViewHolder(AdapterPodcastHeaderBinding.inflate(inflater, parent, false), this)
+            VIEW_TYPE_PODCAST_HEADER -> if (isHeaderRedesigned) {
+                PodcastHeaderViewHolder(parent.context)
+            } else {
+                PodcastViewHolder(AdapterPodcastHeaderBinding.inflate(inflater, parent, false), this)
+            }
             VIEW_TYPE_TABS -> TabsViewHolder(ComposeView(parent.context), theme)
             VIEW_TYPE_EPISODE_HEADER -> EpisodeHeaderViewHolder(AdapterEpisodeHeaderBinding.inflate(inflater, parent, false), onEpisodesOptionsClicked, onSearchFocus)
             VIEW_TYPE_EPISODE_LIMIT_ROW -> EpisodeLimitViewHolder(inflater.inflate(R.layout.adapter_episode_limit, parent, false))
@@ -250,6 +262,7 @@ class PodcastAdapter(
 
     override fun onBindViewHolder(holder: RecyclerView.ViewHolder, position: Int) {
         when (holder) {
+            is PodcastHeaderViewHolder -> holder.bind()
             is EpisodeViewHolder -> bindEpisodeViewHolder(holder, position, fromListUuid)
             is PodcastViewHolder -> bindPodcastViewHolder(holder)
             is TabsViewHolder -> holder.bind(getItem(position) as TabsHeader)
@@ -854,6 +867,27 @@ class PodcastAdapter(
                 }
             })
             set.start()
+        }
+    }
+
+    private class PodcastHeaderViewHolder(
+        context: Context,
+    ) : RecyclerView.ViewHolder(ComposeView(context)) {
+        private val composeView get() = itemView as ComposeView
+
+        init {
+            composeView.setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
+        }
+
+        fun bind() {
+            composeView.setContent {
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(300.dp)
+                        .background(Color.Blue),
+                )
+            }
         }
     }
 

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastAdapter.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastAdapter.kt
@@ -119,13 +119,13 @@ private val differ: DiffUtil.ItemCallback<Any> = object : DiffUtil.ItemCallback<
 }
 
 class PodcastAdapter(
-    private val context: Context,
-    val downloadManager: DownloadManager,
-    val playbackManager: PlaybackManager,
-    val upNextQueue: UpNextQueue,
-    val settings: Settings,
-    val theme: Theme,
     var fromListUuid: String?,
+    private val context: Context,
+    private val downloadManager: DownloadManager,
+    private val playbackManager: PlaybackManager,
+    private val upNextQueue: UpNextQueue,
+    private val settings: Settings,
+    private val theme: Theme,
     private val podcastBookmarksObservable: Observable<List<Bookmark>>,
     private val onHeaderSummaryToggled: (Boolean, Boolean) -> Unit,
     private val onSubscribeClicked: () -> Unit,

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastFragment.kt
@@ -6,19 +6,33 @@ import android.view.LayoutInflater
 import android.view.MenuItem
 import android.view.View
 import android.view.ViewGroup
+import android.widget.LinearLayout
+import android.widget.ProgressBar
+import android.widget.TextView
+import androidx.annotation.ColorInt
+import androidx.annotation.MenuRes
 import androidx.appcompat.app.AppCompatActivity
-import androidx.appcompat.widget.Toolbar
+import androidx.appcompat.widget.Toolbar.OnMenuItemClickListener
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.ComposeView
+import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.dp
 import androidx.core.os.BundleCompat
 import androidx.core.os.bundleOf
-import androidx.core.view.isGone
+import androidx.core.view.isInvisible
 import androidx.core.view.isVisible
 import androidx.core.view.updatePadding
 import androidx.fragment.app.viewModels
@@ -28,6 +42,7 @@ import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
 import androidx.recyclerview.widget.RecyclerView
 import androidx.recyclerview.widget.SimpleItemAnimator
+import androidx.swiperefreshlayout.widget.SwipeRefreshLayout
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTracker
 import au.com.shiftyjelly.pocketcasts.analytics.SourceView
@@ -45,6 +60,7 @@ import au.com.shiftyjelly.pocketcasts.player.view.bookmark.BookmarksSortByDialog
 import au.com.shiftyjelly.pocketcasts.podcasts.BuildConfig
 import au.com.shiftyjelly.pocketcasts.podcasts.R
 import au.com.shiftyjelly.pocketcasts.podcasts.databinding.FragmentPodcastBinding
+import au.com.shiftyjelly.pocketcasts.podcasts.databinding.FragmentPodcastRedesignBinding
 import au.com.shiftyjelly.pocketcasts.podcasts.view.components.PlayButton
 import au.com.shiftyjelly.pocketcasts.podcasts.view.episode.EpisodeContainerFragment
 import au.com.shiftyjelly.pocketcasts.podcasts.view.folders.FolderChooserFragment
@@ -75,6 +91,7 @@ import au.com.shiftyjelly.pocketcasts.ui.extensions.openUrl
 import au.com.shiftyjelly.pocketcasts.ui.helper.FragmentHostListener
 import au.com.shiftyjelly.pocketcasts.ui.helper.StatusBarIconColor
 import au.com.shiftyjelly.pocketcasts.ui.images.CoilManager
+import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import au.com.shiftyjelly.pocketcasts.ui.theme.ThemeColor
 import au.com.shiftyjelly.pocketcasts.utils.extensions.dpToPx
 import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
@@ -94,6 +111,7 @@ import au.com.shiftyjelly.pocketcasts.views.helper.UiUtil
 import au.com.shiftyjelly.pocketcasts.views.multiselect.MultiSelectBookmarksHelper.NavigationState
 import au.com.shiftyjelly.pocketcasts.views.multiselect.MultiSelectHelper
 import au.com.shiftyjelly.pocketcasts.views.multiselect.MultiSelectToolbar
+import com.google.android.material.button.MaterialButton
 import com.google.android.material.snackbar.Snackbar
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
@@ -110,7 +128,7 @@ import au.com.shiftyjelly.pocketcasts.ui.R as UR
 import au.com.shiftyjelly.pocketcasts.views.R as VR
 
 @AndroidEntryPoint
-class PodcastFragment : BaseFragment(), Toolbar.OnMenuItemClickListener {
+class PodcastFragment : BaseFragment() {
 
     companion object {
         private const val NEW_INSTANCE_ARGS = "PodcastFragmentArgs"
@@ -137,6 +155,7 @@ class PodcastFragment : BaseFragment(), Toolbar.OnMenuItemClickListener {
                     sourceView = sourceView,
                     fromListUuid = fromListUuid,
                     featuredPodcast = featuredPodcast,
+                    isHeaderRedesigned = FeatureFlag.isEnabled(Feature.PODCAST_VIEW_CHANGES),
                 ),
             )
         }
@@ -172,9 +191,11 @@ class PodcastFragment : BaseFragment(), Toolbar.OnMenuItemClickListener {
     private val ratingsViewModel: PodcastRatingsViewModel by viewModels()
     private val episodeListBookmarkViewModel: EpisodeListBookmarkViewModel by viewModels()
     private val swipeButtonLayoutViewModel: SwipeButtonLayoutViewModel by viewModels()
-    private var adapter: PodcastAdapter? = null
-    private var binding: FragmentPodcastBinding? = null
+
+    private var binding: BindingWrapper? = null
+
     private var itemTouchHelper: EpisodeItemTouchHelper? = null
+    private var adapter: PodcastAdapter? = null
 
     private var listState: Parcelable? = null
 
@@ -189,7 +210,7 @@ class PodcastFragment : BaseFragment(), Toolbar.OnMenuItemClickListener {
         override fun onScrollStateChanged(recyclerView: RecyclerView, newState: Int) {
             if (newState == RecyclerView.SCROLL_STATE_DRAGGING) {
                 UiUtil.hideKeyboard(recyclerView)
-                binding?.headerBackgroundPlaceholder?.isGone = true
+                binding?.showBackgroundPlaceholder(false)
             }
         }
     }
@@ -628,13 +649,31 @@ class PodcastFragment : BaseFragment(), Toolbar.OnMenuItemClickListener {
     }
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
-        val binding = FragmentPodcastBinding.inflate(inflater, container, false)
+        val binding = BindingWrapper.inflate(inflater, container, isHeaderRedesigned = args.isHeaderRedesigned)
         this.binding = binding
 
-        val context = binding.root.context
-        val headerColor = context.getThemeColor(UR.attr.support_09)
-        binding.headerBackgroundPlaceholder.setBackgroundColor(headerColor)
-        binding.toolbar.setBackgroundColor(headerColor)
+        binding.setStaticToolbarColor(requireContext().getThemeColor(UR.attr.support_09))
+        binding.setUpToolbar(
+            theme = theme,
+            menuId = R.menu.podcast_menu,
+            onChromeCast = {
+                chromeCastAnalytics.trackChromeCastViewShown()
+            },
+            onShare = {
+                share()
+            },
+            onReport = {
+                analyticsTracker.track(AnalyticsEvent.PODCAST_SCREEN_REPORT_TAPPED)
+                openUrl(settings.getReportViolationUrl())
+            },
+            onNavigateBack = {
+                @Suppress("DEPRECATION")
+                activity?.onBackPressed()
+            },
+            onLongClick = {
+                theme.toggleDarkLightThemeActivity(activity as AppCompatActivity)
+            },
+        )
         statusBarIconColor = StatusBarIconColor.Light
         updateStatusBar()
 
@@ -642,35 +681,11 @@ class PodcastFragment : BaseFragment(), Toolbar.OnMenuItemClickListener {
 
         binding.swipeRefreshLayout.isEnabled = FeatureFlag.isEnabled(Feature.PODCAST_FEED_UPDATE)
 
-        binding.toolbar.let {
-            it.inflateMenu(R.menu.podcast_menu)
-            it.setOnMenuItemClickListener(this)
-
-            val reportMenuItem = it.menu.findItem(R.id.report)
-            reportMenuItem.isVisible = FeatureFlag.isEnabled(Feature.REPORT_VIOLATION)
-
-            it.setNavigationOnClickListener {
-                @Suppress("DEPRECATION")
-                activity?.onBackPressed()
-            }
-            val iconColor = it.context.getThemeColor(UR.attr.contrast_01)
-            it.menu.setupChromeCastButton(context) {
-                chromeCastAnalytics.trackChromeCastViewShown()
-            }
-            it.menu.tintIcons(iconColor)
-            it.navigationIcon?.setTint(iconColor)
-            it.navigationContentDescription = getString(LR.string.back)
-            it.setOnLongClickListener {
-                theme.toggleDarkLightThemeActivity(activity as AppCompatActivity)
-                true
-            }
-            it.includeStatusBarPadding()
-        }
-
         playButtonListener.source = SourceView.PODCAST_SCREEN
         if (adapter == null) {
             adapter = PodcastAdapter(
                 context = requireContext(),
+                isHeaderRedesigned = binding.isHeaderRedesigned,
                 downloadManager = downloadManager,
                 playbackManager = playbackManager,
                 upNextQueue = upNextQueue,
@@ -860,7 +875,7 @@ class PodcastFragment : BaseFragment(), Toolbar.OnMenuItemClickListener {
         }
     }
 
-    private fun FragmentPodcastBinding.setupMultiSelect() {
+    private fun BindingWrapper.setupMultiSelect() {
         viewModel.multiSelectEpisodesHelper.setUp(multiSelectEpisodesToolbar)
         viewModel.multiSelectBookmarksHelper.setUp(multiSelectBookmarksToolbar)
     }
@@ -876,7 +891,7 @@ class PodcastFragment : BaseFragment(), Toolbar.OnMenuItemClickListener {
             val episodeContainerFragment = parentFragmentManager.findFragmentByTag(EPISODE_CARD)
             if (episodeContainerFragment != null) return@observe
             multiSelectToolbar.isVisible = it
-            binding?.toolbar?.isVisible = !it
+            binding?.showToolbar(!it)
             adapter?.notifyDataSetChanged()
         }
         coordinatorLayout = (activity as FragmentHostListener).snackBarView()
@@ -950,8 +965,7 @@ class PodcastFragment : BaseFragment(), Toolbar.OnMenuItemClickListener {
             viewLifecycleOwner,
             Observer<Podcast> { podcast ->
                 val backgroundColor = ThemeColor.podcastUi03(theme.activeTheme, podcast.backgroundColor)
-                binding?.toolbar?.setBackgroundColor(backgroundColor)
-                binding?.headerBackgroundPlaceholder?.setBackgroundColor(backgroundColor)
+                binding?.setStaticToolbarColor(backgroundColor)
 
                 val forceHeaderExpanded = !viewModel.shouldShowPodcastTooltip.value && FeatureFlag.isEnabled(Feature.PODCAST_FEED_UPDATE)
                 adapter?.setPodcast(podcast, forceHeaderExpanded = forceHeaderExpanded)
@@ -1109,17 +1123,6 @@ class PodcastFragment : BaseFragment(), Toolbar.OnMenuItemClickListener {
         dialog.show(parentFragmentManager, "confirm_archive_all_played")
     }
 
-    override fun onMenuItemClick(item: MenuItem): Boolean {
-        when (item.itemId) {
-            R.id.share -> share()
-            R.id.report -> {
-                analyticsTracker.track(AnalyticsEvent.PODCAST_SCREEN_REPORT_TAPPED)
-                openUrl(settings.getReportViolationUrl())
-            }
-        }
-        return true
-    }
-
     private fun share() {
         val podcast = viewModel.podcast.value ?: return
 
@@ -1183,5 +1186,202 @@ class PodcastFragment : BaseFragment(), Toolbar.OnMenuItemClickListener {
         val sourceView: SourceView,
         val fromListUuid: String?,
         val featuredPodcast: Boolean,
+        val isHeaderRedesigned: Boolean,
     ) : Parcelable
+}
+
+private sealed interface BindingWrapper {
+    val root: LinearLayout
+    val multiSelectEpisodesToolbar: MultiSelectToolbar
+    val multiSelectBookmarksToolbar: MultiSelectToolbar
+    val swipeRefreshLayout: SwipeRefreshLayout
+    val episodesRecyclerView: RecyclerView
+    val loading: ProgressBar
+    val errorContainer: LinearLayout
+    val errorMessage: TextView
+    val btnRetry: MaterialButton
+    val composeTooltipHost: ComposeView
+
+    val isHeaderRedesigned get() = when (this) {
+        is RedesignBindingWrapper -> true
+        is RegularBindingWrapper -> false
+    }
+
+    fun setStaticToolbarColor(@ColorInt color: Int)
+
+    fun showToolbar(show: Boolean)
+
+    fun setUpToolbar(
+        theme: Theme,
+        @MenuRes menuId: Int,
+        onChromeCast: () -> Unit,
+        onShare: () -> Unit,
+        onReport: () -> Unit,
+        onNavigateBack: () -> Unit,
+        onLongClick: () -> Unit,
+    )
+
+    fun showBackgroundPlaceholder(show: Boolean)
+
+    companion object {
+        fun inflate(
+            inflater: LayoutInflater,
+            container: ViewGroup?,
+            isHeaderRedesigned: Boolean,
+        ): BindingWrapper = if (isHeaderRedesigned) {
+            RedesignBindingWrapper(inflater, container)
+        } else {
+            RegularBindingWrapper(inflater, container)
+        }
+    }
+
+    private class RegularBindingWrapper(inflater: LayoutInflater, container: ViewGroup?) : BindingWrapper {
+        private val binding = FragmentPodcastBinding.inflate(inflater, container, false)
+
+        override fun setStaticToolbarColor(color: Int) {
+            binding.toolbar.setBackgroundColor(color)
+            binding.headerBackgroundPlaceholder.setBackgroundColor(color)
+        }
+
+        override fun showToolbar(show: Boolean) {
+            binding.toolbar.isVisible = show
+        }
+
+        override fun setUpToolbar(
+            theme: Theme,
+            @MenuRes menuId: Int,
+            onChromeCast: () -> Unit,
+            onShare: () -> Unit,
+            onReport: () -> Unit,
+            onNavigateBack: () -> Unit,
+            onLongClick: () -> Unit,
+        ) {
+            binding.toolbar.apply {
+                inflateMenu(menuId)
+                menu.findItem(R.id.report)?.isVisible = FeatureFlag.isEnabled(Feature.REPORT_VIOLATION)
+
+                setNavigationOnClickListener { onNavigateBack() }
+                menu.setupChromeCastButton(context, onChromeCast)
+                setOnMenuItemClickListener(object : OnMenuItemClickListener {
+                    override fun onMenuItemClick(item: MenuItem): Boolean {
+                        when (item.itemId) {
+                            R.id.share -> onShare()
+                            R.id.report -> onReport()
+                        }
+                        return true
+                    }
+                })
+
+                val iconsColor = context.getThemeColor(UR.attr.contrast_01)
+                menu.tintIcons(iconsColor)
+                navigationIcon?.setTint(iconsColor)
+                navigationContentDescription = context.getString(LR.string.back)
+
+                setOnLongClickListener {
+                    onLongClick()
+                    true
+                }
+                includeStatusBarPadding()
+            }
+        }
+
+        override fun showBackgroundPlaceholder(show: Boolean) {
+            binding.headerBackgroundPlaceholder.isVisible = false
+        }
+
+        override val root: LinearLayout
+            get() = binding.root
+
+        override val multiSelectEpisodesToolbar: MultiSelectToolbar
+            get() = binding.multiSelectEpisodesToolbar
+
+        override val multiSelectBookmarksToolbar: MultiSelectToolbar
+            get() = binding.multiSelectBookmarksToolbar
+
+        override val swipeRefreshLayout: SwipeRefreshLayout
+            get() = binding.swipeRefreshLayout
+
+        override val episodesRecyclerView: RecyclerView
+            get() = binding.episodesRecyclerView
+
+        override val loading: ProgressBar
+            get() = binding.loading
+
+        override val errorContainer: LinearLayout
+            get() = binding.errorContainer
+
+        override val errorMessage: TextView
+            get() = binding.errorMessage
+
+        override val btnRetry: MaterialButton
+            get() = binding.btnRetry
+
+        override val composeTooltipHost: ComposeView
+            get() = binding.composeTooltipHost
+    }
+
+    private class RedesignBindingWrapper(inflater: LayoutInflater, container: ViewGroup?) : BindingWrapper {
+        private val binding = FragmentPodcastRedesignBinding.inflate(inflater, container, false)
+
+        init {
+            binding.toolbar.setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
+        }
+
+        override fun setStaticToolbarColor(color: Int) = Unit
+
+        override fun showToolbar(show: Boolean) {
+            binding.toolbar.isInvisible = !show
+        }
+
+        override fun setUpToolbar(
+            theme: Theme,
+            @MenuRes menuId: Int,
+            onChromeCast: () -> Unit,
+            onShare: () -> Unit,
+            onReport: () -> Unit,
+            onNavigateBack: () -> Unit,
+            onLongClick: () -> Unit,
+        ) {
+            binding.toolbar.setContent {
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(80.dp)
+                        .background(Color.Red),
+                )
+            }
+        }
+
+        override fun showBackgroundPlaceholder(show: Boolean) = Unit
+
+        override val root: LinearLayout
+            get() = binding.root
+
+        override val multiSelectEpisodesToolbar: MultiSelectToolbar
+            get() = binding.multiSelectEpisodesToolbar
+
+        override val multiSelectBookmarksToolbar: MultiSelectToolbar
+            get() = binding.multiSelectBookmarksToolbar
+
+        override val swipeRefreshLayout: SwipeRefreshLayout
+            get() = binding.swipeRefreshLayout
+
+        override val episodesRecyclerView: RecyclerView
+            get() = binding.episodesRecyclerView
+
+        override val loading: ProgressBar
+            get() = binding.loading
+
+        override val errorContainer: LinearLayout
+            get() = binding.errorContainer
+
+        override val errorMessage: TextView
+            get() = binding.errorMessage
+
+        override val btnRetry: MaterialButton
+            get() = binding.btnRetry
+
+        override val composeTooltipHost: ComposeView
+            get() = binding.composeTooltipHost
+    }
 }

--- a/modules/features/podcasts/src/main/res/layout/fragment_podcast.xml
+++ b/modules/features/podcasts/src/main/res/layout/fragment_podcast.xml
@@ -4,8 +4,8 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:orientation="vertical"
-    android:background="?attr/primary_ui_02">
+    android:background="?attr/primary_ui_02"
+    android:orientation="vertical">
 
     <androidx.appcompat.widget.Toolbar
         android:id="@+id/toolbar"
@@ -22,16 +22,16 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:minHeight="?android:attr/actionBarSize"
-        app:navigationIcon="?attr/homeAsUpIndicator"
-        android:visibility="gone"/>
+        android:visibility="gone"
+        app:navigationIcon="?attr/homeAsUpIndicator" />
 
     <au.com.shiftyjelly.pocketcasts.views.multiselect.MultiSelectToolbar
         android:id="@+id/multiSelectBookmarksToolbar"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:minHeight="?android:attr/actionBarSize"
-        app:navigationIcon="?attr/homeAsUpIndicator"
-        android:visibility="gone"/>
+        android:visibility="gone"
+        app:navigationIcon="?attr/homeAsUpIndicator" />
 
     <FrameLayout
         android:id="@+id/podcastContentWrapper"
@@ -58,9 +58,9 @@
                     android:layout_width="match_parent"
                     android:layout_height="match_parent"
                     android:clipToPadding="false"
-                    android:scrollbars="vertical"
                     android:scrollbarStyle="outsideOverlay"
-                    app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"/>
+                    android:scrollbars="vertical"
+                    app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager" />
 
                 <ProgressBar
                     android:id="@+id/loading"
@@ -72,44 +72,35 @@
                     android:id="@+id/errorContainer"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:orientation="vertical"
                     android:layout_gravity="center"
                     android:clipChildren="false"
                     android:clipToPadding="false"
+                    android:orientation="vertical"
                     android:padding="16dp">
+
                     <TextView
                         android:id="@+id/errorMessage"
+                        style="?attr/textBody1"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
-                        android:gravity="center"
-                        style="?attr/textBody1"
-                        android:layout_marginBottom="8dp"/>
+                        android:layout_marginBottom="8dp"
+                        android:gravity="center" />
+
                     <com.google.android.material.button.MaterialButton
                         android:id="@+id/btnRetry"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:layout_gravity="center"
-                        android:text="@string/podcasts_download_retry"/>
+                        android:text="@string/podcasts_download_retry" />
                 </LinearLayout>
             </FrameLayout>
 
         </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
-
-        <ImageView
-            android:id="@+id/transitionArtwork"
-            android:layout_width="80dp"
-            android:layout_height="80dp"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent"
-            android:adjustViewBounds="false"
-            android:scaleType="centerCrop"
-            tools:src="@tools:sample/avatars" />
-
+        
         <androidx.compose.ui.platform.ComposeView
             android:id="@+id/composeTooltipHost"
             android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            />
+            android:layout_height="wrap_content" />
 
     </FrameLayout>
 

--- a/modules/features/podcasts/src/main/res/layout/fragment_podcast_redesign.xml
+++ b/modules/features/podcasts/src/main/res/layout/fragment_podcast_redesign.xml
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="?attr/primary_ui_02"
+    android:orientation="vertical">
+
+    <au.com.shiftyjelly.pocketcasts.views.multiselect.MultiSelectToolbar
+        android:id="@+id/multiSelectEpisodesToolbar"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:minHeight="?android:attr/actionBarSize"
+        android:visibility="gone"
+        app:navigationIcon="?attr/homeAsUpIndicator" />
+
+    <au.com.shiftyjelly.pocketcasts.views.multiselect.MultiSelectToolbar
+        android:id="@+id/multiSelectBookmarksToolbar"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:minHeight="?android:attr/actionBarSize"
+        android:visibility="gone"
+        app:navigationIcon="?attr/homeAsUpIndicator" />
+
+    <FrameLayout
+        android:id="@+id/podcastContentWrapper"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+
+        <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
+            android:id="@+id/swipeRefreshLayout"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent">
+
+            <FrameLayout
+                android:id="@+id/podcastContent"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent">
+
+                <androidx.recyclerview.widget.RecyclerView
+                    android:id="@+id/episodesRecyclerView"
+                    android:layout_width="match_parent"
+                    android:layout_height="match_parent"
+                    android:clipToPadding="false"
+                    android:scrollbarStyle="outsideOverlay"
+                    android:scrollbars="vertical"
+                    app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager" />
+
+                <ProgressBar
+                    android:id="@+id/loading"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="center" />
+
+                <LinearLayout
+                    android:id="@+id/errorContainer"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="center"
+                    android:clipChildren="false"
+                    android:clipToPadding="false"
+                    android:orientation="vertical"
+                    android:padding="16dp">
+
+                    <TextView
+                        android:id="@+id/errorMessage"
+                        style="?attr/textBody1"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginBottom="8dp"
+                        android:gravity="center" />
+
+                    <com.google.android.material.button.MaterialButton
+                        android:id="@+id/btnRetry"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_gravity="center"
+                        android:text="@string/podcasts_download_retry" />
+                </LinearLayout>
+            </FrameLayout>
+
+        </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
+
+        <androidx.compose.ui.platform.ComposeView
+            android:id="@+id/toolbar"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content" />
+
+        <androidx.compose.ui.platform.ComposeView
+            android:id="@+id/composeTooltipHost"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content" />
+
+    </FrameLayout>
+
+</LinearLayout>

--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/Feature.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/Feature.kt
@@ -219,6 +219,14 @@ enum class Feature(
         hasFirebaseRemoteFlag = false,
         hasDevToggle = true,
     ),
+    PODCAST_VIEW_CHANGES(
+        key = "podcast_view_changes_2025",
+        title = "Podcast view changes",
+        defaultValue = false,
+        tier = FeatureTier.Free,
+        hasFirebaseRemoteFlag = false,
+        hasDevToggle = true,
+    ),
     ;
 
     companion object {


### PR DESCRIPTION
## Description

This PR introduces the **Podcast View Changes** feature flag and integrates its handling in `PodcastFragment`. To ensure a smooth transition without unexpected issues, I abstracted some logic and introduced a wrapper for XML bindings. This wrapper enables better management of pre- and post-design changes, primarily handling custom toolbar logic.

I considered alternative approaches but found significant drawbacks:

- Handling the feature flag with `if/else` statements is highly error-prone, especially for UI updates (e.g., color changes). Additionally, configuration changes could become tricky since a feature flag's value might change dynamically, leading to inconsistencies.
- Using a separate fragment risks desynchronization between versions.

## Testing Instructions

1. Open any podcast.
2. Verify that the old UI is displayed.
3. Without closing the podcast details, navigate to the **Profile** tab.
4. Open **Settings**.
5. Go to **Beta Features**.
6. Enable the **Podcast View Changes** feature.
7. Return to the podcast view.
8. Rotate your device or trigger any configuration change.
9. The old UI should still be visible.
10. Close the podcast view.
11. Open any podcast.
12. The new UI should now be displayed (note: it currently lacks meaningful UI changes).

## Checklist
- [ ] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] ~I have considered whether it makes sense to add tests for my changes~
- [ ] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [ ] ~Any jetpack compose components I added or changed are covered by compose previews~
- [ ] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [ ] ~for accessibility with TalkBack~