### PR TITLE
Add IME padding to the bookmarks page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
     *   Fixed an issue where the mini player could sometimes hide behind the navigation bar.
         ([#3687](https://github.com/Automattic/pocket-casts-android/pull/3687))
     *   Fixed an issue where bookmark confirmation button was obstructed by keyboard.
-        ([#3760](https://github.com/Automattic/pocket-casts-android/pull/3760))
+        ([#3761](https://github.com/Automattic/pocket-casts-android/pull/3761))
 *   Updates
     *   Close episode details screen when archiving an episode. This reverts [#3473](https://github.com/Automattic/pocket-casts-android/pull/3473). 
         ([#3718](https://github.com/Automattic/pocket-casts-android/pull/3718))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 *   Bug Fixes
     *   Fixed an issue where the mini player could sometimes hide behind the navigation bar.
         ([#3687](https://github.com/Automattic/pocket-casts-android/pull/3687))
+    *   Fixed an issue where bookmark confirmation button was obstructed by keyboard.
+        ([#3760](https://github.com/Automattic/pocket-casts-android/pull/3760))
 *   Updates
     *   Close episode details screen when archiving an episode. This reverts [#3473](https://github.com/Automattic/pocket-casts-android/pull/3473). 
         ([#3718](https://github.com/Automattic/pocket-casts-android/pull/3718))

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/bookmark/BookmarkFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/bookmark/BookmarkFragment.kt
@@ -5,6 +5,9 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.ime
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -44,7 +47,9 @@ class BookmarkFragment : Fragment() {
                 onTitleChange = { viewModel.changeTitle(it) },
                 onSave = ::saveBookmark,
                 onClose = ::close,
-                modifier = Modifier.background(uiState.backgroundColor),
+                modifier = Modifier
+                    .background(uiState.backgroundColor)
+                    .windowInsetsPadding(WindowInsets.ime),
             )
         }
     }


### PR DESCRIPTION
## Description

Fixes #3732

## Testing Instructions

1. Start bookmark creation for an episode.
2. Notice that the button is not hidden behind the keyboard.
3. Hide the keyboard.
4. The button should be at the bottom of the screen.

## Screenshots or Screencast 

| Before | After |
| - | - |
| ![b](https://github.com/user-attachments/assets/b29e81af-048f-4331-88d2-05418a694834) | ![a](https://github.com/user-attachments/assets/cddffff4-ffd8-4f45-a79e-cc7f4de68e7f) |

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] ~I have considered whether it makes sense to add tests for my changes~
- [ ] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [ ] ~Any jetpack compose components I added or changed are covered by compose previews~
- [ ] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] ~with different themes~
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [ ] ~for accessibility with TalkBack~
