### PR TITLE
Refactor PodcastSelectFragment

### DIFF
--- a/modules/services/views/build.gradle.kts
+++ b/modules/services/views/build.gradle.kts
@@ -64,7 +64,11 @@ dependencies {
     implementation(projects.modules.services.images)
     implementation(projects.modules.services.localization)
 
+    testImplementation(libs.coroutines.test)
     testImplementation(libs.junit)
     testImplementation(libs.mockito.core)
     testImplementation(libs.mockito.kotlin)
+    testImplementation(libs.turbine)
+
+    testImplementation(projects.modules.services.sharedtest)
 }

--- a/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/viewmodels/PodcastSelectViewModel.kt
+++ b/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/viewmodels/PodcastSelectViewModel.kt
@@ -2,8 +2,11 @@ package au.com.shiftyjelly.pocketcasts.views.viewmodels
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
+import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTracker
 import au.com.shiftyjelly.pocketcasts.models.type.PodcastsSortType
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
+import au.com.shiftyjelly.pocketcasts.views.fragments.PodcastSelectFragmentSource
 import au.com.shiftyjelly.pocketcasts.views.fragments.SelectablePodcast
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
@@ -12,10 +15,12 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import timber.log.Timber
 
 @HiltViewModel
 class PodcastSelectViewModel @Inject constructor(
     private val podcastManager: PodcastManager,
+    private val analyticsTracker: AnalyticsTracker,
 ) : ViewModel() {
 
     private val _selectablePodcasts = MutableStateFlow<List<SelectablePodcast>>(emptyList())
@@ -33,5 +38,53 @@ class PodcastSelectViewModel @Inject constructor(
 
             _selectablePodcasts.value = sortedSelectable
         }
+    }
+
+    fun trackOnShown(source: PodcastSelectFragmentSource) {
+        analyticsTracker.track(AnalyticsEvent.SETTINGS_SELECT_PODCASTS_SHOWN, source.toEventProperty())
+    }
+
+    fun trackOnPodcastToggled(source: PodcastSelectFragmentSource, podcastUuid: String, enabled: Boolean) {
+        analyticsTracker.track(AnalyticsEvent.SETTINGS_SELECT_PODCASTS_PODCAST_TOGGLED, source.toEventProperty() + mapOf("uuid" to podcastUuid, "enabled" to enabled))
+    }
+
+    fun trackOnSelectNoneTapped(source: PodcastSelectFragmentSource) {
+        analyticsTracker.track(AnalyticsEvent.SETTINGS_SELECT_PODCASTS_SELECT_NONE_TAPPED, source.toEventProperty())
+    }
+
+    fun trackOnSelectAllTapped(source: PodcastSelectFragmentSource) {
+        analyticsTracker.track(AnalyticsEvent.SETTINGS_SELECT_PODCASTS_SELECT_ALL_TAPPED, source.toEventProperty())
+    }
+
+    fun trackOnDismissed(source: PodcastSelectFragmentSource) {
+        analyticsTracker.track(AnalyticsEvent.SETTINGS_SELECT_PODCASTS_DISMISSED, source.toEventProperty())
+    }
+
+    fun trackChange(source: PodcastSelectFragmentSource?, props: Map<String, Int>) {
+        when (source) {
+            PodcastSelectFragmentSource.AUTO_ADD -> {
+                analyticsTracker.track(AnalyticsEvent.SETTINGS_AUTO_ADD_UP_NEXT_PODCASTS_CHANGED, props)
+            }
+
+            PodcastSelectFragmentSource.NOTIFICATIONS -> {
+                analyticsTracker.track(AnalyticsEvent.SETTINGS_NOTIFICATIONS_PODCASTS_CHANGED, props)
+            }
+
+            PodcastSelectFragmentSource.DOWNLOADS -> {
+                analyticsTracker.track(AnalyticsEvent.SETTINGS_AUTO_DOWNLOAD_PODCASTS_CHANGED, props)
+            }
+
+            PodcastSelectFragmentSource.FILTERS -> {
+                // Do not track because the filter_updated event was tracked when the change was persisted
+            }
+
+            null -> {
+                Timber.e("No source set for ${this::class.java.simpleName}")
+            }
+        }
+    }
+
+    private fun PodcastSelectFragmentSource?.toEventProperty(): Map<String, String> {
+        return this?.analyticsValue?.let { mapOf("source" to it) } ?: emptyMap()
     }
 }

--- a/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/viewmodels/PodcastSelectViewModel.kt
+++ b/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/viewmodels/PodcastSelectViewModel.kt
@@ -1,0 +1,37 @@
+package au.com.shiftyjelly.pocketcasts.views.viewmodels
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import au.com.shiftyjelly.pocketcasts.models.type.PodcastsSortType
+import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
+import au.com.shiftyjelly.pocketcasts.views.fragments.SelectablePodcast
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+
+@HiltViewModel
+class PodcastSelectViewModel @Inject constructor(
+    private val podcastManager: PodcastManager,
+) : ViewModel() {
+
+    private val _selectablePodcasts = MutableStateFlow<List<SelectablePodcast>>(emptyList())
+    val selectablePodcasts: StateFlow<List<SelectablePodcast>> = _selectablePodcasts
+
+    fun loadSelectablePodcasts(selectedUuids: List<String>) {
+        viewModelScope.launch {
+            val podcasts = withContext(Dispatchers.IO) {
+                podcastManager.findSubscribedBlocking()
+            }
+
+            val sortedSelectable = podcasts
+                .sortedBy { PodcastsSortType.cleanStringForSort(it.title) }
+                .map { SelectablePodcast(it, selectedUuids.contains(it.uuid)) }
+
+            _selectablePodcasts.value = sortedSelectable
+        }
+    }
+}

--- a/modules/services/views/src/test/java/au/com/shiftyjelly/pocketcasts/views/viewmodels/PodcastSelectViewModelTest.kt
+++ b/modules/services/views/src/test/java/au/com/shiftyjelly/pocketcasts/views/viewmodels/PodcastSelectViewModelTest.kt
@@ -1,0 +1,59 @@
+package au.com.shiftyjelly.pocketcasts.views.viewmodels
+
+import app.cash.turbine.test
+import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTracker
+import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
+import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
+import au.com.shiftyjelly.pocketcasts.sharedtest.MainCoroutineRule
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.Mockito.mock
+import org.mockito.kotlin.whenever
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class PodcastSelectViewModelTest {
+
+    @get:Rule
+    val coroutineRule = MainCoroutineRule()
+
+    @Test
+    fun `should load selectable podcasts`() = runTest {
+        val podcastManager: PodcastManager = mock()
+        val analyticsTracker: AnalyticsTracker = mock()
+
+        val uuid1 = "uuid1"
+        val uuid2 = "uuid2"
+
+        val podcast1 = Podcast(uuid = uuid1, title = "Apple")
+        val podcast2 = Podcast(uuid = uuid2, title = "Zebra")
+
+        whenever(podcastManager.findSubscribedBlocking()).thenReturn(listOf(podcast1, podcast2))
+
+        val viewModel = PodcastSelectViewModel(podcastManager, analyticsTracker)
+
+        viewModel.selectablePodcasts.test {
+            viewModel.loadSelectablePodcasts(listOf(uuid1))
+
+            skipItems(1)
+
+            viewModel.loadSelectablePodcasts(listOf(uuid1))
+            advanceUntilIdle()
+
+            val result = awaitItem()
+
+            assertEquals(2, result.size)
+
+            assertEquals("Apple", result[0].podcast.title)
+            assertTrue(result[0].selected)
+
+            assertEquals("Zebra", result[1].podcast.title)
+            assertFalse(result[1].selected)
+        }
+    }
+}


### PR DESCRIPTION
## Description
- Extracts tracks to viewModel
- Removes rxJava 
- Adds unit tests

## Testing Instructions
- Smoke test `Settings -> Notifications -> Choose podcasts`

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
