### PR TITLE
[Buildkite] Test Android Staging on `ami-0ed66347bb94c070a` -> `ami-03794d38ac4991af7`

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -2,7 +2,7 @@
 ---
 
 agents:
-  queue: "android"
+  queue: "android-staging"
 
 steps:
   - label: Gradle Wrapper Validation


### PR DESCRIPTION
Related: [buildkite-ci#610](https://github.com/Automattic/buildkite-ci/pull/610)

AMI Name: `android-build-image-6.12.0v1.7-rc-1` -> `android-build-image-6.12.0v1.8-rc-1`

---

## Description
<!-- Please include a summary of what this PR is changing and why these changes are needed. -->

This PR changes the Buildkite agent from `android` to `android-staging`. This change is not meant to be merged, but rather used to verify that the new AMI `ami-0ed66347bb94c070a` works as expected.

---

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Tap on the Filters tab -->
<!-- 2. Tap on a filter -->
<!-- 3. etc. -->

Check CI and verify everything is working as expected with the `android-staging` agent.

---

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes... `N/A`
