### PR TITLE
Do not show recommendation page when subscribing via transcripts

### DIFF
--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/OnboardingFlowComposable.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/OnboardingFlowComposable.kt
@@ -90,8 +90,8 @@ private fun Content(
             flow is OnboardingFlow.ReferralLoginOrSignUp -> {
                 exitOnboarding(OnboardingExitInfo(showWelcomeInReferralFlow = true))
             }
-            flow is OnboardingFlow.Upsell && flow.source == OnboardingUpgradeSource.SUGGESTED_FOLDERS -> {
-                navController.navigate(OnboardingNavRoute.PlusUpgrade.routeWithSource(OnboardingUpgradeSource.SUGGESTED_FOLDERS, forcePurchase = true)) {
+            flow is OnboardingFlow.Upsell && flow.source in forcedPurchaseSources -> {
+                navController.navigate(OnboardingNavRoute.PlusUpgrade.routeWithSource(flow.source, forcePurchase = true)) {
                     // clear backstack after account is created
                     popUpTo(OnboardingNavRoute.logInOrSignUp) {
                         inclusive = true
@@ -355,3 +355,8 @@ object OnboardingNavRoute {
         ) = "$routeBase/$source?$forcePurchaseArgumentKey=$forcePurchase"
     }
 }
+
+private val forcedPurchaseSources = listOf(
+    OnboardingUpgradeSource.SUGGESTED_FOLDERS,
+    OnboardingUpgradeSource.GENERATED_TRANSCRIPTS,
+)


### PR DESCRIPTION
## Description

Internal Ref: p1741726917427339-slack-C078746V6UX

## Testing Instructions

1. Enable the `GENERATED_TRANSCRIPTS` feature flag in the code.
2. Install the `release` variant.
3. Open the app.
4. Play an episode with generated transcripts, such as [this one](https://pca.st/episode/08140cb7-aa73-4da9-bc47-30c0303e2555).
5. Tap the "Subscribe to Plus" button.
6. Complete the onboarding flow and purchase Plus.
7. You should not see the recommendations screen during the onboarding.

## Checklist
- [ ] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] ~I have considered whether it makes sense to add tests for my changes`
- [ ] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [ ] ~Any jetpack compose components I added or changed are covered by compose previews~
- [ ] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~