### PR TITLE
Podcast list: align podcast details vertically

### DIFF
--- a/modules/features/discover/src/main/res/layout/row_podcast.xml
+++ b/modules/features/discover/src/main/res/layout/row_podcast.xml
@@ -25,7 +25,8 @@
         android:layout_height="wrap_content"
         android:layout_weight="1"
         android:orientation="vertical"
-        android:gravity="center">
+        android:paddingEnd="4dp"
+        android:layout_gravity="center_vertical">
         <TextView
             android:id="@+id/lblTitle"
             android:layout_width="match_parent"


### PR DESCRIPTION
## Description

This fixes a minor issue I noticed while working on another feature. The podcast title and subtitle alignment isn't vertically centred when viewing a podcast list in the Discover section. We may have accidentally broken this in a [recent accessibility PR](https://github.com/Automattic/pocket-casts-android/pull/3500). 

I also added some padding so a long subtitle doesn't get too close to the subscribe button.

## Testing Instructions
1. Open the Discover tab
2. Tap on "Show all" on a podcast list
3. ✅ Verify the text is vertically centered

## Screenshots 

| Before | After |
| --- | --- |
| ![Screenshot_20250407_110850](https://github.com/user-attachments/assets/28dd062f-88b1-4ddb-a188-b4e3ccfc9a1d) | ![Screenshot_20250407_111824](https://github.com/user-attachments/assets/e34c3f77-01de-4d27-b00d-2fdb8a0cbcf3) | 

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack
