### PR TITLE
Update suggested folder analytics values

### DIFF
--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/folders/SuggestedFoldersFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/folders/SuggestedFoldersFragment.kt
@@ -166,7 +166,7 @@ class SuggestedFoldersFragment : BaseDialogFragment() {
         if (isDismissingWithoutAction()) {
             viewModel.trackPageDismissed()
 
-            if (args.source == Source.PodcastsPopup) {
+            if (args.source == Source.Popup) {
                 viewModel.markPopupAsDismissed()
             }
         }
@@ -226,11 +226,11 @@ class SuggestedFoldersFragment : BaseDialogFragment() {
     enum class Source(
         val analyticsValue: String,
     ) {
-        PodcastsPopup(
-            analyticsValue = "podcasts",
+        Popup(
+            analyticsValue = "popup",
         ),
-        CreateFolderButton(
-            analyticsValue = "create_folder",
+        ToolbarButton(
+            analyticsValue = "podcasts",
         ),
     }
 

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcasts/PodcastsFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcasts/PodcastsFragment.kt
@@ -218,7 +218,7 @@ class PodcastsFragment :
                     }
 
                     is SuggestedFoldersState.Available -> {
-                        showSuggestedFoldersCreation(SuggestedFoldersFragment.Source.CreateFolderButton)
+                        showSuggestedFoldersCreation(SuggestedFoldersFragment.Source.ToolbarButton)
                     }
                 }
             } else {
@@ -259,7 +259,7 @@ class PodcastsFragment :
                     when (state) {
                         is SuggestedFoldersState.Available -> {
                             if (FeatureFlag.isEnabled(Feature.SUGGESTED_FOLDERS) && viewModel.isEligibleForSuggestedFoldersPopup()) {
-                                showSuggestedFoldersCreation(SuggestedFoldersFragment.Source.PodcastsPopup)
+                                showSuggestedFoldersCreation(SuggestedFoldersFragment.Source.Popup)
                             }
                         }
 
@@ -348,7 +348,7 @@ class PodcastsFragment :
 
             is SuggestedFoldersState.Available -> {
                 if (FeatureFlag.isEnabled(Feature.SUGGESTED_FOLDERS)) {
-                    showSuggestedFoldersCreation(SuggestedFoldersFragment.Source.CreateFolderButton)
+                    showSuggestedFoldersCreation(SuggestedFoldersFragment.Source.ToolbarButton)
                 } else {
                     showCustomFolderCreation()
                 }


### PR DESCRIPTION
## Description

This is an update to the source analytics value.

Context: p1741259654419099/1741184037.466609-slack-C08BRS7N9UL

## Testing Instructions

1. Open the app as unsigned user.
2. Follow at least 8 podcasts.
3. Go to podcasts page.
4. You should see in the logs: `🔵 Tracked: suggested_folders_page_shown, Properties: {"source":"popup"`
5. Dismiss the page.
6. Tap on the folder icon in the toolbar.
7. You should see `🔵 Tracked: suggested_folders_page_shown, Properties: {"source":"podcasts"`

## Checklist
- [ ] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] ~I have considered whether it makes sense to add tests for my changes~
- [ ] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [ ] ~Any jetpack compose components I added or changed are covered by compose previews~
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.