### PR TITLE
Podcast Page: Fix pull-to-refresh on episode swipe

### DIFF
--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastFragment.kt
@@ -115,6 +115,7 @@ import au.com.shiftyjelly.pocketcasts.views.extensions.setupChromeCastButton
 import au.com.shiftyjelly.pocketcasts.views.extensions.smoothScrollToTop
 import au.com.shiftyjelly.pocketcasts.views.extensions.tintIcons
 import au.com.shiftyjelly.pocketcasts.views.fragments.BaseFragment
+import au.com.shiftyjelly.pocketcasts.views.helper.EpisodeItemSwipeState
 import au.com.shiftyjelly.pocketcasts.views.helper.EpisodeItemTouchHelper
 import au.com.shiftyjelly.pocketcasts.views.helper.SwipeButtonLayoutFactory
 import au.com.shiftyjelly.pocketcasts.views.helper.SwipeButtonLayoutViewModel
@@ -825,7 +826,9 @@ class PodcastFragment : BaseFragment() {
             it.addOnScrollListener(onScrollListener)
         }
 
-        itemTouchHelper = EpisodeItemTouchHelper().apply {
+        itemTouchHelper = EpisodeItemTouchHelper(
+            onSwipeStateChanged = { state -> binding.updateSwipeRefreshLayout(state) },
+        ).apply {
             attachToRecyclerView(binding.episodesRecyclerView)
         }
 
@@ -1326,6 +1329,15 @@ class PodcastFragment : BaseFragment() {
         val featuredPodcast: Boolean,
         val isHeaderRedesigned: Boolean,
     ) : Parcelable
+}
+
+private fun BindingWrapper.updateSwipeRefreshLayout(
+    episodeItemSwipeState: EpisodeItemSwipeState,
+) {
+    when (episodeItemSwipeState) {
+        EpisodeItemSwipeState.SWIPING -> swipeRefreshLayout.isEnabled = false
+        EpisodeItemSwipeState.IDLE -> swipeRefreshLayout.isEnabled = true
+    }
 }
 
 private sealed interface BindingWrapper {


### PR DESCRIPTION
## Description
This fixes pull to refresh on swiping episode item sideways on the Podcast page.

Fixes #3608

## Testing Instructions

1. Go to Podcast screen
2. Start swiping Episode sideways to archive
3. In the same swipe, start swiping a bit downwards
4. ✅ Notice that pull to refresh doesn't override the swipe action

## Screenshots or Screencast 
[swipe_pull-to-refresh.webm](https://github.com/user-attachments/assets/64ea785c-5d0d-4e74-b6d8-493e5081f9eb)


## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
