### PR TITLE
[Push Notifications Revamp] Add Daily reminders group to Notifications screen

### DIFF
--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/NotificationsSettingsFragment.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/NotificationsSettingsFragment.kt
@@ -83,7 +83,7 @@ class NotificationsSettingsFragment :
     private var notificationActions: PreferenceScreen? = null
     private var playOverNotificationPreference: ListPreference? = null
     private var hidePlaybackNotificationsPreference: SwitchPreference? = null
-    private var dailyRemindersPreference: SwitchPreference? = null
+    private var notifyDailyRemindersPreference: SwitchPreference? = null
 
     private val toolbar
         get() = view?.findViewById<Toolbar>(R.id.toolbar)
@@ -95,7 +95,7 @@ class NotificationsSettingsFragment :
         val view = super.onCreateView(inflater, container, savedInstanceState)
 
         if (!FeatureFlag.isEnabled(Feature.NOTIFICATIONS_REVAMP)) {
-            val generalNotificationsCategory = findPreference<PreferenceCategory>("general_notifications")
+            val generalNotificationsCategory = findPreference<PreferenceCategory>("daily_reminders_category")
             generalNotificationsCategory?.let { category ->
                 preferenceScreen.removePreference(category)
             }
@@ -131,7 +131,7 @@ class NotificationsSettingsFragment :
         systemSettingsPreference = manager.findPreference("openSystemSettings")
         playOverNotificationPreference = manager.findPreference("overrideNotificationAudio")
         hidePlaybackNotificationsPreference = manager.findPreference("hideNotificationOnPause")
-        dailyRemindersPreference = manager.findPreference("dailyRemindersNotification")
+        notifyDailyRemindersPreference = manager.findPreference("notifyDailyReminders")
 
         // turn preferences off by default, because they are enable async, we don't want this view to remove them from the screen after it loads as it looks jarring
         enabledPreferences(false)
@@ -189,7 +189,7 @@ class NotificationsSettingsFragment :
             true
         }
 
-        dailyRemindersPreference?.setOnPreferenceChangeListener { _, newValue ->
+        notifyDailyRemindersPreference?.setOnPreferenceChangeListener { _, newValue ->
             val newBool = (newValue as? Boolean) ?: throw IllegalStateException("Invalid value for daily reminders preference: $newValue")
             settings.dailyRemindersNotification.set(newBool, updateModifiedAt = true)
             analyticsTracker.track(
@@ -518,7 +518,7 @@ class NotificationsSettingsFragment :
     }
 
     private fun setupDailyRemindersNotification() {
-        dailyRemindersPreference?.isChecked = settings.dailyRemindersNotification.value
+        notifyDailyRemindersPreference?.isChecked = settings.dailyRemindersNotification.value
     }
 
     private fun setupPlayOverNotifications() {

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/NotificationsSettingsFragment.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/NotificationsSettingsFragment.kt
@@ -190,7 +190,7 @@ class NotificationsSettingsFragment :
         }
 
         dailyRemindersPreference?.setOnPreferenceChangeListener { _, newValue ->
-            val newBool = (newValue as? Boolean) ?: throw IllegalStateException("Invalid value for hide notification on pause preference: $newValue")
+            val newBool = (newValue as? Boolean) ?: throw IllegalStateException("Invalid value for daily reminders preference: $newValue")
             settings.dailyRemindersNotification.set(newBool, updateModifiedAt = true)
             analyticsTracker.track(
                 AnalyticsEvent.SETTINGS_NOTIFICATIONS_DAILY_REMINDERS_TOGGLED,

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/NotificationsSettingsFragment.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/NotificationsSettingsFragment.kt
@@ -175,6 +175,10 @@ class NotificationsSettingsFragment :
         dailyRemindersPreference?.setOnPreferenceChangeListener { _, newValue ->
             val newBool = (newValue as? Boolean) ?: throw IllegalStateException("Invalid value for hide notification on pause preference: $newValue")
             settings.dailyRemindersNotification.set(newBool, updateModifiedAt = true)
+            analyticsTracker.track(
+                AnalyticsEvent.SETTINGS_NOTIFICATIONS_DAILY_REMINDERS_TOGGLED,
+                mapOf("enabled" to newBool),
+            )
             true
         }
 

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/NotificationsSettingsFragment.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/NotificationsSettingsFragment.kt
@@ -79,6 +79,7 @@ class NotificationsSettingsFragment :
     private var notificationActions: PreferenceScreen? = null
     private var playOverNotificationPreference: ListPreference? = null
     private var hidePlaybackNotificationsPreference: SwitchPreference? = null
+    private var dailyRemindersPreference: SwitchPreference? = null
 
     private val toolbar
         get() = view?.findViewById<Toolbar>(R.id.toolbar)
@@ -113,6 +114,7 @@ class NotificationsSettingsFragment :
         systemSettingsPreference = manager.findPreference("openSystemSettings")
         playOverNotificationPreference = manager.findPreference("overrideNotificationAudio")
         hidePlaybackNotificationsPreference = manager.findPreference("hideNotificationOnPause")
+        dailyRemindersPreference = manager.findPreference("dailyRemindersNotification")
 
         // turn preferences off by default, because they are enable async, we don't want this view to remove them from the screen after it loads as it looks jarring
         enabledPreferences(false)
@@ -169,6 +171,13 @@ class NotificationsSettingsFragment :
 
             true
         }
+
+        dailyRemindersPreference?.setOnPreferenceChangeListener { _, newValue ->
+            val newBool = (newValue as? Boolean) ?: throw IllegalStateException("Invalid value for hide notification on pause preference: $newValue")
+            settings.dailyRemindersNotification.set(newBool, updateModifiedAt = true)
+            true
+        }
+
         changePodcastsSummary()
     }
 
@@ -383,6 +392,7 @@ class NotificationsSettingsFragment :
         setupEnabledNotifications()
         setupNotificationVibrate()
         setupHidePlaybackNotifications()
+        setupDailyRemindersNotification()
         setupPlayOverNotifications()
     }
 
@@ -484,6 +494,10 @@ class NotificationsSettingsFragment :
 
     private fun setupHidePlaybackNotifications() {
         hidePlaybackNotificationsPreference?.isChecked = settings.hideNotificationOnPause.value
+    }
+
+    private fun setupDailyRemindersNotification() {
+        dailyRemindersPreference?.isChecked = settings.dailyRemindersNotification.value
     }
 
     private fun setupPlayOverNotifications() {

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/NotificationsSettingsFragment.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/NotificationsSettingsFragment.kt
@@ -4,7 +4,9 @@ import android.media.RingtoneManager
 import android.net.Uri
 import android.os.Build
 import android.os.Bundle
+import android.view.LayoutInflater
 import android.view.View
+import android.view.ViewGroup
 import androidx.appcompat.widget.Toolbar
 import androidx.core.content.IntentCompat.getParcelableExtra
 import androidx.core.view.updatePadding
@@ -27,6 +29,8 @@ import au.com.shiftyjelly.pocketcasts.preferences.model.PlayOverNotificationSett
 import au.com.shiftyjelly.pocketcasts.repositories.notification.NotificationHelper
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
 import au.com.shiftyjelly.pocketcasts.views.extensions.findToolbar
 import au.com.shiftyjelly.pocketcasts.views.extensions.setup
 import au.com.shiftyjelly.pocketcasts.views.fragments.PodcastSelectFragment
@@ -86,6 +90,19 @@ class NotificationsSettingsFragment :
 
     override val coroutineContext: CoroutineContext
         get() = Dispatchers.Default
+
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
+        val view = super.onCreateView(inflater, container, savedInstanceState)
+
+        if (!FeatureFlag.isEnabled(Feature.NOTIFICATIONS_REVAMP)) {
+            val generalNotificationsCategory = findPreference<PreferenceCategory>("general_notifications")
+            generalNotificationsCategory?.let { category ->
+                preferenceScreen.removePreference(category)
+            }
+        }
+
+        return view
+    }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/NotificationsSettingsFragment.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/NotificationsSettingsFragment.kt
@@ -117,6 +117,7 @@ class NotificationsSettingsFragment :
                 }
             }
         }
+        setDivider(null)
     }
 
     override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {

--- a/modules/features/settings/src/main/res/xml/preferences_notifications.xml
+++ b/modules/features/settings/src/main/res/xml/preferences_notifications.xml
@@ -41,7 +41,7 @@
             android:title="@string/settings_notification_advanced" />
     </PreferenceCategory>
 
-    <PreferenceCategory>
+    <PreferenceCategory android:key="general_notifications">
         <SwitchPreference
             android:key="dailyRemindersNotification"
             android:persistent="false"

--- a/modules/features/settings/src/main/res/xml/preferences_notifications.xml
+++ b/modules/features/settings/src/main/res/xml/preferences_notifications.xml
@@ -41,6 +41,13 @@
             android:title="@string/settings_notification_advanced" />
     </PreferenceCategory>
 
+    <PreferenceCategory>
+        <SwitchPreference
+            android:key="dailyRemindersNotification"
+            android:persistent="false"
+            android:title="@string/settings_notification_daily_reminders" />
+    </PreferenceCategory>
+
     <PreferenceCategory android:title="@string/settings" >
         <ListPreference
             android:key="overrideNotificationAudio"

--- a/modules/features/settings/src/main/res/xml/preferences_notifications.xml
+++ b/modules/features/settings/src/main/res/xml/preferences_notifications.xml
@@ -48,6 +48,10 @@
             android:persistent="false"
             android:minHeight="72dp"
             android:title="@string/settings_notification_notify_me" />
+        <Preference
+            android:key="dailyRemindersSettings"
+            android:summary="@string/settings_notification_advanced_summary_for_daily_reminders"
+            android:title="@string/settings_notification_advanced" />
     </PreferenceCategory>
 
     <PreferenceCategory android:title="@string/settings" >

--- a/modules/features/settings/src/main/res/xml/preferences_notifications.xml
+++ b/modules/features/settings/src/main/res/xml/preferences_notifications.xml
@@ -50,7 +50,7 @@
             android:title="@string/settings_notification_notify_me" />
         <Preference
             android:key="dailyRemindersSettings"
-            android:summary="@string/settings_notification_advanced_summary_for_daily_reminders"
+            android:summary="@string/settings_notification_advanced_summary"
             android:title="@string/settings_notification_advanced" />
     </PreferenceCategory>
 

--- a/modules/features/settings/src/main/res/xml/preferences_notifications.xml
+++ b/modules/features/settings/src/main/res/xml/preferences_notifications.xml
@@ -41,11 +41,13 @@
             android:title="@string/settings_notification_advanced" />
     </PreferenceCategory>
 
-    <PreferenceCategory android:key="general_notifications">
+    <PreferenceCategory android:key="daily_reminders_category" android:title="@string/settings_notification_daily_reminders">
         <SwitchPreference
-            android:key="dailyRemindersNotification"
+            android:defaultValue="false"
+            android:key="notifyDailyReminders"
             android:persistent="false"
-            android:title="@string/settings_notification_daily_reminders" />
+            android:minHeight="72dp"
+            android:title="@string/settings_notification_notify_me" />
     </PreferenceCategory>
 
     <PreferenceCategory android:title="@string/settings" >

--- a/modules/features/shared/src/main/java/au/com/shiftyjelly/pocketcasts/shared/AppLifecycleObserver.kt
+++ b/modules/features/shared/src/main/java/au/com/shiftyjelly/pocketcasts/shared/AppLifecycleObserver.kt
@@ -120,6 +120,9 @@ class AppLifecycleObserver constructor(
 
                     // For new users we want to auto download on follow podcast by default
                     settings.autoDownloadOnFollowPodcast.set(true, updateModifiedAt = false)
+
+                    // For new users we want to enable the daily reminders notification by default
+                    settings.dailyRemindersNotification.set(true, updateModifiedAt = false)
                 }
             }
         } else if (previousVersionCode < versionCode) {

--- a/modules/features/shared/src/test/java/au/com/shiftyjelly/pocketcasts/shared/AppLifecycleObserverTest.kt
+++ b/modules/features/shared/src/test/java/au/com/shiftyjelly/pocketcasts/shared/AppLifecycleObserverTest.kt
@@ -47,6 +47,8 @@ class AppLifecycleObserverTest {
 
     @Mock private lateinit var autoDownloadOnFollowPodcastSetting: UserSetting<Boolean>
 
+    @Mock private lateinit var dailyRemindersNotificationSetting: UserSetting<Boolean>
+
     @Mock private lateinit var appLifecycleAnalytics: AppLifecycleAnalytics
 
     @Mock private lateinit var preferencesFeatureProvider: PreferencesFeatureProvider
@@ -67,6 +69,7 @@ class AppLifecycleObserverTest {
     fun setUp() {
         whenever(settings.autoPlayNextEpisodeOnEmpty).thenReturn(autoPlayNextEpisodeSetting)
         whenever(settings.autoDownloadOnFollowPodcast).thenReturn(autoDownloadOnFollowPodcastSetting)
+        whenever(settings.dailyRemindersNotification).thenReturn(dailyRemindersNotificationSetting)
         whenever(settings.useDarkUpNextTheme).thenReturn(useUpNextDarkThemeSetting)
         whenever(settings.showPodcastHeaderChangesTooltip).thenReturn(showPodcastHeaderChangesSetting)
         whenever(settings.showPodcastsRecentlyPlayedSortOrderTooltip).thenReturn(showPodcastsRecentlyPlayedSortOrderSetting)
@@ -101,6 +104,7 @@ class AppLifecycleObserverTest {
         verify(appLifecycleAnalytics).onNewApplicationInstall()
         verify(autoPlayNextEpisodeSetting).set(true, updateModifiedAt = false)
         verify(autoDownloadOnFollowPodcastSetting).set(true, updateModifiedAt = false)
+        verify(dailyRemindersNotificationSetting).set(true, updateModifiedAt = false)
         verify(useUpNextDarkThemeSetting).set(false, updateModifiedAt = false)
 
         verify(appLifecycleAnalytics, never()).onApplicationUpgrade(any())
@@ -119,6 +123,7 @@ class AppLifecycleObserverTest {
 
         verify(autoPlayNextEpisodeSetting, never()).set(any(), any(), any(), any())
         verify(autoDownloadOnFollowPodcastSetting, never()).set(any(), any(), any(), any())
+        verify(dailyRemindersNotificationSetting, never()).set(any(), any(), any(), any())
         verify(useUpNextDarkThemeSetting).set(false, updateModifiedAt = false)
         verify(appLifecycleAnalytics, never()).onApplicationUpgrade(any())
     }
@@ -136,6 +141,7 @@ class AppLifecycleObserverTest {
 
         verify(autoPlayNextEpisodeSetting, never()).set(any(), any(), any(), any())
         verify(autoDownloadOnFollowPodcastSetting, never()).set(any(), any(), any(), any())
+        verify(dailyRemindersNotificationSetting, never()).set(any(), any(), any(), any())
         verify(useUpNextDarkThemeSetting).set(false, updateModifiedAt = false)
         verify(appLifecycleAnalytics, never()).onApplicationUpgrade(any())
     }
@@ -153,6 +159,7 @@ class AppLifecycleObserverTest {
         verify(appLifecycleAnalytics, never()).onNewApplicationInstall()
         verify(autoPlayNextEpisodeSetting, never()).set(any(), any(), any(), any())
         verify(autoDownloadOnFollowPodcastSetting, never()).set(any(), any(), any(), any())
+        verify(dailyRemindersNotificationSetting, never()).set(any(), any(), any(), any())
         verify(useUpNextDarkThemeSetting, never()).set(any(), any(), any(), any())
     }
 }

--- a/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
+++ b/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
@@ -611,6 +611,7 @@ enum class AnalyticsEvent(val key: String) {
     SETTINGS_NOTIFICATIONS_SOUND_CHANGED("settings_notifications_sound_changed"),
     SETTINGS_NOTIFICATIONS_VIBRATION_CHANGED("settings_notifications_vibration_changed"),
     SETTINGS_NOTIFICATIONS_DAILY_REMINDERS_TOGGLED("settings_notifications_daily_reminders_toggled"),
+    SETTINGS_DAILY_REMINDERS_ADVANCED_SETTINGS_TOGGLED("settings_daily_reminders_advanced_settings_tapped"),
 
     /* Settings - Storage & Data Use */
     SETTINGS_STORAGE_SHOWN("settings_storage_shown"),

--- a/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
+++ b/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
@@ -610,6 +610,7 @@ enum class AnalyticsEvent(val key: String) {
     SETTINGS_NOTIFICATIONS_HIDE_PLAYBACK_NOTIFICATION_ON_PAUSE("settings_notifications_hide_playback_notification_on_pause"),
     SETTINGS_NOTIFICATIONS_SOUND_CHANGED("settings_notifications_sound_changed"),
     SETTINGS_NOTIFICATIONS_VIBRATION_CHANGED("settings_notifications_vibration_changed"),
+    SETTINGS_NOTIFICATIONS_DAILY_REMINDERS_TOGGLED("settings_notifications_daily_reminders_toggled"),
 
     /* Settings - Storage & Data Use */
     SETTINGS_STORAGE_SHOWN("settings_storage_shown"),

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -1358,6 +1358,7 @@
     <string name="settings_notification_choose_podcasts">Choose podcasts</string>
     <string name="settings_notification_hide_on_pause">Hide playback notification on pause</string>
     <string name="settings_notification_notify_me">Notify me</string>
+    <string name="settings_notification_daily_reminders">Daily Reminders</string>
     <string name="settings_notification_play_over">Play over notifications</string>
     <string name="settings_notification_play_over_never">Never</string>
     <string name="settings_notification_play_over_duck">Duck volume</string>

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -1355,6 +1355,7 @@
     <string name="settings_notification_actions">Actions</string>
     <string name="settings_notification_advanced">Advanced settings</string>
     <string name="settings_notification_advanced_summary">Choose sounds and other system options</string>
+    <string name="settings_notification_advanced_summary_for_daily_reminders">Choose sounds and other system options for daily reminders</string>
     <string name="settings_notification_choose_podcasts">Choose podcasts</string>
     <string name="settings_notification_hide_on_pause">Hide playback notification on pause</string>
     <string name="settings_notification_notify_me">Notify me</string>

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -1355,7 +1355,6 @@
     <string name="settings_notification_actions">Actions</string>
     <string name="settings_notification_advanced">Advanced settings</string>
     <string name="settings_notification_advanced_summary">Choose sounds and other system options</string>
-    <string name="settings_notification_advanced_summary_for_daily_reminders">Choose sounds and other system options for daily reminders</string>
     <string name="settings_notification_choose_podcasts">Choose podcasts</string>
     <string name="settings_notification_hide_on_pause">Hide playback notification on pause</string>
     <string name="settings_notification_notify_me">Notify me</string>

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
@@ -334,6 +334,7 @@ interface Settings {
     fun shouldShowLowStorageBannerAfterSnooze(): Boolean
 
     val hideNotificationOnPause: UserSetting<Boolean>
+    val dailyRemindersNotification: UserSetting<Boolean>
 
     val streamingMode: UserSetting<Boolean>
     val keepScreenAwake: UserSetting<Boolean>

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
@@ -557,6 +557,12 @@ class SettingsImpl @Inject constructor(
         sharedPrefs = sharedPreferences,
     )
 
+    override val dailyRemindersNotification = UserSetting.BoolPref(
+        sharedPrefKey = "dailyRemindersNotification",
+        defaultValue = false,
+        sharedPrefs = sharedPreferences,
+    )
+
     override val streamingMode: UserSetting<Boolean> = UserSetting.BoolPref(
         sharedPrefKey = Settings.PREFERENCE_GLOBAL_STREAMING_MODE,
         defaultValue = true,

--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/Feature.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/Feature.kt
@@ -227,6 +227,14 @@ enum class Feature(
         hasFirebaseRemoteFlag = true,
         hasDevToggle = true,
     ),
+    NOTIFICATIONS_REVAMP(
+        key = "notifications_revamp",
+        title = "Notifications Revamp",
+        defaultValue = BuildConfig.DEBUG,
+        tier = FeatureTier.Free,
+        hasFirebaseRemoteFlag = false,
+        hasDevToggle = true,
+    ),
     ;
 
     companion object {


### PR DESCRIPTION
## Description
- This PR adds the Daily reminders section to notifications screen
- Wrap the new toggle behind feature flag
- Track event when the new toggle changes
- There is a slight difference between the proposed design and the implementation. The proposed design requires extra padding for the notification setting. I believe we can fix this by converting this screen to Jetpack Compose in a later PR.
- See: hVHQ8RgGQf1afBWybZExD2-fi-0_618

## Testing Instructions

### Feature flag OFF
1. Install the app
2. Go to Settings -> Notifications
3. Ensure you don't see the `Daily Reminders` toggle ✅

### Feature flag ON - New users
1. Fresh install the app and have the feature flag enabled
2. Go to Settings -> Notifications
3. Ensure you see the `Daily Reminders` section ✅
4. Ensure the toggle is enabled by default ✅
5. Turn off the toggle `Notify me` toggle from daily reminders section
6. Ensure 🔵 Tracked: settings_notifications_daily_reminders_toggled, Properties: {"enabled"... ✅
7. Tap on `Advanced Settings` from `Daily Reminders` section
8. Ensure 🔵 Tracked: settings_daily_reminders_advanced_settings_tapped ✅

### Feature flag ON - Existing users
1. Install the app from `release/7.85` branch
2. Install the app from this branch
3. Go to Settings -> Notifications
4. Ensure you see the `Daily Reminders` toggle ✅
5. Ensure the toggle is disabled by default ✅

## Screenshots or Screencast 

<img src="https://github.com/user-attachments/assets/b1ff15dd-9f0c-4e5f-b4e3-1fa51fffef66" width="300" alt="Screenshot">


## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack