### PR TITLE
[Push Notifications Revamp] Update onboarding notifications intent

### DIFF
--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/deeplink/CreateAccountDeepLinkTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/deeplink/CreateAccountDeepLinkTest.kt
@@ -1,0 +1,22 @@
+package au.com.shiftyjelly.pocketcasts.deeplink
+
+import android.content.Intent.ACTION_VIEW
+import android.net.Uri
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class CreateAccountDeepLinkTest {
+    private val context = InstrumentationRegistry.getInstrumentation().context
+
+    @Test
+    fun createIntent() {
+        val intent = CreateAccountDeepLink.toIntent(context)
+
+        assertEquals(ACTION_VIEW, intent.action)
+        assertEquals(Uri.parse("pktc://signup"), intent.data)
+    }
+}

--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/deeplink/DeepLinkFactoryTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/deeplink/DeepLinkFactoryTest.kt
@@ -553,6 +553,17 @@ class DeepLinkFactoryTest {
     }
 
     @Test
+    fun createAccount() {
+        val intent = Intent()
+            .setAction(ACTION_VIEW)
+            .setData(Uri.parse("pktc://signup"))
+
+        val deepLink = factory.create(intent)
+
+        assertEquals(CreateAccountDeepLink, deepLink)
+    }
+
+    @Test
     fun openApp() {
         val intent = Intent()
             .setAction(ACTION_VIEW)

--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/deeplink/DownloadsDeepLinkTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/deeplink/DownloadsDeepLinkTest.kt
@@ -1,5 +1,6 @@
 package au.com.shiftyjelly.pocketcasts.deeplink
 
+import android.content.Intent.ACTION_VIEW
 import android.net.Uri
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
@@ -15,7 +16,7 @@ class DownloadsDeepLinkTest {
     fun createIntent() {
         val intent = DownloadsDeepLink.toIntent(context)
 
-        assertEquals("INTENT_OPEN_APP_DOWNLOADING", intent.action)
+        assertEquals(ACTION_VIEW, intent.action)
         assertEquals(Uri.parse("pktc://profile/downloads"), intent.data)
     }
 }

--- a/app/src/main/java/au/com/shiftyjelly/pocketcasts/PocketCastsApplication.kt
+++ b/app/src/main/java/au/com/shiftyjelly/pocketcasts/PocketCastsApplication.kt
@@ -21,6 +21,7 @@ import au.com.shiftyjelly.pocketcasts.repositories.file.StorageOptions
 import au.com.shiftyjelly.pocketcasts.repositories.jobs.VersionMigrationsWorker
 import au.com.shiftyjelly.pocketcasts.repositories.notification.NotificationHelper
 import au.com.shiftyjelly.pocketcasts.repositories.notification.NotificationManager
+import au.com.shiftyjelly.pocketcasts.repositories.notification.ReEngagementNotificationType
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
 import au.com.shiftyjelly.pocketcasts.repositories.playback.SleepTimerRestartWhenShakingDevice
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
@@ -188,6 +189,8 @@ class PocketCastsApplication : Application(), Configuration.Provider {
 
             notificationHelper.setupNotificationChannels()
             notificationManager.setupOnboardingNotifications()
+            notificationManager.setupReEngagementNotifications()
+            notificationManager.updateUserFeatureInteraction(ReEngagementNotificationType.notificationId)
             appLifecycleObserver.setup()
 
             Coil.setImageLoader(coilImageLoader)

--- a/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
+++ b/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
@@ -55,6 +55,7 @@ import au.com.shiftyjelly.pocketcasts.deeplink.AppOpenDeepLink
 import au.com.shiftyjelly.pocketcasts.deeplink.AssistantDeepLink
 import au.com.shiftyjelly.pocketcasts.deeplink.ChangeBookmarkTitleDeepLink
 import au.com.shiftyjelly.pocketcasts.deeplink.CloudFilesDeepLink
+import au.com.shiftyjelly.pocketcasts.deeplink.CreateAccountDeepLink
 import au.com.shiftyjelly.pocketcasts.deeplink.DeepLink.Companion.EXTRA_PAGE
 import au.com.shiftyjelly.pocketcasts.deeplink.DeepLinkFactory
 import au.com.shiftyjelly.pocketcasts.deeplink.DeleteBookmarkDeepLink
@@ -1322,6 +1323,9 @@ class MainActivity :
                             }
                         }
                     }
+                }
+                is CreateAccountDeepLink -> {
+                    openOnboardingFlow(OnboardingFlow.LoggedOut)
                 }
                 is ShowFiltersDeepLink -> {
                     closePlayer()

--- a/modules/features/shared/src/main/java/au/com/shiftyjelly/pocketcasts/shared/AppLifecycleObserver.kt
+++ b/modules/features/shared/src/main/java/au/com/shiftyjelly/pocketcasts/shared/AppLifecycleObserver.kt
@@ -20,6 +20,7 @@ import dagger.hilt.android.qualifiers.ApplicationContext
 import javax.inject.Inject
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.cancel
+import kotlinx.coroutines.launch
 
 class AppLifecycleObserver(
     @ApplicationContext private val appContext: Context,
@@ -65,6 +66,9 @@ class AppLifecycleObserver(
         handleNewInstallOrUpgrade()
         setupFeatureFlags()
         networkConnectionWatcher.startWatching()
+        applicationScope.launch {
+            notificationScheduler.setupReEngagementNotification()
+        }
     }
 
     override fun onResume(owner: LifecycleOwner) {

--- a/modules/features/shared/src/test/java/au/com/shiftyjelly/pocketcasts/shared/AppLifecycleObserverTest.kt
+++ b/modules/features/shared/src/test/java/au/com/shiftyjelly/pocketcasts/shared/AppLifecycleObserverTest.kt
@@ -14,6 +14,7 @@ import au.com.shiftyjelly.pocketcasts.utils.featureflag.providers.PreferencesFea
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.test.runTest
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -98,7 +99,7 @@ class AppLifecycleObserverTest {
     /* NEW INSTALL */
 
     @Test
-    fun handlesNewInstallPhone() {
+    fun handlesNewInstallPhone() = runTest {
         whenever(settings.getMigratedVersionCode()).thenReturn(VERSION_CODE_DEFAULT)
 
         appLifecycleObserver = spy(appLifecycleObserver)
@@ -114,10 +115,11 @@ class AppLifecycleObserverTest {
 
         verify(appLifecycleAnalytics, never()).onApplicationUpgrade(any())
         verify(notificationScheduler, times(1)).setupOnboardingNotifications()
+        verify(notificationScheduler, times(1)).setupReEngagementNotification()
     }
 
     @Test
-    fun handlesNewInstallWear() {
+    fun handlesNewInstallWear() = runTest {
         whenever(settings.getMigratedVersionCode()).thenReturn(VERSION_CODE_DEFAULT)
 
         appLifecycleObserver = spy(appLifecycleObserver)
@@ -133,10 +135,11 @@ class AppLifecycleObserverTest {
         verify(useUpNextDarkThemeSetting).set(false, updateModifiedAt = false)
         verify(appLifecycleAnalytics, never()).onApplicationUpgrade(any())
         verify(notificationScheduler, never()).setupOnboardingNotifications()
+        verify(notificationScheduler, times(1)).setupReEngagementNotification()
     }
 
     @Test
-    fun handlesNewInstallAutomotive() {
+    fun handlesNewInstallAutomotive() = runTest {
         whenever(settings.getMigratedVersionCode()).thenReturn(VERSION_CODE_DEFAULT)
 
         appLifecycleObserver = spy(appLifecycleObserver)
@@ -152,12 +155,13 @@ class AppLifecycleObserverTest {
         verify(useUpNextDarkThemeSetting).set(false, updateModifiedAt = false)
         verify(appLifecycleAnalytics, never()).onApplicationUpgrade(any())
         verify(notificationScheduler, never()).setupOnboardingNotifications()
+        verify(notificationScheduler, times(1)).setupReEngagementNotification()
     }
 
     /* UPGRADE */
 
     @Test
-    fun handlesUpgrade() {
+    fun handlesUpgrade() = runTest {
         whenever(settings.getMigratedVersionCode()).thenReturn(VERSION_CODE_AFTER_FIRST_INSTALL)
 
         appLifecycleObserver.setup()
@@ -170,5 +174,6 @@ class AppLifecycleObserverTest {
         verify(dailyRemindersNotificationSetting, never()).set(any(), any(), any(), any())
         verify(useUpNextDarkThemeSetting, never()).set(any(), any(), any(), any())
         verify(notificationScheduler, never()).setupOnboardingNotifications()
+        verify(notificationScheduler, times(1)).setupReEngagementNotification()
     }
 }

--- a/modules/services/deeplink/src/main/kotlin/au/com/shiftyjelly/pocketcasts/deeplink/DeepLink.kt
+++ b/modules/services/deeplink/src/main/kotlin/au/com/shiftyjelly/pocketcasts/deeplink/DeepLink.kt
@@ -179,6 +179,11 @@ data object ShowFiltersDeepLink : IntentableDeepLink {
         .setData(Uri.parse("pktc://filters"))
 }
 
+data object CreateAccountDeepLink : IntentableDeepLink {
+    override fun toIntent(context: Context) = Intent(ACTION_VIEW)
+        .setData(Uri.parse("pktc://signup"))
+}
+
 data object ShowUpNextTabDeepLink : IntentableDeepLink {
     override fun toIntent(context: Context) = Intent(ACTION_VIEW)
         .setData(Uri.parse("pktc://upnext?location=tab"))

--- a/modules/services/deeplink/src/main/kotlin/au/com/shiftyjelly/pocketcasts/deeplink/DeepLinkFactory.kt
+++ b/modules/services/deeplink/src/main/kotlin/au/com/shiftyjelly/pocketcasts/deeplink/DeepLinkFactory.kt
@@ -69,6 +69,7 @@ class DeepLinkFactory(
         AssistantAdapter(),
         ThemesAdapter(),
         AppOpenAdapter(),
+        CreateAccountAdapter(),
     )
 
     fun create(intent: Intent): DeepLink? {
@@ -205,6 +206,20 @@ private class ShowFiltersAdapter : DeepLinkAdapter {
 
         return if (intent.action == ACTION_VIEW && scheme == "pktc" && host == "filters") {
             ShowFiltersDeepLink
+        } else {
+            null
+        }
+    }
+}
+
+private class CreateAccountAdapter : DeepLinkAdapter {
+    override fun create(intent: Intent): DeepLink? {
+        val uriData = intent.data
+        val scheme = uriData?.scheme
+        val host = uriData?.host
+
+        return if (intent.action == ACTION_VIEW && scheme == "pktc" && host == "signup") {
+            CreateAccountDeepLink
         } else {
             null
         }
@@ -571,6 +586,7 @@ private class OpmlAdapter(
             "www.subscribeonandroid.com",
             "discover",
             "open",
+            "signup",
         )
     }
 }

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -2366,4 +2366,13 @@
     <string name="notification_plus_upsell_title">Level up your podcast game</string>
     <string name="notification_plus_upsell_message">Unlock exclusive features like folders, bookmarks, and more with Plus!</string>
 
+    <string name="notification_reengage_we_miss_you_title">We miss you!</string>
+    <string name="notification_reengage_we_miss_you_message">It\'s been a while since you\'ve listened. Jump back in and enjoy!</string>
+
+    <string name="notification_reengage_catch_up_offline_title">Catch up offline</string>
+    <plurals name="notification_reengage_catch_up_offline_message">
+        <item quantity="one">You have %d new episode downloaded and ready to go!</item>
+        <item quantity="other">You have %d new episodes downloaded and ready to go!</item>
+    </plurals>
+
 </resources>

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/EpisodeDao.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/EpisodeDao.kt
@@ -262,6 +262,12 @@ abstract class EpisodeDao {
     @Query("SELECT * FROM podcast_episodes WHERE episode_status == :downloadEpisodeStatusEnum ORDER BY last_download_attempt_date DESC")
     abstract fun findDownloadedEpisodesRxFlowable(downloadEpisodeStatusEnum: EpisodeStatusEnum = EpisodeStatusEnum.DOWNLOADED): Flowable<List<PodcastEpisode>>
 
+    @Query("SELECT COUNT(*) FROM podcast_episodes WHERE episode_status == :downloadEpisodeStatusEnum AND playing_status == :playingStatus")
+    abstract suspend fun downloadedEpisodesThatHaveNotBeenPlayedCount(
+        downloadEpisodeStatusEnum: EpisodeStatusEnum = EpisodeStatusEnum.DOWNLOADED,
+        playingStatus: EpisodePlayingStatus = EpisodePlayingStatus.NOT_PLAYED,
+    ): Int
+
     @Transaction
     @Query("SELECT * FROM podcast_episodes WHERE starred = 1")
     abstract fun findStarredEpisodesRxFlowable(): Flowable<List<PodcastEpisode>>

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
@@ -152,6 +152,7 @@ interface Settings {
         ONBOARDING_THEMES(21483657),
         ONBOARDING_STAFF_PICKS(21483658),
         ONBOARDING_UPSELL(21483659),
+        RE_ENGAGEMENT(21483660),
     }
 
     enum class UpNextAction(val serverId: Int) {

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/notification/NotificationDelayCalculator.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/notification/NotificationDelayCalculator.kt
@@ -1,28 +1,58 @@
 package au.com.shiftyjelly.pocketcasts.repositories.notification
 
+import jakarta.inject.Inject
+import java.time.Clock
 import java.util.Calendar
 import java.util.concurrent.TimeUnit
 
-class NotificationDelayCalculator {
+class NotificationDelayCalculator @Inject constructor(
+    private val clock: Clock,
+) {
     /**
      * Calculates the delay until the notification should be sent.
      *
      * @param type The notification type containing dayOffset
-     * @param currentTimeMillis current time
      * @return Delay in milliseconds until the target 10 AM
      */
     fun calculateDelayForOnboardingNotification(
         type: OnboardingNotificationType,
-        currentTimeMillis: Long = System.currentTimeMillis(),
     ): Long {
-        val next10AM = calculateBase10AM(currentTimeMillis)
-        return next10AM + TimeUnit.DAYS.toMillis(type.dayOffset.toLong()) - currentTimeMillis
+        val now = clock.instant().toEpochMilli()
+        val next10AM = calculateBase10AM(now)
+        return next10AM + TimeUnit.DAYS.toMillis(type.dayOffset.toLong()) - now
     }
 
     private fun calculateBase10AM(currentTimeMillis: Long): Long {
         val calendar = Calendar.getInstance().apply {
             timeInMillis = currentTimeMillis
             set(Calendar.HOUR_OF_DAY, 10)
+            set(Calendar.MINUTE, 0)
+            set(Calendar.SECOND, 0)
+            set(Calendar.MILLISECOND, 0)
+
+            if (timeInMillis <= currentTimeMillis) {
+                add(Calendar.DAY_OF_YEAR, 1)
+            }
+        }
+        return calendar.timeInMillis
+    }
+
+    /**
+     * Calculates the delay until the re-engagement check worker should be triggered.
+     * The worker is set to run daily at 4 PM.
+     *
+     * @return Delay in milliseconds until the next 4 PM.
+     */
+    fun calculateDelayForReEngagementCheck(): Long {
+        val now = clock.instant().toEpochMilli()
+        val next4PM = calculateBase4PM(now)
+        return next4PM - now
+    }
+
+    private fun calculateBase4PM(currentTimeMillis: Long): Long {
+        val calendar = Calendar.getInstance().apply {
+            timeInMillis = currentTimeMillis
+            set(Calendar.HOUR_OF_DAY, 16)
             set(Calendar.MINUTE, 0)
             set(Calendar.SECOND, 0)
             set(Calendar.MILLISECOND, 0)

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/notification/NotificationManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/notification/NotificationManager.kt
@@ -2,7 +2,9 @@ package au.com.shiftyjelly.pocketcasts.repositories.notification
 
 interface NotificationManager {
     suspend fun setupOnboardingNotifications()
-    suspend fun updateUserFeatureInteraction(type: OnboardingNotificationType)
-    suspend fun hasUserInteractedWithFeature(type: OnboardingNotificationType): Boolean
-    suspend fun updateOnboardingNotificationSent(type: OnboardingNotificationType)
+    suspend fun setupReEngagementNotifications()
+    suspend fun updateUserFeatureInteraction(type: NotificationType)
+    suspend fun updateUserFeatureInteraction(id: Int)
+    suspend fun hasUserInteractedWithFeature(type: NotificationType): Boolean
+    suspend fun updateNotificationSent(type: NotificationType)
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/notification/NotificationManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/notification/NotificationManagerImpl.kt
@@ -2,37 +2,64 @@ package au.com.shiftyjelly.pocketcasts.repositories.notification
 
 import au.com.shiftyjelly.pocketcasts.models.db.dao.UserNotificationsDao
 import au.com.shiftyjelly.pocketcasts.models.entity.UserNotifications
+import java.time.Clock
 import javax.inject.Inject
+import kotlin.time.Duration.Companion.days
+import kotlin.time.Duration.Companion.milliseconds
 
 class NotificationManagerImpl @Inject constructor(
     private val userNotificationsDao: UserNotificationsDao,
+    private val clock: Clock,
 ) : NotificationManager {
 
     override suspend fun setupOnboardingNotifications() {
-        val userNotifications = OnboardingNotificationType.values.map { notification ->
-            UserNotifications(notificationId = notification.notificationId)
-        }
-
-        userNotificationsDao.insert(userNotifications)
+        setupNotificationsForType(OnboardingNotificationType.values) { it.notificationId }
     }
 
-    override suspend fun updateUserFeatureInteraction(type: OnboardingNotificationType) {
-        userNotificationsDao.updateInteractedAt(type.notificationId, System.currentTimeMillis())
+    override suspend fun setupReEngagementNotifications() {
+        setupNotificationsForType(ReEngagementNotificationType.values) { it.notificationId }
     }
 
-    override suspend fun hasUserInteractedWithFeature(type: OnboardingNotificationType): Boolean {
+    override suspend fun updateUserFeatureInteraction(type: NotificationType) {
+        val now = clock.instant().toEpochMilli()
+        userNotificationsDao.updateInteractedAt(type.notificationId, now)
+    }
+
+    override suspend fun updateUserFeatureInteraction(id: Int) {
+        val now = clock.instant().toEpochMilli()
+        userNotificationsDao.updateInteractedAt(id, now)
+    }
+
+    override suspend fun hasUserInteractedWithFeature(type: NotificationType): Boolean {
         val userNotification = userNotificationsDao.getUserNotification(type.notificationId)
             ?: return false
+
+        if (type is ReEngagementNotificationType) {
+            val lastInteraction = userNotification.interactedAt ?: return false
+            val elapsed = (clock.instant().toEpochMilli() - lastInteraction).milliseconds
+            return elapsed < 7.days
+        }
 
         return userNotification.interactedAt != null
     }
 
-    override suspend fun updateOnboardingNotificationSent(type: OnboardingNotificationType) {
+    override suspend fun updateNotificationSent(type: NotificationType) {
+        val now = clock.instant().toEpochMilli()
         userNotificationsDao.getUserNotification(type.notificationId)
             ?.apply {
                 sentThisWeek++
-                lastSentAt = System.currentTimeMillis()
+                lastSentAt = now
             }
             ?.let { userNotificationsDao.update(it) }
+    }
+
+    private suspend fun <T> setupNotificationsForType(
+        values: Iterable<T>,
+        getId: (T) -> Int,
+    ) {
+        val userNotifications = values.map { notification ->
+            UserNotifications(notificationId = getId(notification))
+        }
+        userNotificationsDao.insert(userNotifications)
     }
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/notification/NotificationScheduler.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/notification/NotificationScheduler.kt
@@ -2,4 +2,5 @@ package au.com.shiftyjelly.pocketcasts.repositories.notification
 
 interface NotificationScheduler {
     fun setupOnboardingNotifications()
+    suspend fun setupReEngagementNotification()
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/notification/NotificationSchedulerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/notification/NotificationSchedulerImpl.kt
@@ -1,20 +1,30 @@
 package au.com.shiftyjelly.pocketcasts.repositories.notification
 
 import android.content.Context
+import androidx.work.ExistingPeriodicWorkPolicy
 import androidx.work.OneTimeWorkRequest
+import androidx.work.PeriodicWorkRequest
 import androidx.work.WorkManager
 import androidx.work.workDataOf
+import au.com.shiftyjelly.pocketcasts.repositories.notification.ReEngagementNotificationType.Companion.SUBCATEGORY_REENGAGE_CATCH_UP_OFFLINE
+import au.com.shiftyjelly.pocketcasts.repositories.notification.ReEngagementNotificationType.Companion.SUBCATEGORY_REENGAGE_WE_MISS_YOU
+import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
 import dagger.hilt.android.qualifiers.ApplicationContext
 import jakarta.inject.Inject
 import java.util.concurrent.TimeUnit
 
 class NotificationSchedulerImpl @Inject constructor(
     @ApplicationContext private val context: Context,
+    private val episodeManager: EpisodeManager,
+    private val delayCalculator: NotificationDelayCalculator,
 ) : NotificationScheduler {
 
-    override fun setupOnboardingNotifications() {
-        val delayCalculator = NotificationDelayCalculator()
+    companion object {
+        const val SUBCATEGORY = "subcategory"
+        const val DOWNLOADED_EPISODES = "downloaded_episodes"
+    }
 
+    override fun setupOnboardingNotifications() {
         listOf(
             OnboardingNotificationType.Sync,
             OnboardingNotificationType.Import,
@@ -27,10 +37,10 @@ class NotificationSchedulerImpl @Inject constructor(
             val delay = delayCalculator.calculateDelayForOnboardingNotification(type)
 
             val workData = workDataOf(
-                "subcategory" to type.subcategory,
+                SUBCATEGORY to type.subcategory,
             )
 
-            val notificationWork = OneTimeWorkRequest.Builder(OnboardingNotificationWorker::class.java)
+            val notificationWork = OneTimeWorkRequest.Builder(NotificationWorker::class.java)
                 .setInputData(workData)
                 .setInitialDelay(delay, TimeUnit.MILLISECONDS)
                 .addTag("onboarding_notification_${type.subcategory}")
@@ -38,5 +48,30 @@ class NotificationSchedulerImpl @Inject constructor(
 
             WorkManager.getInstance(context).enqueue(notificationWork)
         }
+    }
+
+    override suspend fun setupReEngagementNotification() {
+        val initialDelay = delayCalculator.calculateDelayForReEngagementCheck()
+
+        val downloadedEpisodes = episodeManager.downloadedEpisodesThatHaveNotBeenPlayedCount()
+        val subcategory =
+            if (downloadedEpisodes > 0) SUBCATEGORY_REENGAGE_CATCH_UP_OFFLINE else SUBCATEGORY_REENGAGE_WE_MISS_YOU
+
+        val workData = workDataOf(
+            SUBCATEGORY to subcategory,
+            DOWNLOADED_EPISODES to downloadedEpisodes,
+        )
+
+        val notificationWork = PeriodicWorkRequest.Builder(NotificationWorker::class.java, 1, TimeUnit.DAYS)
+            .setInputData(workData)
+            .setInitialDelay(initialDelay, TimeUnit.MILLISECONDS)
+            .addTag("daily_re_engagement_check")
+            .build()
+
+        WorkManager.getInstance(context).enqueueUniquePeriodicWork(
+            "daily_re_engagement_check",
+            ExistingPeriodicWorkPolicy.UPDATE,
+            notificationWork,
+        )
     }
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/notification/OnboardingNotificationType.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/notification/OnboardingNotificationType.kt
@@ -1,4 +1,14 @@
 package au.com.shiftyjelly.pocketcasts.repositories.notification
+
+import android.content.Context
+import android.content.Intent
+import au.com.shiftyjelly.pocketcasts.deeplink.CreateAccountDeepLink
+import au.com.shiftyjelly.pocketcasts.deeplink.ImportDeepLink
+import au.com.shiftyjelly.pocketcasts.deeplink.ShowFiltersDeepLink
+import au.com.shiftyjelly.pocketcasts.deeplink.ShowUpNextTabDeepLink
+import au.com.shiftyjelly.pocketcasts.deeplink.StaffPicksDeepLink
+import au.com.shiftyjelly.pocketcasts.deeplink.ThemesDeepLink
+import au.com.shiftyjelly.pocketcasts.deeplink.UpsellDeepLink
 import au.com.shiftyjelly.pocketcasts.preferences.Settings.NotificationId
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
@@ -9,13 +19,18 @@ sealed class OnboardingNotificationType(
     val messageRes: Int,
     val dayOffset: Int,
 ) {
+
+    abstract fun toIntent(context: Context): Intent
+
     object Sync : OnboardingNotificationType(
         notificationId = NotificationId.ONBOARDING_SYNC.value,
         subcategory = SUBCATEGORY_SYNC,
         titleRes = LR.string.notification_sync_title,
         messageRes = LR.string.notification_sync_message,
         dayOffset = 0,
-    )
+    ) {
+        override fun toIntent(context: Context) = CreateAccountDeepLink.toIntent(context)
+    }
 
     object Import : OnboardingNotificationType(
         notificationId = NotificationId.ONBOARDING_IMPORT.value,
@@ -23,7 +38,9 @@ sealed class OnboardingNotificationType(
         titleRes = LR.string.notification_import_title,
         messageRes = LR.string.notification_import_message,
         dayOffset = 1,
-    )
+    ) {
+        override fun toIntent(context: Context) = ImportDeepLink.toIntent(context)
+    }
 
     object UpNext : OnboardingNotificationType(
         notificationId = NotificationId.ONBOARDING_UPNEXT.value,
@@ -31,7 +48,9 @@ sealed class OnboardingNotificationType(
         titleRes = LR.string.notification_up_next_title,
         messageRes = LR.string.notification_up_next_message,
         dayOffset = 2,
-    )
+    ) {
+        override fun toIntent(context: Context) = ShowUpNextTabDeepLink.toIntent(context)
+    }
 
     object Filters : OnboardingNotificationType(
         notificationId = NotificationId.ONBOARDING_FILTERS.value,
@@ -39,7 +58,9 @@ sealed class OnboardingNotificationType(
         titleRes = LR.string.notification_filters_title,
         messageRes = LR.string.notification_filters_message,
         dayOffset = 3,
-    )
+    ) {
+        override fun toIntent(context: Context) = ShowFiltersDeepLink.toIntent(context)
+    }
 
     object Themes : OnboardingNotificationType(
         notificationId = NotificationId.ONBOARDING_THEMES.value,
@@ -47,7 +68,9 @@ sealed class OnboardingNotificationType(
         titleRes = LR.string.notification_themes_title,
         messageRes = LR.string.notification_themes_message,
         dayOffset = 4,
-    )
+    ) {
+        override fun toIntent(context: Context) = ThemesDeepLink.toIntent(context)
+    }
 
     object StaffPicks : OnboardingNotificationType(
         notificationId = NotificationId.ONBOARDING_STAFF_PICKS.value,
@@ -55,7 +78,9 @@ sealed class OnboardingNotificationType(
         titleRes = LR.string.notification_staff_picks_title,
         messageRes = LR.string.notification_staff_picks_message,
         dayOffset = 5,
-    )
+    ) {
+        override fun toIntent(context: Context) = StaffPicksDeepLink.toIntent(context)
+    }
 
     object PlusUpsell : OnboardingNotificationType(
         notificationId = NotificationId.ONBOARDING_UPSELL.value,
@@ -63,7 +88,9 @@ sealed class OnboardingNotificationType(
         titleRes = LR.string.notification_plus_upsell_title,
         messageRes = LR.string.notification_plus_upsell_message,
         dayOffset = 6,
-    )
+    ) {
+        override fun toIntent(context: Context) = UpsellDeepLink.toIntent(context)
+    }
 
     companion object {
         const val SUBCATEGORY_SYNC = "sync"

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/notification/OnboardingNotificationWorker.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/notification/OnboardingNotificationWorker.kt
@@ -11,6 +11,7 @@ import androidx.core.content.ContextCompat
 import androidx.hilt.work.HiltWorker
 import androidx.work.CoroutineWorker
 import androidx.work.WorkerParameters
+import au.com.shiftyjelly.pocketcasts.deeplink.CreateAccountDeepLink
 import au.com.shiftyjelly.pocketcasts.deeplink.ImportDeepLink
 import au.com.shiftyjelly.pocketcasts.deeplink.ShowFiltersDeepLink
 import au.com.shiftyjelly.pocketcasts.deeplink.ShowUpNextTabDeepLink
@@ -71,7 +72,7 @@ class OnboardingNotificationWorker @AssistedInject constructor(
             OnboardingNotificationType.Import -> ImportDeepLink.toIntent(applicationContext)
             OnboardingNotificationType.PlusUpsell -> UpsellDeepLink.toIntent(applicationContext)
             OnboardingNotificationType.StaffPicks -> StaffPicksDeepLink.toIntent(applicationContext)
-            OnboardingNotificationType.Sync -> TODO()
+            OnboardingNotificationType.Sync -> CreateAccountDeepLink.toIntent(applicationContext)
             OnboardingNotificationType.Themes -> ThemesDeepLink.toIntent(applicationContext)
             OnboardingNotificationType.UpNext -> ShowUpNextTabDeepLink.toIntent(applicationContext)
         }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/notification/OnboardingNotificationWorker.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/notification/OnboardingNotificationWorker.kt
@@ -11,7 +11,12 @@ import androidx.core.content.ContextCompat
 import androidx.hilt.work.HiltWorker
 import androidx.work.CoroutineWorker
 import androidx.work.WorkerParameters
+import au.com.shiftyjelly.pocketcasts.deeplink.ImportDeepLink
 import au.com.shiftyjelly.pocketcasts.deeplink.ShowFiltersDeepLink
+import au.com.shiftyjelly.pocketcasts.deeplink.ShowUpNextTabDeepLink
+import au.com.shiftyjelly.pocketcasts.deeplink.StaffPicksDeepLink
+import au.com.shiftyjelly.pocketcasts.deeplink.ThemesDeepLink
+import au.com.shiftyjelly.pocketcasts.deeplink.UpsellDeepLink
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.repositories.R
 import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
@@ -57,11 +62,19 @@ class OnboardingNotificationWorker @AssistedInject constructor(
             .setContentTitle(applicationContext.resources.getString(type.titleRes))
             .setContentText(applicationContext.resources.getString(type.messageRes))
             .setColor(ContextCompat.getColor(applicationContext, R.color.notification_color))
-            .setContentIntent(openPageIntent())
+            .setContentIntent(openPageIntent(type))
     }
 
-    private fun openPageIntent(): PendingIntent {
-        val intent = ShowFiltersDeepLink.toIntent(applicationContext)
+    private fun openPageIntent(type: OnboardingNotificationType): PendingIntent {
+        val intent = when (type) {
+            OnboardingNotificationType.Filters -> ShowFiltersDeepLink.toIntent(applicationContext)
+            OnboardingNotificationType.Import -> ImportDeepLink.toIntent(applicationContext)
+            OnboardingNotificationType.PlusUpsell -> UpsellDeepLink.toIntent(applicationContext)
+            OnboardingNotificationType.StaffPicks -> StaffPicksDeepLink.toIntent(applicationContext)
+            OnboardingNotificationType.Sync -> TODO()
+            OnboardingNotificationType.Themes -> ThemesDeepLink.toIntent(applicationContext)
+            OnboardingNotificationType.UpNext -> ShowUpNextTabDeepLink.toIntent(applicationContext)
+        }
         return PendingIntent.getActivity(applicationContext, 0, intent, PendingIntent.FLAG_CANCEL_CURRENT or PendingIntent.FLAG_IMMUTABLE)
     }
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/notification/OnboardingNotificationWorker.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/notification/OnboardingNotificationWorker.kt
@@ -11,13 +11,6 @@ import androidx.core.content.ContextCompat
 import androidx.hilt.work.HiltWorker
 import androidx.work.CoroutineWorker
 import androidx.work.WorkerParameters
-import au.com.shiftyjelly.pocketcasts.deeplink.CreateAccountDeepLink
-import au.com.shiftyjelly.pocketcasts.deeplink.ImportDeepLink
-import au.com.shiftyjelly.pocketcasts.deeplink.ShowFiltersDeepLink
-import au.com.shiftyjelly.pocketcasts.deeplink.ShowUpNextTabDeepLink
-import au.com.shiftyjelly.pocketcasts.deeplink.StaffPicksDeepLink
-import au.com.shiftyjelly.pocketcasts.deeplink.ThemesDeepLink
-import au.com.shiftyjelly.pocketcasts.deeplink.UpsellDeepLink
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.repositories.R
 import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
@@ -67,15 +60,6 @@ class OnboardingNotificationWorker @AssistedInject constructor(
     }
 
     private fun openPageIntent(type: OnboardingNotificationType): PendingIntent {
-        val intent = when (type) {
-            OnboardingNotificationType.Filters -> ShowFiltersDeepLink.toIntent(applicationContext)
-            OnboardingNotificationType.Import -> ImportDeepLink.toIntent(applicationContext)
-            OnboardingNotificationType.PlusUpsell -> UpsellDeepLink.toIntent(applicationContext)
-            OnboardingNotificationType.StaffPicks -> StaffPicksDeepLink.toIntent(applicationContext)
-            OnboardingNotificationType.Sync -> CreateAccountDeepLink.toIntent(applicationContext)
-            OnboardingNotificationType.Themes -> ThemesDeepLink.toIntent(applicationContext)
-            OnboardingNotificationType.UpNext -> ShowUpNextTabDeepLink.toIntent(applicationContext)
-        }
-        return PendingIntent.getActivity(applicationContext, 0, intent, PendingIntent.FLAG_CANCEL_CURRENT or PendingIntent.FLAG_IMMUTABLE)
+        return PendingIntent.getActivity(applicationContext, 0, type.toIntent(applicationContext), PendingIntent.FLAG_CANCEL_CURRENT or PendingIntent.FLAG_IMMUTABLE)
     }
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManager.kt
@@ -51,6 +51,7 @@ interface EpisodeManager {
     fun findDownloadedEpisodesRxFlowable(): Flowable<List<PodcastEpisode>>
     fun findStarredEpisodesRxFlowable(): Flowable<List<PodcastEpisode>>
     suspend fun findStarredEpisodes(): List<PodcastEpisode>
+    suspend fun downloadedEpisodesThatHaveNotBeenPlayedCount(): Int
 
     /** Add methods  */
     fun addBlocking(episode: PodcastEpisode, downloadMetaData: Boolean): Boolean

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManagerImpl.kt
@@ -802,6 +802,10 @@ class EpisodeManagerImpl @Inject constructor(
         return episodeDao.findDownloadedEpisodesRxFlowable()
     }
 
+    override suspend fun downloadedEpisodesThatHaveNotBeenPlayedCount(): Int {
+        return episodeDao.downloadedEpisodesThatHaveNotBeenPlayedCount()
+    }
+
     override fun findStarredEpisodesRxFlowable(): Flowable<List<PodcastEpisode>> {
         return episodeDao.findStarredEpisodesRxFlowable()
     }

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/notification/NotificationDelayCalculatorTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/notification/NotificationDelayCalculatorTest.kt
@@ -1,197 +1,204 @@
 package au.com.shiftyjelly.pocketcasts.repositories.notification
 
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneOffset
 import java.util.Calendar
 import junit.framework.TestCase.assertEquals
 import org.junit.Test
 
 class NotificationDelayCalculatorTest {
 
-    private val calculator = NotificationDelayCalculator()
-
     companion object {
         private const val HOUR_IN_MILLIS = 60 * 60 * 1000L
+
+        private fun getFixedTime(
+            year: Int,
+            month: Int,
+            day: Int,
+            hour: Int,
+            minute: Int,
+            second: Int = 0,
+            millisecond: Int = 0,
+        ): Long {
+            return Calendar.getInstance().apply {
+                set(year, month, day, hour, minute, second)
+                set(Calendar.MILLISECOND, millisecond)
+            }.timeInMillis
+        }
+
+        private fun calculatorAt(fixedTime: Long): NotificationDelayCalculator {
+            val fixedInstant = Instant.ofEpochMilli(fixedTime)
+            val fixedClock = Clock.fixed(fixedInstant, ZoneOffset.UTC)
+            return NotificationDelayCalculator(fixedClock)
+        }
     }
 
-    @Test
-    fun testBefore10AM_Sync() {
-        val fixedTime = getFixedTime(2025, Calendar.APRIL, 10, 9, 0)
-        val expectedDelay = (1 + 0 * 24) * HOUR_IN_MILLIS // 1 hour
-        val delay = calculator.calculateDelayForOnboardingNotification(OnboardingNotificationType.Sync, fixedTime)
-        assertEquals(expectedDelay, delay)
+    @Test fun testBefore10AM_Sync() {
+        val t = getFixedTime(2025, Calendar.APRIL, 10, 9, 0)
+        val calc = calculatorAt(t)
+        val expected = (1 + 0 * 24) * HOUR_IN_MILLIS
+        assertEquals(expected, calc.calculateDelayForOnboardingNotification(OnboardingNotificationType.Sync))
     }
 
-    @Test
-    fun testBefore10AM_Import() {
-        val fixedTime = getFixedTime(2025, Calendar.APRIL, 10, 9, 0)
-        val expectedDelay = (1 + 1 * 24) * HOUR_IN_MILLIS // 25 hours
-        val delay = calculator.calculateDelayForOnboardingNotification(OnboardingNotificationType.Import, fixedTime)
-        assertEquals(expectedDelay, delay)
+    @Test fun testBefore10AM_Import() {
+        val t = getFixedTime(2025, Calendar.APRIL, 10, 9, 0)
+        val calc = calculatorAt(t)
+        val expected = (1 + 1 * 24) * HOUR_IN_MILLIS
+        assertEquals(expected, calc.calculateDelayForOnboardingNotification(OnboardingNotificationType.Import))
     }
 
-    @Test
-    fun testBefore10AM_UpNext() {
-        val fixedTime = getFixedTime(2025, Calendar.APRIL, 10, 9, 0)
-        val expectedDelay = (1 + 2 * 24) * HOUR_IN_MILLIS // 49 hours
-        val delay = calculator.calculateDelayForOnboardingNotification(OnboardingNotificationType.UpNext, fixedTime)
-        assertEquals(expectedDelay, delay)
+    @Test fun testBefore10AM_UpNext() {
+        val t = getFixedTime(2025, Calendar.APRIL, 10, 9, 0)
+        val calc = calculatorAt(t)
+        val expected = (1 + 2 * 24) * HOUR_IN_MILLIS
+        assertEquals(expected, calc.calculateDelayForOnboardingNotification(OnboardingNotificationType.UpNext))
     }
 
-    @Test
-    fun testBefore10AM_Filters() {
-        val fixedTime = getFixedTime(2025, Calendar.APRIL, 10, 9, 0)
-        val expectedDelay = (1 + 3 * 24) * HOUR_IN_MILLIS // 73 hours
-        val delay = calculator.calculateDelayForOnboardingNotification(OnboardingNotificationType.Filters, fixedTime)
-        assertEquals(expectedDelay, delay)
+    @Test fun testBefore10AM_Filters() {
+        val t = getFixedTime(2025, Calendar.APRIL, 10, 9, 0)
+        val calc = calculatorAt(t)
+        val expected = (1 + 3 * 24) * HOUR_IN_MILLIS
+        assertEquals(expected, calc.calculateDelayForOnboardingNotification(OnboardingNotificationType.Filters))
     }
 
-    @Test
-    fun testBefore10AM_Themes() {
-        val fixedTime = getFixedTime(2025, Calendar.APRIL, 10, 9, 0)
-        val expectedDelay = (1 + 4 * 24) * HOUR_IN_MILLIS // 97 hours
-        val delay = calculator.calculateDelayForOnboardingNotification(OnboardingNotificationType.Themes, fixedTime)
-        assertEquals(expectedDelay, delay)
+    @Test fun testBefore10AM_Themes() {
+        val t = getFixedTime(2025, Calendar.APRIL, 10, 9, 0)
+        val calc = calculatorAt(t)
+        val expected = (1 + 4 * 24) * HOUR_IN_MILLIS
+        assertEquals(expected, calc.calculateDelayForOnboardingNotification(OnboardingNotificationType.Themes))
     }
 
-    @Test
-    fun testBefore10AM_StaffPicks() {
-        val fixedTime = getFixedTime(2025, Calendar.APRIL, 10, 9, 0)
-        val expectedDelay = (1 + 5 * 24) * HOUR_IN_MILLIS // 121 hours
-        val delay = calculator.calculateDelayForOnboardingNotification(OnboardingNotificationType.StaffPicks, fixedTime)
-        assertEquals(expectedDelay, delay)
+    @Test fun testBefore10AM_StaffPicks() {
+        val t = getFixedTime(2025, Calendar.APRIL, 10, 9, 0)
+        val calc = calculatorAt(t)
+        val expected = (1 + 5 * 24) * HOUR_IN_MILLIS
+        assertEquals(expected, calc.calculateDelayForOnboardingNotification(OnboardingNotificationType.StaffPicks))
     }
 
-    @Test
-    fun testBefore10AM_PlusUpsell() {
-        val fixedTime = getFixedTime(2025, Calendar.APRIL, 10, 9, 0)
-        val expectedDelay = (1 + 6 * 24) * HOUR_IN_MILLIS // 145 hours
-        val delay = calculator.calculateDelayForOnboardingNotification(OnboardingNotificationType.PlusUpsell, fixedTime)
-        assertEquals(expectedDelay, delay)
+    @Test fun testBefore10AM_PlusUpsell() {
+        val t = getFixedTime(2025, Calendar.APRIL, 10, 9, 0)
+        val calc = calculatorAt(t)
+        val expected = (1 + 6 * 24) * HOUR_IN_MILLIS
+        assertEquals(expected, calc.calculateDelayForOnboardingNotification(OnboardingNotificationType.PlusUpsell))
     }
 
-    @Test
-    fun testExact10AM_Sync() {
-        val fixedTime = getFixedTime(2025, Calendar.APRIL, 10, 10, 0)
-        val expectedDelay = (24 + 0 * 24) * HOUR_IN_MILLIS // 24 hours
-        val delay = calculator.calculateDelayForOnboardingNotification(OnboardingNotificationType.Sync, fixedTime)
-        assertEquals(expectedDelay, delay)
+    @Test fun testExact10AM_Sync() {
+        val t = getFixedTime(2025, Calendar.APRIL, 10, 10, 0)
+        val calc = calculatorAt(t)
+        val expected = (24 + 0 * 24) * HOUR_IN_MILLIS
+        assertEquals(expected, calc.calculateDelayForOnboardingNotification(OnboardingNotificationType.Sync))
     }
 
-    @Test
-    fun testExact10AM_Import() {
-        val fixedTime = getFixedTime(2025, Calendar.APRIL, 10, 10, 0)
-        val expectedDelay = (24 + 1 * 24) * HOUR_IN_MILLIS // 48 hours
-        val delay = calculator.calculateDelayForOnboardingNotification(OnboardingNotificationType.Import, fixedTime)
-        assertEquals(expectedDelay, delay)
+    @Test fun testExact10AM_Import() {
+        val t = getFixedTime(2025, Calendar.APRIL, 10, 10, 0)
+        val calc = calculatorAt(t)
+        val expected = (24 + 1 * 24) * HOUR_IN_MILLIS
+        assertEquals(expected, calc.calculateDelayForOnboardingNotification(OnboardingNotificationType.Import))
     }
 
-    @Test
-    fun testExact10AM_UpNext() {
-        val fixedTime = getFixedTime(2025, Calendar.APRIL, 10, 10, 0)
-        val expectedDelay = (24 + 2 * 24) * HOUR_IN_MILLIS // 72 hours
-        val delay = calculator.calculateDelayForOnboardingNotification(OnboardingNotificationType.UpNext, fixedTime)
-        assertEquals(expectedDelay, delay)
+    @Test fun testExact10AM_UpNext() {
+        val t = getFixedTime(2025, Calendar.APRIL, 10, 10, 0)
+        val calc = calculatorAt(t)
+        val expected = (24 + 2 * 24) * HOUR_IN_MILLIS
+        assertEquals(expected, calc.calculateDelayForOnboardingNotification(OnboardingNotificationType.UpNext))
     }
 
-    @Test
-    fun testExact10AM_Filters() {
-        val fixedTime = getFixedTime(2025, Calendar.APRIL, 10, 10, 0)
-        val expectedDelay = (24 + 3 * 24) * HOUR_IN_MILLIS // 96 hours
-        val delay = calculator.calculateDelayForOnboardingNotification(OnboardingNotificationType.Filters, fixedTime)
-        assertEquals(expectedDelay, delay)
+    @Test fun testExact10AM_Filters() {
+        val t = getFixedTime(2025, Calendar.APRIL, 10, 10, 0)
+        val calc = calculatorAt(t)
+        val expected = (24 + 3 * 24) * HOUR_IN_MILLIS
+        assertEquals(expected, calc.calculateDelayForOnboardingNotification(OnboardingNotificationType.Filters))
     }
 
-    @Test
-    fun testExact10AM_Themes() {
-        val fixedTime = getFixedTime(2025, Calendar.APRIL, 10, 10, 0)
-        val expectedDelay = (24 + 4 * 24) * HOUR_IN_MILLIS // 120 hours
-        val delay = calculator.calculateDelayForOnboardingNotification(OnboardingNotificationType.Themes, fixedTime)
-        assertEquals(expectedDelay, delay)
+    @Test fun testExact10AM_Themes() {
+        val t = getFixedTime(2025, Calendar.APRIL, 10, 10, 0)
+        val calc = calculatorAt(t)
+        val expected = (24 + 4 * 24) * HOUR_IN_MILLIS
+        assertEquals(expected, calc.calculateDelayForOnboardingNotification(OnboardingNotificationType.Themes))
     }
 
-    @Test
-    fun testExact10AM_StaffPicks() {
-        val fixedTime = getFixedTime(2025, Calendar.APRIL, 10, 10, 0)
-        val expectedDelay = (24 + 5 * 24) * HOUR_IN_MILLIS // 144 hours
-        val delay = calculator.calculateDelayForOnboardingNotification(OnboardingNotificationType.StaffPicks, fixedTime)
-        assertEquals(expectedDelay, delay)
+    @Test fun testExact10AM_StaffPicks() {
+        val t = getFixedTime(2025, Calendar.APRIL, 10, 10, 0)
+        val calc = calculatorAt(t)
+        val expected = (24 + 5 * 24) * HOUR_IN_MILLIS
+        assertEquals(expected, calc.calculateDelayForOnboardingNotification(OnboardingNotificationType.StaffPicks))
     }
 
-    @Test
-    fun testExact10AM_PlusUpsell() {
-        val fixedTime = getFixedTime(2025, Calendar.APRIL, 10, 10, 0)
-        val expectedDelay = (24 + 6 * 24) * HOUR_IN_MILLIS // 168 hours
-        val delay = calculator.calculateDelayForOnboardingNotification(OnboardingNotificationType.PlusUpsell, fixedTime)
-        assertEquals(expectedDelay, delay)
+    @Test fun testExact10AM_PlusUpsell() {
+        val t = getFixedTime(2025, Calendar.APRIL, 10, 10, 0)
+        val calc = calculatorAt(t)
+        val expected = (24 + 6 * 24) * HOUR_IN_MILLIS
+        assertEquals(expected, calc.calculateDelayForOnboardingNotification(OnboardingNotificationType.PlusUpsell))
     }
 
-    @Test
-    fun testAfter10AM_Sync() {
-        val fixedTime = getFixedTime(2025, Calendar.APRIL, 10, 11, 0)
-        val expectedDelay = (23 + 0 * 24) * HOUR_IN_MILLIS // 23 hours
-        val delay = calculator.calculateDelayForOnboardingNotification(OnboardingNotificationType.Sync, fixedTime)
-        assertEquals(expectedDelay, delay)
+    @Test fun testAfter10AM_Sync() {
+        val t = getFixedTime(2025, Calendar.APRIL, 10, 11, 0)
+        val calc = calculatorAt(t)
+        val expected = (23 + 0 * 24) * HOUR_IN_MILLIS
+        assertEquals(expected, calc.calculateDelayForOnboardingNotification(OnboardingNotificationType.Sync))
     }
 
-    @Test
-    fun testAfter10AM_Import() {
-        val fixedTime = getFixedTime(2025, Calendar.APRIL, 10, 11, 0)
-        val expectedDelay = (23 + 1 * 24) * HOUR_IN_MILLIS // 47 hours
-        val delay = calculator.calculateDelayForOnboardingNotification(OnboardingNotificationType.Import, fixedTime)
-        assertEquals(expectedDelay, delay)
+    @Test fun testAfter10AM_Import() {
+        val t = getFixedTime(2025, Calendar.APRIL, 10, 11, 0)
+        val calc = calculatorAt(t)
+        val expected = (23 + 1 * 24) * HOUR_IN_MILLIS
+        assertEquals(expected, calc.calculateDelayForOnboardingNotification(OnboardingNotificationType.Import))
     }
 
-    @Test
-    fun testAfter10AM_UpNext() {
-        val fixedTime = getFixedTime(2025, Calendar.APRIL, 10, 11, 0)
-        val expectedDelay = (23 + 2 * 24) * HOUR_IN_MILLIS // 71 hours
-        val delay = calculator.calculateDelayForOnboardingNotification(OnboardingNotificationType.UpNext, fixedTime)
-        assertEquals(expectedDelay, delay)
+    @Test fun testAfter10AM_UpNext() {
+        val t = getFixedTime(2025, Calendar.APRIL, 10, 11, 0)
+        val calc = calculatorAt(t)
+        val expected = (23 + 2 * 24) * HOUR_IN_MILLIS
+        assertEquals(expected, calc.calculateDelayForOnboardingNotification(OnboardingNotificationType.UpNext))
     }
 
-    @Test
-    fun testAfter10AM_Filters() {
-        val fixedTime = getFixedTime(2025, Calendar.APRIL, 10, 11, 0)
-        val expectedDelay = (23 + 3 * 24) * HOUR_IN_MILLIS // 95 hours
-        val delay = calculator.calculateDelayForOnboardingNotification(OnboardingNotificationType.Filters, fixedTime)
-        assertEquals(expectedDelay, delay)
+    @Test fun testAfter10AM_Filters() {
+        val t = getFixedTime(2025, Calendar.APRIL, 10, 11, 0)
+        val calc = calculatorAt(t)
+        val expected = (23 + 3 * 24) * HOUR_IN_MILLIS
+        assertEquals(expected, calc.calculateDelayForOnboardingNotification(OnboardingNotificationType.Filters))
     }
 
-    @Test
-    fun testAfter10AM_Themes() {
-        val fixedTime = getFixedTime(2025, Calendar.APRIL, 10, 11, 0)
-        val expectedDelay = (23 + 4 * 24) * HOUR_IN_MILLIS // 119 hours
-        val delay = calculator.calculateDelayForOnboardingNotification(OnboardingNotificationType.Themes, fixedTime)
-        assertEquals(expectedDelay, delay)
+    @Test fun testAfter10AM_Themes() {
+        val t = getFixedTime(2025, Calendar.APRIL, 10, 11, 0)
+        val calc = calculatorAt(t)
+        val expected = (23 + 4 * 24) * HOUR_IN_MILLIS
+        assertEquals(expected, calc.calculateDelayForOnboardingNotification(OnboardingNotificationType.Themes))
     }
 
-    @Test
-    fun testAfter10AM_StaffPicks() {
-        val fixedTime = getFixedTime(2025, Calendar.APRIL, 10, 11, 0)
-        val expectedDelay = (23 + 5 * 24) * HOUR_IN_MILLIS // 143 hours
-        val delay = calculator.calculateDelayForOnboardingNotification(OnboardingNotificationType.StaffPicks, fixedTime)
-        assertEquals(expectedDelay, delay)
+    @Test fun testAfter10AM_StaffPicks() {
+        val t = getFixedTime(2025, Calendar.APRIL, 10, 11, 0)
+        val calc = calculatorAt(t)
+        val expected = (23 + 5 * 24) * HOUR_IN_MILLIS
+        assertEquals(expected, calc.calculateDelayForOnboardingNotification(OnboardingNotificationType.StaffPicks))
     }
 
-    @Test
-    fun testAfter10AM_PlusUpsell() {
-        val fixedTime = getFixedTime(2025, Calendar.APRIL, 10, 11, 0)
-        val expectedDelay = (23 + 6 * 24) * HOUR_IN_MILLIS // 167 hours
-        val delay = calculator.calculateDelayForOnboardingNotification(OnboardingNotificationType.PlusUpsell, fixedTime)
-        assertEquals(expectedDelay, delay)
+    @Test fun testAfter10AM_PlusUpsell() {
+        val t = getFixedTime(2025, Calendar.APRIL, 10, 11, 0)
+        val calc = calculatorAt(t)
+        val expected = (23 + 6 * 24) * HOUR_IN_MILLIS
+        assertEquals(expected, calc.calculateDelayForOnboardingNotification(OnboardingNotificationType.PlusUpsell))
     }
 
-    private fun getFixedTime(
-        year: Int,
-        month: Int,
-        day: Int,
-        hour: Int,
-        minute: Int,
-        second: Int = 0,
-        millisecond: Int = 0,
-    ): Long {
-        return Calendar.getInstance().apply {
-            set(year, month, day, hour, minute, second)
-            set(Calendar.MILLISECOND, millisecond)
-        }.timeInMillis
+    @Test fun testReEngagementCheck_Before4PM() {
+        val t = getFixedTime(2025, Calendar.APRIL, 10, 15, 0)
+        val calc = calculatorAt(t)
+        val expected = 1 * HOUR_IN_MILLIS
+        assertEquals(expected, calc.calculateDelayForReEngagementCheck())
+    }
+
+    @Test fun testReEngagementCheck_Exactly4PM() {
+        val t = getFixedTime(2025, Calendar.APRIL, 10, 16, 0)
+        val calc = calculatorAt(t)
+        val expected = 24 * HOUR_IN_MILLIS
+        assertEquals(expected, calc.calculateDelayForReEngagementCheck())
+    }
+
+    @Test fun testReEngagementCheck_After4PM() {
+        val t = getFixedTime(2025, Calendar.APRIL, 10, 17, 0)
+        val calc = calculatorAt(t)
+        val expected = 23 * HOUR_IN_MILLIS
+        assertEquals(expected, calc.calculateDelayForReEngagementCheck())
     }
 }


### PR DESCRIPTION
## Description
- This PR updates the onboarding notifications intent in order to make them to open the correct screen


## Testing Instructions
Originally, notifications were triggered once per day, but I prepared this patch to simplify testing so that they trigger every 10 seconds after the app is installed.

[onboarding-notification-scheduler.patch](https://github.com/user-attachments/files/19777723/onboarding-notification-scheduler.patch)

1. Apply the patch above
2. Install the app
3. Grant notification permission
4. Wait 10 seconds until the first notification being displayed
5. Ensure each notification redirects you to the right screen according to the context ✅

## Screenshots or Screencast 

https://github.com/user-attachments/assets/bdcf2fa6-afc2-4b30-a351-da2ed0c9e781


## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.

