### PR TITLE
Remove `custom_playback_settings` feature flag

### DIFF
--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/PlayerViewModel.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/PlayerViewModel.kt
@@ -43,8 +43,6 @@ import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.UserEpisodeManager
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import au.com.shiftyjelly.pocketcasts.utils.Util
-import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
-import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
 import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
 import com.jakewharton.rxrelay2.BehaviorRelay
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -675,13 +673,6 @@ class PlayerViewModel @Inject constructor(
         trackPlaybackEffectsEvent(AnalyticsEvent.PLAYBACK_EFFECT_SETTINGS_CHANGED)
     }
 
-    fun clearPodcastEffects(podcast: Podcast) {
-        launch {
-            podcastManager.updateOverrideGlobalEffectsBlocking(podcast, false)
-            playbackManager.updatePlayerEffects(settings.globalPlaybackEffects.value)
-        }
-    }
-
     fun clearUpNext(context: Context, upNextSource: UpNextSource): ClearUpNextDialog {
         val dialog = ClearUpNextDialog(
             source = upNextSource,
@@ -739,14 +730,12 @@ class PlayerViewModel @Inject constructor(
             event = event,
             props = buildMap {
                 putAll(properties)
-                if (FeatureFlag.isEnabled(Feature.CUSTOM_PLAYBACK_SETTINGS)) {
-                    val settings = if (effectsLive.value?.podcast?.overrideGlobalEffects == true) {
-                        PlaybackEffectsSettingsTab.ThisPodcast.analyticsValue
-                    } else {
-                        PlaybackEffectsSettingsTab.AllPodcasts.analyticsValue
-                    }
-                    put(AnalyticsProp.SETTINGS, settings)
+                val settings = if (effectsLive.value?.podcast?.overrideGlobalEffects == true) {
+                    PlaybackEffectsSettingsTab.ThisPodcast.analyticsValue
+                } else {
+                    PlaybackEffectsSettingsTab.AllPodcasts.analyticsValue
                 }
+                put(AnalyticsProp.SETTINGS, settings)
             },
             sourceView = SourceView.PLAYER_PLAYBACK_EFFECTS,
         )

--- a/modules/features/player/src/main/res/layout/fragment_effects.xml
+++ b/modules/features/player/src/main/res/layout/fragment_effects.xml
@@ -260,45 +260,6 @@
                 app:layout_constraintLeft_toLeftOf="@id/trimSilenceLabel"
                 app:layout_constraintTop_toBottomOf="@id/volumeLabel" />
 
-            <androidx.cardview.widget.CardView
-                android:id="@+id/globalEffectsCard"
-                android:layout_width="match_parent"
-                android:layout_height="64dp"
-                android:layout_marginStart="20dp"
-                android:layout_marginEnd="20dp"
-                android:layout_marginBottom="6dp"
-                android:layout_marginTop="6dp"
-                android:background="#181818"
-                android:elevation="2dp"
-                app:cardCornerRadius="16dp"
-                app:layout_constraintTop_toBottomOf="@id/detailVolumeLabel">
-
-                <ImageView
-                    android:id="@+id/podcastEffectsImage"
-                    android:layout_width="24dp"
-                    android:layout_height="24dp"
-                    android:layout_marginStart="20dp"
-                    android:importantForAccessibility="no"
-                    android:layout_gravity="center_vertical" />
-
-                <TextView
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_gravity="center_vertical"
-                    android:layout_marginStart="60dp"
-                    android:text="@string/player_effects_custom_effects_applied" />
-
-                <com.google.android.material.button.MaterialButton
-                    android:id="@+id/btnClear"
-                    style="@style/Widget.MaterialComponents.Button.TextButton"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_gravity="end|center_vertical"
-                    android:layout_marginEnd="16dp"
-                    android:text="@string/player_effects_clear"
-                    android:textColor="?attr/player_contrast_01" />
-
-            </androidx.cardview.widget.CardView>
         </androidx.constraintlayout.widget.ConstraintLayout>
     </androidx.core.widget.NestedScrollView>
 </FrameLayout>

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/PodcastEffectsViewModel.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/PodcastEffectsViewModel.kt
@@ -14,8 +14,6 @@ import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
 import au.com.shiftyjelly.pocketcasts.utils.Debouncer
 import au.com.shiftyjelly.pocketcasts.utils.extensions.roundedSpeed
-import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
-import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
 import dagger.hilt.android.lifecycle.HiltViewModel
 import io.reactivex.schedulers.Schedulers
 import javax.inject.Inject
@@ -116,9 +114,7 @@ class PodcastEffectsViewModel
             event = event,
             props = buildMap {
                 putAll(props)
-                if (FeatureFlag.isEnabled(Feature.CUSTOM_PLAYBACK_SETTINGS)) {
-                    put("settings", "local")
-                }
+                put("settings", "local")
             },
             sourceView = SourceView.PODCAST_SETTINGS,
         )

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -315,8 +315,6 @@
     <string name="player_chapters" translatable="false">@string/chapters</string>
     <string name="player_close">Close player</string>
     <string name="player_effects">Player effects</string>
-    <string name="player_effects_clear">CLEAR</string>
-    <string name="player_effects_custom_effects_applied">Custom effects applied</string>
     <string name="player_effects_speed">Speed</string>
     <string name="player_effects_speed_down">Speed Down</string>
     <string name="player_effects_speed_up">Speed Up</string>

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/SubscribeManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/SubscribeManager.kt
@@ -187,12 +187,10 @@ class SubscribeManager @Inject constructor(
                 podcast.isSubscribed = subscribed
                 podcast.grouping = settings.podcastGroupingDefault.value
                 podcast.showArchived = settings.showArchivedDefault.value
-                if (FeatureFlag.isEnabled(Feature.CUSTOM_PLAYBACK_SETTINGS)) {
-                    podcastDao.findByUuidBlocking(podcastUuid)?.let { localPodcast ->
-                        podcast.copyPlaybackEffects(
-                            sourcePodcast = localPodcast,
-                        )
-                    }
+                podcastDao.findByUuidBlocking(podcastUuid)?.let { localPodcast ->
+                    podcast.copyPlaybackEffects(
+                        sourcePodcast = localPodcast,
+                    )
                 }
                 if (canDownloadEpisodesAfterFollowPodcast(subscribed, shouldAutoDownload)) {
                     LogBuffer.i(LogBuffer.TAG_BACKGROUND_TASKS, "Update auto download status for $podcastUuid")

--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/Feature.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/Feature.kt
@@ -139,14 +139,6 @@ enum class Feature(
         hasFirebaseRemoteFlag = true,
         hasDevToggle = true,
     ),
-    CUSTOM_PLAYBACK_SETTINGS(
-        key = "custom_playback_settings",
-        title = "Custom playback settings",
-        defaultValue = BuildConfig.DEBUG,
-        tier = FeatureTier.Free,
-        hasFirebaseRemoteFlag = true,
-        hasDevToggle = true,
-    ),
     MANAGE_DOWNLOADED_EPISODES(
         key = "manage_downloaded_episodes",
         title = "Manage Downloaded Episodes",


### PR DESCRIPTION
## Description
This removes `custom_playback_settings` feature flag.

## Testing Instructions
Code review should be sufficient.

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
