### PR TITLE
[Suggested Folders] Add missing tracks

### DIFF
--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/folders/SuggestedFolders.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/folders/SuggestedFolders.kt
@@ -78,11 +78,15 @@ class SuggestedFolders : BaseFragment() {
     }
 
     private fun showConfirmationDialog() {
+        viewModel.onReplaceExistingFoldersShown()
         ConfirmationDialog()
             .setButtonType(ConfirmationDialog.ButtonType.Danger(getString(LR.string.suggested_folders_replace_folders_button)))
             .setTitle(getString(LR.string.suggested_folders_replace_folders_confirmation_tittle))
             .setSummary(getString(LR.string.suggested_folders_replace_folders_confirmation_description))
-            .setOnConfirm { viewModel.overrideFoldersWithSuggested(suggestedFolders) }
+            .setOnConfirm {
+                viewModel.onReplaceExistingFoldersTapped()
+                viewModel.overrideFoldersWithSuggested(suggestedFolders)
+            }
             .setIconId(VR.drawable.ic_replace)
             .setIconTint(UR.attr.primary_interactive_01)
             .show(childFragmentManager, "suggested-folders-confirmation-dialog")

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/folders/SuggestedFoldersPaywallBottomSheet.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/folders/SuggestedFoldersPaywallBottomSheet.kt
@@ -61,6 +61,7 @@ class SuggestedFoldersPaywallBottomSheet : BottomSheetDialogFragment() {
                     viewModel.onShown()
                 },
                 onUseTheseFolders = {
+                    viewModel.onUseTheseFolders()
                     if (signInState.value?.isSignedInAsPlusOrPatron == true) {
                         dismiss()
                         (activity as FragmentHostListener).showModal(SuggestedFolders.newInstance(suggestedFolders))

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/folders/SuggestedFoldersViewModel.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/folders/SuggestedFoldersViewModel.kt
@@ -38,6 +38,14 @@ class SuggestedFoldersViewModel @Inject constructor(
         analyticsTracker.track(AnalyticsEvent.SUGGESTED_FOLDERS_MODAL_DISMISSED)
     }
 
+    fun onReplaceExistingFoldersShown() {
+        analyticsTracker.track(AnalyticsEvent.SUGGESTED_FOLDERS_REPLACE_EXISTING_FOLDERS_MODAL_SHOWN)
+    }
+
+    fun onReplaceExistingFoldersTapped() {
+        analyticsTracker.track(AnalyticsEvent.SUGGESTED_FOLDERS_REPLACE_FOLDERS_TAPPED)
+    }
+
     fun onUseTheseFolders(folders: List<Folder>) {
         analyticsTracker.track(AnalyticsEvent.SUGGESTED_FOLDERS_MODAL_USE_THESE_FOLDERS_TAPPED)
         viewModelScope.launch {

--- a/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
+++ b/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
@@ -746,4 +746,6 @@ enum class AnalyticsEvent(val key: String) {
     SUGGESTED_FOLDERS_PAYWALL_MODAL_SHOWN("suggested_folders_paywall_modal_shown"),
     SUGGESTED_FOLDERS_PAYWALL_MODAL_USE_THESE_FOLDERS_TAPPED("suggested_folders_paywall_modal_use_these_folders_tapped"),
     SUGGESTED_FOLDERS_PAYWALL_MODAL_MAYBE_LATER_TAPPED("suggested_folders_paywall_modal_maybe_later_tapped"),
+    SUGGESTED_FOLDERS_REPLACE_EXISTING_FOLDERS_MODAL_SHOWN("suggested_folders_replace_existing_folders_modal_shown"),
+    SUGGESTED_FOLDERS_REPLACE_FOLDERS_TAPPED("suggested_folders_replace_folders_tapped"),
 }


### PR DESCRIPTION
## Description
- This adds some missing tracks

## Testing Instructions

### Free account
1. With free account. Follow some podcasts
2. Go to Podcasts tab and see the suggested folders paywall
3. Tap on Use these folders button
4. Ensure 🔵 Tracked: suggested_folders_paywall_modal_use_these_folders_tapped

### Paid account
1. Follow some podcasts
2. Have some existing folders
3. Go to suggested folder screen
4. Tap on use these folders
5. See the Replace folders modal
6. Ensure 🔵 Tracked: suggested_folders_replace_existing_folders_modal_shown
7. Tap on Replace folders button
8. Ensure 🔵 Tracked: suggested_folders_replace_folders_tapped


## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
