### PR TITLE
Podcasts Sorting - Update external data dao query for the "Recently played" sort option

### DIFF
--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/models/db/ExternalDataDaoTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/models/db/ExternalDataDaoTest.kt
@@ -233,6 +233,24 @@ class ExternalDataDaoTest {
     }
 
     @Test
+    fun sortSubscribedPodcastsByRecentlyPlayedEpisodes() = runTest {
+        podcastDao.insertBlocking(Podcast(uuid = "id-1", title = "title-1", isSubscribed = true))
+        podcastEpisodeDao.insertBlocking(PodcastEpisode(uuid = "id-1", publishedDate = Date(), lastPlaybackInteraction = 1000L, podcastUuid = "id-1"))
+
+        podcastDao.insertBlocking(Podcast(uuid = "id-2", title = "title-2", isSubscribed = true))
+        podcastEpisodeDao.insertBlocking(PodcastEpisode(uuid = "id-2", publishedDate = Date(), lastPlaybackInteraction = 2000L, podcastUuid = "id-2"))
+
+        podcastDao.insertBlocking(Podcast(uuid = "id-3", title = "title-3", isSubscribed = true))
+
+        podcastDao.insertBlocking(Podcast(uuid = "id-4", title = "title-4", isSubscribed = true))
+        podcastEpisodeDao.insertBlocking(PodcastEpisode(uuid = "id-3", publishedDate = Date(), lastPlaybackInteraction = 3000L, podcastUuid = "id-4"))
+
+        val podcastIds = externalDataDao.getSubscribedPodcasts(PodcastsSortType.RECENTLY_PLAYED, limit = 100).map { it.id }
+
+        assertEquals(listOf("id-4", "id-2", "id-1", "id-3"), podcastIds)
+    }
+
+    @Test
     fun sortSubscribedPodcastsByCustomSortOrder() = runTest {
         podcastDao.insertBlocking(Podcast(uuid = "id-1", title = "title-1", isSubscribed = true, sortPosition = 3))
         podcastDao.insertBlocking(Podcast(uuid = "id-2", title = "title-2", isSubscribed = true, sortPosition = 1))

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/ExternalDataDao.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/ExternalDataDao.kt
@@ -43,7 +43,9 @@ abstract class ExternalDataDao {
           -- Order by newest to oldest episode
           CASE WHEN :sortOrder IS 2 THEN (SELECT IFNULL(MAX(podcast_episodes.published_date), 0) FROM podcast_episodes WHERE podcasts.uuid IS podcast_episodes.podcast_id) END DESC,
           -- Order by drag and drop position, '9223372036854775807' is the max possible value putting things at the bottom
-          CASE WHEN :sortOrder IS 3 THEN IFNULL(podcasts.sort_order, 9223372036854775807) END ASC
+          CASE WHEN :sortOrder IS 3 THEN IFNULL(podcasts.sort_order, 9223372036854775807) END ASC,
+          -- Order by recently played episodes
+          CASE WHEN :sortOrder IS 4 THEN (SELECT IFNULL(MAX(podcast_episodes.last_playback_interaction_date), 0) FROM podcast_episodes WHERE podcasts.uuid IS podcast_episodes.podcast_id) END DESC
         LIMIT
           :limit
         """,


### PR DESCRIPTION
## Description
This updates `ExternalDataDao` `getSubscribedPodcasts(sortOrder: PodcastsSortType, ...)` query for the "Recently played" sort option, just for completeness sake.

## Testing Instructions
✅ CI should be green

Nothing needs to be tested as the entry point for `NovaLauncher`, where the query is used, is removed (pdeCcb-520-p2#comment-5832).

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack