### PR TITLE
Fix subscription mapper not using all offers

### DIFF
--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/winback/WinbackViewModel.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/winback/WinbackViewModel.kt
@@ -261,7 +261,7 @@ class WinbackViewModel @Inject constructor(
             .await()
     }
 
-    private fun List<ProductDetails>.toSubscriptionPlans() = map(subscriptionMapper::mapFromProductDetails)
+    private fun List<ProductDetails>.toSubscriptionPlans() = map { productDetails -> subscriptionMapper.mapFromProductDetails(productDetails, removeWinbackOffer = false) }
         .filterIsInstance<Subscription.Simple>()
         .map(Subscription.Simple::toPlan)
         .sortedWith(PlanComparator)

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/type/SubscriptionMapper.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/type/SubscriptionMapper.kt
@@ -13,11 +13,13 @@ class SubscriptionMapper @Inject constructor() {
         productDetails: ProductDetails,
         isOfferEligible: Boolean = false,
         referralProductDetails: ReferralProductDetails? = null,
+        removeWinbackOffer: Boolean = true,
     ): Subscription? {
         val matchingSubscriptionOfferDetails = if (isOfferEligible || referralProductDetails != null) {
             productDetails
                 .subscriptionOfferDetails
                 ?.filter { referralProductDetails == null && !it.offerTags.contains(REFERRAL_OFFER_TAG) } // get SubscriptionOfferDetails with offers
+                ?.filter { if (removeWinbackOffer) !it.offerTags.contains(WINBACK_OFFER_TAG) else true }
                 ?.filter { it.offerSubscriptionPricingPhase != null } // get SubscriptionOfferDetails with offers
                 ?.ifEmpty { productDetails.subscriptionOfferDetails } // if no special offers, return all offers available
                 ?: productDetails.subscriptionOfferDetails // if null, return all offers
@@ -32,6 +34,7 @@ class SubscriptionMapper @Inject constructor() {
         } else {
             matchingSubscriptionOfferDetails
                 .filter { !it.offerTags.contains(REFERRAL_OFFER_TAG) }
+                .filter { if (removeWinbackOffer) !it.offerTags.contains(WINBACK_OFFER_TAG) else true }
                 // This assumes that base plan has lowest number of pricing phases,
                 // and if something else has the same number of phases,
                 // base plan will be the first one
@@ -163,5 +166,6 @@ class SubscriptionMapper @Inject constructor() {
 
     companion object {
         private const val REFERRAL_OFFER_TAG = "referral-offer"
+        private const val WINBACK_OFFER_TAG = "winback"
     }
 }

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/referrals/ReferralOfferInfoProviderTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/referrals/ReferralOfferInfoProviderTest.kt
@@ -95,7 +95,7 @@ class ReferralOfferInfoProviderTest {
         whenever(productDetails.subscriptionOfferDetails).thenReturn(listOf(subscriptionOfferDetails))
         whenever(subscription.productDetails).thenReturn(productDetails)
         whenever(subscriptionOfferDetails.offerId).thenReturn(offerId)
-        whenever(subscriptionMapper.mapFromProductDetails(eq(productDetails), anyBoolean(), any())).thenReturn(subscription)
+        whenever(subscriptionMapper.mapFromProductDetails(eq(productDetails), anyBoolean(), any(), any())).thenReturn(subscription)
 
         return ProductDetailsState.Loaded(listOf(productDetails))
     }


### PR DESCRIPTION
## Description

This is a very ugly fix for the issue where users only see the yearly offer when a 1-month free trial is available.

The root cause of the issue is that the `SubscriptionMapper` logic is highly sensitive to any changes in our Play Console configuration. When the Winback offer was added, it wasn’t properly filtered out in most of the scenarios. I added a boolean flag to determine whether it should be filtered out or not. As mentioned, this is a temporary and inelegant workaround to restore expected behavior.

I believe our approach to retrieving subscription data needs a significant redesign and rewrite. We shouldn't be in a situation where adding an offer in the Play Console causes issues in unrelated parts of the app.

## Testing Instructions

> [!note]  
> You need to test with an account signed in to the Play Console that has never claimed a free trial offer. Otherwise, you won't be able to see it when purchasing a subscription. If the 1-month free offer doesn't appear, create a new Google account, preferably on a new device or emulator.

1. Sign in.
2. During the onboarding flow, when you see subscription offers, you should be able to switch between them.

I also smoke tested the Winback and Referral flows. You should do that as well. Winback should be tested using the production version of the app communicating with staging, due to the account duration requirement. You can apply [this patch](https://github.com/user-attachments/files/19389381/release.patch) and test with the `debug` variant.

## Screenshots or Screencast 

| Before | After |
| - | - |
| <video src ="https://github.com/user-attachments/assets/721fbae6-2951-45b4-a652-88abee935c10" /> | <video src="https://github.com/user-attachments/assets/feb05994-4f6e-4acc-b37d-616dbd95f1c2" /> |