### PR TITLE
Include podcast details in header

### DIFF
--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastAdapter.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastAdapter.kt
@@ -255,6 +255,7 @@ class PodcastAdapter(
                     onClickFolder = onFoldersClicked,
                     onClickNotification = onNotificationsClicked,
                     onClickSettings = onSettingsClicked,
+                    onClickWebsiteLink = ::onWebsiteLinkClicked,
                     onToggleHeader = {
                         onChangeHeaderExpanded(podcast.uuid, !podcast.isHeaderExpanded)
                     },
@@ -305,6 +306,7 @@ class PodcastAdapter(
                 ratingState,
                 signInState,
             )
+
             is EpisodeViewHolder -> bindEpisodeViewHolder(holder, position, fromListUuid)
             is PodcastViewHolder -> bindPodcastViewHolder(holder)
             is TabsViewHolder -> holder.bind(getItem(position) as TabsHeader)
@@ -362,9 +364,7 @@ class PodcastAdapter(
                                 schedule = podcast.displayableFrequency(context.resources),
                                 next = podcast.displayableNextEpisodeDate(context),
                             ),
-                            onWebsiteLinkClicked = {
-                                onWebsiteLinkClicked(context)
-                            },
+                            onWebsiteLinkClicked = ::onWebsiteLinkClicked,
                         )
                     },
                     ratingsContent = {
@@ -739,7 +739,7 @@ class PodcastAdapter(
         onHeaderSummaryToggled(expanded, true)
     }
 
-    private fun onWebsiteLinkClicked(context: Context) {
+    private fun onWebsiteLinkClicked() {
         podcast.podcastUrl?.let { url ->
             if (url.isNotBlank()) {
                 try {
@@ -931,6 +931,7 @@ class PodcastAdapter(
         private val onClickFolder: () -> Unit,
         private val onClickNotification: () -> Unit,
         private val onClickSettings: () -> Unit,
+        private val onClickWebsiteLink: () -> Unit,
         private val onToggleHeader: () -> Unit,
         private val onToggleDescription: () -> Unit,
         private val onLongClickArtwork: () -> Unit,
@@ -964,6 +965,12 @@ class PodcastAdapter(
                         category = podcast.getFirstCategory(itemView.context.resources),
                         author = podcast.author,
                         description = podcastDescription,
+                        podcastInfoState = PodcastInfoState(
+                            author = podcast.author,
+                            link = podcast.getShortUrl(),
+                            schedule = podcast.displayableFrequency(context.resources),
+                            next = podcast.displayableNextEpisodeDate(context),
+                        ),
                         rating = ratingState,
                         isFollowed = podcast.isSubscribed,
                         areNotificationsEnabled = podcast.isShowNotifications,
@@ -987,6 +994,7 @@ class PodcastAdapter(
                         onClickFolder = onClickFolder,
                         onClickNotification = onClickNotification,
                         onClickSettings = onClickSettings,
+                        onClickWebsiteLink = onClickWebsiteLink,
                         onToggleHeader = onToggleHeader,
                         onToggleDescription = onToggleDescription,
                         onLongClickArtwork = onLongClickArtwork,

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastAdapter.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastAdapter.kt
@@ -21,6 +21,8 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.statusBars
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.compose.ui.text.AnnotatedString
@@ -216,8 +218,10 @@ class PodcastAdapter(
 
     private val disposables = CompositeDisposable()
     private var podcast: Podcast = Podcast()
+    private var podcastDescription = AnnotatedString("")
 
     private var headerExpanded: Boolean = false
+    private var isDescriptionExpanded = false
     private var tintColor: Int = 0x000000
     private var signInState: SignInState = SignInState.SignedOut
     private var ratingState: RatingState = RatingState.Loading
@@ -253,6 +257,10 @@ class PodcastAdapter(
                     onClickSettings = onSettingsClicked,
                     onToggleHeader = {
                         onChangeHeaderExpanded(podcast.uuid, !podcast.isHeaderExpanded)
+                    },
+                    onToggleDescription = {
+                        isDescriptionExpanded = !isDescriptionExpanded
+                        notifyItemChanged(0)
                     },
                     onLongClickArtwork = {
                         onArtworkLongClicked { notifyItemChanged(0) }
@@ -290,7 +298,13 @@ class PodcastAdapter(
 
     override fun onBindViewHolder(holder: RecyclerView.ViewHolder, position: Int) {
         when (holder) {
-            is PodcastHeaderViewHolder -> holder.bind(podcast, ratingState, signInState)
+            is PodcastHeaderViewHolder -> holder.bind(
+                podcast,
+                podcastDescription,
+                isDescriptionExpanded,
+                ratingState,
+                signInState,
+            )
             is EpisodeViewHolder -> bindEpisodeViewHolder(holder, position, fromListUuid)
             is PodcastViewHolder -> bindPodcastViewHolder(holder)
             is TabsViewHolder -> holder.bind(getItem(position) as TabsHeader)
@@ -334,25 +348,12 @@ class PodcastAdapter(
     private fun bindHeaderBottom(holder: PodcastViewHolder, ratingState: RatingState) {
         holder.binding.bottom.root.isVisible = headerExpanded
 
-        val isHtmlDescription = FeatureFlag.isEnabled(Feature.PODCAST_HTML_DESCRIPTION) && podcast.podcastHtmlDescription.isNotEmpty()
-        val descriptionLinkColor: Int = ThemeColor.podcastText02(theme.activeTheme, tintColor)
-
-        val description = if (isHtmlDescription) {
-            HtmlCompat.fromHtml(
-                podcast.podcastHtmlDescription,
-                HtmlCompat.FROM_HTML_MODE_COMPACT and
-                    HtmlCompat.FROM_HTML_SEPARATOR_LINE_BREAK_PARAGRAPH.inv(), // keep the extra line break from paragraphs as it looks better
-            ).toAnnotatedString(urlColor = descriptionLinkColor)
-        } else {
-            AnnotatedString(podcast.podcastDescription)
-        }
-
         holder.binding.bottom.podcastHeaderBottom.setContent {
             AppTheme(theme.activeTheme) {
                 PodcastHeaderBottom(
                     title = podcast.title,
                     category = podcast.getFirstCategory(context.resources),
-                    description = description,
+                    description = podcastDescription,
                     podcastInfoContent = {
                         PodcastInfoView(
                             PodcastInfoState(
@@ -501,6 +502,18 @@ class PodcastAdapter(
             onHeaderSummaryToggled(headerExpanded, false)
         }
         this.podcast = podcast
+        val isHtmlDescription = FeatureFlag.isEnabled(Feature.PODCAST_HTML_DESCRIPTION) && podcast.podcastHtmlDescription.isNotEmpty()
+        this.podcastDescription = if (isHtmlDescription) {
+            val ann = HtmlCompat.fromHtml(
+                podcast.podcastHtmlDescription,
+                HtmlCompat.FROM_HTML_MODE_COMPACT and
+                    HtmlCompat.FROM_HTML_SEPARATOR_LINE_BREAK_PARAGRAPH.inv(), // keep the extra line break from paragraphs as it looks better
+            ).toAnnotatedString(urlColor = ThemeColor.podcastText02(theme.activeTheme, tintColor))
+            ann
+        } else {
+            AnnotatedString(podcast.podcastDescription)
+        }
+
         notifyDataSetChanged()
     }
 
@@ -908,7 +921,7 @@ class PodcastAdapter(
         }
     }
 
-    private class PodcastHeaderViewHolder(
+    private inner class PodcastHeaderViewHolder(
         context: Context,
         private val theme: Theme,
         private val useBlurredArtwork: Boolean,
@@ -919,6 +932,7 @@ class PodcastAdapter(
         private val onClickNotification: () -> Unit,
         private val onClickSettings: () -> Unit,
         private val onToggleHeader: () -> Unit,
+        private val onToggleDescription: () -> Unit,
         private val onLongClickArtwork: () -> Unit,
         private val onArtworkAvailable: (String) -> Unit,
     ) : RecyclerView.ViewHolder(ComposeView(context)) {
@@ -931,6 +945,8 @@ class PodcastAdapter(
 
         fun bind(
             podcast: Podcast,
+            podcastDescription: AnnotatedString,
+            isDescriptionExpanded: Boolean,
             ratingState: RatingState,
             signInState: SignInState,
         ) {
@@ -947,6 +963,7 @@ class PodcastAdapter(
                         title = podcast.title,
                         category = podcast.getFirstCategory(itemView.context.resources),
                         author = podcast.author,
+                        description = podcastDescription,
                         rating = ratingState,
                         isFollowed = podcast.isSubscribed,
                         areNotificationsEnabled = podcast.isShowNotifications,
@@ -956,6 +973,7 @@ class PodcastAdapter(
                             else -> PodcastFolderIcon.NotInFolder
                         },
                         isHeaderExpanded = podcast.isHeaderExpanded,
+                        isDescriptionExpanded = isDescriptionExpanded,
                         contentPadding = PaddingValues(
                             top = statusBarPadding + 40.dp, // Eyeball the position inside app bar
                             start = 16.dp,
@@ -970,6 +988,7 @@ class PodcastAdapter(
                         onClickNotification = onClickNotification,
                         onClickSettings = onClickSettings,
                         onToggleHeader = onToggleHeader,
+                        onToggleDescription = onToggleDescription,
                         onLongClickArtwork = onLongClickArtwork,
                         onArtworkAvailable = { onArtworkAvailable(podcast.uuid) },
                     )

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastHeader.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastHeader.kt
@@ -116,6 +116,7 @@ internal fun PodcastHeader(
     category: String,
     author: String,
     description: AnnotatedString,
+    podcastInfoState: PodcastInfoState,
     rating: RatingState,
     isFollowed: Boolean,
     areNotificationsEnabled: Boolean,
@@ -130,6 +131,7 @@ internal fun PodcastHeader(
     onClickFolder: () -> Unit,
     onClickNotification: () -> Unit,
     onClickSettings: () -> Unit,
+    onClickWebsiteLink: () -> Unit,
     onToggleHeader: () -> Unit,
     onToggleDescription: () -> Unit,
     onLongClickArtwork: () -> Unit,
@@ -199,8 +201,10 @@ internal fun PodcastHeader(
             ) {
                 PodcastDetails(
                     description = description,
+                    podcastInfoState = podcastInfoState,
                     isDescriptionExpanded = isDescriptionExpanded,
                     onClickShowNotes = onToggleDescription,
+                    onClickWebsiteLink = onClickWebsiteLink,
                 )
             }
         }
@@ -531,8 +535,10 @@ private fun ActionButton(
 @Composable
 private fun PodcastDetails(
     description: AnnotatedString,
+    podcastInfoState: PodcastInfoState,
     isDescriptionExpanded: Boolean,
     onClickShowNotes: () -> Unit,
+    onClickWebsiteLink: () -> Unit,
 ) {
     Column {
         Spacer(
@@ -553,6 +559,13 @@ private fun PodcastDetails(
                     interactionSource = null,
                     onClick = onClickShowNotes,
                 ),
+        )
+        Spacer(
+            modifier = Modifier.height(16.dp),
+        )
+        PodcastInfoView(
+            state = podcastInfoState,
+            onWebsiteLinkClicked = onClickWebsiteLink,
         )
     }
 }
@@ -767,6 +780,12 @@ private fun PodcastHeaderPreview() {
                     |Whether you cook or just love to eat, join us for a delicious journey!
                     """.trimMargin().lines().joinToString(separator = " "),
                 ),
+                podcastInfoState = PodcastInfoState(
+                    author = "Pocket Casts",
+                    link = "pocketcasts.com",
+                    schedule = "Every two weeks",
+                    next = "Meaning of life",
+                ),
                 rating = RatingState.Loaded(
                     ratings = PodcastRatings(
                         podcastUuid = "uuid",
@@ -792,6 +811,7 @@ private fun PodcastHeaderPreview() {
                 onClickFolder = {},
                 onClickNotification = {},
                 onClickSettings = {},
+                onClickWebsiteLink = {},
                 onToggleHeader = { isHeaderExpanded = !isHeaderExpanded },
                 onToggleDescription = { isDescriptionExpanded = !isDescriptionExpanded },
                 onLongClickArtwork = {},

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastHeader.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastHeader.kt
@@ -74,8 +74,10 @@ import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.clearAndSetSemantics
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.role
+import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.Placeholder
 import androidx.compose.ui.text.PlaceholderVerticalAlign
+import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
@@ -89,6 +91,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import au.com.shiftyjelly.pocketcasts.compose.AppThemeWithBackground
 import au.com.shiftyjelly.pocketcasts.compose.Devices
+import au.com.shiftyjelly.pocketcasts.compose.components.ExpandableText
 import au.com.shiftyjelly.pocketcasts.compose.components.PodcastImage
 import au.com.shiftyjelly.pocketcasts.compose.components.TextH20
 import au.com.shiftyjelly.pocketcasts.compose.components.TextH40
@@ -112,11 +115,13 @@ internal fun PodcastHeader(
     title: String,
     category: String,
     author: String,
+    description: AnnotatedString,
     rating: RatingState,
     isFollowed: Boolean,
     areNotificationsEnabled: Boolean,
     folderIcon: PodcastFolderIcon,
     isHeaderExpanded: Boolean,
+    isDescriptionExpanded: Boolean,
     contentPadding: PaddingValues,
     useBlurredArtwork: Boolean,
     onClickRating: (RatingTappedSource) -> Unit,
@@ -126,6 +131,7 @@ internal fun PodcastHeader(
     onClickNotification: () -> Unit,
     onClickSettings: () -> Unit,
     onToggleHeader: () -> Unit,
+    onToggleDescription: () -> Unit,
     onLongClickArtwork: () -> Unit,
     onArtworkAvailable: () -> Unit,
     modifier: Modifier = Modifier,
@@ -186,6 +192,17 @@ internal fun PodcastHeader(
                 onClickNotification = onClickNotification,
                 onClickSettings = onClickSettings,
             )
+            AnimatedVisibility(
+                visible = isHeaderExpanded,
+                enter = headerInTranstion,
+                exit = headerOutTranstion,
+            ) {
+                PodcastDetails(
+                    description = description,
+                    isDescriptionExpanded = isDescriptionExpanded,
+                    onClickShowNotes = onToggleDescription,
+                )
+            }
         }
     }
 }
@@ -512,6 +529,35 @@ private fun ActionButton(
 }
 
 @Composable
+private fun PodcastDetails(
+    description: AnnotatedString,
+    isDescriptionExpanded: Boolean,
+    onClickShowNotes: () -> Unit,
+) {
+    Column {
+        Spacer(
+            modifier = Modifier.height(24.dp),
+        )
+        ExpandableText(
+            text = description,
+            overflowText = stringResource(LR.string.see_more),
+            isExpanded = isDescriptionExpanded,
+            style = detailsInfoTextStyle.copy(
+                color = MaterialTheme.theme.colors.primaryText01,
+            ),
+            maxLines = 4,
+            modifier = Modifier
+                .fillMaxWidth()
+                .clickable(
+                    indication = null,
+                    interactionSource = null,
+                    onClick = onClickShowNotes,
+                ),
+        )
+    }
+}
+
+@Composable
 private fun PodcastBackgroundArtwork(
     uuid: String,
     useBlurredArtwork: Boolean,
@@ -630,6 +676,11 @@ internal enum class PodcastFolderIcon(
     ),
 }
 
+val detailsInfoTextStyle = TextStyle(
+    fontSize = 16.sp,
+    lineHeight = 22.sp,
+)
+
 private val buttonRipple = ripple()
 private val controlActionRipple = ripple(bounded = false)
 
@@ -669,6 +720,14 @@ private val chevronRotationSpec = spring<Float>(
     stiffness = 200f,
     visibilityThreshold = 0.001f,
 )
+private val headerInTranstion = expandVertically(
+    animationSpec = spring(stiffness = 200f, visibilityThreshold = IntSize.VisibilityThreshold),
+    expandFrom = Alignment.Top,
+)
+private val headerOutTranstion = shrinkVertically(
+    animationSpec = spring(stiffness = 200f, visibilityThreshold = IntSize.VisibilityThreshold),
+    shrinkTowards = Alignment.Top,
+)
 
 private val previewColors = listOf(
     Color(0xFFCC99C9),
@@ -690,6 +749,7 @@ private val previewColors = listOf(
 private fun PodcastHeaderPreview() {
     var isFollowed by remember { mutableStateOf(false) }
     var isHeaderExpanded by remember { mutableStateOf(true) }
+    var isDescriptionExpanded by remember { mutableStateOf(false) }
 
     AppThemeWithBackground(Theme.ThemeType.LIGHT) {
         Column(
@@ -700,6 +760,13 @@ private fun PodcastHeaderPreview() {
                 title = "The Pitchfork Review",
                 category = "Music",
                 author = "Pitchfork",
+                description = AnnotatedString(
+                    """
+                    |Savor & Stir is a culinary podcast exploring flavors, techniques, and food stories from chefs and home cooks.
+                    |Each episode serves up tips, trends, and recipes to inspire your kitchen adventures.
+                    |Whether you cook or just love to eat, join us for a delicious journey!
+                    """.trimMargin().lines().joinToString(separator = " "),
+                ),
                 rating = RatingState.Loaded(
                     ratings = PodcastRatings(
                         podcastUuid = "uuid",
@@ -711,6 +778,7 @@ private fun PodcastHeaderPreview() {
                 areNotificationsEnabled = true,
                 folderIcon = PodcastFolderIcon.BuyFolders,
                 isHeaderExpanded = isHeaderExpanded,
+                isDescriptionExpanded = isDescriptionExpanded,
                 contentPadding = PaddingValues(
                     top = 48.dp,
                     start = 16.dp,
@@ -725,6 +793,7 @@ private fun PodcastHeaderPreview() {
                 onClickNotification = {},
                 onClickSettings = {},
                 onToggleHeader = { isHeaderExpanded = !isHeaderExpanded },
+                onToggleDescription = { isDescriptionExpanded = !isDescriptionExpanded },
                 onLongClickArtwork = {},
                 onArtworkAvailable = {},
             )

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/ExpandableText.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/ExpandableText.kt
@@ -52,9 +52,9 @@ fun ExpandableText(
                 buildAnnotatedString {
                     // Estimate the number of characters to trim in order to fit the overflow text.
                     // Since character widths vary, we approximate by adding 2 (for the ellipsis and space)
-                    // and multiplying by 1.3 to account for potential width differences.
+                    // and multiplying by 1.5 to account for potential width differences.
                     // The final trimmed length attempts to give enough of the available space.
-                    val trimCharCount = ((overflowText.length + 2) * 1.3f).roundToInt()
+                    val trimCharCount = ((overflowText.length + 2) * 1.5f).roundToInt()
                     append(text, 0, (lastCharIndex - trimCharCount).coerceAtLeast(0))
                     append("… ")
                     withStyle(style.toSpanStyle().copy(fontWeight = FontWeight.Bold)) {

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/ExpandableText.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/ExpandableText.kt
@@ -1,0 +1,130 @@
+package au.com.shiftyjelly.pocketcasts.compose.components
+
+import androidx.compose.animation.animateContentSize
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.rememberTextMeasurer
+import androidx.compose.ui.text.withStyle
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import kotlin.math.roundToInt
+
+@Composable
+fun ExpandableText(
+    text: AnnotatedString,
+    overflowText: String,
+    isExpanded: Boolean,
+    style: TextStyle,
+    maxLines: Int,
+    modifier: Modifier = Modifier,
+) {
+    BoxWithConstraints(
+        modifier = modifier,
+    ) {
+        val measurer = rememberTextMeasurer()
+        val displayedText = remember(measurer, text, isExpanded) {
+            val result = measurer.measure(
+                text = text,
+                style = style,
+                maxLines = maxLines,
+                constraints = constraints,
+            )
+            if (!isExpanded && result.hasVisualOverflow) {
+                val lastCharIndex = result.getLineEnd(lineIndex = result.lineCount - 1, visibleEnd = true)
+                buildAnnotatedString {
+                    val trimCharCount = ((overflowText.length + 2) * 1.2f).roundToInt()
+                    append(text, 0, (lastCharIndex - trimCharCount).coerceAtLeast(0))
+                    append("… ")
+                    withStyle(style.toSpanStyle().copy(fontWeight = FontWeight.Bold)) {
+                        append("See more")
+                    }
+                }
+            } else {
+                text
+            }
+        }
+        Text(
+            text = displayedText,
+            style = style,
+            modifier = Modifier.animateContentSize(),
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun ExpandedTextPreviewRegular() {
+    ExpandableTextPreview(
+        text = buildAnnotatedString {
+            append("Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore. ")
+            append("Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo. ")
+            append("Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla. ")
+        },
+    )
+}
+
+@Preview
+@Composable
+private fun ExpandedTextPreviewEmptySpace() {
+    ExpandableTextPreview(
+        text = buildAnnotatedString {
+            append("Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore. ")
+            append("Ut enim ad minim veniam, \n\n")
+            append("Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla. ")
+        },
+    )
+}
+
+@Preview
+@Composable
+private fun ExpandedTextPreviewShort() {
+    ExpandableTextPreview(
+        text = AnnotatedString("Short text"),
+    )
+}
+
+@Composable
+private fun ExpandableTextPreview(text: AnnotatedString) {
+    var isExpanded by remember { mutableStateOf(false) }
+
+    Column(
+        modifier = Modifier
+            .background(Color.White)
+            .fillMaxWidth()
+            .height(200.dp)
+            .padding(16.dp),
+    ) {
+        ExpandableText(
+            text = text,
+            overflowText = "See more",
+            isExpanded = isExpanded,
+            style = TextStyle(fontSize = 16.sp, lineHeight = 20.sp),
+            maxLines = 4,
+            modifier = Modifier
+                .background(Color.LightGray)
+                .clickable(
+                    indication = null,
+                    interactionSource = null,
+                    onClick = { isExpanded = !isExpanded },
+                ),
+        )
+    }
+}

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/ExpandableText.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/ExpandableText.kt
@@ -50,11 +50,15 @@ fun ExpandableText(
             if (!isExpanded && result.hasVisualOverflow) {
                 val lastCharIndex = result.getLineEnd(lineIndex = result.lineCount - 1, visibleEnd = true)
                 buildAnnotatedString {
-                    val trimCharCount = ((overflowText.length + 2) * 1.2f).roundToInt()
+                    // Estimate the number of characters to trim in order to fit the overflow text.
+                    // Since character widths vary, we approximate by adding 2 (for the ellipsis and space)
+                    // and multiplying by 1.3 to account for potential width differences.
+                    // The final trimmed length attempts to give enough of the available space.
+                    val trimCharCount = ((overflowText.length + 2) * 1.3f).roundToInt()
                     append(text, 0, (lastCharIndex - trimCharCount).coerceAtLeast(0))
                     append("… ")
                     withStyle(style.toSpanStyle().copy(fontWeight = FontWeight.Bold)) {
-                        append("See more")
+                        append(overflowText)
                     }
                 }
             } else {

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/text/Extension.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/text/Extension.kt
@@ -24,10 +24,11 @@ import androidx.compose.ui.unit.sp
 // See: https://iamjosephmj.medium.com/how-to-display-styled-strings-in-jetpack-compose-decd6b705746
 
 fun Spanned.toAnnotatedString(urlColor: Int? = null): AnnotatedString = buildAnnotatedString {
+    val timmedText = this@toAnnotatedString.toString().trim()
     // Step 1: Copy over the raw text
-    append(this@toAnnotatedString.toString())
+    append(timmedText)
     // Step 2: Go through each span
-    getSpans(0, length, Any::class.java).forEach { span ->
+    getSpans(0, timmedText.length, Any::class.java).forEach { span ->
         val start = getSpanStart(span)
         val end = getSpanEnd(span)
         when (span) {

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -188,6 +188,7 @@
     <string name="widget_preview_time_left_4">1h 36m left</string>
     <string name="move_up">Move up</string>
     <string name="move_down">Move down</string>
+    <string name="see_more">See more</string>
 
     <string name="multiselect_actions_shown">Shortcut in toolbar</string>
     <string name="multiselect_actions_hidden">In overflow</string>

--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/Feature.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/Feature.kt
@@ -213,8 +213,8 @@ enum class Feature(
     ),
     PODCAST_VIEW_CHANGES(
         key = "podcast_view_changes_2025",
-        title = "Podcast view changes",
-        defaultValue = false,
+        title = "Podcast View Changes",
+        defaultValue = BuildConfig.DEBUG,
         tier = FeatureTier.Free,
         hasFirebaseRemoteFlag = false,
         hasDevToggle = true,


### PR DESCRIPTION
## Description

This PR adds podcast details to the header UI with the collapse animation.

## Testing Instructions

1. Open any podcast with long enough description.
2. Tap on the description.
3. It should expand.
4. Tap on it again.
5. It should collapse.
6. Tap on the artwork.
7. The whole bottom section should collapse.

## Screenshots or Screencast 

https://github.com/user-attachments/assets/401fca32-fb67-473a-bd23-22738cf82586

## Checklist
- [ ] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] ~I have considered whether it makes sense to add tests for my changes~
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [ ] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [ ] ~for accessibility with TalkBack~
