### PR TITLE
Read data collection default value from local.properties

### DIFF
--- a/modules/services/preferences/build.gradle.kts
+++ b/modules/services/preferences/build.gradle.kts
@@ -1,3 +1,5 @@
+import java.util.Properties
+
 plugins {
     alias(libs.plugins.android.library)
     alias(libs.plugins.kotlin.android)
@@ -9,6 +11,19 @@ android {
     namespace = "au.com.shiftyjelly.pocketcasts.preferences"
     buildFeatures {
         buildConfig = true
+    }
+
+    defaultConfig {
+        val localPropertiesFile = rootProject.file("local.properties")
+        val dataCollectionValue = if (localPropertiesFile.exists() && localPropertiesFile.isFile) {
+            val properties = Properties().apply {
+                load(localPropertiesFile.inputStream())
+            }
+            properties.getProperty("au.com.shiftyjelly.pocketcasts.data.collection")?.toBooleanStrictOrNull()
+        } else {
+            null
+        }
+        buildConfigField("Boolean", "DATA_COLLECTION_DEFAULT_VALUE", dataCollectionValue.toString())
     }
 }
 

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
@@ -1311,13 +1311,13 @@ class SettingsImpl @Inject constructor(
 
     override val collectAnalytics = UserSetting.BoolPref(
         sharedPrefKey = "SendUsageStatsKey",
-        defaultValue = true,
+        defaultValue = BuildConfig.DATA_COLLECTION_DEFAULT_VALUE ?: true,
         sharedPrefs = sharedPreferences,
     )
 
     override val sendCrashReports = UserSetting.BoolPref(
         sharedPrefKey = "SendCrashReportsKey",
-        defaultValue = true,
+        defaultValue = BuildConfig.DATA_COLLECTION_DEFAULT_VALUE ?: true,
         sharedPrefs = sharedPreferences,
     )
 


### PR DESCRIPTION
## Description

This PR adds local override for default data collection value.

Internal Ref: p1741847895036839-slack-C07J5LNP4SF

## Testing Instructions

1. Make a fresh installation.
2. Go to the privacy settings.
3. Notice that analytics and crash reporting is enabled.
4. Add `au.com.shiftyjelly.pocketcasts.data.collection=false` to your `local.properties` file.
5. Reinstall the app.
6. Go to the privacy settings.
7. Notice that the tracking settings are disabled.

## Checklist
- [ ] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] ~I have considered whether it makes sense to add tests for my changes~
- [ ] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [ ] ~Any jetpack compose components I added or changed are covered by compose previews~
- [ ] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~