### PR TITLE
Fix log format exception

### DIFF
--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/log/LogBuffer.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/log/LogBuffer.kt
@@ -10,9 +10,9 @@ import java.io.PrintWriter
 import java.io.StringWriter
 import java.text.SimpleDateFormat
 import java.util.Date
+import java.util.IllegalFormatException
 import java.util.Locale
 import timber.log.Timber
-import timber.log.Timber.Forest.tag
 
 object LogBuffer {
 
@@ -45,11 +45,10 @@ object LogBuffer {
     private fun add(message: String?) {
         val path = logPath
         val backupPath = logBackupPath
-        if (message == null || message.isEmpty() || path == null || backupPath == null) {
+        if (message.isNullOrEmpty() || path == null || backupPath == null) {
             return
         }
 
-        var out: FileWriter? = null
         try {
             val logFile = File(path)
             var exists = logFile.exists()
@@ -62,17 +61,13 @@ object LogBuffer {
                 exists = false
             }
 
-            out = FileWriter(logPath, exists)
-            out.write(message)
-            out.write("\n")
-            out.flush()
+            FileWriter(logPath, exists).use { writer ->
+                writer.write(message)
+                writer.write("\n")
+                writer.flush()
+            }
         } catch (e: IOException) {
             Timber.w(e, "Unable to write log buffer %s", logPath)
-        } finally {
-            try {
-                out?.close()
-            } catch (t: Throwable) {
-            }
         }
     }
 
@@ -96,18 +91,6 @@ object LogBuffer {
         }
     }
 
-    fun clearLog() {
-        val path = logPath
-        val backupPath = logBackupPath
-        if (path == null || backupPath == null) {
-            return
-        }
-        val logFile = File(path)
-        val logBackupFile = File(backupPath)
-        logFile.delete()
-        logBackupFile.delete()
-    }
-
     fun i(tag: String, message: String, vararg args: Any) {
         addLog(Log.INFO, tag, null, message, *args)
     }
@@ -124,31 +107,26 @@ object LogBuffer {
         addLog(Log.ERROR, tag, null, message, *args)
     }
 
-    fun trace(tag: String, message: String, vararg args: Any) {
-        addLog(Log.INFO, tag, null, message + getThreadStackTraceString(), *args)
-    }
-
     fun e(tag: String, throwable: Throwable, message: String, vararg args: Any) {
         addLog(Log.ERROR, tag, throwable, message, *args)
     }
 
-    @Suppress("NAME_SHADOWING")
     fun addLog(priority: Int, tag: String, throwable: Throwable?, message: String?, vararg args: Any) {
-        var message = message
-        if (message != null && message.isEmpty()) {
-            message = null
+        var logMessage = message
+        if (logMessage != null && logMessage.isEmpty()) {
+            logMessage = null
         }
-        if (message == null) {
+        if (logMessage == null) {
             if (throwable == null) {
                 return
             }
-            message = getStackTraceString(throwable)
+            logMessage = getStackTraceString(throwable)
         } else {
             if (args.isNotEmpty()) {
-                message = String.format(message, *args)
+                logMessage = logMessage.formatCatching(*args)
             }
             if (throwable != null) {
-                message += "\n" + getStackTraceString(throwable)
+                logMessage += "\n" + getStackTraceString(throwable)
             }
         }
 
@@ -157,47 +135,26 @@ object LogBuffer {
         when (priority) {
             Log.DEBUG -> {
                 prefix = "D "
-                Timber.d(timberPrefix + message)
+                Timber.d(timberPrefix + logMessage)
             }
             Log.INFO -> {
                 prefix = "I "
-                Timber.i(timberPrefix + message)
+                Timber.i(timberPrefix + logMessage)
             }
             Log.WARN -> {
                 prefix = "W "
-                Timber.w(timberPrefix + message)
+                Timber.w(timberPrefix + logMessage)
             }
             Log.ERROR -> {
                 prefix = "E "
-                Timber.e(timberPrefix + message)
+                Timber.e(timberPrefix + logMessage)
             }
             else -> prefix = ""
         }
 
-        prefix += LOG_FILE_DATE_FORMAT.format(Date()) // + " ["+tag+"]";
+        prefix += LOG_FILE_DATE_FORMAT.format(Date())
 
-        add("$prefix $message")
-    }
-
-    private fun getThreadStackTraceString(): String {
-        val sw = StringWriter(256)
-        val pw = PrintWriter(sw, false)
-        Throwable().printStackTrace(pw)
-        pw.flush()
-        val rawTrace = sw.toString()
-        val lines = rawTrace.split("\n".toRegex()).dropLastWhile { it.isEmpty() }.toTypedArray()
-        val trace = StringBuilder()
-        for (i in lines.indices) {
-            if (i == 0) {
-                continue
-            }
-            val line = lines[i]
-            if (!line.startsWith("\tat au.com.shiftyjelly.pocketcasts.") || line.contains("LogBuffer")) {
-                continue
-            }
-            trace.append("\n at ").append(line.substring(34))
-        }
-        return trace.toString()
+        add("$prefix $logMessage")
     }
 
     private fun getStackTraceString(t: Throwable): String {
@@ -208,5 +165,14 @@ object LogBuffer {
         t.printStackTrace(pw)
         pw.flush()
         return sw.toString()
+    }
+
+    private fun String.formatCatching(vararg args: Any) = try {
+        this.format(*args)
+    } catch (e: IllegalFormatException) {
+        // Return the string without the arguments, including the error
+        val errorDetails = "Unable to format log message with args ${args.contentToString()}"
+        Timber.e(e, errorDetails)
+        "$this ($errorDetails)"
     }
 }


### PR DESCRIPTION
## Description

When looking through the production exceptions I noticed the following:

<img width="859" alt="Screenshot 2025-03-05 at 12 45 24 pm" src="https://github.com/user-attachments/assets/b47f3276-c7c9-47cd-94ad-7eab62038885" />

It doesn't seem to be a common issue but thought it would be worth fixing. I didn't find the route cause of the log format breaking but I have caught the exception to stop the app crashing. 

I also tried to clean up the warnings in the class while I was there.

## Testing Instructions
1. Change the app started log in `PocketCastsApplication.kt` to the following:

```
LogBuffer.i("Application", "App started. ${settings.getVersion()} (${settings.getVersionCode()}) %s %i %d", 1, 2, 3)
```

2. ✅  Verify the app doesn't crash and the log still has the message in it.

```
Application: App started. 7.84-rc-2 (9317) %s %i %d (Unable to format log message with args [1, 2, 3])
```

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 