### PR TITLE
[Push Notifications Revamp] Support deeplinks part 3

### DIFF
--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/deeplink/AppOpenDeepLinkTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/deeplink/AppOpenDeepLinkTest.kt
@@ -1,0 +1,21 @@
+package au.com.shiftyjelly.pocketcasts.deeplink
+
+import android.content.Intent.ACTION_VIEW
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class AppOpenDeepLinkTest {
+    private val context = InstrumentationRegistry.getInstrumentation().context
+
+    @Test
+    fun createIntent() {
+        val intent = AppOpenDeepLink.toIntent(context)
+
+        assertEquals(ACTION_VIEW, intent.action)
+        assertEquals(Uri.parse("pktc://open"), intent.data)
+    }
+}

--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/deeplink/DeepLinkFactoryTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/deeplink/DeepLinkFactoryTest.kt
@@ -617,6 +617,17 @@ class DeepLinkFactoryTest {
     }
 
     @Test
+    fun recommendations() {
+        val intent = Intent()
+            .setAction(ACTION_VIEW)
+            .setData(Uri.parse("pktc://discover/recommendations"))
+
+        val deepLink = factory.create(intent)
+
+        assertEquals(RecommendationsDeepLink, deepLink)
+    }
+
+    @Test
     fun nativeShare() {
         val intent = Intent()
             .setAction(ACTION_VIEW)

--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/deeplink/DeepLinkFactoryTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/deeplink/DeepLinkFactoryTest.kt
@@ -25,7 +25,9 @@ class DeepLinkFactoryTest {
 
     @Test
     fun downloads() {
-        val intent = Intent().setAction("INTENT_OPEN_APP_DOWNLOADING")
+        val intent = Intent()
+            .setAction("INTENT_OPEN_APP_DOWNLOADING")
+            .setData(Uri.parse("pktc://profile/downloads"))
 
         val deepLink = factory.create(intent)
 

--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/deeplink/DeepLinkFactoryTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/deeplink/DeepLinkFactoryTest.kt
@@ -606,6 +606,17 @@ class DeepLinkFactoryTest {
     }
 
     @Test
+    fun trending() {
+        val intent = Intent()
+            .setAction(ACTION_VIEW)
+            .setData(Uri.parse("pktc://discover/trending"))
+
+        val deepLink = factory.create(intent)
+
+        assertEquals(TrendingDeepLink, deepLink)
+    }
+
+    @Test
     fun nativeShare() {
         val intent = Intent()
             .setAction(ACTION_VIEW)

--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/deeplink/DeepLinkFactoryTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/deeplink/DeepLinkFactoryTest.kt
@@ -553,6 +553,17 @@ class DeepLinkFactoryTest {
     }
 
     @Test
+    fun openApp() {
+        val intent = Intent()
+            .setAction(ACTION_VIEW)
+            .setData(Uri.parse("pktc://open"))
+
+        val deepLink = factory.create(intent)
+
+        assertEquals(AppOpenDeepLink, deepLink)
+    }
+
+    @Test
     fun upgradeAccount() {
         val intent = Intent()
             .setAction(ACTION_VIEW)

--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/deeplink/DownloadsDeepLinkTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/deeplink/DownloadsDeepLinkTest.kt
@@ -15,5 +15,6 @@ class DownloadsDeepLinkTest {
         val intent = DownloadsDeepLink.toIntent(context)
 
         assertEquals("INTENT_OPEN_APP_DOWNLOADING", intent.action)
+        assertEquals(Uri.parse("pktc://profile/downloads"), intent.data)
     }
 }

--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/deeplink/RecommendationsDeepLinkTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/deeplink/RecommendationsDeepLinkTest.kt
@@ -1,0 +1,22 @@
+package au.com.shiftyjelly.pocketcasts.deeplink
+
+import android.content.Intent.ACTION_VIEW
+import android.net.Uri
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class RecommendationsDeepLinkTest {
+    private val context = InstrumentationRegistry.getInstrumentation().context
+
+    @Test
+    fun createIntent() {
+        val intent = RecommendationsDeepLink.toIntent(context)
+
+        assertEquals(ACTION_VIEW, intent.action)
+        assertEquals(Uri.parse("pktc://discover/recommendations"), intent.data)
+    }
+}

--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/deeplink/TrendingDeepLinkTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/deeplink/TrendingDeepLinkTest.kt
@@ -1,0 +1,22 @@
+package au.com.shiftyjelly.pocketcasts.deeplink
+
+import android.content.Intent.ACTION_VIEW
+import android.net.Uri
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class TrendingDeepLinkTest {
+    private val context = InstrumentationRegistry.getInstrumentation().context
+
+    @Test
+    fun createIntent() {
+        val intent = TrendingDeepLink.toIntent(context)
+
+        assertEquals(ACTION_VIEW, intent.action)
+        assertEquals(Uri.parse("pktc://discover/trending"), intent.data)
+    }
+}

--- a/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
+++ b/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
@@ -80,6 +80,7 @@ import au.com.shiftyjelly.pocketcasts.deeplink.SignInDeepLink
 import au.com.shiftyjelly.pocketcasts.deeplink.SonosDeepLink
 import au.com.shiftyjelly.pocketcasts.deeplink.StaffPicksDeepLink
 import au.com.shiftyjelly.pocketcasts.deeplink.ThemesDeepLink
+import au.com.shiftyjelly.pocketcasts.deeplink.TrendingDeepLink
 import au.com.shiftyjelly.pocketcasts.deeplink.UpgradeAccountDeepLink
 import au.com.shiftyjelly.pocketcasts.deeplink.UpsellDeepLink
 import au.com.shiftyjelly.pocketcasts.discover.util.DiscoverDeepLinkManager
@@ -1368,6 +1369,8 @@ class MainActivity :
                             addFragment(fragment)
                         }
                     }
+                }
+                is TrendingDeepLink -> {
                 }
                 is PlayFromSearchDeepLink -> {
                     playbackManager.mediaSessionManager.playFromSearchExternal(deepLink.query)

--- a/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
+++ b/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
@@ -64,6 +64,7 @@ import au.com.shiftyjelly.pocketcasts.deeplink.OpmlImportDeepLink
 import au.com.shiftyjelly.pocketcasts.deeplink.PlayFromSearchDeepLink
 import au.com.shiftyjelly.pocketcasts.deeplink.PocketCastsWebsiteGetDeepLink
 import au.com.shiftyjelly.pocketcasts.deeplink.PromoCodeDeepLink
+import au.com.shiftyjelly.pocketcasts.deeplink.RecommendationsDeepLink
 import au.com.shiftyjelly.pocketcasts.deeplink.ReferralsDeepLink
 import au.com.shiftyjelly.pocketcasts.deeplink.ShareListDeepLink
 import au.com.shiftyjelly.pocketcasts.deeplink.ShowBookmarkDeepLink
@@ -1372,6 +1373,8 @@ class MainActivity :
                     if (podcastListFragment?.inferredId != TRENDING) {
                         openDiscoverListDeeplink(TRENDING)
                     }
+                }
+                is RecommendationsDeepLink -> {
                 }
                 is PlayFromSearchDeepLink -> {
                     playbackManager.mediaSessionManager.playFromSearchExternal(deepLink.query)

--- a/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
+++ b/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
@@ -51,6 +51,7 @@ import au.com.shiftyjelly.pocketcasts.analytics.SourceView
 import au.com.shiftyjelly.pocketcasts.compose.AppTheme
 import au.com.shiftyjelly.pocketcasts.databinding.ActivityMainBinding
 import au.com.shiftyjelly.pocketcasts.deeplink.AddBookmarkDeepLink
+import au.com.shiftyjelly.pocketcasts.deeplink.AppOpenDeepLink
 import au.com.shiftyjelly.pocketcasts.deeplink.AssistantDeepLink
 import au.com.shiftyjelly.pocketcasts.deeplink.ChangeBookmarkTitleDeepLink
 import au.com.shiftyjelly.pocketcasts.deeplink.CloudFilesDeepLink
@@ -1257,6 +1258,9 @@ class MainActivity :
             val safeUri = intent.data?.buildUpon()?.clearQuery()?.build() // Remove query parameters from logging
             LogBuffer.i("DeepLink", "Opening deep link: $intent. Safe URI: $safeUri")
             when (val deepLink = deepLinkFactory.create(intent)) {
+                is AppOpenDeepLink -> {
+                    closeToRoot()
+                }
                 is DownloadsDeepLink -> {
                     closeToRoot()
                     addFragment(ProfileEpisodeListFragment.newInstance(ProfileEpisodeListFragment.Mode.Downloaded))

--- a/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
+++ b/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
@@ -86,6 +86,7 @@ import au.com.shiftyjelly.pocketcasts.deeplink.UpsellDeepLink
 import au.com.shiftyjelly.pocketcasts.discover.util.DiscoverDeepLinkManager
 import au.com.shiftyjelly.pocketcasts.discover.util.DiscoverDeepLinkManager.Companion.STAFF_PICKS_LIST_ID
 import au.com.shiftyjelly.pocketcasts.discover.view.DiscoverFragment
+import au.com.shiftyjelly.pocketcasts.discover.view.PodcastGridListFragment
 import au.com.shiftyjelly.pocketcasts.discover.view.PodcastListFragment
 import au.com.shiftyjelly.pocketcasts.endofyear.StoriesActivity
 import au.com.shiftyjelly.pocketcasts.endofyear.StoriesActivity.StoriesSource
@@ -141,6 +142,7 @@ import au.com.shiftyjelly.pocketcasts.search.SearchFragment
 import au.com.shiftyjelly.pocketcasts.servers.ServerCallback
 import au.com.shiftyjelly.pocketcasts.servers.ServiceManager
 import au.com.shiftyjelly.pocketcasts.servers.discover.PodcastSearch
+import au.com.shiftyjelly.pocketcasts.servers.model.NetworkLoadableList.Companion.TRENDING
 import au.com.shiftyjelly.pocketcasts.settings.AppearanceSettingsFragment
 import au.com.shiftyjelly.pocketcasts.settings.ExportSettingsFragment
 import au.com.shiftyjelly.pocketcasts.settings.SettingsFragment
@@ -1360,17 +1362,16 @@ class MainActivity :
                     openImport()
                 }
                 is StaffPicksDeepLink -> {
-                    val podcastListFragment = supportFragmentManager.fragments.find { it is PodcastListFragment } as? PodcastListFragment
+                    val podcastListFragment = supportFragmentManager.fragments.find { it is PodcastGridListFragment } as? PodcastGridListFragment
                     if (podcastListFragment?.listUuid != STAFF_PICKS_LIST_ID) {
-                        openTab(VR.id.navigation_discover)
-                        lifecycleScope.launch {
-                            val staffPicksList = discoverDeepLinkManager.getDiscoverList(STAFF_PICKS_LIST_ID, resources) ?: return@launch
-                            val fragment = PodcastListFragment.newInstance(staffPicksList)
-                            addFragment(fragment)
-                        }
+                        openDiscoverListDeeplink(STAFF_PICKS_LIST_ID)
                     }
                 }
                 is TrendingDeepLink -> {
+                    val podcastListFragment = supportFragmentManager.fragments.find { it is PodcastGridListFragment } as? PodcastGridListFragment
+                    if (podcastListFragment?.inferredId != TRENDING) {
+                        openDiscoverListDeeplink(TRENDING)
+                    }
                 }
                 is PlayFromSearchDeepLink -> {
                     playbackManager.mediaSessionManager.playFromSearchExternal(deepLink.query)
@@ -1396,6 +1397,15 @@ class MainActivity :
         } catch (e: Exception) {
             Timber.e(e)
             crashLogging.sendReport(e)
+        }
+    }
+
+    private fun openDiscoverListDeeplink(listId: String) {
+        openTab(VR.id.navigation_discover)
+        lifecycleScope.launch {
+            val discoverList = discoverDeepLinkManager.getDiscoverList(listId, resources) ?: return@launch
+            val fragment = PodcastListFragment.newInstance(discoverList)
+            addFragment(fragment)
         }
     }
 

--- a/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/util/DiscoverDeepLinkManager.kt
+++ b/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/util/DiscoverDeepLinkManager.kt
@@ -31,7 +31,7 @@ class DiscoverDeepLinkManager @Inject constructor(
         )
 
         val discoverRows: List<DiscoverRow> = discover.layout.transformWithRegion(region, replacements, resources)
-        val staffPicksRow: DiscoverRow? = discoverRows.firstOrNull { it.listUuid == listId }
+        val staffPicksRow: DiscoverRow? = discoverRows.firstOrNull { it.inferredId() == listId }
         staffPicksRow?.transformWithReplacements(replacements, resources)
     }
 }

--- a/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/PodcastGridListFragment.kt
+++ b/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/PodcastGridListFragment.kt
@@ -101,7 +101,7 @@ open class PodcastGridListFragment : BaseFragment(), Toolbar.OnMenuItemClickList
     val listUuid: String?
         get() = arguments?.getString(ARG_LIST_UUID)
 
-    private val inferredId: String
+    val inferredId: String
         get() = arguments?.getString(ARG_INFERRED_ID) ?: NetworkLoadableList.Companion.NONE
 
     val sourceUrl: String?

--- a/modules/services/deeplink/src/main/kotlin/au/com/shiftyjelly/pocketcasts/deeplink/DeepLink.kt
+++ b/modules/services/deeplink/src/main/kotlin/au/com/shiftyjelly/pocketcasts/deeplink/DeepLink.kt
@@ -255,6 +255,11 @@ data object TrendingDeepLink : IntentableDeepLink {
         .setData(Uri.parse("pktc://discover/trending"))
 }
 
+data object RecommendationsDeepLink : IntentableDeepLink {
+    override fun toIntent(context: Context) = Intent(ACTION_VIEW)
+        .setData(Uri.parse("pktc://discover/recommendations"))
+}
+
 data class PlayFromSearchDeepLink(
     val query: String,
 ) : DeepLink

--- a/modules/services/deeplink/src/main/kotlin/au/com/shiftyjelly/pocketcasts/deeplink/DeepLink.kt
+++ b/modules/services/deeplink/src/main/kotlin/au/com/shiftyjelly/pocketcasts/deeplink/DeepLink.kt
@@ -8,7 +8,6 @@ import au.com.shiftyjelly.pocketcasts.deeplink.DeepLink.Companion.ACTION_OPEN_AD
 import au.com.shiftyjelly.pocketcasts.deeplink.DeepLink.Companion.ACTION_OPEN_BOOKMARK
 import au.com.shiftyjelly.pocketcasts.deeplink.DeepLink.Companion.ACTION_OPEN_CHANGE_BOOKMARK_TITLE
 import au.com.shiftyjelly.pocketcasts.deeplink.DeepLink.Companion.ACTION_OPEN_DELETE_BOOKMARK
-import au.com.shiftyjelly.pocketcasts.deeplink.DeepLink.Companion.ACTION_OPEN_DOWNLOADS
 import au.com.shiftyjelly.pocketcasts.deeplink.DeepLink.Companion.ACTION_OPEN_EPISODE
 import au.com.shiftyjelly.pocketcasts.deeplink.DeepLink.Companion.ACTION_OPEN_PODCAST
 import au.com.shiftyjelly.pocketcasts.deeplink.DeepLink.Companion.EXTRA_AUTO_PLAY
@@ -51,8 +50,10 @@ sealed interface UriDeepLink : DeepLink {
 }
 
 data object DownloadsDeepLink : IntentableDeepLink {
-    override fun toIntent(context: Context) = context.launcherIntent
-        .setAction(ACTION_OPEN_DOWNLOADS)
+    private val uri = Uri.parse("pktc://profile/downloads")
+
+    override fun toIntent(context: Context): Intent = Intent(ACTION_VIEW, uri)
+        .setPackage(context.packageName)
 }
 
 data object AddBookmarkDeepLink : IntentableDeepLink {

--- a/modules/services/deeplink/src/main/kotlin/au/com/shiftyjelly/pocketcasts/deeplink/DeepLink.kt
+++ b/modules/services/deeplink/src/main/kotlin/au/com/shiftyjelly/pocketcasts/deeplink/DeepLink.kt
@@ -261,6 +261,11 @@ data object RecommendationsDeepLink : IntentableDeepLink {
         .setData(Uri.parse("pktc://discover/recommendations"))
 }
 
+data object AppOpenDeepLink : IntentableDeepLink {
+    override fun toIntent(context: Context) = Intent(ACTION_VIEW)
+        .setData(Uri.parse("pktc://open"))
+}
+
 data class PlayFromSearchDeepLink(
     val query: String,
 ) : DeepLink

--- a/modules/services/deeplink/src/main/kotlin/au/com/shiftyjelly/pocketcasts/deeplink/DeepLink.kt
+++ b/modules/services/deeplink/src/main/kotlin/au/com/shiftyjelly/pocketcasts/deeplink/DeepLink.kt
@@ -250,6 +250,11 @@ data object StaffPicksDeepLink : IntentableDeepLink {
         .setData(Uri.parse("pktc://discover/staffpicks"))
 }
 
+data object TrendingDeepLink : IntentableDeepLink {
+    override fun toIntent(context: Context) = Intent(ACTION_VIEW)
+        .setData(Uri.parse("pktc://discover/trending"))
+}
+
 data class PlayFromSearchDeepLink(
     val query: String,
 ) : DeepLink

--- a/modules/services/deeplink/src/main/kotlin/au/com/shiftyjelly/pocketcasts/deeplink/DeepLinkFactory.kt
+++ b/modules/services/deeplink/src/main/kotlin/au/com/shiftyjelly/pocketcasts/deeplink/DeepLinkFactory.kt
@@ -68,6 +68,7 @@ class DeepLinkFactory(
         PlayFromSearchAdapter(),
         AssistantAdapter(),
         ThemesAdapter(),
+        AppOpenAdapter(),
     )
 
     fun create(intent: Intent): DeepLink? {
@@ -569,6 +570,7 @@ private class OpmlAdapter(
             "subscribeonandroid.com",
             "www.subscribeonandroid.com",
             "discover",
+            "open",
         )
     }
 }
@@ -582,6 +584,20 @@ private class ImportAdapter : DeepLinkAdapter {
 
         return if (intent.action == ACTION_VIEW && scheme == "pktc" && host == "settings" && path == "/import") {
             ImportDeepLink
+        } else {
+            null
+        }
+    }
+}
+
+private class AppOpenAdapter : DeepLinkAdapter {
+    override fun create(intent: Intent): DeepLink? {
+        val uriData = intent.data ?: return null
+        val scheme = uriData.scheme
+        val host = uriData.host
+
+        return if (intent.action == ACTION_VIEW && scheme == "pktc" && host == "open") {
+            AppOpenDeepLink
         } else {
             null
         }

--- a/modules/services/deeplink/src/main/kotlin/au/com/shiftyjelly/pocketcasts/deeplink/DeepLinkFactory.kt
+++ b/modules/services/deeplink/src/main/kotlin/au/com/shiftyjelly/pocketcasts/deeplink/DeepLinkFactory.kt
@@ -63,7 +63,7 @@ class DeepLinkFactory(
         WebPlayerShareLinkAdapter(webPlayerHost),
         OpmlAdapter(listOf(listHost, shareHost)),
         ImportAdapter(),
-        StaffPicksAdapter(),
+        DiscoverAdapter(),
         PodcastUrlSchemeAdapter(listOf(listHost, shareHost, webBaseHost)),
         PlayFromSearchAdapter(),
         AssistantAdapter(),
@@ -578,18 +578,24 @@ private class ImportAdapter : DeepLinkAdapter {
     }
 }
 
-private class StaffPicksAdapter : DeepLinkAdapter {
+private class DiscoverAdapter : DeepLinkAdapter {
     override fun create(intent: Intent): DeepLink? {
         val uriData = intent.data ?: return null
         val scheme = uriData.scheme
         val host = uriData.host
         val path = uriData.path
 
-        return if (intent.action == ACTION_VIEW && scheme == "pktc" && host == "discover" && path == "/staffpicks") {
-            StaffPicksDeepLink
-        } else {
-            null
-        }
+        return if (intent.action == ACTION_VIEW && scheme == "pktc" && host == "discover") {
+            when (path) {
+                "/staffpicks" -> {
+                    StaffPicksDeepLink
+                }
+                "/trending" -> {
+                    TrendingDeepLink
+                }
+                else -> { null }
+            }
+        } else { null }
     }
 }
 

--- a/modules/services/deeplink/src/main/kotlin/au/com/shiftyjelly/pocketcasts/deeplink/DeepLinkFactory.kt
+++ b/modules/services/deeplink/src/main/kotlin/au/com/shiftyjelly/pocketcasts/deeplink/DeepLinkFactory.kt
@@ -100,10 +100,20 @@ private interface DeepLinkAdapter {
 }
 
 private class DownloadsAdapter : DeepLinkAdapter {
-    override fun create(intent: Intent) = if (intent.action == ACTION_OPEN_DOWNLOADS) {
-        DownloadsDeepLink
-    } else {
-        null
+    override fun create(intent: Intent): DeepLink? {
+        return when {
+            isUriMatch(intent) -> DownloadsDeepLink
+            intent.action == ACTION_OPEN_DOWNLOADS -> DownloadsDeepLink
+            else -> null
+        }
+    }
+
+    private fun isUriMatch(intent: Intent): Boolean {
+        val uri = intent.data ?: return false
+        return intent.action == ACTION_VIEW &&
+            uri.scheme == "pktc" &&
+            uri.host == "profile" &&
+            uri.path == "/downloads"
     }
 }
 

--- a/modules/services/deeplink/src/main/kotlin/au/com/shiftyjelly/pocketcasts/deeplink/DeepLinkFactory.kt
+++ b/modules/services/deeplink/src/main/kotlin/au/com/shiftyjelly/pocketcasts/deeplink/DeepLinkFactory.kt
@@ -593,6 +593,9 @@ private class DiscoverAdapter : DeepLinkAdapter {
                 "/trending" -> {
                     TrendingDeepLink
                 }
+                "/recommendations" -> {
+                    RecommendationsDeepLink
+                }
                 else -> { null }
             }
         } else { null }


### PR DESCRIPTION
## Description
- This PR support the remaining deeplinks that you can found on this doc p1743685755349989/1743684484.596599-slack-C08KX131YRJ
    - Open App
    - Download page
    - Trending
    - Recommendations

## Testing Instructions

### Open App
1. Install the app
2. In Android Studio terminal, run: `adb shell am start -a android.intent.action.VIEW -d "pktc://open"`
3. Ensure the app opens ✅

### Download page
1. Install the app
2. In Android Studio terminal, run: `adb shell am start -a android.intent.action.VIEW -d "pktc://profile/downloads"`
3. Ensure the Downloads screen opens ✅

#### Regression
1. Download an episode
2. Tap on the download notification
3. Ensure the Downloads screen opens ✅

### Trending
1. Install the app
2. In Android Studio terminal, run: `adb shell am start -a android.intent.action.VIEW -d "pktc://discover/trending"`
3. Ensure the Trending screen opens ✅

### Recommendations
- Do code review for this one since we don't have recommendations screen yet
- See: p1744733914647749-slack-C08KX131YRJ


## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [ ] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.