### PR TITLE
[AndroidManifest] Reveal Manifest Changes in PR

### DIFF
--- a/.buildkite/commands/diff-merged-manifest.sh
+++ b/.buildkite/commands/diff-merged-manifest.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+set -euo pipefail
+
+"$(dirname "${BASH_SOURCE[0]}")/restore-cache.sh"
+
+BUILD_VARIANT=$1
+
+echo "--- :rubygems: Setting up Gems"
+install_gems
+
+echo "--- :closed_lock_with_key: Installing Secrets"
+bundle exec fastlane run configure_apply
+
+echo "--- 💾 Diff Merged Manifest (Module: app, Build Variant: ${BUILD_VARIANT})"
+comment_with_manifest_diff "app" ${BUILD_VARIANT}
+
+echo "--- 💾 Diff Merged Manifest (Module: wear, Build Variant: ${BUILD_VARIANT})"
+comment_with_manifest_diff "wear" ${BUILD_VARIANT}
+
+echo "--- 💾 Diff Merged Manifest (Module: automotive, Build Variant: ${BUILD_VARIANT})"
+comment_with_manifest_diff "automotive" ${BUILD_VARIANT}

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -35,12 +35,14 @@ steps:
     command: ".buildkite/commands/run-unit-tests.sh"
     plugins: [$CI_TOOLKIT]
 
-  - label: 'Dependency diff'
-    if: build.pull_request.id != null
-    command: comment_with_dependency_diff 'app' 'releaseRuntimeClasspath'
-    plugins: [$CI_TOOLKIT]
-    artifact_paths:
-      - "**/build/reports/diff/*"
+  - group: "Diff Reports"
+    steps:
+      - label: 'Dependency diff'
+        if: build.pull_request.id != null
+        command: comment_with_dependency_diff 'app' 'releaseRuntimeClasspath'
+        plugins: [$CI_TOOLKIT]
+        artifact_paths:
+          - "**/build/reports/diff/*"
 
   - label: 'Spotless formatting check'
     command: |

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -44,6 +44,13 @@ steps:
         artifact_paths:
           - "**/build/reports/diff/*"
 
+      - label: "Merged Manifest Diff"
+        command: ".buildkite/commands/diff-merged-manifest.sh release"
+        if: build.pull_request.id != null
+        plugins: [$CI_TOOLKIT]
+        artifact_paths:
+          - "**/build/reports/diff_manifest/**/**/*"
+
   - label: 'Spotless formatting check'
     command: |
       echo "--- 🔎 Checking formatting with Spotless"

--- a/.buildkite/shared-pipeline-vars
+++ b/.buildkite/shared-pipeline-vars
@@ -3,4 +3,4 @@
 # This file is `source`'d before calling `buildkite-agent pipeline upload`, and can be used
 # to set up some variables that will be interpolated in the `.yml` pipeline before uploading it.
 
-export CI_TOOLKIT="automattic/a8c-ci-toolkit#3.10.1"
+export CI_TOOLKIT="automattic/a8c-ci-toolkit#5.1.2"


### PR DESCRIPTION
Project Thread: paaHJt-7Tl-p2
Tested By: #3731

---

## Description
<!-- Please include a summary of what this PR is changing and why these changes are needed. -->

This PR introduces the `Merged Manifest Diff` CI job that is aiming to help revealing merged manifest changes a PR might introduce.

The main problem this script is trying to address is the fact that:
1. Although explicit `AndroidManifest.xml` changes are visible on a PR review, just by looking at the `Files changed` tab for that specific change, this doesn't necessarily mean that the actual, auto-generated, merged `AndroidManifest.xml` file should have the same amount of changes.
2. Sometimes, implicit `AndroidManifest.xml` changes can occur (think new/updated dependency). Those changes are actually invisible for both, to the author and reviewer of that specific PR.

For more info on the technical/workflow side of things see: p1740739725150069/1740493471.859349-slack-C030U03RC8Y

---

### Review

@MiSikora I am adding you as an additional reviewer to @wzieba just so that at least one product engineer is aware of this new CI workflow and CI check. I hope this will, through you, give a decent heads-up to other product engineers as well.

FYI: At a later point of time a formal announcement will be posted.

---

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Tap on the Filters tab -->
<!-- 2. Tap on a filter -->
<!-- 3. etc. -->

You could check the associated test PR (#3731) and see when and how such comments might appear ([here](https://github.com/Automattic/pocket-casts-android/pull/3731#issuecomment-2704349009), [here](https://github.com/Automattic/pocket-casts-android/pull/3731#issuecomment-2704350729) and [here](https://github.com/Automattic/pocket-casts-android/pull/3731#issuecomment-2704352031)):

![image](https://github.com/user-attachments/assets/40a8e52c-9a7a-407e-938b-6efaefc8285c)

FYI: The above test comment appeared due to an implicit `AndroidManifest.xml` change, adding the [singular](https://support.singular.net/hc/en-us/articles/360037581952-Android-SDK-Integration-Guide) dependency to the project. It would have been impossible for an engineer to know how the merged `AndroidManifest.xml` file got updated without doing such a check manually.

---

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes... `N/A`
<!-- If this PR does not contain UI changes, ignore these items -->