### PR TITLE
Update header UI

### DIFF
--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastHeader.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastHeader.kt
@@ -257,7 +257,7 @@ private fun PodcastControls(
                 text = text,
                 color = MaterialTheme.theme.colors.primaryText02,
                 textAlign = TextAlign.Center,
-                modifier = Modifier.padding(bottom = 16.dp),
+                modifier = Modifier.padding(bottom = 12.dp),
             )
         }
         val density = LocalDensity.current
@@ -326,7 +326,7 @@ private fun PodcastRatingOrSpacing(
             PodcastRating(
                 state = anyRating,
                 onClick = {},
-                modifier = Modifier.padding(vertical = 8.dp),
+                modifier = Modifier.padding(top = 2.dp, bottom = 6.dp),
             )
         }[0].measure(constraints)
 
@@ -338,7 +338,7 @@ private fun PodcastRatingOrSpacing(
                 is RatingState.Loaded -> PodcastRating(
                     state = rating,
                     onClick = onClickRating,
-                    modifier = Modifier.padding(vertical = 8.dp),
+                    modifier = Modifier.padding(top = 2.dp, bottom = 6.dp),
                 )
 
                 is RatingState.Error, is RatingState.Loading -> Spacer(
@@ -414,7 +414,7 @@ private fun PodcastActions(
         val dummyButton = subcompose("dummyButton") {
             TextH40(
                 text = stringResource(LR.string.subscribe),
-                modifier = Modifier.padding(horizontal = 60.dp, vertical = 12.dp),
+                modifier = Modifier.padding(horizontal = 52.dp, vertical = 10.dp),
             )
         }[0].measure(Constraints())
 
@@ -535,7 +535,7 @@ private fun ActionButton(
     Image(
         painter = painterResource(iconId),
         contentDescription = contentDescription,
-        colorFilter = ColorFilter.tint(MaterialTheme.theme.colors.primaryIcon02),
+        colorFilter = ColorFilter.tint(MaterialTheme.theme.colors.primaryIcon02Active),
         modifier = Modifier
             .padding(4.dp)
             .size(24.dp)
@@ -557,7 +557,7 @@ private fun PodcastDetails(
 ) {
     Column {
         Spacer(
-            modifier = Modifier.height(24.dp),
+            modifier = Modifier.height(16.dp),
         )
         ExpandableText(
             text = description,

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastInfoView.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastInfoView.kt
@@ -2,6 +2,7 @@ package au.com.shiftyjelly.pocketcasts.podcasts.view.podcast
 
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -46,12 +47,12 @@ fun PodcastInfoView(
             .fillMaxWidth(),
     ) {
         Column(
+            verticalArrangement = Arrangement.spacedBy(12.dp),
             modifier = modifier.padding(16.dp),
         ) {
             PodcastInfoItem(
                 state.author,
                 IR.drawable.ic_author,
-                modifier = Modifier.padding(bottom = 12.dp),
             )
 
             if (!state.link.isNullOrEmpty()) {
@@ -60,7 +61,6 @@ fun PodcastInfoView(
                     icon = IR.drawable.ic_link,
                     isLink = true,
                     onWebsiteLinkClicked = onWebsiteLinkClicked,
-                    modifier = Modifier.padding(bottom = 12.dp),
                 )
             }
 
@@ -68,7 +68,6 @@ fun PodcastInfoView(
                 PodcastInfoItem(
                     text = state.schedule,
                     icon = IR.drawable.ic_schedule,
-                    modifier = Modifier.padding(bottom = 12.dp),
                 )
             }
 


### PR DESCRIPTION
## Description

Some minor UI tweaks to the podcast header.

Context: p1740413419003659-slack-C08DPN79CN8

## Testing Instructions

Check the podcast header UI.

## Screenshots or Screencast 

Screenshots don't reflects that but I also fixed the spacing in podcast info UI in 9cdd49f.

| Before | After |
| - | - |
| ![b1](https://github.com/user-attachments/assets/acff141a-717f-4849-8229-95a19f5c85e5) | ![a1](https://github.com/user-attachments/assets/bf1546b7-a039-425d-9b13-e0ea00c0381d) |
| ![b2](https://github.com/user-attachments/assets/d0230610-ca13-4185-82ed-b5c8e1373f47) | ![a2](https://github.com/user-attachments/assets/676d10cc-ee72-4cf5-b355-9975fdcaa9ad) |


## Checklist
- [ ] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] ~I have considered whether it makes sense to add tests for my changes~
- [ ] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [ ] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [ ] ~for accessibility with TalkBack~