### PR TITLE
Initialize volume boost when audio session ID is available

### DIFF
--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/ShiftyRenderersFactory.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/ShiftyRenderersFactory.kt
@@ -6,6 +6,7 @@ import androidx.annotation.OptIn
 import androidx.media3.common.util.UnstableApi
 import androidx.media3.exoplayer.DefaultRenderersFactory
 import androidx.media3.exoplayer.Renderer
+import androidx.media3.exoplayer.analytics.AnalyticsListener
 import androidx.media3.exoplayer.audio.AudioRendererEventListener
 import androidx.media3.exoplayer.audio.AudioSink
 import androidx.media3.exoplayer.audio.DefaultAudioSink
@@ -18,7 +19,11 @@ import au.com.shiftyjelly.pocketcasts.repositories.user.StatsManager
  * PCM.
  */
 @OptIn(UnstableApi::class)
-class ShiftyRenderersFactory(context: Context?, statsManager: StatsManager, private var boostVolume: Boolean) : DefaultRenderersFactory(context!!) {
+class ShiftyRenderersFactory(
+    context: Context,
+    statsManager: StatsManager,
+    private var boostVolume: Boolean,
+) : DefaultRenderersFactory(context), AnalyticsListener {
     private var playbackSpeed = 0f
     private var internalRenderer: ShiftyAudioRendererV2? = null
     private var audioSink: AudioSink? = null
@@ -74,7 +79,7 @@ class ShiftyRenderersFactory(context: Context?, statsManager: StatsManager, priv
         }
     }
 
-    fun onAudioSessionId(audioSessionId: Int) {
+    override fun onAudioSessionIdChanged(eventTime: AnalyticsListener.EventTime, audioSessionId: Int) {
         customAudio.setupVolumeBoost(audioSessionId)
     }
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/SimplePlayer.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/SimplePlayer.kt
@@ -212,8 +212,7 @@ class SimplePlayer(
             .setSeekBackIncrementMs(settings.skipBackInSecs.value * 1000L)
             .build()
         player.addListener(WearUnsuitableOutputPlaybackSuppressionResolverListener(context))
-
-        renderer.onAudioSessionId(player.audioSessionId)
+        player.addAnalyticsListener(renderer)
 
         handleStop()
         this.player = player


### PR DESCRIPTION
## Description

Audio session ID is no longer immediately available but only through a callback in a listener. From [the release notes](https://github.com/androidx/media/releases/tag/1.6.0):

> Initial audio session id is no longer immediately available after creating the player. You can use `AnalyticsListener.onAudioSessionIdChanged` to listen to the initial update if required.

## Testing Instructions

1. Play anything.
2. Verify that volume boost still works.
3. Check other effects.

## Checklist
- [ ] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] ~I have considered whether it makes sense to add tests for my changes~
- [ ] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [ ] ~Any jetpack compose components I added or changed are covered by compose previews~
- [ ] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~