### PR TITLE
Add play action to skipping back and forward headphone actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 7.84
 -----
-
+*   Bug Fixes
+    *   Fix issue with playback not resuming when using headphone actions.
+        ([#3665](https://github.com/Automattic/pocket-casts-android/pull/3665))
 
 7.83
 -----

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/MediaSessionManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/MediaSessionManager.kt
@@ -596,8 +596,18 @@ class MediaSessionManager(
         private fun handleMediaButtonAction(action: HeadphoneAction) {
             when (action) {
                 HeadphoneAction.ADD_BOOKMARK -> onAddBookmark()
-                HeadphoneAction.SKIP_FORWARD -> onSkipToNext()
-                HeadphoneAction.SKIP_BACK -> onSkipToPrevious()
+                HeadphoneAction.SKIP_FORWARD -> {
+                    onSkipToNext()
+                    if (!playbackManager.isPlaying()) {
+                        enqueueCommand("play") { playbackManager.playQueueSuspend(source) }
+                    }
+                }
+                HeadphoneAction.SKIP_BACK -> {
+                    onSkipToPrevious()
+                    if (!playbackManager.isPlaying()) {
+                        enqueueCommand("play") { playbackManager.playQueueSuspend(source) }
+                    }
+                }
                 HeadphoneAction.NEXT_CHAPTER,
                 HeadphoneAction.PREVIOUS_CHAPTER,
                 -> Timber.e(ACTION_NOT_SUPPORTED)


### PR DESCRIPTION
## Description

This fixes an issue where playback was not resuming when using back and forward actions.

## Testing Instructions

1. Play something with headphones connected.
2. Pause the playback.
3. Using the headphones action skip forward.
4. The playback should resume.
5. Do the same test but with the skip back action.

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] ~I have considered whether it makes sense to add tests for my changes~
- [ ] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [ ] ~Any jetpack compose components I added or changed are covered by compose previews~
- [ ] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~