### PR TITLE
Improve media event logging

### DIFF
--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/MediaSessionManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/MediaSessionManager.kt
@@ -530,6 +530,7 @@ class MediaSessionManager(
                 val keyEvent = IntentCompat.getParcelableExtra(mediaButtonEvent, Intent.EXTRA_KEY_EVENT, KeyEvent::class.java) ?: return false
                 logEvent(keyEvent.toString())
                 if (keyEvent.action == KeyEvent.ACTION_DOWN) {
+                    LogBuffer.i(LogBuffer.TAG_PLAYBACK, "Media button Android event: ${keyEvent.action}")
                     val inputEvent = when (keyEvent.keyCode) {
                         /**
                          * KEYCODE_MEDIA_PLAY_PAUSE - called when the player audio has focus
@@ -541,10 +542,12 @@ class MediaSessionManager(
                         KeyEvent.KEYCODE_MEDIA_PREVIOUS -> MediaEvent.TripleTap
                         else -> null
                     }
+                    LogBuffer.i(LogBuffer.TAG_PLAYBACK, "Media button input event: ${keyEvent.action}")
 
                     if (inputEvent != null) {
                         launch {
                             val outputEvent = mediaEventQueue.consumeEvent(inputEvent)
+                            LogBuffer.i(LogBuffer.TAG_PLAYBACK, "Media button output event: ${keyEvent.action}")
                             when (outputEvent) {
                                 MediaEvent.SingleTap -> handleMediaButtonSingleTap()
                                 MediaEvent.DoubleTap -> handleMediaButtonDoubleTap()

--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/log/LogBuffer.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/log/LogBuffer.kt
@@ -10,6 +10,7 @@ import java.io.PrintWriter
 import java.io.StringWriter
 import java.text.SimpleDateFormat
 import java.util.Date
+import java.util.Locale
 import timber.log.Timber
 import timber.log.Timber.Forest.tag
 
@@ -25,7 +26,7 @@ object LogBuffer {
     private const val LOG_FILE_NAME = "debug.log"
     private const val LOG_BACKUP_FILE_NAME = "debug.log.1"
 
-    private val LOG_FILE_DATE_FORMAT = SimpleDateFormat("dd/M HH:mm:ss")
+    private val LOG_FILE_DATE_FORMAT = SimpleDateFormat("dd/M HH:mm:ss.SSS", Locale.US)
     private const val FILE_MAX_SIZE_BYTES = (200 * 1024).toLong()
 
     private var logPath: String? = null


### PR DESCRIPTION
## Description

Add some more logs to diagnose media events. It also increases the resolution of our logs to milliseconds.

## Testing Instructions

Code review should be enough.

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] ~I have considered whether it makes sense to add tests for my changes~
- [ ] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [ ] ~Any jetpack compose components I added or changed are covered by compose previews~
- [ ] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~