### PR TITLE
Close episode details upon archiving

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 *   Bug Fixes
     *   Fixed an issue where the mini player could sometimes hide behind the navigation bar.
         ([#3687](https://github.com/Automattic/pocket-casts-android/pull/3687))
+*   Updates
+    *   Close episode details screen when archiving an episode. This reverts [#3473](https://github.com/Automattic/pocket-casts-android/pull/3473). 
+        ([#3718](https://github.com/Automattic/pocket-casts-android/pull/3718))
 
 7.84
 -----

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/episode/EpisodeFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/episode/EpisodeFragment.kt
@@ -418,6 +418,9 @@ class EpisodeFragment : BaseFragment() {
         binding?.btnArchive?.let { button ->
             button.onStateChange = {
                 viewModel.archiveClicked(button.isOn)
+                if (button.isOn) {
+                    (parentFragment as? BaseDialogFragment)?.dismiss()
+                }
             }
         }
 


### PR DESCRIPTION
## Description

Reverts https://github.com/Automattic/pocket-casts-android/pull/3473

Context: p1741092431617609/1733996004.946999-slack-C02A333D8LQ

## Testing Instructions

1. Open a podcast.
2. Tap on an episode to open the episode details.
3. Tap on the Archive button.
4. The episode details screen should close.

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] ~I have considered whether it makes sense to add tests for my changes~
- [ ] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [ ] ~Any jetpack compose components I added or changed are covered by compose previews~
- [ ] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~