### PR TITLE
[Push Notifications Revamp] Support deeplink for Staff Picks

### DIFF
--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/deeplink/DeepLinkFactoryTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/deeplink/DeepLinkFactoryTest.kt
@@ -595,6 +595,17 @@ class DeepLinkFactoryTest {
     }
 
     @Test
+    fun staffPicks() {
+        val intent = Intent()
+            .setAction(ACTION_VIEW)
+            .setData(Uri.parse("pktc://discover/staffpicks"))
+
+        val deepLink = factory.create(intent)
+
+        assertEquals(StaffPicksDeepLink, deepLink)
+    }
+
+    @Test
     fun nativeShare() {
         val intent = Intent()
             .setAction(ACTION_VIEW)

--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/deeplink/StaffPicksDeepLinkTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/deeplink/StaffPicksDeepLinkTest.kt
@@ -1,0 +1,22 @@
+package au.com.shiftyjelly.pocketcasts.deeplink
+
+import android.content.Intent.ACTION_VIEW
+import android.net.Uri
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class StaffPicksDeepLinkTest {
+    private val context = InstrumentationRegistry.getInstrumentation().context
+
+    @Test
+    fun createIntent() {
+        val intent = StaffPicksDeepLink.toIntent(context)
+
+        assertEquals(ACTION_VIEW, intent.action)
+        assertEquals(Uri.parse("pktc://discover/staffpicks"), intent.data)
+    }
+}

--- a/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
+++ b/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
@@ -82,7 +82,10 @@ import au.com.shiftyjelly.pocketcasts.deeplink.StaffPicksDeepLink
 import au.com.shiftyjelly.pocketcasts.deeplink.ThemesDeepLink
 import au.com.shiftyjelly.pocketcasts.deeplink.UpgradeAccountDeepLink
 import au.com.shiftyjelly.pocketcasts.deeplink.UpsellDeepLink
+import au.com.shiftyjelly.pocketcasts.discover.util.DiscoverDeepLinkManager
+import au.com.shiftyjelly.pocketcasts.discover.util.DiscoverDeepLinkManager.Companion.STAFF_PICKS_LIST_ID
 import au.com.shiftyjelly.pocketcasts.discover.view.DiscoverFragment
+import au.com.shiftyjelly.pocketcasts.discover.view.PodcastListFragment
 import au.com.shiftyjelly.pocketcasts.endofyear.StoriesActivity
 import au.com.shiftyjelly.pocketcasts.endofyear.StoriesActivity.StoriesSource
 import au.com.shiftyjelly.pocketcasts.endofyear.ui.EndOfYearLaunchBottomSheet
@@ -245,6 +248,8 @@ class MainActivity :
     @Inject lateinit var watchSync: WatchSync
 
     @Inject lateinit var notificationHelper: NotificationHelper
+
+    @Inject lateinit var discoverDeepLinkManager: DiscoverDeepLinkManager
 
     @Inject @ApplicationScope
     lateinit var applicationScope: CoroutineScope
@@ -1354,8 +1359,15 @@ class MainActivity :
                     openImport()
                 }
                 is StaffPicksDeepLink -> {
-                    closeToRoot()
-                    openTab(VR.id.navigation_discover)
+                    val podcastListFragment = supportFragmentManager.fragments.find { it is PodcastListFragment } as? PodcastListFragment
+                    if (podcastListFragment?.listUuid != STAFF_PICKS_LIST_ID) {
+                        openTab(VR.id.navigation_discover)
+                        lifecycleScope.launch {
+                            val staffPicksList = discoverDeepLinkManager.getDiscoverList(STAFF_PICKS_LIST_ID, resources) ?: return@launch
+                            val fragment = PodcastListFragment.newInstance(staffPicksList)
+                            addFragment(fragment)
+                        }
+                    }
                 }
                 is PlayFromSearchDeepLink -> {
                     playbackManager.mediaSessionManager.playFromSearchExternal(deepLink.query)

--- a/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
+++ b/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
@@ -78,6 +78,7 @@ import au.com.shiftyjelly.pocketcasts.deeplink.ShowUpNextModalDeepLink
 import au.com.shiftyjelly.pocketcasts.deeplink.ShowUpNextTabDeepLink
 import au.com.shiftyjelly.pocketcasts.deeplink.SignInDeepLink
 import au.com.shiftyjelly.pocketcasts.deeplink.SonosDeepLink
+import au.com.shiftyjelly.pocketcasts.deeplink.StaffPicksDeepLink
 import au.com.shiftyjelly.pocketcasts.deeplink.ThemesDeepLink
 import au.com.shiftyjelly.pocketcasts.deeplink.UpgradeAccountDeepLink
 import au.com.shiftyjelly.pocketcasts.deeplink.UpsellDeepLink
@@ -1351,6 +1352,10 @@ class MainActivity :
                 }
                 is ImportDeepLink -> {
                     openImport()
+                }
+                is StaffPicksDeepLink -> {
+                    closeToRoot()
+                    openTab(VR.id.navigation_discover)
                 }
                 is PlayFromSearchDeepLink -> {
                     playbackManager.mediaSessionManager.playFromSearchExternal(deepLink.query)

--- a/modules/features/discover/build.gradle.kts
+++ b/modules/features/discover/build.gradle.kts
@@ -65,4 +65,6 @@ dependencies {
     testImplementation(libs.okhttp)
     testImplementation(libs.retrofit)
     testImplementation(libs.retrofit.moshi)
+    testImplementation(libs.mockito.kotlin)
+    testImplementation(projects.modules.services.sharedtest)
 }

--- a/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/util/DiscoverDeepLinkManager.kt
+++ b/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/util/DiscoverDeepLinkManager.kt
@@ -1,0 +1,37 @@
+package au.com.shiftyjelly.pocketcasts.discover.util
+
+import android.content.res.Resources
+import au.com.shiftyjelly.pocketcasts.preferences.Settings
+import au.com.shiftyjelly.pocketcasts.servers.model.Discover
+import au.com.shiftyjelly.pocketcasts.servers.model.DiscoverRow
+import au.com.shiftyjelly.pocketcasts.servers.model.NetworkLoadableList
+import au.com.shiftyjelly.pocketcasts.servers.model.transformWithRegion
+import au.com.shiftyjelly.pocketcasts.servers.server.ListRepository
+import javax.inject.Inject
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+class DiscoverDeepLinkManager @Inject constructor(
+    private val repository: ListRepository,
+    private val settings: Settings,
+) {
+    companion object {
+        const val STAFF_PICKS_LIST_ID = "staff-picks"
+    }
+
+    suspend fun getDiscoverList(listId: String, resources: Resources): NetworkLoadableList? = withContext(Dispatchers.IO) {
+        val discover: Discover = repository.getDiscoverFeedSuspend()
+        val currentRegionCode: String = settings.discoverCountryCode.value
+        val defaultRegion: String = discover.defaultRegionCode
+        val region = discover.regions[currentRegionCode] ?: discover.regions[defaultRegion] ?: return@withContext null
+
+        val replacements: Map<String, String> = mapOf(
+            discover.regionCodeToken to region.code,
+            discover.regionNameToken to region.name,
+        )
+
+        val discoverRows: List<DiscoverRow> = discover.layout.transformWithRegion(region, replacements, resources)
+        val staffPicksRow: DiscoverRow? = discoverRows.firstOrNull { it.listUuid == listId }
+        staffPicksRow?.transformWithReplacements(replacements, resources)
+    }
+}

--- a/modules/features/discover/src/test/kotlin/au/com/shiftyjelly/pocketcasts/discover/util/DiscoverDeepLinkManagerTest.kt
+++ b/modules/features/discover/src/test/kotlin/au/com/shiftyjelly/pocketcasts/discover/util/DiscoverDeepLinkManagerTest.kt
@@ -1,0 +1,145 @@
+package au.com.shiftyjelly.pocketcasts.discover.util
+
+import android.content.res.Resources
+import au.com.shiftyjelly.pocketcasts.preferences.Settings
+import au.com.shiftyjelly.pocketcasts.preferences.UserSetting
+import au.com.shiftyjelly.pocketcasts.servers.model.Discover
+import au.com.shiftyjelly.pocketcasts.servers.model.DiscoverRegion
+import au.com.shiftyjelly.pocketcasts.servers.model.DiscoverRow
+import au.com.shiftyjelly.pocketcasts.servers.model.DisplayStyle
+import au.com.shiftyjelly.pocketcasts.servers.model.ExpandedStyle
+import au.com.shiftyjelly.pocketcasts.servers.model.ListType
+import au.com.shiftyjelly.pocketcasts.servers.model.SponsoredPodcast
+import au.com.shiftyjelly.pocketcasts.servers.server.ListRepository
+import au.com.shiftyjelly.pocketcasts.sharedtest.MainCoroutineRule
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.Mock
+import org.mockito.MockitoAnnotations
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+
+@ExperimentalCoroutinesApi
+class DiscoverDeepLinkManagerTest {
+
+    @get:Rule
+    val coroutineRule = MainCoroutineRule()
+
+    @Mock
+    private lateinit var mockRepository: ListRepository
+
+    @Mock
+    private lateinit var mockSettings: Settings
+
+    @Mock
+    private lateinit var mockResources: Resources
+
+    private lateinit var manager: DiscoverDeepLinkManager
+
+    @Before
+    fun setUp() {
+        MockitoAnnotations.openMocks(this)
+        manager = DiscoverDeepLinkManager(mockRepository, mockSettings)
+    }
+
+    @Test
+    fun `loadStaffPicks should return transformed staff picks row`() = runTest {
+        val staffPicksRow = createDiscoverRow(
+            listUuid = "staff-picks",
+            title = "Popular in {region_name}",
+            source = "source_{region_code}",
+            expandedTopItemLabel = "Top in {region_name}",
+        )
+        val discover = createTestDiscover(layout = listOf(staffPicksRow))
+
+        whenever(mockRepository.getDiscoverFeedSuspend()).thenReturn(discover)
+
+        val discoverCountryCodeMock: UserSetting<String> = mock()
+        whenever(discoverCountryCodeMock.flow).thenReturn(MutableStateFlow("US"))
+        whenever(mockSettings.discoverCountryCode).thenReturn(discoverCountryCodeMock)
+
+        whenever(mockResources.getString(any())).thenAnswer { it.arguments[0].toString() }
+
+        val result = manager.getDiscoverList("staff-picks", mockResources)
+
+        assert(result != null)
+        assert(result?.listUuid == "staff-picks")
+    }
+
+    @Test
+    fun `loadStaffPicks should return null when region not in row regions`() = runTest {
+        val row = createDiscoverRow(
+            listUuid = "staff-picks",
+            regions = listOf("JP"),
+        )
+        val discover = createTestDiscover(layout = listOf(row))
+
+        whenever(mockRepository.getDiscoverFeedSuspend()).thenReturn(discover)
+
+        val discoverCountryCodeMock: UserSetting<String> = mock()
+        whenever(discoverCountryCodeMock.flow).thenReturn(MutableStateFlow("US"))
+        whenever(mockSettings.discoverCountryCode).thenReturn(discoverCountryCodeMock)
+
+        val result = manager.getDiscoverList("staff-picks", mockResources)
+
+        assert(result == null)
+    }
+
+    private fun createTestDiscover(
+        layout: List<DiscoverRow> = listOf(createDiscoverRow(listUuid = "staff-picks")),
+        regions: Map<String, DiscoverRegion> = mapOf(
+            "US" to DiscoverRegion("United States", "US-flag", "US"),
+            "UK" to DiscoverRegion("United Kingdom", "UK-flag", "UK"),
+        ),
+        regionCodeToken: String = "{region_code}",
+        regionNameToken: String = "{region_name}",
+        defaultRegionCode: String = "US",
+    ): Discover {
+        return Discover(
+            layout = layout,
+            regions = regions,
+            regionCodeToken = regionCodeToken,
+            regionNameToken = regionNameToken,
+            defaultRegionCode = defaultRegionCode,
+        )
+    }
+
+    private fun createDiscoverRow(
+        id: String? = null,
+        type: ListType = ListType.PodcastList,
+        displayStyle: DisplayStyle = DisplayStyle.SmallList(),
+        expandedStyle: ExpandedStyle = ExpandedStyle.GridList(),
+        expandedTopItemLabel: String? = null,
+        title: String = "Title",
+        source: String = "Source",
+        listUuid: String? = "staff-picks",
+        categoryId: Int? = null,
+        regions: List<String> = listOf("US", "UK"),
+        sponsored: Boolean = false,
+        curated: Boolean = false,
+        sponsoredPodcasts: List<SponsoredPodcast> = emptyList(),
+        mostPopularCategoriesId: List<Int>? = null,
+    ): DiscoverRow {
+        return DiscoverRow(
+            id = id,
+            type = type,
+            displayStyle = displayStyle,
+            expandedStyle = expandedStyle,
+            expandedTopItemLabel = expandedTopItemLabel,
+            title = title,
+            source = source,
+            listUuid = listUuid,
+            categoryId = categoryId,
+            regions = regions,
+            sponsored = sponsored,
+            curated = curated,
+            sponsoredPodcasts = sponsoredPodcasts,
+            mostPopularCategoriesId = mostPopularCategoriesId,
+        )
+    }
+}

--- a/modules/services/deeplink/src/main/kotlin/au/com/shiftyjelly/pocketcasts/deeplink/DeepLink.kt
+++ b/modules/services/deeplink/src/main/kotlin/au/com/shiftyjelly/pocketcasts/deeplink/DeepLink.kt
@@ -245,6 +245,11 @@ data object ImportDeepLink : IntentableDeepLink {
         .setData(Uri.parse("pktc://settings/import"))
 }
 
+data object StaffPicksDeepLink : IntentableDeepLink {
+    override fun toIntent(context: Context) = Intent(ACTION_VIEW)
+        .setData(Uri.parse("pktc://discover/staffpicks"))
+}
+
 data class PlayFromSearchDeepLink(
     val query: String,
 ) : DeepLink

--- a/modules/services/deeplink/src/main/kotlin/au/com/shiftyjelly/pocketcasts/deeplink/DeepLinkFactory.kt
+++ b/modules/services/deeplink/src/main/kotlin/au/com/shiftyjelly/pocketcasts/deeplink/DeepLinkFactory.kt
@@ -63,6 +63,7 @@ class DeepLinkFactory(
         WebPlayerShareLinkAdapter(webPlayerHost),
         OpmlAdapter(listOf(listHost, shareHost)),
         ImportAdapter(),
+        StaffPicksAdapter(),
         PodcastUrlSchemeAdapter(listOf(listHost, shareHost, webBaseHost)),
         PlayFromSearchAdapter(),
         AssistantAdapter(),
@@ -434,6 +435,7 @@ private class ShareLinkNativeAdapter : DeepLinkAdapter {
             "upgrade",
             "redeem",
             "settings",
+            "discover",
         )
     }
 }
@@ -556,6 +558,7 @@ private class OpmlAdapter(
             "settings",
             "subscribeonandroid.com",
             "www.subscribeonandroid.com",
+            "discover",
         )
     }
 }
@@ -569,6 +572,21 @@ private class ImportAdapter : DeepLinkAdapter {
 
         return if (intent.action == ACTION_VIEW && scheme == "pktc" && host == "settings" && path == "/import") {
             ImportDeepLink
+        } else {
+            null
+        }
+    }
+}
+
+private class StaffPicksAdapter : DeepLinkAdapter {
+    override fun create(intent: Intent): DeepLink? {
+        val uriData = intent.data ?: return null
+        val scheme = uriData.scheme
+        val host = uriData.host
+        val path = uriData.path
+
+        return if (intent.action == ACTION_VIEW && scheme == "pktc" && host == "discover" && path == "/staffpicks") {
+            StaffPicksDeepLink
         } else {
             null
         }


### PR DESCRIPTION
## Description
- Supports the deep link for opening discover stuff picks. This will be used for the new Stuff Picks notification that will be implemented in the next PRs: `pktc://discover/staffpicks`
- See document with deeplinks: p1743685755349989/1743684484.596599-slack-C08KX131YRJ

## Testing Instructions
Since we don't have the notifications implemented, we can test this in command line:

1. Install the app
2. In Android Studio terminal, run: `adb shell am start -a android.intent.action.VIEW -d "pktc://discover/staffpicks"`
3. Ensure Stuff Picks screen ✅


## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.