### PR TITLE
[Suggested Folders]  Sync Podcasts after updating folders

### DIFF
--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/models/db/FolderDaoTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/models/db/FolderDaoTest.kt
@@ -155,22 +155,17 @@ class FolderDaoTest {
         )
         folderDao.insertAll(initialFolders)
 
-        var foundFolder1 = folderDao.findByUuid("uuid1")
-        var foundFolder2 = folderDao.findByUuid("uuid2")
-        assertNotNull(foundFolder1)
-        assertNotNull(foundFolder2)
-
         val newFolders = listOf(
             fakeFolder.copy(uuid = "uuid3"),
             fakeFolder.copy(uuid = "uuid4"),
         )
 
-        folderDao.replaceAllFolders(newFolders)
+        folderDao.replaceAllFolders(newFolders, System.currentTimeMillis())
 
-        foundFolder1 = folderDao.findByUuid("uuid1")
-        foundFolder2 = folderDao.findByUuid("uuid2")
-        assertNull(foundFolder1)
-        assertNull(foundFolder2)
+        val foundFolder1 = folderDao.findByUuid("uuid1")
+        val foundFolder2 = folderDao.findByUuid("uuid2")
+        assertEquals(true, foundFolder1!!.deleted)
+        assertEquals(true, foundFolder2!!.deleted)
 
         val foundFolder3 = folderDao.findByUuid("uuid3")
         val foundFolder4 = folderDao.findByUuid("uuid4")

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/folders/SuggestedFolders.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/folders/SuggestedFolders.kt
@@ -50,7 +50,7 @@ class SuggestedFolders : BaseFragment() {
 
             LaunchedEffect(state) {
                 if (state is SuggestedFoldersViewModel.FoldersState.Created) {
-                    (activity as FragmentHostListener).closeToRoot()
+                    (activity as FragmentHostListener).closeModal(this@SuggestedFolders)
                 } else if (state is SuggestedFoldersViewModel.FoldersState.ShowConfirmationDialog) {
                     showConfirmationDialog()
                 }
@@ -63,7 +63,7 @@ class SuggestedFolders : BaseFragment() {
                 },
                 onDismiss = {
                     viewModel.onDismissed()
-                    (activity as FragmentHostListener).closeToRoot()
+                    (activity as FragmentHostListener).closeModal(this)
                 },
                 onUseTheseFolders = {
                     viewModel.onUseTheseFolders(suggestedFolders)
@@ -71,7 +71,7 @@ class SuggestedFolders : BaseFragment() {
                 onCreateCustomFolders = {
                     viewModel.onCreateCustomFolders()
                     FolderCreateFragment.newInstance(source = "suggested_folders").show(parentFragmentManager, "create_folder_card")
-                    (activity as FragmentHostListener).closeToRoot()
+                    (activity as FragmentHostListener).closeModal(this)
                 },
             )
         }

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/folders/SuggestedFoldersViewModel.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/folders/SuggestedFoldersViewModel.kt
@@ -7,6 +7,7 @@ import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTracker
 import au.com.shiftyjelly.pocketcasts.models.entity.SuggestedFolderDetails
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.FolderManager
+import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.SuggestedFoldersManager
 import au.com.shiftyjelly.pocketcasts.utils.UUIDProvider
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -19,6 +20,7 @@ import kotlinx.coroutines.launch
 class SuggestedFoldersViewModel @Inject constructor(
     private val folderManager: FolderManager,
     private val suggestedFoldersManager: SuggestedFoldersManager,
+    private val podcastManager: PodcastManager,
     private val settings: Settings,
     private val analyticsTracker: AnalyticsTracker,
     private val uuidProvider: UUIDProvider,
@@ -65,6 +67,7 @@ class SuggestedFoldersViewModel @Inject constructor(
             }
 
             folderManager.overrideFoldersWithSuggested(newFolders)
+            podcastManager.refreshPodcasts("suggested-folders")
             suggestedFoldersManager.deleteSuggestedFolders(folders.toSuggestedFolders())
             _state.value = FoldersState.Created
         }

--- a/modules/features/podcasts/src/test/java/au/com/shiftyjelly/pocketcasts/podcasts/view/folders/SuggestedFoldersViewModelTest.kt
+++ b/modules/features/podcasts/src/test/java/au/com/shiftyjelly/pocketcasts/podcasts/view/folders/SuggestedFoldersViewModelTest.kt
@@ -6,6 +6,7 @@ import au.com.shiftyjelly.pocketcasts.models.type.PodcastsSortType
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.preferences.UserSetting
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.FolderManager
+import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.SuggestedFoldersManager
 import au.com.shiftyjelly.pocketcasts.utils.UUIDProvider
 import java.util.UUID
@@ -37,6 +38,9 @@ class SuggestedFoldersViewModelTest {
     @Mock
     lateinit var suggestedFoldersManager: SuggestedFoldersManager
 
+    @Mock
+    lateinit var podcastManager: PodcastManager
+
     lateinit var viewModel: SuggestedFoldersViewModel
 
     private var mockedUUID = UUID.randomUUID()
@@ -50,7 +54,7 @@ class SuggestedFoldersViewModelTest {
         whenever(settings.podcastsSortType).thenReturn(mockedPodcastsSortType)
         whenever(uuidProvider.generateUUID()).thenReturn(mockedUUID)
 
-        viewModel = SuggestedFoldersViewModel(folderManager, suggestedFoldersManager, settings, analyticsTracker, uuidProvider)
+        viewModel = SuggestedFoldersViewModel(folderManager, suggestedFoldersManager, podcastManager, settings, analyticsTracker, uuidProvider)
     }
 
     @Ignore("This test is flaky and needs to be fixed")

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/FolderDao.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/FolderDao.kt
@@ -62,6 +62,9 @@ abstract class FolderDao {
     @Query("UPDATE folders SET deleted = :deleted, sync_modified = :syncModified WHERE uuid = :uuid")
     abstract suspend fun updateDeleted(uuid: String, deleted: Boolean, syncModified: Long)
 
+    @Query("UPDATE folders SET deleted = :deleted, sync_modified = :syncModified")
+    abstract suspend fun updateAllDeleted(deleted: Boolean, syncModified: Long)
+
     @Query("UPDATE folders SET sort_position = :sortPosition, sync_modified = :syncModified WHERE uuid = :uuid")
     abstract suspend fun updateSortPosition(sortPosition: Int, uuid: String, syncModified: Long)
 
@@ -76,8 +79,8 @@ abstract class FolderDao {
     }
 
     @Transaction
-    open suspend fun replaceAllFolders(folders: List<Folder>) {
-        deleteAll()
+    open suspend fun replaceAllFolders(folders: List<Folder>, syncModified: Long) {
+        updateAllDeleted(deleted = true, syncModified = syncModified)
         insertAll(folders)
     }
 

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/FolderManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/FolderManagerImpl.kt
@@ -60,7 +60,7 @@ class FolderManagerImpl @Inject constructor(
     }
 
     override suspend fun overrideFoldersWithSuggested(folders: List<SuggestedFolderDetails>) {
-        folderDao.replaceAllFolders(folders.toFolders())
+        folderDao.replaceAllFolders(folders.toFolders(), syncModified = System.currentTimeMillis())
         podcastManager.updateFoldersUuid(folders)
     }
 


### PR DESCRIPTION
## Description
- This syncs the list of podcasts after accepting the suggested folders. While I was testing, I faced a scenario that my folders were not getting synced. In order to fix this issue, I am refreshing the podcasts list after the user applies the suggested folders

## Testing Instructions
1. Log in with a paid account
2. Have a list of podcasts in device A
3. Open the suggested folders screen and use the suggested folders
4. Go to a device B and log in with the same account
5. Sync the account
6. Go to podcasts tab
7. You should see the suggested folders there

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [ ] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
