### PR TITLE
Add padding to the podcast grid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
         ([#3761](https://github.com/Automattic/pocket-casts-android/pull/3761))
     *   Fix issues with Classic widget not syncing its state in some scenarios.
         ([#3777](https://github.com/Automattic/pocket-casts-android/pull/3777))
+    *   Fix podcast grid padding
+        ([#3781](https://github.com/Automattic/pocket-casts-android/pull/3781))
 *   Updates
     *   Close episode details screen when archiving an episode. This reverts [#3473](https://github.com/Automattic/pocket-casts-android/pull/3473). 
         ([#3718](https://github.com/Automattic/pocket-casts-android/pull/3718))

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
@@ -68,9 +68,10 @@ import kotlin.time.Duration.Companion.milliseconds
 import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.distinctUntilChanged
-import kotlinx.coroutines.flow.onStart
 import timber.log.Timber
 
 class SettingsImpl @Inject constructor(
@@ -1509,9 +1510,9 @@ class SettingsImpl @Inject constructor(
         _themeReconfigurationEvents.tryEmit(Unit)
     }
 
-    private val _bottomInset = MutableSharedFlow<Int>(onBufferOverflow = BufferOverflow.DROP_OLDEST, replay = 1)
+    private val _bottomInset = MutableStateFlow(0)
     override val bottomInset: Flow<Int>
-        get() = _bottomInset.asSharedFlow().onStart { emit(0) }
+        get() = _bottomInset.asStateFlow()
 
     override fun updateBottomInset(height: Int) {
         _bottomInset.tryEmit(height)

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
@@ -70,6 +70,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.onStart
 import timber.log.Timber
 
 class SettingsImpl @Inject constructor(
@@ -1510,7 +1511,7 @@ class SettingsImpl @Inject constructor(
 
     private val _bottomInset = MutableSharedFlow<Int>(onBufferOverflow = BufferOverflow.DROP_OLDEST, replay = 1)
     override val bottomInset: Flow<Int>
-        get() = _bottomInset.asSharedFlow()
+        get() = _bottomInset.asSharedFlow().onStart { emit(0) }
 
     override fun updateBottomInset(height: Int) {
         _bottomInset.tryEmit(height)


### PR DESCRIPTION
## Description

If the mini player wasn't open, the podcast grid didn't add the surrounding padding. 

## Testing Instructions

1. Fresh install the app.
2. Follow some podcasts.
3. Go to the Podcasts tab.
4. ✅ Verify the podcast grid has padding on the side so the artwork lines up with the Podcasts title.

## Screenshots 

| Before | After |
| --- | --- |
| ![Screenshot_20250317_171710](https://github.com/user-attachments/assets/bebcc989-c6e7-4c61-bac8-dce2a7fa264a) | ![Screenshot_20250317_171625](https://github.com/user-attachments/assets/d0f3c061-7dbe-40f2-9936-069dfa24a463) | 

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack
