### PR TITLE
Update up next history transition

### DIFF
--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/folders/SuggestedFoldersFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/folders/SuggestedFoldersFragment.kt
@@ -5,8 +5,6 @@ import android.os.Bundle
 import android.os.Parcelable
 import android.view.LayoutInflater
 import android.view.ViewGroup
-import androidx.compose.animation.AnimatedContentTransitionScope
-import androidx.compose.animation.core.tween
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.WindowInsetsSides
@@ -24,13 +22,11 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.platform.rememberNestedScrollInteropConnection
-import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import androidx.core.os.BundleCompat
 import androidx.core.os.bundleOf
 import androidx.fragment.app.viewModels
 import androidx.fragment.compose.content
-import androidx.navigation.NavBackStackEntry
 import androidx.navigation.NavType
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
@@ -38,6 +34,10 @@ import androidx.navigation.compose.rememberNavController
 import androidx.navigation.navArgument
 import au.com.shiftyjelly.pocketcasts.compose.AppThemeWithBackground
 import au.com.shiftyjelly.pocketcasts.compose.CallOnce
+import au.com.shiftyjelly.pocketcasts.compose.extensions.slideInToEnd
+import au.com.shiftyjelly.pocketcasts.compose.extensions.slideInToStart
+import au.com.shiftyjelly.pocketcasts.compose.extensions.slideOutToEnd
+import au.com.shiftyjelly.pocketcasts.compose.extensions.slideOutToStart
 import au.com.shiftyjelly.pocketcasts.podcasts.view.folders.SuggestedFoldersViewModel.UseFoldersState.Applied
 import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingFlow
 import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingLauncher
@@ -250,24 +250,3 @@ private object SuggestedFoldersNavRoutes {
 
     fun folderDetailsDestination(folderName: String) = "$FolderDetails/$folderName"
 }
-
-private val intOffsetAnimationSpec = tween<IntOffset>(350)
-private fun AnimatedContentTransitionScope<NavBackStackEntry>.slideInToStart() = slideIntoContainer(
-    towards = AnimatedContentTransitionScope.SlideDirection.Start,
-    animationSpec = intOffsetAnimationSpec,
-)
-
-private fun AnimatedContentTransitionScope<NavBackStackEntry>.slideOutToStart() = slideOutOfContainer(
-    towards = AnimatedContentTransitionScope.SlideDirection.Start,
-    animationSpec = intOffsetAnimationSpec,
-)
-
-private fun AnimatedContentTransitionScope<NavBackStackEntry>.slideInToEnd() = slideIntoContainer(
-    towards = AnimatedContentTransitionScope.SlideDirection.End,
-    animationSpec = intOffsetAnimationSpec,
-)
-
-private fun AnimatedContentTransitionScope<NavBackStackEntry>.slideOutToEnd() = slideOutOfContainer(
-    towards = AnimatedContentTransitionScope.SlideDirection.End,
-    animationSpec = intOffsetAnimationSpec,
-)

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/history/HistoryFragment.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/history/HistoryFragment.kt
@@ -16,6 +16,10 @@ import androidx.navigation.compose.rememberNavController
 import androidx.navigation.navArgument
 import au.com.shiftyjelly.pocketcasts.compose.AppThemeWithBackground
 import au.com.shiftyjelly.pocketcasts.compose.extensions.contentWithoutConsumedInsets
+import au.com.shiftyjelly.pocketcasts.compose.extensions.slideInToEnd
+import au.com.shiftyjelly.pocketcasts.compose.extensions.slideInToStart
+import au.com.shiftyjelly.pocketcasts.compose.extensions.slideOutToEnd
+import au.com.shiftyjelly.pocketcasts.compose.extensions.slideOutToStart
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.settings.history.upnext.UpNextHistoryDetailsPage
 import au.com.shiftyjelly.pocketcasts.settings.history.upnext.UpNextHistoryDetailsViewModel.UiState
@@ -50,6 +54,10 @@ class HistoryFragment : BaseFragment(), HasBackstack {
             NavHost(
                 navController = navController,
                 startDestination = HistoryNavRoutes.History,
+                enterTransition = { slideInToStart() },
+                exitTransition = { slideOutToStart() },
+                popEnterTransition = { slideInToEnd() },
+                popExitTransition = { slideOutToEnd() },
                 modifier = Modifier.fillMaxSize(),
             ) {
                 composable(HistoryNavRoutes.History) {

--- a/modules/services/compose/build.gradle.kts
+++ b/modules/services/compose/build.gradle.kts
@@ -37,6 +37,7 @@ dependencies {
     implementation(libs.fragment.compose)
     implementation(libs.lottie)
     implementation(libs.lottie.compose)
+    implementation(libs.navigation.compose)
     implementation(libs.reorderable)
 
     implementation(projects.modules.services.images)

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/extensions/Transition.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/extensions/Transition.kt
@@ -1,0 +1,36 @@
+package au.com.shiftyjelly.pocketcasts.compose.extensions
+
+import androidx.compose.animation.AnimatedContentTransitionScope
+import androidx.compose.animation.EnterTransition
+import androidx.compose.animation.ExitTransition
+import androidx.compose.animation.core.tween
+import androidx.compose.ui.unit.IntOffset
+import androidx.navigation.NavBackStackEntry
+
+private const val ANIMATION_DURATION = 350
+
+private val intOffsetAnimationSpec = tween<IntOffset>(ANIMATION_DURATION)
+
+fun AnimatedContentTransitionScope<NavBackStackEntry>.slideInToStart(): EnterTransition =
+    slideIntoContainer(
+        towards = AnimatedContentTransitionScope.SlideDirection.Start,
+        animationSpec = intOffsetAnimationSpec,
+    )
+
+fun AnimatedContentTransitionScope<NavBackStackEntry>.slideOutToStart(): ExitTransition =
+    slideOutOfContainer(
+        towards = AnimatedContentTransitionScope.SlideDirection.Start,
+        animationSpec = intOffsetAnimationSpec,
+    )
+
+fun AnimatedContentTransitionScope<NavBackStackEntry>.slideInToEnd(): EnterTransition =
+    slideIntoContainer(
+        towards = AnimatedContentTransitionScope.SlideDirection.End,
+        animationSpec = intOffsetAnimationSpec,
+    )
+
+fun AnimatedContentTransitionScope<NavBackStackEntry>.slideOutToEnd(): ExitTransition =
+    slideOutOfContainer(
+        towards = AnimatedContentTransitionScope.SlideDirection.End,
+        animationSpec = intOffsetAnimationSpec,
+    )


### PR DESCRIPTION
## Description
This updates "Up Next History" screen transitions.

Relevant discussion: pdeCcb-9hl-p2#comment-7225

## Testing Instructions
1. Add a few episodes to "Up Next" queue
2. Clear the queue
3. Go to `Settings` -> `Restore from local history`
4. Tap `Up Next History` and navigate in and out
5. Notice that the fade in/ fade out transitions are replaced by slide in/ slide out transitions.

## Screenshots or Screencast 
[up_next_history_transition.webm](https://github.com/user-attachments/assets/2b3c0cfa-dd15-4781-8325-a1550ead9b33)

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack