### PR TITLE
[Deps] Group Kotlin & KSP Dependabot Updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,6 +20,14 @@ updates:
     labels:
       - "[Type] Tech Debt"
       - "[Area] Dependencies"
+    groups:
+      kotlin-ksp:
+        applies-to: version-updates
+        patterns:
+          - "org.jetbrains.kotlin*"
+          - "com.google.devtools.ksp*"
+        exclude-patterns:
+          - "org.jetbrains.kotlinx*"
     ignore:
       # Automattic libraries have a custom versioning scheme which doesn't work with Dependabot.
       - dependency-name: "com.automattic:Automattic-Tracks-Android"
@@ -45,5 +53,3 @@ updates:
       - dependency-name: "androidx.wear.compose:compose-foundation"
       - dependency-name: "androidx.wear.compose:compose-material"
       - dependency-name: "androidx.wear.compose:compose-navigation"
-      # Ignore KSP as it needs to be updated together with Kotlin
-      - dependency-name: "com.google.devtools.ksp"


### PR DESCRIPTION
## Description
<!-- Please include a summary of what this PR is changing and why these changes are needed. -->

With this configuration Dependabot (:dependabot:) should update both, the `Kotlin` and `KSP` related dependencies in one go, on a single Dependabot related PR.

FYI: Using the `applies-to key` is optional. If the `applies-to key` is absent from a set of grouping rules, it defaults to `version-updates` for backwards compatibility. I chose to use `applies-to` in order to be explicit about this and avoid any confusion related to the defaults.

For more info see: [Configuration options for the dependabot.yml file -> groups](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#groups)

---

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Tap on the Filters tab -->
<!-- 2. Tap on a filter -->
<!-- 3. etc. -->

FYI: The very same configuration was already tested on [JP/WPAndroid](https://github.com/wordpress-mobile/WordPress-Android) and works as expected ([Config PR](https://github.com/wordpress-mobile/WordPress-Android/pull/21514) -> [Dependabot PR](https://github.com/wordpress-mobile/WordPress-Android/pull/21723)).

---

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes... `N/A`
<!-- If this PR does not contain UI changes, ignore these items -->
