### PR TITLE
Enable podcast view remote feature flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 *   New Features
     *   Add Suggested Folders
         ([#3670](https://github.com/Automattic/pocket-casts-android/pull/3670))
+    *   Redesign podcast header UI
+        ([#3677](https://github.com/Automattic/pocket-casts-android/pull/3671))
 *   Bug Fixes
     *   Fix link not being interactive in a podcast description.
         ([#3666](https://github.com/Automattic/pocket-casts-android/pull/3666))

--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/Feature.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/Feature.kt
@@ -216,7 +216,7 @@ enum class Feature(
         title = "Podcast View Changes",
         defaultValue = BuildConfig.DEBUG,
         tier = FeatureTier.Free,
-        hasFirebaseRemoteFlag = false,
+        hasFirebaseRemoteFlag = true,
         hasDevToggle = true,
     ),
     ;


### PR DESCRIPTION
## Description

This PR enables remote control of the feature.

## Testing Instructions

Code review should be enough.

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] ~I have considered whether it makes sense to add tests for my changes~
- [ ] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [ ] ~Any jetpack compose components I added or changed are covered by compose previews~
- [ ] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~