### PR TITLE
Update CI toolkit to bypass caching when AWS CLI fails

### DIFF
--- a/.buildkite/shared-pipeline-vars
+++ b/.buildkite/shared-pipeline-vars
@@ -3,4 +3,6 @@
 # This file is `source`'d before calling `buildkite-agent pipeline upload`, and can be used
 # to set up some variables that will be interpolated in the `.yml` pipeline before uploading it.
 
-export CI_TOOLKIT="automattic/a8c-ci-toolkit#3.10.1"
+CI_TOOLKIT_VERSION="3.10.1"
+
+export CI_TOOLKIT="automattic/a8c-ci-toolkit#$CI_TOOLKIT_VERSION"

--- a/.buildkite/shared-pipeline-vars
+++ b/.buildkite/shared-pipeline-vars
@@ -3,6 +3,8 @@
 # This file is `source`'d before calling `buildkite-agent pipeline upload`, and can be used
 # to set up some variables that will be interpolated in the `.yml` pipeline before uploading it.
 
-CI_TOOLKIT_VERSION="3.10.1"
+# TODO: Switch back to a stable version once the changes from this branch are available.
+# See: https://github.com/Automattic/a8c-ci-toolkit-buildkite-plugin/pull/162
+CI_TOOLKIT_VERSION="mokagio/fail-early-on-aws-missing-credentials"
 
 export CI_TOOLKIT="automattic/a8c-ci-toolkit#$CI_TOOLKIT_VERSION"


### PR DESCRIPTION
## Description
This is to workaround the kind of failure that @geekygecko reported internally in p1740374258002719/1740354379.359239-slack-CC7L49W13 and can be seen in CI at https://buildkite.com/automattic/pocket-casts-android/builds/10679#019535dd-890f-413d-9c9c-2e0494ee8fe5

The failure was due to the logic to download the automation tooling Ruby gems cache failing silently. The failure itself was due to the AWS CLI somehow failing to authenticate with AWS.

The CI toolkit pudate doesn't fix the issue. It only introduces additional checks to surface failures to authenticate with AWS and bypass caching.

## Testing Instructions

Refer to green CI. However, the CI logs in this repo, unlike say [Studio](https://buildkite.com/automattic/studio) seem quite unaffected by the AWS CLI authentication issue 🤔 

## Screenshots or Screencast 
N.A.

## Checklist

N.A. — Not a UI or app-source-code PR.