### PR TITLE
Fix HTML podcast description crashing

### DIFF
--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/text/Extension.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/text/Extension.kt
@@ -24,13 +24,16 @@ import androidx.compose.ui.unit.sp
 // See: https://iamjosephmj.medium.com/how-to-display-styled-strings-in-jetpack-compose-decd6b705746
 
 fun Spanned.toAnnotatedString(urlColor: Int? = null): AnnotatedString = buildAnnotatedString {
-    val timmedText = this@toAnnotatedString.toString().trim()
-    // Step 1: Copy over the raw text
-    append(timmedText)
-    // Step 2: Go through each span
-    getSpans(0, timmedText.length, Any::class.java).forEach { span ->
-        val start = getSpanStart(span)
-        val end = getSpanEnd(span)
+    // Step 1: Trim text and calculate span offsets due to trimming
+    val text = this@toAnnotatedString.toString()
+    val trimmedText = text.trim()
+    val startOffset = text.takeWhile(Char::isWhitespace).length
+    // Step 2: Copy over the raw text
+    append(trimmedText)
+    // Step 3: Go through each span
+    getSpans(0, length, Any::class.java).forEach { span ->
+        val start = getSpanStart(span) - startOffset
+        val end = (getSpanEnd(span) - startOffset).coerceAtMost(length)
         when (span) {
             // Bold, Italic, Bold-Italic
             is StyleSpan -> {


### PR DESCRIPTION
## Description

When podcast HTML description was trimmed the spans inside of it were not adjusted for the trimmed padding causing a crash when visiting a podcast. This PR fixed that.

The crash was introduced in `7.84` so there's no need to mention the fix in the changelog.

## Testing Instructions

1. Open the [Embedded](https://pca.st/podcast/f6ffd000-c8fc-0133-2e8b-6dc413d6d41d) podcast.
2. The app shouldn't crash and you should be able to see the description.

## Screenshots or Screencast 
<!-- if applicable -->

## Checklist
- [ ] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] ~I have considered whether it makes sense to add tests for my changes~
- [ ] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [ ] ~Any jetpack compose components I added or changed are covered by compose previews~
- [ ] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~