### PR TITLE
Do not resume playback when skipping back with a headset action

### DIFF
--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/MediaSessionManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/MediaSessionManager.kt
@@ -607,9 +607,6 @@ class MediaSessionManager(
                 }
                 HeadphoneAction.SKIP_BACK -> {
                     onSkipToPrevious()
-                    if (!playbackManager.isPlaying()) {
-                        enqueueCommand("play") { playbackManager.playQueueSuspend(source) }
-                    }
                 }
                 HeadphoneAction.NEXT_CHAPTER,
                 HeadphoneAction.PREVIOUS_CHAPTER,


### PR DESCRIPTION
## Description

This PR makes headset back action not resume playback. In general it was inconsistent in the past between different headsets. Now that we have better control over headset actions, skipping back and not resuming playback while it's paused sounds like a more logical option.

Context: p1741274210042099-slack-C05RR9P9RAT

## Testing Instructions

1. Connect headset that can trigger skip back or skip forward actions.
2. Play something and scroll to the middle.
3. Pause playback.
4. Skip back using the headset.
5. Playback should skip back but not resume.
6. Skip forward using the headset.
7. Playback should skip forward and resume.

## Checklist
- [ ] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] ~I have considered whether it makes sense to add tests for my changes~
- [ ] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [ ] ~Any jetpack compose components I added or changed are covered by compose previews~
- [ ] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~