### PR TITLE
[AndroidManifest] Improve Merged Manifest Diff (`Test`)

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -5,74 +5,12 @@ agents:
   queue: "android"
 
 steps:
-  - label: Gradle Wrapper Validation
-    command: validate_gradle_wrapper
-    agents:
-      queue: linter
-
-  # Wait for Gradle Wrapper to be validated before running any other jobs
-  - wait
-
-  - group: "Linters"
-    steps:
-      - label: "☢️ Danger - PR Check"
-        command: danger
-        key: danger
-        if: "build.pull_request.id != null"
-        retry:
-          manual:
-            permit_on_passed: true
-        agents:
-          queue: "linter"
-
-      - label: 'Lint'
-        command: ".buildkite/commands/lint.sh"
-        plugins: [$CI_TOOLKIT]
-        artifact_paths:
-          - "**/build/reports/lint-results*.*"
-
-  - label: 'Unit tests'
-    command: ".buildkite/commands/run-unit-tests.sh"
-    plugins: [$CI_TOOLKIT]
 
   - group: "Diff Reports"
     steps:
-      - label: 'Dependency diff'
-        if: build.pull_request.id != null
-        command: comment_with_dependency_diff 'app' 'releaseRuntimeClasspath'
-        plugins: [$CI_TOOLKIT]
-        artifact_paths:
-          - "**/build/reports/diff/*"
-
       - label: "Merged Manifest Diff"
         command: ".buildkite/commands/diff-merged-manifest.sh release"
         if: build.pull_request.id != null
         plugins: [$CI_TOOLKIT]
         artifact_paths:
           - "**/build/reports/diff_manifest/**/**/*"
-
-  - label: 'Spotless formatting check'
-    command: |
-      echo "--- 🔎 Checking formatting with Spotless"
-      ./gradlew spotlessCheck
-    plugins: [$CI_TOOLKIT]
-
-  - label: "Instrumented tests"
-    command: ".buildkite/commands/run-instrumented-tests.sh"
-    plugins: [$CI_TOOLKIT]
-    artifact_paths:
-      - "**/build/instrumented-tests/**/*"
-
-  - label: "Assemble release APK"
-    command: ".buildkite/commands/assemble-release-apk.sh"
-    plugins: [ $CI_TOOLKIT ]
-    artifact_paths:
-      - "**/build/outputs/apk/**/*"
-
-  - label: "Prototype Builds"
-    if: "build.pull_request.id != null"
-    command: |
-      ".buildkite/commands/prototype-build.sh"
-    plugins: [ $CI_TOOLKIT ]
-    artifact_paths:
-      - "**/build/outputs/apk/**/*"

--- a/.buildkite/shared-pipeline-vars
+++ b/.buildkite/shared-pipeline-vars
@@ -3,4 +3,4 @@
 # This file is `source`'d before calling `buildkite-agent pipeline upload`, and can be used
 # to set up some variables that will be interpolated in the `.yml` pipeline before uploading it.
 
-export CI_TOOLKIT="automattic/a8c-ci-toolkit#5.1.2"
+export CI_TOOLKIT="automattic/a8c-ci-toolkit#7015f291eab370330e011197c2901ed711f66d95"

--- a/modules/features/podcasts/src/test/java/au/com/shiftyjelly/pocketcasts/podcasts/view/folders/SuggestedFoldersViewModelTest.kt
+++ b/modules/features/podcasts/src/test/java/au/com/shiftyjelly/pocketcasts/podcasts/view/folders/SuggestedFoldersViewModelTest.kt
@@ -91,22 +91,6 @@ class SuggestedFoldersViewModelTest {
     }
 
     @Test
-    fun `should use suggested folders`() = runTest {
-        initViewModel()
-
-        viewModel.useSuggestedFolders()
-
-        advanceUntilIdle()
-
-        verify(suggestedFoldersManager).useSuggestedFolders(dbSuggestedFolders)
-        verify(podcastManager).refreshPodcasts("suggested-folders")
-
-        viewModel.state.test {
-            assertEquals(UseFoldersState.Applied, awaitItem().useFoldersState)
-        }
-    }
-
-    @Test
     fun `should track page shown`() = runTest {
         initViewModel()
 

--- a/modules/features/podcasts/src/test/java/au/com/shiftyjelly/pocketcasts/podcasts/view/folders/SuggestedFoldersViewModelTest.kt
+++ b/modules/features/podcasts/src/test/java/au/com/shiftyjelly/pocketcasts/podcasts/view/folders/SuggestedFoldersViewModelTest.kt
@@ -5,7 +5,6 @@ import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTracker
 import au.com.shiftyjelly.pocketcasts.models.to.SignInState
 import au.com.shiftyjelly.pocketcasts.models.to.SubscriptionStatus
-import au.com.shiftyjelly.pocketcasts.podcasts.view.folders.SuggestedFoldersViewModel.UseFoldersState
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.FolderManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.SuggestedFoldersManager
@@ -15,7 +14,6 @@ import io.reactivex.Flowable
 import junit.framework.TestCase.assertEquals
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.flowOf
-import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.junit.Before
 import org.junit.Rule


### PR DESCRIPTION
Based On: #3743

## Description
<!-- Please include a summary of what this PR is changing and why these changes are needed. -->

This draft PR is for testing purposes only. It is about testing the improved merged manifest diff comment via an outdated head branch, outdated in terms of base branch (p1741594194983279/1740493471.859349-slack-C030U03RC8Y).

---

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Tap on the Filters tab -->
<!-- 2. Tap on a filter -->
<!-- 3. etc. -->

`Before` -> [Build](https://buildkite.com/automattic/pocket-casts-android/builds/10987/canvas) -> [Post a new comment](https://buildkite.com/automattic/pocket-casts-android/builds/10987/canvas?jid=01957ffd-f448-4e45-980a-ad050038633e#01957ffd-f448-4e45-980a-ad050038633e/236-356)

![image](https://github.com/user-attachments/assets/128fd81b-cbbe-41f4-adb2-0909d1e530dc)

`After` -> [Build](https://buildkite.com/automattic/pocket-casts-android/builds/10989/canvas?sid=01958003-e806-4fd7-bd4a-77a7c8275519) -> [No new comment to post](https://buildkite.com/automattic/pocket-casts-android/builds/10989/canvas?sid=01958003-e806-4fd7-bd4a-77a7c8275519#01958003-e855-4d44-8fed-89c7062f3181/236-365)

N/A

---

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes... `N/A`
<!-- If this PR does not contain UI changes, ignore these items -->