### PR TITLE
Fix crash with podcast update when offline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
         ([#3666](https://github.com/Automattic/pocket-casts-android/pull/3666))
     *   Fix screen flickering when tapping on item in the navigation bar.
         ([#3674](https://github.com/Automattic/pocket-casts-android/pull/3674))
+    *   Fix crash with podcast update when offline.
+        ([#3718](https://github.com/Automattic/pocket-casts-android/pull/3718))
 
 7.83
 -----

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/refresh/RefreshServiceManager.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/refresh/RefreshServiceManager.kt
@@ -8,7 +8,7 @@ interface RefreshServiceManager {
 
     suspend fun pollImportOpml(pollUuids: List<String>): Response<StatusResponse<ImportOpmlResponse>>
 
-    suspend fun updatePodcast(podcastUuid: String, lastEpisodeUuid: String?): Response<Unit>
+    suspend fun updatePodcast(podcastUuid: String, lastEpisodeUuid: String?): UpdatePodcastResponse
 
-    suspend fun pollUpdatePodcast(url: String): Response<Unit>
+    suspend fun pollUpdatePodcast(url: String): UpdatePodcastResponse
 }


### PR DESCRIPTION
## Description

There's a new exception in production, `UnknownHostException.` This was because if the device was offline, our server call was failing, but we weren't catching the exception. 

As part of this I also moved the HTTP status code and header logic out of the `PodcastManagerImpl.kt` and into `RefreshServiceManagerImpl.kt` as it seems cleaner.

## Testing Instructions
1. Turn off WiFi and mobile data.
2. Follow a podcast.
3. Open the podcast page.
4. Pull down to update the podcast.
5. ✅  Verify the app doesn't crash.
6. ✅  Verify the update is happening by filtering the log by "Refresh podcast".

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack
