### PR TITLE
Add missing technology category mapping

### DIFF
--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/entity/Podcast.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/entity/Podcast.kt
@@ -356,6 +356,7 @@ private val KnownCategoryIds = mapOf(
     "society & culture" to 13,
     "sports" to 14,
     "tech" to 15,
+    "technology" to 15,
     "tv & film" to 16,
     "fiction" to 17,
     "history" to 18,


### PR DESCRIPTION
## Description

This ads missing mapping for the technology category.

## Testing Instructions

1. Open [TechSurge](https://pca.st/jb1ui8gd) podcast.
2. Tap on the "Technology" category in the header.
3. It should open it in the Discover page.

## Checklist
- [ ] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] ~I have considered whether it makes sense to add tests for my changes~
- [ ] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [ ] ~Any jetpack compose components I added or changed are covered by compose previews~
- [ ] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~