### PR TITLE
Remove small files check for downloaded files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 7.85
 -----
-
+*   Updates
+    *   Remove file size limit for downloaded episodes.
+        ([#3686](https://github.com/Automattic/pocket-casts-android/pull/3686))
 
 7.84
 -----

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/download/task/DownloadEpisodeTask.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/download/task/DownloadEpisodeTask.kt
@@ -93,12 +93,6 @@ class DownloadEpisodeTask @AssistedInject constructor(
 
         private const val HTTP_RESUME_SUPPORTED = 206
 
-        // things smaller than 150kbs are suspect, probably text, xml or html error pages
-        private const val SUSPECT_EPISODE_SIZE = (150 * 1024).toLong()
-
-        // things smaller than 10kbs are not episodes, way too small and something has gone wrong
-        private const val BAD_EPISODE_SIZE = (10 * 1024).toLong()
-
         // the minimum amount of time between progress reports about the download to the app
         private const val MIN_TIME_BETWEEN_UPDATE_REPORTS: Long = 500 // ms;
 
@@ -383,8 +377,8 @@ class DownloadEpisodeTask @AssistedInject constructor(
                 episodeDownloadError.expectedContentLength = bytesRemaining
                 val contentType = body.contentType()
 
-                // basic sanity checks to make sure the file looks big enough and it's content type isn't text
-                if (bytesRemaining in 1..<BAD_EPISODE_SIZE || bytesRemaining in 1..<SUSPECT_EPISODE_SIZE && contentType?.toString().orEmpty().contains("text", ignoreCase = true)) {
+                // basic sanity check to make sure the content type isn't text
+                if (contentType?.toString().orEmpty().contains("text", ignoreCase = true)) {
                     episodeDownloadError.reason = EpisodeDownloadError.Reason.SuspiciousContent
                     if (!emitter.isDisposed) {
                         emitter.onError(DownloadFailed(FileNotFoundException(), "File not found. The podcast author may have moved or deleted this episode file.", false))


### PR DESCRIPTION
## Description

This PR removes the checks for downloaded file size.

Context: p1740687176831249-slack-C02A333D8LQ

## Testing Instructions

Download and play episodes from this thread - p1740687176831249-slack-C02A333D8LQ

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] ~I have considered whether it makes sense to add tests for my changes~
- [ ] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [ ] ~Any jetpack compose components I added or changed are covered by compose previews~
- [ ] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~