### PR TITLE
Adds Greek locale support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 7.87
 -----
+*   New Features
+    *   Add Greek locale support
+        ([#3864](https://github.com/Automattic/pocket-casts-android/pull/3864))
 *   Bug Fixes
     *   Fix episode sometimes not updating their metadata.
         ([#3867](https://github.com/Automattic/pocket-casts-android/pull/3867))
@@ -8,7 +11,7 @@
 -----
 *   New Features
     *   Add Creator Funding Support
-        ([#3840](https://github.com/Automattic/pocket-casts-ios/pull/3840))
+        ([#3840](https://github.com/Automattic/pocket-casts-android/pull/3840))
 *   Bug Fixes
     *   Fix share transcript text when API less than 33.
         ([#3789](https://github.com/Automattic/pocket-casts-android/pull/3789))

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -39,6 +39,7 @@ SUPPORTED_LOCALES = [
   { glotpress: 'ar', android: 'ar', promo_config: {} },
   { glotpress: 'ca', android: 'ca', promo_config: {} },
   { glotpress: 'de', android: 'de', promo_config: {} },
+  { glotpress: 'el', android: 'el', promo_config: {} },
   { glotpress: 'es', android: 'es', promo_config: {} },
   { glotpress: 'es', android: 'es-rMX', promo_config: {} },
   { glotpress: 'en-gb', android: 'en-rGB', promo_config: {} },

--- a/modules/services/localization/src/main/res/values-el/strings.xml
+++ b/modules/services/localization/src/main/res/values-el/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<resources>
+    <string name="settings_title_playback">Γενικά</string>
+</resources>


### PR DESCRIPTION
## Description

The Greek [GlotPress translations](https://translate.wordpress.com/projects/pocket-casts/android/) are at 99%. I believe this is the method for including a locale in the regular release process to include the translations. Please let me know if I have missed anything.

Fixes https://github.com/Automattic/pocket-casts-android/issues/3851

## Testing Instructions

I have added one translation manually to test the strings file works.

1. Go to the Profile tab -> settings cog
2. ✅  Verify the General section title is translated

## Screenshots 

| | |
| --- | --- |
| ![Screenshot_20250409_153858](https://github.com/user-attachments/assets/7d84ae15-51f7-4b22-8dde-e824b8cfb2cc) | ![Screenshot_20250409_154018](https://github.com/user-attachments/assets/0c4a13f0-1c30-4b67-847f-ef4e9c266e5f) | 

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack
