### PR TITLE
Include toolbar height in podcast search scrolling offset

### DIFF
--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastFragment.kt
@@ -21,9 +21,7 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableStateOf
@@ -632,7 +630,11 @@ class PodcastFragment : BaseFragment() {
 
     private val onSearchFocus: () -> Unit = {
         // scroll to episode search
-        binding?.episodesRecyclerView?.smoothScrollToTop(position = 1)
+        val toolbarHeight = when (binding?.headerType) {
+            null, HeaderType.SolidColor -> 0
+            HeaderType.Blur, HeaderType.Scrim -> binding?.toolbar?.height ?: 0
+        }
+        binding?.episodesRecyclerView?.smoothScrollToTop(1, offset = toolbarHeight)
     }
 
     private val onShowArchivedClicked: () -> Unit = {
@@ -1106,7 +1108,11 @@ class PodcastFragment : BaseFragment() {
                         }
                     }
                     if (state.searchTerm.isNotEmpty() && state.searchTerm != lastSearchTerm) {
-                        binding?.episodesRecyclerView?.smoothScrollToTop(1)
+                        val toolbarHeight = when (binding?.headerType) {
+                            null, HeaderType.SolidColor -> 0
+                            HeaderType.Blur, HeaderType.Scrim -> binding?.toolbar?.height ?: 0
+                        }
+                        binding?.episodesRecyclerView?.smoothScrollToTop(1, offset = toolbarHeight)
                     }
                     lastSearchTerm = state.searchTerm
                 }

--- a/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/extensions/RecyclerView.kt
+++ b/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/extensions/RecyclerView.kt
@@ -1,6 +1,7 @@
 package au.com.shiftyjelly.pocketcasts.views.extensions
 
 import android.util.DisplayMetrics
+import android.view.View
 import androidx.recyclerview.widget.LinearSmoothScroller
 import androidx.recyclerview.widget.RecyclerView
 
@@ -8,10 +9,14 @@ import androidx.recyclerview.widget.RecyclerView
  * Scrolls the adapter position to the top of the screen.
  * Unlike smoothScrollToPosition which just scrolls the position into view.
  */
-fun RecyclerView.smoothScrollToTop(position: Int) {
+fun RecyclerView.smoothScrollToTop(position: Int, offset: Int = 0) {
     val smoothScroller = object : LinearSmoothScroller(context) {
         override fun getVerticalSnapPreference(): Int {
             return LinearSmoothScroller.SNAP_TO_START
+        }
+
+        override fun calculateDyToMakeVisible(view: View, snapPreference: Int): Int {
+            return super.calculateDyToMakeVisible(view, snapPreference) + offset
         }
     }
     smoothScroller.targetPosition = position


### PR DESCRIPTION
## Description

Tapping on a search bar didn't scroll to a correct position due to toolbar not being part of the same layout.

Context: https://pocketcastsbeta.slack.com/archives/C013F9S9C2W/p1741109744236849

## Testing Instructions

1. Open a podcast with enough episodes that they don't fit on screen.
2. Tap on the search field.
3. The screen should scroll to top but the toolbar should still be visible.

## Checklist
- [ ] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] ~I have considered whether it makes sense to add tests for my changes~
- [ ] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [ ] ~Any jetpack compose components I added or changed are covered by compose previews~
- [ ] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~