### PR TITLE
Parse generated transcripts

### DIFF
--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/models/db/AppDatabaseTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/models/db/AppDatabaseTest.kt
@@ -179,6 +179,7 @@ class AppDatabaseTest {
                 AppDatabase.MIGRATION_107_108,
                 AppDatabase.MIGRATION_108_109,
                 AppDatabase.MIGRATION_109_110,
+                AppDatabase.MIGRATION_110_111,
             )
             .build()
         // close the database and release any stream resources when the test finishes

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/PlayerHeaderFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/PlayerHeaderFragment.kt
@@ -12,6 +12,7 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.activity.result.ActivityResultLauncher
 import androidx.compose.runtime.LaunchedEffect
+import androidx.core.view.isInvisible
 import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
@@ -376,7 +377,7 @@ class PlayerHeaderFragment : BaseFragment(), PlayerClickListener {
                 shelfSharedViewModel.transitionState.collect { transitionState ->
                     when (transitionState) {
                         is TransitionState.OpenTranscript -> binding?.openTranscript()
-                        is TransitionState.UpsellTranscript -> TODO()
+                        is TransitionState.UpsellTranscript -> binding?.hidePlaybackControls()
                         is TransitionState.CloseTranscript -> binding?.closeTranscript(transitionState.withTransition)
                     }
                 }
@@ -401,6 +402,12 @@ class PlayerHeaderFragment : BaseFragment(), PlayerClickListener {
         val containerFragment = parentFragment as? PlayerContainerFragment
         containerFragment?.updateTabsVisibility(false)
         root.setScrollingEnabled(false)
+    }
+
+    private fun AdapterPlayerHeaderBinding.hidePlaybackControls() {
+        playerGroup.layoutTransition = LayoutTransition()
+        seekBar.isInvisible = true
+        playerControlsComposeView.isInvisible = true
     }
 
     private fun AdapterPlayerHeaderBinding.closeTranscript(

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/PlayerHeaderFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/PlayerHeaderFragment.kt
@@ -376,6 +376,7 @@ class PlayerHeaderFragment : BaseFragment(), PlayerClickListener {
                 shelfSharedViewModel.transitionState.collect { transitionState ->
                     when (transitionState) {
                         is TransitionState.OpenTranscript -> binding?.openTranscript()
+                        is TransitionState.UpsellTranscript -> TODO()
                         is TransitionState.CloseTranscript -> binding?.closeTranscript(transitionState.withTransition)
                     }
                 }

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/transcripts/TranscriptError.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/transcripts/TranscriptError.kt
@@ -129,6 +129,7 @@ private fun ErrorPreview() {
                     episodeUuid = "uuid",
                     type = TranscriptFormat.HTML.mimeType,
                     url = "url",
+                    isGenerated = false,
                 ),
             ),
             onRetry = {},

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/transcripts/TranscriptPage.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/transcripts/TranscriptPage.kt
@@ -450,6 +450,7 @@ private fun TranscriptContentPreview(
                     episodeUuid = "uuid",
                     type = TranscriptFormat.HTML.mimeType,
                     url = "url",
+                    isGenerated = false,
                 ),
                 cuesInfo = ImmutableList.of(
                     TranscriptCuesInfo(
@@ -494,6 +495,7 @@ private fun TranscriptEmptyContentPreview() {
                     episodeUuid = "uuid",
                     type = TranscriptFormat.HTML.mimeType,
                     url = "url",
+                    isGenerated = false,
                 ),
                 cuesInfo = emptyList(),
                 displayInfo = DisplayInfo(

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/transcripts/TranscriptPage.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/transcripts/TranscriptPage.kt
@@ -184,7 +184,7 @@ private fun TranscriptContent(
         Box(
             modifier = if (state.showPaywall) {
                 if (Build.VERSION.SDK_INT >= 31) {
-                    Modifier.blur(4.dp)
+                    Modifier.blur(8.dp)
                 } else {
                     Modifier.alpha(0f)
                 }

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/transcripts/TranscriptPage.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/transcripts/TranscriptPage.kt
@@ -25,6 +25,8 @@ import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.draw.blur
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalClipboardManager
 import androidx.compose.ui.platform.LocalConfiguration
@@ -92,7 +94,7 @@ fun TranscriptPage(
     val searchState = searchViewModel.searchState.collectAsStateWithLifecycle()
     val refreshing = transcriptViewModel.isRefreshing.collectAsStateWithLifecycle()
     val pullRefreshState = rememberPullRefreshState(refreshing.value, {
-        transcriptViewModel.parseAndLoadTranscript(isTranscriptViewOpen = true, pulledToRefresh = true)
+        transcriptViewModel.parseAndLoadTranscript(pulledToRefresh = true)
     })
     val playerBackgroundColor = Color(theme.playerBackgroundColor(uiState.value.podcastAndEpisode?.podcast))
     val colors = TranscriptColors(playerBackgroundColor)
@@ -120,7 +122,6 @@ fun TranscriptPage(
                     state = loadedState,
                     searchState = searchState.value,
                     colors = colors,
-                    modifier = modifier,
                     transitionState = transitionState.value,
                 )
 
@@ -138,10 +139,7 @@ fun TranscriptPage(
                 TranscriptError(
                     state = errorState,
                     onRetry = {
-                        transcriptViewModel.parseAndLoadTranscript(
-                            isTranscriptViewOpen = true,
-                            retryOnFail = true,
-                        )
+                        transcriptViewModel.parseAndLoadTranscript(retryOnFail = true)
                     },
                     colors = colors,
                     modifier = modifier,
@@ -151,7 +149,9 @@ fun TranscriptPage(
     }
 
     LaunchedEffect(uiState.value.transcript?.episodeUuid, uiState.value.transcript?.type, transitionState.value) {
-        transcriptViewModel.parseAndLoadTranscript(transitionState.value is TransitionState.OpenTranscript)
+        if (transitionState.value is TransitionState.OpenTranscript) {
+            transcriptViewModel.parseAndLoadTranscript()
+        }
     }
 
     if (uiState.value is UiState.TranscriptLoaded) {
@@ -174,44 +174,55 @@ private fun TranscriptContent(
     state: UiState.TranscriptLoaded,
     searchState: SearchUiState,
     colors: TranscriptColors,
-    modifier: Modifier,
     transitionState: TransitionState?,
 ) {
     Box(
-        modifier = modifier
+        modifier = Modifier
             .fillMaxWidth()
             .background(colors.backgroundColor()),
     ) {
-        if (state.isTranscriptEmpty) {
-            TextP40(
-                text = stringResource(LR.string.transcript_empty),
-                color = TranscriptColors.textColor(),
+        Box(
+            modifier = if (state.showPaywall) {
+                if (Build.VERSION.SDK_INT >= 31) {
+                    Modifier.blur(4.dp)
+                } else {
+                    Modifier.alpha(0f)
+                }
+            } else {
+                Modifier
+            },
+        ) {
+            if (state.isTranscriptEmpty) {
+                TextP40(
+                    text = stringResource(LR.string.transcript_empty),
+                    color = TranscriptColors.textColor(),
+                    modifier = Modifier
+                        .padding(horizontal = 16.dp)
+                        .padding(top = 60.dp),
+                )
+            } else {
+                ScrollableTranscriptView(
+                    state = state,
+                    searchState = searchState,
+                    transitionState = transitionState,
+                )
+            }
+
+            GradientView(
+                baseColor = colors.backgroundColor(),
                 modifier = Modifier
-                    .padding(horizontal = 16.dp)
-                    .padding(top = 60.dp),
+                    .align(Alignment.TopCenter),
+                fadeDirection = FadeDirection.TopToBottom,
             )
-        } else {
-            ScrollableTranscriptView(
-                state = state,
-                searchState = searchState,
-                transitionState = transitionState,
+
+            GradientView(
+                baseColor = colors.backgroundColor(),
+                modifier = Modifier
+                    .align(Alignment.BottomCenter)
+                    .padding(bottom = bottomPadding()),
+                fadeDirection = FadeDirection.BottomToTop,
             )
         }
-
-        GradientView(
-            baseColor = colors.backgroundColor(),
-            modifier = Modifier
-                .align(Alignment.TopCenter),
-            fadeDirection = FadeDirection.TopToBottom,
-        )
-
-        GradientView(
-            baseColor = colors.backgroundColor(),
-            modifier = Modifier
-                .align(Alignment.BottomCenter)
-                .padding(bottom = bottomPadding()),
-            fadeDirection = FadeDirection.BottomToTop,
-        )
     }
 }
 
@@ -474,11 +485,11 @@ private fun TranscriptContentPreview(
                         DisplayItem("Maecenas fermentum senectus penatibus tenectus integer per vulputate tellus ted.", false, 115, 195),
                     ),
                 ),
+                isSubscriptionRequired = false,
             ),
             searchState = searchState,
             transitionState = null,
             colors = TranscriptColors(Color.Black),
-            modifier = Modifier.fillMaxSize(),
         )
     }
 }
@@ -502,11 +513,11 @@ private fun TranscriptEmptyContentPreview() {
                     text = "",
                     items = emptyList(),
                 ),
+                isSubscriptionRequired = false,
             ),
             searchState = SearchUiState(),
             transitionState = null,
             colors = TranscriptColors(Color.Black),
-            modifier = Modifier.fillMaxSize(),
         )
     }
 }

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/transcripts/TranscriptPageWrapper.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/transcripts/TranscriptPageWrapper.kt
@@ -153,7 +153,7 @@ fun TranscriptPageWrapper(
 
         LaunchedEffect(transcriptUiState.value, transitionState.value) {
             showPaywall = (transcriptUiState.value as? TranscriptViewModel.UiState.TranscriptLoaded)?.showPaywall == true
-            if (transitionState.value is TransitionState.OpenTranscript) {
+            if (transitionState.value is TransitionState.OpenTranscript && showPaywall) {
                 shelfSharedViewModel.showUpsell()
             }
         }

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/transcripts/TranscriptPageWrapper.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/transcripts/TranscriptPageWrapper.kt
@@ -86,6 +86,7 @@ fun TranscriptPageWrapper(
 
         val configuration = LocalConfiguration.current
 
+        var showPaywall by remember { mutableStateOf(false) }
         var showSearch by remember { mutableStateOf(false) }
         var expandSearch by remember { mutableStateOf(false) }
         when (transitionState.value) {
@@ -111,6 +112,10 @@ fun TranscriptPageWrapper(
                 modifier = Modifier
                     .height(configuration.screenHeightDp.dp),
             )
+
+            if (showPaywall) {
+                TranscriptsPaywall()
+            }
 
             TranscriptToolbar(
                 onCloseClick = {
@@ -141,7 +146,16 @@ fun TranscriptPageWrapper(
 
         LaunchedEffect(transcriptUiState.value) {
             showSearch = (transcriptUiState.value as? TranscriptViewModel.UiState.TranscriptLoaded)?.showSearch == true
-            if (!showSearch) expandSearch = false
+            if (!showSearch) {
+                expandSearch = false
+            }
+        }
+
+        LaunchedEffect(transcriptUiState.value, transitionState.value) {
+            showPaywall = (transcriptUiState.value as? TranscriptViewModel.UiState.TranscriptLoaded)?.showPaywall == true
+            if (transitionState.value is TransitionState.OpenTranscript) {
+                shelfSharedViewModel.showUpsell()
+            }
         }
     }
 }

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/transcripts/TranscriptViewModel.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/transcripts/TranscriptViewModel.kt
@@ -13,6 +13,7 @@ import au.com.shiftyjelly.pocketcasts.repositories.di.IoDispatcher
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.TranscriptFormat
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.TranscriptsManager
+import au.com.shiftyjelly.pocketcasts.repositories.subscription.SubscriptionManager
 import au.com.shiftyjelly.pocketcasts.utils.exception.EmptyDataException
 import au.com.shiftyjelly.pocketcasts.utils.exception.NoNetworkException
 import au.com.shiftyjelly.pocketcasts.utils.exception.ParsingException
@@ -25,6 +26,7 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
@@ -39,6 +41,7 @@ class TranscriptViewModel @Inject constructor(
     private val playbackManager: PlaybackManager,
     private val analyticsTracker: AnalyticsTracker,
     @IoDispatcher private val ioDispatcher: CoroutineDispatcher,
+    private val subscriptionManager: SubscriptionManager,
 ) : ViewModel() {
     private var _uiState: MutableStateFlow<UiState> = MutableStateFlow(UiState.Empty())
     val uiState: StateFlow<UiState> = _uiState
@@ -65,11 +68,9 @@ class TranscriptViewModel @Inject constructor(
             }
 
     fun parseAndLoadTranscript(
-        isTranscriptViewOpen: Boolean,
         pulledToRefresh: Boolean = false,
         retryOnFail: Boolean = false,
     ) {
-        if (isTranscriptViewOpen.not()) return
         val podcastAndEpisode = _uiState.value.podcastAndEpisode
         if (pulledToRefresh) {
             _isRefreshing.value = true
@@ -96,6 +97,11 @@ class TranscriptViewModel @Inject constructor(
                         podcastAndEpisode = podcastAndEpisode,
                         displayInfo = displayInfo,
                         cuesInfo = cuesInfo,
+                        isSubscriptionRequired = if (transcript.isGenerated) {
+                            !subscriptionManager.subscriptionTier().first().isPaid
+                        } else {
+                            false
+                        },
                     )
 
                     if (!pulledToRefresh) {
@@ -228,15 +234,19 @@ class TranscriptViewModel @Inject constructor(
             override val transcript: Transcript,
             val displayInfo: DisplayInfo,
             val cuesInfo: List<TranscriptCuesInfo>,
+            val isSubscriptionRequired: Boolean,
         ) : UiState() {
             val isTranscriptEmpty: Boolean = cuesInfo.isEmpty()
+
+            val showPaywall = isSubscriptionRequired && !isTranscriptEmpty
+
             val showAsWebPage: Boolean
                 get() = transcript.type == TranscriptFormat.HTML.mimeType &&
                     cuesInfo.isNotEmpty() && cuesInfo[0].cuesWithTiming.cues.any {
                         it.text?.contains("<script type=\"text/javascript\">") ?: false
                     }
 
-            val showSearch = !showAsWebPage
+            val showSearch = !showAsWebPage && !isSubscriptionRequired
         }
 
         data class Error(

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/transcripts/TranscriptViewModel.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/transcripts/TranscriptViewModel.kt
@@ -59,7 +59,7 @@ class TranscriptViewModel @Inject constructor(
     }
 
     private fun transcriptFlow(podcastAndEpisode: PodcastAndEpisode) =
-        transcriptsManager.observerTranscriptForEpisode(podcastAndEpisode.episodeUuid)
+        transcriptsManager.observeTranscriptForEpisode(podcastAndEpisode.episodeUuid)
             .distinctUntilChanged { t1, t2 -> t1?.episodeUuid == t2?.episodeUuid && t1?.type == t2?.type }
             .map { transcript ->
                 transcript?.let {

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/transcripts/TranscriptsPaywall.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/transcripts/TranscriptsPaywall.kt
@@ -1,0 +1,34 @@
+package au.com.shiftyjelly.pocketcasts.player.view.transcripts
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import au.com.shiftyjelly.pocketcasts.compose.AppThemeWithBackground
+import au.com.shiftyjelly.pocketcasts.compose.components.TextH10
+import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
+
+@Composable
+internal fun TranscriptsPaywall() {
+    Box(
+        contentAlignment = Alignment.Center,
+        modifier = Modifier
+            .fillMaxSize()
+            .clickable(indication = null, interactionSource = null, onClick = {}),
+    ) {
+        TextH10(text = "Paywall")
+    }
+}
+
+@Preview
+@Composable
+private fun TranscriptsPaywallPreview() {
+    AppThemeWithBackground(
+        themeType = Theme.ThemeType.DARK,
+    ) {
+        TranscriptsPaywall()
+    }
+}

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/ShelfSharedViewModel.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/ShelfSharedViewModel.kt
@@ -139,6 +139,12 @@ class ShelfSharedViewModel @Inject constructor(
         }
     }
 
+    fun showUpsell() {
+        viewModelScope.launch {
+            _transitionState.emit(TransitionState.UpsellTranscript)
+        }
+    }
+
     fun closeTranscript(
         podcast: Podcast?,
         episode: BaseEpisode?,

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/ShelfSharedViewModel.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/ShelfSharedViewModel.kt
@@ -359,6 +359,7 @@ class ShelfSharedViewModel @Inject constructor(
 
     sealed class TransitionState {
         data object OpenTranscript : TransitionState()
+        data object UpsellTranscript : TransitionState()
         data class CloseTranscript(val withTransition: Boolean) : TransitionState()
     }
 

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/ShelfViewModel.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/ShelfViewModel.kt
@@ -40,7 +40,7 @@ class ShelfViewModel @AssistedInject constructor(
 
     init {
         viewModelScope.launch {
-            transcriptsManager.observerTranscriptForEpisode(episodeId)
+            transcriptsManager.observeTranscriptForEpisode(episodeId)
                 .distinctUntilChangedBy { it?.episodeUuid }
                 .stateIn(viewModelScope)
                 .collectLatest { transcript ->

--- a/modules/features/player/src/test/java/au/com/shiftyjelly/pocketcasts/player/view/transcripts/TranscriptViewModelTest.kt
+++ b/modules/features/player/src/test/java/au/com/shiftyjelly/pocketcasts/player/view/transcripts/TranscriptViewModelTest.kt
@@ -40,7 +40,7 @@ class TranscriptViewModelTest {
     private val transcriptsManager: TranscriptsManager = mock()
     private val playbackManager: PlaybackManager = mock()
     private val podcastId = "podcast_id"
-    private val transcript: Transcript = Transcript("episode_id", "url", "type")
+    private val transcript: Transcript = Transcript("episode_id", "url", "type", isGenerated = false)
     private val playbackStateFlow = MutableStateFlow(PlaybackState(podcast = Podcast("podcast_id"), episodeUuid = "episode_id"))
     private lateinit var viewModel: TranscriptViewModel
 

--- a/modules/features/player/src/test/java/au/com/shiftyjelly/pocketcasts/player/view/transcripts/TranscriptViewModelTest.kt
+++ b/modules/features/player/src/test/java/au/com/shiftyjelly/pocketcasts/player/view/transcripts/TranscriptViewModelTest.kt
@@ -49,7 +49,7 @@ class TranscriptViewModelTest {
 
     @Test
     fun `given no transcript available, then Empty state is returned`() = runTest {
-        whenever(transcriptsManager.observerTranscriptForEpisode(any())).thenReturn(flowOf(null))
+        whenever(transcriptsManager.observeTranscriptForEpisode(any())).thenReturn(flowOf(null))
 
         initViewModel()
 
@@ -60,7 +60,7 @@ class TranscriptViewModelTest {
 
     @Test
     fun `given transcript is available, then transcript found state is returned`() = runTest {
-        whenever(transcriptsManager.observerTranscriptForEpisode(any())).thenReturn(flowOf(transcript))
+        whenever(transcriptsManager.observeTranscriptForEpisode(any())).thenReturn(flowOf(transcript))
 
         initViewModel()
 
@@ -71,7 +71,7 @@ class TranscriptViewModelTest {
 
     @Test
     fun `given transcript view is open, when transcript load invoked, then transcript is loaded`() = runTest {
-        whenever(transcriptsManager.observerTranscriptForEpisode(any())).thenReturn(flowOf(transcript))
+        whenever(transcriptsManager.observeTranscriptForEpisode(any())).thenReturn(flowOf(transcript))
         initViewModel()
 
         viewModel.parseAndLoadTranscript()
@@ -84,7 +84,7 @@ class TranscriptViewModelTest {
 
     @Test
     fun `given transcript is supported but blank, when transcript load invoked, then Empty error is returned`() = runTest {
-        whenever(transcriptsManager.observerTranscriptForEpisode(any())).thenReturn(flowOf(transcript))
+        whenever(transcriptsManager.observeTranscriptForEpisode(any())).thenReturn(flowOf(transcript))
         initViewModel(transcriptLoadException = EmptyDataException(""))
 
         viewModel.parseAndLoadTranscript()
@@ -96,7 +96,7 @@ class TranscriptViewModelTest {
 
     @Test
     fun `given transcript is not supported, when transcript load invoked, then NotSupported error is returned`() = runTest {
-        whenever(transcriptsManager.observerTranscriptForEpisode(any())).thenReturn(flowOf(transcript))
+        whenever(transcriptsManager.observeTranscriptForEpisode(any())).thenReturn(flowOf(transcript))
         initViewModel(transcriptLoadException = UnsupportedOperationException())
 
         viewModel.parseAndLoadTranscript()
@@ -108,7 +108,7 @@ class TranscriptViewModelTest {
 
     @Test
     fun `given transcript type supported but content not valid, then FailedToLoad error is returned`() = runTest {
-        whenever(transcriptsManager.observerTranscriptForEpisode(any())).thenReturn(flowOf(transcript))
+        whenever(transcriptsManager.observeTranscriptForEpisode(any())).thenReturn(flowOf(transcript))
         initViewModel(transcriptLoadException = RuntimeException())
 
         viewModel.parseAndLoadTranscript()
@@ -120,7 +120,7 @@ class TranscriptViewModelTest {
 
     @Test
     fun `given error due to no internet, then NoNetwork error is returned`() = runTest {
-        whenever(transcriptsManager.observerTranscriptForEpisode(any())).thenReturn(flowOf(transcript))
+        whenever(transcriptsManager.observeTranscriptForEpisode(any())).thenReturn(flowOf(transcript))
         initViewModel(transcriptLoadException = NoNetworkException())
 
         viewModel.parseAndLoadTranscript()
@@ -132,7 +132,7 @@ class TranscriptViewModelTest {
 
     @Test
     fun `given force refresh, when transcript load invoked, then transcript is refreshed`() = runTest {
-        whenever(transcriptsManager.observerTranscriptForEpisode(any())).thenReturn(flowOf(transcript))
+        whenever(transcriptsManager.observeTranscriptForEpisode(any())).thenReturn(flowOf(transcript))
         initViewModel()
 
         viewModel.parseAndLoadTranscript(pulledToRefresh = true)
@@ -142,7 +142,7 @@ class TranscriptViewModelTest {
 
     @Test
     fun `given no force refresh, when transcript load invoked, then transcript is not refreshed`() = runTest {
-        whenever(transcriptsManager.observerTranscriptForEpisode(any())).thenReturn(flowOf(transcript))
+        whenever(transcriptsManager.observeTranscriptForEpisode(any())).thenReturn(flowOf(transcript))
         initViewModel()
 
         viewModel.parseAndLoadTranscript(pulledToRefresh = false)
@@ -152,7 +152,7 @@ class TranscriptViewModelTest {
 
     @Test
     fun `given html transcript with javascript, when transcript load invoked, then transcript is shown in webview`() = runTest {
-        whenever(transcriptsManager.observerTranscriptForEpisode(any())).thenReturn(flowOf(transcript.copy(type = "text/html")))
+        whenever(transcriptsManager.observeTranscriptForEpisode(any())).thenReturn(flowOf(transcript.copy(type = "text/html")))
         initViewModel(content = "<html><script type=\"text/javascript\"></html>")
 
         viewModel.parseAndLoadTranscript()
@@ -165,7 +165,7 @@ class TranscriptViewModelTest {
 
     @Test
     fun `given html transcript without javascript, when transcript load invoked, then transcript is not shown in webview`() = runTest {
-        whenever(transcriptsManager.observerTranscriptForEpisode(any())).thenReturn(flowOf(transcript.copy(type = "text/html")))
+        whenever(transcriptsManager.observeTranscriptForEpisode(any())).thenReturn(flowOf(transcript.copy(type = "text/html")))
         initViewModel(content = "<html></html>")
 
         viewModel.parseAndLoadTranscript()
@@ -178,7 +178,7 @@ class TranscriptViewModelTest {
 
     @Test
     fun `given html transcript with javascript, when transcript load invoked, then search is not shown`() = runTest {
-        whenever(transcriptsManager.observerTranscriptForEpisode(any())).thenReturn(flowOf(transcript.copy(type = "text/html")))
+        whenever(transcriptsManager.observeTranscriptForEpisode(any())).thenReturn(flowOf(transcript.copy(type = "text/html")))
         initViewModel(content = "<html><script type=\"text/javascript\"></html>")
 
         viewModel.parseAndLoadTranscript()
@@ -191,7 +191,7 @@ class TranscriptViewModelTest {
 
     @Test
     fun `given html transcript without javascript, when transcript load invoked, then search is shown`() = runTest {
-        whenever(transcriptsManager.observerTranscriptForEpisode(any())).thenReturn(flowOf(transcript.copy(type = "text/html")))
+        whenever(transcriptsManager.observeTranscriptForEpisode(any())).thenReturn(flowOf(transcript.copy(type = "text/html")))
         initViewModel(content = "<html></html>")
 
         viewModel.parseAndLoadTranscript()
@@ -204,7 +204,7 @@ class TranscriptViewModelTest {
 
     @Test
     fun `given generated transcript, when user is not subscribed, then show paywall`() = runTest {
-        whenever(transcriptsManager.observerTranscriptForEpisode(any())).thenReturn(flowOf(transcript.copy(isGenerated = true)))
+        whenever(transcriptsManager.observeTranscriptForEpisode(any())).thenReturn(flowOf(transcript.copy(isGenerated = true)))
         whenever(subscriptionManager.subscriptionTier()).thenReturn(flowOf(SubscriptionTier.NONE))
         initViewModel(content = "Hello")
 
@@ -219,7 +219,7 @@ class TranscriptViewModelTest {
 
     @Test
     fun `given generated transcript, when user is Plus, then do not show paywall`() = runTest {
-        whenever(transcriptsManager.observerTranscriptForEpisode(any())).thenReturn(flowOf(transcript.copy(isGenerated = true)))
+        whenever(transcriptsManager.observeTranscriptForEpisode(any())).thenReturn(flowOf(transcript.copy(isGenerated = true)))
         whenever(subscriptionManager.subscriptionTier()).thenReturn(flowOf(SubscriptionTier.PLUS))
         initViewModel(content = "Hello")
 
@@ -234,7 +234,7 @@ class TranscriptViewModelTest {
 
     @Test
     fun `given generated transcript, when user is Patron, then do not show paywall`() = runTest {
-        whenever(transcriptsManager.observerTranscriptForEpisode(any())).thenReturn(flowOf(transcript.copy(isGenerated = true)))
+        whenever(transcriptsManager.observeTranscriptForEpisode(any())).thenReturn(flowOf(transcript.copy(isGenerated = true)))
         whenever(subscriptionManager.subscriptionTier()).thenReturn(flowOf(SubscriptionTier.PATRON))
         initViewModel(content = "Hello")
 
@@ -249,7 +249,7 @@ class TranscriptViewModelTest {
 
     @Test
     fun `given generated transcript, when user is not subscribed and there is no transcript content, then do not show paywall`() = runTest {
-        whenever(transcriptsManager.observerTranscriptForEpisode(any())).thenReturn(flowOf(transcript.copy(isGenerated = true)))
+        whenever(transcriptsManager.observeTranscriptForEpisode(any())).thenReturn(flowOf(transcript.copy(isGenerated = true)))
         whenever(subscriptionManager.subscriptionTier()).thenReturn(flowOf(SubscriptionTier.NONE))
         initViewModel(content = null)
 

--- a/modules/features/player/src/test/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/ShelfViewModelTest.kt
+++ b/modules/features/player/src/test/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/ShelfViewModelTest.kt
@@ -215,7 +215,7 @@ class ShelfViewModelTest {
     ) {
         val episodeId = "testEpisodeId"
         val transcript = mock<Transcript>()
-        whenever(transcriptsManager.observerTranscriptForEpisode(episodeId)).thenReturn(flowOf(transcript))
+        whenever(transcriptsManager.observeTranscriptForEpisode(episodeId)).thenReturn(flowOf(transcript))
         val userSetting = mock<UserSetting<List<ShelfItem>>>()
         whenever(settings.shelfItems).thenReturn(userSetting)
 

--- a/modules/features/podcasts/src/test/java/au/com/shiftyjelly/pocketcasts/podcasts/view/folders/SuggestedFoldersViewModelTest.kt
+++ b/modules/features/podcasts/src/test/java/au/com/shiftyjelly/pocketcasts/podcasts/view/folders/SuggestedFoldersViewModelTest.kt
@@ -62,24 +62,6 @@ class SuggestedFoldersViewModelTest {
     }
 
     @Test
-    fun `should init with existing folders`() = runTest {
-        initViewModel()
-
-        viewModel.state.test {
-            assertEquals(folderCount, awaitItem().existingFoldersCount)
-        }
-    }
-
-    @Test
-    fun `should init with existing suggested folders`() = runTest {
-        initViewModel()
-
-        viewModel.state.test {
-            assertEquals(dbSuggestedFolders[0].name, awaitItem().suggestedFolders[0].name)
-        }
-    }
-
-    @Test
     fun `popup was marked as dismissed`() = runTest {
         initViewModel()
 

--- a/modules/features/podcasts/src/test/java/au/com/shiftyjelly/pocketcasts/podcasts/view/folders/SuggestedFoldersViewModelTest.kt
+++ b/modules/features/podcasts/src/test/java/au/com/shiftyjelly/pocketcasts/podcasts/view/folders/SuggestedFoldersViewModelTest.kt
@@ -1,6 +1,5 @@
 package au.com.shiftyjelly.pocketcasts.podcasts.view.folders
 
-import app.cash.turbine.test
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTracker
 import au.com.shiftyjelly.pocketcasts.models.to.SignInState
@@ -11,7 +10,6 @@ import au.com.shiftyjelly.pocketcasts.repositories.podcast.SuggestedFoldersManag
 import au.com.shiftyjelly.pocketcasts.repositories.user.UserManager
 import au.com.shiftyjelly.pocketcasts.sharedtest.MainCoroutineRule
 import io.reactivex.Flowable
-import junit.framework.TestCase.assertEquals
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest

--- a/modules/services/model/schemas/au.com.shiftyjelly.pocketcasts.models.db.AppDatabase/111.json
+++ b/modules/services/model/schemas/au.com.shiftyjelly.pocketcasts.models.db.AppDatabase/111.json
@@ -1,7 +1,7 @@
 {
   "formatVersion": 1,
   "database": {
-    "version": 110,
+    "version": 111,
     "identityHash": "53a6c3f5c60a6282e82e8a186799fccc",
     "entities": [
       {

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/AppDatabase.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/AppDatabase.kt
@@ -93,7 +93,7 @@ import au.com.shiftyjelly.pocketcasts.localization.R as LR
         Transcript::class,
         UserPodcastRating::class,
     ],
-    version = 110,
+    version = 111,
     exportSchema = true,
     autoMigrations = [
         AutoMigration(from = 81, to = 82, spec = AppDatabase.Companion.DeleteSilenceRemovedMigration::class),
@@ -960,6 +960,10 @@ abstract class AppDatabase : RoomDatabase() {
             database.execSQL("UPDATE podcasts SET is_header_expanded = 0 WHERE subscribed IS NOT 0")
         }
 
+        val MIGRATION_110_111 = addMigration(110, 111) { database ->
+            database.execSQL("ALTER TABLE episode_transcript ADD COLUMN is_generated INTEGER NOT NULL DEFAULT 0")
+        }
+
         fun addMigrations(databaseBuilder: Builder<AppDatabase>, context: Context) {
             databaseBuilder.addMigrations(
                 addMigration(1, 2) { },
@@ -1360,6 +1364,7 @@ abstract class AppDatabase : RoomDatabase() {
                 MIGRATION_107_108,
                 MIGRATION_108_109,
                 MIGRATION_109_110,
+                MIGRATION_110_111,
             )
         }
 

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/TranscriptDao.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/TranscriptDao.kt
@@ -13,5 +13,5 @@ abstract class TranscriptDao {
     abstract fun insertBlocking(transcript: Transcript)
 
     @Query("SELECT * FROM episode_transcript WHERE episode_uuid IS :episodeUuid")
-    abstract fun observerTranscriptForEpisode(episodeUuid: String): Flow<Transcript?>
+    abstract fun observeTranscriptForEpisode(episodeUuid: String): Flow<Transcript?>
 }

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/to/Transcript.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/to/Transcript.kt
@@ -11,9 +11,10 @@ import androidx.room.Index
         Index(name = "transcript_episode_uuid_index", value = ["episode_uuid"], unique = true),
     ],
 )
-data class Transcript(
+data class Transcript constructor(
     @ColumnInfo(name = "episode_uuid") val episodeUuid: String,
     @ColumnInfo(name = "url") val url: String,
     @ColumnInfo(name = "type") val type: String,
+    @ColumnInfo(name = "is_generated") val isGenerated: Boolean,
     @ColumnInfo(name = "language") val language: String? = null,
 )

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/TranscriptsManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/TranscriptsManager.kt
@@ -15,7 +15,7 @@ interface TranscriptsManager {
         fromUpdateAlternativeTranscript: Boolean = false,
     )
 
-    fun observerTranscriptForEpisode(episodeUuid: String): Flow<Transcript?>
+    fun observeTranscriptForEpisode(episodeUuid: String): Flow<Transcript?>
 
     @OptIn(UnstableApi::class)
     suspend fun loadTranscriptCuesInfo(

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/shownotes/ShowNotesProcessor.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/shownotes/ShowNotesProcessor.kt
@@ -104,14 +104,18 @@ class ShowNotesProcessor @Inject constructor(
 
 internal fun ShowNotesResponse.findTranscripts(episodeUuid: String): List<Transcript> {
     val episode = podcast?.episodes?.firstOrNull { it.uuid == episodeUuid } ?: return emptyList()
-    return episode.transcripts?.mapNotNull { it.toTranscript(episodeUuid) }.orEmpty()
+    return episode.transcripts?.mapNotNull { it.toTranscript(episodeUuid, isGenerated = false) }.orEmpty()
 }
 
-private fun ShowNotesTranscript.toTranscript(episodeUuid: String) = if (url != null && type != null) {
+private fun ShowNotesTranscript.toTranscript(
+    episodeUuid: String,
+    isGenerated: Boolean,
+) = if (url != null && type != null) {
     Transcript(
         episodeUuid = episodeUuid,
         url = requireNotNull(url),
         type = requireNotNull(type),
+        isGenerated = isGenerated,
         language = language,
     )
 } else {

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/TranscriptCuesInfoBuilderTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/TranscriptCuesInfoBuilderTest.kt
@@ -20,7 +20,7 @@ import org.mockito.kotlin.whenever
 class TranscriptCuesInfoBuilderTest {
     private val subtitleParserFactory: SubtitleParser.Factory = mock()
     private val transcriptJsonConverter: TranscriptJsonConverter = mock()
-    private val transcript: Transcript = Transcript("episode_id", "url", "type")
+    private val transcript: Transcript = Transcript("episode_id", "url", "type", isGenerated = false)
     private lateinit var transcriptCuesInfoBuilder: TranscriptCuesInfoBuilder
 
     @Before

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/TranscriptsManagerImplTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/TranscriptsManagerImplTest.kt
@@ -48,8 +48,8 @@ class TranscriptsManagerImplTest {
     private val transcriptCuesInfoBuilder: TranscriptCuesInfoBuilder = mock()
     private val showNotesServiceManager: ShowNotesServiceManager = mock()
     private val podcastId = "podcast_id"
-    private val transcript = Transcript("1", "url_1", "application/srt")
-    private val alternateTranscript = Transcript("1", "url_2", "application/json")
+    private val transcript = Transcript("1", "url_1", "application/srt", isGenerated = false)
+    private val alternateTranscript = Transcript("1", "url_2", "application/json", isGenerated = false)
 
     private val transcriptsManager = TranscriptsManagerImpl(
         transcriptDao = transcriptDao,
@@ -95,9 +95,9 @@ class TranscriptsManagerImplTest {
     @Test
     fun `findBestTranscript returns first supported transcript`() = runTest {
         val transcripts = listOf(
-            Transcript("1", "url_0", "un-supported"),
-            Transcript("1", "url_1", "application/srt"),
-            Transcript("1", "url_2", "text/vtt"),
+            Transcript("1", "url_0", "un-supported", isGenerated = false),
+            Transcript("1", "url_1", "application/srt", isGenerated = false),
+            Transcript("1", "url_2", "text/vtt", isGenerated = false),
         )
         val result = transcriptsManager.findBestTranscript(transcripts)
 
@@ -107,8 +107,8 @@ class TranscriptsManagerImplTest {
     @Test
     fun `findBestTranscript returns first supported transcript for a format with multiple mimetypes`() = runTest {
         val transcripts = listOf(
-            Transcript("1", "url_1", "application/x-subrip"),
-            Transcript("1", "url_2", "application/srt"),
+            Transcript("1", "url_1", "application/x-subrip", isGenerated = false),
+            Transcript("1", "url_2", "application/srt", isGenerated = false),
         )
         val result = transcriptsManager.findBestTranscript(transcripts)
 
@@ -127,8 +127,8 @@ class TranscriptsManagerImplTest {
     @Test
     fun `findBestTranscript returns first un-supported transcript when no other transcript is supported`() = runTest {
         val transcripts = listOf(
-            Transcript("1", "url_1", "un-supported"),
-            Transcript("1", "url_2", "un-supported"),
+            Transcript("1", "url_1", "un-supported", isGenerated = false),
+            Transcript("1", "url_2", "un-supported", isGenerated = false),
         )
 
         val result = transcriptsManager.findBestTranscript(transcripts)
@@ -139,8 +139,8 @@ class TranscriptsManagerImplTest {
     @Test
     fun `updateTranscripts inserts best transcript when available`() = runTest {
         val transcripts = listOf(
-            Transcript("1", "url_1", "application/srt"),
-            Transcript("1", "url_2", "text/vtt"),
+            Transcript("1", "url_1", "application/srt", isGenerated = false),
+            Transcript("1", "url_2", "text/vtt", isGenerated = false),
         )
 
         transcriptsManager.updateTranscripts(podcastId, "1", transcripts, LoadTranscriptSource.DEFAULT)
@@ -213,7 +213,7 @@ class TranscriptsManagerImplTest {
     fun `updateTranscripts loads transcript if the source is download episode`() = runTest {
         whenever(networkWrapper.isConnected()).thenReturn(true)
         val transcripts = listOf(
-            Transcript("1", "url_1", "application/srt"),
+            Transcript("1", "url_1", "application/srt", isGenerated = false),
         )
 
         transcriptsManager.updateTranscripts(podcastId, "1", transcripts, LoadTranscriptSource.DOWNLOAD_EPISODE)
@@ -225,7 +225,7 @@ class TranscriptsManagerImplTest {
     fun `updateTranscripts does not load transcript if the source is not download episode`() = runTest {
         whenever(networkWrapper.isConnected()).thenReturn(true)
         val transcripts = listOf(
-            Transcript("1", "url_1", "application/srt"),
+            Transcript("1", "url_1", "application/srt", isGenerated = false),
         )
 
         transcriptsManager.updateTranscripts(podcastId, "1", transcripts, LoadTranscriptSource.DEFAULT)

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/TranscriptsManagerImplTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/TranscriptsManagerImplTest.kt
@@ -1,6 +1,5 @@
 package au.com.shiftyjelly.pocketcasts.repositories.podcast
 
-import app.cash.turbine.test
 import au.com.shiftyjelly.pocketcasts.models.db.dao.TranscriptDao
 import au.com.shiftyjelly.pocketcasts.models.to.Transcript
 import au.com.shiftyjelly.pocketcasts.models.to.TranscriptCuesInfo

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/TranscriptsManagerImplTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/TranscriptsManagerImplTest.kt
@@ -9,14 +9,11 @@ import au.com.shiftyjelly.pocketcasts.servers.podcast.ShowNotesPodcast
 import au.com.shiftyjelly.pocketcasts.servers.podcast.ShowNotesResponse
 import au.com.shiftyjelly.pocketcasts.servers.podcast.ShowNotesTranscript
 import au.com.shiftyjelly.pocketcasts.servers.podcast.TranscriptCacheService
-import au.com.shiftyjelly.pocketcasts.sharedtest.InMemoryFeatureFlagRule
 import au.com.shiftyjelly.pocketcasts.sharedtest.MainCoroutineRule
 import au.com.shiftyjelly.pocketcasts.utils.NetworkWrapper
 import au.com.shiftyjelly.pocketcasts.utils.exception.EmptyDataException
 import au.com.shiftyjelly.pocketcasts.utils.exception.NoNetworkException
 import au.com.shiftyjelly.pocketcasts.utils.exception.ParsingException
-import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
-import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.SupervisorJob
@@ -44,9 +41,6 @@ import retrofit2.Response
 class TranscriptsManagerImplTest {
     @get:Rule
     val coroutineRule = MainCoroutineRule()
-
-    @get:Rule
-    val featureFlagRule = InMemoryFeatureFlagRule()
 
     private val transcriptDao: TranscriptDao = mock()
     private val transcriptCacheService: TranscriptCacheService = mock()
@@ -143,8 +137,7 @@ class TranscriptsManagerImplTest {
     }
 
     @Test
-    fun `findBestTranscript uses generated transcripts with feature flag enabled`() = runTest {
-        FeatureFlag.setEnabled(Feature.GENERATED_TRANSCRIPTS, true)
+    fun `findBestTranscript uses generated transcripts`() = runTest {
         val transcripts = listOf(
             Transcript("1", "url_1", "application/srt", isGenerated = true),
         )
@@ -155,20 +148,7 @@ class TranscriptsManagerImplTest {
     }
 
     @Test
-    fun `findBestTranscript does not use generated transcripts with feature flag disabled`() = runTest {
-        FeatureFlag.setEnabled(Feature.GENERATED_TRANSCRIPTS, false)
-        val transcripts = listOf(
-            Transcript("1", "url_1", "application/srt", isGenerated = true),
-        )
-
-        val result = transcriptsManager.findBestTranscript(transcripts)
-
-        assertNull(result)
-    }
-
-    @Test
-    fun `findBestTranscript uses non-generated transcripts first`() = runTest {
-        FeatureFlag.setEnabled(Feature.GENERATED_TRANSCRIPTS, true)
+    fun `findBestTranscript prioritizes non-generated transcripts`() = runTest {
         val transcripts = listOf(
             Transcript("1", "url_1", "application/srt", isGenerated = true),
             Transcript("1", "url_2", "application/srt", isGenerated = false),

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/TranscriptsManagerImplTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/TranscriptsManagerImplTest.kt
@@ -253,11 +253,7 @@ class TranscriptsManagerImplTest {
             assertTrue(e is EmptyDataException)
         }
 
-        transcriptsManager.failedTranscriptFormats.test {
-            awaitItem()
-            verify(transcriptDao).insertBlocking(alternateTranscript)
-            cancelAndIgnoreRemainingEvents()
-        }
+        verify(transcriptDao).insertBlocking(alternateTranscript)
     }
 
     @Test
@@ -270,11 +266,7 @@ class TranscriptsManagerImplTest {
             assertTrue(e is ParsingException)
         }
 
-        transcriptsManager.failedTranscriptFormats.test {
-            awaitItem()
-            verify(transcriptDao).insertBlocking(alternateTranscript)
-            cancelAndIgnoreRemainingEvents()
-        }
+        verify(transcriptDao).insertBlocking(alternateTranscript)
     }
 
     @Test
@@ -283,11 +275,7 @@ class TranscriptsManagerImplTest {
 
         transcriptsManager.loadTranscriptCuesInfo(podcastId, transcript, LoadTranscriptSource.DOWNLOAD_EPISODE)
 
-        transcriptsManager.failedTranscriptFormats.test {
-            awaitItem()
-            verify(transcriptDao).insertBlocking(alternateTranscript)
-            cancelAndConsumeRemainingEvents()
-        }
+        verify(transcriptDao).insertBlocking(alternateTranscript)
     }
 
     @Test
@@ -296,10 +284,6 @@ class TranscriptsManagerImplTest {
 
         transcriptsManager.loadTranscriptCuesInfo(podcastId, transcript, LoadTranscriptSource.DOWNLOAD_EPISODE)
 
-        transcriptsManager.failedTranscriptFormats.test {
-            awaitItem()
-            verify(transcriptDao).insertBlocking(alternateTranscript)
-            cancelAndIgnoreRemainingEvents()
-        }
+        verify(transcriptDao).insertBlocking(alternateTranscript)
     }
 }

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/shownotes/ShowNotesProcessTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/shownotes/ShowNotesProcessTest.kt
@@ -447,6 +447,12 @@ class ShowNotesProcessTest {
                     language = "Language 2",
                 ),
             ),
+            pocketCastsTranscripts = listOf(
+                ShowNotesTranscript(
+                    url = "Url 3",
+                    type = "Type 3",
+                ),
+            ),
         )
         val showNotes = ShowNotesResponse(
             podcast = ShowNotesPodcast(
@@ -474,6 +480,12 @@ class ShowNotesProcessTest {
                 language = "Language 2",
                 isGenerated = false,
             ),
+            Transcript(
+                episodeUuid = "episode-id",
+                url = "Url 3",
+                type = "Type 3",
+                isGenerated = true,
+            ),
         )
         verify(transcriptsManager).updateTranscripts("podcast-id", "episode-id", expected1, LoadTranscriptSource.DEFAULT)
     }
@@ -484,6 +496,14 @@ class ShowNotesProcessTest {
         val episodeWithTranscripts2 = ShowNotesEpisode(
             uuid = "episode-id",
             transcripts = listOf(
+                ShowNotesTranscript(
+                    url = "Url",
+                ),
+                ShowNotesTranscript(
+                    type = "Type",
+                ),
+            ),
+            pocketCastsTranscripts = listOf(
                 ShowNotesTranscript(
                     url = "Url",
                 ),
@@ -512,6 +532,7 @@ class ShowNotesProcessTest {
         val episodeWithTranscripts = ShowNotesEpisode(
             uuid = "episode-id",
             transcripts = null,
+            pocketCastsTranscripts = null,
         )
         val showNotes = ShowNotesResponse(
             podcast = ShowNotesPodcast(
@@ -524,7 +545,7 @@ class ShowNotesProcessTest {
         processor.process("episode-id", showNotes)
 
         val expected2 = emptyList<Transcript>()
-        verify(transcriptsManager, never()).updateTranscripts("podcast-id", "episode-id", expected2, LoadTranscriptSource.DEFAULT)
+        verify(transcriptsManager).updateTranscripts("podcast-id", "episode-id", expected2, LoadTranscriptSource.DEFAULT)
     }
 
     @Test

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/shownotes/ShowNotesProcessTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/shownotes/ShowNotesProcessTest.kt
@@ -465,12 +465,14 @@ class ShowNotesProcessTest {
                 url = "Url 1",
                 type = "Type 1",
                 language = "Language 1",
+                isGenerated = false,
             ),
             Transcript(
                 episodeUuid = "episode-id",
                 url = "Url 2",
                 type = "Type 2",
                 language = "Language 2",
+                isGenerated = false,
             ),
         )
         verify(transcriptsManager).updateTranscripts("podcast-id", "episode-id", expected1, LoadTranscriptSource.DEFAULT)

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/podcast/ShowNotesResponse.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/podcast/ShowNotesResponse.kt
@@ -31,6 +31,7 @@ data class ShowNotesEpisode(
     @Json(name = "chapters") val chapters: List<ShowNotesChapter>? = null,
     @Json(name = "chapters_url") val chaptersUrl: String? = null,
     @Json(name = "transcripts") val transcripts: List<ShowNotesTranscript>? = null,
+    @Json(name = "pocket_casts_transcripts") val pocketCastsTranscripts: List<ShowNotesTranscript>? = null,
 )
 
 @JsonClass(generateAdapter = true)

--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/Feature.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/Feature.kt
@@ -211,6 +211,14 @@ enum class Feature(
         hasFirebaseRemoteFlag = false,
         hasDevToggle = true,
     ),
+    GENERATED_TRANSCRIPTS(
+        key = "generated_transcripts",
+        title = "Generated transcripts",
+        defaultValue = BuildConfig.DEBUG,
+        tier = FeatureTier.Free,
+        hasFirebaseRemoteFlag = false,
+        hasDevToggle = true,
+    ),
     ;
 
     companion object {


### PR DESCRIPTION
## Description

This PR adds generated transcripts support.

## Testing Instructions

1. Install the `debug` variant on a device running Android 12 or higher.  
2. Use either no account or a free account.  
3. Play [this episode](https://href.li/?https://nodeweb.pocketcasts.net/admin/podcasts/1213868/episodes/1237292002).  
4. Go to the transcripts.  
5. You should see a blurred paywall.  
6. The content should not be interactive.  
7. Sign in with a Plus or Patron account.  
8. Go back to the transcripts.  
9. You should no longer see the paywall.  
10. Repeat the steps on a device running Android below version 12.  
11. Everything should work the same, except instead of a blur, a blank background should be shown.  
12. Disable the `Generated transcripts` flag.
13. Play a different episode.
14. Play again the episode from 3rd step.
15. You should not see the transcripts from the previous testing steps.  
16. Perform regression tests on regular transcripts.  

## Screenshots or Screencast 

| Pre Android 12 | Android 12+ |
| - | - | 
| ![solid](https://github.com/user-attachments/assets/b659f452-86a4-4264-b33e-4d0313b73015) | ![blur](https://github.com/user-attachments/assets/53384a47-3dcd-4c8d-afa8-d8d887070a25) |

## Checklist
- [ ] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [ ] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [ ] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [ ] ~for accessibility with TalkBack~
