### PR TITLE
Improve small widget accessibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
         ([#3718](https://github.com/Automattic/pocket-casts-android/pull/3718))
     *   Reorder podcasts sorting order based on their popularity. 
         ([#3733](https://github.com/Automattic/pocket-casts-android/pull/3733))
+    *   Improve small widget accessibility.
+        ([#3770](https://github.com/Automattic/pocket-casts-android/pull/3770))
 
 7.84
 -----

--- a/modules/features/widgets/src/main/kotlin/au/com/shiftyjelly/pocketcasts/widget/ui/EpisodeImage.kt
+++ b/modules/features/widgets/src/main/kotlin/au/com/shiftyjelly/pocketcasts/widget/ui/EpisodeImage.kt
@@ -18,6 +18,8 @@ import androidx.glance.action.Action
 import androidx.glance.action.clickable
 import androidx.glance.layout.Alignment
 import androidx.glance.layout.size
+import androidx.glance.semantics.contentDescription
+import androidx.glance.semantics.semantics
 import androidx.glance.unit.ColorProvider
 import au.com.shiftyjelly.pocketcasts.repositories.images.PocketCastsImageRequestFactory
 import au.com.shiftyjelly.pocketcasts.widget.data.PlayerWidgetEpisode
@@ -32,6 +34,7 @@ internal fun EpisodeImage(
     size: Dp,
     backgroundColor: ((WidgetTheme) -> ColorProvider)? = null,
     onClick: Action? = null,
+    contentDescription: String = "",
 ) {
     var episodeBitmap by remember(episode?.uuid, useEpisodeArtwork, size) {
         mutableStateOf<Bitmap?>(null)
@@ -40,7 +43,14 @@ internal fun EpisodeImage(
     RounderCornerBox(
         contentAlignment = Alignment.Center,
         backgroundTint = backgroundColor?.invoke(LocalWidgetTheme.current) ?: LocalWidgetTheme.current.buttonBackground,
-        modifier = GlanceModifier.size(size).applyIf(onClick != null) { it.clickable(onClick!!) },
+        modifier = GlanceModifier
+            .size(size)
+            .applyIf(onClick != null) {
+                it.clickable(onClick!!)
+            }
+            .applyIf(contentDescription.isNotEmpty()) {
+                it.semantics { this.contentDescription = contentDescription }
+            },
     ) {
         PocketCastsLogo(
             size = size / 2.5f,

--- a/modules/features/widgets/src/main/kotlin/au/com/shiftyjelly/pocketcasts/widget/ui/SmallPlayer.kt
+++ b/modules/features/widgets/src/main/kotlin/au/com/shiftyjelly/pocketcasts/widget/ui/SmallPlayer.kt
@@ -12,9 +12,6 @@ import androidx.glance.layout.Alignment
 import androidx.glance.layout.Box
 import androidx.glance.layout.fillMaxSize
 import androidx.glance.layout.size
-import androidx.glance.layout.width
-import androidx.glance.semantics.contentDescription
-import androidx.glance.semantics.semantics
 import au.com.shiftyjelly.pocketcasts.widget.action.OpenPocketCastsAction
 import au.com.shiftyjelly.pocketcasts.widget.action.controlPlaybackAction
 import au.com.shiftyjelly.pocketcasts.widget.data.LocalSource
@@ -30,8 +27,8 @@ internal fun SmallPlayer(state: SmallPlayerWidgetState) {
     }
     val contentDescription = when {
         state.episode == null -> LR.string.pocket_casts
-        state.isPlaying -> LR.string.play_episode
-        else -> LR.string.pause_episode
+        // don't use a pause state as TalkBack will take focus and cause the state to change
+        else -> LR.string.play_episode
     }.let { LocalContext.current.getString(it) }
 
     val size = min(LocalSize.current.width, LocalSize.current.height)
@@ -41,10 +38,7 @@ internal fun SmallPlayer(state: SmallPlayerWidgetState) {
             contentAlignment = Alignment.Center,
             modifier = GlanceModifier
                 .fillMaxSize()
-                .clickable(controlPlayback)
-                .semantics {
-                    this.contentDescription = contentDescription
-                },
+                .clickable(controlPlayback),
         ) {
             EpisodeImage(
                 episode = state.episode,
@@ -52,12 +46,14 @@ internal fun SmallPlayer(state: SmallPlayerWidgetState) {
                 size = size,
                 backgroundColor = { it.background },
                 onClick = controlPlayback,
+                contentDescription = contentDescription,
             )
             if (state.episode != null) {
                 val buttonSize = (size / 2.3f).coerceAtMost(48.dp)
                 PlaybackButton(
                     isPlaying = state.isPlaying,
                     iconPadding = buttonSize / 4.75f,
+                    isClickable = false,
                     modifier = GlanceModifier.size(buttonSize),
                 )
             }

--- a/modules/features/widgets/src/main/kotlin/au/com/shiftyjelly/pocketcasts/widget/ui/SmallPlayer.kt
+++ b/modules/features/widgets/src/main/kotlin/au/com/shiftyjelly/pocketcasts/widget/ui/SmallPlayer.kt
@@ -7,7 +7,6 @@ import androidx.compose.ui.unit.min
 import androidx.glance.GlanceModifier
 import androidx.glance.LocalContext
 import androidx.glance.LocalSize
-import androidx.glance.action.clickable
 import androidx.glance.layout.Alignment
 import androidx.glance.layout.Box
 import androidx.glance.layout.fillMaxSize
@@ -36,9 +35,7 @@ internal fun SmallPlayer(state: SmallPlayerWidgetState) {
     WidgetTheme(state.useDynamicColors) {
         Box(
             contentAlignment = Alignment.Center,
-            modifier = GlanceModifier
-                .fillMaxSize()
-                .clickable(controlPlayback),
+            modifier = GlanceModifier.fillMaxSize(),
         ) {
             EpisodeImage(
                 episode = state.episode,


### PR DESCRIPTION
## Description

This improves the small widget by reducing the number of targets that TalkBack selects. One of them removed is the target that's below the touch target requirement of 48dp.

## Testing Instructions
1. Turn on TalkBack (In the emulator use the "Device UI Shortcuts" to toggle it)
2. Hove your finger over an element above
3. Swipe from left to right to move through the elements
4. ✅ Verify it's possible to pause and play an episode

Internal reference: p1739426497274879/1739426442.471469-slack-C05RR9P9RAT

## Screencast 

You can't hear the TalkBack voice in these videos but there is the text output at the bottom of the screen.

**After**

https://github.com/user-attachments/assets/1f1607e9-21cc-486b-bd5b-decfd0b42196


**Before**


https://github.com/user-attachments/assets/74979826-aaa5-4271-b9a2-763fa97ef70d

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack