### PR TITLE
[Suggested Folders] Filter podcasts to send to suggested folders API

### DIFF
--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/models/db/PodcastDaoTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/models/db/PodcastDaoTest.kt
@@ -11,6 +11,7 @@ import au.com.shiftyjelly.pocketcasts.models.di.addTypeConverters
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import com.squareup.moshi.Moshi
 import java.util.UUID
+import kotlinx.coroutines.runBlocking
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
@@ -99,6 +100,19 @@ class PodcastDaoTest {
         val subscribedList = podcastDao.findSubscribedBlocking()
         assertEquals("Should only be 1 result", 1, subscribedList.count())
         assertEquals("Should only find the subscribed podcast", subscribed.uuid, subscribedList.first().uuid)
+    }
+
+    @Test
+    fun testFindSubscribedNotInFolder() = runBlocking {
+        val subscribed1 = Podcast(uuid = "podcast1", isSubscribed = true, rawFolderUuid = UUID.randomUUID().toString())
+        val subscribed2 = Podcast(uuid = "podcast2", isSubscribed = true, rawFolderUuid = null)
+
+        podcastDao.insertBlocking(subscribed1)
+        podcastDao.insertBlocking(subscribed2)
+
+        val uuids = podcastDao.findFollowedPodcastsNotInFolderUuid()
+        assertEquals(1, uuids.size)
+        assertEquals("podcast2", uuids[0])
     }
 
     @Test

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/PodcastsViewModel.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/PodcastsViewModel.kt
@@ -310,7 +310,7 @@ class PodcastsViewModel
     fun refreshSuggestedFolders() {
         viewModelScope.launch {
             if (FeatureFlag.isEnabled(Feature.SUGGESTED_FOLDERS)) {
-                val uuids = podcastManager.findSubscribedUuids()
+                val uuids = podcastManager.findFollowedPodcastsNotInFolderUuid()
                 suggestedFoldersManager.refreshSuggestedFolders(uuids)
             }
         }

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/PodcastDao.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/PodcastDao.kt
@@ -142,6 +142,9 @@ abstract class PodcastDao {
     @Query("SELECT * FROM podcasts WHERE folder_uuid IS NULL")
     abstract suspend fun findPodcastsNotInFolder(): List<Podcast>
 
+    @Query("SELECT uuid FROM podcasts WHERE subscribed = 1 AND folder_uuid IS NULL")
+    abstract suspend fun findFollowedPodcastsNotInFolderUuid(): List<String>
+
     @Query("SELECT * FROM podcasts WHERE UPPER(title) LIKE UPPER(:title)")
     abstract fun searchByTitleBlocking(title: String): Podcast?
 

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PodcastManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PodcastManager.kt
@@ -40,6 +40,7 @@ interface PodcastManager {
     suspend fun findPodcastsInFolder(folderUuid: String): List<Podcast>
     fun findPodcastsInFolderRxSingle(folderUuid: String): Single<List<Podcast>>
     suspend fun findPodcastsNotInFolder(): List<Podcast>
+    suspend fun findFollowedPodcastsNotInFolderUuid(): List<String>
     fun podcastsInFolderOrderByUserChoiceRxFlowable(folder: Folder): Flowable<List<Podcast>>
     suspend fun findSubscribedUuids(): List<String>
 

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PodcastManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PodcastManagerImpl.kt
@@ -317,6 +317,10 @@ class PodcastManagerImpl @Inject constructor(
         return podcastDao.findPodcastsNotInFolder()
     }
 
+    override suspend fun findFollowedPodcastsNotInFolderUuid(): List<String> {
+        return podcastDao.findFollowedPodcastsNotInFolderUuid()
+    }
+
     override fun findSubscribedBlocking(): List<Podcast> {
         return podcastDao.findSubscribedBlocking()
     }


### PR DESCRIPTION
## Description
- This PR sends only podcasts to the suggested folders API only if they are not already in a folder. This is to prevent that we have a podcast in a folder and create another folder with the same podcast from suggested folder API

> [!IMPORTANT]  
> There is an issue with the current podcast list. If you follow / unfollow a podcast or update its folder, it will not be automatically updated in the Podcast tab for suggested folders. To get the updated list updated sent to the suggested folders API, you will need to navigate away from the Podcast tab, go to another screen, and then return to the Podcast tab. (or tap 2x in Podcast tab to refresh the page) This was already addressed in https://github.com/Automattic/pocket-casts-android/pull/3606

## Testing Instructions
1. Run the app in `debug`
2. Log in with paid account
3. Follow some podcasts
4. Go to Podcasts tab
5. Manually create a folder and add some podcast (Tap on create custom folders button)
7. Tap on Podcasts tab again to refresh the folders due the issue I mentioned above
8. Check the breakpoint I shared above to see if the API returns only suggested folders for podcasts that are not currently in folder ✅

https://github.com/Automattic/pocket-casts-android/blob/ff738f51a3ff17376cbba419cba67023a4516cb0/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/PodcastsViewModel.kt#L303

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
