### PR TITLE
Improve transcript transition animation

### DIFF
--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/PlayerContainerFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/PlayerContainerFragment.kt
@@ -324,7 +324,7 @@ class PlayerContainerFragment : BaseFragment(), HasBackstack {
 
             isTranscriptVisible -> {
                 updateTabsVisibility(true)
-                shelfSharedViewModel.closeTranscript(viewModel.podcast, viewModel.episode, withTransition = true)
+                shelfSharedViewModel.closeTranscript(viewModel.podcast, viewModel.episode)
                 true
             }
 

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/nowplaying/PlayerHeadingSection.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/nowplaying/PlayerHeadingSection.kt
@@ -99,7 +99,7 @@ fun PlayerHeadingSection(
 
     LaunchedEffect(Unit) {
         shelfSharedViewModel.transitionState.collect {
-            disableAccessibility = it is TransitionState.OpenTranscript || it is TransitionState.UpsellTranscript
+            disableAccessibility = it is TransitionState.OpenTranscript
         }
     }
 }

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/transcripts/TranscriptPage.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/transcripts/TranscriptPage.kt
@@ -119,8 +119,10 @@ fun TranscriptPage(
 
             is TranscriptState.Found -> {
                 LoadingView(
-                    modifier = Modifier.background(colors.backgroundColor()),
                     color = TranscriptColors.textColor(),
+                    modifier = Modifier
+                        .background(colors.backgroundColor())
+                        .padding(bottom = bottomPadding()),
                 )
             }
 

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/transcripts/TranscriptPageWrapper.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/transcripts/TranscriptPageWrapper.kt
@@ -116,7 +116,6 @@ fun TranscriptPageWrapper(
                     shelfSharedViewModel.closeTranscript(
                         playerViewModel.podcast,
                         playerViewModel.episode,
-                        withTransition = true,
                     )
                 },
                 showSearch = showSearch,
@@ -167,15 +166,16 @@ fun TranscriptPageWrapper(
         LaunchedEffect(uiState.showPaywall, transitionState) {
             showPaywall = uiState.showPaywall
 
-            when (transitionState) {
+            when (val state = transitionState) {
                 is TransitionState.OpenTranscript -> {
-                    if (showPaywall) {
-                        shelfSharedViewModel.showUpsell()
-                    }
-                }
-                is TransitionState.UpsellTranscript -> {
-                    if (!showPaywall) {
-                        shelfSharedViewModel.closeUpsell()
+                    if (state.showPlayerControls) {
+                        if (showPaywall) {
+                            shelfSharedViewModel.openTranscript(showPlayerControls = false)
+                        }
+                    } else {
+                        if (!showPaywall) {
+                            shelfSharedViewModel.openTranscript(showPlayerControls = true)
+                        }
                     }
                 }
                 is TransitionState.CloseTranscript, null -> Unit

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/ShelfSharedViewModel.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/ShelfSharedViewModel.kt
@@ -125,39 +125,26 @@ class ShelfSharedViewModel @Inject constructor(
     ) {
         viewModelScope.launch {
             if (isTranscriptAvailable) {
-                openTranscript(source)
+                trackShelfAction(ShelfItem.Transcript, source)
+                openTranscript(showPlayerControls = true)
             } else {
                 _snackbarMessages.emit(SnackbarMessage.TranscriptNotAvailable)
             }
         }
     }
 
-    fun openTranscript(source: ShelfItemSource) {
-        trackShelfAction(ShelfItem.Transcript, source)
+    fun openTranscript(showPlayerControls: Boolean) {
         viewModelScope.launch {
-            _transitionState.emit(TransitionState.OpenTranscript)
-        }
-    }
-
-    fun showUpsell() {
-        viewModelScope.launch {
-            _transitionState.emit(TransitionState.UpsellTranscript)
-        }
-    }
-
-    fun closeUpsell() {
-        viewModelScope.launch {
-            _transitionState.emit(TransitionState.OpenTranscript)
+            _transitionState.emit(TransitionState.OpenTranscript(showPlayerControls))
         }
     }
 
     fun closeTranscript(
         podcast: Podcast?,
         episode: BaseEpisode?,
-        withTransition: Boolean = false,
     ) {
         viewModelScope.launch {
-            _transitionState.emit(TransitionState.CloseTranscript(withTransition))
+            _transitionState.emit(TransitionState.CloseTranscript)
             analyticsTracker.track(
                 AnalyticsEvent.TRANSCRIPT_DISMISSED,
                 AnalyticsProp.transcriptDismissed(
@@ -370,9 +357,8 @@ class ShelfSharedViewModel @Inject constructor(
     }
 
     sealed class TransitionState {
-        data object OpenTranscript : TransitionState()
-        data object UpsellTranscript : TransitionState()
-        data class CloseTranscript(val withTransition: Boolean) : TransitionState()
+        data class OpenTranscript(val showPlayerControls: Boolean) : TransitionState()
+        data object CloseTranscript : TransitionState()
     }
 
     enum class ShelfItemSource {

--- a/modules/features/player/src/main/res/values-sw600dp/dimens.xml
+++ b/modules/features/player/src/main/res/values-sw600dp/dimens.xml
@@ -3,5 +3,4 @@
     <item name="seekbar_width_percentage" format="float" type="dimen">0.8</item>
     <dimen name="large_play_button_margin_bottom">40dp</dimen>
     <dimen name="transcript_text_bottom_padding">132dp</dimen>
-    <dimen name="seekbar_margin_bottom">0dp</dimen>
 </resources>

--- a/modules/features/player/src/main/res/values/dimens.xml
+++ b/modules/features/player/src/main/res/values/dimens.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <item name="seekbar_width_percentage" format="float" type="dimen">1.0</item>
-    <dimen name="seekbar_margin_bottom">10dp</dimen>
-    <dimen name="seekbar_margin_bottom_transcript">-25dp</dimen>
     <dimen name="large_play_button_margin_bottom">24dp</dimen>
     <dimen name="player_fragment_start_y">69dp</dimen>
     <dimen name="player_tab_text_size">14sp</dimen>

--- a/modules/features/player/src/test/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/ShelfSharedViewModelTest.kt
+++ b/modules/features/player/src/test/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/ShelfSharedViewModelTest.kt
@@ -119,7 +119,7 @@ class ShelfSharedViewModelTest {
 
             shelfSharedViewModel.transitionState.test {
                 shelfSharedViewModel.onTranscriptClick(true, ShelfItemSource.Shelf)
-                assertEquals(TransitionState.OpenTranscript, awaitItem())
+                assertEquals(TransitionState.OpenTranscript(showPlayerControls = true), awaitItem())
             }
         }
 
@@ -135,28 +135,15 @@ class ShelfSharedViewModelTest {
         }
 
     @Test
-    fun `given with transition true, when close transcript called, then transcript is closed with transition`() =
+    fun `when close transcript called, then transcript is closed with transition`() =
         runTest {
             val podcast = Podcast("podcastUuid")
             val episode = PodcastEpisode("episodeUuid", publishedDate = Date())
             initViewModel()
 
             shelfSharedViewModel.transitionState.test {
-                shelfSharedViewModel.closeTranscript(podcast, episode, true)
-                assertEquals(TransitionState.CloseTranscript(true), awaitItem())
-            }
-        }
-
-    @Test
-    fun `given with transition false, when close transcript called, then transcript is closed without transition`() =
-        runTest {
-            val podcast = Podcast("podcastUuid")
-            val episode = PodcastEpisode("episodeUuid", publishedDate = Date())
-            initViewModel()
-
-            shelfSharedViewModel.transitionState.test {
-                shelfSharedViewModel.closeTranscript(podcast, episode, false)
-                assertEquals(TransitionState.CloseTranscript(false), awaitItem())
+                shelfSharedViewModel.closeTranscript(podcast, episode)
+                assertEquals(TransitionState.CloseTranscript, awaitItem())
             }
         }
 

--- a/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/extensions/Springs.kt
+++ b/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/extensions/Springs.kt
@@ -1,0 +1,47 @@
+package au.com.shiftyjelly.pocketcasts.views.extensions
+
+import android.view.View
+import androidx.annotation.IdRes
+import androidx.dynamicanimation.animation.DynamicAnimation.ViewProperty
+import androidx.dynamicanimation.animation.SpringAnimation
+import androidx.dynamicanimation.animation.SpringForce
+import au.com.shiftyjelly.pocketcasts.views.R
+
+fun View.spring(
+    property: ViewProperty,
+    damping: Float = 1f,
+    stiffness: Float = 350f,
+): SpringAnimation {
+    val tagId = getTagId(property)
+    var animation = getTag(tagId) as? SpringAnimation?
+    if (animation == null) {
+        animation = SpringAnimation(this, property).apply {
+            spring = SpringForce().apply {
+                this.dampingRatio = damping
+                this.stiffness = stiffness
+            }
+        }
+        setTag(tagId, animation)
+    }
+    return animation
+}
+
+@IdRes
+private fun getTagId(property: ViewProperty) = when (property) {
+    SpringAnimation.TRANSLATION_X -> R.id.spring_animation_id_translation_x
+    SpringAnimation.TRANSLATION_Y -> R.id.spring_animation_id_translation_y
+    SpringAnimation.TRANSLATION_Z -> R.id.spring_animation_id_translation_z
+    SpringAnimation.SCALE_X -> R.id.spring_animation_id_scale_x
+    SpringAnimation.SCALE_Y -> R.id.spring_animation_id_scale_y
+    SpringAnimation.ROTATION -> R.id.spring_animation_id_rotation
+    SpringAnimation.ROTATION_X -> R.id.spring_animation_id_rotation_x
+    SpringAnimation.ROTATION_Y -> R.id.spring_animation_id_rotation_y
+    SpringAnimation.X -> R.id.spring_animation_id_x
+    SpringAnimation.Y -> R.id.spring_animation_id_y
+    SpringAnimation.Z -> R.id.spring_animation_id_z
+    SpringAnimation.ALPHA -> R.id.spring_animation_id_alpha
+    SpringAnimation.SCROLL_X -> R.id.spring_animation_id_scroll_x
+    SpringAnimation.SCROLL_Y -> R.id.spring_animation_id_scroll_y
+    else -> error("Unknown view property: $property")
+}
+

--- a/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/extensions/Springs.kt
+++ b/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/extensions/Springs.kt
@@ -44,4 +44,3 @@ private fun getTagId(property: ViewProperty) = when (property) {
     SpringAnimation.SCROLL_Y -> R.id.spring_animation_id_scroll_y
     else -> error("Unknown view property: $property")
 }
-

--- a/modules/services/views/src/main/res/values/ids.xml
+++ b/modules/services/views/src/main/res/values/ids.xml
@@ -1,4 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <item name="multi_swipe_helper_previous_elevation" type="id"/>
+
+    <item name="spring_animation_id_translation_x" type="id" />
+    <item name="spring_animation_id_translation_y" type="id" />
+    <item name="spring_animation_id_translation_z" type="id" />
+    <item name="spring_animation_id_scale_x" type="id" />
+    <item name="spring_animation_id_scale_y" type="id" />
+    <item name="spring_animation_id_rotation" type="id" />
+    <item name="spring_animation_id_rotation_x" type="id" />
+    <item name="spring_animation_id_rotation_y" type="id" />
+    <item name="spring_animation_id_x" type="id" />
+    <item name="spring_animation_id_y" type="id" />
+    <item name="spring_animation_id_z" type="id" />
+    <item name="spring_animation_id_alpha" type="id" />
+    <item name="spring_animation_id_scroll_x" type="id" />
+    <item name="spring_animation_id_scroll_y" type="id" />
+    <item name="spring_animation_id_end_listener" type="id" />
 </resources>


### PR DESCRIPTION
## Description

This PR simplifies transcripts transition state and improves animations.

## Testing Instructions

1. Play an episode with generated transcripts, such as [this one](https://pca.st/episode/08140cb7-aa73-4da9-bc47-30c0303e2555).
2. Toggle transcripts and notice the animation.
3. Repeat the same for an episode with regular transcripts.

## Screenshots or Screencast 

| Before | After |
| - | - |
| <video src="https://github.com/user-attachments/assets/5228a18e-dd69-4d92-a572-73584991af22"/> | <video src="https://github.com/user-attachments/assets/e5787f43-2ed2-4bc0-95c0-bbdd351b7ea2"/> |


## Checklist
- [ ] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] ~I have considered whether it makes sense to add tests for my changes~
- [ ] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [ ] ~Any jetpack compose components I added or changed are covered by compose previews~
- [ ] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~