### PR TITLE
Improve Autoplay setting position

### DIFF
--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/PlaybackSettingsFragment.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/PlaybackSettingsFragment.kt
@@ -346,6 +346,19 @@ class PlaybackSettingsFragment : BaseFragment() {
                             )
                         }
 
+                        SettingsItems.SETTINGS_GENERAL_AUTOPLAY -> {
+                            AutoPlayNextOnEmpty(
+                                saved = settings.autoPlayNextEpisodeOnEmpty.flow.collectAsState().value,
+                                onSave = {
+                                    analyticsTracker.track(
+                                        AnalyticsEvent.SETTINGS_GENERAL_AUTOPLAY_TOGGLED,
+                                        mapOf("enabled" to it),
+                                    )
+                                    settings.autoPlayNextEpisodeOnEmpty.set(it, updateModifiedAt = true)
+                                },
+                            )
+                        }
+
                         SettingsItems.SETTINGS_HEADER_SLEEP_TIMER -> {
                             Column {
                                 Spacer(modifier = Modifier.height(SettingsSection.verticalPadding))
@@ -378,19 +391,6 @@ class PlaybackSettingsFragment : BaseFragment() {
                                         mapOf("enabled" to it),
                                     )
                                     settings.shakeToResetSleepTimer.set(it, updateModifiedAt = true)
-                                },
-                            )
-                        }
-
-                        SettingsItems.SETTINGS_GENERAL_AUTOPLAY -> {
-                            AutoPlayNextOnEmpty(
-                                saved = settings.autoPlayNextEpisodeOnEmpty.flow.collectAsState().value,
-                                onSave = {
-                                    analyticsTracker.track(
-                                        AnalyticsEvent.SETTINGS_GENERAL_AUTOPLAY_TOGGLED,
-                                        mapOf("enabled" to it),
-                                    )
-                                    settings.autoPlayNextEpisodeOnEmpty.set(it, updateModifiedAt = true)
                                 },
                             )
                         }
@@ -739,12 +739,8 @@ private enum class SettingsItems {
     SETTINGS_INTELLIGENT_PLAYBACK,
     SETTINGS_PLAY_UP_NEXT_EPISODE,
     SETTINGS_ADJUST_REMAINING_TIME,
+    SETTINGS_GENERAL_AUTOPLAY,
     SETTINGS_HEADER_SLEEP_TIMER,
     SETTINGS_SLEEP_TIMER_RESTART,
     SETTINGS_SLEEP_TIMER_SHAKE,
-
-    // The [scrollToAutoPlay] fragment argument handling depends on this item being last
-    // in the list. If it's position is changed, make sure you update the handling when
-    // we scroll to this item as well.
-    SETTINGS_GENERAL_AUTOPLAY,
 }


### PR DESCRIPTION
## Description
- This moves the autoplay setting out of sleep timer group
- See: p1739548975417339-slack-C028JAG44VD

## Testing Instructions
- Open general settings and check if autoplay setting is not within sleep timer group setting

## Screenshots or Screencast 

| Before | After |
|--------|--------|
| ![before](https://github.com/user-attachments/assets/61f44945-25d3-41d2-8a09-1a745fce0fca) | ![Screenshot_20250219_092245](https://github.com/user-attachments/assets/caaa845e-3c1a-4f6f-998c-bea13384820b) | 

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.