### PR TITLE
[Empty State] Update for Filters

### DIFF
--- a/app/src/test/java/au/com/shiftyjelly/pocketcasts/filters/FiltersFragmentViewModelTest.kt
+++ b/app/src/test/java/au/com/shiftyjelly/pocketcasts/filters/FiltersFragmentViewModelTest.kt
@@ -1,0 +1,90 @@
+package au.com.shiftyjelly.pocketcasts.filters
+
+import au.com.shiftyjelly.pocketcasts.models.entity.Playlist
+import au.com.shiftyjelly.pocketcasts.preferences.Settings
+import au.com.shiftyjelly.pocketcasts.preferences.UserSetting
+import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
+import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
+import au.com.shiftyjelly.pocketcasts.repositories.podcast.PlaylistManager
+import au.com.shiftyjelly.pocketcasts.repositories.podcast.PlaylistManagerImpl.Companion.IN_PROGRESS_UUID
+import au.com.shiftyjelly.pocketcasts.repositories.podcast.PlaylistManagerImpl.Companion.NEW_RELEASE_UUID
+import au.com.shiftyjelly.pocketcasts.sharedtest.MainCoroutineRule
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.Mockito.mock
+import org.mockito.kotlin.whenever
+
+class FiltersFragmentViewModelTest {
+
+    lateinit var viewModel: FiltersFragmentViewModel
+
+    @get:Rule
+    val coroutineRule = MainCoroutineRule()
+
+    private val defaultFilters = listOf(
+        Playlist(id = 1, uuid = NEW_RELEASE_UUID),
+        Playlist(id = 2, uuid = IN_PROGRESS_UUID),
+    )
+
+    @Before
+    fun setUp() {
+        viewModel = initViewModel(tooltipValue = true)
+    }
+
+    @Test
+    fun `should show tooltip`() = runTest {
+        val result = viewModel.shouldShowTooltip(defaultFilters)
+
+        assertEquals(true, result)
+    }
+
+    @Test
+    fun `should not show tooltip if setting is disabled`() = runTest {
+        val viewModel = initViewModel(tooltipValue = false)
+
+        val result = viewModel.shouldShowTooltip(emptyList())
+
+        assertEquals(false, result)
+    }
+
+    @Test
+    fun `should not show tooltip if created custom filter`() = runTest {
+        val result = viewModel.shouldShowTooltip(defaultFilters + listOf(Playlist(id = 3, uuid = "custom")))
+
+        assertEquals(false, result)
+    }
+
+    @Test
+    fun `should return false when at least one playlist has episodes`() = runTest {
+        val viewModel = initViewModel(tooltipValue = false, shouldMockEpisodeForFirstFilter = true)
+
+        val result = viewModel.shouldShowTooltip(defaultFilters)
+
+        assertEquals(false, result)
+    }
+
+    private fun initViewModel(tooltipValue: Boolean, shouldMockEpisodeForFirstFilter: Boolean = false): FiltersFragmentViewModel {
+        val settings = mock<Settings>()
+        val episodeManager = mock<EpisodeManager>()
+        val playbackManager = mock<PlaybackManager>()
+        val tooltipMock = mock<UserSetting<Boolean>>()
+
+        whenever(tooltipMock.flow).thenReturn(MutableStateFlow(tooltipValue))
+        whenever(tooltipMock.value).thenReturn(tooltipValue)
+
+        whenever(settings.showEmptyFiltersListTooltip).thenReturn(tooltipMock)
+
+        val playlistManager = mock<PlaylistManager>()
+        whenever(playlistManager.findAllRxFlowable()).thenReturn(mock())
+
+        if (shouldMockEpisodeForFirstFilter) {
+            whenever(playlistManager.countEpisodesBlocking(1, episodeManager, playbackManager)).thenReturn(5)
+        }
+
+        return FiltersFragmentViewModel(playlistManager, mock(), settings, episodeManager, playbackManager)
+    }
+}

--- a/app/src/test/java/au/com/shiftyjelly/pocketcasts/podcasts/view/folders/FolderEditViewModelTest.kt
+++ b/app/src/test/java/au/com/shiftyjelly/pocketcasts/podcasts/view/folders/FolderEditViewModelTest.kt
@@ -1,12 +1,24 @@
 package au.com.shiftyjelly.pocketcasts.podcasts.view.folders
 
+import au.com.shiftyjelly.pocketcasts.models.type.PodcastsSortType
+import au.com.shiftyjelly.pocketcasts.preferences.Settings
+import au.com.shiftyjelly.pocketcasts.preferences.UserSetting
+import au.com.shiftyjelly.pocketcasts.preferences.model.PodcastGridLayoutType
+import au.com.shiftyjelly.pocketcasts.repositories.podcast.FolderManager
+import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
 import au.com.shiftyjelly.pocketcasts.sharedtest.MainCoroutineRule
+import io.reactivex.Flowable
+import io.reactivex.Observable
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.flowOf
 import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
+import org.mockito.Mockito
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class FolderEditViewModelTest {
@@ -18,7 +30,33 @@ class FolderEditViewModelTest {
 
     @Before
     fun setUp() {
-        viewModel = FolderEditViewModel(mock(), mock(), mock(), mock())
+        val settings = mock<Settings>()
+
+        val sortType = Mockito.mock<UserSetting<PodcastsSortType>>()
+        whenever(sortType.flow).thenReturn(MutableStateFlow(PodcastsSortType.EPISODE_DATE_NEWEST_TO_OLDEST))
+        whenever(sortType.value).thenReturn(PodcastsSortType.EPISODE_DATE_NEWEST_TO_OLDEST)
+        whenever(settings.podcastsSortType).thenReturn(sortType)
+
+        val gridType = Mockito.mock<UserSetting<PodcastGridLayoutType>>()
+        whenever(gridType.flow).thenReturn(MutableStateFlow(PodcastGridLayoutType.LARGE_ARTWORK))
+        whenever(gridType.value).thenReturn(PodcastGridLayoutType.LARGE_ARTWORK)
+        whenever(settings.podcastGridLayout).thenReturn(gridType)
+
+        val podcastManager = mock<PodcastManager>()
+        whenever(podcastManager.podcastsOrderByLatestEpisodeRxFlowable()).thenReturn(Flowable.just(emptyList()))
+        whenever(podcastManager.subscribedRxFlowable()).thenReturn(Flowable.just(emptyList()))
+
+        val folderManager = mock<FolderManager>()
+        whenever(folderManager.findFoldersFlow()).thenReturn(flowOf(emptyList()))
+
+        whenever(settings.selectPodcastSortTypeObservable).thenReturn(Observable.just(PodcastsSortType.EPISODE_DATE_NEWEST_TO_OLDEST))
+
+        viewModel = FolderEditViewModel(
+            podcastManager = podcastManager,
+            folderManager = folderManager,
+            settings = settings,
+            analyticsTracker = mock(),
+        )
     }
 
     @Test

--- a/modules/features/filters/build.gradle.kts
+++ b/modules/features/filters/build.gradle.kts
@@ -35,6 +35,7 @@ dependencies {
     api(projects.modules.services.repositories)
     api(projects.modules.services.ui)
     api(projects.modules.services.views)
+    api(projects.modules.services.compose)
 
     implementation(libs.androidx.constraintlayout)
     implementation(libs.androidx.core.ktx)

--- a/modules/features/filters/build.gradle.kts
+++ b/modules/features/filters/build.gradle.kts
@@ -51,6 +51,5 @@ dependencies {
     implementation(projects.modules.services.localization)
     implementation(projects.modules.services.utils)
 
-    debugImplementation(libs.compose.ui.tooling)
-    debugProdImplementation(libs.compose.ui.tooling)
+    implementation(libs.compose.ui.tooling.preview)
 }

--- a/modules/features/filters/build.gradle.kts
+++ b/modules/features/filters/build.gradle.kts
@@ -3,6 +3,7 @@ plugins {
     alias(libs.plugins.kotlin.android)
     alias(libs.plugins.ksp)
     alias(libs.plugins.hilt)
+    alias(libs.plugins.compose.compiler)
 }
 
 android {
@@ -10,7 +11,7 @@ android {
     buildFeatures {
         buildConfig = true
         viewBinding = true
-        compose = false
+        compose = true
     }
 }
 
@@ -49,4 +50,7 @@ dependencies {
     implementation(projects.modules.services.images)
     implementation(projects.modules.services.localization)
     implementation(projects.modules.services.utils)
+
+    debugImplementation(libs.compose.ui.tooling)
+    debugProdImplementation(libs.compose.ui.tooling)
 }

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/FiltersFragment.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/FiltersFragment.kt
@@ -35,6 +35,7 @@ import androidx.recyclerview.widget.ItemTouchHelper
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import au.com.shiftyjelly.pocketcasts.compose.AppTheme
+import au.com.shiftyjelly.pocketcasts.compose.CallOnce
 import au.com.shiftyjelly.pocketcasts.compose.extensions.setContentWithViewCompositionStrategy
 import au.com.shiftyjelly.pocketcasts.filters.databinding.FragmentFiltersBinding
 import au.com.shiftyjelly.pocketcasts.models.entity.Playlist
@@ -221,6 +222,10 @@ class FiltersFragment :
                 AppTheme(theme.activeTheme) {
                     val configuration = LocalConfiguration.current
                     var toolbarY by remember { mutableFloatStateOf(0f) }
+
+                    CallOnce {
+                        viewModel.trackTooltipShown()
+                    }
 
                     LaunchedEffect(configuration) {
                         val location = IntArray(2)

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/FiltersFragment.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/FiltersFragment.kt
@@ -108,6 +108,12 @@ class FiltersFragment :
             previousLastFilter = it.lastOrNull()
             viewModel.adapterState = it.toMutableList()
             adapter.submitList(it)
+
+            viewLifecycleOwner.lifecycleScope.launch {
+                if (viewModel.shouldShowTooltip(adapter.currentList)) {
+                    // show tooltip here
+                }
+            }
         }
 
         val touchHelperCallback = FiltersListItemTouchCallback({ from, to ->

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/FiltersFragmentViewModel.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/FiltersFragmentViewModel.kt
@@ -98,6 +98,10 @@ class FiltersFragmentViewModel @Inject constructor(
         analyticsTracker.track(AnalyticsEvent.FILTER_CREATE_BUTTON_TAPPED)
     }
 
+    fun trackTooltipShown() {
+        analyticsTracker.track(AnalyticsEvent.FILTER_TOOLTIP_SHOWN)
+    }
+
     suspend fun shouldShowTooltip(filters: List<Playlist>): Boolean {
         if (!settings.showEmptyFiltersListTooltip.value) return false
         if (filters.size > 2) return false
@@ -117,5 +121,6 @@ class FiltersFragmentViewModel @Inject constructor(
 
     fun onTooltipClosed() {
         settings.showEmptyFiltersListTooltip.set(false, updateModifiedAt = false)
+        analyticsTracker.track(AnalyticsEvent.FILTER_TOOLTIP_CLOSED)
     }
 }

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/FiltersFragmentViewModel.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/FiltersFragmentViewModel.kt
@@ -7,9 +7,12 @@ import androidx.lifecycle.viewModelScope
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTracker
 import au.com.shiftyjelly.pocketcasts.models.entity.Playlist
+import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.PlaylistManager
+import au.com.shiftyjelly.pocketcasts.repositories.podcast.PlaylistManagerImpl.Companion.IN_PROGRESS_UUID
+import au.com.shiftyjelly.pocketcasts.repositories.podcast.PlaylistManagerImpl.Companion.NEW_RELEASE_UUID
 import dagger.hilt.android.lifecycle.HiltViewModel
 import java.util.Collections
 import javax.inject.Inject
@@ -18,13 +21,15 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withContext
 
 @HiltViewModel
 class FiltersFragmentViewModel @Inject constructor(
     val playlistManager: PlaylistManager,
     private val analyticsTracker: AnalyticsTracker,
-    episodeManager: EpisodeManager,
-    playbackManager: PlaybackManager,
+    private val settings: Settings,
+    private val episodeManager: EpisodeManager,
+    private val playbackManager: PlaybackManager,
 ) : ViewModel(), CoroutineScope {
 
     companion object {
@@ -91,5 +96,22 @@ class FiltersFragmentViewModel @Inject constructor(
 
     fun trackOnCreateFilterTap() {
         analyticsTracker.track(AnalyticsEvent.FILTER_CREATE_BUTTON_TAPPED)
+    }
+
+    suspend fun shouldShowTooltip(filters: List<Playlist>): Boolean {
+        if (!settings.showEmptyFiltersListTooltip.value) return false
+        if (filters.size > 2) return false
+
+        val requiredUuids = setOf(NEW_RELEASE_UUID, IN_PROGRESS_UUID)
+        val filterUuids = filters.map { it.uuid }.toSet()
+
+        if (filterUuids != requiredUuids) return false
+
+        return withContext(Dispatchers.IO) {
+            filters.all { playlist ->
+                val episodeCount = playlistManager.countEpisodesBlocking(playlist.id, episodeManager, playbackManager)
+                episodeCount == 0
+            }
+        }
     }
 }

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/FiltersFragmentViewModel.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/FiltersFragmentViewModel.kt
@@ -114,4 +114,8 @@ class FiltersFragmentViewModel @Inject constructor(
             }
         }
     }
+
+    fun onTooltipClosed() {
+        settings.showEmptyFiltersListTooltip.set(false, updateModifiedAt = false)
+    }
 }

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/FiltersTooltip.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/FiltersTooltip.kt
@@ -1,41 +1,19 @@
 package au.com.shiftyjelly.pocketcasts.filters
 
 import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material.Icon
-import androidx.compose.material.IconButton
-import androidx.compose.material.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.Outline
-import androidx.compose.ui.graphics.Path
-import androidx.compose.ui.graphics.Shape
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.semantics.invisibleToUser
-import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.unit.Density
-import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
 import au.com.shiftyjelly.pocketcasts.compose.AppTheme
-import au.com.shiftyjelly.pocketcasts.compose.components.TextH30
-import au.com.shiftyjelly.pocketcasts.compose.components.TextP40
-import au.com.shiftyjelly.pocketcasts.compose.theme
+import au.com.shiftyjelly.pocketcasts.compose.components.Tooltip
+import au.com.shiftyjelly.pocketcasts.compose.components.TriangleDirection
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
-import kotlin.math.sqrt
-import au.com.shiftyjelly.pocketcasts.images.R as IR
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 @Composable
@@ -43,79 +21,15 @@ internal fun FiltersTooltip(
     onClickClose: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    Column(
-        modifier = modifier,
-        verticalArrangement = Arrangement.spacedBy(0.dp),
-    ) {
-        Box(
-            modifier = Modifier
-                .offset(y = 6.dp, x = -16.dp)
-                .align(Alignment.End)
-                .size(16.dp)
-                .background(
-                    color = MaterialTheme.theme.colors.primaryUi01,
-                    shape = UpwardTriangleShape,
-                )
-                .semantics {
-                    invisibleToUser()
-                },
-        )
-
-        Box(
-            modifier = Modifier
-                .background(
-                    color = MaterialTheme.theme.colors.primaryUi01,
-                    shape = RoundedCornerShape(4.dp),
-                )
-                .semantics(mergeDescendants = true) {},
-        ) {
-            Column(
-                modifier = Modifier.padding(24.dp),
-            ) {
-                TextH30(
-                    text = stringResource(LR.string.filters_tooltip_title),
-                    disableAutoScale = true,
-                )
-                Spacer(
-                    modifier = Modifier.height(8.dp),
-                )
-                TextP40(
-                    text = stringResource(LR.string.filters_tooltip_subtitle),
-                    color = MaterialTheme.theme.colors.primaryText02,
-                    disableAutoScale = true,
-                )
-            }
-            IconButton(
-                onClick = onClickClose,
-                modifier = Modifier.align(Alignment.TopEnd),
-            ) {
-                Icon(
-                    painter = painterResource(IR.drawable.ic_close),
-                    contentDescription = stringResource(LR.string.close),
-                    tint = MaterialTheme.theme.colors.primaryText01,
-                )
-            }
-        }
-    }
-}
-
-private object UpwardTriangleShape : Shape {
-    override fun createOutline(
-        size: Size,
-        layoutDirection: LayoutDirection,
-        density: Density,
-    ): Outline {
-        return Outline.Generic(
-            Path().apply {
-                val edgeLength = (size.height * 3 / 2) / sqrt(3f)
-                val triangleHeight = edgeLength * sqrt(3f) / 2
-                moveTo(size.width / 2, 0f)
-                lineTo(0f, triangleHeight)
-                lineTo(size.width, triangleHeight)
-                close()
-            },
-        )
-    }
+    Tooltip(
+        title = stringResource(LR.string.filters_tooltip_title),
+        message = stringResource(LR.string.filters_tooltip_subtitle),
+        onClickClose = onClickClose,
+        triangleHorizontalAlignment = Alignment.End,
+        triangleDirection = TriangleDirection.Up,
+        modifier = modifier
+            .padding(horizontal = 8.dp),
+    )
 }
 
 @Preview

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/FiltersTooltip.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/FiltersTooltip.kt
@@ -1,0 +1,136 @@
+package au.com.shiftyjelly.pocketcasts.filters
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.Icon
+import androidx.compose.material.IconButton
+import androidx.compose.material.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Outline
+import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.invisibleToUser
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.LayoutDirection
+import androidx.compose.ui.unit.dp
+import au.com.shiftyjelly.pocketcasts.compose.AppTheme
+import au.com.shiftyjelly.pocketcasts.compose.components.TextH30
+import au.com.shiftyjelly.pocketcasts.compose.components.TextP40
+import au.com.shiftyjelly.pocketcasts.compose.theme
+import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
+import kotlin.math.sqrt
+import au.com.shiftyjelly.pocketcasts.images.R as IR
+import au.com.shiftyjelly.pocketcasts.localization.R as LR
+
+@Composable
+internal fun FiltersTooltip(
+    onClickClose: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier,
+        verticalArrangement = Arrangement.spacedBy(0.dp),
+    ) {
+        Box(
+            modifier = Modifier
+                .offset(y = 6.dp, x = -16.dp)
+                .align(Alignment.End)
+                .size(16.dp)
+                .background(
+                    color = MaterialTheme.theme.colors.primaryUi01,
+                    shape = UpwardTriangleShape,
+                )
+                .semantics {
+                    invisibleToUser()
+                },
+        )
+
+        Box(
+            modifier = Modifier
+                .background(
+                    color = MaterialTheme.theme.colors.primaryUi01,
+                    shape = RoundedCornerShape(4.dp),
+                )
+                .semantics(mergeDescendants = true) {},
+        ) {
+            Column(
+                modifier = Modifier.padding(24.dp),
+            ) {
+                TextH30(
+                    text = stringResource(LR.string.filters_tooltip_title),
+                    disableAutoScale = true,
+                )
+                Spacer(
+                    modifier = Modifier.height(8.dp),
+                )
+                TextP40(
+                    text = stringResource(LR.string.filters_tooltip_subtitle),
+                    color = MaterialTheme.theme.colors.primaryText02,
+                    disableAutoScale = true,
+                )
+            }
+            IconButton(
+                onClick = onClickClose,
+                modifier = Modifier.align(Alignment.TopEnd),
+            ) {
+                Icon(
+                    painter = painterResource(IR.drawable.ic_close),
+                    contentDescription = stringResource(LR.string.close),
+                    tint = MaterialTheme.theme.colors.primaryText01,
+                )
+            }
+        }
+    }
+}
+
+private object UpwardTriangleShape : Shape {
+    override fun createOutline(
+        size: Size,
+        layoutDirection: LayoutDirection,
+        density: Density,
+    ): Outline {
+        return Outline.Generic(
+            Path().apply {
+                val edgeLength = (size.height * 3 / 2) / sqrt(3f)
+                val triangleHeight = edgeLength * sqrt(3f) / 2
+                moveTo(size.width / 2, 0f)
+                lineTo(0f, triangleHeight)
+                lineTo(size.width, triangleHeight)
+                close()
+            },
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun PodcastHeaderTooltipPreview() {
+    AppTheme(Theme.ThemeType.INDIGO) {
+        Box(
+            modifier = Modifier
+                .background(Color.White)
+                .background(Color.Black.copy(alpha = 0.4f))
+                .padding(16.dp),
+        ) {
+            FiltersTooltip(
+                onClickClose = {},
+            )
+        }
+    }
+}

--- a/modules/features/filters/src/main/res/layout/fragment_filters.xml
+++ b/modules/features/filters/src/main/res/layout/fragment_filters.xml
@@ -26,5 +26,12 @@
     <FrameLayout
         android:id="@+id/filterFrameChildFragment"
         android:layout_width="match_parent"
-        android:layout_height="match_parent" />
+        android:layout_height="match_parent">
+
+        <androidx.compose.ui.platform.ComposeView
+            android:id="@+id/tooltipComposeView"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content" />
+    </FrameLayout>
+
 </FrameLayout>

--- a/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
+++ b/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
@@ -300,6 +300,8 @@ enum class AnalyticsEvent(val key: String) {
     FILTER_SORT_BY_CHANGED("filter_sort_by_changed"),
     FILTER_UPDATED("filter_updated"),
     FILTER_OPTIONS_MODAL_OPTION_TAPPED("filter_options_modal_option_tapped"),
+    FILTER_TOOLTIP_SHOWN("filter_tooltip_shown"),
+    FILTER_TOOLTIP_CLOSED("filter_tooltip_closed"),
 
     /* Discover */
     DISCOVER_SHOWN("discover_shown"),

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -842,6 +842,8 @@
     <string name="filters_warning_delete_summary">This cannot be undone.</string>
     <string name="filters_release_date">Release Date</string>
     <string name="filters_download_options">Download Options</string>
+    <string name="filters_tooltip_title">Organize your episodes</string>
+    <string name="filters_tooltip_subtitle">Create smart filters to organize your episodes. Filter by duration, release date, media type, and more.</string>
 
     <!-- Profile -->
 

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
@@ -570,6 +570,8 @@ interface Settings {
     val showPodcastHeaderChangesTooltip: UserSetting<Boolean>
     val showPodcastsRecentlyPlayedSortOrderTooltip: UserSetting<Boolean>
 
+    val showEmptyFiltersListTooltip: UserSetting<Boolean>
+
     val suggestedFoldersDismissTimestamp: UserSetting<Instant?>
     val suggestedFoldersDismissCount: UserSetting<Int>
     val suggestedFoldersFollowedHash: UserSetting<String>

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
@@ -1573,6 +1573,11 @@ class SettingsImpl @Inject constructor(
         defaultValue = true,
         sharedPrefs = sharedPreferences,
     )
+    override val showEmptyFiltersListTooltip: UserSetting<Boolean> = UserSetting.BoolPref(
+        sharedPrefKey = "show_empty_filters_list_tooltip",
+        defaultValue = true,
+        sharedPrefs = sharedPreferences,
+    )
 
     override val showPodcastsRecentlyPlayedSortOrderTooltip: UserSetting<Boolean> = UserSetting.BoolPref(
         sharedPrefKey = "show_podcasts_recently_played_sort_order_tooltip",

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PlaylistManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PlaylistManagerImpl.kt
@@ -9,7 +9,6 @@ import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.models.type.EpisodePlayingStatus
 import au.com.shiftyjelly.pocketcasts.models.type.EpisodeStatusEnum
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
-import au.com.shiftyjelly.pocketcasts.repositories.di.ApplicationScope
 import au.com.shiftyjelly.pocketcasts.repositories.download.DownloadHelper
 import au.com.shiftyjelly.pocketcasts.repositories.download.DownloadManager
 import au.com.shiftyjelly.pocketcasts.repositories.extensions.calculateCombinedIconId
@@ -37,7 +36,6 @@ class PlaylistManagerImpl @Inject constructor(
     private val playlistUpdateAnalytics: PlaylistUpdateAnalytics,
     private val syncManager: SyncManager,
     @ApplicationContext private val context: Context,
-    @ApplicationScope private val applicationScope: CoroutineScope,
     appDatabase: AppDatabase,
 ) : PlaylistManager, CoroutineScope {
 

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PlaylistManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PlaylistManagerImpl.kt
@@ -40,9 +40,9 @@ class PlaylistManagerImpl @Inject constructor(
 ) : PlaylistManager, CoroutineScope {
 
     companion object {
-        private const val NEW_RELEASE_UUID = "2797DCF8-1C93-4999-B52A-D1849736FA2C"
+        const val NEW_RELEASE_UUID = "2797DCF8-1C93-4999-B52A-D1849736FA2C"
+        const val IN_PROGRESS_UUID = "D89A925C-5CE1-41A4-A879-2751838CE5CE"
         private const val NEW_RELEASE_TITLE = "New Releases"
-        private const val IN_PROGRESS_UUID = "D89A925C-5CE1-41A4-A879-2751838CE5CE"
         private const val IN_PROGRESS_TITLE = "In Progress"
         private const val CREATED_DEFAULT_PLAYLISTS = "createdDefaultPlaylists"
     }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PlaylistManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PlaylistManagerImpl.kt
@@ -31,10 +31,6 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.launch
 import timber.log.Timber
 
-private const val NEWRELEASE_UUID = "2797DCF8-1C93-4999-B52A-D1849736FA2C"
-private const val INPROGRESS_UUID = "D89A925C-5CE1-41A4-A879-2751838CE5CE"
-private const val CREATED_DEFAULT_PLAYLISTS = "createdDefaultPlaylists"
-
 class PlaylistManagerImpl @Inject constructor(
     private val settings: Settings,
     private val downloadManager: DownloadManager,
@@ -44,6 +40,14 @@ class PlaylistManagerImpl @Inject constructor(
     @ApplicationScope private val applicationScope: CoroutineScope,
     appDatabase: AppDatabase,
 ) : PlaylistManager, CoroutineScope {
+
+    companion object {
+        private const val NEW_RELEASE_UUID = "2797DCF8-1C93-4999-B52A-D1849736FA2C"
+        private const val NEW_RELEASE_TITLE = "New Releases"
+        private const val IN_PROGRESS_UUID = "D89A925C-5CE1-41A4-A879-2751838CE5CE"
+        private const val IN_PROGRESS_TITLE = "In Progress"
+        private const val CREATED_DEFAULT_PLAYLISTS = "createdDefaultPlaylists"
+    }
 
     private val playlistDao = appDatabase.playlistDao()
 
@@ -57,7 +61,7 @@ class PlaylistManagerImpl @Inject constructor(
         get() = Dispatchers.Default
 
     private fun setupDefaultPlaylists() {
-        val existingNewRelease = playlistDao.findByUuidBlocking(NEWRELEASE_UUID)
+        val existingNewRelease = playlistDao.findByUuidBlocking(NEW_RELEASE_UUID)
         if (existingNewRelease == null) {
             val newRelease = Playlist()
             newRelease.apply {
@@ -66,11 +70,11 @@ class PlaylistManagerImpl @Inject constructor(
                 audioVideo = Playlist.AUDIO_VIDEO_FILTER_ALL
                 allPodcasts = true
                 sortPosition = 0
-                title = "New Releases"
+                title = NEW_RELEASE_TITLE
                 downloaded = true
                 notDownloaded = true
                 filterHours = Playlist.LAST_2_WEEKS
-                uuid = NEWRELEASE_UUID
+                uuid = NEW_RELEASE_UUID
                 syncStatus = Playlist.SYNC_STATUS_SYNCED
                 iconId = Playlist.calculateCombinedIconId(colorIndex = 0, iconIndex = 2) // Red clock
             }
@@ -80,21 +84,21 @@ class PlaylistManagerImpl @Inject constructor(
             playlistDao.updateBlocking(existingNewRelease)
         }
 
-        val existingInProgress = playlistDao.findByUuidBlocking(INPROGRESS_UUID)
+        val existingInProgress = playlistDao.findByUuidBlocking(IN_PROGRESS_UUID)
         if (existingInProgress == null) {
             val inProgress = Playlist()
             inProgress.apply {
                 allPodcasts = true
                 audioVideo = Playlist.AUDIO_VIDEO_FILTER_ALL
                 sortPosition = 2
-                title = "In Progress"
+                title = IN_PROGRESS_TITLE
                 downloaded = true
                 notDownloaded = true
                 unplayed = false
                 partiallyPlayed = true
                 finished = false
                 filterHours = Playlist.LAST_MONTH
-                uuid = INPROGRESS_UUID
+                uuid = IN_PROGRESS_UUID
                 syncStatus = Playlist.SYNC_STATUS_SYNCED
                 iconId = Playlist.calculateCombinedIconId(colorIndex = 3, iconIndex = 4) // Purple play
             }


### PR DESCRIPTION
## Description
- Adds the tooltip for when have empty state in Filters screen
- There is a small difference between the implementation and the designs: the overlay does not cover the navigation bar. Same thing we did for #3650
- Designs: 2MA6Bz3Vi36BOhuR9pitCU-fi-50_7599

## Testing Instructions
1. Fresh install 
2. Go to Filters
3. You should see the tooltip
4. Tap outside of tooltip or close button
5. Tooltip should be closed
6. Close the app and open it again
7. Go to Filters
8. Ensure you don't see the tooltip anymore

## Screenshots or Screencast 
<img src="https://github.com/user-attachments/assets/677b85f2-f01f-4d4b-82f9-100b8bcab3fd" width="300">


## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack