### PR TITLE
Fix header size for collection

### DIFF
--- a/modules/features/discover/src/main/res/layout/collection_header.xml
+++ b/modules/features/discover/src/main/res/layout/collection_header.xml
@@ -1,7 +1,7 @@
 <com.google.android.material.card.MaterialCardView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="179dp"
-    android:layout_height="208dp"
+    android:layout_height="212dp"
     android:layout_marginTop="8dp"
     android:layout_marginBottom="24dp"
     android:layout_marginLeft="8dp"


### PR DESCRIPTION
## Description
- Just fixes the header size for collection

## Testing Instructions
1. Run the app in debugProd
2. Go to Discover
3. Look for Guest List / Guest Curator list
4. Ensure the header (author) image has the same height of the podcasts

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
