### PR TITLE
Show notification feedback message in a snackbar

### DIFF
--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastAdapter.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastAdapter.kt
@@ -145,7 +145,7 @@ class PodcastAdapter(
     private val onBookmarkRowLongPress: (Bookmark) -> Unit,
     private val onFoldersClicked: () -> Unit,
     private val onPodcastDescriptionClicked: () -> Unit,
-    private val onNotificationsClicked: () -> Unit,
+    private val onNotificationsClicked: (Podcast, Boolean) -> Unit,
     private val onSettingsClicked: () -> Unit,
     private val playButtonListener: PlayButton.OnClickListener,
     private val onRowClicked: (PodcastEpisode) -> Unit,
@@ -161,8 +161,8 @@ class PodcastAdapter(
     private val onBookmarkPlayClicked: (Bookmark) -> Unit,
     private val onHeadsetSettingsClicked: () -> Unit,
     private val onChangeHeaderExpanded: (String, Boolean) -> Unit,
-    private val onClickRating: (String, RatingTappedSource) -> Unit,
-    private val onArtworkAvailable: (String) -> Unit,
+    private val onClickRating: (Podcast, RatingTappedSource) -> Unit,
+    private val onArtworkAvailable: (Podcast) -> Unit,
     private val sourceView: SourceView,
 ) : LargeListAdapter<Any, RecyclerView.ViewHolder>(1500, differ) {
 
@@ -371,7 +371,7 @@ class PodcastAdapter(
                         if (ratingState is RatingState.Loaded) {
                             PodcastRatingRow(
                                 state = ratingState,
-                                onClick = { source -> onClickRating(podcast.uuid, source) },
+                                onClick = { source -> onClickRating(podcast, source) },
                             )
                         }
                     },
@@ -806,7 +806,7 @@ class PodcastAdapter(
                 adapter.onFoldersClicked()
             }
             binding.top.notifications.setOnClickListener {
-                adapter.onNotificationsClicked()
+                adapter.onNotificationsClicked(podcast, !podcast.isShowNotifications)
             }
             binding.top.settings.setOnClickListener {
                 adapter.onSettingsClicked()
@@ -925,17 +925,17 @@ class PodcastAdapter(
         context: Context,
         private val theme: Theme,
         private val useBlurredArtwork: Boolean,
-        private val onClickRating: (String, RatingTappedSource) -> Unit,
+        private val onClickRating: (Podcast, RatingTappedSource) -> Unit,
         private val onClickFollow: () -> Unit,
         private val onClickUnfollow: () -> Unit,
         private val onClickFolder: () -> Unit,
-        private val onClickNotification: () -> Unit,
+        private val onClickNotification: (Podcast, Boolean) -> Unit,
         private val onClickSettings: () -> Unit,
         private val onClickWebsiteLink: () -> Unit,
         private val onToggleHeader: () -> Unit,
         private val onToggleDescription: () -> Unit,
         private val onLongClickArtwork: () -> Unit,
-        private val onArtworkAvailable: (String) -> Unit,
+        private val onArtworkAvailable: (Podcast) -> Unit,
     ) : RecyclerView.ViewHolder(ComposeView(context)) {
         private val composeView get() = itemView as ComposeView
 
@@ -988,17 +988,17 @@ class PodcastAdapter(
                             bottom = 16.dp,
                         ),
                         useBlurredArtwork = useBlurredArtwork,
-                        onClickRating = { source -> onClickRating(podcast.uuid, source) },
+                        onClickRating = { source -> onClickRating(podcast, source) },
                         onClickFollow = onClickFollow,
                         onClickUnfollow = onClickUnfollow,
                         onClickFolder = onClickFolder,
-                        onClickNotification = onClickNotification,
+                        onClickNotification = { onClickNotification(podcast, !podcast.isShowNotifications) },
                         onClickSettings = onClickSettings,
                         onClickWebsiteLink = onClickWebsiteLink,
                         onToggleHeader = onToggleHeader,
                         onToggleDescription = onToggleDescription,
                         onLongClickArtwork = onLongClickArtwork,
-                        onArtworkAvailable = { onArtworkAvailable(podcast.uuid) },
+                        onArtworkAvailable = { onArtworkAvailable(podcast) },
                     )
                 }
             }

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastFragment.kt
@@ -10,7 +10,6 @@ import android.view.ViewGroup
 import android.widget.LinearLayout
 import android.widget.ProgressBar
 import android.widget.TextView
-import android.widget.Toast
 import androidx.annotation.ColorInt
 import androidx.annotation.FloatRange
 import androidx.annotation.MenuRes
@@ -610,7 +609,13 @@ class PodcastFragment : BaseFragment() {
 
     private val onNotificationsClicked: (Podcast, Boolean) -> Unit = { podcast, show ->
         viewModel.showNotifications(podcast.uuid, show)
-        Toast.makeText(context, if (show) LR.string.podcast_notifications_on else LR.string.podcast_notifications_off, Toast.LENGTH_SHORT).show()
+        currentSnackBar?.dismiss()
+        if (show) {
+            showSnackBar(
+                message = getString(LR.string.notifications_enabled_message, podcast.title),
+                duration = 3000,
+            )
+        }
     }
 
     private val onSettingsClicked: () -> Unit = {

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastFragment.kt
@@ -10,6 +10,7 @@ import android.view.ViewGroup
 import android.widget.LinearLayout
 import android.widget.ProgressBar
 import android.widget.TextView
+import android.widget.Toast
 import androidx.annotation.ColorInt
 import androidx.annotation.FloatRange
 import androidx.annotation.MenuRes
@@ -607,10 +608,9 @@ class PodcastFragment : BaseFragment() {
         viewModel.multiSelectBookmarksHelper.isMultiSelecting = false
     }
 
-    private val onNotificationsClicked: () -> Unit = {
-        context?.let {
-            viewModel.toggleNotifications(it)
-        }
+    private val onNotificationsClicked: (Podcast, Boolean) -> Unit = { podcast, show ->
+        viewModel.showNotifications(podcast.uuid, show)
+        Toast.makeText(context, if (show) LR.string.podcast_notifications_on else LR.string.podcast_notifications_off, Toast.LENGTH_SHORT).show()
     }
 
     private val onSettingsClicked: () -> Unit = {
@@ -774,16 +774,16 @@ class PodcastFragment : BaseFragment() {
             onChangeHeaderExpanded = { uuid, isExpanded ->
                 viewModel.updateIsHeaderExpanded(uuid, isExpanded)
             },
-            onClickRating = { podcastUuid, source ->
+            onClickRating = { podcast, source ->
                 ratingsViewModel.onRatingStarsTapped(
-                    podcastUuid = podcastUuid,
+                    podcastUuid = podcast.uuid,
                     fragmentManager = parentFragmentManager,
                     source = source,
                 )
             },
-            onArtworkAvailable = { uuid ->
+            onArtworkAvailable = { podcast ->
                 viewLifecycleOwner.lifecycleScope.launch {
-                    artworkDominantColor = colorAnalyzer.getArtworkDominantColor(uuid)
+                    artworkDominantColor = colorAnalyzer.getArtworkDominantColor(podcast.uuid)
                     updateStausBarForBackground()
                 }
             },

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/PodcastSettingsViewModel.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/PodcastSettingsViewModel.kt
@@ -95,7 +95,7 @@ class PodcastSettingsViewModel @Inject constructor(
     fun showNotifications(show: Boolean) {
         val podcast = this.podcast.value ?: return
         launch {
-            podcastManager.updateShowNotificationsBlocking(podcast, show)
+            podcastManager.updateShowNotifications(podcast.uuid, show)
         }
     }
 

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/PodcastViewModel.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/PodcastViewModel.kt
@@ -334,13 +334,10 @@ class PodcastViewModel
         }
     }
 
-    fun toggleNotifications(context: Context) {
-        val podcast = podcast.value ?: return
-        val showNotifications = !podcast.isShowNotifications
-        analyticsTracker.track(AnalyticsEvent.PODCAST_SCREEN_NOTIFICATIONS_TAPPED, AnalyticsProp.notificationEnabled(showNotifications))
-        Toast.makeText(context, if (showNotifications) LR.string.podcast_notifications_on else LR.string.podcast_notifications_off, Toast.LENGTH_SHORT).show()
-        launch {
-            podcastManager.updateShowNotificationsBlocking(podcast, showNotifications)
+    fun showNotifications(podcastUuid: String, show: Boolean) {
+        analyticsTracker.track(AnalyticsEvent.PODCAST_SCREEN_NOTIFICATIONS_TAPPED, AnalyticsProp.notificationEnabled(show))
+        viewModelScope.launch {
+            podcastManager.updateShowNotifications(podcastUuid, show)
         }
     }
 

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/PodcastViewModel.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/PodcastViewModel.kt
@@ -1,8 +1,6 @@
 package au.com.shiftyjelly.pocketcasts.podcasts.viewmodel
 
-import android.content.Context
 import android.content.res.Resources
-import android.widget.Toast
 import androidx.annotation.StringRes
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/NotificationsSettingsFragment.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/NotificationsSettingsFragment.kt
@@ -184,7 +184,7 @@ class NotificationsSettingsFragment :
     override fun podcastSelectFragmentSelectionChanged(newSelection: List<String>) {
         launch(Dispatchers.Default) {
             podcastManager.findSubscribedBlocking().forEach {
-                podcastManager.updateShowNotificationsBlocking(it, newSelection.contains(it.uuid))
+                podcastManager.updateShowNotifications(it.uuid, newSelection.contains(it.uuid))
             }
         }
     }

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -680,6 +680,8 @@
         <item quantity="one">second</item>
         <item quantity="other">seconds</item>
     </plurals>
+    <!-- %1$s is a podcast's title -->
+    <string name="notifications_enabled_message">We’ll notify you with new episodes of %1$s</string>
 
     <!-- Give Rating -->
 

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -681,7 +681,7 @@
         <item quantity="other">seconds</item>
     </plurals>
     <!-- %1$s is a podcast's title -->
-    <string name="notifications_enabled_message">We’ll notify you with new episodes of %1$s</string>
+    <string name="notifications_enabled_message">We’ll notify you with new episodes of %1$s.</string>
 
     <!-- Give Rating -->
 

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/PodcastDao.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/PodcastDao.kt
@@ -305,7 +305,7 @@ abstract class PodcastDao {
     abstract fun updateEpisodesSortTypeBlocking(episodesSortType: EpisodesSortType, uuid: String, modified: Date = Date())
 
     @Query("UPDATE podcasts SET show_notifications = :show, show_notifications_modified = :modified, sync_status = 0 WHERE uuid = :uuid")
-    abstract fun updateShowNotificationsBlocking(show: Boolean, uuid: String, modified: Date = Date())
+    abstract suspend fun updateShowNotifications(uuid: String, show: Boolean, modified: Date = Date())
 
     @Query("UPDATE podcasts SET subscribed = :subscribed WHERE uuid = :uuid")
     abstract fun updateSubscribedBlocking(subscribed: Boolean, uuid: String)

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PodcastManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PodcastManager.kt
@@ -82,7 +82,7 @@ interface PodcastManager {
     fun updatePlaybackSpeedBlocking(podcast: Podcast, speed: Double)
     fun updateEffectsBlocking(podcast: Podcast, effects: PlaybackEffects)
     fun updateEpisodesSortTypeBlocking(podcast: Podcast, episodesSortType: EpisodesSortType)
-    fun updateShowNotificationsBlocking(podcast: Podcast, show: Boolean)
+    suspend fun updateShowNotifications(podcastUuid: String, show: Boolean)
     suspend fun updatePodcastPositions(podcasts: List<Podcast>)
     suspend fun updateRefreshAvailable(podcastUuid: String, refreshAvailable: Boolean)
     suspend fun updateStartFromInSec(podcast: Podcast, autoStartFrom: Int)

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PodcastManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PodcastManagerImpl.kt
@@ -521,11 +521,11 @@ class PodcastManagerImpl @Inject constructor(
         podcastDao.updateEpisodesSortTypeBlocking(episodesSortType, podcast.uuid)
     }
 
-    override fun updateShowNotificationsBlocking(podcast: Podcast, show: Boolean) {
+    override suspend fun updateShowNotifications(podcastUuid: String, show: Boolean) {
         if (show) {
             settings.notifyRefreshPodcast.set(true, updateModifiedAt = true)
         }
-        podcastDao.updateShowNotificationsBlocking(show, podcast.uuid)
+        podcastDao.updateShowNotifications(podcastUuid, show)
     }
 
     override suspend fun updateRefreshAvailable(podcastUuid: String, refreshAvailable: Boolean) {


### PR DESCRIPTION
## Description

This PR shows snackbar when users enable podcast notifications. This change affects also current UI.

Design: 3LuZimaaH5tGKxIkOpjYAZ-fi-1062_37213

## Testing Instructions

1. Open any podcast.
2. Follow it.
3. Enable notifications.
4. A snackbar should appear.
5. Disable notifications.
6. There should be no snackbar.

## Screenshots or Screencast 

![Screenshot_20250224-133747](https://github.com/user-attachments/assets/c42f7aee-cfe2-497b-b0f9-a144107553f3)

## Checklist
- [ ] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] ~I have considered whether it makes sense to add tests for my changes~
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] ~Any jetpack compose components I added or changed are covered by compose previews~
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.