### PR TITLE
[Slack Webhook] A new workflow to trigger Slack Webhook when high prio label is applied.

### DIFF
--- a/.github/workflows/high-prio-issue-notify-slack.yml
+++ b/.github/workflows/high-prio-issue-notify-slack.yml
@@ -1,0 +1,29 @@
+name: Notify Slack when "[Priority] High" label is applied to new or existing issue.
+
+on:
+  issues:
+    types: [labeled]
+
+jobs:
+  notify_slack:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check for "[Priority] High" Label
+        id: check_label
+        run: |
+          if [[ "${{ github.event.label.name }}" == "[Priority] High" ]]; then
+            echo "SEND_SLACK=true" >> $GITHUB_ENV
+          else
+            echo "SEND_SLACK=false" >> $GITHUB_ENV
+          fi
+
+      - name: Send Slack Notification
+        if: env.SEND_SLACK == 'true'
+        uses: slackapi/slack-github-action@v1.24.0
+        with:
+          payload: |
+            {
+              "text": ":pocket-casts::android: *High Priority Issue Alert!*\n\n*Issue:* <${{ github.event.issue.html_url }}|${{ github.event.issue.title }}>\n*Created By:* ${{ github.event.issue.user.login }}\n*Issue Number:* #${{ github.event.issue.number }}"
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_NOTIFIER_WEBHOOK_URL }}

--- a/.github/workflows/high-prio-issue-notify-slack.yml
+++ b/.github/workflows/high-prio-issue-notify-slack.yml
@@ -1,7 +1,9 @@
-name: Notify Slack when "[Priority] High" label is applied to new or existing issue.
+name: Notify Slack when "[Priority] High" label is applied to an Issue or PR.
 
 on:
   issues:
+    types: [labeled]
+  pull_request:
     types: [labeled]
 
 jobs:
@@ -13,6 +15,10 @@ jobs:
         run: |
           if [[ "${{ github.event.label.name }}" == "[Priority] High" ]]; then
             echo "SEND_SLACK=true" >> $GITHUB_ENV
+            echo "TYPE=${{ github.event_name == 'issues' && 'Issue' || 'Pull Request' }}" >> $GITHUB_ENV
+            echo "LINK=<${{ github.event.issue.html_url || github.event.pull_request.html_url }}|${{ github.event.issue.title || github.event.pull_request.title }}>" >> $GITHUB_ENV
+            echo "AUTHOR=${{ github.event.issue.user.login || github.event.pull_request.user.login }}" >> $GITHUB_ENV
+            echo "NUMBER=${{ github.event.issue.number || github.event.pull_request.number }}" >> $GITHUB_ENV
           else
             echo "SEND_SLACK=false" >> $GITHUB_ENV
           fi
@@ -23,7 +29,7 @@ jobs:
         with:
           payload: |
             {
-              "text": ":pocket-casts::android: *High Priority Issue Alert!*\n\n*Issue:* <${{ github.event.issue.html_url }}|${{ github.event.issue.title }}>\n*Created By:* ${{ github.event.issue.user.login }}\n*Issue Number:* #${{ github.event.issue.number }}"
+              "text": ":pocket-casts::android: *High Priority Alert!*\n\n*Type:* ${{ env.TYPE }}\n*Link:* ${{ env.LINK }}\n*Created By:* ${{ env.AUTHOR }}\n*Number:* ${{ env.NUMBER }}"
             }
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_NOTIFIER_WEBHOOK_URL }}


### PR DESCRIPTION
## Description
Background: https://a8c.slack.com/archives/C07J5LNP4SF/p1740664911286009

When a new or existing issue is labelled with `[Priority] High`, the message is sent to pocket-casts-android Slack channel.

The webhook URL is added as a repo secret, and the channel to be used is defined in the Slack app webhook settings. So, both are configured outside the file added by this PR.

## Testing Instructions
I believe there's no way to test the PR unless it's merged. If this helps, the exact same YML file was tested in my private sandbox repo, using the same webhook reference, and it worked ([see this Slack message](https://a8c.slack.com/archives/C028JAG44VD/p1740765498787409)):

<img width="639" alt="Screenshot 2025-02-28 at 20 05 03" src="https://github.com/user-attachments/assets/7b35a96e-a9e3-49a3-8b1c-d97fa599db4d" />
