### PR TITLE
[Push Notifications Revamp] Support deeplink for Upsell 

### DIFF
--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/deeplink/DeepLinkFactoryTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/deeplink/DeepLinkFactoryTest.kt
@@ -580,6 +580,17 @@ class DeepLinkFactoryTest {
     }
 
     @Test
+    fun upsell() {
+        val intent = Intent()
+            .setAction(ACTION_VIEW)
+            .setData(Uri.parse("pktc://upsell"))
+
+        val deepLink = factory.create(intent)
+
+        assertEquals(UpsellDeepLink, deepLink)
+    }
+
+    @Test
     fun nativeShareWithStartTimestamp() {
         val intent = Intent()
             .setAction(ACTION_VIEW)

--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/deeplink/UpsellDeepLinkTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/deeplink/UpsellDeepLinkTest.kt
@@ -1,0 +1,22 @@
+package au.com.shiftyjelly.pocketcasts.deeplink
+
+import android.content.Intent.ACTION_VIEW
+import android.net.Uri
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class UpsellDeepLinkTest {
+    private val context = InstrumentationRegistry.getInstrumentation().context
+
+    @Test
+    fun createIntent() {
+        val intent = UpsellDeepLink.toIntent(context)
+
+        assertEquals(ACTION_VIEW, intent.action)
+        assertEquals(Uri.parse("pktc://upsell"), intent.data)
+    }
+}

--- a/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
+++ b/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
@@ -76,6 +76,7 @@ import au.com.shiftyjelly.pocketcasts.deeplink.ShowUpNextDeepLink
 import au.com.shiftyjelly.pocketcasts.deeplink.SignInDeepLink
 import au.com.shiftyjelly.pocketcasts.deeplink.SonosDeepLink
 import au.com.shiftyjelly.pocketcasts.deeplink.UpgradeAccountDeepLink
+import au.com.shiftyjelly.pocketcasts.deeplink.UpsellDeepLink
 import au.com.shiftyjelly.pocketcasts.discover.view.DiscoverFragment
 import au.com.shiftyjelly.pocketcasts.endofyear.StoriesActivity
 import au.com.shiftyjelly.pocketcasts.endofyear.StoriesActivity.StoriesSource
@@ -1317,6 +1318,9 @@ class MainActivity :
                 }
                 is CloudFilesDeepLink -> {
                     openCloudFiles()
+                }
+                is UpsellDeepLink -> {
+                    openOnboardingFlow(OnboardingFlow.Upsell(OnboardingUpgradeSource.DEEP_LINK))
                 }
                 is UpgradeAccountDeepLink -> {
                     showAccountUpgradeNowDialog(shouldClose = true)

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/OnboardingFlowComposable.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/OnboardingFlowComposable.kt
@@ -249,6 +249,7 @@ private fun Content(
                 OnboardingUpgradeSource.SLUMBER_STUDIOS,
                 OnboardingUpgradeSource.UP_NEXT_SHUFFLE,
                 OnboardingUpgradeSource.GENERATED_TRANSCRIPTS,
+                OnboardingUpgradeSource.DEEP_LINK,
                 OnboardingUpgradeSource.UNKNOWN,
                 -> false
 

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/onboarding/OnboardingUpgradeSource.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/onboarding/OnboardingUpgradeSource.kt
@@ -24,5 +24,6 @@ enum class OnboardingUpgradeSource(val analyticsValue: String) {
     SLUMBER_STUDIOS("slumber_studios"),
     UP_NEXT_SHUFFLE("up_next_shuffle"),
     GENERATED_TRANSCRIPTS("generated_transcripts"),
+    DEEP_LINK("deep_link"),
     UNKNOWN("unknown"),
 }

--- a/modules/services/deeplink/src/main/kotlin/au/com/shiftyjelly/pocketcasts/deeplink/DeepLink.kt
+++ b/modules/services/deeplink/src/main/kotlin/au/com/shiftyjelly/pocketcasts/deeplink/DeepLink.kt
@@ -202,6 +202,11 @@ data object CloudFilesDeepLink : IntentableDeepLink {
         .setData(Uri.parse("pktc://cloudfiles"))
 }
 
+data object UpsellDeepLink : IntentableDeepLink {
+    override fun toIntent(context: Context) = Intent(ACTION_VIEW)
+        .setData(Uri.parse("pktc://upsell"))
+}
+
 data object UpgradeAccountDeepLink : DeepLink
 
 data class PromoCodeDeepLink(

--- a/modules/services/deeplink/src/main/kotlin/au/com/shiftyjelly/pocketcasts/deeplink/DeepLinkFactory.kt
+++ b/modules/services/deeplink/src/main/kotlin/au/com/shiftyjelly/pocketcasts/deeplink/DeepLinkFactory.kt
@@ -52,6 +52,7 @@ class DeepLinkFactory(
         SubscribeOnAndroidAdapter(),
         AppleAdapter(),
         CloudFilesAdapter(),
+        UpsellAdapter(),
         UpgradeAccountAdapter(),
         PromoCodeAdapter(),
         ShareLinkNativeAdapter(),
@@ -322,6 +323,20 @@ private class CloudFilesAdapter : DeepLinkAdapter {
 
         return if (intent.action == ACTION_VIEW && scheme == "pktc" && host == "cloudfiles") {
             CloudFilesDeepLink
+        } else {
+            null
+        }
+    }
+}
+
+private class UpsellAdapter : DeepLinkAdapter {
+    override fun create(intent: Intent): DeepLink? {
+        val uriData = intent.data
+        val scheme = uriData?.scheme
+        val host = uriData?.host
+
+        return if (intent.action == ACTION_VIEW && scheme == "pktc" && host == "upsell") {
+            UpsellDeepLink
         } else {
             null
         }


### PR DESCRIPTION
## Description
- Supports the deep link for opening up sell. This will be used for the new up sell notification that will be implemented in the next PRs: `pktc://upsell`
- See document with deeplinks: p1743685755349989/1743684484.596599-slack-C08KX131YRJ

## Testing Instructions
Since we don't have the notifications implemented, we can test this in command line:

### Not logged user
1. Install the app
2. Do not log in
3. In Android Studio terminal, run: `adb shell am start -a android.intent.action.VIEW -d "pktc://upsell"`
4. Ensure the app opens in Upsell screen ✅
5. Tap to subscribe to Plus
6. Ensure you see the Sign in screen ✅

### Free user account
1. Install the app
2. Log in with a free user account
3. In Android Studio terminal, run: `adb shell am start -a android.intent.action.VIEW -d "pktc://upsell"`
4. Ensure the app opens in Upsell screen ✅
5. Tap to subscribe to Plus
6. Ensure you don't see the Sign in screen ✅

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.