### PR TITLE
[Push Notifications Revamp] Support deeplink for Import

### DIFF
--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/deeplink/DeepLinkFactoryTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/deeplink/DeepLinkFactoryTest.kt
@@ -573,6 +573,17 @@ class DeepLinkFactoryTest {
     }
 
     @Test
+    fun import() {
+        val intent = Intent()
+            .setAction(ACTION_VIEW)
+            .setData(Uri.parse("pktc://settings/import"))
+
+        val deepLink = factory.create(intent)
+
+        assertEquals(ImportDeepLink, deepLink)
+    }
+
+    @Test
     fun nativeShare() {
         val intent = Intent()
             .setAction(ACTION_VIEW)

--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/deeplink/ImportDeepLinkTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/deeplink/ImportDeepLinkTest.kt
@@ -17,6 +17,6 @@ class ImportDeepLinkTest {
         val intent = ImportDeepLink.toIntent(context)
 
         assertEquals(ACTION_VIEW, intent.action)
-        assertEquals(Uri.parse("pktc://import"), intent.data)
+        assertEquals(Uri.parse("pktc://settings/import"), intent.data)
     }
 }

--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/deeplink/ImportDeepLinkTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/deeplink/ImportDeepLinkTest.kt
@@ -1,0 +1,22 @@
+package au.com.shiftyjelly.pocketcasts.deeplink
+
+import android.content.Intent.ACTION_VIEW
+import android.net.Uri
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class ImportDeepLinkTest {
+    private val context = InstrumentationRegistry.getInstrumentation().context
+
+    @Test
+    fun createIntent() {
+        val intent = ImportDeepLink.toIntent(context)
+
+        assertEquals(ACTION_VIEW, intent.action)
+        assertEquals(Uri.parse("pktc://import"), intent.data)
+    }
+}

--- a/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
+++ b/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
@@ -134,9 +134,9 @@ import au.com.shiftyjelly.pocketcasts.search.SearchFragment
 import au.com.shiftyjelly.pocketcasts.servers.ServerCallback
 import au.com.shiftyjelly.pocketcasts.servers.ServiceManager
 import au.com.shiftyjelly.pocketcasts.servers.discover.PodcastSearch
+import au.com.shiftyjelly.pocketcasts.settings.AppearanceSettingsFragment
 import au.com.shiftyjelly.pocketcasts.settings.ExportSettingsFragment
 import au.com.shiftyjelly.pocketcasts.settings.SettingsFragment
-import au.com.shiftyjelly.pocketcasts.settings.AppearanceSettingsFragment
 import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingFlow
 import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingLauncher
 import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingUpgradeSource

--- a/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
+++ b/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
@@ -58,6 +58,7 @@ import au.com.shiftyjelly.pocketcasts.deeplink.DeepLink.Companion.EXTRA_PAGE
 import au.com.shiftyjelly.pocketcasts.deeplink.DeepLinkFactory
 import au.com.shiftyjelly.pocketcasts.deeplink.DeleteBookmarkDeepLink
 import au.com.shiftyjelly.pocketcasts.deeplink.DownloadsDeepLink
+import au.com.shiftyjelly.pocketcasts.deeplink.ImportDeepLink
 import au.com.shiftyjelly.pocketcasts.deeplink.NativeShareDeepLink
 import au.com.shiftyjelly.pocketcasts.deeplink.OpmlImportDeepLink
 import au.com.shiftyjelly.pocketcasts.deeplink.PlayFromSearchDeepLink
@@ -133,6 +134,8 @@ import au.com.shiftyjelly.pocketcasts.search.SearchFragment
 import au.com.shiftyjelly.pocketcasts.servers.ServerCallback
 import au.com.shiftyjelly.pocketcasts.servers.ServiceManager
 import au.com.shiftyjelly.pocketcasts.servers.discover.PodcastSearch
+import au.com.shiftyjelly.pocketcasts.settings.ExportSettingsFragment
+import au.com.shiftyjelly.pocketcasts.settings.SettingsFragment
 import au.com.shiftyjelly.pocketcasts.settings.AppearanceSettingsFragment
 import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingFlow
 import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingLauncher
@@ -1337,6 +1340,9 @@ class MainActivity :
                 is OpmlImportDeepLink -> {
                     OpmlImportTask.run(deepLink.uri, this)
                 }
+                is ImportDeepLink -> {
+                    openImport()
+                }
                 is PlayFromSearchDeepLink -> {
                     playbackManager.mediaSessionManager.playFromSearchExternal(deepLink.query)
                 }
@@ -1626,5 +1632,12 @@ class MainActivity :
             .setBackgroundTint(ThemeColor.primaryUi01(Theme.ThemeType.DARK))
             .setTextColor(ThemeColor.primaryText01(Theme.ThemeType.DARK))
             .show()
+    }
+
+    private fun openImport() {
+        closePlayer()
+        openTab(VR.id.navigation_profile)
+        addFragment(SettingsFragment())
+        addFragment(ExportSettingsFragment())
     }
 }

--- a/modules/services/deeplink/src/main/kotlin/au/com/shiftyjelly/pocketcasts/deeplink/DeepLink.kt
+++ b/modules/services/deeplink/src/main/kotlin/au/com/shiftyjelly/pocketcasts/deeplink/DeepLink.kt
@@ -230,6 +230,11 @@ data class OpmlImportDeepLink(
     val uri: Uri,
 ) : DeepLink
 
+data object ImportDeepLink : IntentableDeepLink {
+    override fun toIntent(context: Context) = Intent(ACTION_VIEW)
+        .setData(Uri.parse("pktc://import"))
+}
+
 data class PlayFromSearchDeepLink(
     val query: String,
 ) : DeepLink

--- a/modules/services/deeplink/src/main/kotlin/au/com/shiftyjelly/pocketcasts/deeplink/DeepLink.kt
+++ b/modules/services/deeplink/src/main/kotlin/au/com/shiftyjelly/pocketcasts/deeplink/DeepLink.kt
@@ -232,7 +232,7 @@ data class OpmlImportDeepLink(
 
 data object ImportDeepLink : IntentableDeepLink {
     override fun toIntent(context: Context) = Intent(ACTION_VIEW)
-        .setData(Uri.parse("pktc://import"))
+        .setData(Uri.parse("pktc://settings/import"))
 }
 
 data class PlayFromSearchDeepLink(

--- a/modules/services/deeplink/src/main/kotlin/au/com/shiftyjelly/pocketcasts/deeplink/DeepLinkFactory.kt
+++ b/modules/services/deeplink/src/main/kotlin/au/com/shiftyjelly/pocketcasts/deeplink/DeepLinkFactory.kt
@@ -60,6 +60,7 @@ class DeepLinkFactory(
         ShareLinkAdapter(shareHost),
         WebPlayerShareLinkAdapter(webPlayerHost),
         OpmlAdapter(listOf(listHost, shareHost)),
+        ImportAdapter(),
         PodcastUrlSchemeAdapter(listOf(listHost, shareHost, webBaseHost)),
         PlayFromSearchAdapter(),
         AssistantAdapter(),
@@ -525,7 +526,21 @@ private class OpmlAdapter(
             "settings",
             "subscribeonandroid.com",
             "www.subscribeonandroid.com",
+            "import",
         )
+    }
+}
+
+private class ImportAdapter : DeepLinkAdapter {
+    override fun create(intent: Intent): DeepLink? {
+        val uriData = intent.data ?: return null
+        val scheme = uriData.scheme
+        val host = uriData.host
+        return if (intent.action == ACTION_VIEW && scheme == "pktc" && host == "import") {
+            ImportDeepLink
+        } else {
+            null
+        }
     }
 }
 

--- a/modules/services/deeplink/src/main/kotlin/au/com/shiftyjelly/pocketcasts/deeplink/DeepLinkFactory.kt
+++ b/modules/services/deeplink/src/main/kotlin/au/com/shiftyjelly/pocketcasts/deeplink/DeepLinkFactory.kt
@@ -526,7 +526,7 @@ private class OpmlAdapter(
             "settings",
             "subscribeonandroid.com",
             "www.subscribeonandroid.com",
-            "import",
+            "settings",
         )
     }
 }
@@ -536,7 +536,9 @@ private class ImportAdapter : DeepLinkAdapter {
         val uriData = intent.data ?: return null
         val scheme = uriData.scheme
         val host = uriData.host
-        return if (intent.action == ACTION_VIEW && scheme == "pktc" && host == "import") {
+        val path = uriData.path
+
+        return if (intent.action == ACTION_VIEW && scheme == "pktc" && host == "settings" && path == "/import") {
             ImportDeepLink
         } else {
             null


### PR DESCRIPTION
## Description
- Supports the deep link for opening import opml screen: `pktc://settings/import`
- See document with deeplinks: p1743685755349989/1743684484.596599-slack-C08KX131YRJ

## Testing Instructions
Since we don't have the notifications implemented, we can test this in command line:

1. Install the app
2. Run the command line in Android Studio's terminal: `adb shell am start -a android.intent.action.VIEW -d "pktc://settings/import"`
3. Ensure the Import & Export OPML screen opens ✅

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.