### PR TITLE
Folders UI tweaks

### DIFF
--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcasts/FolderViewHolder.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcasts/FolderViewHolder.kt
@@ -92,7 +92,7 @@ private fun FolderGridAdapter(color: Color, name: String, podcastUuids: List<Str
         podcastUuids = podcastUuids,
         badgeCount = badgeCount,
         badgeType = badgeType,
-        textSpacing = podcastGridLayout == PodcastGridLayoutType.LARGE_ARTWORK,
+        textSpacing = podcastGridLayout != PodcastGridLayoutType.LIST_VIEW,
         modifier = modifier.clickable { onClick() },
     )
 }

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/folder/FolderImage.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/folder/FolderImage.kt
@@ -12,6 +12,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -47,7 +48,7 @@ private val gradientBottom = Color(0x33000000)
 private val topPodcastImageGradient = listOf(Color(0x00000000), Color(0x16000000))
 private val bottomPodcastImageGradient = listOf(Color(0x16000000), Color(0x33000000))
 private const val paddingImageRatio = 4f / 120f
-private const val imageSizeRatio = 44f / 120f
+private const val imageSizeRatio = 38f / 120f
 
 @Composable
 fun FolderImage(
@@ -88,6 +89,7 @@ fun FolderImage(
             val podcastSize = (constraints.maxWidth.value * imageSizeRatio).dp
             Column(
                 horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.Center,
                 modifier = Modifier.fillMaxWidth(),
             ) {
                 val imagePadding = (constraints.maxWidth.value * paddingImageRatio).dp
@@ -127,13 +129,13 @@ fun FolderImage(
                 }
                 if (name.isNotBlank()) {
                     if (textSpacing) {
-                        Spacer(modifier = Modifier.height(imagePadding))
+                        Spacer(modifier = Modifier.height(imagePadding * 2))
                     }
                     Text(
                         text = name,
                         color = Color.White,
                         fontSize = fontSize,
-                        fontWeight = FontWeight(500),
+                        fontWeight = FontWeight.W700,
                         letterSpacing = 0.25.sp,
                         maxLines = 1,
                         overflow = TextOverflow.Ellipsis,
@@ -151,6 +153,7 @@ fun FolderImage(
                                 trim = LineHeightStyle.Trim.Both,
                             ),
                         ),
+                        modifier = Modifier.padding(horizontal = 2.dp),
                     )
                 }
             }


### PR DESCRIPTION
## Description
- This PR  fixes some missing paddings for folders, update text weight and podcast size.
- I am not putting this change behind a feature flag because iOS already has these paddings in production


## Testing Instructions
- Check folders spacings for the 3 layouts

## Screenshots or Screencast 

### Before
| ![before1](https://github.com/user-attachments/assets/6f4b5ecf-37ff-4105-bc7b-3127dd813ee4) | ![before2](https://github.com/user-attachments/assets/6b3fe864-4072-46a4-9bfa-f433c6323fe1) | ![before3](https://github.com/user-attachments/assets/03c0b325-3f58-4347-8c39-bc9eed2f78ef) |
| --- | --- | --- |

### After
| ![after1](https://github.com/user-attachments/assets/b3442dc2-c2ba-49a8-b21d-06e9eab536fd) | ![after2](https://github.com/user-attachments/assets/fb61352d-164d-4389-b73c-d8337696e74a) | ![after3](https://github.com/user-attachments/assets/7bab7581-b024-4944-acc3-9850fbbbbcba) |
| --- | --- | --- |




## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] ~I have considered whether it makes sense to add tests for my changes~
- [ ] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [ ] ~Any jetpack compose components I added or changed are covered by compose previews~
- [ ] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] ~with different themes~
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [ ] ~for accessibility with TalkBack~
