### PR TITLE
[Suggested Folders] Suggested Folders Tweaks

### DIFF
--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/folders/SuggestedFolders.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/folders/SuggestedFolders.kt
@@ -10,16 +10,16 @@ import androidx.core.os.BundleCompat
 import androidx.fragment.app.viewModels
 import au.com.shiftyjelly.pocketcasts.compose.AppThemeWithBackground
 import au.com.shiftyjelly.pocketcasts.compose.extensions.contentWithoutConsumedInsets
+import au.com.shiftyjelly.pocketcasts.ui.helper.FragmentHostListener
 import au.com.shiftyjelly.pocketcasts.views.dialog.ConfirmationDialog
-import au.com.shiftyjelly.pocketcasts.views.fragments.BaseDialogFragment
+import au.com.shiftyjelly.pocketcasts.views.fragments.BaseFragment
 import dagger.hilt.android.AndroidEntryPoint
-import kotlin.getValue
 import au.com.shiftyjelly.pocketcasts.images.R as VR
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 import au.com.shiftyjelly.pocketcasts.ui.R as UR
 
 @AndroidEntryPoint
-class SuggestedFolders : BaseDialogFragment() {
+class SuggestedFolders : BaseFragment() {
 
     companion object {
         private const val FOLDERS_KEY = "folders_key"
@@ -50,7 +50,7 @@ class SuggestedFolders : BaseDialogFragment() {
 
             LaunchedEffect(state) {
                 if (state is SuggestedFoldersViewModel.FoldersState.Created) {
-                    dismiss()
+                    (activity as FragmentHostListener).closeToRoot()
                 }
             }
 
@@ -61,7 +61,7 @@ class SuggestedFolders : BaseDialogFragment() {
                 },
                 onDismiss = {
                     viewModel.onDismissed()
-                    dismiss()
+                    (activity as FragmentHostListener).closeToRoot()
                 },
                 onUseTheseFolders = {
                     showConfirmationDialog()
@@ -69,7 +69,7 @@ class SuggestedFolders : BaseDialogFragment() {
                 onCreateCustomFolders = {
                     viewModel.onCreateCustomFolders()
                     FolderCreateFragment.newInstance(source = "suggested_folders").show(parentFragmentManager, "create_folder_card")
-                    dismiss()
+                    (activity as FragmentHostListener).closeToRoot()
                 },
             )
         }

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/folders/SuggestedFolders.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/folders/SuggestedFolders.kt
@@ -51,6 +51,8 @@ class SuggestedFolders : BaseFragment() {
             LaunchedEffect(state) {
                 if (state is SuggestedFoldersViewModel.FoldersState.Created) {
                     (activity as FragmentHostListener).closeToRoot()
+                } else if (state is SuggestedFoldersViewModel.FoldersState.ShowConfirmationDialog) {
+                    showConfirmationDialog()
                 }
             }
 
@@ -64,7 +66,7 @@ class SuggestedFolders : BaseFragment() {
                     (activity as FragmentHostListener).closeToRoot()
                 },
                 onUseTheseFolders = {
-                    showConfirmationDialog()
+                    viewModel.onUseTheseFolders(suggestedFolders)
                 },
                 onCreateCustomFolders = {
                     viewModel.onCreateCustomFolders()
@@ -80,7 +82,7 @@ class SuggestedFolders : BaseFragment() {
             .setButtonType(ConfirmationDialog.ButtonType.Danger(getString(LR.string.suggested_folders_replace_folders_button)))
             .setTitle(getString(LR.string.suggested_folders_replace_folders_confirmation_tittle))
             .setSummary(getString(LR.string.suggested_folders_replace_folders_confirmation_description))
-            .setOnConfirm { viewModel.onUseTheseFolders(suggestedFolders) }
+            .setOnConfirm { viewModel.overrideFoldersWithSuggested(suggestedFolders) }
             .setIconId(VR.drawable.ic_replace)
             .setIconTint(UR.attr.primary_interactive_01)
             .show(childFragmentManager, "suggested-folders-confirmation-dialog")

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/folders/SuggestedFoldersPage.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/folders/SuggestedFoldersPage.kt
@@ -3,9 +3,7 @@ package au.com.shiftyjelly.pocketcasts.podcasts.view.folders
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.WindowInsets
-import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.layout.windowInsetsPadding
@@ -56,7 +54,7 @@ fun SuggestedFoldersPage(
     Column(
         modifier = modifier
             .fillMaxSize()
-            .windowInsetsPadding(WindowInsets.safeDrawing.only(WindowInsetsSides.Horizontal)),
+            .windowInsetsPadding(WindowInsets.safeDrawing),
     ) {
         IconButton(
             onClick = onDismiss,

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/folders/SuggestedFoldersPaywall.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/folders/SuggestedFoldersPaywall.kt
@@ -64,7 +64,6 @@ fun SuggestedFoldersPaywall(
         modifier = modifier
             .windowInsetsPadding(WindowInsets.safeDrawing.only(WindowInsetsSides.Horizontal))
             .wrapContentSize()
-            .padding(horizontal = 16.dp)
             .padding(top = 8.dp, bottom = 16.dp),
         horizontalAlignment = Alignment.CenterHorizontally,
     ) {
@@ -94,19 +93,19 @@ fun SuggestedFoldersPaywall(
             text = stringResource(LR.string.suggested_folders_paywall_tittle),
             fontWeight = FontWeight.W600,
             textAlign = TextAlign.Center,
-            modifier = Modifier.padding(bottom = 12.dp),
+            modifier = Modifier.padding(bottom = 12.dp).padding(horizontal = 16.dp),
         )
 
         TextH50(
             text = stringResource(LR.string.suggested_folders_paywall_subtitle),
             color = MaterialTheme.theme.colors.primaryText02,
             textAlign = TextAlign.Center,
-            modifier = Modifier.padding(bottom = 12.dp),
+            modifier = Modifier.padding(bottom = 12.dp).padding(horizontal = 16.dp),
         )
 
         RowButton(
             text = stringResource(LR.string.suggested_folders_use_these_folders_button),
-            modifier = Modifier.padding(bottom = 16.dp),
+            modifier = Modifier.padding(bottom = 16.dp).padding(horizontal = 16.dp),
             textColor = MaterialTheme.theme.colors.primaryInteractive02,
             fontSize = 18.sp,
             fontWeight = FontWeight.W600,
@@ -119,7 +118,7 @@ fun SuggestedFoldersPaywall(
 
         RowOutlinedButton(
             text = stringResource(id = LR.string.maybe_later),
-            modifier = Modifier.padding(bottom = 16.dp),
+            modifier = Modifier.padding(bottom = 16.dp).padding(horizontal = 16.dp),
             onClick = onMaybeLater,
             includePadding = false,
             colors = ButtonDefaults.outlinedButtonColors(contentColor = MaterialTheme.theme.colors.primaryIcon01, backgroundColor = Color.Transparent),
@@ -156,6 +155,7 @@ private fun SuggestedFoldersPagePreview(@PreviewParameter(ThemePreviewParameterP
             folders = listOf(
                 Folder("Folder 1", listOf("2e61ba20-50a9-0135-902b-63f4b61a9224", "2e61ba20-50a9-0135-902b-63f4b61a9224"), 1),
                 Folder("Folder 2", listOf("2e61ba20-50a9-0135-902b-63f4b61a9224", "2e61ba20-50a9-0135-902b-63f4b61a9224"), 2),
+                Folder("Folder 3", listOf("2e61ba20-50a9-0135-902b-63f4b61a9224", "2e61ba20-50a9-0135-902b-63f4b61a9224"), 5),
             ),
             onUseTheseFolders = {},
             onMaybeLater = {},

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/folders/SuggestedFoldersPaywallBottomSheet.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/folders/SuggestedFoldersPaywallBottomSheet.kt
@@ -14,6 +14,7 @@ import au.com.shiftyjelly.pocketcasts.compose.AppTheme
 import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingFlow
 import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingLauncher
 import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingUpgradeSource
+import au.com.shiftyjelly.pocketcasts.ui.helper.FragmentHostListener
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.google.android.material.bottomsheet.BottomSheetDialog
@@ -62,7 +63,7 @@ class SuggestedFoldersPaywallBottomSheet : BottomSheetDialogFragment() {
                 onUseTheseFolders = {
                     if (signInState.value?.isSignedInAsPlusOrPatron == true) {
                         dismiss()
-                        SuggestedFolders().show(parentFragmentManager, "suggested_folders")
+                        (activity as FragmentHostListener).showModal(SuggestedFolders.newInstance(suggestedFolders))
                     } else {
                         OnboardingLauncher.openOnboardingFlow(activity, OnboardingFlow.Upsell(OnboardingUpgradeSource.SUGGESTED_FOLDERS))
                     }

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/folders/SuggestedFoldersViewModel.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/folders/SuggestedFoldersViewModel.kt
@@ -36,9 +36,23 @@ class SuggestedFoldersViewModel @Inject constructor(
     }
 
     fun onUseTheseFolders(folders: List<Folder>) {
-        _state.value = FoldersState.Creating
         analyticsTracker.track(AnalyticsEvent.SUGGESTED_FOLDERS_MODAL_USE_THESE_FOLDERS_TAPPED)
+        viewModelScope.launch {
+            val currentFoldersCount = folderManager.countFolders()
+            if (currentFoldersCount > 0) {
+                _state.value = FoldersState.ShowConfirmationDialog
+            } else {
+                overrideFoldersWithSuggested(folders)
+            }
+        }
+    }
 
+    fun onCreateCustomFolders() {
+        analyticsTracker.track(AnalyticsEvent.SUGGESTED_FOLDERS_MODAL_CREATE_CUSTOM_FOLDERS_TAPPED)
+    }
+
+    fun overrideFoldersWithSuggested(folders: List<Folder>) {
+        _state.value = FoldersState.Creating
         viewModelScope.launch {
             val newFolders = folders.map {
                 SuggestedFolderDetails(
@@ -56,13 +70,10 @@ class SuggestedFoldersViewModel @Inject constructor(
         }
     }
 
-    fun onCreateCustomFolders() {
-        analyticsTracker.track(AnalyticsEvent.SUGGESTED_FOLDERS_MODAL_CREATE_CUSTOM_FOLDERS_TAPPED)
-    }
-
     sealed class FoldersState {
         data object Idle : FoldersState()
         data object Creating : FoldersState()
         data object Created : FoldersState()
+        data object ShowConfirmationDialog : FoldersState()
     }
 }

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcasts/PodcastsFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcasts/PodcastsFragment.kt
@@ -321,7 +321,7 @@ class PodcastsFragment : BaseFragment(), FolderAdapter.ClickListener, PodcastTou
     private fun createFolder() {
         val state = viewModel.suggestedFoldersState
         if (FeatureFlag.isEnabled(Feature.SUGGESTED_FOLDERS) && state is PodcastsViewModel.SuggestedFoldersState.Loaded) {
-            SuggestedFolders.newInstance(state.folders()).show(parentFragmentManager, "suggested_folders")
+            (activity as FragmentHostListener).showModal(SuggestedFolders.newInstance(state.folders()))
         } else {
             FolderCreateFragment.newInstance(PODCASTS_LIST).show(parentFragmentManager, "create_folder_card")
         }

--- a/modules/features/podcasts/src/test/java/au/com/shiftyjelly/pocketcasts/podcasts/view/folders/SuggestedFoldersViewModelTest.kt
+++ b/modules/features/podcasts/src/test/java/au/com/shiftyjelly/pocketcasts/podcasts/view/folders/SuggestedFoldersViewModelTest.kt
@@ -60,7 +60,7 @@ class SuggestedFoldersViewModelTest {
             Folder("Tech Podcasts", listOf("podcastuuid1"), 1),
         )
 
-        viewModel.onUseTheseFolders(folders)
+        viewModel.overrideFoldersWithSuggested(folders)
 
         val newFolders: List<SuggestedFolderDetails> = folders.map {
             SuggestedFolderDetails(


### PR DESCRIPTION
## Description
- This addresses the feedbacks found on this test: p1740080264895809-slack-C08BRS7N9UL : 
   - Suggested folder being cropped in paywall ✅
   - Scroll issue in Suggested Folder screen ✅
   - Show confirmation dialog only if the user already has folders ✅

## Testing Instructions
Run the app in `debug`

### Suggested folder being cropped in paywall
1. Have a free account
2. Follow some podcasts
3. Go to Podcasts tab to see the suggested folder paywall
4. Ensure the folders are not being cropped ✅

### Confirmation dialog
1. Log in with a paid account
2. Follow some podcasts
3. Go to Podcasts tab
4. Make sure you don't have folders
5. Tap to create a folder
6. Tap on Use these folders
7. Ensure you don't see the confirmation dialog ✅
8. Follow more podcasts
9. Repeat the steps 5 and 6
10. Ensure you see the confirmation dialog ✅

### Scroll issue
1. Log in with a paid account
2. Follow some podcasts. Something like 10 (If you run this test in a small device you don't need to follow so many podcasts
3. Go to Podcasts tab
4. Tap to create a folder
5. You should be able to scroll up and down in Suggested folder screen ✅


## Checklist
- [ ] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [ ] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] ~I have considered whether it makes sense to add tests for my changes~
- [ ] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [ ] ~Any jetpack compose components I added or changed are covered by compose previews~
- [ ] ~I have updated (or requested that someone edit) [the spreadsheet]~(https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~