### PR TITLE
[Tooling] Ensure to checkout `release/` branch on CI release-pipelines

### DIFF
--- a/.buildkite/commands/checkout-release-branch.sh
+++ b/.buildkite/commands/checkout-release-branch.sh
@@ -1,0 +1,26 @@
+#!/bin/bash -eu
+
+# Script to checkout a specific release branch
+# Usage: ./checkout-release-branch.sh <RELEASE_VERSION>
+
+# Buildkite, by default, checks out a specific commit, ending up in a detached HEAD state.
+# But in some cases, we need to ensure to be checked out on the `release/*` branch instead, namely:
+# - When a `release-pipelines/*.yml` will end up needing to do a `git push` to the `release/*` branch (for version bumps)
+# - When doing a new `release-build.sh` from a job that was `pipeline upload`'d by such a pipeline,
+#   to ensure that the job doing the build would include that recent extra commit before starting doing the build.
+
+echo "--- :git: Checkout Release Branch"
+
+if [[ -n "${1:-}" ]]; then
+  RELEASE_VERSION="$1"
+elif [[ "${BUILDKITE_BRANCH:-}" =~ ^release/ ]]; then
+  RELEASE_VERSION="${BUILDKITE_BRANCH#release/}"
+else
+  echo "Error: RELEASE_VERSION parameter missing and BUILDKITE_BRANCH is not a release branch"
+  exit 1
+fi
+BRANCH_NAME="release/${RELEASE_VERSION}"
+
+git fetch origin "$BRANCH_NAME"
+git checkout "$BRANCH_NAME"
+git pull

--- a/.buildkite/commands/release-build.sh
+++ b/.buildkite/commands/release-build.sh
@@ -1,15 +1,8 @@
 #!/bin/bash -eu
 
-echo "--- :git: Checkout Release Branch"
-# Buildkite, by default, checks out a specific commit. But given this step will be run on a CI build that will
-# first push a commit to do the version bump, before `pipeline upload`-ing the job calling this script, we need
-# to checkout the `release/` branch explicitly here, to ensure this job would include that extra commit
-# instead of running on the initial commit the whole CI build/pipeline was initially triggered on.
+# Ensure we get the latest commit of the `release/*` branch, especially to get last version bump commit before building the release
 RELEASE_VERSION="${1:?RELEASE_VERSION parameter missing}"
-BRANCH_NAME="release/${RELEASE_VERSION}"
-git fetch origin "$BRANCH_NAME"
-git checkout "$BRANCH_NAME"
-git pull
+"$(dirname "${BASH_SOURCE[0]}")/checkout-release-branch.sh" "$RELEASE_VERSION"
 
 echo "--- :rubygems: Setting up Gems"
 install_gems

--- a/.buildkite/commands/release-build.sh
+++ b/.buildkite/commands/release-build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -eu
 
-# Ensure we get the latest commit of the `release/*` branch, especially to get last version bump commit before building the release
+# Ensure we get the latest commit of the `release/*` branch, especially to get last version bump commit before building the release and publishing the GitHub Release and creating the git tag
 RELEASE_VERSION="${1:?RELEASE_VERSION parameter missing}"
 "$(dirname "${BASH_SOURCE[0]}")/checkout-release-branch.sh" "$RELEASE_VERSION"
 

--- a/.buildkite/release-pipelines/finalize-hotfix-release.yml
+++ b/.buildkite/release-pipelines/finalize-hotfix-release.yml
@@ -9,6 +9,8 @@ steps:
       echo '--- 🤖 Use bot for Git operations'
       source use-bot-for-git
 
+      .buildkite/commands/checkout-release-branch.sh "${RELEASE_VERSION}"
+
       echo '--- :ruby: Setup Ruby Tools'
       install_gems
 

--- a/.buildkite/release-pipelines/finalize-release.yml
+++ b/.buildkite/release-pipelines/finalize-release.yml
@@ -9,6 +9,8 @@ steps:
       echo '--- 🤖 Use bot for Git operations'
       source use-bot-for-git
 
+      .buildkite/commands/checkout-release-branch.sh "${RELEASE_VERSION}"
+
       echo '--- :ruby: Setup Ruby Tools'
       install_gems
 

--- a/.buildkite/release-pipelines/new-beta-release.yml
+++ b/.buildkite/release-pipelines/new-beta-release.yml
@@ -9,6 +9,8 @@ steps:
       echo '--- 🤖 Use bot for Git operations'
       source use-bot-for-git
 
+      .buildkite/commands/checkout-release-branch.sh "${RELEASE_VERSION}"
+
       echo '--- :ruby: Setup Ruby Tools'
       install_gems
 

--- a/.buildkite/release-pipelines/new-hotfix-release.yml
+++ b/.buildkite/release-pipelines/new-hotfix-release.yml
@@ -3,8 +3,6 @@
 
 # This pipeline is meant to be triggered by the MC scenario in ReleasesV2
 
-# Expected variables passed to the pipeline by ReleasesV2: `RELEASE_VERSION`, `VERSION_CODE`
-
 steps:
   - label: "🚂 New Hotfix Release"
     command: |

--- a/.buildkite/release-pipelines/publish-release.yml
+++ b/.buildkite/release-pipelines/publish-release.yml
@@ -9,6 +9,8 @@ steps:
       echo '--- 🤖 Use bot for Git operations'
       source use-bot-for-git
 
+      .buildkite/commands/checkout-release-branch.sh "${RELEASE_VERSION}"
+
       echo '--- :ruby: Setup Ruby Tools'
       install_gems
 


### PR DESCRIPTION
# What

For all `release-pipelines/*.yml` that are triggered from the `release/` branch by ReleasesV2, we need to `checkout-release-branch.sh` to ensure they are not run on a detached HEAD and will thus be able to create commits and push on the remote branch

This includes most of all `release-pipelines/*.yml`, except for:
 - `code-freeze.yml` and `new-hotfix-release.yml` — which by definition will run from the default branch in order to _create_ the `release/` branch to begin with
 - `update-rollouts.yml`, which runs from the default branch so that it can also be run after Production build has started rollout and `publish-release.yml` was run and has already deleted the `release/` branch.

> [!NOTE]
> See also:
> - [PCiOS counterpart PR](https://github.com/Automattic/pocket-casts-ios/pull/2761)
> - Scenario Template update PR in ReleasesV2 (Internal ref: 174131-ghe-Automattic/wpcom)