### PR TITLE
AppsFlyer setting

### DIFF
--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/privacy/PrivacyFragment.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/privacy/PrivacyFragment.kt
@@ -37,6 +37,8 @@ import au.com.shiftyjelly.pocketcasts.compose.theme
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.ui.extensions.startActivityViewUrl
 import au.com.shiftyjelly.pocketcasts.utils.extensions.pxToDp
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
 import au.com.shiftyjelly.pocketcasts.views.fragments.BaseFragment
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
@@ -71,6 +73,9 @@ class PrivacyFragment : BaseFragment() {
                 onAnalyticsClick = {
                     viewModel.updateAnalyticsSetting(it)
                 },
+                onAnalyticsThirdPartyClick = {
+                    viewModel.updateAnalyticsThirdPartySetting(it)
+                },
                 onCrashReportsClick = {
                     viewModel.updateCrashReportsSetting(it)
                 },
@@ -99,6 +104,7 @@ class PrivacyFragment : BaseFragment() {
     private fun PrivacySettings(
         state: PrivacyViewModel.UiState,
         onAnalyticsClick: (Boolean) -> Unit,
+        onAnalyticsThirdPartyClick: (Boolean) -> Unit,
         onCrashReportsClick: (Boolean) -> Unit,
         onLinkAccountClick: (Boolean) -> Unit,
         onPrivacyPolicyClick: () -> Unit,
@@ -128,8 +134,9 @@ class PrivacyFragment : BaseFragment() {
 
                 if (state is PrivacyViewModel.UiState.Loaded) {
                     item {
+                        val primaryText = if (FeatureFlag.isEnabled(Feature.APPSFLYER_ANALYTICS)) LR.string.settings_privacy_analytics_first_party else LR.string.settings_privacy_analytics
                         SettingRow(
-                            primaryText = stringResource(LR.string.settings_privacy_analytics),
+                            primaryText = stringResource(primaryText),
                             secondaryText = stringResource(LR.string.settings_privacy_analytics_summary),
                             toggle = SettingRowToggle.Switch(checked = state.analytics),
                             modifier = Modifier.toggleable(
@@ -138,6 +145,20 @@ class PrivacyFragment : BaseFragment() {
                             ) { onAnalyticsClick(!state.analytics) },
                             indent = false,
                         )
+                    }
+                    if (FeatureFlag.isEnabled(Feature.APPSFLYER_ANALYTICS)) {
+                        item {
+                            SettingRow(
+                                primaryText = stringResource(LR.string.settings_privacy_analytics_third_party),
+                                secondaryText = stringResource(LR.string.settings_privacy_analytics_third_party_summary),
+                                toggle = SettingRowToggle.Switch(checked = state.analyticsThirdParty),
+                                modifier = Modifier.toggleable(
+                                    value = state.analyticsThirdParty,
+                                    role = Role.Switch,
+                                ) { onAnalyticsThirdPartyClick(!state.analyticsThirdParty) },
+                                indent = false,
+                            )
+                        }
                     }
                     item {
                         SettingRow(

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/privacy/PrivacyViewModel.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/privacy/PrivacyViewModel.kt
@@ -20,6 +20,7 @@ class PrivacyViewModel @Inject constructor(
     sealed class UiState {
         data class Loaded(
             val analytics: Boolean,
+            val analyticsThirdParty: Boolean,
             val crashReports: Boolean,
             val linkAccount: Boolean,
             private val getUserEmail: () -> String?,
@@ -31,6 +32,7 @@ class PrivacyViewModel @Inject constructor(
     private val mutableUiState = MutableStateFlow<UiState>(
         UiState.Loaded(
             analytics = settings.collectAnalytics.value,
+            analyticsThirdParty = settings.collectAnalyticsThirdParty.value,
             crashReports = settings.sendCrashReports.value,
             linkAccount = settings.linkCrashReportsToUser.value,
             getUserEmail = { syncManager.getEmail() },
@@ -41,6 +43,11 @@ class PrivacyViewModel @Inject constructor(
     fun updateAnalyticsSetting(on: Boolean) {
         userAnalyticsSettings.updateAnalyticsSetting(on)
         mutableUiState.value = (mutableUiState.value as UiState.Loaded).copy(analytics = on)
+    }
+
+    fun updateAnalyticsThirdPartySetting(on: Boolean) {
+        userAnalyticsSettings.updateAnalyticsThirdPartySetting(on)
+        mutableUiState.value = (mutableUiState.value as UiState.Loaded).copy(analyticsThirdParty = on)
     }
 
     fun updateCrashReportsSetting(on: Boolean) {

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/privacy/UserAnalyticsSettings.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/privacy/UserAnalyticsSettings.kt
@@ -13,10 +13,23 @@ class UserAnalyticsSettings @Inject constructor(
     fun updateAnalyticsSetting(enabled: Boolean) {
         if (enabled) {
             settings.collectAnalytics.set(true, updateModifiedAt = true)
+            settings.collectAnalyticsThirdParty.set(true, updateModifiedAt = true)
             analyticsTracker.track(AnalyticsEvent.ANALYTICS_OPT_IN)
         } else {
             analyticsTracker.track(AnalyticsEvent.ANALYTICS_OPT_OUT)
             settings.collectAnalytics.set(false, updateModifiedAt = false)
+            settings.collectAnalyticsThirdParty.set(false, updateModifiedAt = false)
+            analyticsTracker.clearAllData()
+        }
+    }
+
+    fun updateAnalyticsThirdPartySetting(enabled: Boolean) {
+        if (enabled) {
+            settings.collectAnalyticsThirdParty.set(true, updateModifiedAt = true)
+            analyticsTracker.track(AnalyticsEvent.ANALYTICS_THIRD_PARTY_OPT_IN)
+        } else {
+            analyticsTracker.track(AnalyticsEvent.ANALYTICS_THIRD_PARTY_OPT_OUT)
+            settings.collectAnalyticsThirdParty.set(false, updateModifiedAt = false)
             analyticsTracker.clearAllData()
         }
     }

--- a/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
+++ b/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
@@ -276,6 +276,8 @@ enum class AnalyticsEvent(val key: String) {
     PRIVACY_SHOWN("privacy_shown"),
     ANALYTICS_OPT_IN("analytics_opt_in"),
     ANALYTICS_OPT_OUT("analytics_opt_out"),
+    ANALYTICS_THIRD_PARTY_OPT_IN("analytics_third_party_opt_in"),
+    ANALYTICS_THIRD_PARTY_OPT_OUT("analytics_third_party_opt_out"),
     CRASH_REPORTS_TOGGLED("crash_reports_toggled"),
     SETTINGS_SHOW_PRIVACY_POLICY("settings_show_privacy_policy"),
 

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -1617,7 +1617,10 @@
     <string name="settings_about_privacy_policy_available_at">Our Privacy policy is available at %s</string>
     <string name="settings_privacy_summary">Allowing us to collect analytics and crash reports helps us build a better app. We understand if you would prefer not to share this information.</string>
     <string name="settings_privacy_analytics">Analytics</string>
+    <string name="settings_privacy_analytics_first_party">First-party analytics</string>
     <string name="settings_privacy_analytics_summary">Allow us to collect analytics.</string>
+    <string name="settings_privacy_analytics_third_party">Third-party analytics</string>
+    <string name="settings_privacy_analytics_third_party_summary">Allow us to use trusted third-party services to collect anonymous data.</string>
     <string name="settings_privacy_crash">Crash reports</string>
     <string name="settings_privacy_crash_summary">Allow us to collect crash reports.</string>
     <string name="settings_privacy_crash_link">Link your account to crashes</string>

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
@@ -477,6 +477,7 @@ interface Settings {
     // Only the AnalyticsTracker object should update SendUsageState directly. Everything else
     // should update this setting through the AnalyticsTracker.
     val collectAnalytics: UserSetting<Boolean>
+    val collectAnalyticsThirdParty: UserSetting<Boolean>
     val sendCrashReports: UserSetting<Boolean>
     val linkCrashReportsToUser: UserSetting<Boolean>
 

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
@@ -1317,6 +1317,12 @@ class SettingsImpl @Inject constructor(
         sharedPrefs = sharedPreferences,
     )
 
+    override val collectAnalyticsThirdParty = UserSetting.BoolPref(
+        sharedPrefKey = "SendUsageStatsThirdPartyKey",
+        defaultValue = false, // Ask for consent before sending third party analytics
+        sharedPrefs = sharedPreferences,
+    )
+
     override val sendCrashReports = UserSetting.BoolPref(
         sharedPrefKey = "SendCrashReportsKey",
         defaultValue = BuildConfig.DATA_COLLECTION_DEFAULT_VALUE ?: true,

--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/Feature.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/Feature.kt
@@ -222,9 +222,9 @@ enum class Feature(
     APPSFLYER_ANALYTICS(
         key = "appsflyer_analytics",
         title = "AppsFlyer Analytics",
-        defaultValue = BuildConfig.DEBUG,
+        defaultValue = true,
         tier = FeatureTier.Free,
-        hasFirebaseRemoteFlag = false,
+        hasFirebaseRemoteFlag = true,
         hasDevToggle = true,
     ),
     ;

--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/Feature.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/Feature.kt
@@ -219,6 +219,14 @@ enum class Feature(
         hasFirebaseRemoteFlag = true,
         hasDevToggle = true,
     ),
+    APPSFLYER_ANALYTICS(
+        key = "appsflyer_analytics",
+        title = "AppsFlyer Analytics",
+        defaultValue = BuildConfig.DEBUG,
+        tier = FeatureTier.Free,
+        hasFirebaseRemoteFlag = false,
+        hasDevToggle = true,
+    ),
     ;
 
     companion object {

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/settings/PrivacySettingsScreen.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/settings/PrivacySettingsScreen.kt
@@ -122,6 +122,7 @@ private fun Preview() {
             scrollState = ScalingLazyColumnState(),
             state = PrivacySettingsViewModel.State(
                 sendAnalytics = true,
+                sendAnalyticsThirdParty = false,
                 sendCrashReports = true,
                 linkCrashReportsToUser = false,
             ),

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/settings/PrivacySettingsViewModel.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/settings/PrivacySettingsViewModel.kt
@@ -17,6 +17,7 @@ class PrivacySettingsViewModel @Inject constructor(
 
     data class State(
         val sendAnalytics: Boolean,
+        val sendAnalyticsThirdParty: Boolean,
         val sendCrashReports: Boolean,
         val linkCrashReportsToUser: Boolean,
     )
@@ -24,6 +25,7 @@ class PrivacySettingsViewModel @Inject constructor(
     private val _state = MutableStateFlow(
         State(
             sendAnalytics = settings.collectAnalytics.value,
+            sendAnalyticsThirdParty = settings.collectAnalyticsThirdParty.value,
             sendCrashReports = settings.sendCrashReports.value,
             linkCrashReportsToUser = settings.linkCrashReportsToUser.value,
         ),
@@ -33,6 +35,11 @@ class PrivacySettingsViewModel @Inject constructor(
     fun onAnalyticsChanged(enabled: Boolean) {
         userAnalyticsSettings.updateAnalyticsSetting(enabled)
         _state.update { it.copy(sendAnalytics = enabled) }
+    }
+
+    fun onAnalyticsThirdPartyChanged(enabled: Boolean) {
+        userAnalyticsSettings.updateAnalyticsThirdPartySetting(enabled)
+        _state.update { it.copy(sendAnalyticsThirdParty = enabled) }
     }
 
     fun onCrashReportingChanged(enabled: Boolean) {


### PR DESCRIPTION
## Description

These are changes for the Apps Flyer integration:
- Adds a feature flag.
- A new setting for the user to decide whether to enable third-party analytics. 
- An extra option is added to the Privacy page to change the settings.

## Testing Instructions
1. Check the AppsFlyer feature flag is turned on
2. Go to the Settings -> Privacy page
3. ✅ Verify there is a new third-party analytics setting and it's off by default
4. Toggle it on
5. Restart the app
6. ✅ Verify it's still turned on
7. Turn the feature flag off
8. Go to the Settings -> Privacy page
9. ✅ Verify the new third-party analytics setting is no longer visible

## Screenshots

| Feature Flag Off | Feature Flag On |
| --- | --- |
| ![Screenshot_20250331_114332](https://github.com/user-attachments/assets/6ff11b79-4956-43d8-a493-f5d0a892b2f9) | ![Screenshot_20250331_114422](https://github.com/user-attachments/assets/ffa862cf-97d3-4693-8cc7-c9469ff9d80a) | 

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack
