### PR TITLE
Fix create filter crash

### DIFF
--- a/app/src/test/java/au/com/shiftyjelly/pocketcasts/filters/FiltersFragmentViewModelTest.kt
+++ b/app/src/test/java/au/com/shiftyjelly/pocketcasts/filters/FiltersFragmentViewModelTest.kt
@@ -37,34 +37,44 @@ class FiltersFragmentViewModelTest {
 
     @Test
     fun `should show tooltip`() = runTest {
-        val result = viewModel.shouldShowTooltip(defaultFilters)
-
-        assertEquals(true, result)
+        var showTooltip = false
+        viewModel.shouldShowTooltipSuspend(defaultFilters) {
+            showTooltip = true
+        }
+        assertEquals(true, showTooltip)
     }
 
     @Test
     fun `should not show tooltip if setting is disabled`() = runTest {
         val viewModel = initViewModel(tooltipValue = false)
 
-        val result = viewModel.shouldShowTooltip(emptyList())
-
-        assertEquals(false, result)
+        var showTooltip = false
+        viewModel.shouldShowTooltip(emptyList()) {
+            showTooltip = true
+        }
+        assertEquals(false, showTooltip)
     }
 
     @Test
     fun `should not show tooltip if created custom filter`() = runTest {
-        val result = viewModel.shouldShowTooltip(defaultFilters + listOf(Playlist(id = 3, uuid = "custom")))
+        var showTooltip = false
+        viewModel.shouldShowTooltip(defaultFilters + listOf(Playlist(id = 3, uuid = "custom"))) {
+            showTooltip = true
+        }
 
-        assertEquals(false, result)
+        assertEquals(false, showTooltip)
     }
 
     @Test
     fun `should return false when at least one playlist has episodes`() = runTest {
         val viewModel = initViewModel(tooltipValue = false, shouldMockEpisodeForFirstFilter = true)
 
-        val result = viewModel.shouldShowTooltip(defaultFilters)
+        var showTooltip = false
+        viewModel.shouldShowTooltip(defaultFilters) {
+            showTooltip = true
+        }
 
-        assertEquals(false, result)
+        assertEquals(false, showTooltip)
     }
 
     private fun initViewModel(tooltipValue: Boolean, shouldMockEpisodeForFirstFilter: Boolean = false): FiltersFragmentViewModel {

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/FiltersFragment.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/FiltersFragment.kt
@@ -132,12 +132,8 @@ class FiltersFragment :
             viewModel.adapterState = it.toMutableList()
             adapter.submitList(it)
 
-            viewLifecycleOwner.lifecycleScope.launch {
-                if (viewModel.shouldShowTooltip(adapter.currentList)) {
-                    binding.toolbar.post {
-                        showTooltip()
-                    }
-                }
+            viewModel.shouldShowTooltip(adapter.currentList) {
+                showTooltip()
             }
         }
 


### PR DESCRIPTION
## Description

This fixes creating a filter crashing the app. The exception is the following:

```
java.lang.IllegalStateException: Can't access the Fragment View's LifecycleOwner for FiltersFragment{41c25bc} (4b43d3e5-fe36-42bd-9004-a37cc22a88ff id=0x7f0a0369 ta
	at androidx.fragment.app.Fragment.getViewLifecycleOwner(Fragment.java:390)
	at au.com.shiftyjelly.pocketcasts.filters.FiltersFragment.onViewCreated$lambda$1(FiltersFragment.kt:135)
	at au.com.shiftyjelly.pocketcasts.filters.FiltersFragment.$r8$lambda$A26OKWmxZ6GBHM5ryjQfN-T8_7Q(Unknown Source:0)
	at au.com.shiftyjelly.pocketcasts.filters.FiltersFragment$$ExternalSyntheticLambda2.invoke(D8$$SyntheticClass:0)
	at au.com.shiftyjelly.pocketcasts.filters.FiltersFragment$sam$androidx_lifecycle_Observer$0.onChanged(Unknown Source:2)
```

## Testing Instructions
1. Tap on the Filters tab
2. Tap on the create button
3. Tap on the "All Your Podcasts" chip
4. Tap on the "Update filter" button
5. Tap on the "Continue" button
6. Enter a filter name
7. Tap on "Save filter"
8. ✅ Verify the app doesn't crash

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 