### PR TITLE
Fix screen flicker upon nav bar navigation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 *   Bug Fixes
     *   Fix link not being interactive in a podcast description.
         ([#3666](https://github.com/Automattic/pocket-casts-android/pull/3666))
+    *   Fix screen flickering when tapping on item in the navigation bar.
+        ([#3674](https://github.com/Automattic/pocket-casts-android/pull/3674))
 
 7.83
 -----

--- a/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
+++ b/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
@@ -155,6 +155,7 @@ import au.com.shiftyjelly.pocketcasts.views.activity.WebViewActivity
 import au.com.shiftyjelly.pocketcasts.views.extensions.setSystemWindowInsetToPadding
 import au.com.shiftyjelly.pocketcasts.views.extensions.showAllowingStateLoss
 import au.com.shiftyjelly.pocketcasts.views.fragments.BaseFragment
+import au.com.shiftyjelly.pocketcasts.views.fragments.TopScrollable
 import au.com.shiftyjelly.pocketcasts.views.helper.HasBackstack
 import au.com.shiftyjelly.pocketcasts.views.helper.UiUtil
 import au.com.shiftyjelly.pocketcasts.views.helper.WarningsHelper
@@ -440,6 +441,12 @@ class MainActivity :
             defaultTab = selectedTab,
             activity = this,
         )
+
+        navigator.resetRootFragmentCommand()
+            .subscribe({ fragment ->
+                (fragment as? TopScrollable)?.scrollToTop()
+            })
+            .addTo(disposables)
 
         val showMiniPlayerImmediately = savedInstanceState?.getBoolean(SAVEDSTATE_MINIPLAYER_SHOWN, false) ?: false
         binding.playerBottomSheet.isVisible = showMiniPlayerImmediately

--- a/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/DiscoverFragment.kt
+++ b/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/DiscoverFragment.kt
@@ -31,14 +31,20 @@ import au.com.shiftyjelly.pocketcasts.servers.model.DiscoverRegion
 import au.com.shiftyjelly.pocketcasts.servers.model.ExpandedStyle
 import au.com.shiftyjelly.pocketcasts.servers.model.NetworkLoadableList
 import au.com.shiftyjelly.pocketcasts.ui.helper.FragmentHostListener
+import au.com.shiftyjelly.pocketcasts.views.extensions.quickScrollToTop
 import au.com.shiftyjelly.pocketcasts.views.fragments.BaseFragment
+import au.com.shiftyjelly.pocketcasts.views.fragments.TopScrollable
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.rx2.asFlowable
 
 @AndroidEntryPoint
-class DiscoverFragment : BaseFragment(), DiscoverAdapter.Listener, RegionSelectFragment.Listener {
+class DiscoverFragment :
+    BaseFragment(),
+    DiscoverAdapter.Listener,
+    RegionSelectFragment.Listener,
+    TopScrollable {
 
     @Inject lateinit var settings: Settings
 
@@ -270,11 +276,14 @@ class DiscoverFragment : BaseFragment(), DiscoverAdapter.Listener, RegionSelectF
         }
     }
 
+    override fun scrollToTop() {
+        binding?.recyclerView?.quickScrollToTop()
+    }
+
     companion object {
         private const val ID_KEY = "id"
         private const val NAME_KEY = "name"
         private const val REGION_KEY = "region"
-        private const val MOST_POPULAR_PODCASTS = 5
         const val LIST_ID_KEY = "list_id"
         const val PODCAST_UUID_KEY = "podcast_uuid"
         const val EPISODE_UUID_KEY = "episode_uuid"

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/FiltersFragment.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/FiltersFragment.kt
@@ -20,8 +20,10 @@ import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.repositories.chromecast.CastManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.PlaylistManager
 import au.com.shiftyjelly.pocketcasts.ui.helper.FragmentHostListener
+import au.com.shiftyjelly.pocketcasts.views.extensions.quickScrollToTop
 import au.com.shiftyjelly.pocketcasts.views.fragments.BaseFragment
 import au.com.shiftyjelly.pocketcasts.views.fragments.BaseFragmentToolbar.ChromeCastButton.Shown
+import au.com.shiftyjelly.pocketcasts.views.fragments.TopScrollable
 import au.com.shiftyjelly.pocketcasts.views.helper.NavigationIcon.None
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
@@ -32,7 +34,11 @@ import kotlinx.coroutines.launch
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 @AndroidEntryPoint
-class FiltersFragment : BaseFragment(), CoroutineScope, Toolbar.OnMenuItemClickListener {
+class FiltersFragment :
+    BaseFragment(),
+    CoroutineScope,
+    Toolbar.OnMenuItemClickListener,
+    TopScrollable {
     @Inject lateinit var settings: Settings
 
     @Inject lateinit var playlistManager: PlaylistManager
@@ -175,6 +181,10 @@ class FiltersFragment : BaseFragment(), CoroutineScope, Toolbar.OnMenuItemClickL
         (activity as? FragmentHostListener)?.addFragment(playlistFragment)
 
         playlistFragment.view?.requestFocus() // Jump to new page for talk back
+    }
+
+    override fun scrollToTop() {
+        binding?.recyclerView?.quickScrollToTop()
     }
 }
 

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/UpNextFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/UpNextFragment.kt
@@ -39,9 +39,11 @@ import au.com.shiftyjelly.pocketcasts.ui.helper.StatusBarIconColor
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import au.com.shiftyjelly.pocketcasts.ui.theme.ThemeColor
 import au.com.shiftyjelly.pocketcasts.utils.extensions.hideShadow
+import au.com.shiftyjelly.pocketcasts.views.extensions.quickScrollToTop
 import au.com.shiftyjelly.pocketcasts.views.extensions.tintIcons
 import au.com.shiftyjelly.pocketcasts.views.fragments.BaseFragment
 import au.com.shiftyjelly.pocketcasts.views.fragments.BaseFragmentToolbar.ChromeCastButton
+import au.com.shiftyjelly.pocketcasts.views.fragments.TopScrollable
 import au.com.shiftyjelly.pocketcasts.views.helper.EpisodeItemTouchHelper
 import au.com.shiftyjelly.pocketcasts.views.helper.EpisodeItemTouchHelper.SwipeSource
 import au.com.shiftyjelly.pocketcasts.views.helper.NavigationIcon
@@ -63,7 +65,11 @@ import au.com.shiftyjelly.pocketcasts.localization.R as LR
 import au.com.shiftyjelly.pocketcasts.views.R as VR
 
 @AndroidEntryPoint
-class UpNextFragment : BaseFragment(), UpNextListener, UpNextTouchCallback.ItemTouchHelperAdapter {
+class UpNextFragment :
+    BaseFragment(),
+    UpNextListener,
+    UpNextTouchCallback.ItemTouchHelperAdapter,
+    TopScrollable {
     companion object {
         private const val ARG_EMBEDDED = "embedded"
         private const val ARG_SOURCE = "source"
@@ -507,6 +513,10 @@ class UpNextFragment : BaseFragment(), UpNextListener, UpNextTouchCallback.ItemT
         properties[SOURCE_KEY] = upNextSource.analyticsValue
         properties.putAll(props)
         analyticsTracker.track(event, properties)
+    }
+
+    override fun scrollToTop() {
+        binding.recyclerView.quickScrollToTop()
     }
 }
 

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcasts/PodcastsFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcasts/PodcastsFragment.kt
@@ -49,9 +49,11 @@ import au.com.shiftyjelly.pocketcasts.utils.extensions.hideShadow
 import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
 import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
 import au.com.shiftyjelly.pocketcasts.views.adapter.PodcastTouchCallback
+import au.com.shiftyjelly.pocketcasts.views.extensions.quickScrollToTop
 import au.com.shiftyjelly.pocketcasts.views.extensions.showIf
 import au.com.shiftyjelly.pocketcasts.views.fragments.BaseFragment
 import au.com.shiftyjelly.pocketcasts.views.fragments.BaseFragmentToolbar.ChromeCastButton.Shown
+import au.com.shiftyjelly.pocketcasts.views.fragments.TopScrollable
 import au.com.shiftyjelly.pocketcasts.views.helper.NavigationIcon
 import au.com.shiftyjelly.pocketcasts.views.helper.ToolbarColors
 import au.com.shiftyjelly.pocketcasts.views.helper.UiUtil
@@ -63,11 +65,15 @@ import au.com.shiftyjelly.pocketcasts.localization.R as LR
 import au.com.shiftyjelly.pocketcasts.views.R as VR
 
 @AndroidEntryPoint
-class PodcastsFragment : BaseFragment(), FolderAdapter.ClickListener, PodcastTouchCallback.ItemTouchHelperAdapter, Toolbar.OnMenuItemClickListener {
+class PodcastsFragment :
+    BaseFragment(),
+    FolderAdapter.ClickListener,
+    PodcastTouchCallback.ItemTouchHelperAdapter,
+    Toolbar.OnMenuItemClickListener,
+    TopScrollable {
 
     companion object {
         private const val LAST_ORIENTATION_NOT_SET = -1
-        private const val SOURCE_KEY = "source"
         private const val PODCASTS_LIST = "podcasts_list"
         private const val SORT_ORDER_KEY = "sort_order"
         private const val OPTION_KEY = "option"
@@ -426,6 +432,10 @@ class PodcastsFragment : BaseFragment(), FolderAdapter.ClickListener, PodcastTou
         }
         val fragment = newInstance(folderUuid = folderUuid)
         (activity as FragmentHostListener).addFragment(fragment)
+    }
+
+    override fun scrollToTop() {
+        binding.recyclerView.quickScrollToTop()
     }
 
     inner class SpaceItemDecoration : RecyclerView.ItemDecoration() {

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/ProfilePage.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/ProfilePage.kt
@@ -15,6 +15,8 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListScope
+import androidx.compose.foundation.lazy.LazyListState
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material.AppBarDefaults
 import androidx.compose.material.Icon
 import androidx.compose.material.IconButton
@@ -71,6 +73,7 @@ internal fun ProfilePage(
     onUpgradeProfileClick: () -> Unit,
     onCloseUpgradeProfileClick: () -> Unit,
     modifier: Modifier = Modifier,
+    listState: LazyListState = rememberLazyListState(),
 ) {
     val isPortrait = LocalConfiguration.current.orientation != Configuration.ORIENTATION_LANDSCAPE
     AppTheme(themeType) {
@@ -88,6 +91,7 @@ internal fun ProfilePage(
                 onSettingsClick = onSettingsClick,
             )
             LazyColumn(
+                state = listState,
                 modifier = modifier.fillMaxSize(),
             ) {
                 item {

--- a/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/extensions/RecyclerView.kt
+++ b/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/extensions/RecyclerView.kt
@@ -1,5 +1,6 @@
 package au.com.shiftyjelly.pocketcasts.views.extensions
 
+import android.util.DisplayMetrics
 import androidx.recyclerview.widget.LinearSmoothScroller
 import androidx.recyclerview.widget.RecyclerView
 
@@ -16,3 +17,30 @@ fun RecyclerView.smoothScrollToTop(position: Int) {
     smoothScroller.targetPosition = position
     this.layoutManager?.startSmoothScroll(smoothScroller)
 }
+
+fun RecyclerView.quickScrollToTop() {
+    val smoothScroller = object : LinearSmoothScroller(context) {
+        init {
+            targetPosition = 0
+        }
+
+        override fun getVerticalSnapPreference() = LinearSmoothScroller.SNAP_TO_START
+
+        override fun calculateSpeedPerPixel(displayMetrics: DisplayMetrics): Float {
+            val scrollOffset = computeVerticalScrollOffset()
+            val scrollRange = computeVerticalScrollRange()
+
+            return if (scrollRange > 0 && scrollOffset > 0) {
+                val pixelsInRange = scrollRange * scrollOffset / scrollRange.toFloat()
+                (MillisPerRange / pixelsInRange).coerceAtMost(MaxMillisPerInch / displayMetrics.densityDpi)
+            } else {
+                super.calculateSpeedPerPixel(displayMetrics)
+            }
+        }
+    }
+
+    layoutManager?.startSmoothScroll(smoothScroller)
+}
+
+private const val MillisPerRange = 1000f
+private const val MaxMillisPerInch = 50f

--- a/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/fragments/TopScrollable.kt
+++ b/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/fragments/TopScrollable.kt
@@ -1,0 +1,5 @@
+package au.com.shiftyjelly.pocketcasts.views.fragments
+
+interface TopScrollable {
+    fun scrollToTop()
+}


### PR DESCRIPTION
## Description

This PR prevents reloading fragments when they are at the root of the back stack and instead ensures they smoothly scroll to the top when navigated to. This aligns with iOS behavior but removes a previous side effect. Previously, the Filters screen toggled between showing all filters and the last opened one when tapping on the navigation bar icon. Now, this behavior is no longer possible, as the screen will always smooth scroll to the top.

Fixes #2149

## Testing Instructions

If you experience animation stuttering try testing this fix with the release variant first.

1. Scroll the content of a fragment and tap on its icon in the navigation bar. The content should smooth scroll to the top without flickering.
2. Perform regression tests to check for any unintended navigation side effects.

## Screenshots or Screencast 

https://github.com/user-attachments/assets/04b45ca1-faab-4e43-8ceb-b3df540df75e

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] ~I have considered whether it makes sense to add tests for my changes~
- [ ] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [ ] ~Any jetpack compose components I added or changed are covered by compose previews~
- [ ] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~