### PR TITLE
Apply window insets to multi-select toolbar across all Android versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@
     *   Fix podcast grid padding
         ([#3781](https://github.com/Automattic/pocket-casts-android/pull/3781))
     *   Fix multi-select toolbar being drawn behind the status bar on older Android versions.
-        ([#3789](https://github.com/Automattic/pocket-casts-android/pull/3789))
+        ([#3792](https://github.com/Automattic/pocket-casts-android/pull/3792))
 *   Updates
     *   Close episode details screen when archiving an episode. This reverts [#3473](https://github.com/Automattic/pocket-casts-android/pull/3473). 
         ([#3718](https://github.com/Automattic/pocket-casts-android/pull/3718))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@
         ([#3777](https://github.com/Automattic/pocket-casts-android/pull/3777))
     *   Fix podcast grid padding
         ([#3781](https://github.com/Automattic/pocket-casts-android/pull/3781))
+    *   Fix multi-select toolbar being drawn behind the status bar on older Android versions.
+        ([#3789](https://github.com/Automattic/pocket-casts-android/pull/3789))
 *   Updates
     *   Close episode details screen when archiving an episode. This reverts [#3473](https://github.com/Automattic/pocket-casts-android/pull/3473). 
         ([#3718](https://github.com/Automattic/pocket-casts-android/pull/3718))

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastFragment.kt
@@ -1363,7 +1363,7 @@ private fun BindingWrapper.updateSwipeRefreshLayout(
 }
 
 private sealed interface BindingWrapper {
-    val root: LinearLayout
+    val root: ViewGroup
     val multiSelectEpisodesToolbar: MultiSelectToolbar
     val multiSelectBookmarksToolbar: MultiSelectToolbar
     val toolbar: View
@@ -1573,7 +1573,7 @@ private sealed interface BindingWrapper {
 
         override fun showBackgroundPlaceholder(show: Boolean) = Unit
 
-        override val root: LinearLayout
+        override val root: ViewGroup
             get() = binding.root
 
         override val toolbar: View

--- a/modules/features/podcasts/src/main/res/layout/fragment_podcast.xml
+++ b/modules/features/podcasts/src/main/res/layout/fragment_podcast.xml
@@ -34,7 +34,6 @@
         app:navigationIcon="?attr/homeAsUpIndicator" />
 
     <FrameLayout
-        android:id="@+id/podcastContentWrapper"
         android:layout_width="match_parent"
         android:layout_height="match_parent">
 

--- a/modules/features/podcasts/src/main/res/layout/fragment_podcast_redesign.xml
+++ b/modules/features/podcasts/src/main/res/layout/fragment_podcast_redesign.xml
@@ -1,98 +1,89 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:background="?attr/primary_ui_02"
-    android:orientation="vertical">
+    android:background="?attr/primary_ui_02">
 
-    <FrameLayout
-        android:id="@+id/podcastContentWrapper"
+    <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
+        android:id="@+id/swipeRefreshLayout"
         android:layout_width="match_parent"
         android:layout_height="match_parent">
 
-        <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
-            android:id="@+id/swipeRefreshLayout"
+        <FrameLayout
+            android:id="@+id/podcastContent"
             android:layout_width="match_parent"
             android:layout_height="match_parent">
 
-            <FrameLayout
-                android:id="@+id/podcastContent"
+            <androidx.recyclerview.widget.RecyclerView
+                android:id="@+id/episodesRecyclerView"
                 android:layout_width="match_parent"
-                android:layout_height="match_parent">
+                android:layout_height="match_parent"
+                android:clipToPadding="false"
+                android:scrollbarStyle="outsideOverlay"
+                android:scrollbars="vertical"
+                app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager" />
 
-                <androidx.recyclerview.widget.RecyclerView
-                    android:id="@+id/episodesRecyclerView"
-                    android:layout_width="match_parent"
-                    android:layout_height="match_parent"
-                    android:clipToPadding="false"
-                    android:scrollbarStyle="outsideOverlay"
-                    android:scrollbars="vertical"
-                    app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager" />
+            <ProgressBar
+                android:id="@+id/loading"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center" />
 
-                <ProgressBar
-                    android:id="@+id/loading"
+            <LinearLayout
+                android:id="@+id/errorContainer"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center"
+                android:clipChildren="false"
+                android:clipToPadding="false"
+                android:orientation="vertical"
+                android:padding="16dp">
+
+                <TextView
+                    android:id="@+id/errorMessage"
+                    style="?attr/textBody1"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:layout_gravity="center" />
+                    android:layout_marginBottom="8dp"
+                    android:gravity="center" />
 
-                <LinearLayout
-                    android:id="@+id/errorContainer"
+                <com.google.android.material.button.MaterialButton
+                    android:id="@+id/btnRetry"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_gravity="center"
-                    android:clipChildren="false"
-                    android:clipToPadding="false"
-                    android:orientation="vertical"
-                    android:padding="16dp">
+                    android:text="@string/podcasts_download_retry" />
+            </LinearLayout>
+        </FrameLayout>
 
-                    <TextView
-                        android:id="@+id/errorMessage"
-                        style="?attr/textBody1"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:layout_marginBottom="8dp"
-                        android:gravity="center" />
+    </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
 
-                    <com.google.android.material.button.MaterialButton
-                        android:id="@+id/btnRetry"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:layout_gravity="center"
-                        android:text="@string/podcasts_download_retry" />
-                </LinearLayout>
-            </FrameLayout>
+    <au.com.shiftyjelly.pocketcasts.views.multiselect.MultiSelectToolbar
+        android:id="@+id/multiSelectEpisodesToolbar"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:minHeight="?android:attr/actionBarSize"
+        android:visibility="gone"
+        app:navigationIcon="?attr/homeAsUpIndicator" />
 
-        </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
+    <au.com.shiftyjelly.pocketcasts.views.multiselect.MultiSelectToolbar
+        android:id="@+id/multiSelectBookmarksToolbar"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:minHeight="?android:attr/actionBarSize"
+        android:visibility="gone"
+        app:navigationIcon="?attr/homeAsUpIndicator" />
 
-        <androidx.compose.ui.platform.ComposeView
-            android:id="@+id/toolbar"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content" />
+    <androidx.compose.ui.platform.ComposeView
+        android:id="@+id/toolbar"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content" />
 
-        <au.com.shiftyjelly.pocketcasts.views.multiselect.MultiSelectToolbar
-            android:id="@+id/multiSelectEpisodesToolbar"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:minHeight="?android:attr/actionBarSize"
-            android:visibility="gone"
-            app:navigationIcon="?attr/homeAsUpIndicator" />
-
-        <au.com.shiftyjelly.pocketcasts.views.multiselect.MultiSelectToolbar
-            android:id="@+id/multiSelectBookmarksToolbar"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:minHeight="?android:attr/actionBarSize"
-            android:visibility="gone"
-            app:navigationIcon="?attr/homeAsUpIndicator" />
-
-        <androidx.compose.ui.platform.ComposeView
-            android:id="@+id/composeTooltipHost"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:visibility="gone" />
-
-    </FrameLayout>
-
-</LinearLayout>
+    <androidx.compose.ui.platform.ComposeView
+        android:id="@+id/composeTooltipHost"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:visibility="gone" />
+</FrameLayout>


### PR DESCRIPTION
## Description

This PR addresses an issue related to window insets. The fix consists of reordering how views are being drawn. Compose modifier for window insets consumes them which means that the multi-select toolbar didn't receive the dispatch event. By moving `ComposeView` containing regular toolbar to be drawn as the last element we allow multi-select toolbars to receive insets.

I also removed outer `LineaerLayout` which is no longer needed after the redesign.

Fixes #3790

## Testing Instructions

1. Select a podcast on a device with a lower Android version.
2. Long press an episode.
3. Notice that the multi-select toolbar does not coincide with the status bar.
4. Test this with different SDKs.

## Screenshots or Screencast 

| Before | After |
| - | - |
| ![Image](https://github.com/user-attachments/assets/d1148e1b-cb52-4c88-a949-74626be42b1b) | ![toolbar](https://github.com/user-attachments/assets/7d69c526-42d2-4bba-ad17-3b7a41e6a0bc) |

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] ~I have considered whether it makes sense to add tests for my changes~
- [ ] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [ ] ~Any jetpack compose components I added or changed are covered by compose previews~
- [ ] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~