### PR TITLE
Fix bookmarks selection toolbar

### DIFF
--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/PlayerContainerFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/PlayerContainerFragment.kt
@@ -236,6 +236,7 @@ class PlayerContainerFragment : BaseFragment(), HasBackstack {
             multiSelectHelper = bookmarksViewModel.multiSelectHelper,
             menuRes = null,
             activity = requireActivity(),
+            includeStatusBarPadding = false,
         )
     }
 


### PR DESCRIPTION
## Description
- This is to remove the extra padding for bookmarks multiselecting

<img width="400" alt="image" src="https://github.com/user-attachments/assets/5a4ecddb-daca-49db-a3bb-fdc5619f53e9" />


## Testing Instructions
1. Log in with paid account
2. Play an episode that you have bookmarks
3. Go to Bookmarks tab
4. Long press the bookmark row
5. Ensure the toolbar does not have extra space ✅

## Screenshots or Screencast 
[Screen_recording_20250219_154221.webm](https://github.com/user-attachments/assets/85e56434-4b15-4783-a25a-a957ca88daa3)


## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [ ] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
