### PR TITLE
Remove `search_in_listening_history` feature flag

### DIFF
--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/ProfileEpisodeListViewModel.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/ProfileEpisodeListViewModel.kt
@@ -9,8 +9,6 @@ import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.podcasts.view.ProfileEpisodeListFragment.Mode
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
-import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
-import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
 import kotlin.coroutines.CoroutineContext
@@ -69,7 +67,6 @@ class ProfileEpisodeListViewModel @Inject constructor(
                 val searchQuery = searchQueryFlow.value
                 val results = if (searchQuery.isNotEmpty()) searchResults else episodeList
                 val showSearchBar = mode.showSearch &&
-                    FeatureFlag.isEnabled(Feature.SEARCH_IN_LISTENING_HISTORY) &&
                     (results.isNotEmpty() || searchQuery.isNotEmpty())
                 _state.value = if (results.isEmpty()) {
                     State.Empty(

--- a/modules/features/podcasts/src/test/java/au/com/shiftyjelly/pocketcasts/podcasts/view/ProfileEpisodeListViewModelTest.kt
+++ b/modules/features/podcasts/src/test/java/au/com/shiftyjelly/pocketcasts/podcasts/view/ProfileEpisodeListViewModelTest.kt
@@ -10,14 +10,11 @@ import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
 import au.com.shiftyjelly.pocketcasts.sharedtest.InMemoryFeatureFlagRule
 import au.com.shiftyjelly.pocketcasts.sharedtest.MainCoroutineRule
-import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
-import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.rx2.asFlowable
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
-import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.mockito.kotlin.any
@@ -45,11 +42,6 @@ class ProfileEpisodeListViewModelTest {
     private val listeningHistoryEpisodesMock = listOf(mock<PodcastEpisode>())
 
     private lateinit var viewModel: ProfileEpisodeListViewModel
-
-    @Before
-    fun setUp() {
-        FeatureFlag.setEnabled(Feature.SEARCH_IN_LISTENING_HISTORY, true)
-    }
 
     @Test
     fun `setup with Downloaded mode updates state with downloaded episodes`() = runTest {
@@ -98,30 +90,6 @@ class ProfileEpisodeListViewModelTest {
                     summaryRes = R.string.profile_empty_history_summary,
                 ),
             )
-        }
-    }
-
-    @Test
-    fun `search bar not shown for listening history when feature flag is false`() = runTest {
-        FeatureFlag.setEnabled(Feature.SEARCH_IN_LISTENING_HISTORY, false)
-        initViewModel()
-
-        viewModel.setup(Mode.History)
-
-        viewModel.state.test {
-            assertEquals(false, (awaitItem() as State.Loaded).showSearchBar)
-        }
-    }
-
-    @Test
-    fun `search bar is shown for listening history when feature flag is true`() = runTest {
-        FeatureFlag.setEnabled(Feature.SEARCH_IN_LISTENING_HISTORY, true)
-        initViewModel()
-
-        viewModel.setup(Mode.History)
-
-        viewModel.state.test {
-            assertEquals(true, (awaitItem() as State.Loaded).showSearchBar)
         }
     }
 

--- a/modules/features/podcasts/src/test/java/au/com/shiftyjelly/pocketcasts/podcasts/view/ProfileEpisodeListViewModelTest.kt
+++ b/modules/features/podcasts/src/test/java/au/com/shiftyjelly/pocketcasts/podcasts/view/ProfileEpisodeListViewModelTest.kt
@@ -8,7 +8,6 @@ import au.com.shiftyjelly.pocketcasts.podcasts.view.ProfileEpisodeListFragment.M
 import au.com.shiftyjelly.pocketcasts.podcasts.view.ProfileEpisodeListViewModel.State
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
-import au.com.shiftyjelly.pocketcasts.sharedtest.InMemoryFeatureFlagRule
 import au.com.shiftyjelly.pocketcasts.sharedtest.MainCoroutineRule
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.flowOf
@@ -29,9 +28,6 @@ import org.mockito.kotlin.whenever
 class ProfileEpisodeListViewModelTest {
     @get:Rule
     val coroutineRule = MainCoroutineRule()
-
-    @get:Rule
-    val featureFlagRule = InMemoryFeatureFlagRule()
 
     private val episodeManager: EpisodeManager = mock()
     private val playbackManager: PlaybackManager = mock()
@@ -90,6 +86,17 @@ class ProfileEpisodeListViewModelTest {
                     summaryRes = R.string.profile_empty_history_summary,
                 ),
             )
+        }
+    }
+
+    @Test
+    fun `search bar is shown for listening history`() = runTest {
+        initViewModel()
+
+        viewModel.setup(Mode.History)
+
+        viewModel.state.test {
+            assertEquals(true, (awaitItem() as State.Loaded).showSearchBar)
         }
     }
 

--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/Feature.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/Feature.kt
@@ -115,14 +115,6 @@ enum class Feature(
         hasFirebaseRemoteFlag = true,
         hasDevToggle = true,
     ),
-    SEARCH_IN_LISTENING_HISTORY(
-        key = "search_in_listening_history",
-        title = "Search in listening history",
-        defaultValue = true,
-        tier = FeatureTier.Free,
-        hasFirebaseRemoteFlag = true,
-        hasDevToggle = true,
-    ),
     AUTO_DOWNLOAD(
         key = "auto_download",
         title = "Auto download episodes after subscribing to a podcast",


### PR DESCRIPTION
## Description
This removes `search_in_listening_history` feature flag.

## Testing Instructions
Code review should be sufficient.

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
