### PR TITLE
[Suggested Folders] Update text color and remove extra bottom padding

### DIFF
--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/folders/SuggestedFoldersFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/folders/SuggestedFoldersFragment.kt
@@ -104,7 +104,7 @@ class SuggestedFoldersFragment : BaseDialogFragment() {
                     modifier = Modifier
                         .nestedScroll(rememberNestedScrollInteropConnection())
                         .fillMaxSize()
-                        .windowInsetsPadding(WindowInsets.safeDrawing.only(WindowInsetsSides.Horizontal + WindowInsetsSides.Bottom)),
+                        .windowInsetsPadding(WindowInsets.safeDrawing.only(WindowInsetsSides.Horizontal)),
                 ) {
                     val navController = rememberNavController()
 

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/folders/SuggestedFoldersPage.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/folders/SuggestedFoldersPage.kt
@@ -153,6 +153,7 @@ private fun SmartFoldersHeader(
                 SuggestedAction.UseFolders -> stringResource(LR.string.suggested_folders_use_subtitle)
                 SuggestedAction.ReplaceFolders -> stringResource(LR.string.suggested_folders_replace_subtitle)
             },
+            color = MaterialTheme.theme.colors.primaryText02,
         )
     }
 }


### PR DESCRIPTION
## Description
- Update text color to match with design
- Removes extra bottom padding
- Design: QmqtGNKfPivyq5BrVRPpyV-fi-383_4220
- Addresses this: pdeCcb-93P-p2#comment-7099

## Testing Instructions
1. Fresh install the app using free user account
2. Follow at least 8 podcasts
3. Go to Podcasts
4. See the Smart Folders screen
5. Check the changes

## Screenshots or Screencast 

| Before | After |
|--------|--------|
| ![before](https://github.com/user-attachments/assets/f47e72c9-6b4f-4d88-bd71-827e8eea01ed) | ![after](https://github.com/user-attachments/assets/c0eef0ac-652b-4478-ab37-87c9d3419d9f) | 


## Checklist
- [ ] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [ ] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] ~I have considered whether it makes sense to add tests for my changes~
- [ ] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [ ] Any jetpack compose components I added or changed are covered by compose previews
- [ ] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~