### PR TITLE
Fix share transcript text when API less than 33

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 7.86
 -----
-
+*   Bug Fixes
+    *   Fix share transcript text when API less than 33.
+        ([#3789](https://github.com/Automattic/pocket-casts-android/pull/3789))
 
 7.85
 -----

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/transcripts/TranscriptPage.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/transcripts/TranscriptPage.kt
@@ -245,6 +245,7 @@ private fun ScrollableTranscriptView(
         LocalTextToolbar provides CustomTextToolbar(
             view = LocalView.current,
             customMenuItems = buildList {
+                // Only show the share option on older versions of Android, as the new versions have a share feature built into the copy
                 if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) {
                     add(CustomMenuItemOption.Share)
                 }

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/toolbars/textselection/CustomTextToolbar.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/toolbars/textselection/CustomTextToolbar.kt
@@ -42,7 +42,12 @@ class CustomTextToolbar(
         textActionModeCallback.onPasteRequested = onPasteRequested
         textActionModeCallback.onSelectAllRequested = onSelectAllRequested
         textActionModeCallback.customMenuItems = customMenuItems
-        textActionModeCallback.onCustomMenuActionRequested = { onCustomMenuItemClicked(it) }
+        textActionModeCallback.onCustomMenuActionRequested = { item ->
+            // Workaround until Google exposes the selected text from the SelectionContainer. Issue: https://issuetracker.google.com/issues/142551575
+            onCopyRequested?.invoke()
+            val text = clipboardManager.getText().toString()
+            onCustomMenuItemClicked(item = item, text = text)
+        }
         if (actionMode == null) {
             status = TextToolbarStatus.Shown
             actionMode =
@@ -62,9 +67,8 @@ class CustomTextToolbar(
         actionMode = null
     }
 
-    private fun onCustomMenuItemClicked(item: CustomMenuItemOption) {
+    private fun onCustomMenuItemClicked(item: CustomMenuItemOption, text: String) {
         try {
-            val text = clipboardManager.getText()
             when (item) {
                 CustomMenuItemOption.Share -> {
                     val context = view.context


### PR DESCRIPTION
## Description

I noticed that when selecting text in a transcript and clicking the share button, the text was incorrect. This only happens on API < 33 when the share button is shown. The current Compose components make it impossible to copy the selected text, but this is coming to a future version. In the meantime, a workaround is to copy the text to the clipboard using the copy function.

## Testing Instructions

1. Use an Android older than API 33
2. Follow the podcast Conan O'Brien
3. Play the latest episode
4. Open the full screen player
5. Tap the more options in the player shelf
6. Tap Transcript
7. Highlight some text
8. Tap Share
9. ✅ Verify the shared text is correct

## Screencast 

https://github.com/user-attachments/assets/83fe8241-48df-44a3-bf42-90a5ccc8d9e3

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack
