### PR TITLE
Upsell transcripts

### DIFF
--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/OnboardingFlowComposable.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/OnboardingFlowComposable.kt
@@ -248,6 +248,7 @@ private fun Content(
                 OnboardingUpgradeSource.SETTINGS,
                 OnboardingUpgradeSource.SLUMBER_STUDIOS,
                 OnboardingUpgradeSource.UP_NEXT_SHUFFLE,
+                OnboardingUpgradeSource.GENERATED_TRANSCRIPTS,
                 OnboardingUpgradeSource.UNKNOWN,
                 -> false
 

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/PlayerHeaderFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/PlayerHeaderFragment.kt
@@ -367,6 +367,9 @@ class PlayerHeaderFragment : BaseFragment(), PlayerClickListener {
                 transcriptViewModel = transcriptViewModel,
                 searchViewModel = transcriptSearchViewModel,
                 theme = theme,
+                onClickSubscribe = {
+                    OnboardingLauncher.openOnboardingFlow(requireActivity(), OnboardingFlow.Upsell(OnboardingUpgradeSource.GENERATED_TRANSCRIPTS))
+                },
             )
         }
     }

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/nowplaying/PlayerHeadingSection.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/nowplaying/PlayerHeadingSection.kt
@@ -99,7 +99,7 @@ fun PlayerHeadingSection(
 
     LaunchedEffect(Unit) {
         shelfSharedViewModel.transitionState.collect {
-            disableAccessibility = it is TransitionState.OpenTranscript
+            disableAccessibility = it is TransitionState.OpenTranscript || it is TransitionState.UpsellTranscript
         }
     }
 }

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/shelf/PlayerShelf.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/shelf/PlayerShelf.kt
@@ -34,6 +34,7 @@ import au.com.shiftyjelly.pocketcasts.compose.theme
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.player.R
 import au.com.shiftyjelly.pocketcasts.player.view.transcripts.TranscriptViewModel
+import au.com.shiftyjelly.pocketcasts.player.view.transcripts.TranscriptViewModel.TranscriptState
 import au.com.shiftyjelly.pocketcasts.player.viewmodel.PlayerViewModel
 import au.com.shiftyjelly.pocketcasts.player.viewmodel.ShelfSharedViewModel
 import au.com.shiftyjelly.pocketcasts.player.viewmodel.ShelfSharedViewModel.PlayerShelfData
@@ -206,7 +207,7 @@ private fun PlayerShelfContent(
                     onClick = onStarClick,
                 )
                 ShelfItem.Transcript -> TranscriptButton(
-                    isTranscriptAvailable = transcriptUiState !is TranscriptViewModel.UiState.Empty,
+                    isTranscriptAvailable = transcriptUiState.transcriptState !is TranscriptState.Empty,
                     iconColors = iconColors,
                     onClick = onTranscriptClick,
                 )
@@ -489,7 +490,7 @@ private fun PlayerShelfPreview(
     AppTheme(themeType) {
         PlayerShelfContent(
             shelfItems = ShelfItem.entries.toList().take(4),
-            transcriptUiState = TranscriptViewModel.UiState.Empty(),
+            transcriptUiState = TranscriptViewModel.UiState.Empty,
             iconColors = PlayerShelfIconColors(
                 normalColor = MaterialTheme.theme.colors.playerContrast03,
                 highlightColor = MaterialTheme.theme.colors.playerContrast01,

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/transcripts/TranscriptError.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/transcripts/TranscriptError.kt
@@ -30,7 +30,7 @@ import au.com.shiftyjelly.pocketcasts.player.view.transcripts.TranscriptDefaults
 import au.com.shiftyjelly.pocketcasts.player.view.transcripts.TranscriptDefaults.TranscriptFontFamily
 import au.com.shiftyjelly.pocketcasts.player.view.transcripts.TranscriptDefaults.bottomPadding
 import au.com.shiftyjelly.pocketcasts.player.view.transcripts.TranscriptViewModel.TranscriptError
-import au.com.shiftyjelly.pocketcasts.player.view.transcripts.TranscriptViewModel.UiState
+import au.com.shiftyjelly.pocketcasts.player.view.transcripts.TranscriptViewModel.TranscriptState
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.TranscriptFormat
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import au.com.shiftyjelly.pocketcasts.images.R as IR
@@ -38,7 +38,7 @@ import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 @Composable
 fun TranscriptError(
-    state: UiState.Error,
+    state: TranscriptState.Error,
     colors: TranscriptColors,
     onRetry: () -> Unit,
     modifier: Modifier = Modifier,
@@ -116,7 +116,7 @@ private fun ErrorTabletPreview() = ErrorPreview()
 private fun ErrorPreview() {
     AppThemeWithBackground(Theme.ThemeType.DARK) {
         TranscriptError(
-            state = UiState.Error(
+            state = TranscriptState.Error(
                 error = TranscriptError.NotSupported(TranscriptFormat.HTML.mimeType),
                 transcript = Transcript(
                     episodeUuid = "uuid",

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/transcripts/TranscriptPageWrapper.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/transcripts/TranscriptPageWrapper.kt
@@ -80,9 +80,10 @@ fun TranscriptPageWrapper(
     transcriptViewModel: TranscriptViewModel,
     searchViewModel: TranscriptSearchViewModel,
     theme: Theme,
+    onClickSubscribe: () -> Unit,
 ) {
     AppTheme(Theme.ThemeType.DARK) {
-        val transitionState = shelfSharedViewModel.transitionState.collectAsStateWithLifecycle(null)
+        val transitionState by shelfSharedViewModel.transitionState.collectAsStateWithLifecycle(null)
         val uiState by transcriptViewModel.uiState.collectAsStateWithLifecycle()
         val searchState by searchViewModel.searchState.collectAsStateWithLifecycle()
         val searchQuery by searchViewModel.searchQueryFlow.collectAsStateWithLifecycle()
@@ -92,7 +93,7 @@ fun TranscriptPageWrapper(
         var showPaywall by remember { mutableStateOf(false) }
         var showSearch by remember { mutableStateOf(false) }
         var expandSearch by remember { mutableStateOf(false) }
-        when (transitionState.value) {
+        when (transitionState) {
             is TransitionState.CloseTranscript -> {
                 if (expandSearch) {
                     expandSearch = false
@@ -148,7 +149,7 @@ fun TranscriptPageWrapper(
 
                 if (showPaywall) {
                     TranscriptsPaywall(
-                        onClickSubscribe = {},
+                        onClickSubscribe = onClickSubscribe,
                         modifier = Modifier.verticalScroll(rememberScrollState()),
                     )
                 }
@@ -163,11 +164,10 @@ fun TranscriptPageWrapper(
             }
         }
 
-
-        LaunchedEffect(uiState.showPaywall) {
+        LaunchedEffect(uiState.showPaywall, transitionState) {
             showPaywall = uiState.showPaywall
 
-            when (transitionState.value) {
+            when (transitionState) {
                 is TransitionState.OpenTranscript -> {
                     if (showPaywall) {
                         shelfSharedViewModel.showUpsell()

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/transcripts/TranscriptViewModel.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/transcripts/TranscriptViewModel.kt
@@ -9,6 +9,7 @@ import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTracker
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.to.Transcript
 import au.com.shiftyjelly.pocketcasts.models.to.TranscriptCuesInfo
+import au.com.shiftyjelly.pocketcasts.models.type.SubscriptionTier
 import au.com.shiftyjelly.pocketcasts.repositories.di.IoDispatcher
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.TranscriptFormat
@@ -24,12 +25,13 @@ import javax.inject.Inject
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.distinctUntilChanged
-import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
@@ -43,28 +45,35 @@ class TranscriptViewModel @Inject constructor(
     @IoDispatcher private val ioDispatcher: CoroutineDispatcher,
     private val subscriptionManager: SubscriptionManager,
 ) : ViewModel() {
-    private var _uiState: MutableStateFlow<UiState> = MutableStateFlow(UiState.Empty())
-    val uiState: StateFlow<UiState> = _uiState
-    private var _isRefreshing: MutableStateFlow<Boolean> = MutableStateFlow(false)
-    val isRefreshing: StateFlow<Boolean> = _isRefreshing
+    private var _uiState = MutableStateFlow<UiState>(UiState.Empty)
+    val uiState = _uiState.asStateFlow()
+    private var _isRefreshing = MutableStateFlow(false)
+    val isRefreshing = _isRefreshing.asStateFlow()
 
     init {
         viewModelScope.launch {
             playbackManager.playbackStateFlow
                 .map { PodcastAndEpisode(it.podcast, it.episodeUuid) }
-                .stateIn(viewModelScope)
+                .onEach { _uiState.update { value -> value.copy(podcastAndEpisode = it) } }
                 .flatMapLatest(::transcriptFlow)
-                .collect { _uiState.value = it }
+                .collect { _uiState.update { value -> value.copy(transcriptState = it) } }
+        }
+        viewModelScope.launch {
+            subscriptionManager.subscriptionTier().collect { tier ->
+                _uiState.update { value -> value.copy(subscriptionTier = tier) }
+            }
         }
     }
 
     private fun transcriptFlow(podcastAndEpisode: PodcastAndEpisode) =
         transcriptsManager.observeTranscriptForEpisode(podcastAndEpisode.episodeUuid)
-            .distinctUntilChanged { t1, t2 -> t1?.episodeUuid == t2?.episodeUuid && t1?.type == t2?.type }
+            .distinctUntilChanged { t1, t2 -> t1?.episodeUuid == t2?.episodeUuid && t1?.url == t2?.url }
             .map { transcript ->
-                transcript?.let {
-                    UiState.TranscriptFound(podcastAndEpisode, transcript)
-                } ?: UiState.Empty(podcastAndEpisode)
+                if (transcript != null) {
+                    TranscriptState.Found(transcript)
+                } else {
+                    TranscriptState.Empty
+                }
             }
 
     fun parseAndLoadTranscript(
@@ -76,10 +85,11 @@ class TranscriptViewModel @Inject constructor(
             _isRefreshing.value = true
             podcastAndEpisode?.let { track(AnalyticsEvent.TRANSCRIPT_PULLED_TO_REFRESH, it) }
         }
-        _uiState.value.transcript?.let { transcript ->
+        _uiState.value.transcriptState.transcript?.let { transcript ->
             clearErrorsIfFound(transcript)
+
             viewModelScope.launch {
-                _uiState.value = try {
+                val newTranscriptState = try {
                     val forceRefresh = pulledToRefresh || retryOnFail
                     val cuesInfo = transcriptsManager.loadTranscriptCuesInfo(
                         podcastUuid = podcastAndEpisode?.podcast?.uuid.orEmpty(),
@@ -92,16 +102,10 @@ class TranscriptViewModel @Inject constructor(
                         transcriptFormat = TranscriptFormat.fromType(transcript.type),
                     )
 
-                    val loaded = UiState.TranscriptLoaded(
+                    val loaded = TranscriptState.Loaded(
                         transcript = transcript,
-                        podcastAndEpisode = podcastAndEpisode,
                         displayInfo = displayInfo,
                         cuesInfo = cuesInfo,
-                        isSubscriptionRequired = if (transcript.isGenerated) {
-                            !subscriptionManager.subscriptionTier().first().isPaid
-                        } else {
-                            false
-                        },
                     )
 
                     if (!pulledToRefresh) {
@@ -122,24 +126,28 @@ class TranscriptViewModel @Inject constructor(
                     track(AnalyticsEvent.TRANSCRIPT_ERROR, podcastAndEpisode, mapOf("error" to e.message.orEmpty()))
                     when (e) {
                         is EmptyDataException ->
-                            UiState.Error(TranscriptError.Empty, transcript, podcastAndEpisode)
+                            TranscriptState.Error(TranscriptError.Empty, transcript)
 
                         is UnsupportedOperationException ->
-                            UiState.Error(TranscriptError.NotSupported(transcript.type), transcript, podcastAndEpisode)
+                            TranscriptState.Error(TranscriptError.NotSupported(transcript.type), transcript)
 
                         is NoNetworkException ->
-                            UiState.Error(TranscriptError.NoNetwork, transcript, podcastAndEpisode)
+                            TranscriptState.Error(TranscriptError.NoNetwork, transcript)
 
                         is ParsingException ->
-                            UiState.Error(TranscriptError.FailedToParse, transcript, podcastAndEpisode)
+                            TranscriptState.Error(TranscriptError.FailedToParse, transcript)
 
                         else -> {
                             LogBuffer.e(LogBuffer.TAG_INVALID_STATE, e, "Failed to load transcript: ${transcript.url}")
-                            UiState.Error(TranscriptError.FailedToLoad, transcript, podcastAndEpisode)
+                            TranscriptState.Error(TranscriptError.FailedToLoad, transcript)
                         }
                     }
                 }
-                if (pulledToRefresh) _isRefreshing.value = false
+                _uiState.update { value -> value.copy(transcriptState = newTranscriptState) }
+
+                if (pulledToRefresh) {
+                    _isRefreshing.value = false
+                }
             }
         }
     }
@@ -190,11 +198,12 @@ class TranscriptViewModel @Inject constructor(
     }
 
     private fun clearErrorsIfFound(transcript: Transcript) {
-        if (_uiState.value is UiState.Error) {
-            _uiState.value = UiState.TranscriptFound(
-                podcastAndEpisode = _uiState.value.podcastAndEpisode,
-                transcript = transcript,
-            )
+        if (_uiState.value.transcriptState is TranscriptState.Error) {
+            _uiState.update { value ->
+                value.copy(
+                    transcriptState = TranscriptState.Found(transcript = transcript),
+                )
+            }
         }
     }
 
@@ -211,50 +220,65 @@ class TranscriptViewModel @Inject constructor(
         )
     }
 
-    data class PodcastAndEpisode(
-        val podcast: Podcast?,
-        val episodeUuid: String,
-    )
+    data class UiState(
+        val subscriptionTier: SubscriptionTier,
+        val podcastAndEpisode: PodcastAndEpisode?,
+        val transcriptState: TranscriptState,
+    ) {
+        private val isSubscriptionRequired = if (transcriptState.transcript?.isGenerated == true) {
+            !subscriptionTier.isPaid
+        } else {
+            false
+        }
 
-    sealed class UiState {
-        open val transcript: Transcript? = null
-        open val podcastAndEpisode: PodcastAndEpisode? = null
+        val showPaywall = (transcriptState as? TranscriptState.Loaded)?.isTranscriptEmpty == false && isSubscriptionRequired
 
-        data class Empty(
-            override val podcastAndEpisode: PodcastAndEpisode? = null,
-        ) : UiState()
+        val showSearch = (transcriptState as? TranscriptState.Loaded)?.showAsWebPage == true && !isSubscriptionRequired
 
-        data class TranscriptFound(
-            override val podcastAndEpisode: PodcastAndEpisode? = null,
+        companion object {
+            val Empty = UiState(
+                subscriptionTier = SubscriptionTier.NONE,
+                podcastAndEpisode = null,
+                transcriptState = TranscriptState.Empty,
+            )
+        }
+    }
+
+    sealed interface TranscriptState {
+        val transcript: Transcript?
+
+        data object Empty : TranscriptState {
+            override val transcript get() = null
+        }
+
+        data class Found(
             override val transcript: Transcript,
-        ) : UiState()
+        ) : TranscriptState
 
-        data class TranscriptLoaded(
-            override val podcastAndEpisode: PodcastAndEpisode? = null,
+        data class Loaded(
             override val transcript: Transcript,
             val displayInfo: DisplayInfo,
             val cuesInfo: List<TranscriptCuesInfo>,
-            val isSubscriptionRequired: Boolean,
-        ) : UiState() {
+        ) : TranscriptState {
             val isTranscriptEmpty: Boolean = cuesInfo.isEmpty()
-
-            val showPaywall = isSubscriptionRequired && !isTranscriptEmpty
 
             val showAsWebPage: Boolean
                 get() = transcript.type == TranscriptFormat.HTML.mimeType &&
                     cuesInfo.isNotEmpty() && cuesInfo[0].cuesWithTiming.cues.any {
                         it.text?.contains("<script type=\"text/javascript\">") ?: false
                     }
-
-            val showSearch = !showAsWebPage && !isSubscriptionRequired
         }
 
         data class Error(
             val error: TranscriptError,
             override val transcript: Transcript,
-            override val podcastAndEpisode: PodcastAndEpisode? = null,
-        ) : UiState()
+        ) : TranscriptState
     }
+
+    data class PodcastAndEpisode(
+        val podcast: Podcast?,
+        val episodeUuid: String,
+    )
 
     data class DisplayInfo(
         val text: String,

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/transcripts/TranscriptViewModel.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/transcripts/TranscriptViewModel.kt
@@ -32,7 +32,6 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
-import timber.log.Timber
 
 @kotlin.OptIn(ExperimentalCoroutinesApi::class)
 @OptIn(UnstableApi::class)

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/ShelfSharedViewModel.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/ShelfSharedViewModel.kt
@@ -145,6 +145,12 @@ class ShelfSharedViewModel @Inject constructor(
         }
     }
 
+    fun closeUpsell() {
+        viewModelScope.launch {
+            _transitionState.emit(TransitionState.OpenTranscript)
+        }
+    }
+
     fun closeTranscript(
         podcast: Podcast?,
         episode: BaseEpisode?,

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/onboarding/OnboardingUpgradeSource.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/onboarding/OnboardingUpgradeSource.kt
@@ -23,5 +23,6 @@ enum class OnboardingUpgradeSource(val analyticsValue: String) {
     SETTINGS("settings"),
     SLUMBER_STUDIOS("slumber_studios"),
     UP_NEXT_SHUFFLE("up_next_shuffle"),
+    GENERATED_TRANSCRIPTS("generated_transcripts"),
     UNKNOWN("unknown"),
 }


### PR DESCRIPTION
## Description

This PR handles upselling and onboarding when subscribing via the generated transcripts paywall. To avoid using a global event bus, I refactored the transcripts view model so that it can listen to the subscription status. This ensures that the paywall is hidden once the subscription is made.

## Testing Instructions

1. Enable the `GENERATED_TRANSCRIPTS` feature flag in the code.
2. Install the `release` variant.
3. Open the app.
4. Play an episode with generated transcripts, such as [this one](https://pca.st/episode/08140cb7-aa73-4da9-bc47-30c0303e2555).
5. Tap the "Subscribe to Plus" button.
6. Complete the onboarding flow and purchase Plus.
7. Once the flow finishes, you should see the generated transcript.

## Screenshots or Screencast 

https://github.com/user-attachments/assets/2f536433-8f77-4cd5-a772-91cd8a684a7b

## Checklist
- [ ] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [ ] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [ ] ~Any jetpack compose components I added or changed are covered by compose previews~
- [ ] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~