### PR TITLE
Track app install event after consent

### DIFF
--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/OnboardingLoginOrSignUpViewModel.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/OnboardingLoginOrSignUpViewModel.kt
@@ -6,6 +6,7 @@ import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTracker
+import au.com.shiftyjelly.pocketcasts.analytics.AppsFlyerAnalyticsTracker
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
@@ -28,6 +29,7 @@ class OnboardingLoginOrSignUpViewModel @Inject constructor(
     @ApplicationContext context: Context,
     private val podcastManager: PodcastManager,
     private val userAnalyticsSettings: UserAnalyticsSettings,
+    private val appsFlyerAnalyticsTracker: AppsFlyerAnalyticsTracker,
     settings: Settings,
 ) : AndroidViewModel(context as Application) {
 
@@ -82,6 +84,10 @@ class OnboardingLoginOrSignUpViewModel @Inject constructor(
 
     fun updateTrackingConsent(consent: Boolean) {
         userAnalyticsSettings.updateAnalyticsThirdPartySetting(consent)
+        // As we need consent to be set before we start tracking, we need to track the install event here
+        if (consent) {
+            appsFlyerAnalyticsTracker.track(AnalyticsEvent.APPLICATION_INSTALLED)
+        }
     }
 
     companion object {

--- a/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AppsFlyerAnalyticsTracker.kt
+++ b/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AppsFlyerAnalyticsTracker.kt
@@ -17,6 +17,8 @@ class AppsFlyerAnalyticsTracker @Inject constructor(
     companion object {
         private const val ANON_ID = "anon_id_apps_flyer_anon_id"
         private val EVENTS = listOf(
+            AnalyticsEvent.APPLICATION_INSTALLED,
+            AnalyticsEvent.APPLICATION_OPENED,
             AnalyticsEvent.USER_SIGNED_IN,
             AnalyticsEvent.USER_ACCOUNT_CREATED,
             AnalyticsEvent.SSO_STARTED,


### PR DESCRIPTION
## Description

Internal discussion: p1744280693940599-slack-C08HG81SZGV   

We want to track the application install event. As it's sent before the consent we need to send it to AppsFlyer after the consent has been given. 

## Testing Instructions
1. Fresh install the app
2. Tap Allow when asked for consent
3. ✅ Verify in logcat that the event 'application_installed' is sent by filtering for the event name.

```
AppsFlyer analytic event: application_installed properties: {}
[General] ******* sendTrackingWithEvent: application_installed
```

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
