### PR TITLE
Revert podcast header to collapsed when subscribed

### DIFF
--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastAdapter.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastAdapter.kt
@@ -446,10 +446,10 @@ class PodcastAdapter(
         }
     }
 
-    fun setPodcast(podcast: Podcast, forceHeaderExpanded: Boolean? = null) {
+    fun setPodcast(podcast: Podcast) {
         // expand the podcast description and details if the user hasn't subscribed
         if (this.podcast.uuid != podcast.uuid) {
-            headerExpanded = forceHeaderExpanded ?: !podcast.isSubscribed
+            headerExpanded = !podcast.isSubscribed
             ratingsViewModel.loadRatings(podcast.uuid)
             ratingsViewModel.refreshPodcastRatings(podcast.uuid)
             onHeaderSummaryToggled(headerExpanded, false)

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastFragment.kt
@@ -953,8 +953,7 @@ class PodcastFragment : BaseFragment(), Toolbar.OnMenuItemClickListener {
                 binding?.toolbar?.setBackgroundColor(backgroundColor)
                 binding?.headerBackgroundPlaceholder?.setBackgroundColor(backgroundColor)
 
-                val forceHeaderExpanded = !viewModel.shouldShowPodcastTooltip.value && FeatureFlag.isEnabled(Feature.PODCAST_FEED_UPDATE)
-                adapter?.setPodcast(podcast, forceHeaderExpanded = forceHeaderExpanded)
+                adapter?.setPodcast(podcast)
 
                 viewModel.archiveEpisodeLimit()
 


### PR DESCRIPTION
## Description

As part of adding the tooltip to explain the podcast feed update feature, the podcast page header is always expanded. This would be annoying if you want to play the latest episode as you have to scroll down the page. This reverts the change so the header is collapsed if you are subscribed to the podcast. 

Fixes https://github.com/Automattic/pocket-casts-android/issues/3612

## Testing Instructions

1. Open the podcast page for a podcast you aren't following.
2. ✅ Verify the podcast header is expanded.
3. Open the podcast page for a podcast you are following.
4. ✅ Verify the podcast header is collapsed.

Check the tooltip position

1. In the class `modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/PodcastViewModel.kt` change the `shouldShowPodcastTooltip` to the following, so it's always showing.
```
    val shouldShowPodcastTooltip = MutableStateFlow(true)
```
2. Open the podcast page for a podcast you are following.
3. ✅ Verify the tooltip is in the correct position.

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
