### PR TITLE
Confirm download file deletes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 *   Bug Fixes
     *   Fix share transcript text when API less than 33.
         ([#3789](https://github.com/Automattic/pocket-casts-android/pull/3789))
+*   Updates
+    *   Show a confirmation dialog when deleting more than three episode downloads.
+        ([#3800](https://github.com/Automattic/pocket-casts-android/pull/3800))
 
 7.85
 -----

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -254,6 +254,10 @@
     <string name="download_warning_title">Download All</string>
     <string name="download_warning_limit_summary">Bulk downloads are limited to %1$d.</string>
 
+    <string name="delete_download_warning_button">Remove %1$d downloads</string>
+    <string name="delete_download_warning_title">Remove downloaded episodes</string>
+    <string name="delete_download_warning_summary">Are you sure you want to remove these downloads? You won\'t be able to play offline.</string>
+
     <string name="episode_was_removed">Episode was removed</string>
     <string name="episode_queued_for_download">Episode queued for download</string>
 

--- a/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/dialog/ConfirmationDialog.kt
+++ b/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/dialog/ConfirmationDialog.kt
@@ -81,6 +81,20 @@ open class ConfirmationDialog : BottomSheetDialogFragment() {
                     .setOnConfirm(onConfirm)
             }
         }
+
+        fun deleteDownloadWarningDialog(episodeCount: Int, warningLimit: Int, resources: Resources, onConfirm: () -> Unit): ConfirmationDialog? {
+            return if (episodeCount <= warningLimit) {
+                onConfirm()
+                null
+            } else {
+                ConfirmationDialog()
+                    .setIconId(IR.drawable.ic_delete)
+                    .setTitle(resources.getString(LR.string.delete_download_warning_title))
+                    .setSummary(resources.getString(LR.string.delete_download_warning_summary))
+                    .setButtonType(ButtonType.Danger(resources.getString(LR.string.delete_download_warning_button, episodeCount)))
+                    .setOnConfirm(onConfirm)
+            }
+        }
     }
 
     fun setForceDarkTheme(force: Boolean): ConfirmationDialog {

--- a/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/multiselect/MultiSelectEpisodesHelper.kt
+++ b/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/multiselect/MultiSelectEpisodesHelper.kt
@@ -97,7 +97,7 @@ class MultiSelectEpisodesHelper @Inject constructor(
                 true
             }
             UR.id.menu_undownload -> {
-                deleteDownload()
+                deleteDownload(resources, fragmentManager)
                 true
             }
             R.id.menu_mark_played -> {
@@ -345,13 +345,23 @@ class MultiSelectEpisodesHelper @Inject constructor(
         }?.show(fragmentManager, "multiselect_download")
     }
 
-    private fun deleteDownload() {
+    private fun deleteDownload(resources: Resources, fragmentManager: FragmentManager) {
         if (selectedList.isEmpty()) {
             closeMultiSelect()
             return
         }
 
         val list = selectedList.toList()
+        ConfirmationDialog.deleteDownloadWarningDialog(
+            episodeCount = list.size,
+            warningLimit = WARNING_LIMIT,
+            resources = resources,
+        ) {
+            performDeleteDownload(list)
+        }?.show(fragmentManager, "confirm_delete_downloads")
+    }
+
+    private fun performDeleteDownload(list: List<BaseEpisode>) {
         launch {
             val episodes = list.filterIsInstance<PodcastEpisode>()
             episodeManager.deleteEpisodeFiles(episodes, playbackManager)


### PR DESCRIPTION
## Description

When using the multi-select toolbar and deleting over three episodes, it will now show a confirmation dialog. This was a user request after they accidentally deleted over 200 downloads.

## Testing Instructions
1. Open a podcast page
2. Download four of the episodes
3. Long press on an episode row to change into multi-select mode
4. Select the four episodes
5. Tap the delete downloads button in the toolbar
6. ✅ Verify a confirmation is shown and tapping it deletes the episode files.

## Screenshots 

<img  width="300" src="https://github.com/user-attachments/assets/aceecff8-70f3-495c-af09-8843e871be30" /> 

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack
