### PR TITLE
Update bottom controls position with every layout change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 7.85
 -----
 *   Bug Fixes
-    *   Fix the mini player sometimes hiding behind the navigation bar.
+    *   Fixed an issue where the mini player could sometimes hide behind the navigation bar.
         ([#3687](https://github.com/Automattic/pocket-casts-android/pull/3687))
 
 7.84

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 7.85
 -----
-
+*   Bug Fixes
+    *   Fix the mini player sometimes hiding behind the navigation bar.
+        ([#3687](https://github.com/Automattic/pocket-casts-android/pull/3687))
 
 7.84
 -----

--- a/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
+++ b/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
@@ -376,7 +376,7 @@ class MainActivity :
 
         binding.root.setSystemWindowInsetToPadding(left = true, right = true)
 
-        binding.bottomNavigation.doOnLayout {
+        binding.bottomNavigation.addOnLayoutChangeListener { _, _, _, _, _, _, _, _, _ ->
             val miniPlayerHeight = miniPlayerHeight
             val bottomNavigationHeight = binding.bottomNavigation.height
             val bottomSheetBehavior = BottomSheetBehavior.from(binding.playerBottomSheet)

--- a/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
+++ b/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
@@ -24,7 +24,6 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.platform.ComposeView
 import androidx.core.content.ContextCompat
 import androidx.core.view.WindowCompat
-import androidx.core.view.doOnLayout
 import androidx.core.view.isVisible
 import androidx.core.view.updateLayoutParams
 import androidx.core.view.updatePadding


### PR DESCRIPTION
## Description

Updating mini player position only once is incorrect as there is a race condition between updating bottom insets and said position. This PR changes the logic to update the bottom offset properties whenever the layout changes.

Fixes #3568

This change potentially deals with #3631 as well but I don't really know as I can't replicate that behavior at all.

## Testing Instructions

It's hard to give the steps as the bug is not deterministic but try to replicate #3568.

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] ~I have considered whether it makes sense to add tests for my changes~
- [ ] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [ ] ~Any jetpack compose components I added or changed are covered by compose previews~
- [ ] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~