### PR TITLE
[Push Notifications Revamp] Update user interaction onboarding features part 1

### DIFF
--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/profile/accountmanager/PocketCastsAccountAuthenticatorTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/profile/accountmanager/PocketCastsAccountAuthenticatorTest.kt
@@ -74,6 +74,7 @@ class PocketCastsAccountAuthenticatorTest {
             syncAccountManager = syncAccountManager,
             syncServiceManager = syncServiceManager,
             moshi = moshi,
+            notificationManager = mock(),
         )
         // make sure the test device is signed out
         syncManager.signOut()

--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/repositories/sync/PodcastSyncProcessTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/repositories/sync/PodcastSyncProcessTest.kt
@@ -142,6 +142,7 @@ class PodcastSyncProcessTest {
                 syncAccountManager = syncAccountManager,
                 syncServiceManager = syncServiceManager,
                 moshi = moshi,
+                notificationManager = mock(),
             )
 
             val syncProcess = PodcastSyncProcess(

--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/servers/account/SyncAccountTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/servers/account/SyncAccountTest.kt
@@ -56,6 +56,7 @@ internal class SyncAccountTest {
             syncAccountManager = syncAccountManager,
             syncServiceManager = syncServiceManager,
             moshi = moshi,
+            notificationManager = mock(),
         )
         syncManager.signOut()
     }

--- a/app/src/test/java/au/com/shiftyjelly/pocketcasts/podcasts/view/folders/FolderEditViewModelTest.kt
+++ b/app/src/test/java/au/com/shiftyjelly/pocketcasts/podcasts/view/folders/FolderEditViewModelTest.kt
@@ -92,7 +92,7 @@ class FolderEditViewModelTest {
 
         advanceUntilIdle()
 
-        verify(notificationManager).trackUserInteractedWithFeature(OnboardingNotificationType.Filters)
+        verify(notificationManager).updateUserFeatureInteraction(OnboardingNotificationType.Filters)
     }
 
     @Test
@@ -101,6 +101,6 @@ class FolderEditViewModelTest {
 
         advanceUntilIdle()
 
-        verify(notificationManager, never()).trackUserInteractedWithFeature(OnboardingNotificationType.Filters)
+        verify(notificationManager, never()).updateUserFeatureInteraction(OnboardingNotificationType.Filters)
     }
 }

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/folders/FolderEditViewModel.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/folders/FolderEditViewModel.kt
@@ -312,7 +312,7 @@ class FolderEditViewModel
         analyticsTracker.track(analyticsEvent, properties)
         viewModelScope.launch {
             if (analyticsEvent == AnalyticsEvent.FOLDER_SAVED) {
-                notificationManager.trackUserInteractedWithFeature(OnboardingNotificationType.Filters)
+                notificationManager.updateUserFeatureInteraction(OnboardingNotificationType.Filters)
             }
         }
     }

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/viewmodel/SettingsAppearanceViewModel.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/viewmodel/SettingsAppearanceViewModel.kt
@@ -5,10 +5,13 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.toLiveData
+import androidx.lifecycle.viewModelScope
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTracker
 import au.com.shiftyjelly.pocketcasts.models.to.SignInState
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
+import au.com.shiftyjelly.pocketcasts.repositories.notification.NotificationManager
+import au.com.shiftyjelly.pocketcasts.repositories.notification.OnboardingNotificationType
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.UserEpisodeManager
 import au.com.shiftyjelly.pocketcasts.repositories.user.UserManager
 import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingUpgradeSource
@@ -16,6 +19,7 @@ import au.com.shiftyjelly.pocketcasts.ui.helper.AppIcon
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
+import kotlinx.coroutines.launch
 
 @HiltViewModel
 class SettingsAppearanceViewModel @Inject constructor(
@@ -25,6 +29,7 @@ class SettingsAppearanceViewModel @Inject constructor(
     val theme: Theme,
     private val appIcon: AppIcon,
     private val analyticsTracker: AnalyticsTracker,
+    private val notificationManager: NotificationManager,
 ) : ViewModel() {
 
     val signInState: LiveData<SignInState> = userManager.getSignInState().toLiveData()
@@ -61,6 +66,9 @@ class SettingsAppearanceViewModel @Inject constructor(
                 },
             ),
         )
+        viewModelScope.launch {
+            notificationManager.updateUserFeatureInteraction(OnboardingNotificationType.Themes)
+        }
     }
 
     fun loadThemesAndIcons() {

--- a/modules/features/settings/src/test/java/au/com/shiftyjelly/pocketcasts/settings/viewmodel/SettingsAppearanceViewModelTest.kt
+++ b/modules/features/settings/src/test/java/au/com/shiftyjelly/pocketcasts/settings/viewmodel/SettingsAppearanceViewModelTest.kt
@@ -1,0 +1,103 @@
+package au.com.shiftyjelly.pocketcasts.settings.viewmodel
+
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTracker
+import au.com.shiftyjelly.pocketcasts.models.to.SignInState
+import au.com.shiftyjelly.pocketcasts.models.to.SubscriptionStatus
+import au.com.shiftyjelly.pocketcasts.preferences.Settings
+import au.com.shiftyjelly.pocketcasts.preferences.UserSetting
+import au.com.shiftyjelly.pocketcasts.preferences.model.ArtworkConfiguration
+import au.com.shiftyjelly.pocketcasts.repositories.notification.NotificationManager
+import au.com.shiftyjelly.pocketcasts.repositories.notification.OnboardingNotificationType
+import au.com.shiftyjelly.pocketcasts.repositories.podcast.UserEpisodeManager
+import au.com.shiftyjelly.pocketcasts.repositories.user.UserManager
+import au.com.shiftyjelly.pocketcasts.sharedtest.MainCoroutineRule
+import au.com.shiftyjelly.pocketcasts.ui.helper.AppIcon
+import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
+import au.com.shiftyjelly.pocketcasts.ui.theme.Theme.ThemeType
+import io.reactivex.Flowable
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.mockito.Mockito.mock
+import org.mockito.MockitoAnnotations
+import org.mockito.junit.MockitoJUnitRunner
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+
+@RunWith(MockitoJUnitRunner::class)
+@OptIn(ExperimentalCoroutinesApi::class)
+class SettingsAppearanceViewModelTest {
+
+    @get:Rule
+    val coroutineRule = MainCoroutineRule()
+
+    @get:Rule
+    val instantTaskExecutorRule = InstantTaskExecutorRule()
+
+    @Mock
+    private lateinit var userManager: UserManager
+
+    @Mock
+    private lateinit var settings: Settings
+
+    @Mock
+    private lateinit var userEpisodeManager: UserEpisodeManager
+
+    @Mock
+    private lateinit var theme: Theme
+
+    @Mock
+    private lateinit var appIcon: AppIcon
+
+    @Mock
+    private lateinit var analyticsTracker: AnalyticsTracker
+
+    @Mock
+    private lateinit var notificationManager: NotificationManager
+
+    private lateinit var viewModel: SettingsAppearanceViewModel
+
+    @Before
+    fun setup() {
+        MockitoAnnotations.openMocks(this)
+        whenever(userManager.getSignInState()).thenReturn(
+            Flowable.just(
+                SignInState.SignedIn(
+                    email = "",
+                    subscriptionStatus = SubscriptionStatus.Free(),
+                ),
+            ),
+        )
+
+        val showArtworkOnLockScreen: UserSetting<Boolean> = mock()
+        whenever(showArtworkOnLockScreen.flow).thenReturn(MutableStateFlow(false))
+        whenever(settings.showArtworkOnLockScreen).thenReturn(showArtworkOnLockScreen)
+
+        val artworkConfiguration: UserSetting<ArtworkConfiguration> = mock()
+        whenever(artworkConfiguration.flow).thenReturn(MutableStateFlow(ArtworkConfiguration(false)))
+        whenever(settings.artworkConfiguration).thenReturn(artworkConfiguration)
+
+        viewModel = SettingsAppearanceViewModel(
+            userManager = userManager,
+            settings = settings,
+            userEpisodeManager = userEpisodeManager,
+            theme = theme,
+            appIcon = appIcon,
+            analyticsTracker = analyticsTracker,
+            notificationManager = notificationManager,
+        )
+    }
+
+    @Test
+    fun `when theme is updated, should track notification interaction`() = runTest {
+        viewModel.onThemeChanged(ThemeType.DARK)
+
+        verify(notificationManager).updateUserFeatureInteraction(OnboardingNotificationType.Themes)
+    }
+}

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/notification/NotificationManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/notification/NotificationManager.kt
@@ -2,7 +2,7 @@ package au.com.shiftyjelly.pocketcasts.repositories.notification
 
 interface NotificationManager {
     suspend fun setupOnboardingNotifications()
-    suspend fun trackUserInteractedWithFeature(type: OnboardingNotificationType)
+    suspend fun updateUserFeatureInteraction(type: OnboardingNotificationType)
     suspend fun hasUserInteractedWithFeature(type: OnboardingNotificationType): Boolean
     suspend fun updateOnboardingNotificationSent(type: OnboardingNotificationType)
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/notification/NotificationManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/notification/NotificationManagerImpl.kt
@@ -16,7 +16,7 @@ class NotificationManagerImpl @Inject constructor(
         userNotificationsDao.insert(userNotifications)
     }
 
-    override suspend fun trackUserInteractedWithFeature(type: OnboardingNotificationType) {
+    override suspend fun updateUserFeatureInteraction(type: OnboardingNotificationType) {
         userNotificationsDao.updateInteractedAt(type.notificationId, System.currentTimeMillis())
     }
 

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/opml/OpmlImportTask.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/opml/OpmlImportTask.kt
@@ -48,8 +48,7 @@ import okio.Source
 import okio.source
 import au.com.shiftyjelly.pocketcasts.images.R as IR
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
-
-typealias OnboardingNotificationManager = au.com.shiftyjelly.pocketcasts.repositories.notification.NotificationManager
+import au.com.shiftyjelly.pocketcasts.repositories.notification.NotificationManager as OnboardingNotificationManager
 
 @HiltWorker
 class OpmlImportTask @AssistedInject constructor(

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/opml/OpmlImportTask.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/opml/OpmlImportTask.kt
@@ -22,6 +22,7 @@ import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTracker
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.repositories.notification.NotificationHelper
+import au.com.shiftyjelly.pocketcasts.repositories.notification.OnboardingNotificationType
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
 import au.com.shiftyjelly.pocketcasts.servers.di.Downloads
 import au.com.shiftyjelly.pocketcasts.servers.refresh.ImportOpmlResponse
@@ -48,6 +49,8 @@ import okio.source
 import au.com.shiftyjelly.pocketcasts.images.R as IR
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
+typealias OnboardingNotificationManager = au.com.shiftyjelly.pocketcasts.repositories.notification.NotificationManager
+
 @HiltWorker
 class OpmlImportTask @AssistedInject constructor(
     @Assisted context: Context,
@@ -57,6 +60,7 @@ class OpmlImportTask @AssistedInject constructor(
     @Downloads private val httpClient: OkHttpClient,
     private val notificationHelper: NotificationHelper,
     private val analyticsTracker: AnalyticsTracker,
+    private val onboardingNotificationManager: OnboardingNotificationManager,
 ) : CoroutineWorker(context, parameters) {
 
     companion object {
@@ -97,6 +101,7 @@ class OpmlImportTask @AssistedInject constructor(
 
     override suspend fun doWork(): Result {
         try {
+            onboardingNotificationManager.updateUserFeatureInteraction(OnboardingNotificationType.Import)
             analyticsTracker.track(AnalyticsEvent.OPML_IMPORT_STARTED)
             val url = inputData.getString(INPUT_URL)?.toHttpUrlOrNull()
             val uri = inputData.getString(INPUT_URI)?.toUri()

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
@@ -46,6 +46,8 @@ import au.com.shiftyjelly.pocketcasts.repositories.download.DownloadManager
 import au.com.shiftyjelly.pocketcasts.repositories.file.CloudFilesManager
 import au.com.shiftyjelly.pocketcasts.repositories.history.upnext.UpNextHistoryManager
 import au.com.shiftyjelly.pocketcasts.repositories.notification.NotificationHelper
+import au.com.shiftyjelly.pocketcasts.repositories.notification.NotificationManager
+import au.com.shiftyjelly.pocketcasts.repositories.notification.OnboardingNotificationType
 import au.com.shiftyjelly.pocketcasts.repositories.playback.LocalPlayer.Companion.VOLUME_DUCK
 import au.com.shiftyjelly.pocketcasts.repositories.playback.LocalPlayer.Companion.VOLUME_NORMAL
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.ChapterManager
@@ -140,6 +142,7 @@ open class PlaybackManager @Inject constructor(
     @ApplicationScope private val applicationScope: CoroutineScope,
     private val crashLogging: CrashLogging,
     private val upNextHistoryManager: UpNextHistoryManager,
+    private val notificationManager: NotificationManager,
 ) : FocusManager.FocusChangeListener, AudioNoisyManager.AudioBecomingNoisyListener, CoroutineScope {
 
     companion object {
@@ -612,6 +615,7 @@ open class PlaybackManager @Inject constructor(
         upNextQueue.playNextBlocking(episode, downloadManager, null)
         if (userInitiated) {
             episodeAnalytics.trackEvent(AnalyticsEvent.EPISODE_ADDED_TO_UP_NEXT, source, true, episode)
+            notificationManager.updateUserFeatureInteraction(OnboardingNotificationType.UpNext)
         }
         if (wasEmpty) {
             loadCurrentEpisode(play = false)
@@ -627,6 +631,7 @@ open class PlaybackManager @Inject constructor(
         upNextQueue.playLastBlocking(episode, downloadManager, null)
         if (userInitiated) {
             episodeAnalytics.trackEvent(AnalyticsEvent.EPISODE_ADDED_TO_UP_NEXT, source, false, episode)
+            notificationManager.updateUserFeatureInteraction(OnboardingNotificationType.UpNext)
         }
         if (wasEmpty) {
             loadCurrentEpisode(play = false)
@@ -702,6 +707,7 @@ open class PlaybackManager @Inject constructor(
                 toTop = false,
                 source = source,
             )
+            notificationManager.updateUserFeatureInteraction(OnboardingNotificationType.UpNext)
             if (wasEmpty) {
                 loadCurrentEpisode(play = false)
             }
@@ -723,6 +729,7 @@ open class PlaybackManager @Inject constructor(
                 toTop = true,
                 source = source,
             )
+            notificationManager.updateUserFeatureInteraction(OnboardingNotificationType.UpNext)
             if (wasEmpty) {
                 loadCurrentEpisode(play = false)
             }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PlaylistManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PlaylistManagerImpl.kt
@@ -224,7 +224,7 @@ class PlaylistManagerImpl @Inject constructor(
     ) {
         if (isCreatingFilter) {
             launch(Dispatchers.IO) {
-                notificationManager.trackUserInteractedWithFeature(OnboardingNotificationType.Filters)
+                notificationManager.updateUserFeatureInteraction(OnboardingNotificationType.Filters)
             }
         }
         playlistDao.updateBlocking(playlist)

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/notification/NotificationManagerTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/notification/NotificationManagerTest.kt
@@ -44,7 +44,7 @@ class NotificationManagerTest {
 
     @Test
     fun `should update interacted_at when tracking user interaction feature`() = runTest {
-        notificationManager.trackUserInteractedWithFeature(Filters)
+        notificationManager.updateUserFeatureInteraction(Filters)
 
         val idCaptor = argumentCaptor<Int>()
         val timestampCaptor = argumentCaptor<Long>()

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PlaylistManagerImplTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PlaylistManagerImplTest.kt
@@ -43,7 +43,7 @@ class PlaylistManagerImplTest {
 
         advanceUntilIdle()
 
-        verify(notificationManager).trackUserInteractedWithFeature(OnboardingNotificationType.Filters)
+        verify(notificationManager).updateUserFeatureInteraction(OnboardingNotificationType.Filters)
     }
 
     @Test
@@ -54,7 +54,7 @@ class PlaylistManagerImplTest {
 
         advanceUntilIdle()
 
-        verify(notificationManager, never()).trackUserInteractedWithFeature(OnboardingNotificationType.Filters)
+        verify(notificationManager, never()).updateUserFeatureInteraction(OnboardingNotificationType.Filters)
     }
 
     private fun initViewModel(): PlaylistManagerImpl {

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/sync/SyncManagerImplTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/sync/SyncManagerImplTest.kt
@@ -1,0 +1,106 @@
+package au.com.shiftyjelly.pocketcasts.repositories.sync
+
+import android.content.Context
+import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTracker
+import au.com.shiftyjelly.pocketcasts.preferences.Settings
+import au.com.shiftyjelly.pocketcasts.repositories.notification.NotificationManager
+import au.com.shiftyjelly.pocketcasts.repositories.notification.OnboardingNotificationType
+import au.com.shiftyjelly.pocketcasts.servers.sync.SyncServiceManager
+import au.com.shiftyjelly.pocketcasts.servers.sync.login.LoginTokenResponse
+import com.squareup.moshi.Moshi
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.mockito.MockitoAnnotations
+import org.mockito.junit.MockitoJUnitRunner
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+
+@RunWith(MockitoJUnitRunner::class)
+class SyncManagerImplTest {
+
+    @Mock
+    private lateinit var analyticsTracker: AnalyticsTracker
+
+    @Mock
+    private lateinit var context: Context
+
+    @Mock
+    private lateinit var settings: Settings
+
+    @Mock
+    private lateinit var syncAccountManager: SyncAccountManager
+
+    @Mock
+    private lateinit var syncServiceManager: SyncServiceManager
+
+    @Mock
+    private lateinit var moshi: Moshi
+
+    @Mock
+    private lateinit var notificationManager: NotificationManager
+
+    private lateinit var syncManager: SyncManagerImpl
+
+    @Before
+    fun setUp() {
+        MockitoAnnotations.openMocks(this)
+
+        syncManager = SyncManagerImpl(
+            analyticsTracker = analyticsTracker,
+            context = context,
+            settings = settings,
+            syncAccountManager = syncAccountManager,
+            syncServiceManager = syncServiceManager,
+            moshi = moshi,
+            notificationManager = notificationManager,
+        )
+    }
+
+    @Test
+    fun `should update user interaction with sync feature on user registration with password`() = runTest {
+        val response = createMockLoginResponse(isNew = true)
+        whenever(syncServiceManager.register(any(), any())).thenReturn(response)
+        syncManager.createUserWithEmailAndPassword("test@example.com", "password123")
+        verifyNotificationCalled()
+    }
+
+    @Test
+    fun `should update user interaction with sync feature on user registration with google account`() = runTest {
+        val response = createMockLoginResponse(isNew = true)
+        whenever(syncServiceManager.loginGoogle(any())).thenReturn(response)
+        syncManager.loginWithGoogle("google_token", SignInSource.UserInitiated.Onboarding)
+        verifyNotificationCalled()
+    }
+
+    @Test
+    fun `should not update user interaction when is not user registration`() = runTest {
+        val response = createMockLoginResponse(isNew = false)
+        whenever(syncServiceManager.loginGoogle(any())).thenReturn(response)
+        syncManager.loginWithGoogle("google_token", SignInSource.UserInitiated.Onboarding)
+        verifyNotificationNotCalled()
+    }
+
+    private fun createMockLoginResponse(isNew: Boolean): LoginTokenResponse {
+        return mock<LoginTokenResponse>().apply {
+            whenever(email).thenReturn("test@example.com")
+            whenever(uuid).thenReturn("uuid")
+            whenever(refreshToken).thenReturn(mock())
+            whenever(accessToken).thenReturn(mock())
+            whenever(this.isNew).thenReturn(isNew)
+        }
+    }
+
+    private suspend fun verifyNotificationCalled() {
+        verify(notificationManager).updateUserFeatureInteraction(OnboardingNotificationType.Sync)
+    }
+
+    private suspend fun verifyNotificationNotCalled() {
+        verify(notificationManager, never()).updateUserFeatureInteraction(OnboardingNotificationType.Sync)
+    }
+}


### PR DESCRIPTION
## Description
- Rename `trackUserInteractedWithFeature` to `updateUserFeatureInteraction`
- Updates user interaction for: `Sync`, `Import`, `Up next` and `Theme` feature.
- See the rules: p1744338501260579/1744127181.427989-slack-C08KX131YRJ 

## Testing Instructions

### Sync
1. Create an account
2. Inspect `user_notifications` database
3. Ensure `interacted_at` was updated for `notification_id = 21483653`

### Import
1. Import OPML file
2. Inspect `user_notifications` database
3. Ensure `interacted_at` was updated for `notification_id = 21483654`

### Up next
1. Add an episode to up next
2. Inspect `user_notifications` database
3. Ensure `interacted_at` was updated for `notification_id = 21483655`

### Theme
1. Change a theme
2. Inspect `user_notifications` database
3. Ensure `interacted_at` was updated for `notification_id = 21483657`

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.