### PR TITLE
[Suggested Folders] Remove existing folders when accepting suggested folders

### DIFF
--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/models/db/FolderDaoTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/models/db/FolderDaoTest.kt
@@ -165,7 +165,7 @@ class FolderDaoTest {
             fakeFolder.copy(uuid = "uuid4"),
         )
 
-        folderDao.deleteAndInsertAll(newFolders)
+        folderDao.replaceAllFolders(newFolders)
 
         foundFolder1 = folderDao.findByUuid("uuid1")
         foundFolder2 = folderDao.findByUuid("uuid2")

--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/models/db/FolderDaoTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/models/db/FolderDaoTest.kt
@@ -146,4 +146,37 @@ class FolderDaoTest {
         assertEquals(newName, updatedFolder?.name)
         assertEquals(syncModified, updatedFolder?.syncModified)
     }
+
+    @Test
+    fun shouldReplaceOldFoldersWithNewOnes() = runTest {
+        val initialFolders = listOf(
+            fakeFolder.copy(uuid = "uuid1"),
+            fakeFolder.copy(uuid = "uuid2"),
+        )
+        folderDao.insertAll(initialFolders)
+
+        var foundFolder1 = folderDao.findByUuid("uuid1")
+        var foundFolder2 = folderDao.findByUuid("uuid2")
+        assertNotNull(foundFolder1)
+        assertNotNull(foundFolder2)
+
+        val newFolders = listOf(
+            fakeFolder.copy(uuid = "uuid3"),
+            fakeFolder.copy(uuid = "uuid4"),
+        )
+
+        folderDao.deleteAndInsertAll(newFolders)
+
+        foundFolder1 = folderDao.findByUuid("uuid1")
+        foundFolder2 = folderDao.findByUuid("uuid2")
+        assertNull(foundFolder1)
+        assertNull(foundFolder2)
+
+        val foundFolder3 = folderDao.findByUuid("uuid3")
+        val foundFolder4 = folderDao.findByUuid("uuid4")
+        assertNotNull(foundFolder3)
+        assertNotNull(foundFolder4)
+        assertEquals("uuid3", foundFolder3?.uuid)
+        assertEquals("uuid4", foundFolder4?.uuid)
+    }
 }

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/folders/SuggestedFoldersViewModel.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/folders/SuggestedFoldersViewModel.kt
@@ -50,7 +50,7 @@ class SuggestedFoldersViewModel @Inject constructor(
                 )
             }
 
-            folderManager.createFolders(newFolders)
+            folderManager.overrideFoldersWithSuggested(newFolders)
             suggestedFoldersManager.deleteSuggestedFolders(folders.toSuggestedFolders())
             _state.value = FoldersState.Created
         }

--- a/modules/features/podcasts/src/test/java/au/com/shiftyjelly/pocketcasts/podcasts/view/folders/SuggestedFoldersViewModelTest.kt
+++ b/modules/features/podcasts/src/test/java/au/com/shiftyjelly/pocketcasts/podcasts/view/folders/SuggestedFoldersViewModelTest.kt
@@ -72,7 +72,7 @@ class SuggestedFoldersViewModelTest {
             )
         }
 
-        verify(folderManager).createFolders(newFolders)
+        verify(folderManager).overrideFoldersWithSuggested(newFolders)
         verify(suggestedFoldersManager).deleteSuggestedFolders(any())
     }
 }

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/FolderDao.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/FolderDao.kt
@@ -75,6 +75,12 @@ abstract class FolderDao {
         }
     }
 
+    @Transaction
+    open suspend fun deleteAndInsertAll(folders: List<Folder>) {
+        deleteAll()
+        insertAll(folders)
+    }
+
     @Query("SELECT COUNT(*) FROM folders WHERE deleted = 0")
     abstract suspend fun count(): Int
 }

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/FolderDao.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/FolderDao.kt
@@ -76,7 +76,7 @@ abstract class FolderDao {
     }
 
     @Transaction
-    open suspend fun deleteAndInsertAll(folders: List<Folder>) {
+    open suspend fun replaceAllFolders(folders: List<Folder>) {
         deleteAll()
         insertAll(folders)
     }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/FolderManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/FolderManager.kt
@@ -12,7 +12,7 @@ import kotlinx.coroutines.flow.Flow
 interface FolderManager {
 
     suspend fun create(name: String, color: Int, podcastsSortType: PodcastsSortType, podcastUuids: List<String>): Folder
-    suspend fun createFolders(folders: List<SuggestedFolderDetails>)
+    suspend fun overrideFoldersWithSuggested(folders: List<SuggestedFolderDetails>)
     suspend fun delete(folder: Folder)
     suspend fun deleteAll()
     suspend fun upsertSynced(folder: Folder): Folder

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/FolderManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/FolderManagerImpl.kt
@@ -59,7 +59,7 @@ class FolderManagerImpl @Inject constructor(
         return newFolder
     }
 
-    override suspend fun createFolders(folders: List<SuggestedFolderDetails>) {
+    override suspend fun overrideFoldersWithSuggested(folders: List<SuggestedFolderDetails>) {
         val existingFolders = folderDao.findFolders().map { FolderItem.Folder(it, emptyList()) }
 
         val newFolders = folders.toFolders()

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/FolderManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/FolderManagerImpl.kt
@@ -60,20 +60,8 @@ class FolderManagerImpl @Inject constructor(
     }
 
     override suspend fun overrideFoldersWithSuggested(folders: List<SuggestedFolderDetails>) {
-        val existingFolders = folderDao.findFolders().map { FolderItem.Folder(it, emptyList()) }
-
-        val newFolders = folders.toFolders()
-
-        folderDao.deleteAndInsertAll(newFolders)
+        folderDao.deleteAndInsertAll(folders.toFolders())
         podcastManager.updateFoldersUuid(folders)
-
-        val podcasts = podcastManager.findPodcastsNotInFolder().map { FolderItem.Podcast(it) }
-        val sorted = (existingFolders + podcasts).sortedBy { it.sortPosition }
-        val convertedFolders = newFolders.map {
-            FolderItem.Folder(it, emptyList())
-        }
-
-        updateSortPosition(convertedFolders + sorted)
     }
 
     override suspend fun upsertSynced(folder: Folder): Folder {

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/FolderManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/FolderManagerImpl.kt
@@ -60,7 +60,7 @@ class FolderManagerImpl @Inject constructor(
     }
 
     override suspend fun overrideFoldersWithSuggested(folders: List<SuggestedFolderDetails>) {
-        folderDao.deleteAndInsertAll(folders.toFolders())
+        folderDao.replaceAllFolders(folders.toFolders())
         podcastManager.updateFoldersUuid(folders)
     }
 

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/FolderManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/FolderManagerImpl.kt
@@ -64,7 +64,7 @@ class FolderManagerImpl @Inject constructor(
 
         val newFolders = folders.toFolders()
 
-        folderDao.insertAll(newFolders)
+        folderDao.deleteAndInsertAll(newFolders)
         podcastManager.updateFoldersUuid(folders)
 
         val podcasts = podcastManager.findPodcastsNotInFolder().map { FolderItem.Podcast(it) }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/SuggestedFoldersManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/SuggestedFoldersManager.kt
@@ -20,11 +20,8 @@ class SuggestedFoldersManager @Inject constructor(
 
     suspend fun refreshSuggestedFolders(podcastUuids: List<String>) {
         try {
-            val request = SuggestedFoldersRequest(podcastUuids)
-            val folders: List<SuggestedFolder> = podcastCacheService.suggestedFolders(request)
-            if (!folders.isEmpty()) {
-                suggestedFoldersDao.deleteAndInsertAll(folders)
-            }
+            val folders = podcastCacheService.suggestedFolders(SuggestedFoldersRequest(podcastUuids))
+            suggestedFoldersDao.deleteAndInsertAll(folders)
         } catch (e: Exception) {
             Timber.e(e, "Refreshing suggested folders failed")
         }


### PR DESCRIPTION
## Description
- This will clean the existing folders when accepting the suggested ones
- See for context: p1739971321715109-slack-C08BRS7N9UL

## Testing Instructions

1. Run the app in `debug`
2. Have an account with some folders
3. Tap to create a new folder
4. See the suggested folders screen
5. Tap on `Use these folders`
6. Ensure the new folders were created and the existing ones were removed ✅

## Screenshots or Screencast 

### Before

https://github.com/user-attachments/assets/c48be6b9-8634-4c11-8a0c-4b78f6d5335f


### After
[Screen_recording_20250220_094630.webm](https://github.com/user-attachments/assets/1c3925f9-5676-4a6a-9674-6c10ceab5131)


## Checklist
- [ ] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [ ] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [ ] ~Any jetpack compose components I added or changed are covered by compose previews~
- [ ] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~