### PR TITLE
Skip recommendations when upselling from some features

### DIFF
--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/OnboardingFlowComposable.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/OnboardingFlowComposable.kt
@@ -357,11 +357,11 @@ object OnboardingNavRoute {
 }
 
 private val forcedPurchaseSources = listOf(
-    OnboardingUpgradeSource.APPEARANCE,
     OnboardingUpgradeSource.BOOKMARKS,
     OnboardingUpgradeSource.BOOKMARKS_SHELF_ACTION,
     OnboardingUpgradeSource.GENERATED_TRANSCRIPTS,
     OnboardingUpgradeSource.SKIP_CHAPTERS,
     OnboardingUpgradeSource.SUGGESTED_FOLDERS,
+    OnboardingUpgradeSource.THEMES,
     OnboardingUpgradeSource.UP_NEXT_SHUFFLE,
 )

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/OnboardingFlowComposable.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/OnboardingFlowComposable.kt
@@ -357,6 +357,11 @@ object OnboardingNavRoute {
 }
 
 private val forcedPurchaseSources = listOf(
-    OnboardingUpgradeSource.SUGGESTED_FOLDERS,
+    OnboardingUpgradeSource.APPEARANCE,
+    OnboardingUpgradeSource.BOOKMARKS,
+    OnboardingUpgradeSource.BOOKMARKS_SHELF_ACTION,
     OnboardingUpgradeSource.GENERATED_TRANSCRIPTS,
+    OnboardingUpgradeSource.SKIP_CHAPTERS,
+    OnboardingUpgradeSource.SUGGESTED_FOLDERS,
+    OnboardingUpgradeSource.UP_NEXT_SHUFFLE,
 )


### PR DESCRIPTION
## Description

This PR removes podcasts recommendation step from the login flow when starting it from some of the paid features.

Fixes #3774

## Testing Instructions

Verify that going through the upsell flow from these features doesn't offer you podcast recommendations:
- Bookmarks
- Preselect Chapters
- Up Next Shuffle
- Themes
- Generated Transcripts

## Checklist
- [ ] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] ~I have considered whether it makes sense to add tests for my changes~
- [ ] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [ ] ~Any jetpack compose components I added or changed are covered by compose previews~
- [ ] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.`~