### PR TITLE
Restrcuture transcripts page UI

### DIFF
--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/transcripts/TranscriptDefaults.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/transcripts/TranscriptDefaults.kt
@@ -17,7 +17,7 @@ import au.com.shiftyjelly.pocketcasts.player.R
 import au.com.shiftyjelly.pocketcasts.ui.R as UR
 
 object TranscriptDefaults {
-    val ContentOffsetTop = 64.dp
+    val ContentOffsetTop = 8.dp
     val ContentOffsetBottom = 80.dp
     val TranscriptFontFamily = FontFamily(listOf(Font(UR.font.roboto_serif)))
     val SearchOccurrenceDefaultSpanStyle = SpanStyle(fontSize = 16.sp, fontWeight = FontWeight.W500, fontFamily = TranscriptFontFamily, background = Color.White.copy(alpha = .2f), color = Color.White)
@@ -31,24 +31,19 @@ object TranscriptDefaults {
         if (LocalConfiguration.current.orientation == Configuration.ORIENTATION_LANDSCAPE) 0.dp else 100.dp
 
     data class TranscriptColors(
-        val playerBackgroundColor: Color,
+        private val playerBackgroundColor: Color,
     ) {
-        @Composable
-        fun backgroundColor() =
-            playerBackgroundColor
+        fun backgroundColor() = playerBackgroundColor
 
         companion object {
             @Composable
-            fun contentColor() =
-                MaterialTheme.theme.colors.playerContrast06
+            fun contentColor() = MaterialTheme.theme.colors.playerContrast06
 
             @Composable
-            fun textColor() =
-                MaterialTheme.theme.colors.playerContrast02
+            fun textColor() = MaterialTheme.theme.colors.playerContrast02
 
             @Composable
-            fun iconColor() =
-                MaterialTheme.theme.colors.playerContrast02
+            fun iconColor() = MaterialTheme.theme.colors.playerContrast02
         }
     }
 }

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/transcripts/TranscriptError.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/transcripts/TranscriptError.kt
@@ -4,7 +4,6 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -42,7 +41,7 @@ fun TranscriptError(
     state: UiState.Error,
     colors: TranscriptColors,
     onRetry: () -> Unit,
-    modifier: Modifier,
+    modifier: Modifier = Modifier,
 ) {
     val errorMessage = when (val error = state.error) {
         is TranscriptError.Empty ->
@@ -62,47 +61,41 @@ fun TranscriptError(
     }
 
     Column(
-        modifier = modifier
-            .fillMaxWidth()
-            .background(colors.backgroundColor())
-            .verticalScroll(rememberScrollState()),
         verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally,
+        modifier = modifier
+            .fillMaxSize()
+            .verticalScroll(rememberScrollState())
+            .background(colors.backgroundColor())
+            .padding(horizontal = 16.dp)
+            .padding(bottom = bottomPadding()),
     ) {
-        Column(
-            verticalArrangement = Arrangement.Center,
-            horizontalAlignment = Alignment.CenterHorizontally,
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(horizontal = 16.dp)
-                .padding(bottom = bottomPadding()),
+        Icon(
+            painter = painterResource(IR.drawable.ic_warning),
+            contentDescription = null,
+            tint = TranscriptColors.iconColor().copy(alpha = 0.5f),
+        )
+        TextP40(
+            text = errorMessage,
+            textAlign = TextAlign.Center,
+            modifier = Modifier.padding(top = 12.dp),
+            color = TranscriptColors.textColor(),
+            fontFamily = TranscriptFontFamily,
+            fontWeight = FontWeight.W500,
+            lineHeight = 24.sp,
+        )
+        Button(
+            onClick = onRetry,
+            modifier = Modifier.padding(top = 16.dp),
+            shape = RoundedCornerShape(40.dp),
+            colors = ButtonDefaults.buttonColors(backgroundColor = TranscriptColors.contentColor()),
         ) {
-            Icon(
-                painter = painterResource(IR.drawable.ic_warning),
-                contentDescription = null,
-                tint = TranscriptColors.iconColor().copy(alpha = 0.5f),
-            )
             TextP40(
-                text = errorMessage,
-                textAlign = TextAlign.Center,
-                modifier = Modifier.padding(top = 12.dp),
-                color = TranscriptColors.textColor(),
-                fontFamily = TranscriptFontFamily,
-                fontWeight = FontWeight.W500,
-                lineHeight = 24.sp,
+                text = stringResource(LR.string.try_again),
+                color = Color.White,
+                fontSize = 15.sp,
+                fontWeight = FontWeight.W400,
             )
-            Button(
-                onClick = onRetry,
-                modifier = Modifier.padding(top = 16.dp),
-                shape = RoundedCornerShape(40.dp),
-                colors = ButtonDefaults.buttonColors(backgroundColor = TranscriptColors.contentColor()),
-            ) {
-                TextP40(
-                    text = stringResource(LR.string.try_again),
-                    color = Color.White,
-                    fontSize = 15.sp,
-                    fontWeight = FontWeight.W400,
-                )
-            }
         }
     }
 }
@@ -134,7 +127,6 @@ private fun ErrorPreview() {
             ),
             onRetry = {},
             colors = TranscriptColors(Color.Black),
-            modifier = Modifier.fillMaxSize(),
         )
     }
 }

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/transcripts/TranscriptPage.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/transcripts/TranscriptPage.kt
@@ -11,7 +11,6 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.text.selection.SelectionContainer
@@ -54,6 +53,7 @@ import androidx.webkit.WebSettingsCompat
 import androidx.webkit.WebViewFeature
 import au.com.shiftyjelly.pocketcasts.compose.AppThemeWithBackground
 import au.com.shiftyjelly.pocketcasts.compose.Devices
+import au.com.shiftyjelly.pocketcasts.compose.components.FadedLazyColumn
 import au.com.shiftyjelly.pocketcasts.compose.components.TextP40
 import au.com.shiftyjelly.pocketcasts.compose.extensions.FadeDirection
 import au.com.shiftyjelly.pocketcasts.compose.extensions.gradientBackground
@@ -90,7 +90,7 @@ fun TranscriptPage(
     transcriptViewModel: TranscriptViewModel,
     searchViewModel: TranscriptSearchViewModel,
     theme: Theme,
-    modifier: Modifier,
+    modifier: Modifier = Modifier,
 ) {
     val uiState = transcriptViewModel.uiState.collectAsStateWithLifecycle()
     val transitionState = shelfSharedViewModel.transitionState.collectAsStateWithLifecycle(null)
@@ -103,7 +103,7 @@ fun TranscriptPage(
     val colors = TranscriptColors(playerBackgroundColor)
     Box(
         modifier = modifier
-            .fillMaxWidth()
+            .fillMaxSize()
             .pullRefresh(pullRefreshState),
     ) {
         when (uiState.value) {
@@ -223,21 +223,6 @@ private fun TranscriptContent(
                     transitionState = transitionState,
                 )
             }
-
-            GradientView(
-                baseColor = colors.backgroundColor(),
-                modifier = Modifier
-                    .align(Alignment.TopCenter),
-                fadeDirection = FadeDirection.TopToBottom,
-            )
-
-            GradientView(
-                baseColor = colors.backgroundColor(),
-                modifier = Modifier
-                    .align(Alignment.BottomCenter)
-                    .padding(bottom = bottomPadding()),
-                fadeDirection = FadeDirection.BottomToTop,
-            )
         }
     }
 }
@@ -278,14 +263,14 @@ private fun ScrollableTranscriptView(
             if (state.showAsWebPage) {
                 TranscriptWebView(state, transitionState)
             } else {
-                LazyColumn(
+                FadedLazyColumn(
                     state = scrollState,
                     modifier = scrollableContentModifier,
                     contentPadding = PaddingValues(
                         start = horizontalContentPadding,
                         end = horizontalContentPadding,
-                        top = 64.dp,
-                        bottom = 80.dp,
+                        top = TranscriptDefaults.ContentOffsetTop,
+                        bottom = TranscriptDefaults.ContentOffsetBottom,
                     ),
                 ) {
                     items(state.displayInfo.items) { item ->

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/transcripts/TranscriptPage.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/transcripts/TranscriptPage.kt
@@ -145,7 +145,6 @@ fun TranscriptPage(
                         transcriptViewModel.parseAndLoadTranscript(retryOnFail = true)
                     },
                     colors = colors,
-                    modifier = modifier,
                 )
             }
         }

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/transcripts/TranscriptPageWrapper.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/transcripts/TranscriptPageWrapper.kt
@@ -9,9 +9,10 @@ import androidx.compose.animation.fadeOut
 import androidx.compose.animation.shrinkHorizontally
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
@@ -102,29 +103,13 @@ fun TranscriptPageWrapper(
             else -> Unit
         }
 
-        Box(
+        val playerBackgroundColor = Color(theme.playerBackgroundColor(transcriptUiState.value.podcastAndEpisode?.podcast))
+        Column(
             modifier = Modifier
-                .fillMaxSize(),
+                .fillMaxWidth()
+                .height(configuration.screenHeightDp.dp)
+                .background(playerBackgroundColor),
         ) {
-            TranscriptPage(
-                shelfSharedViewModel = shelfSharedViewModel,
-                transcriptViewModel = transcriptViewModel,
-                searchViewModel = searchViewModel,
-                theme = theme,
-                modifier = Modifier
-                    .height(configuration.screenHeightDp.dp),
-            )
-
-            if (showPaywall) {
-                TranscriptsPaywall(
-                    onClickSubscribe = {},
-                    modifier = Modifier
-                        .padding(top = 56.dp)
-                        .height(configuration.screenHeightDp.dp)
-                        .verticalScroll(rememberScrollState()),
-                )
-            }
-
             TranscriptToolbar(
                 onCloseClick = {
                     shelfSharedViewModel.closeTranscript(
@@ -150,6 +135,24 @@ fun TranscriptPageWrapper(
                 onSearchQueryChanged = searchViewModel::onSearchQueryChanged,
                 expandSearch = expandSearch,
             )
+
+            Box(
+                modifier = Modifier.weight(1f),
+            ) {
+                TranscriptPage(
+                    shelfSharedViewModel = shelfSharedViewModel,
+                    transcriptViewModel = transcriptViewModel,
+                    searchViewModel = searchViewModel,
+                    theme = theme,
+                )
+
+                if (showPaywall) {
+                    TranscriptsPaywall(
+                        onClickSubscribe = {},
+                        modifier = Modifier.verticalScroll(rememberScrollState()),
+                    )
+                }
+            }
         }
 
         LaunchedEffect(transcriptUiState.value) {
@@ -191,7 +194,7 @@ fun TranscriptToolbar(
             contentAlignment = Alignment.TopEnd,
             modifier = Modifier
                 .padding(top = 8.dp)
-                .fillMaxSize(),
+                .fillMaxWidth(),
         ) {
             val transition = updateTransition(expandSearch, label = "Searchbar transition")
             CompositionLocalProvider(LocalRippleConfiguration provides ToolbarRippleConfiguration) {

--- a/modules/features/player/src/main/res/values-sw600dp/dimens.xml
+++ b/modules/features/player/src/main/res/values-sw600dp/dimens.xml
@@ -2,6 +2,6 @@
 <resources>
     <item name="seekbar_width_percentage" format="float" type="dimen">0.8</item>
     <dimen name="large_play_button_margin_bottom">40dp</dimen>
-    <dimen name="transcript_text_bottom_padding">125dp</dimen>
+    <dimen name="transcript_text_bottom_padding">140dp</dimen>
     <dimen name="seekbar_margin_bottom">0dp</dimen>
 </resources>

--- a/modules/features/player/src/main/res/values/dimens.xml
+++ b/modules/features/player/src/main/res/values/dimens.xml
@@ -15,5 +15,5 @@
     <dimen name="mini_player_margin">6dp</dimen>
     <dimen name="mini_player_play_button_size_40">40dp</dimen>
     <dimen name="mini_player_skip_button_size_56">56dp</dimen>
-    <dimen name="transcript_text_bottom_padding">125dp</dimen>
+    <dimen name="transcript_text_bottom_padding">140dp</dimen>
 </resources>

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/FadedLazyList.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/FadedLazyList.kt
@@ -126,7 +126,7 @@ sealed interface FadeSize {
         val value: Dp,
     ) : FadeSize {
         init {
-            check(value > 0.dp) { "Fade threshold must be positive: $value" }
+            check(value > 0.dp) { "Fade size must be positive: $value" }
         }
     }
 
@@ -136,7 +136,7 @@ sealed interface FadeSize {
     ) : FadeSize {
         init {
             check(value > 0.0f && value <= 1.0f) {
-                "Fade threshold must be between 0.0 (exclusive) and 1.0 (inclusive): $value"
+                "Fade size must be between 0.0 (exclusive) and 1.0 (inclusive): $value"
             }
         }
     }
@@ -150,7 +150,7 @@ private class FadedEdgeState(
 ) {
     private val layoutInfo get() = listState.layoutInfo
 
-    val boxSize by derivedStateOf {
+    private val boxSize by derivedStateOf {
         val viewportSize = layoutInfo.viewportSize.toSize()
         when (layoutInfo.orientation) {
             Orientation.Vertical -> viewportSize.copy(
@@ -168,7 +168,7 @@ private class FadedEdgeState(
         }
     }
 
-    val startAlpha by derivedStateOf {
+    private val startAlpha by derivedStateOf {
         val firstItemInfo = layoutInfo.visibleItemsInfo.firstOrNull() ?: return@derivedStateOf 0f
         val lastItemInfo = layoutInfo.visibleItemsInfo.lastOrNull() ?: return@derivedStateOf 0f
 
@@ -199,7 +199,7 @@ private class FadedEdgeState(
         }
     }
 
-    val endAlpha by derivedStateOf {
+    private val endAlpha by derivedStateOf {
         val firstItemInfo = layoutInfo.visibleItemsInfo.firstOrNull() ?: return@derivedStateOf 0f
         val lastItemInfo = layoutInfo.visibleItemsInfo.lastOrNull() ?: return@derivedStateOf 0f
 

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/FadedLazyList.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/FadedLazyList.kt
@@ -1,0 +1,299 @@
+package au.com.shiftyjelly.pocketcasts.compose.components
+
+import androidx.annotation.FloatRange
+import androidx.compose.foundation.gestures.FlingBehavior
+import androidx.compose.foundation.gestures.Orientation
+import androidx.compose.foundation.gestures.ScrollableDefaults
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyListScope
+import androidx.compose.foundation.lazy.LazyListState
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawWithContent
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.BlendMode
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.CompositingStrategy
+import androidx.compose.ui.graphics.drawscope.ContentDrawScope
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.IntSize
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.toSize
+import kotlin.math.abs
+
+@Composable
+fun FadedLazyColumn(
+    modifier: Modifier = Modifier,
+    fadeThreshold: Dp = 32.dp,
+    fadeSize: FadeSize = FadeSize.Relative(0.125f),
+    state: LazyListState = rememberLazyListState(),
+    contentPadding: PaddingValues = PaddingValues(0.dp),
+    reverseLayout: Boolean = false,
+    verticalArrangement: Arrangement.Vertical = if (reverseLayout) Arrangement.Bottom else Arrangement.Top,
+    horizontalAlignment: Alignment.Horizontal = Alignment.Start,
+    flingBehavior: FlingBehavior = ScrollableDefaults.flingBehavior(),
+    userScrollEnabled: Boolean = true,
+    content: LazyListScope.() -> Unit,
+) {
+    val density = LocalDensity.current
+    val edgeState = remember(fadeSize, fadeThreshold, state, density) {
+        FadedEdgeState(
+            fadeSize = fadeSize,
+            fadeThreshold = fadeThreshold,
+            listState = state,
+            density = density,
+        )
+    }
+
+    LazyColumn(
+        state = state,
+        contentPadding = contentPadding,
+        reverseLayout = reverseLayout,
+        verticalArrangement = verticalArrangement,
+        horizontalAlignment = horizontalAlignment,
+        flingBehavior = flingBehavior,
+        userScrollEnabled = userScrollEnabled,
+        content = content,
+        modifier = modifier
+            .graphicsLayer(compositingStrategy = CompositingStrategy.Offscreen)
+            .drawWithContent {
+                drawContent()
+                with(edgeState) { drawStartRect() }
+                with(edgeState) { drawEndRect() }
+            },
+    )
+}
+
+@Composable
+fun FadedLazyRow(
+    modifier: Modifier = Modifier,
+    fadeThreshold: Dp = 32.dp,
+    fadeSize: FadeSize = FadeSize.Relative(0.125f),
+    state: LazyListState = rememberLazyListState(),
+    contentPadding: PaddingValues = PaddingValues(0.dp),
+    reverseLayout: Boolean = false,
+    horizontalArrangement: Arrangement.Horizontal = if (reverseLayout) Arrangement.End else Arrangement.Start,
+    verticalAlignment: Alignment.Vertical = Alignment.Top,
+    flingBehavior: FlingBehavior = ScrollableDefaults.flingBehavior(),
+    userScrollEnabled: Boolean = true,
+    content: LazyListScope.() -> Unit,
+) {
+    val density = LocalDensity.current
+    val edgeState = remember(fadeSize, fadeThreshold, state, density) {
+        FadedEdgeState(
+            fadeSize = fadeSize,
+            fadeThreshold = fadeThreshold,
+            listState = state,
+            density = density,
+        )
+    }
+
+    LazyRow(
+        state = state,
+        contentPadding = contentPadding,
+        reverseLayout = reverseLayout,
+        horizontalArrangement = horizontalArrangement,
+        verticalAlignment = verticalAlignment,
+        flingBehavior = flingBehavior,
+        userScrollEnabled = userScrollEnabled,
+        content = content,
+        modifier = modifier
+            .graphicsLayer(compositingStrategy = CompositingStrategy.Offscreen)
+            .drawWithContent {
+                drawContent()
+                with(edgeState) { drawStartRect() }
+                with(edgeState) { drawEndRect() }
+            },
+    )
+}
+
+sealed interface FadeSize {
+    @JvmInline
+    value class Fixed(
+        val value: Dp,
+    ) : FadeSize {
+        init {
+            check(value > 0.dp) { "Fade threshold must be positive: $value" }
+        }
+    }
+
+    @JvmInline
+    value class Relative(
+        @FloatRange(0.0, 1.0, fromInclusive = false) val value: Float,
+    ) : FadeSize {
+        init {
+            check(value > 0.0f && value <= 1.0f) {
+                "Fade threshold must be between 0.0 (exclusive) and 1.0 (inclusive): $value"
+            }
+        }
+    }
+}
+
+private class FadedEdgeState(
+    private val fadeSize: FadeSize,
+    private val fadeThreshold: Dp,
+    private val listState: LazyListState,
+    private val density: Density,
+) {
+    private val layoutInfo get() = listState.layoutInfo
+
+    val boxSize by derivedStateOf {
+        val viewportSize = layoutInfo.viewportSize.toSize()
+        when (layoutInfo.orientation) {
+            Orientation.Vertical -> viewportSize.copy(
+                height = when (fadeSize) {
+                    is FadeSize.Fixed -> density.run { fadeSize.value.toPx() }
+                    is FadeSize.Relative -> viewportSize.height * fadeSize.value
+                },
+            )
+            Orientation.Horizontal -> viewportSize.copy(
+                width = when (fadeSize) {
+                    is FadeSize.Fixed -> density.run { fadeSize.value.toPx() }
+                    is FadeSize.Relative -> viewportSize.width * fadeSize.value
+                },
+            )
+        }
+    }
+
+    val startAlpha by derivedStateOf {
+        val firstItemInfo = layoutInfo.visibleItemsInfo.firstOrNull() ?: return@derivedStateOf 0f
+        val lastItemInfo = layoutInfo.visibleItemsInfo.lastOrNull() ?: return@derivedStateOf 0f
+
+        val lastItemIndex = layoutInfo.totalItemsCount - 1
+
+        val viewportMainAxisSize = layoutInfo.viewportSize.mainAxis
+        val spacingSize = layoutInfo.mainAxisItemSpacing * lastItemIndex
+        val visibleItemsSize = layoutInfo.visibleItemsInfo.sumOf { it.size } + spacingSize
+        val clippingSize = visibleItemsSize - viewportMainAxisSize
+
+        val isFirstVisible = firstItemInfo.index == 0
+        val isLastClipped = lastItemInfo.index == lastItemIndex && clippingSize > 0
+
+        if (isFirstVisible) {
+            val fadeThreshold = minOf(
+                density.run { fadeThreshold.toPx() },
+                firstItemInfo.size.toFloat(),
+                if (isLastClipped) clippingSize.toFloat() else Float.MAX_VALUE,
+            )
+            val unpaddedOffset = abs(firstItemInfo.offset) - layoutInfo.beforeContentPadding
+            if (unpaddedOffset > 0) {
+                unpaddedOffset / fadeThreshold
+            } else {
+                0f
+            }
+        } else {
+            1f
+        }
+    }
+
+    val endAlpha by derivedStateOf {
+        val firstItemInfo = layoutInfo.visibleItemsInfo.firstOrNull() ?: return@derivedStateOf 0f
+        val lastItemInfo = layoutInfo.visibleItemsInfo.lastOrNull() ?: return@derivedStateOf 0f
+
+        val lastItemIndex = layoutInfo.totalItemsCount - 1
+
+        val viewportMainAxisSize = layoutInfo.viewportSize.mainAxis
+        val spacingSize = layoutInfo.mainAxisItemSpacing * lastItemIndex
+        val visibleItemsSize = layoutInfo.visibleItemsInfo.sumOf { it.size } + spacingSize
+        val clippingSize = visibleItemsSize - viewportMainAxisSize
+
+        val isLastVisible = lastItemInfo.index == lastItemIndex
+        val isFirstClipped = firstItemInfo.index == 0 && clippingSize > 0
+
+        if (isLastVisible) {
+            val fadeThreshold = minOf(
+                density.run { fadeThreshold.toPx() },
+                lastItemInfo.size.toFloat(),
+                if (isFirstClipped) clippingSize.toFloat() else Float.MAX_VALUE,
+            )
+            val lastUnpaddedVisibleSize = viewportMainAxisSize - lastItemInfo.offset - layoutInfo.afterContentPadding
+            val unpaddedOffsetLeft = lastItemInfo.size - lastUnpaddedVisibleSize
+            if (unpaddedOffsetLeft > 0) {
+                unpaddedOffsetLeft / fadeThreshold
+            } else {
+                0f
+            }
+        } else {
+            1f
+        }
+    }
+
+    fun ContentDrawScope.drawStartRect() {
+        drawRect(
+            brush = gradientBrush(
+                0f to Color.Black.copy(alpha = startAlpha),
+                0.15f to Color.Black.copy(alpha = startAlpha),
+                1f to Color.Transparent,
+                start = 0f,
+                end = boxSize.mainAxis,
+            ),
+            size = boxSize,
+            topLeft = Offset.Zero,
+            blendMode = BlendMode.DstOut,
+        )
+    }
+
+    fun ContentDrawScope.drawEndRect() {
+        val viewportMainAxis = layoutInfo.viewportSize.mainAxis.toFloat()
+        val endOffset = viewportMainAxis - boxSize.mainAxis
+        drawRect(
+            brush = gradientBrush(
+                0f to Color.Black.copy(alpha = endAlpha),
+                0.15f to Color.Black.copy(alpha = endAlpha),
+                1f to Color.Transparent,
+                start = viewportMainAxis,
+                end = endOffset,
+            ),
+            size = boxSize,
+            topLeft = offset(mainAxis = endOffset),
+            blendMode = BlendMode.DstOut,
+        )
+    }
+
+    private val Size.mainAxis get() = when (listState.layoutInfo.orientation) {
+        Orientation.Vertical -> height
+        Orientation.Horizontal -> width
+    }
+
+    private val IntSize.mainAxis get() = when (listState.layoutInfo.orientation) {
+        Orientation.Vertical -> height
+        Orientation.Horizontal -> width
+    }
+
+    private fun gradientBrush(
+        vararg colorStops: Pair<Float, Color>,
+        start: Float = 0f,
+        end: Float = Float.POSITIVE_INFINITY,
+    ) = when (listState.layoutInfo.orientation) {
+        Orientation.Vertical -> Brush.verticalGradient(
+            colorStops = colorStops,
+            startY = start,
+            endY = end,
+        )
+        Orientation.Horizontal -> Brush.horizontalGradient(
+            colorStops = colorStops,
+            startX = start,
+            endX = end,
+        )
+    }
+
+    private fun offset(
+        mainAxis: Float,
+    ) = when (listState.layoutInfo.orientation) {
+        Orientation.Vertical -> Offset(x = 0f, y = mainAxis)
+        Orientation.Horizontal -> Offset(x = mainAxis, y = 0f)
+    }
+}

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/extensions/Modifier.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/extensions/Modifier.kt
@@ -40,11 +40,6 @@ fun Modifier.brush(brush: Brush) = this
         }
     }
 
-fun Modifier.ifThen(
-    predicate: Boolean,
-    then: () -> Modifier,
-) = then(if (predicate) then() else Modifier)
-
 /**
  * When the user presses enter run the action.
  */

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/extensions/Modifier.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/extensions/Modifier.kt
@@ -40,6 +40,11 @@ fun Modifier.brush(brush: Brush) = this
         }
     }
 
+fun Modifier.ifThen(
+    predicate: Boolean,
+    then: () -> Modifier,
+) = then(if (predicate) then() else Modifier)
+
 /**
  * When the user presses enter run the action.
  */


### PR DESCRIPTION
## Description

This PR restructures the transcripts page UI. Previously, all content was placed inside a `Box` with padding applied to create the illusion of a column-like layout. Now, the components are inside a `Column`, making it easier to support the "generated transcripts" info header.

To simplify edge fading and eliminate the need for gradients, I introduced a FadedLazyColumn type. It automatically applies edge fading based on the scroll position. When the content is scrolled to the top, the top edge does not fade. Likewise, when scrolled to the bottom, the bottom edge remains clear.

## Testing Instructions

Smoke test transcripts UI.

## Checklist
- [ ] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] ~I have considered whether it makes sense to add tests for my changes~
- [ ] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [ ] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [ ] ~for accessibility with TalkBack~