### PR TITLE
[Tooling] Workaround: disable running `lint_task` during `finalize_release`

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -363,8 +363,11 @@ platform :android do
     android_download_translations(
       res_dir: File.join('modules', 'services', 'localization', 'src', 'main', 'res'),
       glotpress_url: GLOTPRESS_APP_STRINGS_PROJECT_URL,
-      locales: SUPPORTED_LOCALES,
-      lint_task: 'aggregatedLintRelease'
+      locales: SUPPORTED_LOCALES
+      # FIXME: The `finalize_release` lane runs on `tumblr-metal` agent (needed as a trusted agent so we can git push), but that agent shouldn't be
+      #        used for running gradle task. Besides, it currently fails because that agent is behind a proxy but `-Dhttp.proxyHost` is not provided.
+      # FIXME: We should thus split the `finalize_release` lane into 2 lanes, one to download the translations + create a PR (in which the lint task will run), one to finalize the release.
+      # lint_task: 'aggregatedLintRelease'
     )
 
     version = release_version_current


### PR DESCRIPTION
Context: p1740990351304109/1740786797.612419-slack-CC7L49W13

## Description

@geekygecko reported during last release that the `finalize_release` automation running on CI failed to download Gradle, which made the lane and CI build fail.

```
[18:47:07]: Exit status of command './gradlew aggregatedLintRelease' was 1 instead of 0.
Downloading https://services.gradle.org/distributions/gradle-8.12.1-all.zip
Exception in thread "main" java.io.IOException: Downloading from https://services.gradle.org/distributions/gradle-8.12.1-all.zip failed: timeout (10000ms)
	at org.gradle.wrapper.Install.forceFetch(SourceFile:4)
	at org.gradle.wrapper.Install$1.call(SourceFile:8)
	at org.gradle.wrapper.GradleWrapperMain.main(SourceFile:67)
Caused by: java.net.SocketTimeoutException: connect timed out
```

This PR temporarily disables the running of `aggregatedLintRelease` gradle task after having downloaded the translations, because the `finalize_release` lane runs on CI agents that are not supposed to run build/gradle tools, and are behind a proxy which prevents them from downloading the `gradle` binary in the first place anyway. This is a temporary fix just for `release/7.84`, as the proper fix will involve an update of the scenario (see "What's Next" below)

<details><summary>Technical details</summary>

The `finalize_release` lane now runs on CI, but uses the `tumblr-metal` agent to do so because we need a trusted agent with permissions to `git push`.

Those agents are not supposed to be used to run `gradle` tasks or doing build stuff, but rather only to do small commit tasks (like version bump or translations file download). So we shouldn't make the `android_download_translations` task run the gradle `lint_task: 'aggregatedLintRelease'` on those CI agents.

This commit temporarily disable the linting task to workaround the issue that the `tumblr-metal` agent can't even download the gradle binary (because it's behind a proxy and gradle is not provided the values of `HTTP_PROXY` env vars as `-Dhttp.proxyHost` system properties, so it fails when trying to download it anyway) and failed the CI build.

In a future PR we will split the lane in 2 to run the translations download on one lane (run on `tumblr-metal` so it can push), then let CI do the linting on a proper `android` agent, then have a second lane do the rest of the release finalization. This will require an update of the release scenario though, so would only be applicable for the next release
</details>

## Testing Instructions

This workaround will be tested live by @ashiagr, as part of the `7.84` release: when she'll get to the "Trigger the release finalization" task of the release scenario, with this workaround in place, the CI should not fail like it did for @geekygecko last sprint on that same scenario task.

## What's Next

This is just a workaround for `release/7.84` branch, because the proper fix for this will require an update of the release scenario to extract the download of the translations from the `finalize_release` lane and into a dedicated scenario task

The proper fix has been implemented in https://github.com/Automattic/pocket-casts-android/pull/3695 with the corresponding update to the release scenario template ready in 175590-ghe-Automattic/wpcom. But since the release scenario for `7.84` have already started, we'll only be able to apply those proper scenario changes (by resetting the MC scenarios after the scenario template PRs have landed) starting `7.85`