### PR TITLE
Add description link navigation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 7.84
 -----
-
+*   Bug Fixes
+    *   Fix link not being interactive in a podcast description.
+        ([#3666](https://github.com/Automattic/pocket-casts-android/pull/3666))
 
 7.83
 -----

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastAdapter.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastAdapter.kt
@@ -518,7 +518,7 @@ class PodcastAdapter(
         this.podcastDescription = HtmlCompat.fromHtml(
             rawDescription,
             HtmlCompat.FROM_HTML_MODE_COMPACT and
-                    HtmlCompat.FROM_HTML_SEPARATOR_LINE_BREAK_PARAGRAPH.inv(), // keep the extra line break from paragraphs as it looks better
+                HtmlCompat.FROM_HTML_SEPARATOR_LINE_BREAK_PARAGRAPH.inv(), // keep the extra line break from paragraphs as it looks better
         ).toAnnotatedString(urlColor = ThemeColor.podcastText02(theme.activeTheme, tintColor))
 
         notifyDataSetChanged()

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastAdapter.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastAdapter.kt
@@ -514,16 +514,12 @@ class PodcastAdapter(
         }
         this.podcast = podcast
         val isHtmlDescription = FeatureFlag.isEnabled(Feature.PODCAST_HTML_DESCRIPTION) && podcast.podcastHtmlDescription.isNotEmpty()
-        this.podcastDescription = if (isHtmlDescription) {
-            val ann = HtmlCompat.fromHtml(
-                podcast.podcastHtmlDescription,
-                HtmlCompat.FROM_HTML_MODE_COMPACT and
+        val rawDescription = if (isHtmlDescription) { podcast.podcastHtmlDescription } else { podcast.podcastDescription }
+        this.podcastDescription = HtmlCompat.fromHtml(
+            rawDescription,
+            HtmlCompat.FROM_HTML_MODE_COMPACT and
                     HtmlCompat.FROM_HTML_SEPARATOR_LINE_BREAK_PARAGRAPH.inv(), // keep the extra line break from paragraphs as it looks better
-            ).toAnnotatedString(urlColor = ThemeColor.podcastText02(theme.activeTheme, tintColor))
-            ann
-        } else {
-            AnnotatedString(podcast.podcastDescription)
-        }
+        ).toAnnotatedString(urlColor = ThemeColor.podcastText02(theme.activeTheme, tintColor))
 
         notifyDataSetChanged()
     }

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/text/Extension.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/text/Extension.kt
@@ -13,6 +13,7 @@ import android.text.style.URLSpan
 import android.text.style.UnderlineSpan
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.LinkAnnotation
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontStyle
@@ -110,6 +111,7 @@ fun Spanned.toAnnotatedString(urlColor: Int? = null): AnnotatedString = buildAnn
                     start = start,
                     end = end,
                 )
+                addLink(LinkAnnotation.Url(span.url), start, end)
                 // Optional: add a style (color or underline) to make it look clickable
                 val color = if (urlColor != null) Color(urlColor) else Color.Blue
                 addStyle(


### PR DESCRIPTION
## Description

Fixes #3660

## Testing Instructions

1. Open a podcast like [Dirtbag Rich](https://pca.st/zkf1jxjd) that has a HTML description or like [No Such Thing](https://pca.st/hourucli) that has a plain text description.
2. Tap on link in the description.
3. The link should open.

## Screenshots or Screencast 

https://github.com/user-attachments/assets/d43750f7-5f27-4d5c-86f1-b00057cded44

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] ~I have considered whether it makes sense to add tests for my changes~
- [ ] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [ ] ~Any jetpack compose components I added or changed are covered by compose previews~
- [ ] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~