### PR TITLE
Podcasts Sorting: Show tooltip

### DIFF
--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastHeaderTooltip.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastHeaderTooltip.kt
@@ -2,38 +2,18 @@ package au.com.shiftyjelly.pocketcasts.podcasts.view.podcast
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material.Icon
-import androidx.compose.material.IconButton
-import androidx.compose.material.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.Outline
-import androidx.compose.ui.graphics.Path
-import androidx.compose.ui.graphics.Shape
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.unit.Density
-import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
 import au.com.shiftyjelly.pocketcasts.compose.AppTheme
-import au.com.shiftyjelly.pocketcasts.compose.components.TextH30
-import au.com.shiftyjelly.pocketcasts.compose.components.TextP40
-import au.com.shiftyjelly.pocketcasts.compose.theme
+import au.com.shiftyjelly.pocketcasts.compose.components.Tooltip
+import au.com.shiftyjelly.pocketcasts.compose.components.TriangleDirection
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
-import kotlin.math.sqrt
-import au.com.shiftyjelly.pocketcasts.images.R as IR
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 @Composable
@@ -41,66 +21,13 @@ internal fun PodcastHeaderTooltip(
     onClickClose: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    Column(
+    Tooltip(
+        title = stringResource(LR.string.podcast_header_redesign_title),
+        message = stringResource(LR.string.podcast_header_redesign_message),
+        onClickClose = onClickClose,
+        triangleHorizontalAlignment = Alignment.CenterHorizontally,
+        triangleDirection = TriangleDirection.Down,
         modifier = modifier,
-    ) {
-        Box(
-            modifier = Modifier.background(
-                color = MaterialTheme.theme.colors.primaryUi01,
-                shape = RoundedCornerShape(4.dp),
-            ),
-        ) {
-            Column(
-                modifier = Modifier.padding(24.dp),
-            ) {
-                TextH30(
-                    text = stringResource(LR.string.podcast_header_redesign_title),
-                    disableAutoScale = true,
-                )
-                Spacer(
-                    modifier = Modifier.height(8.dp),
-                )
-                TextP40(
-                    text = stringResource(LR.string.podcast_header_redesign_message),
-                    color = MaterialTheme.theme.colors.primaryText02,
-                    disableAutoScale = true,
-                )
-            }
-            IconButton(
-                onClick = onClickClose,
-                modifier = Modifier.align(Alignment.TopEnd),
-            ) {
-                Icon(
-                    painter = painterResource(IR.drawable.ic_close),
-                    contentDescription = stringResource(LR.string.close),
-                    tint = MaterialTheme.theme.colors.primaryText01,
-                )
-            }
-        }
-        Box(
-            modifier = Modifier
-                .offset(y = -1.dp)
-                .align(Alignment.CenterHorizontally)
-                .background(MaterialTheme.theme.colors.primaryUi01, TriangleShape)
-                .size(16.dp),
-        )
-    }
-}
-
-private object TriangleShape : Shape {
-    override fun createOutline(
-        size: Size,
-        layoutDirection: LayoutDirection,
-        density: Density,
-    ) = Outline.Generic(
-        Path().apply {
-            val edgeLength = (size.height * 3 / 2) / sqrt(3f)
-            val triangleHeight = edgeLength * sqrt(3f) / 2
-            moveTo(0f, 0f)
-            lineTo(size.width, 0f)
-            lineTo(size.width / 2, triangleHeight)
-            close()
-        },
     )
 }
 

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcasts/PodcastsFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcasts/PodcastsFragment.kt
@@ -44,6 +44,7 @@ import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTracker
 import au.com.shiftyjelly.pocketcasts.analytics.SourceView
 import au.com.shiftyjelly.pocketcasts.compose.AppTheme
+import au.com.shiftyjelly.pocketcasts.compose.CallOnce
 import au.com.shiftyjelly.pocketcasts.compose.extensions.setContentWithViewCompositionStrategy
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.to.RefreshState
@@ -498,6 +499,9 @@ class PodcastsFragment :
         binding.tooltipComposeView.apply {
             isVisible = true
             setContentWithViewCompositionStrategy {
+                CallOnce {
+                    viewModel.onTooltipShown()
+                }
                 AppTheme(theme.activeTheme) {
                     val configuration = LocalConfiguration.current
                     var toolbarY by remember { mutableIntStateOf(0) }

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcasts/RecentlyPlayedSortOptionTooltip.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcasts/RecentlyPlayedSortOptionTooltip.kt
@@ -1,45 +1,18 @@
 package au.com.shiftyjelly.pocketcasts.podcasts.view.podcasts
 
-import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.widthIn
-import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material.Icon
-import androidx.compose.material.IconButton
-import androidx.compose.material.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.geometry.Size
-import androidx.compose.ui.graphics.Outline
-import androidx.compose.ui.graphics.Path
-import androidx.compose.ui.graphics.Shape
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.semantics.invisibleToUser
-import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
-import androidx.compose.ui.unit.Density
-import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
 import au.com.shiftyjelly.pocketcasts.compose.AppTheme
-import au.com.shiftyjelly.pocketcasts.compose.components.TextH30
-import au.com.shiftyjelly.pocketcasts.compose.components.TextP40
+import au.com.shiftyjelly.pocketcasts.compose.components.Tooltip
+import au.com.shiftyjelly.pocketcasts.compose.components.TriangleDirection
 import au.com.shiftyjelly.pocketcasts.compose.preview.ThemePreviewParameterProvider
-import au.com.shiftyjelly.pocketcasts.compose.theme
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme.ThemeType
-import kotlin.math.sqrt
-import au.com.shiftyjelly.pocketcasts.images.R as IR
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 @Composable
@@ -47,92 +20,20 @@ fun RecentlyPlayedSortOptionTooltip(
     onClickClose: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    Column(
+    Tooltip(
+        title = stringResource(LR.string.podcasts_sort_by_tooltip_title),
+        message = stringResource(LR.string.podcasts_sort_by_tooltip_message),
+        onClickClose = onClickClose,
+        triangleHorizontalAlignment = Alignment.End,
+        triangleDirection = TriangleDirection.Up,
         modifier = modifier
-            .widthIn(max = 326.dp)
-            .padding(horizontal = 8.dp)
-            .clickable(
-                indication = null,
-                interactionSource = null,
-                onClick = {}, // Prevent clicks from propagating to overlay
-            ),
-        verticalArrangement = Arrangement.spacedBy(0.dp),
-    ) {
-        // Triangle pointer
-        Box(
-            modifier = Modifier
-                .offset(y = 6.dp, x = -(8).dp)
-                .align(Alignment.End)
-                .size(16.dp)
-                .background(
-                    color = MaterialTheme.theme.colors.primaryUi01,
-                    shape = TriangleShape,
-                )
-                .semantics {
-                    invisibleToUser()
-                },
-        )
-
-        Box(
-            modifier = Modifier
-                .background(
-                    color = MaterialTheme.theme.colors.primaryUi01,
-                    shape = RoundedCornerShape(4.dp),
-                )
-                .semantics(mergeDescendants = true) {},
-        ) {
-            Column(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(24.dp),
-            ) {
-                TextH30(
-                    text = stringResource(LR.string.podcasts_sort_by_tooltip_title),
-                    disableAutoScale = true,
-                )
-                Spacer(
-                    modifier = Modifier.height(8.dp),
-                )
-                TextP40(
-                    text = stringResource(LR.string.podcasts_sort_by_tooltip_message),
-                    color = MaterialTheme.theme.colors.primaryText02,
-                    disableAutoScale = true,
-                )
-            }
-            IconButton(
-                onClick = onClickClose,
-                modifier = Modifier.align(Alignment.TopEnd),
-            ) {
-                Icon(
-                    painter = painterResource(IR.drawable.ic_close),
-                    contentDescription = stringResource(LR.string.close),
-                    tint = MaterialTheme.theme.colors.primaryText01,
-                )
-            }
-        }
-    }
-}
-
-private object TriangleShape : Shape {
-    override fun createOutline(
-        size: Size,
-        layoutDirection: LayoutDirection,
-        density: Density,
-    ): Outline = Outline.Generic(
-        Path().apply {
-            val edgeLength = (size.height * 3 / 2) / sqrt(3f)
-            val triangleHeight = edgeLength * sqrt(3f) / 2
-            moveTo(size.width / 2, 0f)
-            lineTo(0f, triangleHeight)
-            lineTo(size.width, triangleHeight)
-            close()
-        },
+            .padding(horizontal = 8.dp),
     )
 }
 
 @Preview
 @Composable
-private fun TooltipPreview(
+private fun RecentlyPlayedSortOptionTooltipPreview(
     @PreviewParameter(ThemePreviewParameterProvider::class) themeType: ThemeType,
 ) {
     AppTheme(themeType) {

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcasts/RecentlyPlayedSortOptionTooltip.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcasts/RecentlyPlayedSortOptionTooltip.kt
@@ -1,0 +1,143 @@
+package au.com.shiftyjelly.pocketcasts.podcasts.view.podcasts
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.Icon
+import androidx.compose.material.IconButton
+import androidx.compose.material.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Outline
+import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.invisibleToUser
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewParameter
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.LayoutDirection
+import androidx.compose.ui.unit.dp
+import au.com.shiftyjelly.pocketcasts.compose.AppTheme
+import au.com.shiftyjelly.pocketcasts.compose.components.TextH30
+import au.com.shiftyjelly.pocketcasts.compose.components.TextP40
+import au.com.shiftyjelly.pocketcasts.compose.preview.ThemePreviewParameterProvider
+import au.com.shiftyjelly.pocketcasts.compose.theme
+import au.com.shiftyjelly.pocketcasts.ui.theme.Theme.ThemeType
+import kotlin.math.sqrt
+import au.com.shiftyjelly.pocketcasts.images.R as IR
+import au.com.shiftyjelly.pocketcasts.localization.R as LR
+
+@Composable
+fun RecentlyPlayedSortOptionTooltip(
+    onClickClose: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier
+            .widthIn(max = 326.dp)
+            .padding(horizontal = 8.dp)
+            .clickable(
+                indication = null,
+                interactionSource = null,
+                onClick = {}, // Prevent clicks from propagating to overlay
+            ),
+        verticalArrangement = Arrangement.spacedBy(0.dp),
+    ) {
+        // Triangle pointer
+        Box(
+            modifier = Modifier
+                .offset(y = 6.dp, x = -(8).dp)
+                .align(Alignment.End)
+                .size(16.dp)
+                .background(
+                    color = MaterialTheme.theme.colors.primaryUi01,
+                    shape = TriangleShape,
+                )
+                .semantics {
+                    invisibleToUser()
+                },
+        )
+
+        Box(
+            modifier = Modifier
+                .background(
+                    color = MaterialTheme.theme.colors.primaryUi01,
+                    shape = RoundedCornerShape(4.dp),
+                )
+                .semantics(mergeDescendants = true) {},
+        ) {
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(24.dp),
+            ) {
+                TextH30(
+                    text = stringResource(LR.string.podcasts_sort_by_tooltip_title),
+                    disableAutoScale = true,
+                )
+                Spacer(
+                    modifier = Modifier.height(8.dp),
+                )
+                TextP40(
+                    text = stringResource(LR.string.podcasts_sort_by_tooltip_message),
+                    color = MaterialTheme.theme.colors.primaryText02,
+                    disableAutoScale = true,
+                )
+            }
+            IconButton(
+                onClick = onClickClose,
+                modifier = Modifier.align(Alignment.TopEnd),
+            ) {
+                Icon(
+                    painter = painterResource(IR.drawable.ic_close),
+                    contentDescription = stringResource(LR.string.close),
+                    tint = MaterialTheme.theme.colors.primaryText01,
+                )
+            }
+        }
+    }
+}
+
+private object TriangleShape : Shape {
+    override fun createOutline(
+        size: Size,
+        layoutDirection: LayoutDirection,
+        density: Density,
+    ): Outline = Outline.Generic(
+        Path().apply {
+            val edgeLength = (size.height * 3 / 2) / sqrt(3f)
+            val triangleHeight = edgeLength * sqrt(3f) / 2
+            moveTo(size.width / 2, 0f)
+            lineTo(0f, triangleHeight)
+            lineTo(size.width, triangleHeight)
+            close()
+        },
+    )
+}
+
+@Preview
+@Composable
+private fun TooltipPreview(
+    @PreviewParameter(ThemePreviewParameterProvider::class) themeType: ThemeType,
+) {
+    AppTheme(themeType) {
+        RecentlyPlayedSortOptionTooltip(
+            onClickClose = {},
+        )
+    }
+}

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/PodcastsViewModel.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/PodcastsViewModel.kt
@@ -321,6 +321,9 @@ class PodcastsViewModel
     fun shouldShowTooltip() =
         FeatureFlag.isEnabled(Feature.PODCASTS_SORT_CHANGES) && settings.showPodcastsRecentlyPlayedSortOrderTooltip.value
 
+    fun onTooltipClosed() {
+        settings.showPodcastsRecentlyPlayedSortOrderTooltip.set(false, updateModifiedAt = false)
+    }
 
     sealed class SuggestedFoldersState {
         data object Empty : SuggestedFoldersState()

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/PodcastsViewModel.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/PodcastsViewModel.kt
@@ -318,6 +318,10 @@ class PodcastsViewModel
         return suggestedFoldersPopupPolicy.isEligibleForPopup()
     }
 
+    fun shouldShowTooltip() =
+        FeatureFlag.isEnabled(Feature.PODCASTS_SORT_CHANGES) && settings.showPodcastsRecentlyPlayedSortOrderTooltip.value
+
+
     sealed class SuggestedFoldersState {
         data object Empty : SuggestedFoldersState()
 

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/PodcastsViewModel.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/PodcastsViewModel.kt
@@ -321,8 +321,12 @@ class PodcastsViewModel
     fun shouldShowTooltip() =
         FeatureFlag.isEnabled(Feature.PODCASTS_SORT_CHANGES) && settings.showPodcastsRecentlyPlayedSortOrderTooltip.value
 
+    fun onTooltipShown() {
+        analyticsTracker.track(AnalyticsEvent.EPISODE_RECENTLY_PLAYED_SORT_OPTION_TOOLTIP_SHOWN)
+    }
     fun onTooltipClosed() {
         settings.showPodcastsRecentlyPlayedSortOrderTooltip.set(false, updateModifiedAt = false)
+        analyticsTracker.track(AnalyticsEvent.EPISODE_RECENTLY_PLAYED_SORT_OPTION_TOOLTIP_DISMISSED)
     }
 
     sealed class SuggestedFoldersState {

--- a/modules/features/podcasts/src/main/res/layout/fragment_podcasts.xml
+++ b/modules/features/podcasts/src/main/res/layout/fragment_podcasts.xml
@@ -1,173 +1,183 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<FrameLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:orientation="vertical"
-    android:importantForAccessibility="no">
-
-    <com.google.android.material.appbar.AppBarLayout
-        android:id="@+id/appBarLayout"
+    android:layout_height="match_parent">
+    <LinearLayout
         android:layout_width="match_parent"
-        android:layout_height="wrap_content">
+        android:layout_height="match_parent"
+        android:orientation="vertical"
+        android:importantForAccessibility="no">
 
-        <androidx.appcompat.widget.Toolbar
-            android:id="@+id/toolbar"
+        <com.google.android.material.appbar.AppBarLayout
+            android:id="@+id/appBarLayout"
             android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:background="?attr/secondary_ui_01"
-            android:minHeight="?android:attr/actionBarSize"
-            app:title="@string/podcasts" />
-    </com.google.android.material.appbar.AppBarLayout>
+            android:layout_height="wrap_content">
 
-    <FrameLayout
-        android:layout_width="match_parent"
-        android:layout_height="match_parent">
-
-        <ScrollView
-            android:id="@+id/emptyViewPodcasts"
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:fillViewport="true"
-            android:visibility="gone"
-            tools:visibility="visible">
-
-            <FrameLayout
+            <androidx.appcompat.widget.Toolbar
+                android:id="@+id/toolbar"
                 android:layout_width="match_parent"
-                android:layout_height="wrap_content">
+                android:layout_height="wrap_content"
+                android:background="?attr/secondary_ui_01"
+                android:minHeight="?android:attr/actionBarSize"
+                app:title="@string/podcasts" />
+        </com.google.android.material.appbar.AppBarLayout>
 
-                <LinearLayout
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_gravity="center"
-                    android:clipToPadding="false"
-                    android:gravity="center"
-                    android:orientation="vertical"
-                    android:padding="16dp"
-                    android:layout_marginTop="16dp">
-
-                    <ImageView
-                        android:id="@+id/add_podcast_image"
-                        android:layout_width="39dp"
-                        android:layout_height="39dp"
-                        android:layout_marginBottom="16dp"
-                        app:tint="?attr/primary_icon_01"
-                        android:src="@drawable/ic_podcasts" />
-
-                    <TextView
-                        android:id="@+id/title"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:layout_gravity="center_horizontal"
-                        android:gravity="center"
-                        android:layout_marginBottom="16dp"
-                        android:text="@string/podcasts_time_to_add_some_podcasts"
-                        style="?attr/textH2" />
-
-                    <TextView
-                        android:id="@+id/submessage"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:layout_gravity="center_horizontal"
-                        android:layout_marginBottom="32dp"
-                        android:text="@string/podcasts_time_to_add_some_podcasts_summary"
-                        style="?attr/textBody2"
-                        android:gravity="center" />
-
-                    <com.google.android.material.button.MaterialButton
-                        android:id="@+id/btnDiscover"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:textAllCaps="false"
-                        style="@style/MaterialButtonStyle"
-                        android:text="@string/podcasts_discover" />
-
-                </LinearLayout>
-
-            </FrameLayout>
-
-        </ScrollView>
-
-        <ScrollView
-            android:id="@+id/emptyViewFolders"
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:fillViewport="true"
-            android:visibility="gone"
-            tools:visibility="visible">
-
-            <FrameLayout
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content">
-
-                <LinearLayout
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_gravity="center"
-                    android:gravity="center"
-                    android:orientation="vertical"
-                    android:padding="16dp">
-
-                    <au.com.shiftyjelly.pocketcasts.views.component.GradientIcon
-                        android:layout_width="160dp"
-                        android:layout_height="160dp"
-                        android:layout_gravity="center_horizontal|top"
-                        android:layout_marginBottom="16dp"
-                        app:src="@drawable/gradient_nothing_podcasts"
-                        app:gradient="gradient_2" />
-
-                    <TextView
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:layout_gravity="center_horizontal"
-                        android:gravity="center"
-                        android:layout_marginBottom="16dp"
-                        android:text="@string/podcasts_empty_folder"
-                        android:textColor="?attr/primary_text_01"
-                        style="?attr/textH2" />
-
-                    <TextView
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:layout_gravity="center_horizontal"
-                        android:layout_marginBottom="24dp"
-                        android:text="@string/podcasts_empty_folder_summary"
-                        android:maxWidth="220dp"
-                        style="?attr/textBody1"
-                        android:textColor="?attr/primary_text_02"
-                        android:gravity="center" />
-
-                    <Button
-                        android:id="@+id/addToFolderButton"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:text="@string/add_podcasts"
-                        android:textAllCaps="false"
-                        android:textSize="16sp"
-                        style="@style/Widget.MaterialComponents.Button.TextButton" />
-
-                </LinearLayout>
-
-            </FrameLayout>
-
-        </ScrollView>
-
-        <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
-            android:id="@+id/swipeRefreshLayout"
+        <FrameLayout
             android:layout_width="match_parent"
             android:layout_height="match_parent">
 
-            <androidx.recyclerview.widget.RecyclerView
-                android:id="@+id/recyclerView"
+            <ScrollView
+                android:id="@+id/emptyViewPodcasts"
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
-                android:clipToPadding="false"
-                android:clipChildren="false"
-                android:scrollbarStyle="outsideOverlay"
-                android:scrollbars="vertical" />
+                android:fillViewport="true"
+                android:visibility="gone"
+                tools:visibility="visible">
 
-        </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
+                <FrameLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content">
 
-    </FrameLayout>
-</LinearLayout>
+                    <LinearLayout
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_gravity="center"
+                        android:clipToPadding="false"
+                        android:gravity="center"
+                        android:orientation="vertical"
+                        android:padding="16dp"
+                        android:layout_marginTop="16dp">
+
+                        <ImageView
+                            android:id="@+id/add_podcast_image"
+                            android:layout_width="39dp"
+                            android:layout_height="39dp"
+                            android:layout_marginBottom="16dp"
+                            app:tint="?attr/primary_icon_01"
+                            android:src="@drawable/ic_podcasts" />
+
+                        <TextView
+                            android:id="@+id/title"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:layout_gravity="center_horizontal"
+                            android:gravity="center"
+                            android:layout_marginBottom="16dp"
+                            android:text="@string/podcasts_time_to_add_some_podcasts"
+                            style="?attr/textH2" />
+
+                        <TextView
+                            android:id="@+id/submessage"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:layout_gravity="center_horizontal"
+                            android:layout_marginBottom="32dp"
+                            android:text="@string/podcasts_time_to_add_some_podcasts_summary"
+                            style="?attr/textBody2"
+                            android:gravity="center" />
+
+                        <com.google.android.material.button.MaterialButton
+                            android:id="@+id/btnDiscover"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:textAllCaps="false"
+                            style="@style/MaterialButtonStyle"
+                            android:text="@string/podcasts_discover" />
+
+                    </LinearLayout>
+
+                </FrameLayout>
+
+            </ScrollView>
+
+            <ScrollView
+                android:id="@+id/emptyViewFolders"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:fillViewport="true"
+                android:visibility="gone"
+                tools:visibility="visible">
+
+                <FrameLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content">
+
+                    <LinearLayout
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_gravity="center"
+                        android:gravity="center"
+                        android:orientation="vertical"
+                        android:padding="16dp">
+
+                        <au.com.shiftyjelly.pocketcasts.views.component.GradientIcon
+                            android:layout_width="160dp"
+                            android:layout_height="160dp"
+                            android:layout_gravity="center_horizontal|top"
+                            android:layout_marginBottom="16dp"
+                            app:src="@drawable/gradient_nothing_podcasts"
+                            app:gradient="gradient_2" />
+
+                        <TextView
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:layout_gravity="center_horizontal"
+                            android:gravity="center"
+                            android:layout_marginBottom="16dp"
+                            android:text="@string/podcasts_empty_folder"
+                            android:textColor="?attr/primary_text_01"
+                            style="?attr/textH2" />
+
+                        <TextView
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:layout_gravity="center_horizontal"
+                            android:layout_marginBottom="24dp"
+                            android:text="@string/podcasts_empty_folder_summary"
+                            android:maxWidth="220dp"
+                            style="?attr/textBody1"
+                            android:textColor="?attr/primary_text_02"
+                            android:gravity="center" />
+
+                        <Button
+                            android:id="@+id/addToFolderButton"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="@string/add_podcasts"
+                            android:textAllCaps="false"
+                            android:textSize="16sp"
+                            style="@style/Widget.MaterialComponents.Button.TextButton" />
+
+                    </LinearLayout>
+
+                </FrameLayout>
+
+            </ScrollView>
+
+            <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
+                android:id="@+id/swipeRefreshLayout"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent">
+
+                <androidx.recyclerview.widget.RecyclerView
+                    android:id="@+id/recyclerView"
+                    android:layout_width="match_parent"
+                    android:layout_height="match_parent"
+                    android:clipToPadding="false"
+                    android:clipChildren="false"
+                    android:scrollbarStyle="outsideOverlay"
+                    android:scrollbars="vertical" />
+
+            </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
+
+        </FrameLayout>
+    </LinearLayout>
+    <androidx.compose.ui.platform.ComposeView
+        android:id="@+id/tooltipComposeView"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:visibility="gone"/>
+</FrameLayout>

--- a/modules/features/referrals/src/main/kotlin/au/com/shiftyjelly/pocketcasts/referrals/ReferralsIconWithTooltip.kt
+++ b/modules/features/referrals/src/main/kotlin/au/com/shiftyjelly/pocketcasts/referrals/ReferralsIconWithTooltip.kt
@@ -9,7 +9,6 @@ import androidx.compose.material.Icon
 import androidx.compose.material.IconButton
 import androidx.compose.material.MaterialTheme
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
@@ -23,7 +22,7 @@ import au.com.shiftyjelly.pocketcasts.compose.Devices
 import au.com.shiftyjelly.pocketcasts.compose.LocalColors
 import au.com.shiftyjelly.pocketcasts.compose.ThemeColors
 import au.com.shiftyjelly.pocketcasts.compose.components.TextH40
-import au.com.shiftyjelly.pocketcasts.compose.components.Tooltip
+import au.com.shiftyjelly.pocketcasts.compose.components.PopupDropdownMenuTooltip
 import au.com.shiftyjelly.pocketcasts.compose.preview.ThemePreviewParameterProvider
 import au.com.shiftyjelly.pocketcasts.compose.theme
 import au.com.shiftyjelly.pocketcasts.models.type.ReferralsOfferInfo
@@ -68,7 +67,7 @@ private fun ReferralsIconWithTooltip(
                 colors = LocalColors.current.colors,
             )
 
-            Tooltip(
+            PopupDropdownMenuTooltip(
                 show = state.showTooltip,
             ) {
                 state.referralsOfferInfo?.let {

--- a/modules/features/referrals/src/main/kotlin/au/com/shiftyjelly/pocketcasts/referrals/ReferralsIconWithTooltip.kt
+++ b/modules/features/referrals/src/main/kotlin/au/com/shiftyjelly/pocketcasts/referrals/ReferralsIconWithTooltip.kt
@@ -21,8 +21,8 @@ import au.com.shiftyjelly.pocketcasts.compose.CallOnce
 import au.com.shiftyjelly.pocketcasts.compose.Devices
 import au.com.shiftyjelly.pocketcasts.compose.LocalColors
 import au.com.shiftyjelly.pocketcasts.compose.ThemeColors
-import au.com.shiftyjelly.pocketcasts.compose.components.TextH40
 import au.com.shiftyjelly.pocketcasts.compose.components.PopupDropdownMenuTooltip
+import au.com.shiftyjelly.pocketcasts.compose.components.TextH40
 import au.com.shiftyjelly.pocketcasts.compose.preview.ThemePreviewParameterProvider
 import au.com.shiftyjelly.pocketcasts.compose.theme
 import au.com.shiftyjelly.pocketcasts.models.type.ReferralsOfferInfo

--- a/modules/features/shared/src/main/java/au/com/shiftyjelly/pocketcasts/shared/AppLifecycleObserver.kt
+++ b/modules/features/shared/src/main/java/au/com/shiftyjelly/pocketcasts/shared/AppLifecycleObserver.kt
@@ -105,6 +105,7 @@ class AppLifecycleObserver constructor(
 
             // new installations default to not displaying the tooltip
             settings.showPodcastHeaderChangesTooltip.set(false, updateModifiedAt = false)
+            settings.showPodcastsRecentlyPlayedSortOrderTooltip.set(false, updateModifiedAt = false)
 
             when (getAppPlatform()) {
                 // do nothing because this already defaults to true for all users on automotive

--- a/modules/features/shared/src/test/java/au/com/shiftyjelly/pocketcasts/shared/AppLifecycleObserverTest.kt
+++ b/modules/features/shared/src/test/java/au/com/shiftyjelly/pocketcasts/shared/AppLifecycleObserverTest.kt
@@ -43,6 +43,8 @@ class AppLifecycleObserverTest {
 
     @Mock private lateinit var showPodcastHeaderChangesSetting: UserSetting<Boolean>
 
+    @Mock private lateinit var showPodcastsRecentlyPlayedSortOrderSetting: UserSetting<Boolean>
+
     @Mock private lateinit var autoDownloadOnFollowPodcastSetting: UserSetting<Boolean>
 
     @Mock private lateinit var appLifecycleAnalytics: AppLifecycleAnalytics
@@ -67,6 +69,7 @@ class AppLifecycleObserverTest {
         whenever(settings.autoDownloadOnFollowPodcast).thenReturn(autoDownloadOnFollowPodcastSetting)
         whenever(settings.useDarkUpNextTheme).thenReturn(useUpNextDarkThemeSetting)
         whenever(settings.showPodcastHeaderChangesTooltip).thenReturn(showPodcastHeaderChangesSetting)
+        whenever(settings.showPodcastsRecentlyPlayedSortOrderTooltip).thenReturn(showPodcastsRecentlyPlayedSortOrderSetting)
 
         whenever(appLifecycleOwner.lifecycle).thenReturn(appLifecycle)
 

--- a/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
+++ b/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
@@ -111,6 +111,8 @@ enum class AnalyticsEvent(val key: String) {
     PODCASTS_LIST_LAYOUT_CHANGED("podcasts_list_layout_changed"),
     PODCASTS_LIST_BADGES_CHANGED("podcasts_list_badges_changed"),
     PODCASTS_LIST_DISCOVER_BUTTON_TAPPED("podcasts_list_discover_button_tapped"),
+    EPISODE_RECENTLY_PLAYED_SORT_OPTION_TOOLTIP_SHOWN("episode_recently_played_sort_option_tooltip_shown"),
+    EPISODE_RECENTLY_PLAYED_SORT_OPTION_TOOLTIP_DISMISSED("episode_recently_played_sort_option_tooltip_dismissed"),
 
     /* Tab bar items */
     PODCASTS_TAB_OPENED("podcasts_tab_opened"),

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/PopupDropdownMenuTooltip.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/PopupDropdownMenuTooltip.kt
@@ -56,7 +56,7 @@ import com.airbnb.android.showkase.annotation.ShowkaseComposable
  */
 
 @Composable
-fun Tooltip(
+fun PopupDropdownMenuTooltip(
     show: Boolean,
     modifier: Modifier = Modifier,
     offset: DpOffset = TooltipDefaults.tooltipOffset(),

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/Tooltip.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/Tooltip.kt
@@ -1,0 +1,182 @@
+package au.com.shiftyjelly.pocketcasts.compose.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.Icon
+import androidx.compose.material.IconButton
+import androidx.compose.material.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Outline
+import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.invisibleToUser
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.DpOffset
+import androidx.compose.ui.unit.LayoutDirection
+import androidx.compose.ui.unit.dp
+import au.com.shiftyjelly.pocketcasts.compose.AppTheme
+import au.com.shiftyjelly.pocketcasts.compose.theme
+import au.com.shiftyjelly.pocketcasts.ui.theme.Theme.ThemeType
+import kotlin.math.sqrt
+import au.com.shiftyjelly.pocketcasts.images.R as IR
+import au.com.shiftyjelly.pocketcasts.localization.R as LR
+
+@OptIn(ExperimentalComposeUiApi::class)
+@Composable
+fun Tooltip(
+    title: String,
+    message: String,
+    onClickClose: () -> Unit,
+    triangleHorizontalAlignment: Alignment.Horizontal,
+    triangleDirection: TriangleDirection,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier
+            .widthIn(max = 326.dp)
+            .clickable(
+                indication = null,
+                interactionSource = null,
+                onClick = {},
+            ),
+    ) {
+        val triangleOffset = when (triangleDirection) {
+            TriangleDirection.Up -> DpOffset(-(8).dp, 6.dp)
+            TriangleDirection.Down -> DpOffset(0.dp, -(1).dp)
+        }
+        val triangleComposable = @Composable {
+            Box(
+                modifier = Modifier
+                    .offset(x = triangleOffset.x, y = triangleOffset.y)
+                    .align(triangleHorizontalAlignment)
+                    .size(16.dp)
+                    .background(
+                        color = MaterialTheme.theme.colors.primaryUi01,
+                        shape = TriangleShape(direction = triangleDirection),
+                    )
+                    .semantics {
+                        invisibleToUser()
+                    },
+            )
+        }
+        if (triangleDirection == TriangleDirection.Up) {
+            triangleComposable()
+        }
+
+        Box(
+            modifier = Modifier.background(
+                color = MaterialTheme.theme.colors.primaryUi01,
+                shape = RoundedCornerShape(4.dp),
+            ),
+        ) {
+            Column(
+                modifier = Modifier.padding(24.dp),
+            ) {
+                TextH30(
+                    text = title,
+                    disableAutoScale = true,
+                )
+                Spacer(
+                    modifier = Modifier.height(8.dp),
+                )
+                TextP40(
+                    text = message,
+                    color = MaterialTheme.theme.colors.primaryText02,
+                    disableAutoScale = true,
+                )
+            }
+            IconButton(
+                onClick = onClickClose,
+                modifier = Modifier.align(Alignment.TopEnd),
+            ) {
+                Icon(
+                    painter = painterResource(IR.drawable.ic_close),
+                    contentDescription = stringResource(LR.string.close),
+                    tint = MaterialTheme.theme.colors.primaryText01,
+                )
+            }
+        }
+        if (triangleDirection == TriangleDirection.Down) {
+            triangleComposable()
+        }
+    }
+}
+
+private class TriangleShape(val direction: TriangleDirection) : Shape {
+    override fun createOutline(
+        size: Size,
+        layoutDirection: LayoutDirection,
+        density: Density,
+    ) = Outline.Generic(
+        Path().apply {
+            val edgeLength = (size.height * 3 / 2) / sqrt(3f)
+            val triangleHeight = edgeLength * sqrt(3f) / 2
+            when (direction) {
+                TriangleDirection.Up -> {
+                    moveTo(size.width / 2, 0f)
+                    lineTo(0f, triangleHeight)
+                    lineTo(size.width, triangleHeight)
+                    close()
+                }
+                TriangleDirection.Down -> {
+                    moveTo(0f, 0f)
+                    lineTo(size.width, 0f)
+                    lineTo(size.width / 2, triangleHeight)
+                    close()
+                }
+            }
+        },
+    )
+}
+
+enum class TriangleDirection {
+    Up,
+    Down,
+}
+
+@Preview
+@Composable
+private fun TooltipUpPreview() {
+    AppTheme(ThemeType.DARK) {
+        Tooltip(
+            title = "Title",
+            message = "This is a tooltip!",
+            onClickClose = {},
+            triangleHorizontalAlignment = Alignment.End,
+            triangleDirection = TriangleDirection.Up,
+            modifier = Modifier,
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun TooltipDownPreview() {
+    AppTheme(ThemeType.LIGHT) {
+        Tooltip(
+            title = "Title",
+            message = "This is a tooltip!",
+            onClickClose = {},
+            triangleHorizontalAlignment = Alignment.CenterHorizontally,
+            triangleDirection = TriangleDirection.Down,
+            modifier = Modifier,
+        )
+    }
+}

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -501,6 +501,8 @@
     <string name="podcasts_sort_by_duration_asc">"Shortest to longest"</string>
     <string name="podcasts_sort_by_release_date">Episode release date</string>
     <string name="podcasts_sort_by_title">"Title (A - Z)"</string>
+    <string name="podcasts_sort_by_tooltip_title">Sort by \“Recently Played\”</string>
+    <string name="podcasts_sort_by_tooltip_message">You can now sort by Recently Played and quickly pick up where you left off.</string>
     <string name="podcasts_sort_order">Sort order</string>
     <string name="podcasts_subscribe_on_phone">Follow podcasts on your phone and they\'ll appear here.</string>
     <string name="podcasts_time_to_add_some_podcasts">Time to add some Podcasts!</string>

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
@@ -13,6 +13,8 @@ import au.com.shiftyjelly.pocketcasts.models.type.AutoDownloadLimitSetting
 import au.com.shiftyjelly.pocketcasts.models.type.PodcastsSortType
 import au.com.shiftyjelly.pocketcasts.models.type.SubscriptionFrequency
 import au.com.shiftyjelly.pocketcasts.models.type.SubscriptionTier
+import au.com.shiftyjelly.pocketcasts.preferences.Settings.CloudSortOrder.entries
+import au.com.shiftyjelly.pocketcasts.preferences.Settings.UpNextAction.entries
 import au.com.shiftyjelly.pocketcasts.preferences.model.AppIconSetting
 import au.com.shiftyjelly.pocketcasts.preferences.model.ArtworkConfiguration
 import au.com.shiftyjelly.pocketcasts.preferences.model.AutoAddUpNextLimitBehaviour
@@ -566,6 +568,7 @@ interface Settings {
     val useRealTimeForPlaybackRemaingTime: UserSetting<Boolean>
 
     val showPodcastHeaderChangesTooltip: UserSetting<Boolean>
+    val showPodcastsRecentlyPlayedSortOrderTooltip: UserSetting<Boolean>
 
     val suggestedFoldersDismissTimestamp: UserSetting<Instant?>
     val suggestedFoldersDismissCount: UserSetting<Int>

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
@@ -1574,6 +1574,12 @@ class SettingsImpl @Inject constructor(
         sharedPrefs = sharedPreferences,
     )
 
+    override val showPodcastsRecentlyPlayedSortOrderTooltip: UserSetting<Boolean> = UserSetting.BoolPref(
+        sharedPrefKey = "show_podcasts_recently_played_sort_order_tooltip",
+        defaultValue = true,
+        sharedPrefs = sharedPreferences,
+    )
+
     override val suggestedFoldersDismissTimestamp = UserSetting.PrefFromString<Instant?>(
         sharedPrefKey = "suggested_folders_dismiss_timestamp",
         defaultValue = null,


### PR DESCRIPTION
## Description
This displays a tooltip for the "Recently played" sort option.
(It extracts the already available tooltip added for the Podcast screen as it now appears to be a common component.)

Designs: 4F4PokoLUFmOl5eIT57B5z-fi-34_1951

## Testing Instructions
1. Install and open the app from the main branch
2. Install the app from this branch (as the tooltip should be shown only for existing users)
3. Open the podcasts tab
4. ✅ Notice that the tooltip is shown
5. ✅ Notice in logs `episode_recently_played_sort_option_tooltip_shown` 
6. Dismiss the tooltip either by tapping the close button or by tapping outside the tooltip
8. ✅ Notice in the logs `episode_recently_played_sort_option_tooltip_dismissed` 

## Screenshots or Screencast 
<img width=320 src="https://github.com/user-attachments/assets/cca5279b-0295-4c72-972d-b96bbaf4d404"/>


## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack