### PR TITLE
[Suggested Folders] General UI updates

### DIFF
--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/folders/SuggestedFoldersMapper.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/folders/SuggestedFoldersMapper.kt
@@ -1,17 +1,17 @@
 package au.com.shiftyjelly.pocketcasts.podcasts.view.folders
 
 import au.com.shiftyjelly.pocketcasts.models.entity.SuggestedFolder
-import kotlin.random.Random
 import au.com.shiftyjelly.pocketcasts.podcasts.view.folders.Folder as SuggestedFolderModel
 
 fun List<SuggestedFolder>.toFolders(): List<SuggestedFolderModel> {
     val grouped = this.groupBy { it.name }
 
     return grouped.map { (folderName, folderItems) ->
+        val index = grouped.keys.indexOf(folderName)
         SuggestedFolderModel(
             name = folderName,
             podcasts = folderItems.map { it.podcastUuid },
-            color = Random.nextInt(0, 12),
+            color = index % 12,
         )
     }
 }

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/folders/SuggestedFoldersViewModel.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/folders/SuggestedFoldersViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.viewModelScope
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTracker
 import au.com.shiftyjelly.pocketcasts.models.entity.SuggestedFolderDetails
+import au.com.shiftyjelly.pocketcasts.models.type.PodcastsSortType
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.FolderManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
@@ -65,7 +66,7 @@ class SuggestedFoldersViewModel @Inject constructor(
                     podcasts = it.podcasts,
                 )
             }
-
+            settings.podcastsSortType.set(PodcastsSortType.NAME_A_TO_Z, updateModifiedAt = true)
             folderManager.overrideFoldersWithSuggested(newFolders)
             podcastManager.refreshPodcasts("suggested-folders")
             suggestedFoldersManager.deleteSuggestedFolders(folders.toSuggestedFolders())

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -2285,7 +2285,7 @@
     <string name="suggested_folders_use_create_custom_folders_button">Create custom folders</string>
     <string name="folder_content_description">Folder %s</string>
     <string name="suggested_folders_paywall_tittle">Your podcasts, automatically organized</string>
-    <string name="suggested_folders_paywall_subtitle">We\'ve pre-made folders for your podcasts. Unlock this and features like bookmarks, transcripts, and more with Pocket Casts Plus.</string>
+    <string name="suggested_folders_paywall_subtitle">We\'ve created folders for your podcasts, making it easier than ever to keep your favorites organized and accessible.</string>
     <string name="suggested_folders_replace_folders_button">Replace folders</string>
     <string name="suggested_folders_replace_folders_confirmation_tittle">Replace existing folders?</string>
     <string name="suggested_folders_replace_folders_confirmation_description">Accepting suggested folders will overwrite your current folders. This can\'t be undone.</string>

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -189,6 +189,7 @@
     <string name="move_up">Move up</string>
     <string name="move_down">Move down</string>
     <string name="see_more">See more</string>
+    <string name="maybe_later">Maybe later</string>
 
     <string name="multiselect_actions_shown">Shortcut in toolbar</string>
     <string name="multiselect_actions_hidden">In overflow</string>
@@ -2234,7 +2235,6 @@
     <string name="need_to_free_up_space">Need to free up space?</string>
     <string name="save_space_by_managing_downloaded_episodes">Save %1$s – by managing downloaded episodes.</string>
     <string name="manage_downloads">Manage downloads</string>
-    <string name="maybe_later">Maybe Later</string>
     <string name="dismiss_manage_download_banner">Dismiss</string>
     <string name="manage_download_dismiss_content_description">Manage Download Banner Dismiss</string>
 


### PR DESCRIPTION
## Description
- These are some minor UI changes requested:
   - cycle folder colors instead of random numbers to avoid repeating colors next to each other.
   - `Maybe later` instead `Maybe Later`
   - set alphabetical sort after accepting suggested folders
   - update suggested folders paywall copy

- Request: p1740630237193229/1740621534.095339-slack-C08BRS7N9UL
- Request 2: p1740631091561499/1740626371.709879-slack-C08BRS7N9UL

## Testing Instructions
1. Using paid account with some followed podcasts
2. Open the suggested folder screen
3. You should not see folders with the same color side by side ✅
4. Accept the new suggested folders
5. The folders should be sorted by Name ✅

## Screenshots or Screencast 

[Screen_recording_20250227_101501.webm](https://github.com/user-attachments/assets/bc5d7fa6-2c7e-4a26-89c3-a23e78614051)

<img src="https://github.com/user-attachments/assets/a81bd3e1-2a08-4c57-b096-c0a6304a33ed" width="300">



## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.