### PR TITLE
Add podcast_screen_podcast_details_link_tapped event

### DIFF
--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastFragment.kt
@@ -1,5 +1,7 @@
 package au.com.shiftyjelly.pocketcasts.podcasts.view.podcast
 
+import android.content.Intent
+import android.net.Uri
 import android.os.Build
 import android.os.Bundle
 import android.os.Parcelable
@@ -134,6 +136,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.rx2.asObservable
 import kotlinx.coroutines.withContext
 import kotlinx.parcelize.Parcelize
+import timber.log.Timber
 import au.com.shiftyjelly.pocketcasts.images.R as IR
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 import au.com.shiftyjelly.pocketcasts.ui.R as UR
@@ -805,6 +808,25 @@ class PodcastFragment : BaseFragment() {
                     val hostListener = (requireActivity() as FragmentHostListener)
                     hostListener.closeToRoot()
                     hostListener.openTab(VR.id.navigation_discover)
+                }
+            },
+            onClickWebsite = { podcast ->
+                podcast.podcastUrl?.let { url ->
+                    if (url.isNotBlank()) {
+                        analyticsTracker.track(
+                            AnalyticsEvent.PODCAST_SCREEN_PODCAST_DETAILS_LINK_TAPPED,
+                            mapOf("podcast_uuid" to podcast.uuid),
+                        )
+                        try {
+                            var uri = Uri.parse(url)
+                            if (uri.scheme.isNullOrBlank() && !url.contains("://")) {
+                                uri = Uri.parse("http://$url")
+                            }
+                            startActivity(Intent(Intent.ACTION_VIEW, uri), null)
+                        } catch (e: Exception) {
+                            Timber.e(e, "Failed to open podcast web page.")
+                        }
+                    }
                 }
             },
             onArtworkAvailable = { podcast ->

--- a/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
+++ b/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
@@ -232,6 +232,7 @@ enum class AnalyticsEvent(val key: String) {
     PODCAST_SCREEN_REFRESH_NEW_EPISODE_FOUND("podcast_screen_refresh_new_episode_found"),
     PODCAST_SCREEN_REFRESH_NO_EPISODES_FOUND("podcast_screen_refresh_no_episodes_found"),
     PODCAST_SCREEN_CATEGORY_TAPPED("podcast_screen_category_tapped"),
+    PODCAST_SCREEN_PODCAST_DETAILS_LINK_TAPPED("podcast_screen_podcast_details_link_tapped"),
 
     /* Podcast Settings */
     PODCAST_SETTINGS_FEED_ERROR_TAPPED("podcast_settings_feed_error_tapped"),


### PR DESCRIPTION
## Description

This PR adds a new analytics event.

Internal ref: p1741859946460429/1741859769.286699-slack-C08DPN79CN8

## Testing Instructions

1. Open podcast.
2. Tap on a link in the podcast details info.
3. Notice `podcast_screen_podcast_details_link_tapped` event tracked.

## Checklist
- [ ] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] ~I have considered whether it makes sense to add tests for my changes~
- [ ] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [ ] ~Any jetpack compose components I added or changed are covered by compose previews~
- [ ] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~