### PR TITLE
Improve logs for episode download url updates

### DIFF
--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/download/task/UpdateEpisodeTask.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/download/task/UpdateEpisodeTask.kt
@@ -8,6 +8,7 @@ import androidx.work.WorkerParameters
 import au.com.shiftyjelly.pocketcasts.models.db.AppDatabase
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.servers.podcast.PodcastCacheServiceManager
+import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedInject
 import timber.log.Timber
@@ -52,13 +53,17 @@ class UpdateEpisodeTask @AssistedInject constructor(
                 !serverEpisodeUrl.isNullOrBlank() &&
                 episode.downloadUrl != serverEpisodeUrl
             ) {
+                val oldUrl = episode.downloadUrl
                 episode.downloadUrl = serverEpisodeUrl
                 episodeDao.updateDownloadUrl(serverEpisodeUrl, episode.uuid)
+                LogBuffer.i(LogBuffer.TAG_BACKGROUND_TASKS, "Episode download url updated. Podcast: $podcastUuid Episode: $episodeUuid Old URL: $oldUrl New URL: $serverEpisodeUrl")
             }
 
             return Result.success()
         } catch (e: Exception) {
-            Timber.i(e, "Failed to update episode download url. Podcast: $podcastUuid Episode: $episodeUuid")
+            val message = "Failed to update episode download url. Podcast: $podcastUuid Episode: $episodeUuid"
+            Timber.i(e, message)
+            LogBuffer.e(LogBuffer.TAG_BACKGROUND_TASKS, e, message)
             return Result.success()
         }
     }


### PR DESCRIPTION
## Description
This improves logs for updates to the episode download URL. 

## Testing Instructions
Code review should be sufficient.

## Screenshots or Screencast 
I just want to make sure when auto-downloads are stuck, it is not due to changes to the download URL and failure to update those. 
As the `UpdateEpisodeTask`(that checks for changes to the download URL)  is chained with `DownloadEpisodeTask`, any failures to this task can block the download.

https://github.com/Automattic/pocket-casts-android/blob/1ccba5b75049cbdaf2e3a610c3f923dd3b9a6e8c/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/download/DownloadManagerImpl.kt#L373-L376


9501516-zd-a8c

Relevant Logs: 

`WorkInfo{id='544e8019-e8be-4dcd-9164-6e45bfb101bf', state=BLOCKED, outputData=Data {}, tags=[au.com.shiftyjelly.pocketcasts.repositories.download.task.DownloadEpisodeTask, b724ebb0-b896-405f-bd6f-cfc21e0731d1, downloadTask]`

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack