### PR TITLE
Navigate to folder details

### DIFF
--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/folders/SuggestedFolderPodcastsPage.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/folders/SuggestedFolderPodcastsPage.kt
@@ -1,0 +1,125 @@
+package au.com.shiftyjelly.pocketcasts.podcasts.view.folders
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.lazy.grid.items
+import androidx.compose.material.Icon
+import androidx.compose.material.IconButton
+import androidx.compose.material.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewParameter
+import androidx.compose.ui.unit.dp
+import au.com.shiftyjelly.pocketcasts.compose.AppThemeWithBackground
+import au.com.shiftyjelly.pocketcasts.compose.Devices
+import au.com.shiftyjelly.pocketcasts.compose.components.PodcastImage
+import au.com.shiftyjelly.pocketcasts.compose.components.TextH30
+import au.com.shiftyjelly.pocketcasts.compose.components.TextP40
+import au.com.shiftyjelly.pocketcasts.compose.preview.ThemePreviewParameterProvider
+import au.com.shiftyjelly.pocketcasts.compose.theme
+import au.com.shiftyjelly.pocketcasts.images.R
+import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
+import au.com.shiftyjelly.pocketcasts.localization.R as LR
+
+@Composable
+fun SuggestedFolderPodcastsPage(
+    folder: SuggestedFolder?,
+    onGoBackClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val folderColor = folder?.colorIndex
+        ?.let { MaterialTheme.theme.colors.getFolderColor(it) }
+        ?: MaterialTheme.theme.colors.primaryInteractive01
+
+    Column(
+        modifier = modifier,
+    ) {
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier.heightIn(min = 64.dp),
+        ) {
+            IconButton(
+                onClick = onGoBackClick,
+            ) {
+                Icon(
+                    painter = painterResource(R.drawable.ic_arrow_back),
+                    contentDescription = stringResource(LR.string.back),
+                    tint = folderColor,
+                )
+            }
+
+            TextH30(
+                text = folder?.name.orEmpty(),
+                color = folderColor,
+                maxLines = 1,
+                textAlign = TextAlign.Center,
+                modifier = Modifier.weight(1f),
+            )
+
+            Spacer(
+                modifier = Modifier.size(48.dp),
+            )
+        }
+
+        Spacer(
+            modifier = Modifier.height(4.dp),
+        )
+
+        if (folder != null) {
+            LazyVerticalGrid(
+                columns = GridCells.Adaptive(110.dp),
+                horizontalArrangement = Arrangement.spacedBy(6.dp),
+                verticalArrangement = Arrangement.spacedBy(6.dp),
+                modifier = Modifier
+                    .weight(1f)
+                    .padding(bottom = 8.dp)
+                    .padding(horizontal = 16.dp),
+            ) {
+                items(folder.podcastIds) { podcastId ->
+                    PodcastImage(podcastId)
+                }
+            }
+        } else {
+            Box(
+                contentAlignment = Alignment.Center,
+                modifier = Modifier.fillMaxSize(),
+            ) {
+                TextP40(
+                    text = stringResource(LR.string.error_generic_message),
+                )
+            }
+        }
+    }
+}
+
+@Preview(device = Devices.PortraitRegular)
+@Composable
+private fun SuggestedFolderPodcastsPagePreview(
+    @PreviewParameter(ThemePreviewParameterProvider::class) themeType: Theme.ThemeType,
+) {
+    AppThemeWithBackground(Theme.ThemeType.LIGHT) {
+        SuggestedFolderPodcastsPage(
+            folder = SuggestedFolder(
+                name = "Folder name",
+                colorIndex = 0,
+                podcastIds = listOf("1", "2", "3", "4", "5"),
+            ),
+            onGoBackClick = {},
+        )
+    }
+}

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/folders/SuggestedFolderPodcastsPage.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/folders/SuggestedFolderPodcastsPage.kt
@@ -112,7 +112,7 @@ fun SuggestedFolderPodcastsPage(
 private fun SuggestedFolderPodcastsPagePreview(
     @PreviewParameter(ThemePreviewParameterProvider::class) themeType: Theme.ThemeType,
 ) {
-    AppThemeWithBackground(Theme.ThemeType.LIGHT) {
+    AppThemeWithBackground(themeType) {
         SuggestedFolderPodcastsPage(
             folder = SuggestedFolder(
                 name = "Folder name",

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/folders/SuggestedFoldersFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/folders/SuggestedFoldersFragment.kt
@@ -16,11 +16,10 @@ import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material.Text
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.ui.Alignment
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.input.nestedscroll.nestedScroll
@@ -130,12 +129,12 @@ class SuggestedFoldersFragment : BaseDialogFragment() {
                             val folderName = requireNotNull(arguments.getString(SuggestedFoldersNavRoutes.SuggestedFolderNameArgument)) {
                                 "Missing folder name period argument"
                             }
-                            Box(
-                                contentAlignment = Alignment.Center,
-                                modifier = Modifier.fillMaxSize(),
-                            ) {
-                                Text(folderName)
-                            }
+                            SuggestedFolderPodcastsPage(
+                                folder = remember(folderName, state.suggestedFolders) {
+                                    state.suggestedFolders.find { it.name == folderName }
+                                },
+                                onGoBackClick = navController::popBackStack,
+                            )
                         }
                     }
                 }

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/folders/SuggestedFoldersPage.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/folders/SuggestedFoldersPage.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.GridItemSpan
@@ -25,6 +26,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.min
 import androidx.compose.ui.unit.sp
 import au.com.shiftyjelly.pocketcasts.compose.AppThemeWithBackground
 import au.com.shiftyjelly.pocketcasts.compose.Devices
@@ -54,14 +56,18 @@ fun SuggestedFoldersPage(
     ) {
         IconButton(
             onClick = onCloseClick,
+            modifier = Modifier.heightIn(min = 64.dp),
         ) {
             Icon(
                 painter = painterResource(R.drawable.ic_close),
                 contentDescription = stringResource(LR.string.close),
                 tint = MaterialTheme.theme.colors.primaryInteractive01,
-                modifier = Modifier.padding(16.dp),
             )
         }
+
+        Spacer(
+            modifier = Modifier.height(4.dp),
+        )
 
         if (action != null) {
             LazyVerticalGrid(

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/folders/SuggestedFoldersPage.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/folders/SuggestedFoldersPage.kt
@@ -11,10 +11,13 @@ import androidx.compose.foundation.lazy.grid.GridItemSpan
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.material.ButtonDefaults
+import androidx.compose.material.Icon
+import androidx.compose.material.IconButton
 import androidx.compose.material.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.clearAndSetSemantics
 import androidx.compose.ui.semantics.contentDescription
@@ -32,85 +35,100 @@ import au.com.shiftyjelly.pocketcasts.compose.components.TextP40
 import au.com.shiftyjelly.pocketcasts.compose.folder.FolderImage
 import au.com.shiftyjelly.pocketcasts.compose.preview.ThemePreviewParameterProvider
 import au.com.shiftyjelly.pocketcasts.compose.theme
+import au.com.shiftyjelly.pocketcasts.images.R
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 @Composable
 fun SuggestedFoldersPage(
-    action: SuggestedAction,
+    action: SuggestedAction?,
     folders: List<SuggestedFolder>,
     onActionClick: () -> Unit,
     onCreateCustomFolderClick: () -> Unit,
     onFolderClick: (SuggestedFolder) -> Unit,
+    onCloseClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Column(
         modifier = modifier,
     ) {
-        LazyVerticalGrid(
-            columns = GridCells.Adaptive(110.dp),
-            horizontalArrangement = Arrangement.spacedBy(6.dp),
-            verticalArrangement = Arrangement.spacedBy(6.dp),
-            modifier = Modifier
-                .weight(1f)
-                .padding(bottom = 8.dp)
-                .padding(horizontal = 16.dp),
+        IconButton(
+            onClick = onCloseClick,
         ) {
-            item(span = { GridItemSpan(maxLineSpan) }) {
-                SmartFoldersHeader(action)
-            }
-            item(span = { GridItemSpan(maxLineSpan) }) {
-                Spacer(
-                    modifier = Modifier.height(10.dp),
-                )
-            }
-            items(folders) { folder ->
-                val color = MaterialTheme.theme.colors.getFolderColor(folder.colorIndex)
-                val description = stringResource(LR.string.suggested_folder_content_description, folder.name)
-
-                FolderImage(
-                    name = folder.name,
-                    color = color,
-                    podcastUuids = folder.podcastIds,
-                    textSpacing = true,
-                    modifier = Modifier
-                        .clickable(onClick = { onFolderClick(folder) })
-                        .clearAndSetSemantics {
-                            contentDescription = description
-                        },
-                )
-            }
+            Icon(
+                painter = painterResource(R.drawable.ic_close),
+                contentDescription = stringResource(LR.string.close),
+                tint = MaterialTheme.theme.colors.primaryInteractive01,
+                modifier = Modifier.padding(16.dp),
+            )
         }
 
-        RowButton(
-            text = when (action) {
-                SuggestedAction.UseFolders -> stringResource(LR.string.suggested_folders_use_these_folders_button)
-                SuggestedAction.ReplaceFolders -> stringResource(LR.string.suggested_folders_replace_folders_button)
-            },
-            modifier = Modifier
-                .padding(bottom = 16.dp)
-                .padding(horizontal = 16.dp),
-            textColor = MaterialTheme.theme.colors.primaryInteractive02,
-            fontSize = 18.sp,
-            fontWeight = FontWeight.W600,
-            colors = ButtonDefaults.buttonColors(
-                backgroundColor = MaterialTheme.theme.colors.primaryInteractive01,
-            ),
-            includePadding = false,
-            onClick = onActionClick,
-        )
+        if (action != null) {
+            LazyVerticalGrid(
+                columns = GridCells.Adaptive(110.dp),
+                horizontalArrangement = Arrangement.spacedBy(6.dp),
+                verticalArrangement = Arrangement.spacedBy(6.dp),
+                modifier = Modifier
+                    .weight(1f)
+                    .padding(bottom = 8.dp)
+                    .padding(horizontal = 16.dp),
+            ) {
+                item(span = { GridItemSpan(maxLineSpan) }) {
+                    SmartFoldersHeader(action)
+                }
+                item(span = { GridItemSpan(maxLineSpan) }) {
+                    Spacer(
+                        modifier = Modifier.height(10.dp),
+                    )
+                }
+                items(folders) { folder ->
+                    val color = MaterialTheme.theme.colors.getFolderColor(folder.colorIndex)
+                    val description = stringResource(LR.string.suggested_folder_content_description, folder.name)
 
-        RowOutlinedButton(
-            text = stringResource(LR.string.suggested_folders_create_custom_folder_button),
-            onClick = onCreateCustomFolderClick,
-            includePadding = false,
-            colors = ButtonDefaults.outlinedButtonColors(contentColor = MaterialTheme.theme.colors.primaryIcon01, backgroundColor = Color.Transparent),
-            fontSize = 18.sp,
-            fontWeight = FontWeight.W600,
-            modifier = Modifier
-                .padding(bottom = 16.dp)
-                .padding(horizontal = 16.dp),
-        )
+                    FolderImage(
+                        name = folder.name,
+                        color = color,
+                        podcastUuids = folder.podcastIds,
+                        textSpacing = true,
+                        modifier = Modifier
+                            .clickable(onClick = { onFolderClick(folder) })
+                            .clearAndSetSemantics {
+                                contentDescription = description
+                            },
+                    )
+                }
+            }
+
+            RowButton(
+                text = when (action) {
+                    SuggestedAction.UseFolders -> stringResource(LR.string.suggested_folders_use_these_folders_button)
+                    SuggestedAction.ReplaceFolders -> stringResource(LR.string.suggested_folders_replace_folders_button)
+                },
+                modifier = Modifier
+                    .padding(bottom = 16.dp)
+                    .padding(horizontal = 16.dp),
+                textColor = MaterialTheme.theme.colors.primaryInteractive02,
+                fontSize = 18.sp,
+                fontWeight = FontWeight.W600,
+                colors = ButtonDefaults.buttonColors(
+                    backgroundColor = MaterialTheme.theme.colors.primaryInteractive01,
+                ),
+                includePadding = false,
+                onClick = onActionClick,
+            )
+
+            RowOutlinedButton(
+                text = stringResource(LR.string.suggested_folders_create_custom_folder_button),
+                onClick = onCreateCustomFolderClick,
+                includePadding = false,
+                colors = ButtonDefaults.outlinedButtonColors(contentColor = MaterialTheme.theme.colors.primaryIcon01, backgroundColor = Color.Transparent),
+                fontSize = 18.sp,
+                fontWeight = FontWeight.W600,
+                modifier = Modifier
+                    .padding(bottom = 16.dp)
+                    .padding(horizontal = 16.dp),
+            )
+        }
     }
 }
 
@@ -160,6 +178,7 @@ private fun SuggestedFoldersPagePreview() {
             onActionClick = {},
             onCreateCustomFolderClick = {},
             onFolderClick = {},
+            onCloseClick = {},
         )
     }
 }
@@ -182,6 +201,7 @@ private fun SuggestedFoldersPagePreview(
             onActionClick = {},
             onCreateCustomFolderClick = {},
             onFolderClick = {},
+            onCloseClick = {},
         )
     }
 }

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/folders/SuggestedFoldersViewModel.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/folders/SuggestedFoldersViewModel.kt
@@ -76,7 +76,7 @@ class SuggestedFoldersViewModel @Inject constructor(
         }
         viewModelScope.launch(NonCancellable) {
             _state.update { value ->
-                value.copy(useFolderesState = UseFoldersState.Applying)
+                value.copy(useFoldersState = UseFoldersState.Applying)
             }
             val suggestedFolders = withContext(Dispatchers.Default) {
                 state.value.suggestedFolders.flatMap { folder ->
@@ -87,7 +87,7 @@ class SuggestedFoldersViewModel @Inject constructor(
             }
             suggestedFoldersManager.useSuggestedFolders(suggestedFolders)
             _state.update { value ->
-                value.copy(useFolderesState = UseFoldersState.Applied)
+                value.copy(useFoldersState = UseFoldersState.Applied)
             }
             podcastManager.refreshPodcasts("suggested-folders")
         }
@@ -101,7 +101,7 @@ class SuggestedFoldersViewModel @Inject constructor(
         val isUserPlusOrPatreon: Boolean,
         val existingFoldersCount: Int?,
         val suggestedFolders: List<SuggestedFolder>,
-        val useFolderesState: UseFoldersState,
+        val useFoldersState: UseFoldersState,
     ) {
         val action
             get() = if (isUserPlusOrPatreon) {
@@ -119,7 +119,7 @@ class SuggestedFoldersViewModel @Inject constructor(
                 isUserPlusOrPatreon = false,
                 existingFoldersCount = null,
                 suggestedFolders = emptyList(),
-                useFolderesState = UseFoldersState.Idle,
+                useFoldersState = UseFoldersState.Idle,
             )
         }
     }

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcasts/PodcastsFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcasts/PodcastsFragment.kt
@@ -89,11 +89,14 @@ class PodcastsFragment :
         }
     }
 
-    @Inject lateinit var settings: Settings
+    @Inject
+    lateinit var settings: Settings
 
-    @Inject lateinit var castManager: CastManager
+    @Inject
+    lateinit var castManager: CastManager
 
-    @Inject lateinit var analyticsTracker: AnalyticsTracker
+    @Inject
+    lateinit var analyticsTracker: AnalyticsTracker
 
     private var podcastOptionsDialog: PodcastsOptionsDialog? = null
     private var folderOptionsDialog: FolderOptionsDialog? = null
@@ -234,15 +237,21 @@ class PodcastsFragment :
         viewLifecycleOwner.lifecycleScope.launch {
             viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
                 viewModel.refreshSuggestedFolders()
+            }
+        }
 
-                when (viewModel.suggestedFoldersState.value) {
-                    is SuggestedFoldersState.Available -> {
-                        if (FeatureFlag.isEnabled(Feature.SUGGESTED_FOLDERS) && viewModel.isEligibleForSuggestedFoldersPopup()) {
-                            showSuggestedFoldersCreation(SuggestedFoldersFragment.Source.PodcastsPopup)
+        viewLifecycleOwner.lifecycleScope.launch {
+            viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
+                viewModel.suggestedFoldersState.collect { state ->
+                    when (state) {
+                        is SuggestedFoldersState.Available -> {
+                            if (FeatureFlag.isEnabled(Feature.SUGGESTED_FOLDERS) && viewModel.isEligibleForSuggestedFoldersPopup()) {
+                                showSuggestedFoldersCreation(SuggestedFoldersFragment.Source.PodcastsPopup)
+                            }
                         }
-                    }
 
-                    is SuggestedFoldersState.Empty -> Unit
+                        is SuggestedFoldersState.Empty -> Unit
+                    }
                 }
             }
         }
@@ -263,15 +272,18 @@ class PodcastsFragment :
                 openOptions()
                 true
             }
+
             R.id.search_podcasts -> {
                 search()
                 true
             }
+
             R.id.create_folder -> {
                 analyticsTracker.track(AnalyticsEvent.PODCASTS_LIST_FOLDER_BUTTON_TAPPED)
                 handleFolderCreation()
                 true
             }
+
             else -> false
         }
     }
@@ -320,6 +332,7 @@ class PodcastsFragment :
             is SuggestedFoldersState.Empty -> {
                 showCustomFolderCreation()
             }
+
             is SuggestedFoldersState.Available -> {
                 if (FeatureFlag.isEnabled(Feature.SUGGESTED_FOLDERS)) {
                     showSuggestedFoldersCreation(SuggestedFoldersFragment.Source.CreateFolderButton)

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/PodcastsViewModel.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/PodcastsViewModel.kt
@@ -32,6 +32,7 @@ import javax.inject.Inject
 import kotlin.coroutines.CoroutineContext
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
@@ -303,9 +304,13 @@ class PodcastsViewModel
         }
     }
 
-    suspend fun refreshSuggestedFolders() {
-        if (FeatureFlag.isEnabled(Feature.SUGGESTED_FOLDERS)) {
-            suggestedFoldersManager.refreshSuggestedFolders()
+    private var refreshSuggestedFoldersJob: Job? = null
+
+    fun refreshSuggestedFolders() {
+        if (FeatureFlag.isEnabled(Feature.SUGGESTED_FOLDERS) && refreshSuggestedFoldersJob?.isActive != true) {
+            refreshSuggestedFoldersJob = viewModelScope.launch {
+                suggestedFoldersManager.refreshSuggestedFolders()
+            }
         }
     }
 


### PR DESCRIPTION
## Description

This PR adds navigation to podcast list after tapping on the suggested folder.

Designs: QmqtGNKfPivyq5BrVRPpyV-fi-347_3478

## Testing Instructions

1. Follow at least 8 podcasts.
2. Start the suggested folders flow either from the popup as a free user or folders button as a paid one.
3. Tap on any folder.
4. Notice that you see it's details.
5. Navigate back either with back button or top left arrow.

## Screenshots or Screencast 

https://github.com/user-attachments/assets/e9a5b871-5d20-4cae-bfa8-06b0b43dffe3

## Checklist
- [ ] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] ~I have considered whether it makes sense to add tests for my changes~
- [ ] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [ ] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack