### PR TITLE
Increase the Work Manager version to 2.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
         ([#3566](https://github.com/Automattic/pocket-casts-android/pull/3566))
     *   Fix issue causing the Account Details page to become unresponsive after viewing an offer
         ([#3574](https://github.com/Automattic/pocket-casts-android/pull/3574))
+    *   Fix timeout crash from the Work Manager library
+        ([#3632](https://github.com/Automattic/pocket-casts-android/pull/3632))
 *   Updates
     *   Filter out chapters that do not belong in table of contents. See [the specification](https://github.com/Podcastindex-org/podcast-namespace/blob/main/chapters/jsonChapters.md) for more details.
         ([#3556](https://github.com/Automattic/pocket-casts-android/pull/3556))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
         ([#3566](https://github.com/Automattic/pocket-casts-android/pull/3566))
     *   Fix issue causing the Account Details page to become unresponsive after viewing an offer
         ([#3574](https://github.com/Automattic/pocket-casts-android/pull/3574))
-    *   Fix timeout crash from the Work Manager library
+    *   Fix crash in Android 15 with the background task manager
         ([#3632](https://github.com/Automattic/pocket-casts-android/pull/3632))
 *   Updates
     *   Filter out chapters that do not belong in table of contents. See [the specification](https://github.com/Podcastindex-org/podcast-namespace/blob/main/chapters/jsonChapters.md) for more details.

--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/repositories/download/UpdateEpisodeDetailsTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/repositories/download/UpdateEpisodeDetailsTest.kt
@@ -60,7 +60,7 @@ class UpdateEpisodeDetailsTest {
             onBlocking { findByUuid(episode.uuid) }.doReturn(episode)
         }
 
-        val episodeUuids = listOf(episode.uuid).toTypedArray()
+        val episodeUuids: Array<String?> = listOf(episode.uuid).toTypedArray()
         val data = Data.Builder().putStringArray(UpdateEpisodeDetailsTask.INPUT_EPISODE_UUIDS, episodeUuids).build()
         val worker = TestListenableWorkerBuilder<UpdateEpisodeDetailsTask>(context, inputData = data)
             .setWorkerFactory(TestWorkerFactory(episodeManager))

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -55,7 +55,7 @@ test = "1.6.1"
 tracks = "6.0.3"
 wear-compose = "1.4.1"
 webkit = "1.12.1"
-work = "2.9.1"
+work = "2.10.0"
 
 [libraries]
 # About Libraries

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/download/DownloadManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/download/DownloadManagerImpl.kt
@@ -143,7 +143,7 @@ class DownloadManagerImpl @Inject constructor(
 
                                     // FIXME this is a hack to avoid an issue where this listener says downloads
                                     //  on the watch app are enqueued when they are actually still running.
-                                    val queriedState = workManager.getWorkInfoById(workInfo.id).get().state
+                                    val queriedState = workManager.getWorkInfoById(workInfo.id).get()?.state
                                     if (Util.isWearOs(context) && queriedState == WorkInfo.State.RUNNING) {
                                         getRequirementsAsync(episode)
                                     } else {

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/PodcastSyncProcess.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/PodcastSyncProcess.kt
@@ -62,6 +62,7 @@ import kotlin.math.roundToInt
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.rx2.rxCompletable
@@ -314,7 +315,7 @@ class PodcastSyncProcess(
             emitter.onComplete()
         } else {
             ProcessLifecycleOwner.get().lifecycleScope.launch {
-                WorkManager.getInstance(context).getWorkInfoByIdFlow(workRequestId).first { it.state.isFinished }
+                WorkManager.getInstance(context).getWorkInfoByIdFlow(workRequestId).firstOrNull { it?.state?.isFinished ?: true }
                 logTime("Refresh - sync up next", startTime)
                 emitter.onComplete()
             }


### PR DESCRIPTION
## Description

We are seeing the following exception from version 7.82.

```
Exception android.app.RemoteServiceException$ForegroundServiceDidNotStopInTimeException: 
  A foreground service of type dataSync did not stop within its timeout: 
  ComponentInfo{au.com.shiftyjelly.pocketcasts/androidx.work.impl.foreground.SystemForegroundService}
```

There's a [Google issue on the crash](https://issuetracker.google.com/issues/364508145). The recommended fix is to upgrade Work Manager. The [release notes of 2.10.0-alpha04](https://developer.android.com/jetpack/androidx/releases/work#2.10.0-alpha04) have the following:

> Add the stop reason STOP_REASON_FOREGROUND_SERVICE_TIMEOUT for when a foreground worker is stopped due to execution timeout based on the foreground service type.

I have targeted the 7.83 beta as a production crash is happening. 

Internal reference p1740088814869259/1740056552.366629-slack-C07J5LNP4SF

## Testing Instructions

I'm unsure how to cause this crash but trying out some Work Manager tasks would be good. Some of these are UpdateShowNotesTask, UpdateEpisodeTask, and DownloadEpisodeTask.

There were a couple of code changes required. It would also be worth testing the refresh process with Up Next.

1. Go to the Profile tab
2. Tap the refresh now button
3. ✅ Verify refresh completes successfully. Check for the following log: `Refresh - sync up next - xx ms`

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 