### PR TITLE
Add suggested folders analytics

### DIFF
--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/folders/SuggestedFoldersFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/folders/SuggestedFoldersFragment.kt
@@ -44,6 +44,7 @@ import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingUpgradeSourc
 import au.com.shiftyjelly.pocketcasts.views.dialog.ConfirmationDialog
 import au.com.shiftyjelly.pocketcasts.views.fragments.BaseDialogFragment
 import dagger.hilt.android.AndroidEntryPoint
+import dagger.hilt.android.lifecycle.withCreationCallback
 import kotlinx.parcelize.Parcelize
 import au.com.shiftyjelly.pocketcasts.images.R as VR
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
@@ -66,12 +67,18 @@ class SuggestedFoldersFragment : BaseDialogFragment() {
         }
     }
 
-    private val viewModel by viewModels<SuggestedFoldersViewModel>()
-
     private val args
         get() = requireNotNull(BundleCompat.getParcelable(requireArguments(), ARGS_KEY, Args::class.java)) {
             "Missing input parameters"
         }
+
+    private val viewModel by viewModels<SuggestedFoldersViewModel>(
+        extrasProducer = {
+            defaultViewModelCreationExtras.withCreationCallback<SuggestedFoldersViewModel.Factory> { factory ->
+                factory.crate(args.source)
+            }
+        }
+    )
 
     private var isFinalizingActionUsed = false
 
@@ -198,9 +205,15 @@ class SuggestedFoldersFragment : BaseDialogFragment() {
             .show(childFragmentManager, "suggested-folders-confirmation-dialog")
     }
 
-    enum class Source {
-        PodcastsPopup,
-        CreateFolderButton,
+    enum class Source(
+        val analyticsValue: String,
+    ) {
+        PodcastsPopup(
+            analyticsValue = "podcasts",
+        ),
+        CreateFolderButton(
+            analyticsValue = "create_folder"
+        ),
     }
 
     @Parcelize

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/folders/SuggestedFoldersViewModel.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/folders/SuggestedFoldersViewModel.kt
@@ -7,6 +7,9 @@ import au.com.shiftyjelly.pocketcasts.repositories.podcast.FolderManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.SuggestedFoldersManager
 import au.com.shiftyjelly.pocketcasts.repositories.user.UserManager
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedFactory
+import dagger.assisted.AssistedInject
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
 import kotlinx.coroutines.Dispatchers
@@ -21,8 +24,9 @@ import kotlinx.coroutines.reactive.asFlow
 import kotlinx.coroutines.withContext
 import au.com.shiftyjelly.pocketcasts.models.entity.SuggestedFolder as DbSuggestedFolder
 
-@HiltViewModel
-class SuggestedFoldersViewModel @Inject constructor(
+@HiltViewModel(assistedFactory = SuggestedFoldersViewModel.Factory::class)
+class SuggestedFoldersViewModel @AssistedInject constructor(
+    @Assisted private val source: SuggestedFoldersFragment.Source,
     private val folderManager: FolderManager,
     private val suggestedFoldersManager: SuggestedFoldersManager,
     private val suggestedFoldersPopupPolicy: SuggestedFoldersPopupPolicy,
@@ -97,6 +101,34 @@ class SuggestedFoldersViewModel @Inject constructor(
         suggestedFoldersPopupPolicy.markPolicyUsed()
     }
 
+    fun trackPageShown() {
+
+    }
+
+    fun trackPageDismissed() {
+
+    }
+
+    fun trackUseSuggestedFoldersTapped() {
+
+    }
+
+    fun trackCreateCustomFolderTapped() {
+
+    }
+
+    fun trackReplaceFolderTapped() {
+
+    }
+
+    fun trackReplaceFoldersConfirmationTapped() {
+
+    }
+
+    fun trackPreviewFolderTapped() {
+
+    }
+
     data class State(
         val isUserPlusOrPatreon: Boolean,
         val existingFoldersCount: Int?,
@@ -128,5 +160,10 @@ class SuggestedFoldersViewModel @Inject constructor(
         Idle,
         Applying,
         Applied,
+    }
+
+    @AssistedFactory
+    interface Factory {
+        fun crate(source: SuggestedFoldersFragment.Source): SuggestedFoldersViewModel
     }
 }

--- a/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
+++ b/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
@@ -737,4 +737,13 @@ enum class AnalyticsEvent(val key: String) {
     WINBACK_AVAILABLE_PLANS_NEW_PLAN_PURCHASE_SUCCESSFUL("winback_available_plans_new_plan_purchase_successful"),
     WINBACK_CANCEL_CONFIRMATION_STAY_BUTTON_TAPPED("winback_cancel_confirmation_stay_button_tapped"),
     WINBACK_CANCEL_CONFIRMATION_CANCEL_BUTTON_TAPPED("winback_cancel_confirmation_cancel_button_tapped"),
+
+    /* Suggested Folders */
+    SUGGESTED_FOLDERS_PAGE_SHOWN("suggested_folders_page_shown"),
+    SUGGESTED_FOLDERS_PAGE_DISMISSED("suggested_folders_page_dismissed"),
+    SUGGESTED_FOLDERS_USE_SUGGESTED_FOLDERS_TAPPED("suggested_folders_use_suggested_folders_tapped"),
+    SUGGESTED_FOLDERS_CREATE_CUSTOM_FOLDER_TAPPED("suggested_folders_create_custom_folder_tapped"),
+    SUGGESTED_FOLDERS_REPLACE_FOLDERS_TAPPED("suggested_folders_replace_folders_tapped"),
+    SUGGESTED_FOLDERS_REPLACE_FOLDERS_CONFIRM_TAPPED("suggested_folders_replace_folders_confirm_tapped"),
+    SUGGESTED_FOLDERS_PREVIEW_FOLDER_TAPPED("suggested_folders_preview_folder_tapped"),
 }


### PR DESCRIPTION
## Description

Tracks events for suggested folders.

## Testing Instructions

Verify suggested folders events from [the Tracking Plan](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?gid=0#gid=0).

<img width="1223" alt="Screenshot 2025-03-05 at 11 51 19" src="https://github.com/user-attachments/assets/56d3eaa1-7b2f-4f9b-b003-8da5e70d1f0a" />

## Checklist
- [ ] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] ~I have considered whether it makes sense to add tests for my changes~
- [ ] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [ ] ~Any jetpack compose components I added or changed are covered by compose previews~
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.