### PR TITLE
[Guest List and Network Highlight] Add header

### DIFF
--- a/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/CollectionListRowAdapter.kt
+++ b/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/CollectionListRowAdapter.kt
@@ -1,8 +1,6 @@
 package au.com.shiftyjelly.pocketcasts.discover.view
 
-import android.content.res.Configuration
 import android.view.LayoutInflater
-import android.view.View
 import android.view.ViewGroup
 import androidx.core.view.isVisible
 import androidx.recyclerview.widget.DiffUtil
@@ -10,7 +8,11 @@ import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTracker
+import au.com.shiftyjelly.pocketcasts.discover.databinding.CollectionHeaderBinding
 import au.com.shiftyjelly.pocketcasts.discover.databinding.ItemCollectionListBinding
+import au.com.shiftyjelly.pocketcasts.discover.view.CollectionListRowAdapter.CollectionItem
+import au.com.shiftyjelly.pocketcasts.discover.view.CollectionListRowAdapter.CollectionItem.CollectionHeader
+import au.com.shiftyjelly.pocketcasts.discover.view.CollectionListRowAdapter.CollectionItem.CollectionPodcast
 import au.com.shiftyjelly.pocketcasts.discover.view.CollectionListRowAdapter.CollectionListViewHolder.Companion.NUMBER_OF_ROWS_PER_PAGE
 import au.com.shiftyjelly.pocketcasts.discover.view.DiscoverFragment.Companion.LIST_ID_KEY
 import au.com.shiftyjelly.pocketcasts.discover.view.DiscoverFragment.Companion.PODCAST_UUID_KEY
@@ -21,45 +23,50 @@ import au.com.shiftyjelly.pocketcasts.servers.model.DiscoverPodcast
 import au.com.shiftyjelly.pocketcasts.ui.extensions.themed
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
-private val differ = object : DiffUtil.ItemCallback<List<Any>>() {
-    override fun areItemsTheSame(oldItem: List<Any>, newItem: List<Any>): Boolean {
-        return oldItem.filterIsInstance<DiscoverPodcast>()
-            .map { it.uuid }
-            .toTypedArray()
-            .contentDeepEquals(
-                newItem
-                    .filterIsInstance<DiscoverPodcast>()
-                    .map { it.uuid }.toTypedArray(),
-            )
+private val differ = object : DiffUtil.ItemCallback<List<CollectionItem>>() {
+    override fun areItemsTheSame(oldItem: List<CollectionItem>, newItem: List<CollectionItem>): Boolean {
+        if (oldItem.size != newItem.size) return false
+        return oldItem.zip(newItem).all { (old, new) ->
+            when {
+                old is CollectionPodcast && new is CollectionPodcast ->
+                    old.podcast.uuid == new.podcast.uuid
+
+                old is CollectionHeader && new is CollectionHeader ->
+                    old.title == new.title && old.subtitle == new.subtitle
+
+                else -> false
+            }
+        }
     }
 
-    override fun areContentsTheSame(oldItem: List<Any>, newItem: List<Any>): Boolean {
-        return oldItem.filterIsInstance<DiscoverPodcast>().toTypedArray().contentDeepEquals(newItem.filterIsInstance<DiscoverPodcast>().toTypedArray())
+    override fun areContentsTheSame(oldItem: List<CollectionItem>, newItem: List<CollectionItem>): Boolean {
+        return oldItem.toTypedArray().contentDeepEquals(newItem.toTypedArray())
     }
 }
 
-internal class CollectionListRowAdapter(
+class CollectionListRowAdapter(
     val onPodcastClicked: ((DiscoverPodcast, String?) -> Unit),
     val onPodcastSubscribe: (DiscoverPodcast, String?) -> Unit,
     val onHeaderClicked: () -> Unit,
     val analyticsTracker: AnalyticsTracker,
-) : ListAdapter<List<Any>, CollectionListRowAdapter.CollectionListViewHolder>(differ) {
+) : ListAdapter<List<CollectionItem>, RecyclerView.ViewHolder>(differ) {
+
+    private var fromListId: String? = null
+
+    companion object {
+        const val HEADER_OFFSET = 2
+        private const val TYPE_HEADER = 0
+        private const val TYPE_PODCAST = 1
+    }
 
     class CollectionListViewHolder(
         val binding: ItemCollectionListBinding,
         onItemClicked: (Int, Int) -> Unit,
-        onHeaderClicked: () -> Unit,
         onPodcastSubscribe: (Int, Int) -> Unit,
     ) : RecyclerView.ViewHolder(binding.root) {
 
-        private val imageRequestFactory = PocketCastsImageRequestFactory(
-            binding.root.context,
-            placeholderType = PlaceholderType.Large,
-        ).themed()
-
         companion object {
             const val NUMBER_OF_ROWS_PER_PAGE = 2
-            const val NUMBER_OF_PODCASTS_TO_DISPLAY_TWICE = 2
         }
 
         init {
@@ -68,9 +75,6 @@ internal class CollectionListRowAdapter(
             }
             binding.row1.setOnClickListener {
                 onItemClicked(bindingAdapterPosition, 1)
-            }
-            binding.header.root.setOnClickListener {
-                onHeaderClicked()
             }
             binding.row0.onSubscribeClicked = {
                 onPodcastSubscribe(bindingAdapterPosition, 0)
@@ -82,106 +86,111 @@ internal class CollectionListRowAdapter(
 
         val rows = listOf(binding.row0, binding.row1)
 
-        fun bindPodcasts(podcastSublist: List<Any>, isSubscribeButtonVisible: Boolean) {
+        fun bindPodcasts(podcastSublist: List<Any>) {
             rows.forEachIndexed { index, row ->
-                row.clear()
                 row.isVisible = index < podcastSublist.size
-
                 val podcast = podcastSublist.getOrNull(index) as? DiscoverPodcast
                 row.podcast = podcast
+            }
+        }
+    }
 
-                val isLandscape = row.resources.configuration.orientation == Configuration.ORIENTATION_LANDSCAPE
-                row.setSubscribeButtonVisibility(isSubscribeButtonVisible || isLandscape)
+    class CollectionHeaderViewHolder(
+        val binding: CollectionHeaderBinding,
+        onHeaderClicked: () -> Unit,
+    ) : RecyclerView.ViewHolder(binding.root) {
+
+        private val imageRequestFactory = PocketCastsImageRequestFactory(
+            binding.root.context,
+            placeholderType = PlaceholderType.Large,
+        ).themed()
+
+        init {
+            binding.root.setOnClickListener {
+                onHeaderClicked()
             }
         }
 
-        fun bindHeader(header: CollectionHeader) {
-            binding.header.root.isVisible = true
-            binding.header.lblTitle.text = header.title
-            binding.header.lblSubtitle.text = header.subtitle
-            imageRequestFactory.createForFileOrUrl(header.imageUrl).loadInto(binding.header.imageHeader)
-            binding.header.root.contentDescription =
+        fun bind(header: CollectionHeader) {
+            binding.lblTitle.text = header.title
+            binding.lblSubtitle.text = header.subtitle
+            imageRequestFactory.createForFileOrUrl(header.imageUrl).loadInto(binding.imageHeader)
+            binding.root.contentDescription =
                 binding.root.context.getString(LR.string.discover_collection_header_content_description, header.title)
-
-            val height = getPodcastsHeight(binding.podcasts)
-            val layoutParams = binding.root.layoutParams
-            layoutParams.height = height
-            binding.root.layoutParams = layoutParams
-        }
-
-        private fun getPodcastsHeight(view: View): Int {
-            // It's necessary because it performs the calculation of the view's width and height based on its internal properties.
-            // Without calling it, the measuredHeight and measuredWidth properties wouldn't be correctly defined,
-            // as these properties are calculated after the view is measured.
-            view.measure(0, 0)
-            return view.measuredHeight
         }
     }
 
-    private var fromListId: String? = null
-    private var header: CollectionHeader? = null
-
-    fun submitPodcastList(list: List<DiscoverPodcast>, header: CollectionHeader?, commitCallback: Runnable?) {
-        this.header = header
+    fun submitPodcastList(list: List<CollectionItem>, header: CollectionItem?, commitCallback: Runnable?) {
         val chunkedList = list.chunked(NUMBER_OF_ROWS_PER_PAGE)
+        val headerList = header?.let { listOf(listOf(it)) } ?: emptyList()
 
-        // We want to display the first two podcasts on the next page as well, without the header. That's why we duplicate them in the list.
-        val modifiedList = if (chunkedList.isNotEmpty()) {
-            listOf(chunkedList[0]) + chunkedList
-        } else {
-            chunkedList
-        }
-        submitList(modifiedList, commitCallback)
+        submitList(headerList + chunkedList, commitCallback)
     }
 
-    fun showLoadingList() {
-        val loadingList = listOf(MutableList(NUMBER_OF_ROWS_PER_PAGE) { LoadingItem() })
-        submitList(loadingList)
-    }
-
-    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): CollectionListViewHolder {
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): RecyclerView.ViewHolder {
         val inflater = LayoutInflater.from(parent.context)
-        val binding = ItemCollectionListBinding.inflate(inflater, parent, false)
 
-        return CollectionListViewHolder(
-            binding,
-            onItemClicked = { pageIndex, podcastIndex ->
-                val podcastSublist = getItem(pageIndex)
-                val podcast = podcastSublist.getOrNull(podcastIndex) as? DiscoverPodcast
+        when (viewType) {
+            TYPE_PODCAST -> {
+                return CollectionListViewHolder(
+                    ItemCollectionListBinding.inflate(inflater, parent, false),
+                    onItemClicked = { pageIndex, podcastIndex ->
+                        val items = getItem(pageIndex)
+                        val podcasts = items.filterIsInstance<CollectionPodcast>().map { it.podcast }
+                        val podcast = podcasts.getOrNull(podcastIndex) as? DiscoverPodcast
 
-                if (podcast == null) return@CollectionListViewHolder
+                        if (podcast == null) return@CollectionListViewHolder
 
-                fromListId?.let {
-                    analyticsTracker.track(
-                        AnalyticsEvent.DISCOVER_LIST_PODCAST_TAPPED,
-                        mapOf(
-                            LIST_ID_KEY to it,
-                            PODCAST_UUID_KEY to podcast.uuid,
-                        ),
-                    )
+                        fromListId?.let {
+                            analyticsTracker.track(
+                                AnalyticsEvent.DISCOVER_LIST_PODCAST_TAPPED,
+                                mapOf(
+                                    LIST_ID_KEY to it,
+                                    PODCAST_UUID_KEY to podcast.uuid,
+                                ),
+                            )
+                        }
+                        onPodcastClicked(podcast, fromListId)
+                    },
+                    onPodcastSubscribe = { pageIndex, podcastIndex ->
+                        val items = getItem(pageIndex)
+                        val podcasts = items.filterIsInstance<CollectionPodcast>().map { it.podcast }
+                        val podcast = podcasts.getOrNull(podcastIndex) as? DiscoverPodcast
+                        podcast?.let { onPodcastSubscribe(it, fromListId) }
+                    },
+                )
+            }
+
+            TYPE_HEADER -> {
+                return CollectionHeaderViewHolder(CollectionHeaderBinding.inflate(inflater, parent, false)) {
+                    onHeaderClicked()
                 }
-                onPodcastClicked(podcast, fromListId)
-            },
-            onHeaderClicked = {
-                onHeaderClicked()
-            },
-            onPodcastSubscribe = { pageIndex, podcastIndex ->
-                val podcastSublist = getItem(pageIndex)
-                val podcast = podcastSublist.getOrNull(podcastIndex) as? DiscoverPodcast
-                podcast?.let { onPodcastSubscribe(it, fromListId) }
-            },
-        )
+            }
+
+            else -> throw IllegalArgumentException("Invalid view type")
+        }
     }
 
-    override fun onBindViewHolder(holder: CollectionListViewHolder, position: Int) {
-        val podcastSublist = getItem(position)
+    override fun onBindViewHolder(holder: RecyclerView.ViewHolder, position: Int) {
+        val items = getItem(position) ?: emptyList()
+        when (val collectionItem = items.firstOrNull()) {
+            is CollectionHeader -> (holder as CollectionHeaderViewHolder).bind(collectionItem)
+            is CollectionPodcast -> {
+                val podcasts = items.filterIsInstance<CollectionPodcast>().map { it.podcast }
+                (holder as CollectionListViewHolder).bindPodcasts(podcasts)
+            }
 
-        holder.bindPodcasts(podcastSublist, isSubscribeButtonVisible = position != 0)
+            else -> throw IllegalArgumentException("Unknown item type at position $position")
+        }
+    }
 
-        if (position == 0) {
-            this.header?.let { holder.bindHeader(it) }
-        } else {
-            holder.binding.header.root.isVisible = false
+    override fun getItemViewType(position: Int): Int {
+        val itemList: List<CollectionItem> = getItem(position) ?: emptyList()
+
+        return when (itemList.firstOrNull()) {
+            is CollectionHeader -> TYPE_HEADER
+            is CollectionPodcast -> TYPE_PODCAST
+            else -> throw IllegalArgumentException("Unknown type at position $position")
         }
     }
 
@@ -189,5 +198,10 @@ internal class CollectionListRowAdapter(
         this.fromListId = value
     }
 
-    data class CollectionHeader(val imageUrl: String, val title: String?, val subtitle: String?)
+    fun getListId() = this.fromListId
+
+    sealed class CollectionItem {
+        data class CollectionHeader(val imageUrl: String, val title: String?, val subtitle: String?) : CollectionItem()
+        data class CollectionPodcast(val podcast: DiscoverPodcast) : CollectionItem()
+    }
 }

--- a/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/CollectionListRowAdapter.kt
+++ b/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/CollectionListRowAdapter.kt
@@ -155,7 +155,7 @@ internal class CollectionListRowAdapter(
                 holder.binding.header.lblSubtitle.text = it.subtitle
                 holder.binding.header.imageHeader.load(it.imageUrl)
                 holder.binding.header.root.contentDescription =
-                    it.title + " " + holder.binding.root.context.getString(LR.string.discover_collection_header_content_description_suffix)
+                    holder.binding.root.context.getString(LR.string.discover_collection_header_content_description, it.title)
 
                 val height = getPodcastsHeight(holder.binding.podcasts)
                 val layoutParams = holder.binding.root.layoutParams

--- a/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/CollectionListRowAdapter.kt
+++ b/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/CollectionListRowAdapter.kt
@@ -27,6 +27,7 @@ internal class CollectionListRowAdapter(
 
         companion object {
             const val NUMBER_OF_ROWS_PER_PAGE = 2
+            const val NUMBER_OF_PODCASTS_TO_DISPLAY_TWICE = 2
         }
 
         init {
@@ -59,7 +60,15 @@ internal class CollectionListRowAdapter(
 
     fun submitPodcastList(list: List<DiscoverPodcast>, header: CollectionHeader, commitCallback: Runnable?) {
         this.header = header
-        submitList(list.chunked(NUMBER_OF_ROWS_PER_PAGE), commitCallback)
+        val chunkedList = list.chunked(NUMBER_OF_ROWS_PER_PAGE)
+
+        // We want to display the first two podcasts on the next page as well, without the header. That's why we duplicate them in the list.
+        val modifiedList = if (chunkedList.isNotEmpty()) {
+            listOf(chunkedList[0]) + chunkedList
+        } else {
+            chunkedList
+        }
+        submitList(modifiedList, commitCallback)
     }
 
     fun showLoadingList() {

--- a/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/CollectionListRowAdapter.kt
+++ b/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/CollectionListRowAdapter.kt
@@ -18,10 +18,11 @@ import coil.load
 internal class CollectionListRowAdapter(
     val onPodcastClicked: ((DiscoverPodcast, String?) -> Unit),
     val onPodcastSubscribe: (DiscoverPodcast, String?) -> Unit,
+    val onHeaderClicked: () -> Unit,
     val analyticsTracker: AnalyticsTracker,
 ) : ListAdapter<List<Any>, CollectionListRowAdapter.CollectionListViewHolder>(SmallListDiffer) {
 
-    class CollectionListViewHolder(val binding: ItemCollectionListBinding, onItemClicked: (Int, Int) -> Unit) : RecyclerView.ViewHolder(binding.root) {
+    class CollectionListViewHolder(val binding: ItemCollectionListBinding, onItemClicked: (Int, Int) -> Unit, onHeaderClicked: () -> Unit) : RecyclerView.ViewHolder(binding.root) {
 
         companion object {
             const val NUMBER_OF_ROWS_PER_PAGE = 2
@@ -33,6 +34,9 @@ internal class CollectionListRowAdapter(
             }
             binding.row1.setOnClickListener {
                 onItemClicked(bindingAdapterPosition, 1)
+            }
+            binding.header.root.setOnClickListener {
+                onHeaderClicked()
             }
         }
 
@@ -66,23 +70,29 @@ internal class CollectionListRowAdapter(
         val inflater = LayoutInflater.from(parent.context)
         val binding = ItemCollectionListBinding.inflate(inflater, parent, false)
 
-        return CollectionListViewHolder(binding) { pageIndex, podcastIndex ->
-            val podcastSublist = getItem(pageIndex)
-            val podcast = podcastSublist.getOrNull(podcastIndex) as? DiscoverPodcast
+        return CollectionListViewHolder(
+            binding,
+            onItemClicked = { pageIndex, podcastIndex ->
+                val podcastSublist = getItem(pageIndex)
+                val podcast = podcastSublist.getOrNull(podcastIndex) as? DiscoverPodcast
 
-            if (podcast == null) return@CollectionListViewHolder
+                if (podcast == null) return@CollectionListViewHolder
 
-            fromListId?.let {
-                analyticsTracker.track(
-                    AnalyticsEvent.DISCOVER_LIST_PODCAST_TAPPED,
-                    mapOf(
-                        LIST_ID_KEY to it,
-                        PODCAST_UUID_KEY to podcast.uuid,
-                    ),
-                )
-            }
-            onPodcastClicked(podcast, fromListId)
-        }
+                fromListId?.let {
+                    analyticsTracker.track(
+                        AnalyticsEvent.DISCOVER_LIST_PODCAST_TAPPED,
+                        mapOf(
+                            LIST_ID_KEY to it,
+                            PODCAST_UUID_KEY to podcast.uuid,
+                        ),
+                    )
+                }
+                onPodcastClicked(podcast, fromListId)
+            },
+            onHeaderClicked = {
+                onHeaderClicked()
+            },
+        )
     }
 
     override fun onBindViewHolder(holder: CollectionListViewHolder, position: Int) {

--- a/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/CollectionListRowAdapter.kt
+++ b/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/CollectionListRowAdapter.kt
@@ -1,6 +1,7 @@
 package au.com.shiftyjelly.pocketcasts.discover.view
 
 import android.view.LayoutInflater
+import android.view.View
 import android.view.ViewGroup
 import androidx.core.view.isVisible
 import androidx.recyclerview.widget.DiffUtil
@@ -117,6 +118,18 @@ class CollectionListRowAdapter(
             imageRequestFactory.createForFileOrUrl(header.imageUrl).loadInto(binding.imageHeader)
             binding.root.contentDescription =
                 binding.root.context.getString(LR.string.discover_collection_header_content_description, header.title)
+        }
+
+        fun updateVisibility(isVisible: Boolean) {
+            if (isVisible) {
+                binding.root.animate()
+                    .alpha(1f)
+                    .setDuration(300)
+                    .withStartAction { binding.root.visibility = View.VISIBLE }
+                    .start()
+            } else {
+                binding.root.visibility = View.INVISIBLE
+            }
         }
     }
 

--- a/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/CollectionListRowAdapter.kt
+++ b/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/CollectionListRowAdapter.kt
@@ -14,6 +14,7 @@ import au.com.shiftyjelly.pocketcasts.discover.view.DiscoverFragment.Companion.L
 import au.com.shiftyjelly.pocketcasts.discover.view.DiscoverFragment.Companion.PODCAST_UUID_KEY
 import au.com.shiftyjelly.pocketcasts.servers.model.DiscoverPodcast
 import coil.load
+import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 internal class CollectionListRowAdapter(
     val onPodcastClicked: ((DiscoverPodcast, String?) -> Unit),
@@ -106,6 +107,8 @@ internal class CollectionListRowAdapter(
                 holder.binding.header.lblTitle.text = it.title
                 holder.binding.header.lblSubtitle.text = it.subtitle
                 holder.binding.header.imageHeader.load(it.imageUrl)
+                holder.binding.header.root.contentDescription =
+                    it.title + " " + holder.binding.root.context.getString(LR.string.discover_collection_header_content_description_suffix)
 
                 val height = getPodcastsHeight(holder.binding.podcasts)
                 val layoutParams = holder.binding.root.layoutParams

--- a/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/CollectionListRowAdapter.kt
+++ b/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/CollectionListRowAdapter.kt
@@ -13,7 +13,7 @@ import au.com.shiftyjelly.pocketcasts.discover.databinding.ItemCollectionListBin
 import au.com.shiftyjelly.pocketcasts.discover.view.CollectionListRowAdapter.CollectionItem
 import au.com.shiftyjelly.pocketcasts.discover.view.CollectionListRowAdapter.CollectionItem.CollectionHeader
 import au.com.shiftyjelly.pocketcasts.discover.view.CollectionListRowAdapter.CollectionItem.CollectionPodcast
-import au.com.shiftyjelly.pocketcasts.discover.view.CollectionListRowAdapter.CollectionListViewHolder.Companion.NUMBER_OF_ROWS_PER_PAGE
+import au.com.shiftyjelly.pocketcasts.discover.view.CollectionListRowAdapter.PodcastsViewHolder.Companion.NUMBER_OF_ROWS_PER_PAGE
 import au.com.shiftyjelly.pocketcasts.discover.view.DiscoverFragment.Companion.LIST_ID_KEY
 import au.com.shiftyjelly.pocketcasts.discover.view.DiscoverFragment.Companion.PODCAST_UUID_KEY
 import au.com.shiftyjelly.pocketcasts.repositories.images.PocketCastsImageRequestFactory
@@ -59,7 +59,7 @@ class CollectionListRowAdapter(
         private const val TYPE_PODCAST = 1
     }
 
-    class CollectionListViewHolder(
+    class PodcastsViewHolder(
         val binding: ItemCollectionListBinding,
         onItemClicked: (Int, Int) -> Unit,
         onPodcastSubscribe: (Int, Int) -> Unit,
@@ -95,7 +95,7 @@ class CollectionListRowAdapter(
         }
     }
 
-    class CollectionHeaderViewHolder(
+    class HeaderViewHolder(
         val binding: CollectionHeaderBinding,
         onHeaderClicked: () -> Unit,
     ) : RecyclerView.ViewHolder(binding.root) {
@@ -132,14 +132,14 @@ class CollectionListRowAdapter(
 
         when (viewType) {
             TYPE_PODCAST -> {
-                return CollectionListViewHolder(
+                return PodcastsViewHolder(
                     ItemCollectionListBinding.inflate(inflater, parent, false),
                     onItemClicked = { pageIndex, podcastIndex ->
                         val items = getItem(pageIndex)
                         val podcasts = items.filterIsInstance<CollectionPodcast>().map { it.podcast }
                         val podcast = podcasts.getOrNull(podcastIndex) as? DiscoverPodcast
 
-                        if (podcast == null) return@CollectionListViewHolder
+                        if (podcast == null) return@PodcastsViewHolder
 
                         fromListId?.let {
                             analyticsTracker.track(
@@ -162,7 +162,7 @@ class CollectionListRowAdapter(
             }
 
             TYPE_HEADER -> {
-                return CollectionHeaderViewHolder(CollectionHeaderBinding.inflate(inflater, parent, false)) {
+                return HeaderViewHolder(CollectionHeaderBinding.inflate(inflater, parent, false)) {
                     onHeaderClicked()
                 }
             }
@@ -174,10 +174,10 @@ class CollectionListRowAdapter(
     override fun onBindViewHolder(holder: RecyclerView.ViewHolder, position: Int) {
         val items = getItem(position) ?: emptyList()
         when (val collectionItem = items.firstOrNull()) {
-            is CollectionHeader -> (holder as CollectionHeaderViewHolder).bind(collectionItem)
+            is CollectionHeader -> (holder as HeaderViewHolder).bind(collectionItem)
             is CollectionPodcast -> {
                 val podcasts = items.filterIsInstance<CollectionPodcast>().map { it.podcast }
-                (holder as CollectionListViewHolder).bindPodcasts(podcasts)
+                (holder as PodcastsViewHolder).bindPodcasts(podcasts)
             }
 
             else -> throw IllegalArgumentException("Unknown item type at position $position")

--- a/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/CollectionListRowAdapter.kt
+++ b/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/CollectionListRowAdapter.kt
@@ -110,6 +110,9 @@ internal class CollectionListRowAdapter(
         }
 
         private fun getPodcastsHeight(view: View): Int {
+            // It's necessary because it performs the calculation of the view's width and height based on its internal properties.
+            // Without calling it, the measuredHeight and measuredWidth properties wouldn't be correctly defined,
+            // as these properties are calculated after the view is measured.
             view.measure(0, 0)
             return view.measuredHeight
         }

--- a/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/CollectionListRowAdapter.kt
+++ b/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/CollectionListRowAdapter.kt
@@ -1,6 +1,7 @@
 package au.com.shiftyjelly.pocketcasts.discover.view
 
 import android.view.LayoutInflater
+import android.view.View
 import android.view.ViewGroup
 import androidx.core.view.isVisible
 import androidx.recyclerview.widget.ListAdapter
@@ -12,6 +13,7 @@ import au.com.shiftyjelly.pocketcasts.discover.view.CollectionListRowAdapter.Col
 import au.com.shiftyjelly.pocketcasts.discover.view.DiscoverFragment.Companion.LIST_ID_KEY
 import au.com.shiftyjelly.pocketcasts.discover.view.DiscoverFragment.Companion.PODCAST_UUID_KEY
 import au.com.shiftyjelly.pocketcasts.servers.model.DiscoverPodcast
+import coil.load
 
 internal class CollectionListRowAdapter(
     val onPodcastClicked: ((DiscoverPodcast, String?) -> Unit),
@@ -48,8 +50,10 @@ internal class CollectionListRowAdapter(
     }
 
     private var fromListId: String? = null
+    private var header: CollectionHeader? = null
 
-    fun submitPodcastList(list: List<DiscoverPodcast>, commitCallback: Runnable?) {
+    fun submitPodcastList(list: List<DiscoverPodcast>, header: CollectionHeader, commitCallback: Runnable?) {
+        this.header = header
         submitList(list.chunked(NUMBER_OF_ROWS_PER_PAGE), commitCallback)
     }
 
@@ -83,10 +87,34 @@ internal class CollectionListRowAdapter(
 
     override fun onBindViewHolder(holder: CollectionListViewHolder, position: Int) {
         val podcastSublist = getItem(position)
+
         holder.bind(podcastSublist)
+
+        if (position == 0) {
+            this.header?.let {
+                holder.binding.header.root.visibility = View.VISIBLE
+                holder.binding.header.lblTitle.text = it.title
+                holder.binding.header.lblSubtitle.text = it.subtitle
+                holder.binding.header.imageHeader.load(it.imageUrl)
+
+                val height = getPodcastsHeight(holder.binding.podcasts)
+                val layoutParams = holder.binding.root.layoutParams
+                layoutParams.height = height
+                holder.binding.root.layoutParams = layoutParams
+            }
+        } else {
+            holder.binding.header.root.visibility = View.GONE
+        }
+    }
+
+    fun getPodcastsHeight(view: View): Int {
+        view.measure(0, 0)
+        return view.measuredHeight
     }
 
     fun setFromListId(value: String) {
         this.fromListId = value
     }
+
+    data class CollectionHeader(val imageUrl: String?, val title: String?, val subtitle: String?)
 }

--- a/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/CollectionListRowAdapter.kt
+++ b/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/CollectionListRowAdapter.kt
@@ -112,7 +112,7 @@ internal class CollectionListRowAdapter(
 
         if (position == 0) {
             this.header?.let {
-                holder.binding.header.root.visibility = View.VISIBLE
+                holder.binding.header.root.isVisible = true
                 holder.binding.header.lblTitle.text = it.title
                 holder.binding.header.lblSubtitle.text = it.subtitle
                 holder.binding.header.imageHeader.load(it.imageUrl)
@@ -125,7 +125,7 @@ internal class CollectionListRowAdapter(
                 holder.binding.root.layoutParams = layoutParams
             }
         } else {
-            holder.binding.header.root.visibility = View.GONE
+            holder.binding.header.root.isVisible = false
         }
     }
 

--- a/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/DiscoverAdapter.kt
+++ b/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/DiscoverAdapter.kt
@@ -37,6 +37,8 @@ import au.com.shiftyjelly.pocketcasts.discover.databinding.RowSinglePodcastBindi
 import au.com.shiftyjelly.pocketcasts.discover.extensions.updateSubscribeButtonIcon
 import au.com.shiftyjelly.pocketcasts.discover.util.AutoScrollHelper
 import au.com.shiftyjelly.pocketcasts.discover.util.ScrollingLinearLayoutManager
+import au.com.shiftyjelly.pocketcasts.discover.view.CollectionListRowAdapter.CollectionListViewHolder.Companion.NUMBER_OF_PODCASTS_TO_DISPLAY_TWICE
+import au.com.shiftyjelly.pocketcasts.discover.view.CollectionListRowAdapter.CollectionListViewHolder.Companion.NUMBER_OF_ROWS_PER_PAGE
 import au.com.shiftyjelly.pocketcasts.discover.view.DiscoverFragment.Companion.EPISODE_UUID_KEY
 import au.com.shiftyjelly.pocketcasts.discover.view.DiscoverFragment.Companion.LIST_ID_KEY
 import au.com.shiftyjelly.pocketcasts.discover.view.DiscoverFragment.Companion.PODCAST_UUID_KEY
@@ -834,7 +836,8 @@ internal class DiscoverAdapter(
                         loadPodcastList(row.source),
                         onNext = {
                             val podcasts = it.podcasts.subList(0, MAX_ROWS_SMALL_LIST.coerceAtMost(it.podcasts.count()))
-                            holder.binding.pageIndicatorView.count = ceil(podcasts.count().toDouble() / CollectionListRowAdapter.CollectionListViewHolder.NUMBER_OF_ROWS_PER_PAGE.toDouble()).toInt()
+                            val podcastsCount = podcasts.count().toDouble() + NUMBER_OF_PODCASTS_TO_DISPLAY_TWICE
+                            holder.binding.pageIndicatorView.count = ceil(podcastsCount / NUMBER_OF_ROWS_PER_PAGE.toDouble()).toInt()
 
                             row.listUuid?.let { listUuid -> holder.adapter.setFromListId(listUuid) }
 

--- a/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/DiscoverAdapter.kt
+++ b/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/DiscoverAdapter.kt
@@ -486,6 +486,14 @@ internal class DiscoverAdapter(
                         mapOf(CURRENT_PAGE to position, TOTAL_PAGES to adapter.itemCount, LIST_ID_KEY to it.inferredId()),
                     )
                 }
+                // Adds extra right padding starting from page 1 to preview the next page, except for the last page
+                if (position == 0) {
+                    recyclerView?.setPadding(8.dpToPx(itemView.context), 0, 0, 0)
+                } else if (position == adapter.itemCount - 1) {
+                    recyclerView?.setPadding(8.dpToPx(itemView.context), 0, 0, 0)
+                } else {
+                    recyclerView?.setPadding(8.dpToPx(itemView.context), 0, 20.dpToPx(itemView.context), 0)
+                }
             }
 
             recyclerView?.adapter = adapter

--- a/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/DiscoverAdapter.kt
+++ b/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/DiscoverAdapter.kt
@@ -848,7 +848,8 @@ internal class DiscoverAdapter(
 
                             holder.binding.lblTitle.text = it.subtitle?.tryToLocalise(resources)
 
-                            val collectionHeader = CollectionListRowAdapter.CollectionHeader(it.collectionImageUrl, it.title, it.description)
+                            val collectionHeader =
+                                it.collectionImageUrl?.let { imageUrl -> CollectionListRowAdapter.CollectionHeader(imageUrl, it.title, it.description) }
 
                             holder.adapter.submitPodcastList(podcasts, collectionHeader) { onRestoreInstanceState(holder) }
                         },

--- a/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/DiscoverAdapter.kt
+++ b/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/DiscoverAdapter.kt
@@ -40,8 +40,8 @@ import au.com.shiftyjelly.pocketcasts.discover.util.AutoScrollHelper
 import au.com.shiftyjelly.pocketcasts.discover.util.ScrollingLinearLayoutManager
 import au.com.shiftyjelly.pocketcasts.discover.view.CollectionListRowAdapter.CollectionItem.CollectionHeader
 import au.com.shiftyjelly.pocketcasts.discover.view.CollectionListRowAdapter.CollectionItem.CollectionPodcast
-import au.com.shiftyjelly.pocketcasts.discover.view.CollectionListRowAdapter.CollectionListViewHolder.Companion.NUMBER_OF_ROWS_PER_PAGE
 import au.com.shiftyjelly.pocketcasts.discover.view.CollectionListRowAdapter.Companion.HEADER_OFFSET
+import au.com.shiftyjelly.pocketcasts.discover.view.CollectionListRowAdapter.PodcastsViewHolder.Companion.NUMBER_OF_ROWS_PER_PAGE
 import au.com.shiftyjelly.pocketcasts.discover.view.DiscoverFragment.Companion.EPISODE_UUID_KEY
 import au.com.shiftyjelly.pocketcasts.discover.view.DiscoverFragment.Companion.LIST_ID_KEY
 import au.com.shiftyjelly.pocketcasts.discover.view.DiscoverFragment.Companion.PODCAST_UUID_KEY

--- a/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/DiscoverAdapter.kt
+++ b/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/DiscoverAdapter.kt
@@ -41,6 +41,7 @@ import au.com.shiftyjelly.pocketcasts.discover.util.ScrollingLinearLayoutManager
 import au.com.shiftyjelly.pocketcasts.discover.view.CollectionListRowAdapter.CollectionItem.CollectionHeader
 import au.com.shiftyjelly.pocketcasts.discover.view.CollectionListRowAdapter.CollectionItem.CollectionPodcast
 import au.com.shiftyjelly.pocketcasts.discover.view.CollectionListRowAdapter.Companion.HEADER_OFFSET
+import au.com.shiftyjelly.pocketcasts.discover.view.CollectionListRowAdapter.HeaderViewHolder
 import au.com.shiftyjelly.pocketcasts.discover.view.CollectionListRowAdapter.PodcastsViewHolder.Companion.NUMBER_OF_ROWS_PER_PAGE
 import au.com.shiftyjelly.pocketcasts.discover.view.DiscoverFragment.Companion.EPISODE_UUID_KEY
 import au.com.shiftyjelly.pocketcasts.discover.view.DiscoverFragment.Companion.LIST_ID_KEY
@@ -487,6 +488,8 @@ internal class DiscoverAdapter(
                     if (newState == RecyclerView.SCROLL_STATE_IDLE) {
                         val position = linearLayoutManager.getCurrentPosition()
 
+                        updateHeader(recyclerView, position)
+
                         // Adds extra right padding starting from page 1 to preview the next page, except for the first page
                         if (position == 0) {
                             recyclerView.setPadding(8.dpToPx(itemView.context), 0, 0, 0)
@@ -514,6 +517,14 @@ internal class DiscoverAdapter(
                             recyclerView.setPadding(8.dpToPx(itemView.context), 0, 0, 0)
                         }
                     }
+                }
+
+                private fun updateHeader(
+                    recyclerView: RecyclerView,
+                    position: Int,
+                ) {
+                    val headerViewHolder = recyclerView.findViewHolderForAdapterPosition(0) as? HeaderViewHolder
+                    headerViewHolder?.updateVisibility(position != 1)
                 }
 
                 private fun trackPageChangedEvent(position: Int) {

--- a/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/DiscoverAdapter.kt
+++ b/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/DiscoverAdapter.kt
@@ -452,7 +452,10 @@ internal class DiscoverAdapter(
     inner class CollectionListViewHolder(val binding: RowCollectionListBinding) : NetworkLoadableViewHolder(binding.root), ShowAllRow {
         val adapter = CollectionListRowAdapter(
             listener::onPodcastClicked,
-            listener::onPodcastSubscribe,
+            onPodcastSubscribe = { podcast, listId ->
+                listId?.let { analyticsTracker.track(AnalyticsEvent.DISCOVER_LIST_PODCAST_SUBSCRIBED, mapOf(LIST_ID_KEY to it, PODCAST_UUID_KEY to podcast.uuid)) }
+                listener.onPodcastSubscribe(podcast, listId)
+            },
             onHeaderClicked = {
                 collectionList?.let { listener.onCollectionHeaderClicked(it) }
             },

--- a/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/DiscoverAdapter.kt
+++ b/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/DiscoverAdapter.kt
@@ -826,7 +826,9 @@ internal class DiscoverAdapter(
 
                             holder.binding.lblTitle.text = it.subtitle?.tryToLocalise(resources)
 
-                            holder.adapter.submitPodcastList(podcasts) { onRestoreInstanceState(holder) }
+                            val collectionHeader = CollectionListRowAdapter.CollectionHeader(it.collectionImageUrl, it.title, it.description)
+
+                            holder.adapter.submitPodcastList(podcasts, collectionHeader) { onRestoreInstanceState(holder) }
                         },
                     )
                 }

--- a/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/DiscoverFragment.kt
+++ b/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/DiscoverFragment.kt
@@ -101,6 +101,18 @@ class DiscoverFragment :
         }
     }
 
+    override fun onCollectionHeaderClicked(list: NetworkLoadableList) {
+        val transformedList = viewModel.transformNetworkLoadableList(list, resources)
+        val listId = list.listUuid
+        if (listId != null) {
+            analyticsTracker.track(AnalyticsEvent.DISCOVER_LIST_COLLECTION_HEADER_TAPPED, mapOf(LIST_ID_KEY to listId))
+        }
+        if (list.expandedStyle is ExpandedStyle.GridList) {
+            val fragment = PodcastGridFragment.newInstance(transformedList)
+            (activity as FragmentHostListener).addFragment(fragment)
+        }
+    }
+
     override fun onEpisodeClicked(episode: DiscoverEpisode, listUuid: String?) {
         val fragment = EpisodeContainerFragment.newInstance(
             episodeUuid = episode.uuid,

--- a/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/PodcastCollectionItem.kt
+++ b/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/PodcastCollectionItem.kt
@@ -4,7 +4,9 @@ import android.content.Context
 import android.util.AttributeSet
 import android.view.LayoutInflater
 import android.widget.LinearLayout
+import androidx.core.view.isVisible
 import au.com.shiftyjelly.pocketcasts.discover.databinding.PodcastCollectionItemBinding
+import au.com.shiftyjelly.pocketcasts.discover.extensions.updateSubscribeButtonIcon
 import au.com.shiftyjelly.pocketcasts.repositories.images.PocketCastsImageRequestFactory
 import au.com.shiftyjelly.pocketcasts.repositories.images.loadInto
 import au.com.shiftyjelly.pocketcasts.servers.model.DiscoverPodcast
@@ -35,8 +37,18 @@ class PodcastCollectionItem @JvmOverloads constructor(
                 binding.lblTitle.text = value.title
                 binding.lblSubtitle.text = value.author
                 imageRequestFactory.createForPodcast(podcast?.uuid).loadInto(binding.imageView)
+                binding.btnSubscribe.updateSubscribeButtonIcon(value.isSubscribed)
             } else {
                 clear()
+            }
+        }
+
+    var onSubscribeClicked: (() -> Unit)? = null
+        set(value) {
+            field = value
+            binding?.btnSubscribe?.setOnClickListener {
+                binding?.btnSubscribe?.updateSubscribeButtonIcon(true)
+                onSubscribeClicked?.invoke()
             }
         }
 
@@ -46,5 +58,10 @@ class PodcastCollectionItem @JvmOverloads constructor(
         binding.lblTitle.text = null
         binding.lblSubtitle.text = null
         binding.imageView.setImageResource(binding.imageView.context.getThemeDrawable(UR.attr.defaultArtworkSmall))
+    }
+
+    fun setSubscribeButtonVisibility(isVisible: Boolean) {
+        val binding = binding ?: return
+        binding.btnSubscribe.isVisible = isVisible
     }
 }

--- a/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/PodcastCollectionItem.kt
+++ b/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/PodcastCollectionItem.kt
@@ -4,7 +4,6 @@ import android.content.Context
 import android.util.AttributeSet
 import android.view.LayoutInflater
 import android.widget.LinearLayout
-import androidx.core.view.isVisible
 import au.com.shiftyjelly.pocketcasts.discover.databinding.PodcastCollectionItemBinding
 import au.com.shiftyjelly.pocketcasts.discover.extensions.updateSubscribeButtonIcon
 import au.com.shiftyjelly.pocketcasts.repositories.images.PocketCastsImageRequestFactory
@@ -58,10 +57,5 @@ class PodcastCollectionItem @JvmOverloads constructor(
         binding.lblTitle.text = null
         binding.lblSubtitle.text = null
         binding.imageView.setImageResource(binding.imageView.context.getThemeDrawable(UR.attr.defaultArtworkSmall))
-    }
-
-    fun setSubscribeButtonVisibility(isVisible: Boolean) {
-        val binding = binding ?: return
-        binding.btnSubscribe.isVisible = isVisible
     }
 }

--- a/modules/features/discover/src/main/res/layout/collection_header.xml
+++ b/modules/features/discover/src/main/res/layout/collection_header.xml
@@ -44,7 +44,7 @@
             android:layout_height="wrap_content"
             android:ellipsize="end"
             android:gravity="center_horizontal"
-            android:maxLines="1"
+            android:maxLines="2"
             android:textAlignment="center"
             android:textColor="#EFF3F5"
             android:textSize="13sp" />

--- a/modules/features/discover/src/main/res/layout/collection_header.xml
+++ b/modules/features/discover/src/main/res/layout/collection_header.xml
@@ -27,7 +27,7 @@
             android:layout_gravity="bottom|center_horizontal"
             android:gravity="center_horizontal"
             android:orientation="vertical"
-            android:paddingHorizontal="2dp"
+            android:paddingHorizontal="12dp"
             android:paddingBottom="12dp">
 
             <TextView

--- a/modules/features/discover/src/main/res/layout/collection_header.xml
+++ b/modules/features/discover/src/main/res/layout/collection_header.xml
@@ -1,0 +1,61 @@
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="wrap_content"
+    android:layout_height="match_parent"
+    android:layout_marginVertical="8dp"
+    android:layout_marginLeft="8dp">
+
+    <com.google.android.material.card.MaterialCardView
+        android:layout_width="179dp"
+        android:layout_height="match_parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent">
+
+        <ImageView
+            android:id="@+id/imageHeader"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:background="?attr/defaultArtwork"
+            android:scaleType="centerCrop"
+            tools:ignore="ContentDescription" />
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_gravity="bottom|center_horizontal"
+            android:gravity="center_horizontal"
+            android:orientation="vertical"
+            android:paddingHorizontal="2dp"
+            android:paddingBottom="12dp">
+
+            <TextView
+                android:id="@+id/lblTitle"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:ellipsize="end"
+                android:gravity="center_horizontal"
+                android:maxLines="2"
+                android:paddingBottom="8dp"
+                android:textAlignment="center"
+                android:textColor="@color/white"
+                android:textSize="13sp"
+                android:textStyle="bold" />
+
+            <TextView
+                android:id="@+id/lblSubtitle"
+                style="@style/P60"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:ellipsize="end"
+                android:gravity="center_horizontal"
+                android:maxLines="1"
+                android:textSize="13sp"
+                android:textAlignment="center"
+                android:textColor="#EFF3F5" />
+
+        </LinearLayout>
+
+    </com.google.android.material.card.MaterialCardView>
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/modules/features/discover/src/main/res/layout/collection_header.xml
+++ b/modules/features/discover/src/main/res/layout/collection_header.xml
@@ -1,62 +1,53 @@
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
+<com.google.android.material.card.MaterialCardView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
-    android:layout_width="wrap_content"
+    android:layout_width="179dp"
     android:layout_height="match_parent"
     android:layout_marginVertical="8dp"
     android:layout_marginLeft="8dp"
     android:clickable="true"
     android:focusable="true">
 
-    <com.google.android.material.card.MaterialCardView
-        android:layout_width="179dp"
+    <ImageView
+        android:id="@+id/imageHeader"
+        android:layout_width="match_parent"
         android:layout_height="match_parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent">
+        android:scaleType="centerCrop"
+        tools:ignore="ContentDescription" />
 
-        <ImageView
-            android:id="@+id/imageHeader"
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:scaleType="centerCrop"
-            tools:ignore="ContentDescription" />
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_gravity="bottom|center_horizontal"
+        android:gravity="center_horizontal"
+        android:orientation="vertical"
+        android:paddingHorizontal="12dp"
+        android:paddingBottom="12dp">
 
-        <LinearLayout
+        <TextView
+            android:id="@+id/lblTitle"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_gravity="bottom|center_horizontal"
+            android:ellipsize="end"
             android:gravity="center_horizontal"
-            android:orientation="vertical"
-            android:paddingHorizontal="12dp"
-            android:paddingBottom="12dp">
+            android:maxLines="2"
+            android:paddingBottom="8dp"
+            android:textAlignment="center"
+            android:textColor="@color/white"
+            android:textSize="13sp"
+            android:textStyle="bold" />
 
-            <TextView
-                android:id="@+id/lblTitle"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:ellipsize="end"
-                android:gravity="center_horizontal"
-                android:maxLines="2"
-                android:paddingBottom="8dp"
-                android:textAlignment="center"
-                android:textColor="@color/white"
-                android:textSize="13sp"
-                android:textStyle="bold" />
+        <TextView
+            android:id="@+id/lblSubtitle"
+            style="@style/P60"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:ellipsize="end"
+            android:gravity="center_horizontal"
+            android:maxLines="1"
+            android:textAlignment="center"
+            android:textColor="#EFF3F5"
+            android:textSize="13sp" />
 
-            <TextView
-                android:id="@+id/lblSubtitle"
-                style="@style/P60"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:ellipsize="end"
-                android:gravity="center_horizontal"
-                android:maxLines="1"
-                android:textSize="13sp"
-                android:textAlignment="center"
-                android:textColor="#EFF3F5" />
+    </LinearLayout>
 
-        </LinearLayout>
-
-    </com.google.android.material.card.MaterialCardView>
-
-</androidx.constraintlayout.widget.ConstraintLayout>
+</com.google.android.material.card.MaterialCardView>

--- a/modules/features/discover/src/main/res/layout/collection_header.xml
+++ b/modules/features/discover/src/main/res/layout/collection_header.xml
@@ -18,7 +18,6 @@
             android:id="@+id/imageHeader"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            android:background="?attr/defaultArtwork"
             android:scaleType="centerCrop"
             tools:ignore="ContentDescription" />
 

--- a/modules/features/discover/src/main/res/layout/collection_header.xml
+++ b/modules/features/discover/src/main/res/layout/collection_header.xml
@@ -4,7 +4,9 @@
     android:layout_width="wrap_content"
     android:layout_height="match_parent"
     android:layout_marginVertical="8dp"
-    android:layout_marginLeft="8dp">
+    android:layout_marginLeft="8dp"
+    android:clickable="true"
+    android:focusable="true">
 
     <com.google.android.material.card.MaterialCardView
         android:layout_width="179dp"

--- a/modules/features/discover/src/main/res/layout/collection_header.xml
+++ b/modules/features/discover/src/main/res/layout/collection_header.xml
@@ -1,8 +1,9 @@
 <com.google.android.material.card.MaterialCardView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="179dp"
-    android:layout_height="match_parent"
-    android:layout_marginVertical="8dp"
+    android:layout_height="208dp"
+    android:layout_marginTop="8dp"
+    android:layout_marginBottom="24dp"
     android:layout_marginLeft="8dp"
     android:clickable="true"
     android:focusable="true">

--- a/modules/features/discover/src/main/res/layout/item_collection_list.xml
+++ b/modules/features/discover/src/main/res/layout/item_collection_list.xml
@@ -1,14 +1,29 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    android:orientation="vertical" android:layout_width="match_parent"
+    android:orientation="horizontal" android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-    <au.com.shiftyjelly.pocketcasts.discover.view.PodcastCollectionItem
-        android:id="@+id/row0"
-        android:layout_width="371dp"
-        android:layout_height="wrap_content" />
-    <au.com.shiftyjelly.pocketcasts.discover.view.PodcastCollectionItem
-        android:id="@+id/row1"
-        android:layout_width="371dp"
-        android:layout_height="wrap_content" />
+    <include
+        android:id="@+id/header"
+        layout="@layout/collection_header" />
+
+    <LinearLayout
+        android:id="@+id/podcasts"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:orientation="vertical">
+
+        <au.com.shiftyjelly.pocketcasts.discover.view.PodcastCollectionItem
+            android:id="@+id/row0"
+            android:paddingHorizontal="8dp"
+            android:paddingTop="8dp"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content" />
+        <au.com.shiftyjelly.pocketcasts.discover.view.PodcastCollectionItem
+            android:id="@+id/row1"
+            android:padding="8dp"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content" />
+
+    </LinearLayout>
 </LinearLayout>

--- a/modules/features/discover/src/main/res/layout/item_collection_list.xml
+++ b/modules/features/discover/src/main/res/layout/item_collection_list.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:orientation="horizontal" android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    android:layout_marginBottom="24dp">
 
     <include
         android:id="@+id/header"

--- a/modules/features/discover/src/main/res/layout/item_collection_list.xml
+++ b/modules/features/discover/src/main/res/layout/item_collection_list.xml
@@ -6,13 +6,17 @@
 
         <au.com.shiftyjelly.pocketcasts.discover.view.PodcastCollectionItem
             android:id="@+id/row0"
-            android:paddingHorizontal="8dp"
+            android:paddingLeft="6dp"
+            android:paddingRight="8dp"
             android:paddingTop="8dp"
             android:layout_width="match_parent"
             android:layout_height="wrap_content" />
         <au.com.shiftyjelly.pocketcasts.discover.view.PodcastCollectionItem
             android:id="@+id/row1"
-            android:padding="8dp"
+            android:paddingTop="6dp"
+            android:paddingBottom="8dp"
+            android:paddingLeft="6dp"
+            android:paddingRight="8dp"
             android:layout_width="match_parent"
             android:layout_height="wrap_content" />
 </LinearLayout>

--- a/modules/features/discover/src/main/res/layout/item_collection_list.xml
+++ b/modules/features/discover/src/main/res/layout/item_collection_list.xml
@@ -5,10 +5,10 @@
 
     <au.com.shiftyjelly.pocketcasts.discover.view.PodcastCollectionItem
         android:id="@+id/row0"
-        android:layout_width="wrap_content"
+        android:layout_width="371dp"
         android:layout_height="wrap_content" />
     <au.com.shiftyjelly.pocketcasts.discover.view.PodcastCollectionItem
         android:id="@+id/row1"
-        android:layout_width="wrap_content"
+        android:layout_width="371dp"
         android:layout_height="wrap_content" />
 </LinearLayout>

--- a/modules/features/discover/src/main/res/layout/item_collection_list.xml
+++ b/modules/features/discover/src/main/res/layout/item_collection_list.xml
@@ -1,18 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    android:orientation="horizontal" android:layout_width="match_parent"
+    android:orientation="vertical" android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:layout_marginBottom="24dp">
-
-    <include
-        android:id="@+id/header"
-        layout="@layout/collection_header" />
-
-    <LinearLayout
-        android:id="@+id/podcasts"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:orientation="vertical">
 
         <au.com.shiftyjelly.pocketcasts.discover.view.PodcastCollectionItem
             android:id="@+id/row0"
@@ -25,6 +15,4 @@
             android:padding="8dp"
             android:layout_width="match_parent"
             android:layout_height="wrap_content" />
-
-    </LinearLayout>
 </LinearLayout>

--- a/modules/features/discover/src/main/res/layout/podcast_collection_item.xml
+++ b/modules/features/discover/src/main/res/layout/podcast_collection_item.xml
@@ -47,7 +47,7 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:textAppearance="@style/H50"
-            android:maxLines="1"
+            android:maxLines="2"
             android:ellipsize="end"
             android:textColor="?attr/primary_text_02"
             tools:text="Author" />

--- a/modules/features/discover/src/main/res/layout/podcast_collection_item.xml
+++ b/modules/features/discover/src/main/res/layout/podcast_collection_item.xml
@@ -36,7 +36,8 @@
             android:id="@+id/lblTitle"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:maxLines="1"
+            android:maxLines="2"
+            android:ellipsize="end"
             android:textAppearance="@style/H40"
             tools:text="Title" />
 
@@ -45,6 +46,8 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:textAppearance="@style/H50"
+            android:maxLines="1"
+            android:ellipsize="end"
             android:textColor="?attr/primary_text_02"
             tools:text="Author" />
     </LinearLayout>

--- a/modules/features/discover/src/main/res/layout/podcast_collection_item.xml
+++ b/modules/features/discover/src/main/res/layout/podcast_collection_item.xml
@@ -7,9 +7,7 @@
     android:background="?attr/selectableItemBackground"
     android:clipChildren="false"
     android:clipToPadding="false"
-    android:orientation="horizontal"
-    android:padding="8dp"
-    tools:parentTag="android.widget.LinearLayout">
+    android:orientation="horizontal">
 
     <androidx.cardview.widget.CardView
         android:layout_width="100dp"
@@ -23,6 +21,7 @@
             android:id="@+id/imageView"
             android:layout_width="100dp"
             android:layout_height="100dp"
+            android:background="?attr/defaultArtwork"
             tools:ignore="ContentDescription" />
     </androidx.cardview.widget.CardView>
 

--- a/modules/features/discover/src/main/res/layout/podcast_collection_item.xml
+++ b/modules/features/discover/src/main/res/layout/podcast_collection_item.xml
@@ -14,6 +14,8 @@
         android:layout_height="100dp"
         android:layout_gravity="center_vertical"
         android:layout_marginRight="12dp"
+        android:layout_marginVertical="2dp"
+        android:layout_marginStart="2dp"
         android:elevation="2dp"
         app:cardCornerRadius="4dp">
 
@@ -30,6 +32,8 @@
         android:layout_width="0dp"
         android:layout_height="match_parent"
         android:layout_weight="1"
+        android:clipChildren="false"
+        android:clipToPadding="false"
         android:gravity="center_vertical"
         android:orientation="vertical">
 

--- a/modules/features/discover/src/main/res/layout/podcast_collection_item.xml
+++ b/modules/features/discover/src/main/res/layout/podcast_collection_item.xml
@@ -26,8 +26,10 @@
     </androidx.cardview.widget.CardView>
 
     <LinearLayout
-        android:layout_width="match_parent"
+        android:id="@+id/textsLayout"
+        android:layout_width="0dp"
         android:layout_height="match_parent"
+        android:layout_weight="1"
         android:gravity="center_vertical"
         android:orientation="vertical">
 
@@ -50,4 +52,20 @@
             android:textColor="?attr/primary_text_02"
             tools:text="Author" />
     </LinearLayout>
+
+    <ImageView
+        android:id="@+id/btnSubscribe"
+        android:layout_width="48dp"
+        android:layout_height="48dp"
+        android:layout_gravity="center_vertical|end"
+        android:background="?android:attr/actionBarItemBackground"
+        android:clickable="true"
+        android:focusable="true"
+        android:scaleType="centerInside"
+        android:layout_marginEnd="4dp"
+        android:layout_marginStart="4dp"
+        android:layout_marginBottom="4dp"
+        android:contentDescription="@string/subscribe"
+        app:tint="?attr/primary_icon_02" />
+
 </LinearLayout>

--- a/modules/features/discover/src/main/res/layout/podcast_collection_item.xml
+++ b/modules/features/discover/src/main/res/layout/podcast_collection_item.xml
@@ -3,7 +3,7 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="wrap_content"
+    android:layout_height="match_parent"
     android:background="?attr/selectableItemBackground"
     android:clipChildren="false"
     android:clipToPadding="false"
@@ -55,16 +55,14 @@
 
     <ImageView
         android:id="@+id/btnSubscribe"
-        android:layout_width="48dp"
-        android:layout_height="48dp"
+        android:layout_width="24dp"
+        android:layout_height="24dp"
         android:layout_gravity="center_vertical|end"
         android:background="?android:attr/actionBarItemBackground"
         android:clickable="true"
         android:focusable="true"
         android:scaleType="centerInside"
-        android:layout_marginEnd="4dp"
-        android:layout_marginStart="4dp"
-        android:layout_marginBottom="4dp"
+        android:layout_marginEnd="8dp"
         android:contentDescription="@string/subscribe"
         app:tint="?attr/primary_icon_02" />
 

--- a/modules/features/discover/src/main/res/layout/row_collection_list.xml
+++ b/modules/features/discover/src/main/res/layout/row_collection_list.xml
@@ -1,25 +1,26 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
-    android:orientation="vertical"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
+    android:orientation="vertical"
     android:paddingTop="16dp">
+
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        android:paddingRight="16dp"
-        android:paddingLeft="16dp">
+        android:paddingHorizontal="16dp">
+
         <TextView
             android:id="@+id/lblTitle"
             android:layout_width="0dp"
-            android:layout_weight="1"
             android:layout_height="wrap_content"
             android:layout_marginBottom="8dp"
+            android:layout_weight="1"
             android:textAppearance="@style/H20"
             android:textColor="?attr/primary_text_01"
-            tools:text="Popular"/>
+            tools:text="Popular" />
 
         <TextView
             android:id="@+id/btnShowAll"

--- a/modules/features/discover/src/main/res/layout/row_collection_list.xml
+++ b/modules/features/discover/src/main/res/layout/row_collection_list.xml
@@ -35,11 +35,9 @@
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/rowRecyclerView"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:paddingLeft="8dp"
-        android:paddingRight="8dp"
-        android:clipToPadding="false"
-        tools:listItem="@layout/item_small_list"/>
+        android:layout_height="match_parent"
+        android:paddingHorizontal="8dp"
+        android:clipToPadding="false"/>
 
     <au.com.shiftyjelly.pocketcasts.views.component.PagerIndicator
         android:id="@+id/pageIndicatorView"

--- a/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
+++ b/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
@@ -310,6 +310,7 @@ enum class AnalyticsEvent(val key: String) {
     DISCOVER_FEATURED_PODCAST_SUBSCRIBED("discover_featured_podcast_subscribed"),
     DISCOVER_SHOW_ALL_TAPPED("discover_show_all_tapped"),
     DISCOVER_LIST_SHOW_ALL_TAPPED("discover_list_show_all_tapped"),
+    DISCOVER_LIST_COLLECTION_HEADER_TAPPED("discover_list_collection_header_tapped"),
     DISCOVER_LIST_IMPRESSION("discover_list_impression"),
     DISCOVER_LIST_EPISODE_TAPPED("discover_list_episode_tapped"),
     DISCOVER_LIST_EPISODE_PLAY("discover_list_episode_play"),

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -524,6 +524,7 @@
     <string name="go_to_folder">Go to folder</string>
     <string name="number_stepper_plus_content_description">Plus</string>
     <string name="number_stepper_minus_content_description">Minus</string>
+    <string name="discover_collection_header_content_description_suffix">header</string>
 
     <!-- Podcast -->
 

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -524,7 +524,7 @@
     <string name="go_to_folder">Go to folder</string>
     <string name="number_stepper_plus_content_description">Plus</string>
     <string name="number_stepper_minus_content_description">Minus</string>
-    <string name="discover_collection_header_content_description_suffix">header</string>
+    <string name="discover_collection_header_content_description">%s header</string>
 
     <!-- Podcast -->
 


### PR DESCRIPTION
## Description
- This PR adds the header to the collection
- Track header tapping event
- Add subscribe button 
- Design: [zfZ5UzmdLBk3k4CwaFIN3E-fi-3646_53376](https://href.li/?https://www.figma.com/file/zfZ5UzmdLBk3k4CwaFIN3E/?node-id=3646-53376)

## Testing Instructions
1. With `GUEST_LISTS_NETWORK_HIGHLIGHTS_REDESIGN` ON
2. Open Discover
3. Scroll until you see the Guest list, Guest Curator or Network highlight collection 
4. See that the collection shows a header only for the fist page ✅
5. Tap on the header
6. Ensure 🔵 Tracked: discover_list_collection_header_tapped, Properties: {"list_id":"ilst-name", ✅
7. Ensure the collection opens ✅ (same behavior as tapping on show all button)

## Screenshots or Screencast 


| Regular device | Large font size | Landscape |
|--------|--------|--------|
| ![Screenshot_20250319_123111](https://github.com/user-attachments/assets/7134bc58-44ca-460a-8be8-970830343b09) | ![Screenshot_20250319_123134](https://github.com/user-attachments/assets/229cbcd1-af3f-440a-a975-6e1dea91e866) | ![Screenshot_20250319_123155](https://github.com/user-attachments/assets/6c33ee32-52a8-41f0-a3d7-51e778312efc) | 

[Screen_recording_20250319_122915.webm](https://github.com/user-attachments/assets/b7c60cc1-f311-471e-b25a-52d84172d65b)



## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack
