### PR TITLE
Increase threshold for triggering podcast view swipe refresh

### DIFF
--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastFragment.kt
@@ -718,6 +718,7 @@ class PodcastFragment : BaseFragment() {
         ).also { binding = it }
 
         binding.swipeRefreshLayout.isEnabled = FeatureFlag.isEnabled(Feature.PODCAST_FEED_UPDATE)
+        binding.swipeRefreshLayout.setDistanceToTriggerSync(resources.getDimensionPixelSize(R.dimen.podcast_view_swipe_refresh_distance).toInt())
         binding.setToolbarStaticColor(requireContext().getThemeColor(UR.attr.support_09))
         binding.setUpToolbar(
             theme = theme,

--- a/modules/features/podcasts/src/main/res/values/dimens.xml
+++ b/modules/features/podcasts/src/main/res/values/dimens.xml
@@ -7,4 +7,5 @@
     <dimen name="episode_card_action_middle_padding">20dp</dimen>
     <dimen name="episode_card_image_size">96dp</dimen>
     <dimen name="podcast_header_height">113dp</dimen>
+    <dimen name="podcast_view_swipe_refresh_distance">120dp</dimen>
 </resources>


### PR DESCRIPTION
## Description
This increases the threshold for triggering podcast view swipe refresh.

Internal Ref: p1741430474966019-slack-C02A333D8LQ

## Testing Instructions
1. Open a podcast
2. Pull to refresh 
3. ✅  Notice that now the drag distance should be slightly more than before to trigger pull to refresh

## Screenshots or Screencast 

https://github.com/user-attachments/assets/71c5f49b-c7ca-4ac6-b5ac-507b67c23c81

https://github.com/user-attachments/assets/e3c10cc9-85e7-4226-bacb-3b139cfb4f7c


## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack