### PR TITLE
[Empty states] Update for Up next

### DIFF
--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/PlayerClickListener.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/PlayerClickListener.kt
@@ -1,7 +1,6 @@
 package au.com.shiftyjelly.pocketcasts.player.view
 
 import androidx.recyclerview.widget.RecyclerView
-import au.com.shiftyjelly.pocketcasts.models.to.Chapter
 
 interface PlayerClickListener {
     fun onShowNotesClick(episodeUuid: String)
@@ -11,15 +10,11 @@ interface PlayerClickListener {
     fun onSeekPositionChangeStop(progress: Int, seekComplete: () -> Unit)
 }
 
-interface ChapterListener {
-    fun onChapterClick(chapter: Chapter)
-    fun onChapterUrlClick(chapter: Chapter)
-}
-
 interface UpNextListener {
     fun onClearUpNext()
     fun onUpNextEpisodeStartDrag(viewHolder: RecyclerView.ViewHolder)
     fun onEpisodeActionsClick(episodeUuid: String, podcastUuid: String?)
     fun onEpisodeActionsLongPress(episodeUuid: String, podcastUuid: String?)
     fun onNowPlayingClick()
+    fun onDiscoverTapped()
 }

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/UpNextAdapter.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/UpNextAdapter.kt
@@ -196,6 +196,9 @@ class UpNextAdapter(
                                 subtitle = root.resources.getString(LR.string.player_up_next_empty_subtitle),
                                 iconResourcerId = IR.drawable.ic_upnext,
                                 buttonText = root.resources.getString(LR.string.go_to_discover),
+                                onButtonClick = {
+                                    listener.onDiscoverTapped()
+                                },
                             )
                         }
                     }

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/UpNextAdapter.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/UpNextAdapter.kt
@@ -9,6 +9,9 @@ import android.view.ViewGroup
 import android.widget.ImageButton
 import androidx.annotation.ColorInt
 import androidx.appcompat.widget.TooltipCompat
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
 import androidx.core.view.isVisible
 import androidx.fragment.app.FragmentManager
 import androidx.recyclerview.widget.DiffUtil
@@ -16,6 +19,9 @@ import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTracker
+import au.com.shiftyjelly.pocketcasts.compose.AppTheme
+import au.com.shiftyjelly.pocketcasts.compose.components.EmptyState
+import au.com.shiftyjelly.pocketcasts.compose.extensions.setContentWithViewCompositionStrategy
 import au.com.shiftyjelly.pocketcasts.localization.helper.RelativeDateFormatter
 import au.com.shiftyjelly.pocketcasts.localization.helper.TimeHelper
 import au.com.shiftyjelly.pocketcasts.models.entity.BaseEpisode
@@ -178,7 +184,23 @@ class UpNextAdapter(
 
         fun bind(header: PlayerViewModel.UpNextSummary) {
             with(binding) {
-                emptyUpNextContainer.isVisible = header.episodeCount == 0
+                binding.emptyUpNextComposeView.setContentWithViewCompositionStrategy {
+                    AppTheme(theme) {
+                        AnimatedVisibility(
+                            visible = header.episodeCount == 0,
+                            enter = fadeIn(),
+                            exit = fadeOut(),
+                        ) {
+                            EmptyState(
+                                title = root.resources.getString(LR.string.player_up_next_empty_title),
+                                subtitle = root.resources.getString(LR.string.player_up_next_empty_subtitle),
+                                iconResourcerId = IR.drawable.ic_upnext,
+                                buttonText = root.resources.getString(LR.string.go_to_discover),
+                            )
+                        }
+                    }
+                }
+
                 val time = TimeHelper.getTimeDurationShortString(timeMs = (header.totalTimeSecs * 1000).toLong(), context = root.context)
                 lblUpNextTime.isVisible = hasEpisodeInProgress()
                 lblUpNextTime.text = if (header.episodeCount == 0) {

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/UpNextAdapter.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/UpNextAdapter.kt
@@ -12,6 +12,10 @@ import androidx.appcompat.widget.TooltipCompat
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
 import androidx.core.view.isVisible
 import androidx.fragment.app.FragmentManager
 import androidx.recyclerview.widget.DiffUtil
@@ -199,6 +203,9 @@ class UpNextAdapter(
                                 onButtonClick = {
                                     listener.onDiscoverTapped()
                                 },
+                                modifier = Modifier
+                                    .fillMaxSize()
+                                    .padding(horizontal = 32.dp),
                             )
                         }
                     }

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/UpNextFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/UpNextFragment.kt
@@ -416,7 +416,7 @@ class UpNextFragment :
         } else if (upNextSource == UpNextSource.MINI_PLAYER) {
             close()
         }
-        analyticsTracker.track(AnalyticsEvent.UP_NEXT_DISCOVER_BUTTON_TAPPED, mapOf("source" to upNextSource))
+        analyticsTracker.track(AnalyticsEvent.UP_NEXT_DISCOVER_BUTTON_TAPPED, mapOf("source" to upNextSource.analyticsValue))
         (activity as FragmentHostListener).openTab(VR.id.navigation_discover)
     }
 

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/UpNextFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/UpNextFragment.kt
@@ -410,6 +410,16 @@ class UpNextFragment :
             .showClearUpNextConfirmationDialog(parentFragmentManager, tag = "up_next_clear_dialog")
     }
 
+    override fun onDiscoverTapped() {
+        if (upNextSource == UpNextSource.NOW_PLAYING) {
+            (activity as FragmentHostListener).closePlayer()
+        } else if (upNextSource == UpNextSource.MINI_PLAYER) {
+            close()
+        }
+        analyticsTracker.track(AnalyticsEvent.UP_NEXT_DISCOVER_BUTTON_TAPPED, mapOf("source" to upNextSource))
+        (activity as FragmentHostListener).openTab(VR.id.navigation_discover)
+    }
+
     override fun onUpNextEpisodeStartDrag(viewHolder: RecyclerView.ViewHolder) {
         val recyclerView = realBinding?.recyclerView ?: return
         val itemTouchHelper = itemTouchHelper ?: return

--- a/modules/features/player/src/main/res/drawable/up_next_card.xml
+++ b/modules/features/player/src/main/res/drawable/up_next_card.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<shape xmlns:android="http://schemas.android.com/apk/res/android">
-    <solid android:color="?attr/primary_ui_06"/>
-    <corners android:radius="12dp"/>
-</shape>

--- a/modules/features/player/src/main/res/layout/adapter_up_next_footer.xml
+++ b/modules/features/player/src/main/res/layout/adapter_up_next_footer.xml
@@ -38,40 +38,12 @@
             app:srcCompat="@drawable/shuffle" />
     </LinearLayout>
 
-    <LinearLayout
-        android:id="@+id/emptyUpNextContainer"
-        android:background="@drawable/up_next_card"
+    <androidx.compose.ui.platform.ComposeView
+        android:id="@+id/emptyUpNextComposeView"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:orientation="vertical"
-        android:layout_marginTop="8dp"
-        android:layout_marginStart="8dp"
-        android:layout_marginEnd="8dp"
-        android:layout_marginBottom="20dp"
-        android:gravity="center_horizontal">
-
-        <TextView
-            android:id="@+id/emptyTitle"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="24dp"
-            android:text="@string/player_up_next_empty"
-            android:textAppearance="?attr/textH2"
-            android:textColor="?attr/primary_text_01"/>
-
-        <TextView
-            android:id="@+id/emptyDesc"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="@string/player_up_next_empty_desc"
-            android:textAppearance="?attr/textSubtitle2"
-            android:textColor="?attr/primary_text_02"
-            android:gravity="center_horizontal"
-            android:lineSpacingExtra="6sp"
-            android:layout_marginTop="12dp"
-            android:layout_marginStart="50dp"
-            android:layout_marginEnd="50dp"
-            android:layout_marginBottom="37dp" />
-    </LinearLayout>
+        android:gravity="center_vertical"
+        android:layout_marginBottom="4dp"
+        />
 
 </LinearLayout>

--- a/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
+++ b/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
@@ -341,6 +341,7 @@ enum class AnalyticsEvent(val key: String) {
     UP_NEXT_QUEUE_REORDERED("up_next_queue_reordered"),
     UP_NEXT_DISMISSED("up_next_dismissed"),
     UP_NEXT_SHUFFLE_ENABLED("up_next_shuffle_enabled"),
+    UP_NEXT_DISCOVER_BUTTON_TAPPED("up_next_discover_button_tapped"),
 
     /* Player */
     PLAYER_SHOWN("player_shown"),

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -381,6 +381,8 @@
     <string name="player_up_next_empty">Nothing in Up Next</string>
     <string name="player_up_next_empty_desc">You can queue episodes to play next by swiping right on episode rows, or tapping the icon on an episode card.</string>
     <string name="player_up_next_empty_desc_watch">You can queue episodes to play next in the episode details screen.</string>
+    <string name="player_up_next_empty_title">Curate your listening session</string>
+    <string name="player_up_next_empty_subtitle">You can queue episodes to play next by swiping right on episode rows, or tapping the icon on an episode card.</string>
     <string name="player_up_next_move_to_bottom">Move to bottom</string>
     <string name="player_up_next_move_to_top">Move to top</string>
     <string name="player_up_next_select">Select</string>


### PR DESCRIPTION
## Description
- Updates the empty state view for Up next
- I confirmed with Dom that we will not center the new empty state view vertically and will keep the current alignment instead: p1742345128275369/1741960558.481799-slack-C08HR9DR065
- Design: 2MA6Bz3Vi36BOhuR9pitCU-fi-50_7599

## Testing Instructions
1. Fresh install the app
2. Have empty up next
3. Check the empty view layout
4. Tap on Go to discover button
5. Ensure Tracked: `up_next_discover_button_tapped`

## Screenshots or Screencast  

|  | |
|--------|--------|
| ![Screenshot_20250319_144005](https://github.com/user-attachments/assets/fbfc4a8e-da81-497e-a7b0-eabbd08adc22) | ![Screenshot_20250319_144013](https://github.com/user-attachments/assets/5202203b-948b-47d5-88ff-ac3ccefce40a) | 

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack