### PR TITLE
[Guest List and Network Highlight] UI Tweaks

### DIFF
--- a/modules/features/discover/src/main/res/drawable/header_text_linear_gradient.xml
+++ b/modules/features/discover/src/main/res/drawable/header_text_linear_gradient.xml
@@ -1,0 +1,9 @@
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+
+    <gradient
+        android:angle="90"
+        android:endColor="#332D1207"
+        android:startColor="#FF2D1207"
+        android:type="linear" />
+</shape>

--- a/modules/features/discover/src/main/res/drawable/header_text_linear_gradient.xml
+++ b/modules/features/discover/src/main/res/drawable/header_text_linear_gradient.xml
@@ -3,7 +3,8 @@
 
     <gradient
         android:angle="90"
-        android:endColor="#332D1207"
-        android:startColor="#FF2D1207"
+        android:endColor="#00180C07"
+        android:centerColor="#992D1207"
+        android:startColor="#B22D1207"
         android:type="linear" />
 </shape>

--- a/modules/features/discover/src/main/res/layout/collection_header.xml
+++ b/modules/features/discover/src/main/res/layout/collection_header.xml
@@ -21,6 +21,7 @@
         android:layout_gravity="bottom|center_horizontal"
         android:gravity="center_horizontal"
         android:orientation="vertical"
+        android:background="@drawable/header_text_linear_gradient"
         android:paddingHorizontal="12dp"
         android:paddingBottom="12dp">
 

--- a/modules/features/discover/src/main/res/layout/collection_header.xml
+++ b/modules/features/discover/src/main/res/layout/collection_header.xml
@@ -23,7 +23,7 @@
         android:orientation="vertical"
         android:background="@drawable/header_text_linear_gradient"
         android:paddingHorizontal="12dp"
-        android:paddingBottom="12dp">
+        android:paddingBottom="10dp">
 
         <TextView
             android:id="@+id/lblTitle"
@@ -32,7 +32,7 @@
             android:ellipsize="end"
             android:gravity="center_horizontal"
             android:maxLines="2"
-            android:paddingBottom="8dp"
+            android:paddingBottom="5dp"
             android:textAlignment="center"
             android:textColor="@color/white"
             android:textSize="13sp"

--- a/modules/features/discover/src/main/res/layout/collection_header.xml
+++ b/modules/features/discover/src/main/res/layout/collection_header.xml
@@ -1,7 +1,7 @@
 <com.google.android.material.card.MaterialCardView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="179dp"
-    android:layout_height="212dp"
+    android:layout_height="210dp"
     android:layout_marginTop="8dp"
     android:layout_marginBottom="24dp"
     android:layout_marginLeft="8dp"

--- a/modules/features/discover/src/main/res/layout/item_collection_list.xml
+++ b/modules/features/discover/src/main/res/layout/item_collection_list.xml
@@ -6,17 +6,18 @@
 
         <au.com.shiftyjelly.pocketcasts.discover.view.PodcastCollectionItem
             android:id="@+id/row0"
-            android:paddingLeft="6dp"
-            android:paddingRight="8dp"
-            android:paddingTop="8dp"
+            android:layout_marginTop="6dp"
+            android:layout_marginStart="6dp"
+            android:layout_marginEnd="8dp"
+            android:layout_marginBottom="4dp"
             android:layout_width="match_parent"
-            android:layout_height="wrap_content" />
+            android:layout_height="wrap_content"
+            />
         <au.com.shiftyjelly.pocketcasts.discover.view.PodcastCollectionItem
             android:id="@+id/row1"
-            android:paddingTop="6dp"
-            android:paddingBottom="8dp"
-            android:paddingLeft="6dp"
-            android:paddingRight="8dp"
+            android:layout_marginStart="6dp"
+            android:layout_marginEnd="8dp"
             android:layout_width="match_parent"
-            android:layout_height="wrap_content" />
+            android:layout_height="wrap_content"
+             />
 </LinearLayout>

--- a/modules/features/discover/src/main/res/layout/podcast_collection_item.xml
+++ b/modules/features/discover/src/main/res/layout/podcast_collection_item.xml
@@ -10,19 +10,21 @@
     android:orientation="horizontal">
 
     <androidx.cardview.widget.CardView
-        android:layout_width="100dp"
-        android:layout_height="100dp"
+        android:layout_width="101dp"
+        android:layout_height="101dp"
         android:layout_gravity="center_vertical"
-        android:layout_marginRight="12dp"
+        android:layout_marginRight="10dp"
+        android:elevation="1dp"
+        app:cardElevation="1dp"
+        app:contentPadding="0dp"
         android:layout_marginVertical="2dp"
         android:layout_marginStart="2dp"
-        android:elevation="2dp"
         app:cardCornerRadius="4dp">
 
         <ImageView
             android:id="@+id/imageView"
-            android:layout_width="100dp"
-            android:layout_height="100dp"
+            android:layout_width="101dp"
+            android:layout_height="101dp"
             android:background="?attr/defaultArtwork"
             tools:ignore="ContentDescription" />
     </androidx.cardview.widget.CardView>


### PR DESCRIPTION
## Description
- This addresses the feedbacks provided here: p1743011376465069-slack-C08HC6RUH40
  - Fixes spaces between podcasts
  - Update shadow
  - Adds background for header texts
  - Align header and podcasts
- I am currently wait for David so we can decide the hexadecimal value for the rectangle background text

## Testing Instructions
1. Go to Discover
2. Check the Guest list section redesign

## Screenshots or Screencast 
[Screen_recording_20250402_154810.webm](https://github.com/user-attachments/assets/f6dcb216-44a8-4eec-b8aa-95917d456890)


## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack