### PR TITLE
Fix multiselect toolbar position

### DIFF
--- a/modules/features/podcasts/src/main/res/layout/fragment_podcast_redesign.xml
+++ b/modules/features/podcasts/src/main/res/layout/fragment_podcast_redesign.xml
@@ -7,22 +7,6 @@
     android:background="?attr/primary_ui_02"
     android:orientation="vertical">
 
-    <au.com.shiftyjelly.pocketcasts.views.multiselect.MultiSelectToolbar
-        android:id="@+id/multiSelectEpisodesToolbar"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:minHeight="?android:attr/actionBarSize"
-        android:visibility="gone"
-        app:navigationIcon="?attr/homeAsUpIndicator" />
-
-    <au.com.shiftyjelly.pocketcasts.views.multiselect.MultiSelectToolbar
-        android:id="@+id/multiSelectBookmarksToolbar"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:minHeight="?android:attr/actionBarSize"
-        android:visibility="gone"
-        app:navigationIcon="?attr/homeAsUpIndicator" />
-
     <FrameLayout
         android:id="@+id/podcastContentWrapper"
         android:layout_width="match_parent"
@@ -86,6 +70,22 @@
             android:id="@+id/toolbar"
             android:layout_width="match_parent"
             android:layout_height="wrap_content" />
+
+        <au.com.shiftyjelly.pocketcasts.views.multiselect.MultiSelectToolbar
+            android:id="@+id/multiSelectEpisodesToolbar"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:minHeight="?android:attr/actionBarSize"
+            android:visibility="gone"
+            app:navigationIcon="?attr/homeAsUpIndicator" />
+
+        <au.com.shiftyjelly.pocketcasts.views.multiselect.MultiSelectToolbar
+            android:id="@+id/multiSelectBookmarksToolbar"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:minHeight="?android:attr/actionBarSize"
+            android:visibility="gone"
+            app:navigationIcon="?attr/homeAsUpIndicator" />
 
         <androidx.compose.ui.platform.ComposeView
             android:id="@+id/composeTooltipHost"


### PR DESCRIPTION
## Description

Multi-select toolbar added unnecessary spacing to podcast content. Now it is aligned with the toolbar.

## Testing Instructions

1. Open any podcast.
2. Long press an episode or a bookmark.
3. Notice that the multiselect toolbar doesn't offset the content and is displayed over it instead.

## Screenshots or Screencast 

| Before | After |
| - | - |
| ![b](https://github.com/user-attachments/assets/5cf75dfa-a1c3-43a5-b436-177dc54ba1d4) | ![a](https://github.com/user-attachments/assets/a1c64dec-91a1-4843-b0a8-eb2310144e1d) |

## Checklist
- [ ] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] ~I have considered whether it makes sense to add tests for my changes~
- [ ] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [ ] ~Any jetpack compose components I added or changed are covered by compose previews~
- [ ] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [ ] ~for accessibility with TalkBack~
