### PR TITLE
Handle free users suggested folders flow

### DIFF
--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/folders/SuggestedFoldersFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/folders/SuggestedFoldersFragment.kt
@@ -110,7 +110,7 @@ class SuggestedFoldersFragment : BaseDialogFragment() {
                                 folders = state.suggestedFolders,
                                 action = state.action,
                                 onActionClick = { state.action?.let { handleSuggestedAction(it, state.isUserPlusOrPatreon) } },
-                                onCreateCustomFolderClick = ::goToCustomFolderCreation,
+                                onCreateCustomFolderClick = { handleCustomFolderCreation(state.isUserPlusOrPatreon) },
                                 onFolderClick = { folder ->
                                     navController.navigate(SuggestedFoldersNavRoutes.folderDetailsDestination(folder.name))
                                 },
@@ -165,11 +165,15 @@ class SuggestedFoldersFragment : BaseDialogFragment() {
             !isFinalizingActionUsed &&
             args.source == Source.PodcastsPopup
 
-    private fun goToCustomFolderCreation() {
-        FolderCreateFragment
-            .newInstance(source = "suggested_folders")
-            .show(parentFragmentManager, "create_folder_card")
-        finalizeAndDismiss()
+    private fun handleCustomFolderCreation(isUserPlusOrPatreon: Boolean) {
+        if (isUserPlusOrPatreon) {
+            FolderCreateFragment
+                .newInstance(source = "suggested_folders")
+                .show(parentFragmentManager, "create_folder_card")
+            finalizeAndDismiss()
+        } else {
+            OnboardingLauncher.openOnboardingFlow(activity, OnboardingFlow.Upsell(OnboardingUpgradeSource.FOLDERS))
+        }
     }
 
     private fun handleSuggestedAction(action: SuggestedAction, isUserPlusOrPatreon: Boolean) {

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcasts/PodcastsFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcasts/PodcastsFragment.kt
@@ -210,7 +210,20 @@ class PodcastsFragment :
         toolbar.setOnMenuItemClickListener(this)
 
         toolbar.menu.findItem(R.id.folders_locked).setOnMenuItemClickListener {
-            OnboardingLauncher.openOnboardingFlow(activity, OnboardingFlow.Upsell(OnboardingUpgradeSource.FOLDERS))
+            if (FeatureFlag.isEnabled(Feature.SUGGESTED_FOLDERS)) {
+                val state = viewModel.suggestedFoldersState.value
+                when (state) {
+                    is SuggestedFoldersState.Empty -> {
+                        OnboardingLauncher.openOnboardingFlow(activity, OnboardingFlow.Upsell(OnboardingUpgradeSource.FOLDERS))
+                    }
+
+                    is SuggestedFoldersState.Available -> {
+                        showSuggestedFoldersCreation(SuggestedFoldersFragment.Source.CreateFolderButton)
+                    }
+                }
+            } else {
+                OnboardingLauncher.openOnboardingFlow(activity, OnboardingFlow.Upsell(OnboardingUpgradeSource.FOLDERS))
+            }
             true
         }
 


### PR DESCRIPTION
## Description

This adds suggested folder flow to our regular folder button and onboarding flow to custom folder.

## Testing Instructions

1. Start the app as an unsigned or a free user.
2. Go to the podcasts page.
3. Tap folder icon.
4. You should see the onboarding flow.
5. Dismiss it.
6. Follow at least 8 podcasts.
7. Go back to the podcasts page.
8. Dismiss the folders popup.
9. Tap on the folders icon.
10. You should see the suggested folders flow.
11. Tap "Use these folders".
12. Onboarding should start.
13. Go back.
14. Tap "Create custom folder".
15. Onboarding should start.

## Checklist
- [ ] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] ~I have considered whether it makes sense to add tests for my changes~
- [ ] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [ ] ~Any jetpack compose components I added or changed are covered by compose previews~
- [ ] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~