### PR TITLE
Update header icon color

### DIFF
--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastHeader.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastHeader.kt
@@ -86,6 +86,7 @@ import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.Constraints
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.IntOffset
@@ -101,6 +102,7 @@ import au.com.shiftyjelly.pocketcasts.compose.components.PodcastImage
 import au.com.shiftyjelly.pocketcasts.compose.components.TextH20
 import au.com.shiftyjelly.pocketcasts.compose.components.TextH40
 import au.com.shiftyjelly.pocketcasts.compose.components.TextP60
+import au.com.shiftyjelly.pocketcasts.compose.preview.ThemePreviewParameterProvider
 import au.com.shiftyjelly.pocketcasts.compose.theme
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastRatings
 import au.com.shiftyjelly.pocketcasts.podcasts.view.components.ratings.PodcastRating
@@ -567,7 +569,7 @@ private fun ActionButton(
     Image(
         painter = painterResource(iconId),
         contentDescription = contentDescription,
-        colorFilter = ColorFilter.tint(MaterialTheme.theme.colors.primaryIcon02Active),
+        colorFilter = ColorFilter.tint(MaterialTheme.theme.colors.primaryIcon03),
         modifier = Modifier
             .padding(4.dp)
             .size(24.dp)
@@ -806,12 +808,14 @@ private val previewColors = listOf(
 
 @Preview(device = Devices.PortraitRegular)
 @Composable
-private fun PodcastHeaderPreview() {
-    var isFollowed by remember { mutableStateOf(false) }
+private fun PodcastHeaderPreview(
+    @PreviewParameter(ThemePreviewParameterProvider::class) themeType: Theme.ThemeType,
+) {
+    var isFollowed by remember { mutableStateOf(true) }
     var isHeaderExpanded by remember { mutableStateOf(true) }
     var isDescriptionExpanded by remember { mutableStateOf(false) }
 
-    AppThemeWithBackground(Theme.ThemeType.LIGHT) {
+    AppThemeWithBackground(themeType) {
         Column(
             modifier = Modifier.fillMaxSize(),
         ) {

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/ExpandableText.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/ExpandableText.kt
@@ -37,7 +37,7 @@ fun ExpandableText(
     modifier: Modifier = Modifier,
 ) {
     BoxWithConstraints(
-        modifier = modifier,
+        modifier = modifier.animateContentSize(),
     ) {
         val measurer = rememberTextMeasurer()
         val displayedText = remember(measurer, text, isExpanded) {
@@ -68,7 +68,6 @@ fun ExpandableText(
         Text(
             text = displayedText,
             style = style,
-            modifier = Modifier.animateContentSize(),
         )
     }
 }


### PR DESCRIPTION
## Description

This fixes wrong color for the header icons.

## Testing Instructions

Check header icons with different themes, especially Dark Constrast.

## Screenshots or Screencast 

| Before | After |
| - | - |
| <img width="415" alt="Screenshot 2025-03-03 at 21 42 06" src="https://github.com/user-attachments/assets/139decc9-efe6-4ef4-a75f-188385b71bb7" /> | <img width="415" alt="Screenshot 2025-03-03 at 21 41 51" src="https://github.com/user-attachments/assets/c51e2a50-d289-4feb-8ff6-263bfc1d8d6c" /> |


## Checklist
- [ ] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] ~I have considered whether it makes sense to add tests for my changes~
- [ ] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [ ] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [ ] ~with a landscape orientation~
- [ ] ~with the device set to have a large display and font size~
- [ ] ~for accessibility with TalkBack~
