### PR TITLE
Adds tracking consent dialog to onboarding flow

### DIFF
--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/OnboardingLoginOrSignUpViewModel.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/OnboardingLoginOrSignUpViewModel.kt
@@ -10,6 +10,7 @@ import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
 import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingFlow
+import au.com.shiftyjelly.pocketcasts.settings.privacy.UserAnalyticsSettings
 import au.com.shiftyjelly.pocketcasts.utils.extensions.isGooglePlayServicesAvailableSuccess
 import com.google.android.gms.common.GoogleApiAvailability
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -26,6 +27,8 @@ class OnboardingLoginOrSignUpViewModel @Inject constructor(
     private val analyticsTracker: AnalyticsTracker,
     @ApplicationContext context: Context,
     private val podcastManager: PodcastManager,
+    private val userAnalyticsSettings: UserAnalyticsSettings,
+    settings: Settings,
 ) : AndroidViewModel(context as Application) {
 
     val showContinueWithGoogleButton =
@@ -34,6 +37,7 @@ class OnboardingLoginOrSignUpViewModel @Inject constructor(
 
     private val _uiState = MutableStateFlow<UiState>(UiState.Loading)
     val uiState: StateFlow<UiState> = _uiState
+    val isTrackingConsentRequired: StateFlow<Boolean> = settings.isTrackingConsentRequired.flow
 
     sealed class UiState {
         object Loading : UiState()
@@ -74,6 +78,10 @@ class OnboardingLoginOrSignUpViewModel @Inject constructor(
             AnalyticsEvent.SETUP_ACCOUNT_BUTTON_TAPPED,
             mapOf(AnalyticsProp.flow(flow), AnalyticsProp.ButtonTapped.signIn),
         )
+    }
+
+    fun updateTrackingConsent(consent: Boolean) {
+        userAnalyticsSettings.updateAnalyticsThirdPartySetting(consent)
     }
 
     companion object {

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/consent/TrackingConsentDialog.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/consent/TrackingConsentDialog.kt
@@ -13,6 +13,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import au.com.shiftyjelly.pocketcasts.compose.buttons.RowButton
@@ -71,4 +72,13 @@ fun TrackingConsentDialog(
             }
         }
     }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun TrackingConsentDialogPreview() {
+    TrackingConsentDialog(
+        onAllow = {},
+        onAskAppNotToTrack = {},
+    )
 }

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/consent/TrackingConsentDialog.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/consent/TrackingConsentDialog.kt
@@ -16,6 +16,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
 import au.com.shiftyjelly.pocketcasts.compose.buttons.RowButton
 import au.com.shiftyjelly.pocketcasts.compose.buttons.RowOutlinedButton
 import au.com.shiftyjelly.pocketcasts.compose.components.TextP30
@@ -28,7 +29,13 @@ fun TrackingConsentDialog(
     onAllow: () -> Unit,
     onAskAppNotToTrack: () -> Unit,
 ) {
-    Dialog(onDismissRequest = { onAskAppNotToTrack() }) {
+    Dialog(
+        onDismissRequest = { onAskAppNotToTrack() },
+        properties = DialogProperties(
+            dismissOnBackPress = true,
+            dismissOnClickOutside = false,
+        ),
+    ) {
         Card(
             modifier = Modifier.fillMaxWidth(),
             shape = RoundedCornerShape(16.dp),

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/consent/TrackingConsentDialog.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/consent/TrackingConsentDialog.kt
@@ -1,0 +1,74 @@
+package au.com.shiftyjelly.pocketcasts.settings.consent
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.Card
+import androidx.compose.material.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import au.com.shiftyjelly.pocketcasts.compose.buttons.RowButton
+import au.com.shiftyjelly.pocketcasts.compose.buttons.RowOutlinedButton
+import au.com.shiftyjelly.pocketcasts.compose.components.TextP30
+import au.com.shiftyjelly.pocketcasts.compose.components.TextP50
+import au.com.shiftyjelly.pocketcasts.compose.theme
+import au.com.shiftyjelly.pocketcasts.localization.R as LR
+
+@Composable
+fun TrackingConsentDialog(
+    onAllow: () -> Unit,
+    onAskAppNotToTrack: () -> Unit,
+) {
+    Dialog(onDismissRequest = { onAskAppNotToTrack() }) {
+        Card(
+            modifier = Modifier.fillMaxWidth(),
+            shape = RoundedCornerShape(16.dp),
+            backgroundColor = MaterialTheme.colors.surface,
+        ) {
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 24.dp, vertical = 24.dp),
+                horizontalAlignment = Alignment.CenterHorizontally,
+            ) {
+                TextP30(
+                    text = stringResource(LR.string.tracking_consent_dialog_title),
+                    textAlign = TextAlign.Center,
+                )
+
+                Spacer(Modifier.height(16.dp))
+
+                TextP50(
+                    text = stringResource(LR.string.tracking_consent_dialog_message),
+                    textAlign = TextAlign.Center,
+                    color = MaterialTheme.theme.colors.primaryText02,
+                )
+
+                Spacer(Modifier.height(16.dp))
+
+                RowOutlinedButton(
+                    text = stringResource(LR.string.tracking_consent_dialog_reject),
+                    includePadding = false,
+                    maxLines = 1,
+                    onClick = { onAskAppNotToTrack() },
+                )
+
+                Spacer(Modifier.height(8.dp))
+
+                RowButton(
+                    text = stringResource(LR.string.tracking_consent_dialog_allow),
+                    includePadding = false,
+                    onClick = { onAllow() },
+                )
+            }
+        }
+    }
+}

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/privacy/UserAnalyticsSettings.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/privacy/UserAnalyticsSettings.kt
@@ -13,25 +13,24 @@ class UserAnalyticsSettings @Inject constructor(
     fun updateAnalyticsSetting(enabled: Boolean) {
         if (enabled) {
             settings.collectAnalytics.set(true, updateModifiedAt = true)
-            settings.collectAnalyticsThirdParty.set(true, updateModifiedAt = true)
             analyticsTracker.track(AnalyticsEvent.ANALYTICS_OPT_IN)
         } else {
             analyticsTracker.track(AnalyticsEvent.ANALYTICS_OPT_OUT)
             settings.collectAnalytics.set(false, updateModifiedAt = false)
-            settings.collectAnalyticsThirdParty.set(false, updateModifiedAt = false)
             analyticsTracker.clearAllData()
         }
     }
 
     fun updateAnalyticsThirdPartySetting(enabled: Boolean) {
         if (enabled) {
-            settings.collectAnalyticsThirdParty.set(true, updateModifiedAt = true)
+            settings.collectAnalyticsThirdParty.set(value = true, updateModifiedAt = true)
             analyticsTracker.track(AnalyticsEvent.ANALYTICS_THIRD_PARTY_OPT_IN)
         } else {
             analyticsTracker.track(AnalyticsEvent.ANALYTICS_THIRD_PARTY_OPT_OUT)
-            settings.collectAnalyticsThirdParty.set(false, updateModifiedAt = false)
+            settings.collectAnalyticsThirdParty.set(value = false, updateModifiedAt = true)
             analyticsTracker.clearAllData()
         }
+        settings.isTrackingConsentRequired.set(value = false, updateModifiedAt = true)
     }
 
     fun updateCrashReportsSetting(enabled: Boolean) {

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/buttons/RowOutlinedButton.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/buttons/RowOutlinedButton.kt
@@ -51,6 +51,7 @@ fun RowOutlinedButton(
     disableScale: Boolean = false,
     textIcon: Painter? = null,
     textPadding: Dp = 6.dp,
+    maxLines: Int = Int.MAX_VALUE,
     fontFamily: FontFamily? = null,
     fontSize: TextUnit? = null,
     fontWeight: FontWeight? = null,
@@ -94,6 +95,7 @@ fun RowOutlinedButton(
                         fontFamily = fontFamily,
                         fontWeight = fontWeight,
                         fontSize = if (disableScale) fontSize?.value?.nonScaledSp else fontSize,
+                        maxLines = maxLines,
                         modifier = Modifier.padding(textPadding),
                     )
                 }

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -313,6 +313,11 @@
     <string name="time_short_seconds">%ds</string>
     <string name="time_left">%s left</string>
 
+    <string name="tracking_consent_dialog_title">Allow "Pocket Casts" to track your activity across other companies\' apps and websites?</string>
+    <string name="tracking_consent_dialog_message">We use analytics to make the app better and to measure if our ad campaigns are successful.</string>
+    <string name="tracking_consent_dialog_allow">Allow</string>
+    <string name="tracking_consent_dialog_reject">Ask App Not to Track</string>
+
     <!-- Player -->
 
     <string name="player_action_next_chapter">Next chapter</string>

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
@@ -576,4 +576,6 @@ interface Settings {
     val suggestedFoldersDismissTimestamp: UserSetting<Instant?>
     val suggestedFoldersDismissCount: UserSetting<Int>
     val suggestedFoldersFollowedHash: UserSetting<String>
+
+    val isTrackingConsentRequired: UserSetting<Boolean>
 }

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
@@ -1610,4 +1610,10 @@ class SettingsImpl @Inject constructor(
         defaultValue = "",
         sharedPrefs = sharedPreferences,
     )
+
+    override val isTrackingConsentRequired = UserSetting.BoolPref(
+        sharedPrefKey = "tracking_consent_required",
+        defaultValue = true,
+        sharedPrefs = sharedPreferences,
+    )
 }


### PR DESCRIPTION
## Description

Presents a consent dialog to new users, allowing them to choose whether to allow tracking or ask the app not to track their activity. Respects user privacy choices by updating settings accordingly. 

## Testing Instructions

#### New user, Allow

1. Fresh install the app
2. Tap "Allow" notifications
3. ✅ Verify the consent dialog is shown to you
4. Tap "Allow"
5. Tap "Sign up"
6. ✅ Verify logcat has the entry "Starting AppsFlyer"
7. ✅ Verify logcat has the entry "sendTrackingWithEvent: setup_account_button_tapped"
8. Navigate to Profile tab -> settings cog -> Privacy
9. ✅ Verify Third-party analytics is turned on

## New user, Ask App Not to Track

1. Fresh install the app
2. Tap "Allow" notifications
3. ✅ Verify the consent dialog is shown to you
4. Tap "Ask App Not to Track"
5. Tap "Sign up"
6. ✅ Verify logcat doesn't have the entry "Starting AppsFlyer"
7. ✅ Verify logcat doesn't have the entry "sendTrackingWithEvent: setup_account_button_tapped"
8. 8. Navigate to Profile tab -> settings cog -> Privacy
9. ✅ Verify Third-party analytics is turned off

#### Existing user

1. Checkout at the tag `7.86-rc-1`
2. Fresh install the app
3. Tap the cross to exit the onboarding flow
4. Checkout this branch again and install
5. ✅ Verify the consent dialog isn't shown to you

## Screenshots 


| Light system theme | Dark system theme |
| --- | --- |
| ![Screenshot_20250402_112502](https://github.com/user-attachments/assets/10d59bd3-348d-48fb-a6ba-68a67cc82e0c) | ![Screenshot_20250402_112622](https://github.com/user-attachments/assets/bbb12393-66d7-47f4-95d5-378a3dde6d3b) | 

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack
