### PR TITLE
Add generated transcripts Tracks

### DIFF
--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/PlayerContainerFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/PlayerContainerFragment.kt
@@ -324,7 +324,7 @@ class PlayerContainerFragment : BaseFragment(), HasBackstack {
 
             isTranscriptVisible -> {
                 updateTabsVisibility(true)
-                shelfSharedViewModel.closeTranscript(viewModel.podcast, viewModel.episode)
+                shelfSharedViewModel.closeTranscript()
                 true
             }
 

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/transcripts/TranscriptPageWrapper.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/transcripts/TranscriptPageWrapper.kt
@@ -113,10 +113,7 @@ fun TranscriptPageWrapper(
         ) {
             TranscriptToolbar(
                 onCloseClick = {
-                    shelfSharedViewModel.closeTranscript(
-                        playerViewModel.podcast,
-                        playerViewModel.episode,
-                    )
+                    shelfSharedViewModel.closeTranscript()
                 },
                 showSearch = showSearch,
                 onSearchDoneClicked = {

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/ShelfSharedViewModel.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/ShelfSharedViewModel.kt
@@ -139,19 +139,9 @@ class ShelfSharedViewModel @Inject constructor(
         }
     }
 
-    fun closeTranscript(
-        podcast: Podcast?,
-        episode: BaseEpisode?,
-    ) {
+    fun closeTranscript() {
         viewModelScope.launch {
             _transitionState.emit(TransitionState.CloseTranscript)
-            analyticsTracker.track(
-                AnalyticsEvent.TRANSCRIPT_DISMISSED,
-                AnalyticsProp.transcriptDismissed(
-                    episodeId = episode?.uuid.orEmpty(),
-                    podcastId = podcast?.uuid.orEmpty(),
-                ),
-            )
         }
     }
 

--- a/modules/features/player/src/test/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/ShelfSharedViewModelTest.kt
+++ b/modules/features/player/src/test/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/ShelfSharedViewModelTest.kt
@@ -137,12 +137,10 @@ class ShelfSharedViewModelTest {
     @Test
     fun `when close transcript called, then transcript is closed with transition`() =
         runTest {
-            val podcast = Podcast("podcastUuid")
-            val episode = PodcastEpisode("episodeUuid", publishedDate = Date())
             initViewModel()
 
             shelfSharedViewModel.transitionState.test {
-                shelfSharedViewModel.closeTranscript(podcast, episode)
+                shelfSharedViewModel.closeTranscript()
                 assertEquals(TransitionState.CloseTranscript, awaitItem())
             }
         }

--- a/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
+++ b/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
@@ -702,6 +702,9 @@ enum class AnalyticsEvent(val key: String) {
     TRANSCRIPT_SEARCH_SHOWN("transcript_search_shown"),
     TRANSCRIPT_SEARCH_NEXT_RESULT("transcript_search_next_result"),
     TRANSCRIPT_SEARCH_PREVIOUS_RESULT("transcript_search_previous_result"),
+    TRANSCRIPT_GENERATED_PAYWALL_SHOWN("transcript_generated_paywall_shown"),
+    TRANSCRIPT_GENERATED_PAYWALL_DISMISSED("transcript_generated_paywall_dismissed"),
+    TRANSCRIPT_GENERATED_PAYWALL_SUBSCRIBE_TAPPED("transcript_generated_paywall_subscribe_tapped"),
 
     /* Referrals */
     REFERRAL_TOOLTIP_SHOWN("referral_tooltip_shown"),


### PR DESCRIPTION
## Description

This PR adds analytics for the generated transcripts.

## Testing Instructions

Verify these events are triggered with podcast ID and episode ID properties.

<img width="995" alt="Screenshot 2025-03-12 at 09 03 10" src="https://github.com/user-attachments/assets/9e8bda06-9358-4571-8c3a-02c30d8d0d86" />

Starting the upsell flow should use `generated_transcripts` as the `source` property.

## Checklist
- [ ] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] ~I have considered whether it makes sense to add tests for my changes~
- [ ] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [ ] ~Any jetpack compose components I added or changed are covered by compose previews~
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.