### PR TITLE
Add background artwork to podcast view

### DIFF
--- a/modules/features/podcasts/build.gradle.kts
+++ b/modules/features/podcasts/build.gradle.kts
@@ -53,6 +53,8 @@ dependencies {
     implementation(libs.compose.material)
     implementation(libs.compose.material.icons.extended)
     implementation(libs.compose.ui)
+    implementation(libs.coil.base)
+    implementation(libs.coil.compose)
     implementation(libs.compose.ui.tooling.preview)
     implementation(libs.coroutines.core)
     implementation(libs.coroutines.rx2)

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastHeader.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastHeader.kt
@@ -502,7 +502,7 @@ private val previewColors = listOf(
     Color(0xFFFF6663),
 )
 
-private fun Modifier.blurOrScrim(useBlur: Boolean) = this then if (useBlur) {
+private fun Modifier.blurOrScrim(useBlur: Boolean) = if (useBlur) {
     blur(80.dp, BlurredEdgeTreatment.Unbounded)
 } else {
     graphicsLayer(

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastHeader.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastHeader.kt
@@ -434,16 +434,27 @@ private fun PodcastBackgroundArtwork(
         onArtworkAvailable = onArtworkAvailable,
         modifier = Modifier
             .layout { measurable, constraints ->
+                val imageHeightPx = if (useBlurredArtwork) {
+                    imageSizePx
+                } else {
+                    imageSizePx - imageBottomOffsetPx
+                }
                 val const = constraints.copy(
                     minWidth = imageSizePx,
                     maxWidth = imageSizePx,
-                    minHeight = imageSizePx - imageBottomOffsetPx,
-                    maxHeight = imageSizePx - imageBottomOffsetPx,
+                    minHeight = imageHeightPx,
+                    maxHeight = imageHeightPx,
                 )
+
                 val placeable = measurable.measure(const)
                 val width = const.constrainWidth(placeable.width)
                 val height = const.constrainHeight(placeable.height)
-                layout(width, height) { placeable.placeRelative(0, 0) }
+                val offset = if (useBlurredArtwork) {
+                    imageBottomOffsetPx
+                } else {
+                    0
+                }
+                layout(width, height - offset) { placeable.place(0, -offset) }
             }
             .blurOrScrim(useBlur = useBlurredArtwork),
     )

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastToolbar.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastToolbar.kt
@@ -191,13 +191,7 @@ private fun toolbarColors(progress: Float): PodcastToolbarColors {
 
     return remember(progress) {
         PodcastToolbarColors(
-            backgroundColor = Color(
-                ColorUtils.blendARGB(
-                    backgroundColor.toArgb(),
-                    Color.Transparent.toArgb(),
-                    progress,
-                ),
-            ),
+            backgroundColor = backgroundColor.copy(alpha = 1f - progress),
             titleColor = Color(
                 ColorUtils.blendARGB(
                     titleColor.toArgb(),

--- a/modules/services/repositories/build.gradle.kts
+++ b/modules/services/repositories/build.gradle.kts
@@ -41,6 +41,7 @@ dependencies {
 
     implementation(libs.androidx.appcompat)
     implementation(libs.androidx.core.ktx)
+    implementation(libs.androidx.palette)
     implementation(libs.androidx.preference.ktx)
     implementation(libs.coil)
     implementation(libs.compose.ui.graphics)

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/images/PodcastImageColorAnalyzer.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/images/PodcastImageColorAnalyzer.kt
@@ -1,0 +1,36 @@
+package au.com.shiftyjelly.pocketcasts.repositories.images
+
+import android.content.Context
+import androidx.compose.ui.graphics.Color
+import androidx.palette.graphics.Palette
+import coil.ImageLoader
+import coil.request.ErrorResult
+import coil.request.SuccessResult
+import dagger.hilt.android.qualifiers.ApplicationContext
+import javax.inject.Inject
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+class PodcastImageColorAnalyzer @Inject constructor(
+    @ApplicationContext context: Context,
+    private val imageLoader: ImageLoader,
+) {
+    private val requestFactory = PocketCastsImageRequestFactory(context)
+
+    suspend fun getArtworkDominantColor(uuid: String): Color? {
+        val request = requestFactory.createForPodcast(uuid)
+        val bitmap = when (val result = imageLoader.execute(request)) {
+            is SuccessResult -> result.memoryCacheKey?.let { key ->
+                imageLoader.memoryCache?.get(key)?.bitmap
+            }
+
+            is ErrorResult -> null
+        }
+        val palette = withContext(Dispatchers.IO) {
+            bitmap?.let(Palette::from)
+                ?.clearFilters()
+                ?.generate()
+        }
+        return palette?.dominantSwatch?.rgb?.let(::Color)
+    }
+}


### PR DESCRIPTION
## Description

This PR adds background artwork images to the podcast view. On SDK 31 and above, it applies a blurred artwork effect. On lower versions, vertical scrims are used instead.  

## Testing Instructions  

### Blur  

1. Start the app on a device running SDK 31 or higher.  
2. Go to **Settings**.  
3. Enable the `Podcast view changes` feature flag.  
4. Open any podcast.  
5. Observe the blurred artwork.  
6. Scroll through the content and check if the status bar icons maintain good contrast at all times. Some complex artworks may cause contrast issues when the toolbar is transparent, though I haven't encountered such cases.  
7. Test with different themes and podcasts.  

### Scrim  

1. Start the app on a device running SDK 30 or lower.  
2. Go to **Settings**.  
3. Enable the `Podcast view changes` feature flag.  
4. Open any podcast.  
5. Observe that a scrim is applied to the artwork.  
6. Scroll through the content and check if the status bar icons maintain good contrast at all times. Some complex artworks may cause contrast issues when the toolbar is transparent, though I haven't encountered such cases.  
7. Test with different themes and podcasts.  


### Old UI

1. Make sure that `Podcast view changes` feature flag is disabled.
2. Open any podcast.
3. Check if there any issues with the status bar icon colors.

| Blur | Scrim |
| - | - |
| ![blur](https://github.com/user-attachments/assets/4ea6b9c4-cc7a-470b-a9ab-293e0c36a8e0) | ![scrim](https://github.com/user-attachments/assets/c8594010-cde9-4fe4-86fb-dd789936a002) |

## Checklist
- [ ] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] ~I have considered whether it makes sense to add tests for my changes~
- [ ] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [ ] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack
