### PR TITLE
Define policy for showing smart folders incetive

### DIFF
--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/folders/SuggestedFoldersFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/folders/SuggestedFoldersFragment.kt
@@ -1,82 +1,118 @@
 package au.com.shiftyjelly.pocketcasts.podcasts.view.folders
 
+import android.content.DialogInterface
 import android.os.Bundle
+import android.os.Parcelable
 import android.view.LayoutInflater
 import android.view.ViewGroup
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.unit.dp
 import androidx.core.os.BundleCompat
+import androidx.core.os.bundleOf
 import androidx.fragment.app.viewModels
 import au.com.shiftyjelly.pocketcasts.compose.AppThemeWithBackground
 import au.com.shiftyjelly.pocketcasts.compose.extensions.contentWithoutConsumedInsets
-import au.com.shiftyjelly.pocketcasts.ui.helper.FragmentHostListener
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import au.com.shiftyjelly.pocketcasts.views.dialog.ConfirmationDialog
-import au.com.shiftyjelly.pocketcasts.views.fragments.BaseFragment
+import au.com.shiftyjelly.pocketcasts.views.fragments.BaseDialogFragment
 import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.parcelize.Parcelize
 import au.com.shiftyjelly.pocketcasts.images.R as VR
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 import au.com.shiftyjelly.pocketcasts.ui.R as UR
 
 @AndroidEntryPoint
-class SuggestedFoldersFragment : BaseFragment() {
+class SuggestedFoldersFragment : BaseDialogFragment() {
 
     companion object {
-        private const val FOLDERS_KEY = "folders_key"
+        private const val ARGS_KEY = "args"
 
-        fun newInstance(folders: List<Folder>): SuggestedFoldersFragment {
+        fun newInstance(
+            source: Source,
+            folders: List<Folder>,
+        ): SuggestedFoldersFragment {
             return SuggestedFoldersFragment().apply {
-                arguments = Bundle().apply {
-                    putParcelableArrayList(FOLDERS_KEY, ArrayList(folders))
-                }
+                arguments = bundleOf(
+                    ARGS_KEY to Args(source, folders),
+                )
             }
         }
     }
 
-    private val viewModel: SuggestedFoldersViewModel by viewModels<SuggestedFoldersViewModel>()
+    private val viewModel by viewModels<SuggestedFoldersViewModel>()
 
-    private val suggestedFolders
-        get() = requireNotNull(BundleCompat.getParcelableArrayList(requireArguments(), FOLDERS_KEY, Folder::class.java)) {
+    private val args
+        get() = requireNotNull(BundleCompat.getParcelable(requireArguments(), ARGS_KEY, Args::class.java)) {
             "Missing input parameters"
         }
+
+    private var isFinalizingActionUsed = false
 
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
         savedInstanceState: Bundle?,
     ) = contentWithoutConsumedInsets {
-        AppThemeWithBackground(theme.activeTheme) {
-            val state by viewModel.state.collectAsState()
+        Box(
+            modifier = Modifier
+                .fillMaxHeight(0.93f)
+                .clip(RoundedCornerShape(topStart = 16.dp, topEnd = 16.dp)),
+        ) {
+            AppThemeWithBackground(theme.activeTheme) {
+                val state by viewModel.state.collectAsState()
 
-            LaunchedEffect(state) {
-                if (state is SuggestedFoldersViewModel.FoldersState.Created) {
-                    (activity as FragmentHostListener).closeModal(this@SuggestedFoldersFragment)
-                } else if (state is SuggestedFoldersViewModel.FoldersState.ShowConfirmationDialog) {
-                    showConfirmationDialog()
+                LaunchedEffect(state) {
+                    if (state is SuggestedFoldersViewModel.FoldersState.Created) {
+                        finalizeAndDismiss()
+                    } else if (state is SuggestedFoldersViewModel.FoldersState.ShowConfirmationDialog) {
+                        showConfirmationDialog()
+                    }
                 }
-            }
 
-            SuggestedFoldersPage(
-                folders = suggestedFolders,
-                useWhiteColorForHowItWorks = theme.activeTheme == Theme.ThemeType.ELECTRIC,
-                onShown = {
-                },
-                onDismiss = {
-                    (activity as FragmentHostListener).closeModal(this)
-                },
-                onUseTheseFolders = {
-                    viewModel.onUseTheseFolders(suggestedFolders)
-                },
-                onHowItWorks = {
-                },
-                onCreateCustomFolders = {
-                    FolderCreateFragment.newInstance(source = "suggested_folders").show(parentFragmentManager, "create_folder_card")
-                    (activity as FragmentHostListener).closeModal(this)
-                },
-            )
+                SuggestedFoldersPage(
+                    folders = args.folders,
+                    useWhiteColorForHowItWorks = theme.activeTheme == Theme.ThemeType.ELECTRIC,
+                    onShown = {},
+                    onDismiss = {
+                        dismiss()
+                    },
+                    onUseTheseFolders = {
+                        viewModel.onUseTheseFolders(args.folders)
+                    },
+                    onHowItWorks = {
+                    },
+                    onCreateCustomFolders = {
+                        FolderCreateFragment.newInstance(source = "suggested_folders").show(parentFragmentManager, "create_folder_card")
+                        finalizeAndDismiss()
+                    },
+                )
+            }
         }
     }
+
+    override fun onDismiss(dialog: DialogInterface) {
+        super.onDismiss(dialog)
+        if (isDismissingPopupWithoutAction()) {
+            viewModel.markPopupAsDismissed()
+        }
+    }
+
+    private fun finalizeAndDismiss() {
+        isFinalizingActionUsed = true
+        dismiss()
+    }
+
+    private fun isDismissingPopupWithoutAction() =
+        !requireActivity().isChangingConfigurations &&
+            !isFinalizingActionUsed &&
+            args.source == Source.PodcastsPopup
 
     private fun showConfirmationDialog() {
         viewModel.onReplaceExistingFoldersShown()
@@ -85,10 +121,21 @@ class SuggestedFoldersFragment : BaseFragment() {
             .setTitle(getString(LR.string.suggested_folders_replace_folders_confirmation_tittle))
             .setSummary(getString(LR.string.suggested_folders_replace_folders_confirmation_description))
             .setOnConfirm {
-                viewModel.overrideFoldersWithSuggested(suggestedFolders)
+                viewModel.overrideFoldersWithSuggested(args.folders)
             }
             .setIconId(VR.drawable.ic_replace)
             .setIconTint(UR.attr.primary_interactive_01)
             .show(childFragmentManager, "suggested-folders-confirmation-dialog")
     }
+
+    enum class Source {
+        PodcastsPopup,
+        CreateFolderButton,
+    }
+
+    @Parcelize
+    private class Args(
+        val source: SuggestedFoldersFragment.Source,
+        val folders: List<Folder>,
+    ) : Parcelable
 }

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/folders/SuggestedFoldersPopupPolicy.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/folders/SuggestedFoldersPopupPolicy.kt
@@ -1,0 +1,38 @@
+package au.com.shiftyjelly.pocketcasts.podcasts.view.folders
+
+import au.com.shiftyjelly.pocketcasts.models.to.SubscriptionStatus
+import au.com.shiftyjelly.pocketcasts.preferences.Settings
+import java.time.Clock
+import javax.inject.Inject
+import kotlin.time.Duration.Companion.days
+
+class SuggestedFoldersPopupPolicy @Inject constructor(
+    settings: Settings,
+    private val clock: Clock,
+) {
+    private val timestampSetting = settings.suggestedFoldersDismissTimestamp
+    private val countSetting = settings.suggestedFoldersDismissCount
+    private val subscriptionStatusSetting = settings.cachedSubscriptionStatus
+
+    fun isEligibleForPopup(): Boolean {
+        val subscriptionStatus = subscriptionStatusSetting.value
+        val currentCount = countSetting.value
+
+        return when {
+            subscriptionStatus is SubscriptionStatus.Paid -> false
+            currentCount == 0 -> true
+            currentCount == 1 -> {
+                timestampSetting.value
+                    ?.plusMillis(7.days.inWholeMilliseconds)
+                    ?.isBefore(clock.instant())
+                    ?: true
+            }
+            else -> false
+        }
+    }
+
+    fun markPolicyUsed() {
+        timestampSetting.set(clock.instant(), updateModifiedAt = false)
+        countSetting.set(countSetting.value + 1, updateModifiedAt = false)
+    }
+}

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/folders/SuggestedFoldersViewModel.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/folders/SuggestedFoldersViewModel.kt
@@ -20,6 +20,7 @@ import kotlinx.coroutines.launch
 class SuggestedFoldersViewModel @Inject constructor(
     private val folderManager: FolderManager,
     private val suggestedFoldersManager: SuggestedFoldersManager,
+    private val suggestedFoldersPopupPolicy: SuggestedFoldersPopupPolicy,
     private val podcastManager: PodcastManager,
     private val settings: Settings,
     private val analyticsTracker: AnalyticsTracker,
@@ -59,9 +60,13 @@ class SuggestedFoldersViewModel @Inject constructor(
             settings.podcastsSortType.set(PodcastsSortType.NAME_A_TO_Z, updateModifiedAt = true)
             folderManager.overrideFoldersWithSuggested(newFolders)
             podcastManager.refreshPodcasts("suggested-folders")
-            suggestedFoldersManager.deleteSuggestedFolders(folders.toSuggestedFolders())
+            suggestedFoldersManager.replaceSuggestedFolders(folders.toSuggestedFolders())
             _state.value = FoldersState.Created
         }
+    }
+
+    fun markPopupAsDismissed() {
+        suggestedFoldersPopupPolicy.markPolicyUsed()
     }
 
     sealed class FoldersState {

--- a/modules/features/podcasts/src/test/java/au/com/shiftyjelly/pocketcasts/podcasts/view/folders/SuggestedFoldersPopupPolicyTest.kt
+++ b/modules/features/podcasts/src/test/java/au/com/shiftyjelly/pocketcasts/podcasts/view/folders/SuggestedFoldersPopupPolicyTest.kt
@@ -1,0 +1,126 @@
+package au.com.shiftyjelly.pocketcasts.podcasts.view.folders
+
+import au.com.shiftyjelly.pocketcasts.models.to.SubscriptionStatus
+import au.com.shiftyjelly.pocketcasts.models.type.SubscriptionPlatform
+import au.com.shiftyjelly.pocketcasts.models.type.SubscriptionTier
+import au.com.shiftyjelly.pocketcasts.preferences.Settings
+import au.com.shiftyjelly.pocketcasts.preferences.UserSetting
+import au.com.shiftyjelly.pocketcasts.sharedtest.MutableClock
+import java.time.Instant
+import java.util.Date
+import kotlin.time.Duration.Companion.days
+import kotlin.time.Duration.Companion.milliseconds
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doAnswer
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+
+class SuggestedFoldersPopupPolicyTest {
+    private val clock = MutableClock()
+    private var currentSubscriptionStatus: SubscriptionStatus? = null
+
+    private lateinit var policy: SuggestedFoldersPopupPolicy
+
+    @Before
+    fun setUp() {
+        var currentTimestamp: Instant? = null
+        val timestampSetting = mock<UserSetting<Instant?>>()
+        whenever(timestampSetting.value) doAnswer { currentTimestamp }
+        whenever(timestampSetting.set(any(), any(), any(), any())) doAnswer { answer ->
+            currentTimestamp = answer.arguments[0] as Instant?
+        }
+
+        var currentCount: Int = 0
+        val countSetting = mock<UserSetting<Int>>()
+        whenever(countSetting.value) doAnswer { currentCount }
+        whenever(countSetting.set(any(), any(), any(), any())) doAnswer { answer ->
+            currentCount = answer.arguments[0] as Int
+        }
+
+        val subscriptionStatusSetting = mock<UserSetting<SubscriptionStatus?>>()
+        whenever(subscriptionStatusSetting.value) doAnswer { currentSubscriptionStatus }
+
+        policy = SuggestedFoldersPopupPolicy(
+            settings = mock<Settings> {
+                on { suggestedFoldersDismissTimestamp } doReturn timestampSetting
+                on { suggestedFoldersDismissCount } doReturn countSetting
+                on { cachedSubscriptionStatus } doReturn subscriptionStatusSetting
+            },
+            clock = clock,
+        )
+    }
+
+    @Test
+    fun `initial policy for unsinged unser`() {
+        currentSubscriptionStatus = null
+
+        assertTrue(policy.isEligibleForPopup())
+    }
+
+    @Test
+    fun `initial policy for free unser`() {
+        currentSubscriptionStatus = SubscriptionStatus.Free()
+
+        assertTrue(policy.isEligibleForPopup())
+    }
+
+    @Test
+    fun `initial policy for paid unser`() {
+        currentSubscriptionStatus = SubscriptionStatus.Paid(
+            expiryDate = Date(),
+            tier = SubscriptionTier.PLUS,
+            platform = SubscriptionPlatform.ANDROID,
+            autoRenew = false,
+            index = 0,
+        )
+
+        assertFalse(policy.isEligibleForPopup())
+    }
+
+    @Test
+    fun `policy after using it once`() {
+        policy.markPolicyUsed()
+
+        assertFalse(policy.isEligibleForPopup())
+    }
+
+    @Test
+    fun `policy after using it once before 7 days pass`() {
+        policy.markPolicyUsed()
+        clock += 7.days
+
+        assertFalse(policy.isEligibleForPopup())
+    }
+
+    @Test
+    fun `policy after using it once after 7 days pass`() {
+        policy.markPolicyUsed()
+        clock += 7.days + 1.milliseconds
+
+        assertTrue(policy.isEligibleForPopup())
+    }
+
+    @Test
+    fun `policy after using it twice`() {
+        policy.markPolicyUsed()
+        clock += 7.days + 1.milliseconds
+        policy.markPolicyUsed()
+
+        assertFalse(policy.isEligibleForPopup())
+    }
+
+    @Test
+    fun `policy after using it twice and a lot time passes`() {
+        policy.markPolicyUsed()
+        clock += 7.days + 1.milliseconds
+        policy.markPolicyUsed()
+        clock += 10_000.days
+
+        assertFalse(policy.isEligibleForPopup())
+    }
+}

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/developer/DeveloperFragment.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/developer/DeveloperFragment.kt
@@ -44,6 +44,7 @@ class DeveloperFragment : BaseFragment() {
                 bottomInset = bottomInset.value.pxToDp(LocalContext.current).dp,
                 onSendCrash = viewModel::onSendCrash,
                 onShowWhatsNewClick = ::onShowWhatsNewClick,
+                onResetSuggestedFoldersSuggestion = viewModel::resetSuggestedFoldersSuggestion,
             )
         }
     }

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/developer/DeveloperPage.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/developer/DeveloperPage.kt
@@ -22,6 +22,7 @@ import androidx.compose.material.icons.outlined.BugReport
 import androidx.compose.material.icons.outlined.Delete
 import androidx.compose.material.icons.outlined.Downloading
 import androidx.compose.material.icons.outlined.EditCalendar
+import androidx.compose.material.icons.outlined.Folder
 import androidx.compose.material.icons.outlined.HomeRepairService
 import androidx.compose.material.icons.outlined.NewReleases
 import androidx.compose.material.icons.outlined.Notifications
@@ -59,6 +60,7 @@ fun DeveloperPage(
     bottomInset: Dp,
     onSendCrash: (String) -> Unit,
     onShowWhatsNewClick: () -> Unit,
+    onResetSuggestedFoldersSuggestion: () -> Unit,
 ) {
     var openCrashMessageDialog by remember { mutableStateOf(false) }
     var crashMessage by remember { mutableStateOf("Test crash") }
@@ -96,6 +98,9 @@ fun DeveloperPage(
         }
         item {
             EndOfYear(onClick = onTriggerResetEoYModalProfileBadge)
+        }
+        item {
+            ResetSuggestedFoldersSuggestion(onClick = onResetSuggestedFoldersSuggestion)
         }
         item {
             ShowWhatsNew(onClick = onShowWhatsNewClick)
@@ -280,6 +285,19 @@ private fun ShowWhatsNew(
     )
 }
 
+@Composable
+private fun ResetSuggestedFoldersSuggestion(
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    SettingRow(
+        primaryText = "Reset Smart Folders",
+        secondaryText = "Allows to retrigger suggested folders",
+        icon = rememberVectorPainter(Icons.Outlined.Folder),
+        modifier = modifier.clickable { onClick() },
+    )
+}
+
 @Preview(name = "Light")
 @Composable
 private fun DeveloperPageLightPreview() {
@@ -309,6 +327,7 @@ private fun DeveloperPagePreview() {
         bottomInset = 0.dp,
         onSendCrash = {},
         onShowWhatsNewClick = {},
+        onResetSuggestedFoldersSuggestion = {},
     )
 }
 

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/developer/DeveloperViewModel.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/developer/DeveloperViewModel.kt
@@ -9,6 +9,7 @@ import au.com.shiftyjelly.pocketcasts.repositories.download.UpdateEpisodeDetails
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
+import au.com.shiftyjelly.pocketcasts.repositories.podcast.SuggestedFoldersManager
 import com.automattic.android.tracks.crashlogging.CrashLogging
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
@@ -29,6 +30,7 @@ class DeveloperViewModel
     private val podcastManager: PodcastManager,
     private val episodeManager: EpisodeManager,
     private val playbackManager: PlaybackManager,
+    private val suggestedFoldersManager: SuggestedFoldersManager,
     private val settings: Settings,
     @ApplicationContext private val context: Context,
     private val crashLogging: CrashLogging,
@@ -156,5 +158,14 @@ class DeveloperViewModel
     fun onSendCrash(crashMessage: String) {
         crashLogging.sendReport(Exception(crashMessage))
         Timber.d("Test crash message: \"$crashMessage\"")
+    }
+
+    fun resetSuggestedFoldersSuggestion() {
+        viewModelScope.launch {
+            suggestedFoldersManager.deleteAllSuggestedFolders()
+            settings.suggestedFoldersFollowedHash.set("", updateModifiedAt = false)
+            settings.suggestedFoldersDismissCount.set(0, updateModifiedAt = false)
+            settings.suggestedFoldersDismissTimestamp.set(null, updateModifiedAt = false)
+        }
     }
 }

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
@@ -75,8 +75,6 @@ interface Settings {
         const val LAST_UPDATE_TIME = "LastUpdateTime"
         const val LAST_DISMISS_LOW_STORAGE_MODAL_TIME = "LastDismissLowStorageModalTime"
         const val LAST_DISMISS_LOW_STORAGE_BANNER_TIME = "LastDismissLowStorageBannerTime"
-        const val LAST_DISMISS_SUGGESTED_FOLDER_PAYWALL_TIME = "LastDismissSuggestedFolderPaywallTime"
-        const val DISMISS_SUGGESTED_FOLDER_PAYWALL_COUNT = "DismissSuggestedFolderPaywallCount"
         const val PREFERENCE_SKIP_FORWARD = "skipForward"
         const val PREFERENCE_SKIP_BACKWARD = "skipBack"
         const val PREFERENCE_STORAGE_CHOICE = "storageChoice"
@@ -335,10 +333,6 @@ interface Settings {
 
     val hideNotificationOnPause: UserSetting<Boolean>
 
-    fun setDismissedSuggestedFolderPaywallTime()
-    fun isEligibleToShowSuggestedFolderPaywall(): Boolean
-    fun updateDismissedSuggestedFolderPaywallCount()
-
     val streamingMode: UserSetting<Boolean>
     val keepScreenAwake: UserSetting<Boolean>
     val openPlayerAutomatically: UserSetting<Boolean>
@@ -573,5 +567,7 @@ interface Settings {
 
     val showPodcastHeaderChangesTooltip: UserSetting<Boolean>
 
-    val followedPodcastsForSuggestedFoldersHash: UserSetting<String>
+    val suggestedFoldersDismissTimestamp: UserSetting<Instant?>
+    val suggestedFoldersDismissCount: UserSetting<Int>
+    val suggestedFoldersFollowedHash: UserSetting<String>
 }

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
@@ -339,26 +339,6 @@ class SettingsImpl @Inject constructor(
         return timeSinceDismiss >= 7.days
     }
 
-    override fun setDismissedSuggestedFolderPaywallTime() {
-        sharedPreferences.edit { putLong(Settings.LAST_DISMISS_SUGGESTED_FOLDER_PAYWALL_TIME, System.currentTimeMillis()) }
-    }
-
-    override fun isEligibleToShowSuggestedFolderPaywall(): Boolean {
-        val lastDismissedTime = sharedPreferences.getLong(Settings.LAST_DISMISS_SUGGESTED_FOLDER_PAYWALL_TIME, 0L)
-        val currentDismissedCount = sharedPreferences.getInt(Settings.DISMISS_SUGGESTED_FOLDER_PAYWALL_COUNT, 0)
-
-        if (lastDismissedTime == 0L) return true
-
-        val timeSinceDismiss = (System.currentTimeMillis() - lastDismissedTime).milliseconds
-
-        return timeSinceDismiss >= 7.days && currentDismissedCount < 2
-    }
-
-    override fun updateDismissedSuggestedFolderPaywallCount() {
-        val currentCount = sharedPreferences.getInt(Settings.DISMISS_SUGGESTED_FOLDER_PAYWALL_COUNT, 0)
-        sharedPreferences.edit { putInt(Settings.DISMISS_SUGGESTED_FOLDER_PAYWALL_COUNT, currentCount + 1) }
-    }
-
     override fun setDismissLowStorageBannerTime(lastUpdateTime: Long) {
         sharedPreferences.edit {
             putLong(Settings.LAST_DISMISS_LOW_STORAGE_BANNER_TIME, lastUpdateTime)
@@ -1592,8 +1572,22 @@ class SettingsImpl @Inject constructor(
         sharedPrefs = sharedPreferences,
     )
 
-    override val followedPodcastsForSuggestedFoldersHash = UserSetting.StringPref(
-        sharedPrefKey = "followed_podcasts_hash_for_suggested_folders",
+    override val suggestedFoldersDismissTimestamp = UserSetting.PrefFromString<Instant?>(
+        sharedPrefKey = "suggested_folders_dismiss_timestamp",
+        defaultValue = null,
+        fromString = { value -> runCatching { Instant.parse(value) }.getOrNull() },
+        toString = { value -> value.toString() },
+        sharedPrefs = sharedPreferences,
+    )
+
+    override val suggestedFoldersDismissCount = UserSetting.IntPref(
+        sharedPrefKey = "suggested_folders_dismiss_count",
+        defaultValue = 0,
+        sharedPrefs = sharedPreferences,
+    )
+
+    override val suggestedFoldersFollowedHash = UserSetting.StringPref(
+        sharedPrefKey = "suggested_folders_followed_hash",
         defaultValue = "",
         sharedPrefs = sharedPreferences,
     )

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/SuggestedFoldersManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/SuggestedFoldersManager.kt
@@ -28,14 +28,14 @@ class SuggestedFoldersManager @Inject constructor(
             withContext(Dispatchers.IO) {
                 if (podcastUuids.isEmpty()) {
                     suggestedFoldersDao.deleteAll()
-                    settings.followedPodcastsForSuggestedFoldersHash.set("", updateModifiedAt = false)
+                    settings.suggestedFoldersFollowedHash.set("", updateModifiedAt = false)
                 } else {
                     val currentHash = podcastUuids.sorted().md5()
 
-                    if (currentHash != settings.followedPodcastsForSuggestedFoldersHash.value) {
+                    if (currentHash != settings.suggestedFoldersFollowedHash.value) {
                         val folders = podcastCacheService.suggestedFolders(SuggestedFoldersRequest(podcastUuids))
                         suggestedFoldersDao.deleteAndInsertAll(folders)
-                        currentHash?.let { settings.followedPodcastsForSuggestedFoldersHash.set(it, updateModifiedAt = false) }
+                        currentHash?.let { settings.suggestedFoldersFollowedHash.set(it, updateModifiedAt = false) }
                     }
                 }
             }
@@ -44,7 +44,11 @@ class SuggestedFoldersManager @Inject constructor(
         }
     }
 
-    suspend fun deleteSuggestedFolders(folders: List<SuggestedFolder>) {
-        suggestedFoldersDao.deleteFolders(folders)
+    suspend fun replaceSuggestedFolders(newFolders: List<SuggestedFolder>) {
+        suggestedFoldersDao.deleteFolders(newFolders)
+    }
+
+    suspend fun deleteAllSuggestedFolders() {
+        suggestedFoldersDao.deleteAll()
     }
 }

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/SuggestedFoldersManagerTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/SuggestedFoldersManagerTest.kt
@@ -44,7 +44,7 @@ class SuggestedFoldersManagerTest {
     fun setup() {
         whenever(mockAppDatabase.suggestedFoldersDao()).thenReturn(mockSuggestedFoldersDao)
         whenever(hashMock.value).thenReturn("123")
-        whenever(settings.followedPodcastsForSuggestedFoldersHash).thenReturn(hashMock)
+        whenever(settings.suggestedFoldersFollowedHash).thenReturn(hashMock)
         suggestedFoldersManager = SuggestedFoldersManager(mockPodcastCacheService, settings, mockAppDatabase)
     }
 
@@ -81,7 +81,7 @@ class SuggestedFoldersManagerTest {
         val podcastUuids = listOf("podcastUuid")
 
         whenever(hashMock.value).thenReturn("different-hash")
-        whenever(settings.followedPodcastsForSuggestedFoldersHash).thenReturn(hashMock)
+        whenever(settings.suggestedFoldersFollowedHash).thenReturn(hashMock)
 
         suggestedFoldersManager.refreshSuggestedFolders(podcastUuids)
 
@@ -105,7 +105,7 @@ class SuggestedFoldersManagerTest {
             SuggestedFolder("uuid", "Folder1"),
         )
 
-        suggestedFoldersManager.deleteSuggestedFolders(folders)
+        suggestedFoldersManager.replaceSuggestedFolders(folders)
 
         verify(mockSuggestedFoldersDao).deleteFolders(folders)
     }

--- a/modules/services/sharedtest/src/main/java/au/com/shiftyjelly/pocketcasts/sharedtest/MutableClock.kt
+++ b/modules/services/sharedtest/src/main/java/au/com/shiftyjelly/pocketcasts/sharedtest/MutableClock.kt
@@ -1,0 +1,25 @@
+package au.com.shiftyjelly.pocketcasts.sharedtest
+
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneId
+import kotlin.time.Duration
+
+class MutableClock(
+    private var instant: Instant = Instant.EPOCH,
+    private val zoneId: ZoneId = ZoneId.of("UTC"),
+) : Clock() {
+    override fun instant() = instant
+
+    override fun getZone() = zoneId
+
+    override fun withZone(zone: ZoneId) = MutableClock(instant, zone)
+
+    operator fun plusAssign(duration: Duration) {
+        instant = instant.plusMillis(duration.inWholeMilliseconds)
+    }
+
+    operator fun minusAssign(duration: Duration) {
+        instant = instant.minusMillis(duration.inWholeMilliseconds)
+    }
+}


### PR DESCRIPTION
## Description

This PR defines the rules for showing smart folders popup.

> [!note]
> The current UI and logic of applying folders is most likely broken or has some bugs. This PR is only about showing the popup. Nothing else.

## Testing Instructions

1. Start the app without being signed in.
2. Follow at least 8 podcasts.
3. Go to the Podcasts page.
4. A popup with smart folders should appear.
5. Dismiss the popup.
6. Navigate to a different page.
7. Return to the Podcasts page.
8. The popup should not appear.
9. Close the app.
10. Open device settings.
11. Set the date on your device to 7 days in the future.
12. Open the Pocket Casts app. You might experience network request failures due to the changed date, but ignore them.
13. Go to the Podcasts page.
14. You should see the smart folders popup.
15. Dismiss the popup.
16. Go back and forth between the Podcasts page and some other page.
17. At no point you should see the popup.
18. Close the app.
19. Go back to the device settings and reset the date to the correct value.
20. Open Settings.
21. Navigate to the Developer Features section.
22. Tap **"Reset Smart Folders."**
23. Sign in with a free account.
24. Repeat steps 2 to 23.
25. Sign out.
26. Sign in with a paid account.
27. Follow at least 8 podcasts.
28. Go to the Podcasts page.
29. You should not see the smart folders popup.

## Checklist
- [ ] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [ ] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [ ] ~Any jetpack compose components I added or changed are covered by compose previews~
- [ ] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~