### PR TITLE
Remove `deselect_chapter` feature flag and patron exclusive tier criteria

### DIFF
--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/OnboardingFlowComposable.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/OnboardingFlowComposable.kt
@@ -247,7 +247,6 @@ private fun Content(
                 OnboardingUpgradeSource.SKIP_CHAPTERS,
                 OnboardingUpgradeSource.SETTINGS,
                 OnboardingUpgradeSource.SLUMBER_STUDIOS,
-                OnboardingUpgradeSource.WHATS_NEW_SKIP_CHAPTERS,
                 OnboardingUpgradeSource.UP_NEXT_SHUFFLE,
                 OnboardingUpgradeSource.UNKNOWN,
                 -> false

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/UpgradeFeatureCard.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/UpgradeFeatureCard.kt
@@ -8,7 +8,6 @@ import au.com.shiftyjelly.pocketcasts.models.type.SubscriptionFrequency
 import au.com.shiftyjelly.pocketcasts.models.type.SubscriptionTier
 import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingUpgradeSource
 import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
-import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
 import au.com.shiftyjelly.pocketcasts.images.R as IR
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
@@ -40,7 +39,6 @@ sealed class UpgradeFeatureCard(
         ) = when {
             (
                 source in listOf(OnboardingUpgradeSource.SKIP_CHAPTERS, OnboardingUpgradeSource.WHATS_NEW_SKIP_CHAPTERS) &&
-                    FeatureFlag.isEnabled(Feature.DESELECT_CHAPTERS) &&
                     SubscriptionTier.fromFeatureTier(Feature.DESELECT_CHAPTERS) == SubscriptionTier.PLUS
                 )
             -> LR.string.skip_chapters_plus_prompt
@@ -82,7 +80,6 @@ sealed class UpgradeFeatureCard(
         ) = when {
             (
                 source in listOf(OnboardingUpgradeSource.SKIP_CHAPTERS, OnboardingUpgradeSource.WHATS_NEW_SKIP_CHAPTERS) &&
-                    FeatureFlag.isEnabled(Feature.DESELECT_CHAPTERS) &&
                     SubscriptionTier.fromFeatureTier(Feature.DESELECT_CHAPTERS) == SubscriptionTier.PATRON
                 )
             -> LR.string.skip_chapters_patron_prompt

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/UpgradeFeatureCard.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/UpgradeFeatureCard.kt
@@ -38,8 +38,7 @@ sealed class UpgradeFeatureCard(
             source: OnboardingUpgradeSource,
         ) = when {
             (
-                source in listOf(OnboardingUpgradeSource.SKIP_CHAPTERS, OnboardingUpgradeSource.WHATS_NEW_SKIP_CHAPTERS) &&
-                    SubscriptionTier.fromFeatureTier(Feature.DESELECT_CHAPTERS) == SubscriptionTier.PLUS
+                source in listOf(OnboardingUpgradeSource.SKIP_CHAPTERS, OnboardingUpgradeSource.WHATS_NEW_SKIP_CHAPTERS)
                 )
             -> LR.string.skip_chapters_plus_prompt
 
@@ -73,19 +72,7 @@ sealed class UpgradeFeatureCard(
         },
         subscriptionTier = SubscriptionTier.PATRON,
     ) {
-        override val titleRes: (OnboardingUpgradeSource) -> Int = { source -> getTitleForSource(source) }
-
-        private fun getTitleForSource(
-            source: OnboardingUpgradeSource,
-        ) = when {
-            (
-                source in listOf(OnboardingUpgradeSource.SKIP_CHAPTERS, OnboardingUpgradeSource.WHATS_NEW_SKIP_CHAPTERS) &&
-                    SubscriptionTier.fromFeatureTier(Feature.DESELECT_CHAPTERS) == SubscriptionTier.PATRON
-                )
-            -> LR.string.skip_chapters_patron_prompt
-
-            else -> LR.string.onboarding_patron_features_title
-        }
+        override val titleRes: (OnboardingUpgradeSource) -> Int = { _ -> LR.string.onboarding_patron_features_title }
     }
 }
 

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/UpgradeFeatureCard.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/UpgradeFeatureCard.kt
@@ -37,10 +37,8 @@ sealed class UpgradeFeatureCard(
         private fun getTitleForSource(
             source: OnboardingUpgradeSource,
         ) = when {
-            (
-                source in listOf(OnboardingUpgradeSource.SKIP_CHAPTERS, OnboardingUpgradeSource.WHATS_NEW_SKIP_CHAPTERS)
-                )
-            -> LR.string.skip_chapters_plus_prompt
+            source == OnboardingUpgradeSource.SKIP_CHAPTERS
+                -> LR.string.skip_chapters_plus_prompt
 
             source == OnboardingUpgradeSource.UP_NEXT_SHUFFLE &&
                 SubscriptionTier.fromFeatureTier(Feature.UP_NEXT_SHUFFLE) == SubscriptionTier.PLUS

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/UpgradeFeatureCard.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/UpgradeFeatureCard.kt
@@ -38,7 +38,7 @@ sealed class UpgradeFeatureCard(
             source: OnboardingUpgradeSource,
         ) = when {
             source == OnboardingUpgradeSource.SKIP_CHAPTERS
-                -> LR.string.skip_chapters_plus_prompt
+            -> LR.string.skip_chapters_plus_prompt
 
             source == OnboardingUpgradeSource.UP_NEXT_SHUFFLE &&
                 SubscriptionTier.fromFeatureTier(Feature.UP_NEXT_SHUFFLE) == SubscriptionTier.PLUS

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/UpgradeFeatureItem.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/UpgradeFeatureItem.kt
@@ -44,10 +44,8 @@ enum class PlusUpgradeFeatureItem(
     SkipChapters(
         image = IR.drawable.ic_plus_feature_chapters,
         title = LR.string.onboarding_plus_feature_chapters_title,
-        isYearlyFeature = FeatureFlag.isEnabled(Feature.DESELECT_CHAPTERS) &&
-            SubscriptionTier.fromFeatureTier(Feature.DESELECT_CHAPTERS) == SubscriptionTier.PLUS,
-        isMonthlyFeature = FeatureFlag.isEnabled(Feature.DESELECT_CHAPTERS) &&
-            SubscriptionTier.fromFeatureTier(Feature.DESELECT_CHAPTERS) == SubscriptionTier.PLUS,
+        isYearlyFeature = SubscriptionTier.fromFeatureTier(Feature.DESELECT_CHAPTERS) == SubscriptionTier.PLUS,
+        isMonthlyFeature = SubscriptionTier.fromFeatureTier(Feature.DESELECT_CHAPTERS) == SubscriptionTier.PLUS,
     ),
     CloudStorage(
         image = IR.drawable.ic_plus_feature_cloud_storage,

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/UpgradeFeatureItem.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/UpgradeFeatureItem.kt
@@ -2,7 +2,6 @@ package au.com.shiftyjelly.pocketcasts.account.onboarding.upgrade
 
 import androidx.annotation.DrawableRes
 import androidx.annotation.StringRes
-import au.com.shiftyjelly.pocketcasts.models.type.SubscriptionTier
 import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
 import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
 import au.com.shiftyjelly.pocketcasts.images.R as IR
@@ -44,8 +43,6 @@ enum class PlusUpgradeFeatureItem(
     SkipChapters(
         image = IR.drawable.ic_plus_feature_chapters,
         title = LR.string.onboarding_plus_feature_chapters_title,
-        isYearlyFeature = SubscriptionTier.fromFeatureTier(Feature.DESELECT_CHAPTERS) == SubscriptionTier.PLUS,
-        isMonthlyFeature = SubscriptionTier.fromFeatureTier(Feature.DESELECT_CHAPTERS) == SubscriptionTier.PLUS,
     ),
     CloudStorage(
         image = IR.drawable.ic_plus_feature_cloud_storage,

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/chapters/ChaptersFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/chapters/ChaptersFragment.kt
@@ -17,7 +17,6 @@ import androidx.core.net.toUri
 import androidx.core.os.BundleCompat
 import androidx.core.os.bundleOf
 import androidx.fragment.app.viewModels
-import androidx.fragment.compose.content
 import au.com.shiftyjelly.pocketcasts.compose.AppThemeWithBackground
 import au.com.shiftyjelly.pocketcasts.compose.extensions.contentWithoutConsumedInsets
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
@@ -29,8 +28,6 @@ import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingFlow
 import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingLauncher
 import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingUpgradeSource
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
-import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
-import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureTier
 import au.com.shiftyjelly.pocketcasts.views.fragments.BaseFragment
 import au.com.shiftyjelly.pocketcasts.views.helper.UiUtil
 import dagger.hilt.android.AndroidEntryPoint
@@ -126,7 +123,6 @@ class ChaptersFragment : BaseFragment() {
         val source = OnboardingUpgradeSource.SKIP_CHAPTERS
         val onboardingFlow = OnboardingFlow.Upsell(
             source = source,
-            showPatronOnly = Feature.DESELECT_CHAPTERS.tier == FeatureTier.Patron || Feature.DESELECT_CHAPTERS.isCurrentlyExclusiveToPatron(),
         )
         OnboardingLauncher.openOnboardingFlow(requireActivity(), onboardingFlow)
     }

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/chapters/ChaptersViewModel.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/chapters/ChaptersViewModel.kt
@@ -17,7 +17,6 @@ import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackState
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.ChapterManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
 import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
-import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
 import au.com.shiftyjelly.pocketcasts.utils.featureflag.UserTier
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
@@ -169,7 +168,7 @@ class ChaptersViewModel @AssistedInject constructor(
         allChapters = chapters.toChapterStates(playbackPosition(playbackState, episode)),
         isTogglingChapters = isToggling,
         canSkipChapters = subscriptionStatus.canSkipChapters(),
-        showHeader = FeatureFlag.isEnabled(Feature.DESELECT_CHAPTERS) && episode is PodcastEpisode,
+        showHeader = episode is PodcastEpisode,
     )
 
     private fun playbackPosition(playbackState: PlaybackState, episode: BaseEpisode) = when (mode) {
@@ -191,7 +190,7 @@ class ChaptersViewModel @AssistedInject constructor(
         }
     }
 
-    private fun SubscriptionStatus?.canSkipChapters() = FeatureFlag.isEnabled(Feature.DESELECT_CHAPTERS) &&
+    private fun SubscriptionStatus?.canSkipChapters() =
         Feature.isUserEntitled(Feature.DESELECT_CHAPTERS, toUserTier())
 
     private fun SubscriptionStatus?.toUserTier() = (this as? SubscriptionStatus.Paid)?.tier?.toUserTier() ?: UserTier.Free

--- a/modules/features/player/src/test/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/ChaptersViewModelTest.kt
+++ b/modules/features/player/src/test/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/ChaptersViewModelTest.kt
@@ -18,7 +18,6 @@ import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackState
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.ChapterManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
-import au.com.shiftyjelly.pocketcasts.sharedtest.InMemoryFeatureFlagRule
 import au.com.shiftyjelly.pocketcasts.sharedtest.MainCoroutineRule
 import java.util.Date
 import kotlin.time.Duration.Companion.milliseconds
@@ -47,9 +46,6 @@ class ChaptersViewModelTest {
 
     @get:Rule
     val coroutineRule = MainCoroutineRule(testDispatcher)
-
-    @get:Rule
-    val featureFlagRule = InMemoryFeatureFlagRule()
 
     private val chapterManager = mock<ChapterManager>()
     private val playbackManager = mock<PlaybackManager>()

--- a/modules/features/player/src/test/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/ChaptersViewModelTest.kt
+++ b/modules/features/player/src/test/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/ChaptersViewModelTest.kt
@@ -20,8 +20,6 @@ import au.com.shiftyjelly.pocketcasts.repositories.podcast.ChapterManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
 import au.com.shiftyjelly.pocketcasts.sharedtest.InMemoryFeatureFlagRule
 import au.com.shiftyjelly.pocketcasts.sharedtest.MainCoroutineRule
-import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
-import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
 import java.util.Date
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
@@ -92,8 +90,6 @@ class ChaptersViewModelTest {
         whenever(userSetting.flow).thenReturn(subscriptionStatusFlow)
         whenever(settings.cachedSubscriptionStatus).thenReturn(userSetting)
 
-        FeatureFlag.setEnabled(Feature.DESELECT_CHAPTERS, true)
-
         chaptersViewModel = ChaptersViewModel(
             Mode.Episode(episode.uuid),
             chapterManager,
@@ -109,15 +105,6 @@ class ChaptersViewModelTest {
     fun `paid user can skip chapters`() = runTest {
         chaptersViewModel.uiState.test {
             assertTrue(awaitItem().canSkipChapters)
-        }
-    }
-
-    @Test
-    fun `paid user cant skip chapters if feature is disabled`() = runTest {
-        FeatureFlag.setEnabled(Feature.DESELECT_CHAPTERS, false)
-
-        chaptersViewModel.uiState.test {
-            assertFalse(awaitItem().canSkipChapters)
         }
     }
 
@@ -156,15 +143,6 @@ class ChaptersViewModelTest {
     fun `show header for podcast episode`() = runTest {
         chaptersViewModel.uiState.test {
             assertTrue(awaitItem().showHeader)
-        }
-    }
-
-    @Test
-    fun `do not show header when feature is disabled`() = runTest {
-        FeatureFlag.setEnabled(Feature.DESELECT_CHAPTERS, false)
-
-        chaptersViewModel.uiState.test {
-            assertFalse(awaitItem().showHeader)
         }
     }
 

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/onboarding/OnboardingUpgradeSource.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/onboarding/OnboardingUpgradeSource.kt
@@ -22,7 +22,6 @@ enum class OnboardingUpgradeSource(val analyticsValue: String) {
     SKIP_CHAPTERS("skip_chapters"),
     SETTINGS("settings"),
     SLUMBER_STUDIOS("slumber_studios"),
-    WHATS_NEW_SKIP_CHAPTERS("what_new_skip_chapters"),
     UP_NEXT_SHUFFLE("up_next_shuffle"),
     UNKNOWN("unknown"),
 }

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/whatsnew/WhatsNewFragment.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/whatsnew/WhatsNewFragment.kt
@@ -22,7 +22,6 @@ import au.com.shiftyjelly.pocketcasts.settings.whatsnew.WhatsNewViewModel.Naviga
 import au.com.shiftyjelly.pocketcasts.ui.helper.FragmentHostListener
 import au.com.shiftyjelly.pocketcasts.ui.helper.StatusBarIconColor
 import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
-import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
 import au.com.shiftyjelly.pocketcasts.views.fragments.BaseFragment
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
@@ -100,7 +99,7 @@ class WhatsNewFragment : BaseFragment() {
         val onboardingFlow = OnboardingFlow.Upsell(
             source = source,
             showPatronOnly = when (source) {
-                OnboardingUpgradeSource.WHATS_NEW_SKIP_CHAPTERS -> FeatureFlag.isEnabled(Feature.DESELECT_CHAPTERS) &&
+                OnboardingUpgradeSource.WHATS_NEW_SKIP_CHAPTERS ->
                     SubscriptionTier.fromFeatureTier(Feature.DESELECT_CHAPTERS) == SubscriptionTier.PATRON
 
                 else -> false

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/whatsnew/WhatsNewFragment.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/whatsnew/WhatsNewFragment.kt
@@ -13,7 +13,6 @@ import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTracker
 import au.com.shiftyjelly.pocketcasts.compose.AppTheme
 import au.com.shiftyjelly.pocketcasts.compose.CallOnce
 import au.com.shiftyjelly.pocketcasts.compose.extensions.contentWithoutConsumedInsets
-import au.com.shiftyjelly.pocketcasts.models.type.SubscriptionTier
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingFlow
 import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingLauncher
@@ -21,7 +20,6 @@ import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingUpgradeSourc
 import au.com.shiftyjelly.pocketcasts.settings.whatsnew.WhatsNewViewModel.NavigationState
 import au.com.shiftyjelly.pocketcasts.ui.helper.FragmentHostListener
 import au.com.shiftyjelly.pocketcasts.ui.helper.StatusBarIconColor
-import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
 import au.com.shiftyjelly.pocketcasts.views.fragments.BaseFragment
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
@@ -98,12 +96,6 @@ class WhatsNewFragment : BaseFragment() {
     private fun startUpsellFlow(source: OnboardingUpgradeSource) {
         val onboardingFlow = OnboardingFlow.Upsell(
             source = source,
-            showPatronOnly = when (source) {
-                OnboardingUpgradeSource.WHATS_NEW_SKIP_CHAPTERS ->
-                    SubscriptionTier.fromFeatureTier(Feature.DESELECT_CHAPTERS) == SubscriptionTier.PATRON
-
-                else -> false
-            },
         )
         OnboardingLauncher.openOnboardingFlow(activity, onboardingFlow)
     }

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -422,7 +422,6 @@
     <string name="number_of_chapters_summary_plural">%1$d chapters &#x2022; %2$d hidden</string>
     <string name="number_of_chapters_summary_singular">1 chapter &#x2022; %d hidden</string>
     <string name="skip_chapters_plus_prompt">Preselect chapters and more with Pocket Casts Plus</string>
-    <string name="skip_chapters_patron_prompt">Preselect chapters and more with Pocket Casts Patron</string>
     <!-- %1$d is the current selected chapter. %2$d is the total number of chapters. -->
     <string name="chapter_count_summary">%1$d of %2$d</string>
     <plurals name="chapter">

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/to/Chapters.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/to/Chapters.kt
@@ -1,7 +1,5 @@
 package au.com.shiftyjelly.pocketcasts.models.to
 
-import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
-import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
 import kotlin.time.Duration
 
 data class Chapters(
@@ -12,7 +10,7 @@ data class Chapters(
 
     fun getNextSelectedChapter(time: Duration): Chapter? {
         val currentTimeFinal = time.coerceAtLeast(Duration.ZERO)
-        val items = if (FeatureFlag.isEnabled(Feature.DESELECT_CHAPTERS)) selectedItems else items
+        val items = selectedItems
         for (chapter in items) {
             if (chapter.startTime > currentTimeFinal) {
                 return chapter
@@ -27,7 +25,7 @@ data class Chapters(
         }
         var foundChapter: Chapter? = null
         var lastChapter: Chapter? = null
-        val items = if (FeatureFlag.isEnabled(Feature.DESELECT_CHAPTERS)) selectedItems else items
+        val items = selectedItems
         for (chapter in items) {
             if (time in chapter) {
                 if (foundChapter != null) {
@@ -67,19 +65,15 @@ data class Chapters(
     }
 
     fun skippedChaptersDuration(time: Duration): Duration {
-        return if (FeatureFlag.isEnabled(Feature.DESELECT_CHAPTERS)) {
-            items
-                .filter { !it.selected && it.endTime > time }
-                .fold(Duration.ZERO) { duration, chapter ->
-                    duration + if (time in chapter) {
-                        chapter.endTime - time
-                    } else {
-                        chapter.duration
-                    }
+        return items
+            .filter { !it.selected && it.endTime > time }
+            .fold(Duration.ZERO) { duration, chapter ->
+                duration + if (time in chapter) {
+                    chapter.endTime - time
+                } else {
+                    chapter.duration
                 }
-        } else {
-            Duration.ZERO
-        }
+            }
     }
 }
 

--- a/modules/services/model/src/test/java/au/com/shiftyjelly/pocketcasts/models/to/ChaptersTest.kt
+++ b/modules/services/model/src/test/java/au/com/shiftyjelly/pocketcasts/models/to/ChaptersTest.kt
@@ -1,21 +1,12 @@
 package au.com.shiftyjelly.pocketcasts.models.to
 
-import au.com.shiftyjelly.pocketcasts.sharedtest.InMemoryFeatureFlagRule
-import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
-import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
-import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
 import org.junit.Assert.assertEquals
-import org.junit.Rule
 import org.junit.Test
 
 class ChaptersTest {
-    @get:Rule
-    val featureFlagRule = InMemoryFeatureFlagRule()
-
     @Test
-    fun `given feature flag true, then next chapter returned from selected chapters`() {
-        FeatureFlag.setEnabled(Feature.DESELECT_CHAPTERS, true)
+    fun `next chapter returned correctly from selected chapters`() {
         val chapters = initChapters()
 
         val chapter = chapters.getNextSelectedChapter(150.milliseconds)
@@ -24,8 +15,7 @@ class ChaptersTest {
     }
 
     @Test
-    fun `given feature flag true, then prev chapter returned from selected chapters`() {
-        FeatureFlag.setEnabled(Feature.DESELECT_CHAPTERS, true)
+    fun `prev chapter returned correctly from selected chapters`() {
         val chapters = initChapters()
 
         val chapter = chapters.getPreviousSelectedChapter(350.milliseconds)
@@ -34,41 +24,12 @@ class ChaptersTest {
     }
 
     @Test
-    fun `given feature flag false, then next chapter returned from all chapters`() {
-        FeatureFlag.setEnabled(Feature.DESELECT_CHAPTERS, false)
-        val chapters = initChapters()
-
-        val chapter = chapters.getNextSelectedChapter(150.milliseconds)
-
-        assert(chapter?.title == "3")
-    }
-
-    @Test
-    fun `given feature flag false, then prev chapter returned from all chapters`() {
-        FeatureFlag.setEnabled(Feature.DESELECT_CHAPTERS, false)
-        val chapters = initChapters()
-
-        val chapter = chapters.getPreviousSelectedChapter(350.milliseconds)
-
-        assert(chapter?.title == "3")
-    }
-
-    @Test
-    fun `given feature flag true, then calculate skipped chapters duration`() {
-        FeatureFlag.setEnabled(Feature.DESELECT_CHAPTERS, true)
+    fun `skipped chapters duration calculated correctly`() {
         val chapters = initChapters()
 
         assertEquals(300.milliseconds, chapters.skippedChaptersDuration(0.milliseconds))
         assertEquals(100.milliseconds, chapters.skippedChaptersDuration(301.milliseconds))
         assertEquals(150.milliseconds, chapters.skippedChaptersDuration(251.milliseconds))
-    }
-
-    @Test
-    fun `given feature flag false, then do not calculate skipped chapters duration`() {
-        FeatureFlag.setEnabled(Feature.DESELECT_CHAPTERS, false)
-        val chapters = initChapters()
-
-        assertEquals(Duration.ZERO, chapters.skippedChaptersDuration(0.milliseconds))
     }
 
     private fun initChapters(): Chapters {

--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/Feature.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/Feature.kt
@@ -47,7 +47,7 @@ enum class Feature(
         key = "deselect_chapters_enabled",
         title = "Deselect Chapters",
         defaultValue = true,
-        tier = FeatureTier.Plus(ReleaseVersion(7, 60)),
+        tier = FeatureTier.Plus(patronExclusiveAccessRelease = null),
         hasFirebaseRemoteFlag = true,
         hasDevToggle = true,
     ),


### PR DESCRIPTION
## Description
This removes `deselect_chapter` feature flag and patron exclusive tier criteria as the feature is available to all Plus users.

## Testing Instructions
1. Launch the app without login or with a free account
2. Play an episode with chapters (e.g. episode for podcast `Upgrade`)
3. Go to `Chapters` tab
4. Notice upsell for `Preselect chapters` (for Plus)  
5. Tap upsell for `Preselect chapters`
6. Notice that the feature is listed under `Plus` plan and the title is "Preselect chapters and more with Pocket Casts"
7. Repeat steps 2-3 with a paid account (Plus or Patron)
8. Notice that you can preselect chapters properly.

## Screenshots or Screencast 
Chapters| Upsell
---|----
<img width=320 src="https://github.com/user-attachments/assets/19d0fd39-af93-4110-957d-2cf990acdec5"/>|<img width=320 src="https://github.com/user-attachments/assets/e6c6c7b2-6a62-49c6-8ac5-c3e3e83fafed"/>


## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [ ] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
