### PR TITLE
[Suggested Folders] Tweaks part 3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 7.84
 -----
 *   New Features
-    *   Add Suggested Folders
+    *   Add Smart Folders
         ([#3670](https://github.com/Automattic/pocket-casts-android/pull/3670))
     *   Redesign podcast header UI
         ([#3677](https://github.com/Automattic/pocket-casts-android/pull/3671))

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/folders/SuggestedFoldersPage.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/folders/SuggestedFoldersPage.kt
@@ -78,7 +78,7 @@ fun SuggestedFoldersPage(
         ) {
             item(span = { GridItemSpan(maxLineSpan) }) {
                 TextH10(
-                    text = stringResource(LR.string.suggested_folders),
+                    text = stringResource(LR.string.smart_folders),
                     lineHeight = 36.sp,
                     modifier = Modifier.padding(bottom = 2.dp),
                 )

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/folders/SuggestedFoldersPaywallBottomSheet.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/folders/SuggestedFoldersPaywallBottomSheet.kt
@@ -70,7 +70,7 @@ class SuggestedFoldersPaywallBottomSheet : BottomSheetDialogFragment() {
                     }
                 },
                 onMaybeLater = {
-                    viewModel.onMaybeLater()
+                    viewModel.onDismissed()
                     dismiss()
                 },
             )
@@ -79,6 +79,10 @@ class SuggestedFoldersPaywallBottomSheet : BottomSheetDialogFragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+
+        dialog?.setOnDismissListener {
+            viewModel.onDismissed()
+        }
 
         view.doOnLayout {
             val dialog = dialog as BottomSheetDialog

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/folders/SuggestedFoldersPaywallViewModel.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/folders/SuggestedFoldersPaywallViewModel.kt
@@ -18,17 +18,19 @@ class SuggestedFoldersPaywallViewModel @Inject constructor(
 
     val signInState = userManager.getSignInState().asFlow()
 
-    fun onDismissed() {
-        analyticsTracker.track(AnalyticsEvent.SUGGESTED_FOLDERS_PAYWALL_MODAL_MAYBE_LATER_TAPPED)
-        settings.setDismissedSuggestedFolderPaywallTime()
-        settings.updateDismissedSuggestedFolderPaywallCount()
+    fun onDismissed(source: String) {
+        analyticsTracker.track(AnalyticsEvent.SUGGESTED_FOLDERS_PAYWALL_MODAL_MAYBE_LATER_TAPPED, mapOf("source" to source))
+        if (source == SuggestedFoldersPaywallBottomSheet.PODCASTS_SOURCE) {
+            settings.setDismissedSuggestedFolderPaywallTime()
+            settings.updateDismissedSuggestedFolderPaywallCount()
+        }
     }
 
-    fun onShown() {
-        analyticsTracker.track(AnalyticsEvent.SUGGESTED_FOLDERS_PAYWALL_MODAL_SHOWN)
+    fun onShown(source: String) {
+        analyticsTracker.track(AnalyticsEvent.SUGGESTED_FOLDERS_PAYWALL_MODAL_SHOWN, mapOf("source" to source))
     }
 
-    fun onUseTheseFolders() {
-        analyticsTracker.track(AnalyticsEvent.SUGGESTED_FOLDERS_PAYWALL_MODAL_USE_THESE_FOLDERS_TAPPED)
+    fun onUseTheseFolders(source: String) {
+        analyticsTracker.track(AnalyticsEvent.SUGGESTED_FOLDERS_PAYWALL_MODAL_USE_THESE_FOLDERS_TAPPED, mapOf("source" to source))
     }
 }

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/folders/SuggestedFoldersPaywallViewModel.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/folders/SuggestedFoldersPaywallViewModel.kt
@@ -18,7 +18,7 @@ class SuggestedFoldersPaywallViewModel @Inject constructor(
 
     val signInState = userManager.getSignInState().asFlow()
 
-    fun onMaybeLater() {
+    fun onDismissed() {
         analyticsTracker.track(AnalyticsEvent.SUGGESTED_FOLDERS_PAYWALL_MODAL_MAYBE_LATER_TAPPED)
         settings.suggestedFolderPaywallDismissTime.set(System.currentTimeMillis(), updateModifiedAt = false)
     }

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/folders/SuggestedFoldersPaywallViewModel.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/folders/SuggestedFoldersPaywallViewModel.kt
@@ -20,7 +20,8 @@ class SuggestedFoldersPaywallViewModel @Inject constructor(
 
     fun onDismissed() {
         analyticsTracker.track(AnalyticsEvent.SUGGESTED_FOLDERS_PAYWALL_MODAL_MAYBE_LATER_TAPPED)
-        settings.suggestedFolderPaywallDismissTime.set(System.currentTimeMillis(), updateModifiedAt = false)
+        settings.setDismissedSuggestedFolderPaywallTime()
+        settings.updateDismissedSuggestedFolderPaywallCount()
     }
 
     fun onShown() {

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/folders/SuggestedFoldersViewModel.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/folders/SuggestedFoldersViewModel.kt
@@ -40,6 +40,7 @@ class SuggestedFoldersViewModel @Inject constructor(
 
     fun onReplaceExistingFoldersShown() {
         analyticsTracker.track(AnalyticsEvent.SUGGESTED_FOLDERS_REPLACE_EXISTING_FOLDERS_MODAL_SHOWN)
+        _state.value = FoldersState.Idle
     }
 
     fun onReplaceExistingFoldersTapped() {

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcasts/PodcastsFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcasts/PodcastsFragment.kt
@@ -34,6 +34,8 @@ import au.com.shiftyjelly.pocketcasts.podcasts.view.folders.FolderEditFragment
 import au.com.shiftyjelly.pocketcasts.podcasts.view.folders.FolderEditPodcastsFragment
 import au.com.shiftyjelly.pocketcasts.podcasts.view.folders.SuggestedFolders
 import au.com.shiftyjelly.pocketcasts.podcasts.view.folders.SuggestedFoldersPaywallBottomSheet
+import au.com.shiftyjelly.pocketcasts.podcasts.view.folders.SuggestedFoldersPaywallBottomSheet.Companion.CREATE_FOLDER_SOURCE
+import au.com.shiftyjelly.pocketcasts.podcasts.view.folders.SuggestedFoldersPaywallBottomSheet.Companion.PODCASTS_SOURCE
 import au.com.shiftyjelly.pocketcasts.podcasts.view.podcast.PodcastFragment
 import au.com.shiftyjelly.pocketcasts.podcasts.viewmodel.PodcastsViewModel
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
@@ -204,7 +206,7 @@ class PodcastsFragment : BaseFragment(), FolderAdapter.ClickListener, PodcastTou
         toolbar.menu.findItem(R.id.folders_locked).setOnMenuItemClickListener {
             val state = viewModel.suggestedFoldersState
             if (FeatureFlag.isEnabled(Feature.SUGGESTED_FOLDERS) && state is PodcastsViewModel.SuggestedFoldersState.Loaded) {
-                SuggestedFoldersPaywallBottomSheet.newInstance(state.folders()).show(childFragmentManager, "suggested_folders_paywall")
+                SuggestedFoldersPaywallBottomSheet.newInstance(state.folders(), CREATE_FOLDER_SOURCE).show(parentFragmentManager, SuggestedFoldersPaywallBottomSheet.TAG)
             } else {
                 OnboardingLauncher.openOnboardingFlow(activity, OnboardingFlow.Upsell(OnboardingUpgradeSource.FOLDERS))
             }
@@ -242,7 +244,7 @@ class PodcastsFragment : BaseFragment(), FolderAdapter.ClickListener, PodcastTou
         viewLifecycleOwner.lifecycleScope.launch {
             viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
                 viewModel.userSuggestedFoldersState.collectLatest { (signInState, state) ->
-                    val existingModal = parentFragmentManager.findFragmentByTag("suggested_folders_paywall")
+                    val existingModal = parentFragmentManager.findFragmentByTag(SuggestedFoldersPaywallBottomSheet.TAG)
                     if (state is PodcastsViewModel.SuggestedFoldersState.Loaded) {
                         if (existingModal != null && existingModal is SuggestedFoldersPaywallBottomSheet && !signInState.isSignedInAsPlusOrPatron) {
                             // We don't want to close this modal for Paid users because this scenario might occur when the user upgrades their account
@@ -251,7 +253,7 @@ class PodcastsFragment : BaseFragment(), FolderAdapter.ClickListener, PodcastTou
                             existingModal.dismiss()
                         }
                         if (viewModel.showSuggestedFoldersPaywallOnOpen(signInState.isSignedInAsPlusOrPatron)) {
-                            SuggestedFoldersPaywallBottomSheet.newInstance(state.folders()).show(parentFragmentManager, "suggested_folders_paywall")
+                            SuggestedFoldersPaywallBottomSheet.newInstance(state.folders(), PODCASTS_SOURCE).show(parentFragmentManager, SuggestedFoldersPaywallBottomSheet.TAG)
                         }
                     } else if (state is PodcastsViewModel.SuggestedFoldersState.Empty) {
                         if (existingModal != null && existingModal is SuggestedFoldersPaywallBottomSheet) {

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/PodcastsViewModel.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/PodcastsViewModel.kt
@@ -327,8 +327,13 @@ class PodcastsViewModel
         }
     }
 
-    fun showSuggestedFoldersPaywallOnOpen(isSignedInAsPlusOrPatron: Boolean) =
-        FeatureFlag.isEnabled(Feature.SUGGESTED_FOLDERS) && !isSignedInAsPlusOrPatron && settings.suggestedFolderPaywallDismissTime.value == 0L
+    suspend fun showSuggestedFoldersPaywallOnOpen(isSignedInAsPlusOrPatron: Boolean): Boolean {
+        val uuids = podcastManager.findSubscribedUuids()
+        return FeatureFlag.isEnabled(Feature.SUGGESTED_FOLDERS) &&
+            !isSignedInAsPlusOrPatron &&
+            settings.suggestedFolderPaywallDismissTime.value == 0L &&
+            uuids.size >= FOLLOWED_PODCASTS_THRESHOLD
+    }
 
     sealed class SuggestedFoldersState {
         data object Idle : SuggestedFoldersState()
@@ -349,5 +354,6 @@ class PodcastsViewModel
         private const val BADGE_TYPE_KEY = "badge_type"
         private const val LAYOUT_KEY = "layout"
         private const val SORT_ORDER_KEY = "sort_order"
+        private const val FOLLOWED_PODCASTS_THRESHOLD = 4
     }
 }

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/PodcastsViewModel.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/PodcastsViewModel.kt
@@ -331,7 +331,7 @@ class PodcastsViewModel
         val uuids = podcastManager.findSubscribedUuids()
         return FeatureFlag.isEnabled(Feature.SUGGESTED_FOLDERS) &&
             !isSignedInAsPlusOrPatron &&
-            settings.suggestedFolderPaywallDismissTime.value == 0L &&
+            settings.isEligibleToShowSuggestedFolderPaywall() &&
             uuids.size >= FOLLOWED_PODCASTS_THRESHOLD
     }
 

--- a/modules/features/podcasts/src/test/java/au/com/shiftyjelly/pocketcasts/podcasts/view/folders/SuggestedFoldersPaywallViewModelTest.kt
+++ b/modules/features/podcasts/src/test/java/au/com/shiftyjelly/pocketcasts/podcasts/view/folders/SuggestedFoldersPaywallViewModelTest.kt
@@ -2,12 +2,16 @@ package au.com.shiftyjelly.pocketcasts.podcasts.view.folders
 
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTracker
+import au.com.shiftyjelly.pocketcasts.podcasts.view.folders.SuggestedFoldersPaywallBottomSheet.Companion.CREATE_FOLDER_SOURCE
+import au.com.shiftyjelly.pocketcasts.podcasts.view.folders.SuggestedFoldersPaywallBottomSheet.Companion.PODCASTS_SOURCE
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.repositories.user.UserManager
 import org.junit.Before
 import org.junit.Test
 import org.mockito.Mock
+import org.mockito.Mockito.times
 import org.mockito.MockitoAnnotations
+import org.mockito.kotlin.eq
 import org.mockito.kotlin.verify
 
 class SuggestedFoldersPaywallViewModelTest {
@@ -32,24 +36,45 @@ class SuggestedFoldersPaywallViewModelTest {
 
     @Test
     fun `onDismissed should track event and update settings`() {
-        viewModel.onDismissed()
+        viewModel.onDismissed(PODCASTS_SOURCE)
 
-        verify(analyticsTracker).track(AnalyticsEvent.SUGGESTED_FOLDERS_PAYWALL_MODAL_MAYBE_LATER_TAPPED)
+        verify(analyticsTracker).track(
+            eq(AnalyticsEvent.SUGGESTED_FOLDERS_PAYWALL_MODAL_MAYBE_LATER_TAPPED),
+            eq(mapOf("source" to PODCASTS_SOURCE)),
+        )
         verify(settings).setDismissedSuggestedFolderPaywallTime()
         verify(settings).updateDismissedSuggestedFolderPaywallCount()
     }
 
     @Test
-    fun `onShown should track event`() {
-        viewModel.onShown()
+    fun `onDismissed should track event and not update settings`() {
+        viewModel.onDismissed(CREATE_FOLDER_SOURCE)
 
-        verify(analyticsTracker).track(AnalyticsEvent.SUGGESTED_FOLDERS_PAYWALL_MODAL_SHOWN)
+        verify(analyticsTracker).track(
+            eq(AnalyticsEvent.SUGGESTED_FOLDERS_PAYWALL_MODAL_MAYBE_LATER_TAPPED),
+            eq(mapOf("source" to CREATE_FOLDER_SOURCE)),
+        )
+        verify(settings, times(0)).setDismissedSuggestedFolderPaywallTime()
+        verify(settings, times(0)).updateDismissedSuggestedFolderPaywallCount()
+    }
+
+    @Test
+    fun `onShown should track event`() {
+        viewModel.onShown(PODCASTS_SOURCE)
+
+        verify(analyticsTracker).track(
+            eq(AnalyticsEvent.SUGGESTED_FOLDERS_PAYWALL_MODAL_SHOWN),
+            eq(mapOf("source" to PODCASTS_SOURCE)),
+        )
     }
 
     @Test
     fun `onUseTheseFolders should track event`() {
-        viewModel.onUseTheseFolders()
+        viewModel.onUseTheseFolders(PODCASTS_SOURCE)
 
-        verify(analyticsTracker).track(AnalyticsEvent.SUGGESTED_FOLDERS_PAYWALL_MODAL_USE_THESE_FOLDERS_TAPPED)
+        verify(analyticsTracker).track(
+            eq(AnalyticsEvent.SUGGESTED_FOLDERS_PAYWALL_MODAL_USE_THESE_FOLDERS_TAPPED),
+            eq(mapOf("source" to PODCASTS_SOURCE)),
+        )
     }
 }

--- a/modules/features/podcasts/src/test/java/au/com/shiftyjelly/pocketcasts/podcasts/view/folders/SuggestedFoldersPaywallViewModelTest.kt
+++ b/modules/features/podcasts/src/test/java/au/com/shiftyjelly/pocketcasts/podcasts/view/folders/SuggestedFoldersPaywallViewModelTest.kt
@@ -1,0 +1,55 @@
+package au.com.shiftyjelly.pocketcasts.podcasts.view.folders
+
+import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
+import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTracker
+import au.com.shiftyjelly.pocketcasts.preferences.Settings
+import au.com.shiftyjelly.pocketcasts.repositories.user.UserManager
+import org.junit.Before
+import org.junit.Test
+import org.mockito.Mock
+import org.mockito.MockitoAnnotations
+import org.mockito.kotlin.verify
+
+class SuggestedFoldersPaywallViewModelTest {
+
+    @Mock
+    lateinit var settings: Settings
+
+    @Mock
+    lateinit var analyticsTracker: AnalyticsTracker
+
+    @Mock
+    lateinit var userManager: UserManager
+
+    lateinit var viewModel: SuggestedFoldersPaywallViewModel
+
+    @Before
+    fun setUp() {
+        MockitoAnnotations.openMocks(this)
+
+        viewModel = SuggestedFoldersPaywallViewModel(userManager, settings, analyticsTracker)
+    }
+
+    @Test
+    fun `onDismissed should track event and update settings`() {
+        viewModel.onDismissed()
+
+        verify(analyticsTracker).track(AnalyticsEvent.SUGGESTED_FOLDERS_PAYWALL_MODAL_MAYBE_LATER_TAPPED)
+        verify(settings).setDismissedSuggestedFolderPaywallTime()
+        verify(settings).updateDismissedSuggestedFolderPaywallCount()
+    }
+
+    @Test
+    fun `onShown should track event`() {
+        viewModel.onShown()
+
+        verify(analyticsTracker).track(AnalyticsEvent.SUGGESTED_FOLDERS_PAYWALL_MODAL_SHOWN)
+    }
+
+    @Test
+    fun `onUseTheseFolders should track event`() {
+        viewModel.onUseTheseFolders()
+
+        verify(analyticsTracker).track(AnalyticsEvent.SUGGESTED_FOLDERS_PAYWALL_MODAL_USE_THESE_FOLDERS_TAPPED)
+    }
+}

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -2279,7 +2279,7 @@
     <string name="winback_cancel_subscription_cancel_button_label">Yes, Cancel my Subscription</string>
 
     <!-- Suggested Folders -->
-    <string name="suggested_folders">Suggested Folders</string>
+    <string name="smart_folders">Smart folders</string>
     <string name="suggested_folders_subtitle">We\'ve organized your podcasts into folders. Save them now and customize later to fit your style.</string>
     <string name="suggested_folders_use_these_folders_button">Use these folders</string>
     <string name="suggested_folders_use_create_custom_folders_button">Create custom folders</string>

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
@@ -75,6 +75,8 @@ interface Settings {
         const val LAST_UPDATE_TIME = "LastUpdateTime"
         const val LAST_DISMISS_LOW_STORAGE_MODAL_TIME = "LastDismissLowStorageModalTime"
         const val LAST_DISMISS_LOW_STORAGE_BANNER_TIME = "LastDismissLowStorageBannerTime"
+        const val LAST_DISMISS_SUGGESTED_FOLDER_PAYWALL_TIME = "LastDismissSuggestedFolderPaywallTime"
+        const val DISMISS_SUGGESTED_FOLDER_PAYWALL_COUNT = "DismissSuggestedFolderPaywallCount"
         const val PREFERENCE_SKIP_FORWARD = "skipForward"
         const val PREFERENCE_SKIP_BACKWARD = "skipBack"
         const val PREFERENCE_STORAGE_CHOICE = "storageChoice"
@@ -333,7 +335,9 @@ interface Settings {
 
     val hideNotificationOnPause: UserSetting<Boolean>
 
-    val suggestedFolderPaywallDismissTime: UserSetting<Long>
+    fun setDismissedSuggestedFolderPaywallTime()
+    fun isEligibleToShowSuggestedFolderPaywall(): Boolean
+    fun updateDismissedSuggestedFolderPaywallCount()
 
     val streamingMode: UserSetting<Boolean>
     val keepScreenAwake: UserSetting<Boolean>

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
@@ -340,9 +340,7 @@ class SettingsImpl @Inject constructor(
     }
 
     override fun setDismissedSuggestedFolderPaywallTime() {
-        val editor = sharedPreferences.edit()
-        editor.putLong(Settings.LAST_DISMISS_SUGGESTED_FOLDER_PAYWALL_TIME, System.currentTimeMillis())
-        editor.apply()
+        sharedPreferences.edit { putLong(Settings.LAST_DISMISS_SUGGESTED_FOLDER_PAYWALL_TIME, System.currentTimeMillis()) }
     }
 
     override fun isEligibleToShowSuggestedFolderPaywall(): Boolean {
@@ -358,9 +356,7 @@ class SettingsImpl @Inject constructor(
 
     override fun updateDismissedSuggestedFolderPaywallCount() {
         val currentCount = sharedPreferences.getInt(Settings.DISMISS_SUGGESTED_FOLDER_PAYWALL_COUNT, 0)
-        val editor = sharedPreferences.edit()
-        editor.putInt(Settings.DISMISS_SUGGESTED_FOLDER_PAYWALL_COUNT, currentCount + 1)
-        editor.apply()
+        sharedPreferences.edit { putInt(Settings.DISMISS_SUGGESTED_FOLDER_PAYWALL_COUNT, currentCount + 1) }
     }
 
     override fun setDismissLowStorageBannerTime(lastUpdateTime: Long) {

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
@@ -339,6 +339,30 @@ class SettingsImpl @Inject constructor(
         return timeSinceDismiss >= 7.days
     }
 
+    override fun setDismissedSuggestedFolderPaywallTime() {
+        val editor = sharedPreferences.edit()
+        editor.putLong(Settings.LAST_DISMISS_SUGGESTED_FOLDER_PAYWALL_TIME, System.currentTimeMillis())
+        editor.apply()
+    }
+
+    override fun isEligibleToShowSuggestedFolderPaywall(): Boolean {
+        val lastDismissedTime = sharedPreferences.getLong(Settings.LAST_DISMISS_SUGGESTED_FOLDER_PAYWALL_TIME, 0L)
+        val currentDismissedCount = sharedPreferences.getInt(Settings.DISMISS_SUGGESTED_FOLDER_PAYWALL_COUNT, 0)
+
+        if (lastDismissedTime == 0L) return true
+
+        val timeSinceDismiss = (System.currentTimeMillis() - lastDismissedTime).milliseconds
+
+        return timeSinceDismiss >= 7.days && currentDismissedCount < 2
+    }
+
+    override fun updateDismissedSuggestedFolderPaywallCount() {
+        val currentCount = sharedPreferences.getInt(Settings.DISMISS_SUGGESTED_FOLDER_PAYWALL_COUNT, 0)
+        val editor = sharedPreferences.edit()
+        editor.putInt(Settings.DISMISS_SUGGESTED_FOLDER_PAYWALL_COUNT, currentCount + 1)
+        editor.apply()
+    }
+
     override fun setDismissLowStorageBannerTime(lastUpdateTime: Long) {
         sharedPreferences.edit {
             putLong(Settings.LAST_DISMISS_LOW_STORAGE_BANNER_TIME, lastUpdateTime)
@@ -552,12 +576,6 @@ class SettingsImpl @Inject constructor(
     override val hideNotificationOnPause = UserSetting.BoolPref(
         sharedPrefKey = "hideNotificationOnPause",
         defaultValue = false,
-        sharedPrefs = sharedPreferences,
-    )
-
-    override val suggestedFolderPaywallDismissTime = UserSetting.LongPref(
-        sharedPrefKey = "suggestedFolderPaywallDismissTime",
-        defaultValue = 0L,
         sharedPrefs = sharedPreferences,
     )
 


### PR DESCRIPTION
## Description
- This address some small changes
   - Rename to Smart folders: p1740723674015329/1740626371.709879-slack-C08BRS7N9UL
   - Update the dismiss rule: p1740739349215759/1740662999.868259-slack-C08BRS7N9UL
   - Show paywall only when following at least 4 podcasts: p1740753502698749/1740745238.160689-slack-C08BRS7N9UL
   - Fix this small issue: p1740719275171009-slack-C08BRS7N9UL

## Testing Instructions

To test the dismiss rule, I recommend to change from `7.days` to `7.seconds` here: https://github.com/Automattic/pocket-casts-android/pull/3675/files#r1975639312

### Free flow
1. Fresh install
2. Do not follow any podcast
3. Go to Podcasts tab
4. Ensure you don't see the paywall ✅
5. Follow 4 podcasts
6. Go to Podcasts tab again
7. Ensure you see the paywall ✅
8. Tap outside of the modal to dismiss it
9. Go to Discover
10. Back to Podcasts tab again in less than 7 seconds
11. Ensure should not see the paywall ✅
12. Go to Discover and ensure more than 7 seconds passed
13. Go to Podcasts tab and ensure you see the paywall modal ✅
14. Dismiss the modal
15. Go to Discover and back to podcasts tab
16. You should not see the modal anymore ✅

### Paid flow
1. Install the app, using paid account and have some existing folders
2. Open the suggested folder screen (renamed to Smart folders)
3. Tap on `Use these folders`
4. See the dialog confirmation 
5. Tap outside of it to dismiss
6. Tap on `Use these folders`
7. Ensure the dialog opens again ✅

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.