### PR TITLE
Support the Web Player share pages

### DIFF
--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/deeplink/DeepLinkFactoryTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/deeplink/DeepLinkFactoryTest.kt
@@ -20,6 +20,7 @@ class DeepLinkFactoryTest {
         webBaseHost = "pocketcasts.com",
         listHost = "lists.pocketcasts.com",
         shareHost = "pca.st",
+        webPlayerHost = "play.pocketcasts.com",
     )
 
     @Test
@@ -733,6 +734,56 @@ class DeepLinkFactoryTest {
                 startTimestamp = 15.seconds,
                 endTimestamp = 55.seconds,
                 sourceView = null,
+                autoPlay = false,
+            ),
+            deepLink,
+        )
+    }
+
+    @Test
+    fun webPlayerSharePodcast() {
+        val intent = Intent()
+            .setAction(ACTION_VIEW)
+            .setData(Uri.parse("https://play.pocketcasts.com/podcasts/podcast-id?source_view=source"))
+
+        val deepLink = factory.create(intent)
+
+        assertEquals(ShowPodcastDeepLink("podcast-id", sourceView = "source"), deepLink)
+    }
+
+    @Test
+    fun webPlayerShareEpisode() {
+        val intent = Intent()
+            .setAction(ACTION_VIEW)
+            .setData(Uri.parse("https://play.pocketcasts.com/podcasts/podcast-id/episode-id?source_view=source"))
+
+        val deepLink = factory.create(intent)
+
+        assertEquals(
+            ShowEpisodeDeepLink(
+                episodeUuid = "episode-id",
+                podcastUuid = "podcast-id",
+                sourceView = "source",
+                autoPlay = false,
+            ),
+            deepLink,
+        )
+    }
+
+    @Test
+    fun webPlayerShareEpisodeWithStartTimestamp() {
+        val intent = Intent()
+            .setAction(ACTION_VIEW)
+            .setData(Uri.parse("https://play.pocketcasts.com/podcasts/podcast-id/episode-id?source_view=source&t=15"))
+
+        val deepLink = factory.create(intent)
+
+        assertEquals(
+            ShowEpisodeDeepLink(
+                episodeUuid = "episode-id",
+                podcastUuid = "podcast-id",
+                startTimestamp = 15.seconds,
+                sourceView = "source",
                 autoPlay = false,
             ),
             deepLink,

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -121,6 +121,24 @@
                 <category android:name="android.intent.category.DEFAULT"/>
                 <category android:name="android.intent.category.BROWSABLE"/>
                 <data
+                    android:host="play.pocketcasts.com"
+                    android:scheme="https"
+                    android:pathPrefix="/podcasts/" />
+            </intent-filter>
+            <intent-filter android:autoVerify="true">
+                <action android:name="android.intent.action.VIEW"/>
+                <category android:name="android.intent.category.DEFAULT"/>
+                <category android:name="android.intent.category.BROWSABLE"/>
+                <data
+                    android:host="play.pocketcasts.net"
+                    android:scheme="https"
+                    android:pathPrefix="/podcasts/" />
+            </intent-filter>
+            <intent-filter android:autoVerify="true">
+                <action android:name="android.intent.action.VIEW"/>
+                <category android:name="android.intent.category.DEFAULT"/>
+                <category android:name="android.intent.category.BROWSABLE"/>
+                <data
                     android:host="pocket-casts-main-development.mystagingwebsite.com"
                     android:scheme="https"
                     android:pathPrefix="/redeem" />

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -204,6 +204,7 @@ subprojects {
     val SERVER_LIST_HOST_PROD = "\"lists.pocketcasts.com\""
     val SERVER_SHORT_URL_PROD = "\"https://pca.st\""
     val SERVER_SHORT_HOST_PROD = "\"pca.st\""
+    val SERVER_WEB_PLAYER_HOST_PROD = "\"play.pocketcasts.com\""
     val WEB_BASE_HOST_PROD = "\"pocketcasts.com\""
 
     plugins.withType<BasePlugin>().configureEach {
@@ -286,6 +287,7 @@ subprojects {
                     buildConfigField("String", "SERVER_SHARING_URL", "\"https://sharing.pocketcasts.net\"")
                     buildConfigField("String", "SERVER_SHORT_URL", "\"https://pcast.pocketcasts.net\"")
                     buildConfigField("String", "SERVER_SHORT_HOST", "\"pcast.pocketcasts.net\"")
+                    buildConfigField("String", "SERVER_WEB_PLAYER_HOST", "\"play.pocketcasts.net\"")
                     buildConfigField("String", "WEB_BASE_HOST", "\"pocket-casts-main-development.mystagingwebsite.com\"")
                     buildConfigField("String", "SERVER_LIST_URL", "\"https://lists.pocketcasts.net\"")
                     buildConfigField("String", "SERVER_LIST_HOST", "\"lists.pocketcasts.net\"")
@@ -308,6 +310,7 @@ subprojects {
                     buildConfigField("String", "SERVER_SHARING_URL", SERVER_SHARING_URL_PROD)
                     buildConfigField("String", "SERVER_SHORT_URL", SERVER_SHORT_URL_PROD)
                     buildConfigField("String", "SERVER_SHORT_HOST", SERVER_SHORT_HOST_PROD)
+                    buildConfigField("String", "SERVER_WEB_PLAYER_HOST", SERVER_WEB_PLAYER_HOST_PROD)
                     buildConfigField("String", "WEB_BASE_HOST", WEB_BASE_HOST_PROD)
                     buildConfigField("String", "SERVER_LIST_URL", SERVER_LIST_URL_PROD)
                     buildConfigField("String", "SERVER_LIST_HOST", SERVER_LIST_HOST_PROD)
@@ -325,6 +328,7 @@ subprojects {
                     buildConfigField("String", "SERVER_SHARING_URL", SERVER_SHARING_URL_PROD)
                     buildConfigField("String", "SERVER_SHORT_URL", SERVER_SHORT_URL_PROD)
                     buildConfigField("String", "SERVER_SHORT_HOST", SERVER_SHORT_HOST_PROD)
+                    buildConfigField("String", "SERVER_WEB_PLAYER_HOST", SERVER_WEB_PLAYER_HOST_PROD)
                     buildConfigField("String", "WEB_BASE_HOST", WEB_BASE_HOST_PROD)
                     buildConfigField("String", "SERVER_LIST_URL", SERVER_LIST_URL_PROD)
                     buildConfigField("String", "SERVER_LIST_HOST", SERVER_LIST_HOST_PROD)


### PR DESCRIPTION
## Description

To support the Web Player share pages, we need to add a new intent filter and logic similar to the pca.st share page. 

## Testing Instructions

The assetlinks.json file is only available in staging at the moment so this will only work in our debug version.

1. Install the `debug` build variant
2. Click on the following links. They won't work if you use them directly in the browser. I posted them to a private Slack channel and clicked them from the posted message. Or you could use this PR message.
3. Tap the podcast share https://play.pocketcasts.net/podcasts/4eb5b260-c933-0134-10da-25324e2a541d
4. ✅ Verify it opens The Daily podcast page
5. Tap the episode share https://play.pocketcasts.net/podcasts/4eb5b260-c933-0134-10da-25324e2a541d/1c82ee02-01cb-4c36-bc13-020c8c15cd8c
6. ✅ Verify it opens The Daily - A Constitutional Crisis episode page
7. Tap the episode share https://play.pocketcasts.net/podcasts/4eb5b260-c933-0134-10da-25324e2a541d/1c82ee02-01cb-4c36-bc13-020c8c15cd8c?t=57s
8. ✅ Verify it opens The Daily - A Constitutional Crisis episode page and if you tap play it starts playing from 57 seconds

## Screencast 

https://github.com/user-attachments/assets/e7bd38c0-c619-47e9-adca-4f4a9243a14e

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack
