### PR TITLE
Fix text clipping at large font sizes on the Podcast Select screen

### DIFF
--- a/modules/services/views/src/main/res/layout/settings_fragment_podcast_select.xml
+++ b/modules/services/views/src/main/res/layout/settings_fragment_podcast_select.xml
@@ -1,47 +1,60 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    xmlns:tools="http://schemas.android.com/tools"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:background="?attr/primary_ui_01"
     android:orientation="vertical">
+
     <com.google.android.material.appbar.AppBarLayout
         android:id="@+id/toolbarLayout"
         android:layout_width="match_parent"
         android:layout_height="wrap_content">
+
         <androidx.appcompat.widget.Toolbar
             android:id="@+id/toolbar"
             android:layout_width="match_parent"
-            android:layout_height="wrap_content"
+            android:layout_height="?attr/actionBarSize"
             android:background="?attr/secondary_ui_01"
-            app:title="@string/settings_choose_podcasts"/>
+            app:title="@string/settings_choose_podcasts" />
     </com.google.android.material.appbar.AppBarLayout>
+
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:orientation="horizontal"
         android:layout_marginStart="16dp"
+        android:layout_marginTop="8dp"
         android:layout_marginEnd="16dp"
-        android:layout_marginBottom="16dp">
+        android:layout_marginBottom="16dp"
+        android:minHeight="48dp"
+        android:orientation="horizontal">
+
         <TextView
             android:id="@+id/lblPodcastsChosen"
+            style="?attr/textBody2"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
+            android:layout_gravity="center_vertical"
             android:layout_weight="1"
-            style="?attr/textBody2"
+            android:ellipsize="end"
+            android:maxLines="2"
             android:textColor="?attr/primary_text_02"
-            tools:text="21 podcasts chosen"/>
+            tools:text="21 podcasts chosen" />
+
         <com.google.android.material.button.MaterialButton
             android:id="@+id/btnSelect"
+            style="@style/Widget.MaterialComponents.Button.TextButton"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:textAllCaps="false"
+            android:layout_gravity="center_vertical"
             android:text="@string/select_all"
-            style="@style/Widget.MaterialComponents.Button.TextButton"/>
+            android:textAllCaps="false" />
     </LinearLayout>
+
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/recyclerView"
         android:layout_width="match_parent"
-        android:layout_height="match_parent" />
+        android:layout_height="0dp"
+        android:layout_weight="1" />
 </LinearLayout>

--- a/modules/services/views/src/main/res/layout/settings_row_podcast.xml
+++ b/modules/services/views/src/main/res/layout/settings_row_podcast.xml
@@ -13,10 +13,11 @@
     android:paddingBottom="8dp">
     <androidx.cardview.widget.CardView
         android:layout_width="56dp"
-        android:layout_height="56dp"
+        android:layout_height="wrap_content"
+        android:minHeight="56dp"
         android:elevation="2dp"
         app:cardCornerRadius="4dp"
-        android:layout_marginRight="8dp">
+        android:layout_marginEnd="8dp">
         <ImageView
             android:id="@+id/imageView"
             android:layout_width="56dp"
@@ -26,14 +27,15 @@
 
     <LinearLayout
         android:layout_width="0dp"
-        android:layout_height="match_parent"
+        android:layout_height="wrap_content"
         android:layout_weight="1"
         android:orientation="vertical"
-        android:gravity="center">
+        android:gravity="center_vertical">
         <TextView
             android:id="@+id/lblTitle"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:includeFontPadding="true"
             android:maxLines="1"
             style="@style/row_podcast_title"
             android:textColor="?attr/primary_text_01"
@@ -42,6 +44,7 @@
             android:id="@+id/lblSubtitle"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:includeFontPadding="true"
             style="@style/row_podcast_subtitle"
             android:textColor="?attr/primary_text_02"
             tools:text="Author" />
@@ -49,8 +52,8 @@
 
     <CheckBox
         android:id="@+id/checkbox"
-        android:paddingRight="16dp"
+        android:paddingEnd="16dp"
         android:layout_width="44dp"
-        android:layout_height="44dp"
+        android:layout_height="wrap_content"
         android:layout_gravity="center_vertical" />
 </LinearLayout>


### PR DESCRIPTION
## Description
- Fixes the subtitle text and podcast selected count

## Testing Instructions
1. Increase device font size
2. Follow some podcasts
3. Open Settings -> Notifications
4. Enable Notify me
5. Open Choose podcasts
6. Check the screen 

## Screenshots or Screencast 

| Before | After |
|--------|--------|
| ![Screenshot_20250328_104807](https://github.com/user-attachments/assets/818080ab-bf31-4f69-8468-297c8ac98418) | ![Screenshot_20250328_103847](https://github.com/user-attachments/assets/8c02f59e-dca0-466b-a935-965766c66a4c) | 






## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [x] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
