### PR TITLE
Add free account banner to profile page

### DIFF
--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/ProfileFragment.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/ProfileFragment.kt
@@ -57,6 +57,7 @@ class ProfileFragment : BaseFragment(), TopScrollable {
             isSendReferralsEnabled = FeatureFlag.isEnabled(Feature.REFERRALS_SEND),
             isPlaybackEnabled = profileViewModel.isPlaybackAvailable.collectAsState().value,
             isClaimReferralsEnabled = FeatureFlag.isEnabled(Feature.REFERRALS_CLAIM),
+            isFreeAccountBannerVisible = profileViewModel.isFreeAccountBannerVisible.collectAsState().value,
             isUpgradeBannerVisible = profileViewModel.showUpgradeBanner.collectAsState(false).value,
             miniPlayerPadding = profileViewModel.miniPlayerInset.collectAsState().value.pxToDp(requireContext()).dp,
             headerState = profileViewModel.profileHeaderState.collectAsState().value,
@@ -98,6 +99,15 @@ class ProfileFragment : BaseFragment(), TopScrollable {
                 } else {
                     OnboardingLauncher.openOnboardingFlow(requireActivity(), OnboardingFlow.LoggedOut)
                 }
+            },
+            onCreateFreeAccountBannerClick = {
+                OnboardingLauncher.openOnboardingFlow(
+                    activity = requireActivity(),
+                    onboardingFlow = OnboardingFlow.Upsell(OnboardingUpgradeSource.PROFILE),
+                )
+            },
+            onDismissCreateFreeAccountBannerClick = {
+                profileViewModel.dismissFreeAccountBanner()
             },
             onPlaybackClick = {
                 profileViewModel.onPlaybackClick()

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/ProfileFragment.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/ProfileFragment.kt
@@ -103,7 +103,7 @@ class ProfileFragment : BaseFragment(), TopScrollable {
             onCreateFreeAccountBannerClick = {
                 OnboardingLauncher.openOnboardingFlow(
                     activity = requireActivity(),
-                    onboardingFlow = OnboardingFlow.Upsell(OnboardingUpgradeSource.PROFILE),
+                    onboardingFlow = OnboardingFlow.LoggedOut,
                 )
             },
             onDismissCreateFreeAccountBannerClick = {

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/ProfilePage.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/ProfilePage.kt
@@ -38,6 +38,7 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import au.com.shiftyjelly.pocketcasts.compose.AppTheme
 import au.com.shiftyjelly.pocketcasts.compose.OrientationPreview
+import au.com.shiftyjelly.pocketcasts.compose.components.Banner
 import au.com.shiftyjelly.pocketcasts.compose.components.HorizontalDivider
 import au.com.shiftyjelly.pocketcasts.compose.preview.ThemePreviewParameterProvider
 import au.com.shiftyjelly.pocketcasts.compose.theme
@@ -53,6 +54,8 @@ import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import java.util.Date
 import kotlin.time.Duration.Companion.hours
 import kotlin.time.Duration.Companion.minutes
+import au.com.shiftyjelly.pocketcasts.images.R as IR
+import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 @Composable
 internal fun ProfilePage(
@@ -63,6 +66,8 @@ internal fun ProfilePage(
     onReferralsTooltipShown: () -> Unit,
     onSettingsClick: () -> Unit,
     onHeaderClick: () -> Unit,
+    onCreateFreeAccountBannerClick: () -> Unit,
+    onDismissCreateFreeAccountBannerClick: () -> Unit,
     onPlaybackClick: () -> Unit,
     onClaimReferralsClick: () -> Unit,
     onHideReferralsCardClick: () -> Unit,
@@ -105,6 +110,24 @@ internal fun ProfilePage(
                 )
                 item {
                     VerticalSpacer()
+                }
+                if (state.isFreeAccountBannerVisible) {
+                    item {
+                        Banner(
+                            title = stringResource(LR.string.encourage_account_sync_banner_title),
+                            description = stringResource(LR.string.encourage_account_sync_banner_description),
+                            actionLabel = stringResource(LR.string.encourage_account_banner_action_label),
+                            icon = painterResource(IR.drawable.ic_heart_2),
+                            onActionClick = onCreateFreeAccountBannerClick,
+                            onDismiss = onDismissCreateFreeAccountBannerClick,
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(horizontal = horizontalPadding),
+                        )
+                    }
+                    item {
+                        VerticalSpacer()
+                    }
                 }
                 if (state.isPlaybackEnabled) {
                     item {
@@ -192,6 +215,7 @@ internal data class ProfilePageState(
     val isSendReferralsEnabled: Boolean,
     val isPlaybackEnabled: Boolean,
     val isClaimReferralsEnabled: Boolean,
+    val isFreeAccountBannerVisible: Boolean,
     val isUpgradeBannerVisible: Boolean,
     val miniPlayerPadding: Dp,
     val headerState: ProfileHeaderState,
@@ -346,6 +370,7 @@ private fun ProfilePageStub(
             isPlaybackEnabled = true,
             isClaimReferralsEnabled = true,
             isUpgradeBannerVisible = true,
+            isFreeAccountBannerVisible = true,
             miniPlayerPadding = 64.dp,
             headerState = ProfileHeaderState(
                 email = "noreply@pocketcasts.com",
@@ -373,6 +398,8 @@ private fun ProfilePageStub(
         onReferralsTooltipShown = {},
         onSettingsClick = {},
         onHeaderClick = {},
+        onCreateFreeAccountBannerClick = {},
+        onDismissCreateFreeAccountBannerClick = {},
         onPlaybackClick = {},
         onSendReferralsClick = {},
         onHideReferralsCardClick = {},

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/ProfileViewModel.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/ProfileViewModel.kt
@@ -14,6 +14,8 @@ import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
 import au.com.shiftyjelly.pocketcasts.repositories.user.StatsManager
 import au.com.shiftyjelly.pocketcasts.repositories.user.UserManager
 import au.com.shiftyjelly.pocketcasts.utils.Gravatar
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
 import au.com.shiftyjelly.pocketcasts.utils.toDurationFromNow
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
@@ -110,6 +112,17 @@ class ProfileViewModel @Inject constructor(
         initialValue = false,
     )
 
+    internal val isFreeAccountBannerVisible = combine(
+        signInState.map { it.isSignedIn },
+        settings.isFreeAccountProfileBannerDismissed.flow,
+    ) { isSignedIn, isBannerDismissed ->
+        !isSignedIn && !isBannerDismissed && FeatureFlag.isEnabled(Feature.ENCOURAGE_ACCOUNT_CREATION)
+    }.stateIn(
+        scope = viewModelScope,
+        started = SharingStarted.Eagerly,
+        initialValue = false,
+    )
+
     internal val refreshState = settings.refreshStateObservable.asFlow().stateIn(
         scope = viewModelScope,
         started = SharingStarted.Eagerly,
@@ -182,5 +195,9 @@ class ProfileViewModel @Inject constructor(
     internal fun closeUpgradeProfile(source: SourceView) {
         tracker.track(AnalyticsEvent.UPGRADE_BANNER_DISMISSED, mapOf("source" to source.analyticsValue))
         settings.upgradeProfileClosed.set(true, updateModifiedAt = false)
+    }
+
+    internal fun dismissFreeAccountBanner() {
+        settings.isFreeAccountProfileBannerDismissed.set(true, updateModifiedAt = true)
     }
 }

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/Banner.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/Banner.kt
@@ -139,7 +139,7 @@ fun Banner(
                         interactionSource = null,
                     )
                     .semantics { contentDescription = dismissText },
-                )
+            )
         }
     }
 }

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/Banner.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/Banner.kt
@@ -1,0 +1,153 @@
+package au.com.shiftyjelly.pocketcasts.compose.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.ExperimentalMaterialApi
+import androidx.compose.material.Icon
+import androidx.compose.material.LocalRippleConfiguration
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.RippleConfiguration
+import androidx.compose.material.ripple
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.painter.Painter
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewParameter
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import au.com.shiftyjelly.pocketcasts.compose.AppTheme
+import au.com.shiftyjelly.pocketcasts.compose.preview.ThemePreviewParameterProvider
+import au.com.shiftyjelly.pocketcasts.compose.theme
+import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
+import au.com.shiftyjelly.pocketcasts.images.R as IR
+
+@OptIn(ExperimentalMaterialApi::class)
+@Composable
+fun Banner(
+    title: String,
+    description: String,
+    actionLabel: String,
+    icon: Painter,
+    onActionClick: () -> Unit,
+    onDismiss: () -> Unit,
+    modifier: Modifier = Modifier,
+    backgroundColor: Color = MaterialTheme.theme.colors.primaryUi02Active,
+    titleColor: Color = MaterialTheme.theme.colors.primaryText01,
+    descriptionColor: Color = MaterialTheme.theme.colors.primaryText02,
+    actionLabelColor: Color = MaterialTheme.theme.colors.primaryInteractive01,
+    iconTint: Color = MaterialTheme.theme.colors.primaryText01,
+) {
+    Box(
+        modifier = modifier
+            .background(backgroundColor, RoundedCornerShape(8.dp))
+            .padding(start = 16.dp, end = 16.dp, top = 20.dp, bottom = 14.dp),
+    ) {
+        Row(
+            modifier = Modifier,
+        ) {
+            Icon(
+                painter = icon,
+                contentDescription = null,
+                tint = iconTint,
+                modifier = Modifier.size(24.dp),
+            )
+
+            Spacer(
+                modifier = Modifier.width(12.dp),
+            )
+
+            Column(
+                modifier = Modifier.weight(1f),
+            ) {
+                TextH40(
+                    text = title,
+                    color = titleColor,
+                )
+                Spacer(
+                    modifier = Modifier.height(4.dp),
+                )
+                TextP50(
+                    text = description,
+                    lineHeight = 16.sp,
+                    color = descriptionColor,
+                )
+
+                CompositionLocalProvider(
+                    LocalRippleConfiguration provides RippleConfiguration(color = actionLabelColor),
+                ) {
+                    TextH50(
+                        text = actionLabel,
+                        color = actionLabelColor,
+                        modifier = Modifier
+                            .offset(x = -6.dp)
+                            .clip(RoundedCornerShape(4.dp))
+                            .clickable(onClick = onActionClick)
+                            .padding(6.dp),
+                    )
+                }
+            }
+
+            Spacer(
+                modifier = Modifier.width(16.dp),
+            )
+
+            Icon(
+                painter = painterResource(IR.drawable.ic_close),
+                contentDescription = null,
+                tint = iconTint,
+                modifier = Modifier.size(24.dp),
+            )
+        }
+
+        CompositionLocalProvider(
+            LocalRippleConfiguration provides RippleConfiguration(color = iconTint),
+        ) {
+            Box(
+                modifier = Modifier
+                    .offset(x = 12.dp, y = -12.dp)
+                    .align(Alignment.TopEnd)
+                    .size(48.dp)
+                    .clickable(
+                        onClick = onDismiss,
+                        indication = dismissRipple,
+                        interactionSource = null,
+                    ),
+
+            )
+        }
+    }
+}
+
+private val dismissRipple = ripple(radius = 24.dp)
+
+@Preview
+@Composable
+private fun BannerPreview(
+    @PreviewParameter(ThemePreviewParameterProvider::class) themeType: Theme.ThemeType,
+) {
+    AppTheme(themeType) {
+        Banner(
+            title = "Your shows, on any device",
+            description = "Create a free account to sync your shows and listen anywhere.",
+            actionLabel = "Create a free account",
+            icon = painterResource(IR.drawable.ic_heart_2),
+            onActionClick = {},
+            onDismiss = {},
+        )
+    }
+}

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/Banner.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/Banner.kt
@@ -26,6 +26,11 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.role
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.dp
@@ -35,6 +40,7 @@ import au.com.shiftyjelly.pocketcasts.compose.preview.ThemePreviewParameterProvi
 import au.com.shiftyjelly.pocketcasts.compose.theme
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import au.com.shiftyjelly.pocketcasts.images.R as IR
+import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 @OptIn(ExperimentalMaterialApi::class)
 @Composable
@@ -96,7 +102,10 @@ fun Banner(
                         modifier = Modifier
                             .offset(x = -6.dp)
                             .clip(RoundedCornerShape(4.dp))
-                            .clickable(onClick = onActionClick)
+                            .clickable(
+                                onClick = onActionClick,
+                                role = Role.Button,
+                            )
                             .padding(6.dp),
                     )
                 }
@@ -117,6 +126,7 @@ fun Banner(
         CompositionLocalProvider(
             LocalRippleConfiguration provides RippleConfiguration(color = iconTint),
         ) {
+            val dismissText = stringResource(LR.string.dismiss)
             Box(
                 modifier = Modifier
                     .offset(x = 12.dp, y = -12.dp)
@@ -124,11 +134,12 @@ fun Banner(
                     .size(48.dp)
                     .clickable(
                         onClick = onDismiss,
+                        role = Role.Button,
                         indication = dismissRipple,
                         interactionSource = null,
-                    ),
-
-            )
+                    )
+                    .semantics { contentDescription = dismissText },
+                )
         }
     }
 }

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -36,6 +36,7 @@
     <string name="close">Close</string>
     <string name="create_account">Create account</string>
     <string name="delete">Delete</string>
+    <string name="dismiss">Dismiss</string>
     <string name="donate">Donate</string>
     <string name="done">Done</string>
     <string name="download">Download</string>

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -2326,4 +2326,13 @@
     <string name="up_next_history_restore_button">@string/restore</string>
     <string name="up_next_history_restore_confirmation_title">Restore Up Next?</string>
     <string name="up_next_history_restore_confirmation_description">These episodes will be added to the bottom of your current Up Next.</string>
+
+    <!-- Encourage account creation -->
+    <string name="encourage_account_banner_action_label">Create a free account</string>
+    <string name="encourage_account_sync_banner_title">Your shows, on any device</string>
+    <string name="encourage_account_sync_banner_description">Create a free account to sync your shows and listen anywhere.</string>
+    <string name="encourage_account_filters_banner_title">Keep your filters in sync</string>
+    <string name="encourage_account_filters_banner_description">Create a free account to sync your filters on any device.</string>
+    <string name="encourage_account_history_banner_title">Keep track of what you’ve played</string>
+    <string name="encourage_account_history_banner_description">Create a free account to sync your listening history everywhere.</string>
 </resources>

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
@@ -578,4 +578,6 @@ interface Settings {
     val suggestedFoldersFollowedHash: UserSetting<String>
 
     val isTrackingConsentRequired: UserSetting<Boolean>
+
+    val isFreeAccountProfileBannerDismissed: UserSetting<Boolean>
 }

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
@@ -1616,4 +1616,10 @@ class SettingsImpl @Inject constructor(
         defaultValue = true,
         sharedPrefs = sharedPreferences,
     )
+
+    override val isFreeAccountProfileBannerDismissed = UserSetting.BoolPref(
+        sharedPrefKey = "free_account_banner_dismissed_profile",
+        defaultValue = false,
+        sharedPrefs = sharedPreferences,
+    )
 }


### PR DESCRIPTION
## Description

This PR adds free account banner to the profile tab.

Designs: SzmGxNTLiuwUr2IecE3m07-fi-416_17546

## Testing Instructions

1. Install the app.
2. Go to the profile page.
3. Notice the banner.
4. Tap on the CTA.
5. Sign in or sign up.
6. Go back to the profile.
7. The banner should no longer be there.
8. Sign out.
9. Got back to the profile.
10. The banner should be visible.
11. Go to the beta settings and disable the account creation FF.
12. Restart the app.
13. Go to the profile.
14. The banner should not be there.
15. Go to the beta settings and enable the feature flag.
16. Restart the app.
17. Go to the profile.
18. Dismiss the banner.
19. The banner should not be visible.
20. Restart the app.
21. Go to the profile.
22. The banner should not be visible.

## Screenshots or Screencast 

![Screenshot_20250410-104209](https://github.com/user-attachments/assets/bf9c1540-37c6-48d3-9054-6562252c2bd8)

## Checklist
- [ ] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] ~I have considered whether it makes sense to add tests for my changes~
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [ ] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack