### PR TITLE
[Push Notifications Revamp] Setup remaining notifications channels

### DIFF
--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -2034,6 +2034,7 @@
     <string name="notification_channel_description_daily_reminders">Shows daily tips to get you started during your first week.</string>
     <string name="notification_channel_description_trending_and_recommendations">Shows trending podcasts and curated recommendations to help you discover new favorites</string>
     <string name="notification_channel_description_new_features_and_tips">Shows notifications about new features, updates, and handy tips to help you optimize your Pocket Casts experience</string>
+    <string name="notification_channel_description_offers">Shows notifications about exclusive offers, discounts, and promotions to help you make the most of your Pocket Casts experience</string>
 
     <!-- Bookmarks -->
 

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -2031,7 +2031,7 @@
     <string name="notification_channel_description_bookmark">Shows when bookmark is added using headphones</string>
     <string name="notification_channel_description_fix_downloads">Shows when downloads fix is triggered</string>
     <string name="notification_channel_description_fix_downloads_complete">Shows when downloads fix is complete</string>
-    <string name="notification_channel_description_daily_reminders">Shows daily tips to get you started during your first week.</string>
+    <string name="notification_channel_description_daily_reminders">Shows helpful suggestions to support your listening routine.</string>
     <string name="notification_channel_description_trending_and_recommendations">Shows trending podcasts and curated recommendations to help you discover new favorites</string>
     <string name="notification_channel_description_new_features_and_tips">Shows notifications about new features, updates, and handy tips to help you optimize your Pocket Casts experience</string>
     <string name="notification_channel_description_offers">Shows notifications about exclusive offers, discounts, and promotions to help you make the most of your Pocket Casts experience</string>

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -2031,7 +2031,7 @@
     <string name="notification_channel_description_bookmark">Shows when bookmark is added using headphones</string>
     <string name="notification_channel_description_fix_downloads">Shows when downloads fix is triggered</string>
     <string name="notification_channel_description_fix_downloads_complete">Shows when downloads fix is complete</string>
-    <string name="notification_channel_description_onboarding">Shows daily tips to get you started during your first week.</string>
+    <string name="notification_channel_description_daily_reminders">Shows daily tips to get you started during your first week.</string>
     <string name="notification_channel_description_trending_and_recommendations">Shows trending podcasts and curated recommendations to help you discover new favorites</string>
     <string name="notification_channel_description_new_features_and_tips">Shows notifications about new features, updates, and handy tips to help you optimize your Pocket Casts experience</string>
 

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -2033,6 +2033,7 @@
     <string name="notification_channel_description_fix_downloads_complete">Shows when downloads fix is complete</string>
     <string name="notification_channel_description_onboarding">Shows daily tips to get you started during your first week.</string>
     <string name="notification_channel_description_trending_and_recommendations">Shows trending podcasts and curated recommendations to help you discover new favorites</string>
+    <string name="notification_channel_description_new_features_and_tips">Shows notifications about new features, updates, and handy tips to help you optimize your Pocket Casts experience</string>
 
     <!-- Bookmarks -->
 

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -2032,6 +2032,7 @@
     <string name="notification_channel_description_fix_downloads">Shows when downloads fix is triggered</string>
     <string name="notification_channel_description_fix_downloads_complete">Shows when downloads fix is complete</string>
     <string name="notification_channel_description_onboarding">Shows daily tips to get you started during your first week.</string>
+    <string name="notification_channel_description_trending_and_recommendations">Shows trending podcasts and curated recommendations to help you discover new favorites</string>
 
     <!-- Bookmarks -->
 

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
@@ -134,6 +134,7 @@ interface Settings {
         NOTIFICATION_CHANNEL_ID_FIX_DOWNLOADS("fixDownloads"),
         NOTIFICATION_CHANNEL_ID_FIX_DOWNLOADS_COMPLETE("fixDownloadsComplete"),
         NOTIFICATION_CHANNEL_ID_ONBOARDING("onboarding"),
+        NOTIFICATION_CHANNEL_ID_TRENDING_AND_RECOMMENDATIONS("trendingAndRecommendations"),
     }
 
     enum class NotificationId(val value: Int) {

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
@@ -135,6 +135,7 @@ interface Settings {
         NOTIFICATION_CHANNEL_ID_FIX_DOWNLOADS_COMPLETE("fixDownloadsComplete"),
         NOTIFICATION_CHANNEL_ID_ONBOARDING("onboarding"),
         NOTIFICATION_CHANNEL_ID_TRENDING_AND_RECOMMENDATIONS("trendingAndRecommendations"),
+        NOTIFICATION_CHANNEL_ID_NEW_FEATURES_AND_TIPS("newFeaturesAndTips"),
     }
 
     enum class NotificationId(val value: Int) {

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
@@ -134,6 +134,7 @@ interface Settings {
         NOTIFICATION_CHANNEL_ID_DAILY_REMINDERS("dailyReminders"),
         NOTIFICATION_CHANNEL_ID_TRENDING_AND_RECOMMENDATIONS("trendingAndRecommendations"),
         NOTIFICATION_CHANNEL_ID_NEW_FEATURES_AND_TIPS("newFeaturesAndTips"),
+        NOTIFICATION_CHANNEL_ID_OFFERS("offers"),
     }
 
     enum class NotificationId(val value: Int) {

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
@@ -13,8 +13,6 @@ import au.com.shiftyjelly.pocketcasts.models.type.AutoDownloadLimitSetting
 import au.com.shiftyjelly.pocketcasts.models.type.PodcastsSortType
 import au.com.shiftyjelly.pocketcasts.models.type.SubscriptionFrequency
 import au.com.shiftyjelly.pocketcasts.models.type.SubscriptionTier
-import au.com.shiftyjelly.pocketcasts.preferences.Settings.CloudSortOrder.entries
-import au.com.shiftyjelly.pocketcasts.preferences.Settings.UpNextAction.entries
 import au.com.shiftyjelly.pocketcasts.preferences.model.AppIconSetting
 import au.com.shiftyjelly.pocketcasts.preferences.model.ArtworkConfiguration
 import au.com.shiftyjelly.pocketcasts.preferences.model.AutoAddUpNextLimitBehaviour
@@ -133,7 +131,7 @@ interface Settings {
         NOTIFICATION_CHANNEL_ID_BOOKMARK("bookmark"),
         NOTIFICATION_CHANNEL_ID_FIX_DOWNLOADS("fixDownloads"),
         NOTIFICATION_CHANNEL_ID_FIX_DOWNLOADS_COMPLETE("fixDownloadsComplete"),
-        NOTIFICATION_CHANNEL_ID_ONBOARDING("onboarding"),
+        NOTIFICATION_CHANNEL_ID_DAILY_REMINDERS("dailyReminders"),
         NOTIFICATION_CHANNEL_ID_TRENDING_AND_RECOMMENDATIONS("trendingAndRecommendations"),
         NOTIFICATION_CHANNEL_ID_NEW_FEATURES_AND_TIPS("newFeaturesAndTips"),
     }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/notification/NotificationHelper.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/notification/NotificationHelper.kt
@@ -17,7 +17,7 @@ interface NotificationHelper {
     fun downloadsFixChannelBuilder(): NotificationCompat.Builder
     fun downloadsFixCompleteChannelBuilder(): NotificationCompat.Builder
     fun openEpisodeNotificationSettings(activity: Activity?)
-    fun onboardingChannelBuilder(): NotificationCompat.Builder
+    fun dailyRemindersChannelBuilder(): NotificationCompat.Builder
     fun isShowing(notificationId: Int): Boolean
     fun removeNotification(intentExtras: Bundle?, notificationId: Int)
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/notification/NotificationHelper.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/notification/NotificationHelper.kt
@@ -18,6 +18,9 @@ interface NotificationHelper {
     fun downloadsFixCompleteChannelBuilder(): NotificationCompat.Builder
     fun openEpisodeNotificationSettings(activity: Activity?)
     fun dailyRemindersChannelBuilder(): NotificationCompat.Builder
+    fun trendingAndRecommendationsChannelBuilder(): NotificationCompat.Builder
+    fun featuresAndTipsChannelBuilder(): NotificationCompat.Builder
+    fun offersChannelBuilder(): NotificationCompat.Builder
     fun isShowing(notificationId: Int): Boolean
     fun removeNotification(intentExtras: Bundle?, notificationId: Int)
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/notification/NotificationHelperImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/notification/NotificationHelperImpl.kt
@@ -121,6 +121,14 @@ class NotificationHelperImpl @Inject constructor(@ApplicationContext private val
         }
         channelList.add(trendingAndRecommendationsChannel)
 
+        val newFeaturesAndTipsChannel = NotificationChannel(Settings.NotificationChannel.NOTIFICATION_CHANNEL_ID_NEW_FEATURES_AND_TIPS.id, "New Features & Tips", NotificationManager.IMPORTANCE_DEFAULT).apply {
+            description = context.getString(LR.string.notification_channel_description_new_features_and_tips)
+            setShowBadge(false)
+            enableVibration(true)
+            lockscreenVisibility = Notification.VISIBILITY_PUBLIC
+        }
+        channelList.add(newFeaturesAndTipsChannel)
+
         notificationManager.createNotificationChannels(channelList)
     }
 

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/notification/NotificationHelperImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/notification/NotificationHelperImpl.kt
@@ -129,6 +129,14 @@ class NotificationHelperImpl @Inject constructor(@ApplicationContext private val
         }
         channelList.add(newFeaturesAndTipsChannel)
 
+        val offersChannel = NotificationChannel(Settings.NotificationChannel.NOTIFICATION_CHANNEL_ID_OFFERS.id, "Offers", NotificationManager.IMPORTANCE_DEFAULT).apply {
+            description = context.getString(LR.string.notification_channel_description_offers)
+            setShowBadge(false)
+            enableVibration(true)
+            lockscreenVisibility = Notification.VISIBILITY_PUBLIC
+        }
+        channelList.add(offersChannel)
+
         notificationManager.createNotificationChannels(channelList)
     }
 

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/notification/NotificationHelperImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/notification/NotificationHelperImpl.kt
@@ -176,6 +176,18 @@ class NotificationHelperImpl @Inject constructor(@ApplicationContext private val
         return NotificationCompat.Builder(context, Settings.NotificationChannel.NOTIFICATION_CHANNEL_ID_DAILY_REMINDERS.id)
     }
 
+    override fun trendingAndRecommendationsChannelBuilder(): NotificationCompat.Builder {
+        return NotificationCompat.Builder(context, Settings.NotificationChannel.NOTIFICATION_CHANNEL_ID_TRENDING_AND_RECOMMENDATIONS.id)
+    }
+
+    override fun featuresAndTipsChannelBuilder(): NotificationCompat.Builder {
+        return NotificationCompat.Builder(context, Settings.NotificationChannel.NOTIFICATION_CHANNEL_ID_NEW_FEATURES_AND_TIPS.id)
+    }
+
+    override fun offersChannelBuilder(): NotificationCompat.Builder {
+        return NotificationCompat.Builder(context, Settings.NotificationChannel.NOTIFICATION_CHANNEL_ID_OFFERS.id)
+    }
+
     /**
      * Opens the system notification activity for the episode channel.
      */

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/notification/NotificationHelperImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/notification/NotificationHelperImpl.kt
@@ -113,6 +113,14 @@ class NotificationHelperImpl @Inject constructor(@ApplicationContext private val
         }
         channelList.add(onboardingChannel)
 
+        val trendingAndRecommendationsChannel = NotificationChannel(Settings.NotificationChannel.NOTIFICATION_CHANNEL_ID_TRENDING_AND_RECOMMENDATIONS.id, "Trending & Recommendations", NotificationManager.IMPORTANCE_DEFAULT).apply {
+            description = context.getString(LR.string.notification_channel_description_trending_and_recommendations)
+            setShowBadge(false)
+            enableVibration(true)
+            lockscreenVisibility = Notification.VISIBILITY_PUBLIC
+        }
+        channelList.add(trendingAndRecommendationsChannel)
+
         notificationManager.createNotificationChannels(channelList)
     }
 

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/notification/NotificationHelperImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/notification/NotificationHelperImpl.kt
@@ -105,13 +105,13 @@ class NotificationHelperImpl @Inject constructor(@ApplicationContext private val
         }
         channelList.add(fixDownloadsCompleteChannel)
 
-        val onboardingChannel = NotificationChannel(Settings.NotificationChannel.NOTIFICATION_CHANNEL_ID_ONBOARDING.id, "Onboarding", NotificationManager.IMPORTANCE_DEFAULT).apply {
-            description = context.getString(LR.string.notification_channel_description_onboarding)
+        val dailyRemindersChannel = NotificationChannel(Settings.NotificationChannel.NOTIFICATION_CHANNEL_ID_DAILY_REMINDERS.id, "Daily Reminders", NotificationManager.IMPORTANCE_DEFAULT).apply {
+            description = context.getString(LR.string.notification_channel_description_daily_reminders)
             setShowBadge(false)
             enableVibration(true)
             lockscreenVisibility = Notification.VISIBILITY_PUBLIC
         }
-        channelList.add(onboardingChannel)
+        channelList.add(dailyRemindersChannel)
 
         val trendingAndRecommendationsChannel = NotificationChannel(Settings.NotificationChannel.NOTIFICATION_CHANNEL_ID_TRENDING_AND_RECOMMENDATIONS.id, "Trending & Recommendations", NotificationManager.IMPORTANCE_DEFAULT).apply {
             description = context.getString(LR.string.notification_channel_description_trending_and_recommendations)
@@ -164,8 +164,8 @@ class NotificationHelperImpl @Inject constructor(@ApplicationContext private val
         return NotificationCompat.Builder(context, Settings.NotificationChannel.NOTIFICATION_CHANNEL_ID_FIX_DOWNLOADS_COMPLETE.id)
     }
 
-    override fun onboardingChannelBuilder(): NotificationCompat.Builder {
-        return NotificationCompat.Builder(context, Settings.NotificationChannel.NOTIFICATION_CHANNEL_ID_ONBOARDING.id)
+    override fun dailyRemindersChannelBuilder(): NotificationCompat.Builder {
+        return NotificationCompat.Builder(context, Settings.NotificationChannel.NOTIFICATION_CHANNEL_ID_DAILY_REMINDERS.id)
     }
 
     /**

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/notification/OnboardingNotificationWorker.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/notification/OnboardingNotificationWorker.kt
@@ -51,7 +51,7 @@ class OnboardingNotificationWorker @AssistedInject constructor(
     }
 
     private fun getNotificationBuilder(type: OnboardingNotificationType): NotificationCompat.Builder {
-        return notificationHelper.onboardingChannelBuilder()
+        return notificationHelper.dailyRemindersChannelBuilder()
             .setSmallIcon(IR.drawable.notification)
             .setVisibility(NotificationCompat.VISIBILITY_PUBLIC)
             .setContentTitle(applicationContext.resources.getString(type.titleRes))


### PR DESCRIPTION
## Description
- Setup `Trending & Recommendations`, `New Features & Tips` and `Pocket Casts Offers` channel
- Rename `Daily Reminders` channel

## Testing Instructions
1. Install the app
2. Open system notification settings for Pocket Casts
3. ✅ Ensure the channels were created

## Screenshots or Screencast 

<img src="https://github.com/user-attachments/assets/2b6f63f0-65cb-4999-ba30-7dd19355f44e" width="300">


## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
