### PR TITLE
[Tooling] Split `download_translations` from `finalize_release`

### DIFF
--- a/.buildkite/release-pipelines/code-freeze.yml
+++ b/.buildkite/release-pipelines/code-freeze.yml
@@ -22,5 +22,5 @@ steps:
       queue: "tumblr-metal"
     retry:
       manual:
-        # If those jobs fail, one should always prefer re-triggering a new build from ReleaseV2 rather than retrying the individual job from Buildkite
         allowed: false
+        reason: "Always prefer re-triggering a new build from ReleaseV2 rather than retrying the individual job from Buildkite"

--- a/.buildkite/release-pipelines/download-translations.yml
+++ b/.buildkite/release-pipelines/download-translations.yml
@@ -9,8 +9,6 @@ steps:
       echo '--- 🤖 Use bot for Git operations'
       source use-bot-for-git
 
-      .buildkite/commands/checkout-release-branch.sh "${RELEASE_VERSION}"
-
       echo '--- :ruby: Setup Ruby Tools'
       install_gems
 

--- a/.buildkite/release-pipelines/download-translations.yml
+++ b/.buildkite/release-pipelines/download-translations.yml
@@ -4,7 +4,7 @@
 # This pipeline is meant to be triggered by the MC scenario in ReleasesV2
 
 steps:
-  - label: "🚂 Finalize Release"
+  - label: "🚂 Download Translations"
     command: |
       echo '--- 🤖 Use bot for Git operations'
       source use-bot-for-git
@@ -17,8 +17,8 @@ steps:
       echo '--- 🔐 Access Secrets'
       bundle exec fastlane run configure_apply
 
-      echo '--- 🚀 Finalize Release'
-      bundle exec fastlane finalize_release skip_confirm:true skip_translations_download:true
+      echo '--- 🚀 Download Translations'
+      bundle exec fastlane download_translations
     plugins: [$CI_TOOLKIT]
     agents:
       queue: "tumblr-metal"

--- a/.buildkite/release-pipelines/finalize-hotfix-release.yml
+++ b/.buildkite/release-pipelines/finalize-hotfix-release.yml
@@ -24,5 +24,5 @@ steps:
       queue: "tumblr-metal"
     retry:
       manual:
-        # If those jobs fail, one should always prefer re-triggering a new build from ReleaseV2 rather than retrying the individual job from Buildkite
         allowed: false
+        reason: "Always prefer re-triggering a new build from ReleaseV2 rather than retrying the individual job from Buildkite"

--- a/.buildkite/release-pipelines/finalize-release.yml
+++ b/.buildkite/release-pipelines/finalize-release.yml
@@ -24,5 +24,5 @@ steps:
       queue: "tumblr-metal"
     retry:
       manual:
-        # If those jobs fail, one should always prefer re-triggering a new build from ReleaseV2 rather than retrying the individual job from Buildkite
         allowed: false
+        reason: "Always prefer re-triggering a new build from ReleaseV2 rather than retrying the individual job from Buildkite"

--- a/.buildkite/release-pipelines/new-beta-release.yml
+++ b/.buildkite/release-pipelines/new-beta-release.yml
@@ -24,5 +24,5 @@ steps:
       queue: "tumblr-metal"
     retry:
       manual:
-        # If those jobs fail, one should always prefer re-triggering a new build from ReleaseV2 rather than retrying the individual job from Buildkite
         allowed: false
+        reason: "Always prefer re-triggering a new build from ReleaseV2 rather than retrying the individual job from Buildkite"

--- a/.buildkite/release-pipelines/new-hotfix-release.yml
+++ b/.buildkite/release-pipelines/new-hotfix-release.yml
@@ -22,5 +22,5 @@ steps:
       queue: "tumblr-metal"
     retry:
       manual:
-        # If those jobs fail, one should always prefer re-triggering a new build from ReleaseV2 rather than retrying the individual job from Buildkite
         allowed: false
+        reason: "Always prefer re-triggering a new build from ReleaseV2 rather than retrying the individual job from Buildkite"

--- a/.buildkite/release-pipelines/publish-release.yml
+++ b/.buildkite/release-pipelines/publish-release.yml
@@ -24,5 +24,5 @@ steps:
       queue: "tumblr-metal"
     retry:
       manual:
-        # If those jobs fail, one should always prefer re-triggering a new build from ReleaseV2 rather than retrying the individual job from Buildkite
         allowed: false
+        reason: "Always prefer re-triggering a new build from ReleaseV2 rather than retrying the individual job from Buildkite"

--- a/.buildkite/release-pipelines/update-rollouts.yml
+++ b/.buildkite/release-pipelines/update-rollouts.yml
@@ -24,5 +24,5 @@ steps:
       queue: "tumblr-metal"
     retry:
       manual:
-        # If those jobs fail, one should always prefer re-triggering a new build from ReleaseV2 rather than retrying the individual job from Buildkite
         allowed: false
+        reason: "Always prefer re-triggering a new build from ReleaseV2 rather than retrying the individual job from Buildkite"

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -375,6 +375,8 @@ platform :android do
   end
 
   # @param skip_confirm [Boolean] If true, avoids any interactive prompt
+  # @param skip_translations_download [Boolean] If true, skips downloading the latest translations from GlotPress
+  #        Typically set it to `true` if the `download_translations` lane was already run earlier
   #
   lane :finalize_release do |skip_confirm: false, skip_translations_download: false|
     UI.user_error!('Please use `finalize_hotfix_release` lane for hotfixes') if release_is_hotfix?

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -362,7 +362,8 @@ platform :android do
         head: pr_branch,
         title: "Download latest translations for `#{version}`",
         body: "This PR integrates the latest translations from GlotPress into the `#{base_branch}` branch.",
-        labels: ['releases', '[Area] Translations i18n']
+        labels: ['releases', '[Area] Translations i18n'],
+        api_token: ENV.fetch('GITHUB_TOKEN')
       )
 
       buildkite_annotate(context: 'translations-pr-url', message: "Translations PR: #{pr_url || 'Error creating PR'}") if is_ci?

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -338,6 +338,8 @@ platform :android do
     UI.user_error!('None of the 3 app variants were found in Google Play Console. We expected at least one') if not_found_variants.count == APPS.count
   end
 
+  # Downloads the latest translations from GlotPress and creates a PR to integrate them into the current `release/*` branch
+  #
   lane :download_translations do
     version = release_version_current
     base_branch = "release/#{version}"

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -355,7 +355,7 @@ platform :android do
     )
 
     if commit_created
-      push_to_git_remote(tags: false)
+      push_to_git_remote(tags: false, set_upstream: true)
       pr_url = create_pull_request(
         repo: GITHUB_REPO,
         base: base_branch,
@@ -365,7 +365,7 @@ platform :android do
         labels: ['releases', '[Area] Translations i18n']
       )
 
-      buildkite_annotate(context: 'translations-pr-url', message: "Translations PR: #{pr_url}") if is_ci?
+      buildkite_annotate(context: 'translations-pr-url', message: "Translations PR: #{pr_url || 'Error creating PR'}") if is_ci?
     else
       UI.important('No translations were downloaded, so no PR was created')
       buildkite_annotate(context: 'translations-pr-url', message: 'No translations were downloaded, so no PR was created') if is_ci?

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -338,9 +338,43 @@ platform :android do
     UI.user_error!('None of the 3 app variants were found in Google Play Console. We expected at least one') if not_found_variants.count == APPS.count
   end
 
+  lane :download_translations do
+    version = release_version_current
+    base_branch = "release/#{version}"
+    pr_branch = "translations/release-#{version}"
+
+    Fastlane::Helper::GitHelper.create_branch(pr_branch, from: base_branch)
+
+    commit_created = android_download_translations(
+      res_dir: File.join('modules', 'services', 'localization', 'src', 'main', 'res'),
+      glotpress_url: GLOTPRESS_APP_STRINGS_PROJECT_URL,
+      locales: SUPPORTED_LOCALES
+      # Important: don't pass a `lint_task` here, because this lane runs on a dedicated trusted agent on CI which is not intended to run gradle tasks
+    )
+
+    if commit_created
+      push_to_git_remote(tags: false)
+      pr_url = create_pull_request(
+        repo: GITHUB_REPO,
+        base: base_branch,
+        head: pr_branch,
+        title: "Download latest translations for `#{version}`",
+        body: "This PR integrates the latest translations from GlotPress into the `#{base_branch}` branch.",
+        labels: ['releases', '[Area] Translations i18n']
+      )
+
+      buildkite_annotate(context: 'translations-pr-url', message: "Translations PR: #{pr_url}") if is_ci?
+    else
+      UI.important('No translations were downloaded, so no PR was created')
+      buildkite_annotate(context: 'translations-pr-url', message: 'No translations were downloaded, so no PR was created') if is_ci?
+      Fastlane::Helper::GitHelper.checkout_and_pull(base_branch)
+      Fastlane::Helper::GitHelper.delete_local_branch_if_exists!(pr_branch)
+    end
+  end
+
   # @param skip_confirm [Boolean] If true, avoids any interactive prompt
   #
-  lane :finalize_release do |skip_confirm: false|
+  lane :finalize_release do |skip_confirm: false, skip_translations_download: false|
     UI.user_error!('Please use `finalize_hotfix_release` lane for hotfixes') if release_is_hotfix?
     ensure_git_branch(branch: '^release/') # Match branch names that begin with `release/`
     ensure_git_status_clean
@@ -359,13 +393,13 @@ platform :android do
     commit_version_bump
     UI.success("Done! New Release Version: #{release_version_current}. New Build Code: #{build_code_current}")
 
-    # Download Localizations
+    # Download Localizations, unless we asked to skip it (e.g. `download_translations` lane was already run earlier)
     android_download_translations(
       res_dir: File.join('modules', 'services', 'localization', 'src', 'main', 'res'),
       glotpress_url: GLOTPRESS_APP_STRINGS_PROJECT_URL,
-      locales: SUPPORTED_LOCALES,
-      lint_task: 'aggregatedLintRelease'
-    )
+      locales: SUPPORTED_LOCALES
+      # Important: don't pass a `lint_task` here, because this lane runs on a dedicated trusted agent on CI, which is not intended to run gradle tasks
+    ) unless skip_translations_download
 
     version = release_version_current
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -396,12 +396,14 @@ platform :android do
     UI.success("Done! New Release Version: #{release_version_current}. New Build Code: #{build_code_current}")
 
     # Download Localizations, unless we asked to skip it (e.g. `download_translations` lane was already run earlier)
-    android_download_translations(
-      res_dir: File.join('modules', 'services', 'localization', 'src', 'main', 'res'),
-      glotpress_url: GLOTPRESS_APP_STRINGS_PROJECT_URL,
-      locales: SUPPORTED_LOCALES
-      # Important: don't pass a `lint_task` here, because this lane runs on a dedicated trusted agent on CI, which is not intended to run gradle tasks
-    ) unless skip_translations_download
+    unless skip_translations_download
+      android_download_translations(
+        res_dir: File.join('modules', 'services', 'localization', 'src', 'main', 'res'),
+        glotpress_url: GLOTPRESS_APP_STRINGS_PROJECT_URL,
+        locales: SUPPORTED_LOCALES
+        # Important: don't pass a `lint_task` here, because this lane runs on a dedicated trusted agent on CI, which is not intended to run gradle tasks
+      )
+    end
 
     version = release_version_current
 


### PR DESCRIPTION
## Context / Why

 - Follow-up on https://github.com/Automattic/pocket-casts-android/pull/3688
 - Slack context: p1740990351304109/1740786797.612419-slack-CC7L49W13

@geekygecko reported during last release that the `finalize_release` automation running on CI failed to download Gradle, which made the lane and CI build fail.

```
[18:47:07]: Exit status of command './gradlew aggregatedLintRelease' was 1 instead of 0.
Downloading https://services.gradle.org/distributions/gradle-8.12.1-all.zip
Exception in thread "main" java.io.IOException: Downloading from https://services.gradle.org/distributions/gradle-8.12.1-all.zip failed: timeout (10000ms)
	at org.gradle.wrapper.Install.forceFetch(SourceFile:4)
	at org.gradle.wrapper.Install$1.call(SourceFile:8)
	at org.gradle.wrapper.GradleWrapperMain.main(SourceFile:67)
Caused by: java.net.SocketTimeoutException: connect timed out
```

## Description / What

This PR extracts the task about downloading translations from the `finalize_release` lane into a dedicated lane, so it can be now be run via a separate task in the scenario, and thus have the linting be made as part of the PR CI checks on the proper `android` CI agent, thus solving the gradle download issue mentioned above.

> [!NOTE]
> This change goes in concert with a PR updating the release scenario in MC (internal ref: 175590-ghe-Automattic/wpcom) to add tasks about "Download latest translations into the release branch" + "Merge the translations PR" to just before the `Trigger the release finalization` task in the scenario.
>
> This PR targets `main` intentionally (and not `release/7.84`), because it will have to land in concert with the release scenario template update (175590-ghe-Automattic/wpcom). Since the `7.84` scenario have already started, we won't be able to reset it to include that fix in `7.84`—and instead [applied a temp workaround to `release/7.84`](https://github.com/Automattic/pocket-casts-android/pull/3688) in the meantime—and will only be able to account for the new scenario template starting `7.85`.

<details><summary>Rationale / Techincal details</summary>
With this new approach:

 - The linting of the app after the new translations have been downloaded would now happen as part of the translations PR created by `download_translations`, and thus run on the proper CI agent (`android`)—instead of running on our trusted agent dedicated for smaller tasks and not for gradle tasks
 - If the linting of the translations fails, this will show up on the PR and make it easier to recover from (e.g. fix the issue in GlotPress, then close the PR and re-trigger the task in the release scenario to download the latest translations again)—as opposed to it currently making the `finalize_release` CI build fail after the version bump has already happened
 - If one needs to redo the `finalize_release` task for some reason (e.g. if the app was rejected and the team had to make an extra commit to fix then resubmit a new version to Google Play for review, etc), this could be done separately from the download of the latest translations, without those steps being intertwined.
</details>

The only drawback of this new setup is that it will add some new tasks to go through in the scenario, including an additional wait time for the CI to run on the PR before going through the release finalization task in the scenario.  
But I think the separation of the tasks and the added ability to retry them independently (+ the fact that it solves the issue of CI not being able to lint the translations otherwise) is still the better choice.

## Testing Instructions

✅ This was already tested using the following steps:

 - [x] [Trigger a new manual build on Buildkite CI](https://buildkite.com/automattic/pocket-casts-android/builds/10844/summary/annotations) (using the "New Build" button), using the following parameters:
   - Message: `Test new 'download_translations' lane — see https://github.com/Automattic/pocket-casts-android/pull/3695`
   - Branch: `tooling/split-finalize-release-download-translations`
   - Options > Environment Variables:
   ```
    PIPELINE=release-pipelines/download-translations.yml
    RELEASE_VERSION=7.84
    ```
 - [x] Check that [it ultimately creates a PR containing the new translations](https://github.com/Automattic/pocket-casts-android/pull/3697), and that this PR targets the `release/7.84` branch
 - [x] Close the PR it created