### PR TITLE
Widgets: update titles and add descriptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 *   Updates
     *   Close episode details screen when archiving an episode. This reverts [#3473](https://github.com/Automattic/pocket-casts-android/pull/3473). 
         ([#3718](https://github.com/Automattic/pocket-casts-android/pull/3718))
+    *   Update widget titles and add descriptions.
+        ([#3769](https://github.com/Automattic/pocket-casts-android/pull/3769))
     *   Reorder podcasts sorting order based on their popularity. 
         ([#3733](https://github.com/Automattic/pocket-casts-android/pull/3733))
 

--- a/modules/features/widgets/src/main/res/xml/large_player_widget.xml
+++ b/modules/features/widgets/src/main/res/xml/large_player_widget.xml
@@ -8,4 +8,5 @@
     android:previewLayout="@layout/widget_player_large_preview"
     android:resizeMode="vertical|horizontal"
     android:targetCellWidth="4"
-    android:targetCellHeight="3" />
+    android:targetCellHeight="3"
+    android:description="@string/large_player_widget_description" />

--- a/modules/features/widgets/src/main/res/xml/medium_player_widget.xml
+++ b/modules/features/widgets/src/main/res/xml/medium_player_widget.xml
@@ -8,4 +8,5 @@
     android:previewLayout="@layout/widget_player_medium_preview"
     android:resizeMode="horizontal"
     android:targetCellWidth="4"
-    android:targetCellHeight="1" />
+    android:targetCellHeight="1"
+    android:description="@string/medium_player_widget_description" />

--- a/modules/features/widgets/src/main/res/xml/small_player_widget.xml
+++ b/modules/features/widgets/src/main/res/xml/small_player_widget.xml
@@ -6,4 +6,5 @@
     android:previewImage="@drawable/widget_player_small_preview"
     android:previewLayout="@layout/widget_player_small_preview"
     android:targetCellWidth="1"
-    android:targetCellHeight="1" />
+    android:targetCellHeight="1"
+    android:description="@string/small_player_widget_description" />

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -173,10 +173,13 @@
     <string name="got_it">Got it</string>
     <string name="submit">Submit</string>
     <string name="widget">Widget</string>
-    <string name="medium_player_classic_widget_label">Medium Player (Classic)</string>
-    <string name="small_player_widget_label">Small Player</string>
-    <string name="medium_player_widget_label">Medium Player</string>
-    <string name="large_player_widget_label">Large Player</string>
+    <string name="medium_player_classic_widget_label">Podcast Playback Controls (Classic)</string>
+    <string name="small_player_widget_label">Podcast Play Button</string>
+    <string name="small_player_widget_description">Play or pause your episode with one tap</string>
+    <string name="medium_player_widget_label">Podcast Playback Controls</string>
+    <string name="medium_player_widget_description">Play, pause, or skip through your episode</string>
+    <string name="large_player_widget_label">Podcast Controls &amp; Up Next Queue</string>
+    <string name="large_player_widget_description">Control playback or switch episodes</string>
     <string name="widget_no_episode_playing">No episode playing</string>
     <string name="widget_nothing_in_up_next">Nothing in Up Next</string>
     <string name="widget_check_out_discover">Check out Discover for more</string>

--- a/modules/services/repositories/src/main/res/xml/widget.xml
+++ b/modules/services/repositories/src/main/res/xml/widget.xml
@@ -7,4 +7,5 @@
     android:updatePeriodMillis="1000"
     android:initialLayout="@layout/widget_default_theme"
     android:previewImage="@drawable/widget_old_preview"
-    android:resizeMode="horizontal"/>
+    android:resizeMode="horizontal"
+    android:description="@string/medium_player_widget_description" />


### PR DESCRIPTION
## Description

This updates the widget existing titles and adds the new descriptions field. These are now more similar to how Google labels their widgets, for example:

| | |
|--------|--------|
| ![Screenshot_20250213_173941 (1)](https://github.com/user-attachments/assets/30d5bbfe-61d3-495c-9691-e8d9c93ca7f8) | ![Screenshot_20250213_173921 (1)](https://github.com/user-attachments/assets/14a2b8a3-d44d-4076-be72-e67872de44eb) | 

Internal reference: p1739426473618099/1739426442.471469-slack-C05RR9P9RAT

## Testing Instructions
1. Long press on the home screen
2. Tap "Widgets"
3. Scroll down to the Pocket Casts widget
4. ✅ Verify the widget text 

## Screenshots

| Before | After |
| --- | --- |
| ![Screenshot_20250314_141441](https://github.com/user-attachments/assets/94aaca1d-1908-4301-88bb-d4e1b09d219e)  | ![Screenshot_20250314_142521](https://github.com/user-attachments/assets/51f7d6ef-5f1a-429d-ae8c-1eedcd6c414c) | 
| ![Screenshot_20250314_141434](https://github.com/user-attachments/assets/67ce64a1-c21f-4c8b-9858-c876234d3094) | ![Screenshot_20250314_142604](https://github.com/user-attachments/assets/9e954550-3516-4d41-97a6-60813416ba8a) | 

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack