### PR TITLE
Set ellipsis as default overflow for toolbar text

### DIFF
--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/bars/ThemedTopAppBar.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/bars/ThemedTopAppBar.kt
@@ -24,6 +24,7 @@ import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.dp
@@ -65,6 +66,7 @@ fun ThemedTopAppBar(
         ThemedTopAppBar.Style.Immersive -> MaterialTheme.theme.colors.primaryUi01
     },
     bottomShadow: Boolean = false,
+    titleOverflow: TextOverflow = TextOverflow.Ellipsis,
     windowInsets: WindowInsets = AppBarDefaults.topAppBarWindowInsets,
     actions: @Composable RowScope.(Color) -> Unit = {},
     onNavigationClick: () -> Unit,
@@ -85,6 +87,7 @@ fun ThemedTopAppBar(
                     Text(
                         text = title,
                         color = textColor,
+                        overflow = titleOverflow,
                     )
                 }
             },


### PR DESCRIPTION
## Description
- This is to fix some issues when we set the largest font size. 


## Testing Instructions
1. Use the largest font size and check the `Name your folder` toolbar (Start creating a new folder to see this screen)

## Screenshots or Screencast 

| Before | After |
|--------|--------|
| ![before](https://github.com/user-attachments/assets/8f03b26c-899d-4fd3-bd5b-0e63017a4852) | ![after](https://github.com/user-attachments/assets/b85af942-f6a2-4a9d-89b2-186a4d48d537) | 





## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [ ] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
