### PR TITLE
[Push Notifications Revamp] Support deeplink for UpNext tab

### DIFF
--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/deeplink/DeepLinkFactoryTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/deeplink/DeepLinkFactoryTest.kt
@@ -223,14 +223,25 @@ class DeepLinkFactoryTest {
     }
 
     @Test
-    fun showUpNext() {
+    fun showUpNextModal() {
         val intent = Intent()
             .setAction(ACTION_VIEW)
             .putExtra("launch-page", "upnext")
 
         val deepLink = factory.create(intent)
 
-        assertEquals(ShowUpNextDeepLink, deepLink)
+        assertEquals(ShowUpNextModalDeepLink, deepLink)
+    }
+
+    @Test
+    fun showUpNextTab() {
+        val intent = Intent()
+            .setAction(ACTION_VIEW)
+            .setData(Uri.parse("pktc://upnext?location=tab"))
+
+        val deepLink = factory.create(intent)
+
+        assertEquals(ShowUpNextTabDeepLink, deepLink)
     }
 
     @Test

--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/deeplink/ShowPageDeepLinkTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/deeplink/ShowPageDeepLinkTest.kt
@@ -29,7 +29,7 @@ class ShowPageDeepLinkTest {
 
     @Test
     fun createShowUpNextIntent() {
-        val intent = ShowUpNextDeepLink.toIntent(context)
+        val intent = ShowUpNextModalDeepLink.toIntent(context)
 
         assertEquals(ACTION_VIEW, intent.action)
         assertEquals("upnext", intent.getStringExtra("launch-page"))

--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/deeplink/ShowUpNextTabDeepLinkTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/deeplink/ShowUpNextTabDeepLinkTest.kt
@@ -1,0 +1,22 @@
+package au.com.shiftyjelly.pocketcasts.deeplink
+
+import android.content.Intent.ACTION_VIEW
+import android.net.Uri
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class ShowUpNextTabDeepLinkTest {
+    private val context = InstrumentationRegistry.getInstrumentation().context
+
+    @Test
+    fun createIntent() {
+        val intent = ShowUpNextTabDeepLink.toIntent(context)
+
+        assertEquals(ACTION_VIEW, intent.action)
+        assertEquals(Uri.parse("pktc://upnext?location=tab"), intent.data)
+    }
+}

--- a/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
+++ b/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
@@ -74,7 +74,7 @@ import au.com.shiftyjelly.pocketcasts.deeplink.ShowFiltersDeepLink
 import au.com.shiftyjelly.pocketcasts.deeplink.ShowPodcastDeepLink
 import au.com.shiftyjelly.pocketcasts.deeplink.ShowPodcastFromUrlDeepLink
 import au.com.shiftyjelly.pocketcasts.deeplink.ShowPodcastsDeepLink
-import au.com.shiftyjelly.pocketcasts.deeplink.ShowUpNextDeepLink
+import au.com.shiftyjelly.pocketcasts.deeplink.ShowUpNextModalDeepLink
 import au.com.shiftyjelly.pocketcasts.deeplink.SignInDeepLink
 import au.com.shiftyjelly.pocketcasts.deeplink.SonosDeepLink
 import au.com.shiftyjelly.pocketcasts.deeplink.ThemesDeepLink
@@ -1010,7 +1010,7 @@ class MainActivity :
         settings.updateBottomInset(miniPlayerHeight)
 
         // Handle up next shortcut
-        if (intent.getStringExtra(EXTRA_PAGE) == ShowUpNextDeepLink.pageId) {
+        if (intent.getStringExtra(EXTRA_PAGE) == ShowUpNextModalDeepLink.pageId) {
             intent.removeExtra(EXTRA_PAGE)
             binding.playerBottomSheet.openPlayer()
             showUpNextFragment(UpNextSource.UP_NEXT_SHORTCUT)
@@ -1288,7 +1288,7 @@ class MainActivity :
                 is ShowDiscoverDeepLink -> {
                     openTab(VR.id.navigation_discover)
                 }
-                is ShowUpNextDeepLink -> {
+                is ShowUpNextModalDeepLink -> {
                     // Do nothig, handled in onMiniPlayerVisible()
                 }
                 is ShowFilterDeepLink -> {

--- a/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
+++ b/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
@@ -75,6 +75,7 @@ import au.com.shiftyjelly.pocketcasts.deeplink.ShowPodcastDeepLink
 import au.com.shiftyjelly.pocketcasts.deeplink.ShowPodcastFromUrlDeepLink
 import au.com.shiftyjelly.pocketcasts.deeplink.ShowPodcastsDeepLink
 import au.com.shiftyjelly.pocketcasts.deeplink.ShowUpNextModalDeepLink
+import au.com.shiftyjelly.pocketcasts.deeplink.ShowUpNextTabDeepLink
 import au.com.shiftyjelly.pocketcasts.deeplink.SignInDeepLink
 import au.com.shiftyjelly.pocketcasts.deeplink.SonosDeepLink
 import au.com.shiftyjelly.pocketcasts.deeplink.ThemesDeepLink
@@ -1290,6 +1291,10 @@ class MainActivity :
                 }
                 is ShowUpNextModalDeepLink -> {
                     // Do nothig, handled in onMiniPlayerVisible()
+                }
+                is ShowUpNextTabDeepLink -> {
+                    closePlayer()
+                    openTab(VR.id.navigation_upnext)
                 }
                 is ShowFilterDeepLink -> {
                     launch(Dispatchers.Default) {

--- a/modules/services/deeplink/src/main/kotlin/au/com/shiftyjelly/pocketcasts/deeplink/DeepLink.kt
+++ b/modules/services/deeplink/src/main/kotlin/au/com/shiftyjelly/pocketcasts/deeplink/DeepLink.kt
@@ -160,7 +160,7 @@ data object ShowDiscoverDeepLink : ShowPageDeepLink {
     override val pageId = "search"
 }
 
-data object ShowUpNextDeepLink : ShowPageDeepLink {
+data object ShowUpNextModalDeepLink : ShowPageDeepLink {
     override val pageId = "upnext"
 }
 

--- a/modules/services/deeplink/src/main/kotlin/au/com/shiftyjelly/pocketcasts/deeplink/DeepLink.kt
+++ b/modules/services/deeplink/src/main/kotlin/au/com/shiftyjelly/pocketcasts/deeplink/DeepLink.kt
@@ -178,6 +178,11 @@ data object ShowFiltersDeepLink : IntentableDeepLink {
         .setData(Uri.parse("pktc://filters"))
 }
 
+data object ShowUpNextTabDeepLink : IntentableDeepLink {
+    override fun toIntent(context: Context) = Intent(ACTION_VIEW)
+        .setData(Uri.parse("pktc://upnext?location=tab"))
+}
+
 data object PocketCastsWebsiteGetDeepLink : DeepLink
 
 data class ShowPodcastFromUrlDeepLink(

--- a/modules/services/deeplink/src/main/kotlin/au/com/shiftyjelly/pocketcasts/deeplink/DeepLinkFactory.kt
+++ b/modules/services/deeplink/src/main/kotlin/au/com/shiftyjelly/pocketcasts/deeplink/DeepLinkFactory.kt
@@ -175,7 +175,7 @@ private class ShowPageAdapter : DeepLinkAdapter {
         when (intent.getStringExtra(EXTRA_PAGE)) {
             "podcasts" -> ShowPodcastsDeepLink
             "search" -> ShowDiscoverDeepLink
-            "upnext" -> ShowUpNextDeepLink
+            "upnext" -> ShowUpNextModalDeepLink
             "playlist" -> ShowFilterDeepLink(filterId = intent.getLongExtra(EXTRA_FILTER_ID, -1))
             else -> null
         }

--- a/modules/services/deeplink/src/main/kotlin/au/com/shiftyjelly/pocketcasts/deeplink/DeepLinkFactory.kt
+++ b/modules/services/deeplink/src/main/kotlin/au/com/shiftyjelly/pocketcasts/deeplink/DeepLinkFactory.kt
@@ -44,6 +44,7 @@ class DeepLinkFactory(
         ShowEpisodeAdapter(),
         ShowPageAdapter(),
         ShowFiltersAdapter(),
+        UpNextAdapter(),
         PocketCastsWebsiteGetAdapter(webBaseHost),
         ReferralsAdapter(webBaseHost),
         PodloveAdapter(),
@@ -195,6 +196,20 @@ private class ShowFiltersAdapter : DeepLinkAdapter {
         } else {
             null
         }
+    }
+}
+
+private class UpNextAdapter : DeepLinkAdapter {
+    override fun create(intent: Intent): DeepLink? {
+        val uriData = intent.data ?: return null
+        val scheme = uriData.scheme
+        val host = uriData.host
+        val location = uriData.getQueryParameter("location")
+
+        if (intent.action == ACTION_VIEW && scheme == "pktc" && host == "upnext" && location == "tab") {
+            return ShowUpNextTabDeepLink
+        }
+        return null
     }
 }
 
@@ -541,7 +556,6 @@ private class OpmlAdapter(
             "settings",
             "subscribeonandroid.com",
             "www.subscribeonandroid.com",
-            "settings",
         )
     }
 }


### PR DESCRIPTION
## Description
- Supports the deep link for opening  upnext tab. This will be used for the new Up next notification that will be implemented in the next PRs: `pktc://upnext?location=tab`
- See document with deeplinks: p1743685755349989/1743684484.596599-slack-C08KX131YRJ

## Testing Instructions
Since we don't have the notifications implemented, we can test this in command line:

1. Install the app
2. In Android Studio terminal, run: `adb shell am start -a android.intent.action.VIEW -d "pktc://upnext?location=tab"`
3. Ensure Up next tab opens ✅

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.