### PR TITLE
Add account encouregement analytics

### DIFF
--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/AccountBenefit.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/AccountBenefit.kt
@@ -9,23 +9,27 @@ internal enum class AccountBenefit(
     @StringRes val description: Int,
     @DrawableRes val cardImage: Int,
     @DrawableRes val listIcon: Int,
+    val analyticsValue: String,
 ) {
     Sync(
         title = R.string.account_benefit_sync_title,
         description = R.string.account_benefit_sync_description,
         cardImage = au.com.shiftyjelly.pocketcasts.images.R.drawable.account_benefit_sync,
         listIcon = au.com.shiftyjelly.pocketcasts.images.R.drawable.ic_account_benefit_sync,
+        analyticsValue = "sync",
     ),
     Backups(
         title = R.string.account_benefit_backups_title,
         description = R.string.account_benefit_backups_description,
         cardImage = au.com.shiftyjelly.pocketcasts.images.R.drawable.account_benefit_backups,
         listIcon = au.com.shiftyjelly.pocketcasts.images.R.drawable.ic_account_benefit_backups,
+        analyticsValue = "backups",
     ),
     Recommendations(
         title = R.string.account_benefit_recommendations_title,
         description = R.string.account_benefit_recommendations_description,
         cardImage = au.com.shiftyjelly.pocketcasts.images.R.drawable.account_benefit_recommendations,
         listIcon = au.com.shiftyjelly.pocketcasts.images.R.drawable.ic_account_benefit_recommendations,
+        analyticsValue = "recommendation",
     ),
 }

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/AccountBenefitsDialog.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/AccountBenefitsDialog.kt
@@ -18,6 +18,8 @@ import androidx.compose.material.Icon
 import androidx.compose.material.IconButton
 import androidx.compose.material.MaterialTheme
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
@@ -47,6 +49,7 @@ internal fun AccountBenefitsDialog(
     onGetStarted: () -> Unit,
     onLogIn: () -> Unit,
     onDismiss: () -> Unit,
+    onBenefitShown: (AccountBenefit) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Dialog(
@@ -71,7 +74,9 @@ internal fun AccountBenefitsDialog(
                 modifier = Modifier.height(20.dp),
             )
 
-            BenefitsPager()
+            BenefitsPager(
+                onBenefitShown = onBenefitShown,
+            )
 
             Spacer(
                 modifier = Modifier.height(32.dp),
@@ -147,10 +152,17 @@ private fun HeaderTexts(
 
 @Composable
 private fun BenefitsPager(
+    onBenefitShown: (AccountBenefit) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val benefits = AccountBenefit.entries
     val pagerState = PagerState { benefits.size }
+
+    LaunchedEffect(pagerState) {
+        snapshotFlow { pagerState.currentPage }.collect { page ->
+            onBenefitShown(benefits[page])
+        }
+    }
 
     HorizontalPager(
         state = pagerState,
@@ -244,6 +256,7 @@ private fun AccountBenefitsDialogPreview(
             onGetStarted = {},
             onLogIn = {},
             onDismiss = {},
+            onBenefitShown = {},
         )
     }
 }

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/AccountBenefitsFragment.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/AccountBenefitsFragment.kt
@@ -39,7 +39,7 @@ class AccountBenefitsFragment : BaseDialogFragment() {
                 onLogIn = {
                     tracker.track(AnalyticsEvent.INFORMATIONAL_MODAL_VIEW_LOGIN_TAP)
                     dismiss()
-                    OnboardingLauncher.openOnboardingFlow(requireActivity(), OnboardingFlow.LogIn)
+                    OnboardingLauncher.openOnboardingFlow(requireActivity(), OnboardingFlow.LoggedOut)
                 },
                 onBenefitShown = { benefit ->
                     tracker.track(AnalyticsEvent.INFORMATIONAL_MODAL_VIEW_CARD_SHOWED, mapOf("card" to benefit.analyticsValue))

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/AccountBenefitsFragment.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/AccountBenefitsFragment.kt
@@ -4,31 +4,50 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.fragment.compose.content
+import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
+import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTracker
 import au.com.shiftyjelly.pocketcasts.compose.AppTheme
+import au.com.shiftyjelly.pocketcasts.compose.CallOnce
 import au.com.shiftyjelly.pocketcasts.compose.theme
 import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingFlow
 import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingLauncher
 import au.com.shiftyjelly.pocketcasts.views.fragments.BaseDialogFragment
 import dagger.hilt.android.AndroidEntryPoint
+import javax.inject.Inject
 
 @AndroidEntryPoint
 class AccountBenefitsFragment : BaseDialogFragment() {
+    @Inject
+    internal lateinit var tracker: AnalyticsTracker
+
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
         savedInstanceState: Bundle?,
     ) = content {
+        CallOnce {
+            tracker.track(AnalyticsEvent.INFORMATIONAL_MODAL_VIEW_SHOWED)
+        }
+
         AppTheme(theme.activeTheme) {
             AccountBenefitsDialog(
                 onGetStarted = {
+                    tracker.track(AnalyticsEvent.INFORMATIONAL_MODAL_VIEW_GET_STARTED_TAP)
                     dismiss()
                     OnboardingLauncher.openOnboardingFlow(requireActivity(), OnboardingFlow.LoggedOut)
                 },
                 onLogIn = {
+                    tracker.track(AnalyticsEvent.INFORMATIONAL_MODAL_VIEW_LOGIN_TAP)
                     dismiss()
                     OnboardingLauncher.openOnboardingFlow(requireActivity(), OnboardingFlow.LogIn)
                 },
-                onDismiss = ::dismiss,
+                onBenefitShown = { benefit ->
+                    tracker.track(AnalyticsEvent.INFORMATIONAL_MODAL_VIEW_CARD_SHOWED, mapOf("card" to benefit.analyticsValue))
+                },
+                onDismiss = {
+                    tracker.track(AnalyticsEvent.INFORMATIONAL_MODAL_VIEW_DISMISSED)
+                    dismiss()
+                },
             )
         }
     }

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/AccountBenefitsPage.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/AccountBenefitsPage.kt
@@ -24,6 +24,8 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.ButtonDefaults
 import androidx.compose.material.MaterialTheme
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.ColorFilter
@@ -59,6 +61,7 @@ internal fun AccountBenefitsPage(
     onGetStarted: () -> Unit,
     onLogIn: () -> Unit,
     onClose: () -> Unit,
+    onBenefitShown: (AccountBenefit) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Column(
@@ -72,6 +75,7 @@ internal fun AccountBenefitsPage(
         )
 
         BenefitsAdaptiveContent(
+            onBenefitShown = onBenefitShown,
             modifier = Modifier.weight(1f),
         )
 
@@ -180,6 +184,7 @@ private fun ActionButtons(
 
 @Composable
 private fun BenefitsAdaptiveContent(
+    onBenefitShown: (AccountBenefit) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     SubcomposeLayout(
@@ -214,6 +219,7 @@ private fun BenefitsAdaptiveContent(
                         modifier = Modifier.padding(24.dp),
                     )
                     BenefitPager(
+                        onBenefitShown = onBenefitShown,
                         contentPadding = PaddingValues(horizontal = 24.dp),
                         contentSpacing = 16.dp,
                         modifier = Modifier.padding(vertical = 20.dp),
@@ -251,6 +257,7 @@ private fun BenefitsAdaptiveContent(
 
 @Composable
 private fun BenefitPager(
+    onBenefitShown: (AccountBenefit) -> Unit,
     contentPadding: PaddingValues,
     contentSpacing: Dp,
     modifier: Modifier = Modifier,
@@ -261,6 +268,12 @@ private fun BenefitPager(
     ) {
         val benefits = AccountBenefit.entries
         val pagerState = PagerState { benefits.size }
+
+        LaunchedEffect(pagerState) {
+            snapshotFlow { pagerState.currentPage }.collect { page ->
+                onBenefitShown(benefits[page])
+            }
+        }
 
         HorizontalPager(
             state = pagerState,
@@ -392,6 +405,7 @@ private fun AccountBenefitsPagePreview(
             onGetStarted = {},
             onLogIn = {},
             onClose = {},
+            onBenefitShown = {},
         )
     }
 }

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/OnboardingFlowComposable.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/OnboardingFlowComposable.kt
@@ -81,8 +81,6 @@ private fun Content(
         is OnboardingFlow.ReferralLoginOrSignUp,
         -> OnboardingNavRoute.logInOrSignUp
 
-        is OnboardingFlow.LogIn -> OnboardingNavRoute.logIn
-
         // Cannot use OnboardingNavRoute.PlusUpgrade.routeWithSource here, it is set as a defaultValue in the PlusUpgrade composable,
         // see https://stackoverflow.com/a/70410872/1910286
         is OnboardingFlow.PlusAccountUpgrade,
@@ -157,7 +155,11 @@ private fun Content(
                     },
                     onLogIn = {
                         viewModel.onLogInClick()
-                        navController.navigate(OnboardingNavRoute.logIn)
+                        navController.navigate(OnboardingNavRoute.logInOrSignUp) {
+                            popUpTo(OnboardingNavRoute.encourageFreeAccount) {
+                                inclusive = true
+                            }
+                        }
                     },
                     onClose = {
                         viewModel.onDismissClick()
@@ -195,7 +197,6 @@ private fun Content(
 
                         is OnboardingFlow.InitialOnboarding,
                         is OnboardingFlow.LoggedOut,
-                        is OnboardingFlow.LogIn,
                         is OnboardingFlow.EngageSdk,
                         is OnboardingFlow.ReferralLoginOrSignUp,
                         -> exitOnboarding(OnboardingExitInfo())
@@ -226,16 +227,7 @@ private fun Content(
         composable(OnboardingNavRoute.logIn) {
             OnboardingLoginPage(
                 theme = theme,
-                onBackPressed = {
-                    val popped = navController.popBackStack()
-                    if (!popped) {
-                        navController.navigate(OnboardingNavRoute.logInOrSignUp) {
-                            popUpTo(OnboardingNavRoute.logIn) {
-                                inclusive = true
-                            }
-                        }
-                    }
-                },
+                onBackPressed = { navController.popBackStack() },
                 onLoginComplete = {
                     onLoginToExistingAccount(flow, exitOnboarding, navController)
                 },
@@ -363,7 +355,6 @@ private fun onLoginToExistingAccount(
         is OnboardingFlow.AccountEncouragement,
         is OnboardingFlow.InitialOnboarding,
         is OnboardingFlow.LoggedOut,
-        is OnboardingFlow.LogIn,
         is OnboardingFlow.EngageSdk,
         -> exitOnboarding(OnboardingExitInfo(showPlusPromotionForFreeUser = true))
 

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/OnboardingFlowComposable.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/OnboardingFlowComposable.kt
@@ -4,6 +4,7 @@ import androidx.annotation.VisibleForTesting
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavHostController
 import androidx.navigation.NavType
 import androidx.navigation.compose.NavHost
@@ -15,8 +16,10 @@ import au.com.shiftyjelly.pocketcasts.account.onboarding.import.OnboardingImport
 import au.com.shiftyjelly.pocketcasts.account.onboarding.recommendations.OnboardingRecommendationsFlow
 import au.com.shiftyjelly.pocketcasts.account.onboarding.recommendations.OnboardingRecommendationsFlow.onboardingRecommendationsFlowGraph
 import au.com.shiftyjelly.pocketcasts.account.onboarding.upgrade.OnboardingUpgradeFlow
+import au.com.shiftyjelly.pocketcasts.account.viewmodel.OnboardingAccountBenefitsViewModel
 import au.com.shiftyjelly.pocketcasts.compose.AppTheme
 import au.com.shiftyjelly.pocketcasts.compose.AppThemeWithBackground
+import au.com.shiftyjelly.pocketcasts.compose.CallOnce
 import au.com.shiftyjelly.pocketcasts.compose.bars.SystemBarsStyles
 import au.com.shiftyjelly.pocketcasts.models.to.SignInState
 import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingExitInfo
@@ -136,17 +139,33 @@ private fun Content(
         )
 
         composable(OnboardingNavRoute.encourageFreeAccount) {
+            val viewModel = hiltViewModel<OnboardingAccountBenefitsViewModel>()
+
+            CallOnce {
+                viewModel.onScreenShown()
+            }
+
             AppTheme(theme) {
                 AccountBenefitsPage(
                     onGetStarted = {
+                        viewModel.onGetStartedClick()
                         navController.navigate(OnboardingNavRoute.logInOrSignUp) {
                             popUpTo(OnboardingNavRoute.encourageFreeAccount) {
                                 inclusive = true
                             }
                         }
                     },
-                    onLogIn = { navController.navigate(OnboardingNavRoute.logIn) },
-                    onClose = { exitOnboarding(OnboardingExitInfo()) },
+                    onLogIn = {
+                        viewModel.onLogInClick()
+                        navController.navigate(OnboardingNavRoute.logIn)
+                    },
+                    onClose = {
+                        viewModel.onDismissClick()
+                        exitOnboarding(OnboardingExitInfo())
+                    },
+                    onBenefitShown = { benefit ->
+                        viewModel.onBenefitShown(benefit.analyticsValue)
+                    },
                     modifier = Modifier.fillMaxSize(),
                 )
             }

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/OnboardingAccountBenefitsViewModel.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/OnboardingAccountBenefitsViewModel.kt
@@ -1,0 +1,32 @@
+package au.com.shiftyjelly.pocketcasts.account.viewmodel
+
+import androidx.lifecycle.ViewModel
+import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
+import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTracker
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+
+@HiltViewModel
+class OnboardingAccountBenefitsViewModel @Inject constructor(
+    private val tracker: AnalyticsTracker,
+) : ViewModel() {
+    fun onScreenShown() {
+        tracker.track(AnalyticsEvent.INFORMATIONAL_MODAL_VIEW_SHOWED)
+    }
+
+    fun onGetStartedClick() {
+        tracker.track(AnalyticsEvent.INFORMATIONAL_MODAL_VIEW_GET_STARTED_TAP)
+    }
+
+    fun onLogInClick() {
+        tracker.track(AnalyticsEvent.INFORMATIONAL_MODAL_VIEW_LOGIN_TAP)
+    }
+
+    fun onDismissClick() {
+        tracker.track(AnalyticsEvent.INFORMATIONAL_MODAL_VIEW_DISMISSED)
+    }
+
+    fun onBenefitShown(cardAnalyticsValue: String) {
+        tracker.track(AnalyticsEvent.INFORMATIONAL_MODAL_VIEW_CARD_SHOWED, mapOf("card" to cardAnalyticsValue))
+    }
+}

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/FiltersFragment.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/FiltersFragment.kt
@@ -127,6 +127,7 @@ class FiltersFragment :
                     actionLabel = stringResource(LR.string.encourage_account_banner_action_label),
                     icon = painterResource(IR.drawable.ic_refresh),
                     onActionClick = {
+                        viewModel.onCreateFreeAccountClick()
                         OnboardingLauncher.openOnboardingFlow(
                             activity = requireActivity(),
                             onboardingFlow = OnboardingFlow.LoggedOut,

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/FiltersFragmentViewModel.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/FiltersFragmentViewModel.kt
@@ -155,7 +155,12 @@ class FiltersFragmentViewModel @Inject constructor(
         initialValue = false,
     )
 
+    internal fun onCreateFreeAccountClick() {
+        analyticsTracker.track(AnalyticsEvent.INFORMATIONAL_BANNER_VIEW_CREATE_ACCOUNT_TAP, mapOf("source" to "filters"))
+    }
+
     internal fun dismissFreeAccountBanner() {
+        analyticsTracker.track(AnalyticsEvent.INFORMATIONAL_BANNER_VIEW_DISMISSED, mapOf("source" to "filters"))
         settings.isFreeAccountFiltersBannerDismissed.set(true, updateModifiedAt = true)
     }
 }

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/ProfileEpisodeListFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/ProfileEpisodeListFragment.kt
@@ -311,6 +311,7 @@ class ProfileEpisodeListFragment : BaseFragment(), Toolbar.OnMenuItemClickListen
                         actionLabel = stringResource(LR.string.encourage_account_banner_action_label),
                         icon = painterResource(IR.drawable.ic_filters_clock),
                         onActionClick = {
+                            viewModel.onCreateFreeAccountClick()
                             OnboardingLauncher.openOnboardingFlow(
                                 activity = requireActivity(),
                                 onboardingFlow = OnboardingFlow.LoggedOut,

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/ProfileEpisodeListViewModel.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/ProfileEpisodeListViewModel.kt
@@ -125,7 +125,12 @@ class ProfileEpisodeListViewModel @Inject constructor(
         initialValue = false,
     )
 
+    internal fun onCreateFreeAccountClick() {
+        analyticsTracker.track(AnalyticsEvent.INFORMATIONAL_BANNER_VIEW_CREATE_ACCOUNT_TAP, mapOf("source" to "listening_history"))
+    }
+
     internal fun dismissFreeAccountBanner() {
+        analyticsTracker.track(AnalyticsEvent.INFORMATIONAL_BANNER_VIEW_DISMISSED, mapOf("source" to "listening_history"))
         settings.isFreeAccountHistoryBannerDismissed.set(true, updateModifiedAt = true)
     }
 

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/ProfileFragment.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/ProfileFragment.kt
@@ -101,6 +101,7 @@ class ProfileFragment : BaseFragment(), TopScrollable {
                 }
             },
             onCreateFreeAccountBannerClick = {
+                profileViewModel.onCreateFreeAccountClick()
                 OnboardingLauncher.openOnboardingFlow(
                     activity = requireActivity(),
                     onboardingFlow = OnboardingFlow.LoggedOut,

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/ProfileViewModel.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/ProfileViewModel.kt
@@ -197,7 +197,12 @@ class ProfileViewModel @Inject constructor(
         settings.upgradeProfileClosed.set(true, updateModifiedAt = false)
     }
 
+    internal fun onCreateFreeAccountClick() {
+        tracker.track(AnalyticsEvent.INFORMATIONAL_BANNER_VIEW_CREATE_ACCOUNT_TAP, mapOf("source" to "profile"))
+    }
+
     internal fun dismissFreeAccountBanner() {
+        tracker.track(AnalyticsEvent.INFORMATIONAL_BANNER_VIEW_DISMISSED, mapOf("source" to "profile"))
         settings.isFreeAccountProfileBannerDismissed.set(true, updateModifiedAt = true)
     }
 }

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/onboarding/OnboardingFlow.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/onboarding/OnboardingFlow.kt
@@ -7,8 +7,6 @@ import kotlinx.parcelize.Parcelize
 sealed class OnboardingFlow(val analyticsValue: String) : Parcelable {
     @Parcelize object LoggedOut : OnboardingFlow("logged_out")
 
-    @Parcelize object LogIn : OnboardingFlow("log_in")
-
     @Parcelize object InitialOnboarding : OnboardingFlow("initial_onboarding")
 
     @Parcelize object EngageSdk : OnboardingFlow("engage_sdk")

--- a/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
+++ b/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
@@ -762,4 +762,13 @@ enum class AnalyticsEvent(val key: String) {
     SUGGESTED_FOLDERS_REPLACE_FOLDERS_TAPPED("suggested_folders_replace_folders_tapped"),
     SUGGESTED_FOLDERS_REPLACE_FOLDERS_CONFIRM_TAPPED("suggested_folders_replace_folders_confirm_tapped"),
     SUGGESTED_FOLDERS_PREVIEW_FOLDER_TAPPED("suggested_folders_preview_folder_tapped"),
+
+    /* Account Encouragement */
+    INFORMATIONAL_MODAL_VIEW_SHOWED("informational_modal_view_showed"),
+    INFORMATIONAL_MODAL_VIEW_DISMISSED("informational_modal_view_dismissed"),
+    INFORMATIONAL_MODAL_VIEW_GET_STARTED_TAP("informational_modal_view_get_started_tap"),
+    INFORMATIONAL_MODAL_VIEW_LOGIN_TAP("informational_modal_view_login_tap"),
+    INFORMATIONAL_MODAL_VIEW_CARD_SHOWED("informational_modal_view_card_showed"),
+    INFORMATIONAL_BANNER_VIEW_DISMISSED("informational_banner_view_dismissed"),
+    INFORMATIONAL_BANNER_VIEW_CREATE_ACCOUNT_TAP("informational_banner_view_create_account_tap"),
 }


### PR DESCRIPTION
## Description

This PR adds analytics for the account encouragement feature.

## Testing Instructions

Verify these events:

<img width="1295" alt="Screenshot 2025-04-15 at 12 50 46" src="https://github.com/user-attachments/assets/c08d8028-5071-49e4-8987-71844832b916" />

For testing steps you can check these PRs: #3869, #3870, #3871, #3887, #3890

## Checklist
- [ ] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] ~I have considered whether it makes sense to add tests for my changes~
- [ ] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [ ] ~Any jetpack compose components I added or changed are covered by compose previews~
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.