### PR TITLE
[Push Notifications Revamp] Implement Re-engagement notifications

### DIFF
--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/deeplink/DownloadsDeepLinkTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/deeplink/DownloadsDeepLinkTest.kt
@@ -1,5 +1,6 @@
 package au.com.shiftyjelly.pocketcasts.deeplink
 
+import android.content.Intent.ACTION_VIEW
 import android.net.Uri
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
@@ -15,7 +16,7 @@ class DownloadsDeepLinkTest {
     fun createIntent() {
         val intent = DownloadsDeepLink.toIntent(context)
 
-        assertEquals("INTENT_OPEN_APP_DOWNLOADING", intent.action)
+        assertEquals(ACTION_VIEW, intent.action)
         assertEquals(Uri.parse("pktc://profile/downloads"), intent.data)
     }
 }

--- a/app/src/main/java/au/com/shiftyjelly/pocketcasts/PocketCastsApplication.kt
+++ b/app/src/main/java/au/com/shiftyjelly/pocketcasts/PocketCastsApplication.kt
@@ -21,6 +21,7 @@ import au.com.shiftyjelly.pocketcasts.repositories.file.StorageOptions
 import au.com.shiftyjelly.pocketcasts.repositories.jobs.VersionMigrationsWorker
 import au.com.shiftyjelly.pocketcasts.repositories.notification.NotificationHelper
 import au.com.shiftyjelly.pocketcasts.repositories.notification.NotificationManager
+import au.com.shiftyjelly.pocketcasts.repositories.notification.ReEngagementNotificationType
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
 import au.com.shiftyjelly.pocketcasts.repositories.playback.SleepTimerRestartWhenShakingDevice
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
@@ -189,6 +190,7 @@ class PocketCastsApplication : Application(), Configuration.Provider {
             notificationHelper.setupNotificationChannels()
             notificationManager.setupOnboardingNotifications()
             notificationManager.setupReEngagementNotifications()
+            notificationManager.updateUserFeatureInteraction(ReEngagementNotificationType.notificationId)
             appLifecycleObserver.setup()
 
             Coil.setImageLoader(coilImageLoader)

--- a/app/src/main/java/au/com/shiftyjelly/pocketcasts/PocketCastsApplication.kt
+++ b/app/src/main/java/au/com/shiftyjelly/pocketcasts/PocketCastsApplication.kt
@@ -188,6 +188,7 @@ class PocketCastsApplication : Application(), Configuration.Provider {
 
             notificationHelper.setupNotificationChannels()
             notificationManager.setupOnboardingNotifications()
+            notificationManager.setupReEngagementNotifications()
             appLifecycleObserver.setup()
 
             Coil.setImageLoader(coilImageLoader)

--- a/modules/features/shared/src/main/java/au/com/shiftyjelly/pocketcasts/shared/AppLifecycleObserver.kt
+++ b/modules/features/shared/src/main/java/au/com/shiftyjelly/pocketcasts/shared/AppLifecycleObserver.kt
@@ -20,6 +20,7 @@ import dagger.hilt.android.qualifiers.ApplicationContext
 import javax.inject.Inject
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.cancel
+import kotlinx.coroutines.launch
 
 class AppLifecycleObserver(
     @ApplicationContext private val appContext: Context,
@@ -65,7 +66,9 @@ class AppLifecycleObserver(
         handleNewInstallOrUpgrade()
         setupFeatureFlags()
         networkConnectionWatcher.startWatching()
-        notificationScheduler.setupReEngagementNotification()
+        applicationScope.launch {
+            notificationScheduler.setupReEngagementNotification()
+        }
     }
 
     override fun onResume(owner: LifecycleOwner) {

--- a/modules/features/shared/src/main/java/au/com/shiftyjelly/pocketcasts/shared/AppLifecycleObserver.kt
+++ b/modules/features/shared/src/main/java/au/com/shiftyjelly/pocketcasts/shared/AppLifecycleObserver.kt
@@ -65,6 +65,7 @@ class AppLifecycleObserver(
         handleNewInstallOrUpgrade()
         setupFeatureFlags()
         networkConnectionWatcher.startWatching()
+        notificationScheduler.setupReEngagementNotification()
     }
 
     override fun onResume(owner: LifecycleOwner) {

--- a/modules/features/shared/src/test/java/au/com/shiftyjelly/pocketcasts/shared/AppLifecycleObserverTest.kt
+++ b/modules/features/shared/src/test/java/au/com/shiftyjelly/pocketcasts/shared/AppLifecycleObserverTest.kt
@@ -14,6 +14,7 @@ import au.com.shiftyjelly.pocketcasts.utils.featureflag.providers.PreferencesFea
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.test.runTest
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -98,7 +99,7 @@ class AppLifecycleObserverTest {
     /* NEW INSTALL */
 
     @Test
-    fun handlesNewInstallPhone() {
+    fun handlesNewInstallPhone() = runTest {
         whenever(settings.getMigratedVersionCode()).thenReturn(VERSION_CODE_DEFAULT)
 
         appLifecycleObserver = spy(appLifecycleObserver)
@@ -118,7 +119,7 @@ class AppLifecycleObserverTest {
     }
 
     @Test
-    fun handlesNewInstallWear() {
+    fun handlesNewInstallWear() = runTest {
         whenever(settings.getMigratedVersionCode()).thenReturn(VERSION_CODE_DEFAULT)
 
         appLifecycleObserver = spy(appLifecycleObserver)
@@ -138,7 +139,7 @@ class AppLifecycleObserverTest {
     }
 
     @Test
-    fun handlesNewInstallAutomotive() {
+    fun handlesNewInstallAutomotive() = runTest {
         whenever(settings.getMigratedVersionCode()).thenReturn(VERSION_CODE_DEFAULT)
 
         appLifecycleObserver = spy(appLifecycleObserver)
@@ -160,7 +161,7 @@ class AppLifecycleObserverTest {
     /* UPGRADE */
 
     @Test
-    fun handlesUpgrade() {
+    fun handlesUpgrade() = runTest {
         whenever(settings.getMigratedVersionCode()).thenReturn(VERSION_CODE_AFTER_FIRST_INSTALL)
 
         appLifecycleObserver.setup()

--- a/modules/features/shared/src/test/java/au/com/shiftyjelly/pocketcasts/shared/AppLifecycleObserverTest.kt
+++ b/modules/features/shared/src/test/java/au/com/shiftyjelly/pocketcasts/shared/AppLifecycleObserverTest.kt
@@ -114,6 +114,7 @@ class AppLifecycleObserverTest {
 
         verify(appLifecycleAnalytics, never()).onApplicationUpgrade(any())
         verify(notificationScheduler, times(1)).setupOnboardingNotifications()
+        verify(notificationScheduler, times(1)).setupReEngagementNotification()
     }
 
     @Test
@@ -133,6 +134,7 @@ class AppLifecycleObserverTest {
         verify(useUpNextDarkThemeSetting).set(false, updateModifiedAt = false)
         verify(appLifecycleAnalytics, never()).onApplicationUpgrade(any())
         verify(notificationScheduler, never()).setupOnboardingNotifications()
+        verify(notificationScheduler, times(1)).setupReEngagementNotification()
     }
 
     @Test
@@ -152,6 +154,7 @@ class AppLifecycleObserverTest {
         verify(useUpNextDarkThemeSetting).set(false, updateModifiedAt = false)
         verify(appLifecycleAnalytics, never()).onApplicationUpgrade(any())
         verify(notificationScheduler, never()).setupOnboardingNotifications()
+        verify(notificationScheduler, times(1)).setupReEngagementNotification()
     }
 
     /* UPGRADE */
@@ -170,5 +173,6 @@ class AppLifecycleObserverTest {
         verify(dailyRemindersNotificationSetting, never()).set(any(), any(), any(), any())
         verify(useUpNextDarkThemeSetting, never()).set(any(), any(), any(), any())
         verify(notificationScheduler, never()).setupOnboardingNotifications()
+        verify(notificationScheduler, times(1)).setupReEngagementNotification()
     }
 }

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -2370,6 +2370,6 @@
     <string name="notification_reengage_we_miss_you_message">It\'s been awhile since you\'ve listened. Jump back in and enjoy!</string>
 
     <string name="notification_reengage_catch_up_offline_title">Catch up offline</string>
-    <string name="notification_reengage_catch_up_offline_message">You have X new episodes downloaded and ready to go!</string>
+    <string name="notification_reengage_catch_up_offline_message">You have %d new episodes downloaded and ready to go!</string>
 
 </resources>

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -2367,7 +2367,7 @@
     <string name="notification_plus_upsell_message">Unlock exclusive features like folders, bookmarks, and more with Plus!</string>
 
     <string name="notification_reengage_we_miss_you_title">We miss you!</string>
-    <string name="notification_reengage_we_miss_you_message">It\'s been awhile since you\'ve listened. Jump back in and enjoy!</string>
+    <string name="notification_reengage_we_miss_you_message">It\'s been a while since you\'ve listened. Jump back in and enjoy!</string>
 
     <string name="notification_reengage_catch_up_offline_title">Catch up offline</string>
     <string name="notification_reengage_catch_up_offline_message">You have %d new episodes downloaded and ready to go!</string>

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -2370,6 +2370,9 @@
     <string name="notification_reengage_we_miss_you_message">It\'s been a while since you\'ve listened. Jump back in and enjoy!</string>
 
     <string name="notification_reengage_catch_up_offline_title">Catch up offline</string>
-    <string name="notification_reengage_catch_up_offline_message">You have %d new episodes downloaded and ready to go!</string>
+    <plurals name="notification_reengage_catch_up_offline_message">
+        <item quantity="one">You have %d new episode downloaded and ready to go!</item>
+        <item quantity="other">You have %d new episodes downloaded and ready to go!</item>
+    </plurals>
 
 </resources>

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -2366,4 +2366,10 @@
     <string name="notification_plus_upsell_title">Level up your podcast game</string>
     <string name="notification_plus_upsell_message">Unlock exclusive features like folders, bookmarks, and more with Plus!</string>
 
+    <string name="notification_reengage_we_miss_you_title">We miss you!</string>
+    <string name="notification_reengage_we_miss_you_message">It\'s been awhile since you\'ve listened. Jump back in and enjoy!</string>
+
+    <string name="notification_reengage_catch_up_offline_title">Catch up offline</string>
+    <string name="notification_reengage_catch_up_offline_message">You have X new episodes downloaded and ready to go!</string>
+
 </resources>

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/EpisodeDao.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/EpisodeDao.kt
@@ -263,7 +263,7 @@ abstract class EpisodeDao {
     abstract fun findDownloadedEpisodesRxFlowable(downloadEpisodeStatusEnum: EpisodeStatusEnum = EpisodeStatusEnum.DOWNLOADED): Flowable<List<PodcastEpisode>>
 
     @Query("SELECT COUNT(*) FROM podcast_episodes WHERE episode_status == :downloadEpisodeStatusEnum AND playing_status == :playingStatus")
-    abstract suspend fun downloadedEpisodesThatHaveNotBeenPlayedCountBlocking(
+    abstract suspend fun downloadedEpisodesThatHaveNotBeenPlayedCount(
         downloadEpisodeStatusEnum: EpisodeStatusEnum = EpisodeStatusEnum.DOWNLOADED,
         playingStatus: EpisodePlayingStatus = EpisodePlayingStatus.NOT_PLAYED,
     ): Int

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/EpisodeDao.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/EpisodeDao.kt
@@ -262,6 +262,12 @@ abstract class EpisodeDao {
     @Query("SELECT * FROM podcast_episodes WHERE episode_status == :downloadEpisodeStatusEnum ORDER BY last_download_attempt_date DESC")
     abstract fun findDownloadedEpisodesRxFlowable(downloadEpisodeStatusEnum: EpisodeStatusEnum = EpisodeStatusEnum.DOWNLOADED): Flowable<List<PodcastEpisode>>
 
+    @Query("SELECT COUNT(*) FROM podcast_episodes WHERE episode_status == :downloadEpisodeStatusEnum AND playing_status == :playingStatus")
+    abstract suspend fun downloadedEpisodesThatHaveNotBeenPlayedCountBlocking(
+        downloadEpisodeStatusEnum: EpisodeStatusEnum = EpisodeStatusEnum.DOWNLOADED,
+        playingStatus: EpisodePlayingStatus = EpisodePlayingStatus.NOT_PLAYED,
+    ): Int
+
     @Transaction
     @Query("SELECT * FROM podcast_episodes WHERE starred = 1")
     abstract fun findStarredEpisodesRxFlowable(): Flowable<List<PodcastEpisode>>

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
@@ -152,6 +152,7 @@ interface Settings {
         ONBOARDING_THEMES(21483657),
         ONBOARDING_STAFF_PICKS(21483658),
         ONBOARDING_UPSELL(21483659),
+        RE_ENGAGEMENT(21483660),
     }
 
     enum class UpNextAction(val serverId: Int) {

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/notification/NotificationDelayCalculator.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/notification/NotificationDelayCalculator.kt
@@ -33,4 +33,31 @@ class NotificationDelayCalculator {
         }
         return calendar.timeInMillis
     }
+
+    /**
+     * Calculates the delay until the re-engagement check worker should be triggered.
+     * The worker is set to run daily at 4 PM.
+     *
+     * @param currentTimeMillis The current time in milliseconds.
+     * @return Delay in milliseconds until the next 4 PM.
+     */
+    fun calculateDelayForReEngagementCheck(currentTimeMillis: Long = System.currentTimeMillis()): Long {
+        val next4PM = calculateBase4PM(currentTimeMillis)
+        return next4PM - currentTimeMillis
+    }
+
+    private fun calculateBase4PM(currentTimeMillis: Long): Long {
+        val calendar = Calendar.getInstance().apply {
+            timeInMillis = currentTimeMillis
+            set(Calendar.HOUR_OF_DAY, 16)
+            set(Calendar.MINUTE, 0)
+            set(Calendar.SECOND, 0)
+            set(Calendar.MILLISECOND, 0)
+
+            if (timeInMillis <= currentTimeMillis) {
+                add(Calendar.DAY_OF_YEAR, 1)
+            }
+        }
+        return calendar.timeInMillis
+    }
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/notification/NotificationDelayCalculator.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/notification/NotificationDelayCalculator.kt
@@ -1,22 +1,25 @@
 package au.com.shiftyjelly.pocketcasts.repositories.notification
 
+import jakarta.inject.Inject
+import java.time.Clock
 import java.util.Calendar
 import java.util.concurrent.TimeUnit
 
-class NotificationDelayCalculator {
+class NotificationDelayCalculator @Inject constructor(
+    private val clock: Clock,
+) {
     /**
      * Calculates the delay until the notification should be sent.
      *
      * @param type The notification type containing dayOffset
-     * @param currentTimeMillis current time
      * @return Delay in milliseconds until the target 10 AM
      */
     fun calculateDelayForOnboardingNotification(
         type: OnboardingNotificationType,
-        currentTimeMillis: Long = System.currentTimeMillis(),
     ): Long {
-        val next10AM = calculateBase10AM(currentTimeMillis)
-        return next10AM + TimeUnit.DAYS.toMillis(type.dayOffset.toLong()) - currentTimeMillis
+        val now = clock.instant().toEpochMilli()
+        val next10AM = calculateBase10AM(now)
+        return next10AM + TimeUnit.DAYS.toMillis(type.dayOffset.toLong()) - now
     }
 
     private fun calculateBase10AM(currentTimeMillis: Long): Long {
@@ -38,12 +41,12 @@ class NotificationDelayCalculator {
      * Calculates the delay until the re-engagement check worker should be triggered.
      * The worker is set to run daily at 4 PM.
      *
-     * @param currentTimeMillis The current time in milliseconds.
      * @return Delay in milliseconds until the next 4 PM.
      */
-    fun calculateDelayForReEngagementCheck(currentTimeMillis: Long = System.currentTimeMillis()): Long {
-        val next4PM = calculateBase4PM(currentTimeMillis)
-        return next4PM - currentTimeMillis
+    fun calculateDelayForReEngagementCheck(): Long {
+        val now = clock.instant().toEpochMilli()
+        val next4PM = calculateBase4PM(now)
+        return next4PM - now
     }
 
     private fun calculateBase4PM(currentTimeMillis: Long): Long {

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/notification/NotificationManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/notification/NotificationManager.kt
@@ -4,6 +4,7 @@ interface NotificationManager {
     suspend fun setupOnboardingNotifications()
     suspend fun setupReEngagementNotifications()
     suspend fun updateUserFeatureInteraction(type: NotificationType)
+    suspend fun updateUserFeatureInteraction(id: Int)
     suspend fun hasUserInteractedWithFeature(type: NotificationType): Boolean
     suspend fun updateOnboardingNotificationSent(type: NotificationType)
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/notification/NotificationManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/notification/NotificationManager.kt
@@ -2,6 +2,7 @@ package au.com.shiftyjelly.pocketcasts.repositories.notification
 
 interface NotificationManager {
     suspend fun setupOnboardingNotifications()
+    suspend fun setupReEngagementNotifications()
     suspend fun updateUserFeatureInteraction(type: NotificationType)
     suspend fun hasUserInteractedWithFeature(type: NotificationType): Boolean
     suspend fun updateOnboardingNotificationSent(type: NotificationType)

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/notification/NotificationManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/notification/NotificationManager.kt
@@ -2,7 +2,7 @@ package au.com.shiftyjelly.pocketcasts.repositories.notification
 
 interface NotificationManager {
     suspend fun setupOnboardingNotifications()
-    suspend fun updateUserFeatureInteraction(type: OnboardingNotificationType)
-    suspend fun hasUserInteractedWithFeature(type: OnboardingNotificationType): Boolean
-    suspend fun updateOnboardingNotificationSent(type: OnboardingNotificationType)
+    suspend fun updateUserFeatureInteraction(type: NotificationType)
+    suspend fun hasUserInteractedWithFeature(type: NotificationType): Boolean
+    suspend fun updateOnboardingNotificationSent(type: NotificationType)
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/notification/NotificationManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/notification/NotificationManager.kt
@@ -6,5 +6,5 @@ interface NotificationManager {
     suspend fun updateUserFeatureInteraction(type: NotificationType)
     suspend fun updateUserFeatureInteraction(id: Int)
     suspend fun hasUserInteractedWithFeature(type: NotificationType): Boolean
-    suspend fun updateOnboardingNotificationSent(type: NotificationType)
+    suspend fun updateNotificationSent(type: NotificationType)
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/notification/NotificationManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/notification/NotificationManagerImpl.kt
@@ -31,7 +31,7 @@ class NotificationManagerImpl @Inject constructor(
         return userNotification.interactedAt != null
     }
 
-    override suspend fun updateOnboardingNotificationSent(type: NotificationType) {
+    override suspend fun updateNotificationSent(type: NotificationType) {
         userNotificationsDao.getUserNotification(type.notificationId)
             ?.apply {
                 sentThisWeek++

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/notification/NotificationManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/notification/NotificationManagerImpl.kt
@@ -9,11 +9,11 @@ class NotificationManagerImpl @Inject constructor(
 ) : NotificationManager {
 
     override suspend fun setupOnboardingNotifications() {
-        val userNotifications = OnboardingNotificationType.values.map { notification ->
-            UserNotifications(notificationId = notification.notificationId)
-        }
+        setupNotificationsForType(OnboardingNotificationType.values) { it.notificationId }
+    }
 
-        userNotificationsDao.insert(userNotifications)
+    override suspend fun setupReEngagementNotifications() {
+        setupNotificationsForType(ReEngagementNotificationType.values) { it.notificationId }
     }
 
     override suspend fun updateUserFeatureInteraction(type: NotificationType) {
@@ -34,5 +34,15 @@ class NotificationManagerImpl @Inject constructor(
                 lastSentAt = System.currentTimeMillis()
             }
             ?.let { userNotificationsDao.update(it) }
+    }
+
+    private suspend fun <T> setupNotificationsForType(
+        values: Iterable<T>,
+        getId: (T) -> Int,
+    ) {
+        val userNotifications = values.map { notification ->
+            UserNotifications(notificationId = getId(notification))
+        }
+        userNotificationsDao.insert(userNotifications)
     }
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/notification/NotificationManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/notification/NotificationManagerImpl.kt
@@ -20,6 +20,10 @@ class NotificationManagerImpl @Inject constructor(
         userNotificationsDao.updateInteractedAt(type.notificationId, System.currentTimeMillis())
     }
 
+    override suspend fun updateUserFeatureInteraction(id: Int) {
+        userNotificationsDao.updateInteractedAt(id, System.currentTimeMillis())
+    }
+
     override suspend fun hasUserInteractedWithFeature(type: NotificationType): Boolean {
         val userNotification = userNotificationsDao.getUserNotification(type.notificationId)
             ?: return false

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/notification/NotificationManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/notification/NotificationManagerImpl.kt
@@ -16,18 +16,18 @@ class NotificationManagerImpl @Inject constructor(
         userNotificationsDao.insert(userNotifications)
     }
 
-    override suspend fun updateUserFeatureInteraction(type: OnboardingNotificationType) {
+    override suspend fun updateUserFeatureInteraction(type: NotificationType) {
         userNotificationsDao.updateInteractedAt(type.notificationId, System.currentTimeMillis())
     }
 
-    override suspend fun hasUserInteractedWithFeature(type: OnboardingNotificationType): Boolean {
+    override suspend fun hasUserInteractedWithFeature(type: NotificationType): Boolean {
         val userNotification = userNotificationsDao.getUserNotification(type.notificationId)
             ?: return false
 
         return userNotification.interactedAt != null
     }
 
-    override suspend fun updateOnboardingNotificationSent(type: OnboardingNotificationType) {
+    override suspend fun updateOnboardingNotificationSent(type: NotificationType) {
         userNotificationsDao.getUserNotification(type.notificationId)
             ?.apply {
                 sentThisWeek++

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/notification/NotificationManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/notification/NotificationManagerImpl.kt
@@ -3,6 +3,8 @@ package au.com.shiftyjelly.pocketcasts.repositories.notification
 import au.com.shiftyjelly.pocketcasts.models.db.dao.UserNotificationsDao
 import au.com.shiftyjelly.pocketcasts.models.entity.UserNotifications
 import javax.inject.Inject
+import kotlin.time.Duration.Companion.days
+import kotlin.time.Duration.Companion.milliseconds
 
 class NotificationManagerImpl @Inject constructor(
     private val userNotificationsDao: UserNotificationsDao,
@@ -27,6 +29,12 @@ class NotificationManagerImpl @Inject constructor(
     override suspend fun hasUserInteractedWithFeature(type: NotificationType): Boolean {
         val userNotification = userNotificationsDao.getUserNotification(type.notificationId)
             ?: return false
+
+        if (type is ReEngagementNotificationType) {
+            val lastInteraction = userNotification.interactedAt ?: return false
+            val elapsed = (System.currentTimeMillis() - lastInteraction).milliseconds
+            return elapsed < 7.days
+        }
 
         return userNotification.interactedAt != null
     }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/notification/NotificationScheduler.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/notification/NotificationScheduler.kt
@@ -2,5 +2,5 @@ package au.com.shiftyjelly.pocketcasts.repositories.notification
 
 interface NotificationScheduler {
     fun setupOnboardingNotifications()
-    fun setupReEngagementNotification()
+    suspend fun setupReEngagementNotification()
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/notification/NotificationScheduler.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/notification/NotificationScheduler.kt
@@ -2,4 +2,5 @@ package au.com.shiftyjelly.pocketcasts.repositories.notification
 
 interface NotificationScheduler {
     fun setupOnboardingNotifications()
+    fun setupReEngagementNotification()
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/notification/NotificationSchedulerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/notification/NotificationSchedulerImpl.kt
@@ -57,7 +57,7 @@ class NotificationSchedulerImpl @Inject constructor(
 
         WorkManager.getInstance(context).enqueueUniquePeriodicWork(
             "daily_re_engagement_check",
-            ExistingPeriodicWorkPolicy.REPLACE,
+            ExistingPeriodicWorkPolicy.UPDATE,
             notificationWork,
         )
     }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/notification/NotificationSchedulerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/notification/NotificationSchedulerImpl.kt
@@ -46,7 +46,7 @@ class NotificationSchedulerImpl @Inject constructor(
         val initialDelay = NotificationDelayCalculator().calculateDelayForReEngagementCheck()
 
         val workData = workDataOf(
-            "subcategory" to ReEngagementNotificationType.SUBCATEGORY_REENGAGE_CATCH_UP_OFFLINE, // This is the default re-engagement notification
+            "subcategory" to ReEngagementNotificationType.SUBCATEGORY_REENGAGE_WE_MISS_YOU,
         )
 
         val notificationWork = PeriodicWorkRequest.Builder(NotificationWorker::class.java, 1, TimeUnit.DAYS)

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/notification/NotificationSchedulerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/notification/NotificationSchedulerImpl.kt
@@ -30,7 +30,7 @@ class NotificationSchedulerImpl @Inject constructor(
                 "subcategory" to type.subcategory,
             )
 
-            val notificationWork = OneTimeWorkRequest.Builder(OnboardingNotificationWorker::class.java)
+            val notificationWork = OneTimeWorkRequest.Builder(NotificationWorker::class.java)
                 .setInputData(workData)
                 .setInitialDelay(delay, TimeUnit.MILLISECONDS)
                 .addTag("onboarding_notification_${type.subcategory}")

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/notification/NotificationSchedulerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/notification/NotificationSchedulerImpl.kt
@@ -16,6 +16,7 @@ import java.util.concurrent.TimeUnit
 class NotificationSchedulerImpl @Inject constructor(
     @ApplicationContext private val context: Context,
     private val episodeManager: EpisodeManager,
+    private val delayCalculator: NotificationDelayCalculator,
 ) : NotificationScheduler {
 
     companion object {
@@ -24,8 +25,6 @@ class NotificationSchedulerImpl @Inject constructor(
     }
 
     override fun setupOnboardingNotifications() {
-        val delayCalculator = NotificationDelayCalculator()
-
         listOf(
             OnboardingNotificationType.Sync,
             OnboardingNotificationType.Import,
@@ -52,7 +51,7 @@ class NotificationSchedulerImpl @Inject constructor(
     }
 
     override suspend fun setupReEngagementNotification() {
-        val initialDelay = NotificationDelayCalculator().calculateDelayForReEngagementCheck()
+        val initialDelay = delayCalculator.calculateDelayForReEngagementCheck()
 
         val downloadedEpisodes = episodeManager.downloadedEpisodesThatHaveNotBeenPlayedCount()
         val subcategory =

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/notification/NotificationType.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/notification/NotificationType.kt
@@ -150,7 +150,7 @@ sealed class ReEngagementNotificationType(
         titleRes = LR.string.notification_reengage_we_miss_you_title,
         messageRes = LR.string.notification_reengage_we_miss_you_message,
     ) {
-        override fun toIntent(context: Context): Intent = DownloadsDeepLink.toIntent(context)
+        override fun toIntent(context: Context): Intent = StaffPicksDeepLink.toIntent(context)
     }
 
     object CatchUpOffline : ReEngagementNotificationType(

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/notification/NotificationType.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/notification/NotificationType.kt
@@ -10,6 +10,7 @@ import au.com.shiftyjelly.pocketcasts.deeplink.ShowUpNextTabDeepLink
 import au.com.shiftyjelly.pocketcasts.deeplink.StaffPicksDeepLink
 import au.com.shiftyjelly.pocketcasts.deeplink.ThemesDeepLink
 import au.com.shiftyjelly.pocketcasts.deeplink.UpsellDeepLink
+import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.preferences.Settings.NotificationId
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
@@ -20,6 +21,7 @@ sealed interface NotificationType {
     val messageRes: Int
 
     fun toIntent(context: Context): Intent
+    fun isSettingsToggleOn(settings: Settings): Boolean
 }
 
 sealed class OnboardingNotificationType(
@@ -29,6 +31,10 @@ sealed class OnboardingNotificationType(
     override val messageRes: Int,
     val dayOffset: Int,
 ) : NotificationType {
+
+    override fun isSettingsToggleOn(settings: Settings): Boolean {
+        return settings.dailyRemindersNotification.value
+    }
 
     object Sync : OnboardingNotificationType(
         notificationId = NotificationId.ONBOARDING_SYNC.value,
@@ -134,6 +140,10 @@ sealed class ReEngagementNotificationType(
 
     override val notificationId: Int
         get() = ReEngagementNotificationType.notificationId
+
+    override fun isSettingsToggleOn(settings: Settings): Boolean {
+        return settings.dailyRemindersNotification.value
+    }
 
     object WeMissYou : ReEngagementNotificationType(
         subcategory = SUBCATEGORY_REENGAGE_WE_MISS_YOU,

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/notification/NotificationType.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/notification/NotificationType.kt
@@ -127,14 +127,15 @@ sealed class OnboardingNotificationType(
 }
 
 sealed class ReEngagementNotificationType(
-    override val notificationId: Int,
     override val subcategory: String,
     override val titleRes: Int,
     override val messageRes: Int,
 ) : NotificationType {
 
+    override val notificationId: Int
+        get() = ReEngagementNotificationType.notificationId
+
     object WeMissYou : ReEngagementNotificationType(
-        notificationId = NotificationId.RE_ENGAGEMENT.value,
         subcategory = SUBCATEGORY_REENGAGE_WE_MISS_YOU,
         titleRes = LR.string.notification_reengage_we_miss_you_title,
         messageRes = LR.string.notification_reengage_we_miss_you_message,
@@ -143,7 +144,6 @@ sealed class ReEngagementNotificationType(
     }
 
     object CatchUpOffline : ReEngagementNotificationType(
-        notificationId = NotificationId.RE_ENGAGEMENT.value,
         subcategory = SUBCATEGORY_REENGAGE_CATCH_UP_OFFLINE,
         titleRes = LR.string.notification_reengage_catch_up_offline_title,
         messageRes = LR.string.notification_reengage_catch_up_offline_message,
@@ -154,6 +154,9 @@ sealed class ReEngagementNotificationType(
     companion object {
         const val SUBCATEGORY_REENGAGE_WE_MISS_YOU = "we_miss_you"
         const val SUBCATEGORY_REENGAGE_CATCH_UP_OFFLINE = "catch_up_offline"
+
+        val notificationId: Int
+            get() = NotificationId.RE_ENGAGEMENT.value
 
         val values: List<ReEngagementNotificationType>
             get() = listOf(

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/notification/NotificationWorker.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/notification/NotificationWorker.kt
@@ -70,7 +70,7 @@ class NotificationWorker @AssistedInject constructor(
     }
 
     private suspend fun buildReEngagementNotification(type: ReEngagementNotificationType): NotificationCompat.Builder {
-        val downloadedEpisodes = episodeManager.downloadedEpisodesThatHaveNotBeenPlayedCountBlocking()
+        val downloadedEpisodes = episodeManager.downloadedEpisodesThatHaveNotBeenPlayedCount()
 
         val contentTitle = if (downloadedEpisodes > 0) {
             applicationContext.resources.getString(ReEngagementNotificationType.CatchUpOffline.titleRes)

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/notification/NotificationWorker.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/notification/NotificationWorker.kt
@@ -54,36 +54,13 @@ class NotificationWorker @AssistedInject constructor(
     }
 
     private fun getNotificationBuilder(type: NotificationType): NotificationCompat.Builder {
-        return when (type) {
-            is OnboardingNotificationType -> buildOnboardingNotification(type)
-            is ReEngagementNotificationType -> buildReEngagementNotification(type)
-        }
-    }
-
-    private fun buildOnboardingNotification(type: OnboardingNotificationType): NotificationCompat.Builder {
-        return notificationHelper.dailyRemindersChannelBuilder()
-            .setSmallIcon(IR.drawable.notification)
-            .setVisibility(NotificationCompat.VISIBILITY_PUBLIC)
-            .setContentTitle(applicationContext.resources.getString(type.titleRes))
-            .setContentText(applicationContext.resources.getString(type.messageRes))
-            .setColor(ContextCompat.getColor(applicationContext, R.color.notification_color))
-            .setContentIntent(openPageIntent(type))
-    }
-
-    private fun buildReEngagementNotification(type: ReEngagementNotificationType): NotificationCompat.Builder {
         val downloadedEpisodes = inputData.getInt(DOWNLOADED_EPISODES, 0)
 
-        val contentText = if (type is ReEngagementNotificationType.CatchUpOffline && downloadedEpisodes != 0) {
-            applicationContext.resources.getString(type.messageRes, downloadedEpisodes)
-        } else {
-            applicationContext.resources.getString(type.messageRes)
-        }
-
         return notificationHelper.dailyRemindersChannelBuilder()
             .setSmallIcon(IR.drawable.notification)
             .setVisibility(NotificationCompat.VISIBILITY_PUBLIC)
             .setContentTitle(applicationContext.resources.getString(type.titleRes))
-            .setContentText(contentText)
+            .setContentText(type.formattedMessage(applicationContext, downloadedEpisodes))
             .setColor(ContextCompat.getColor(applicationContext, R.color.notification_color))
             .setContentIntent(openPageIntent(type))
     }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/notification/NotificationWorker.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/notification/NotificationWorker.kt
@@ -13,7 +13,8 @@ import androidx.work.CoroutineWorker
 import androidx.work.WorkerParameters
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.repositories.R
-import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
+import au.com.shiftyjelly.pocketcasts.repositories.notification.NotificationSchedulerImpl.Companion.DOWNLOADED_EPISODES
+import au.com.shiftyjelly.pocketcasts.repositories.notification.NotificationSchedulerImpl.Companion.SUBCATEGORY
 import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
 import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
 import dagger.assisted.Assisted
@@ -27,10 +28,10 @@ class NotificationWorker @AssistedInject constructor(
     private val settings: Settings,
     private val notificationHelper: NotificationHelper,
     private val notificationManager: NotificationManager,
-    private val episodeManager: EpisodeManager,
 ) : CoroutineWorker(context, params) {
     override suspend fun doWork(): Result {
-        val subcategory = inputData.getString("subcategory") ?: return Result.failure()
+        val subcategory = inputData.getString(SUBCATEGORY) ?: return Result.failure()
+
         val type =
             OnboardingNotificationType.fromSubcategory(subcategory) ?: ReEngagementNotificationType.fromSubcategory(subcategory) ?: return Result.failure()
 
@@ -52,7 +53,7 @@ class NotificationWorker @AssistedInject constructor(
         return Result.success()
     }
 
-    private suspend fun getNotificationBuilder(type: NotificationType): NotificationCompat.Builder {
+    private fun getNotificationBuilder(type: NotificationType): NotificationCompat.Builder {
         return when (type) {
             is OnboardingNotificationType -> buildOnboardingNotification(type)
             is ReEngagementNotificationType -> buildReEngagementNotification(type)
@@ -69,34 +70,22 @@ class NotificationWorker @AssistedInject constructor(
             .setContentIntent(openPageIntent(type))
     }
 
-    private suspend fun buildReEngagementNotification(type: ReEngagementNotificationType): NotificationCompat.Builder {
-        val downloadedEpisodes = episodeManager.downloadedEpisodesThatHaveNotBeenPlayedCount()
+    private fun buildReEngagementNotification(type: ReEngagementNotificationType): NotificationCompat.Builder {
+        val downloadedEpisodes = inputData.getInt(DOWNLOADED_EPISODES, 0)
 
-        val contentTitle = if (downloadedEpisodes > 0) {
-            applicationContext.resources.getString(ReEngagementNotificationType.CatchUpOffline.titleRes)
-        } else {
-            applicationContext.resources.getString(type.titleRes)
-        }
-
-        val contentText = if (downloadedEpisodes > 0) {
-            applicationContext.resources.getString(ReEngagementNotificationType.CatchUpOffline.messageRes, downloadedEpisodes)
+        val contentText = if (type is ReEngagementNotificationType.CatchUpOffline && downloadedEpisodes != 0) {
+            applicationContext.resources.getString(type.messageRes, downloadedEpisodes)
         } else {
             applicationContext.resources.getString(type.messageRes)
-        }
-
-        val pendingIntent = if (downloadedEpisodes > 0) {
-            openPageIntent(ReEngagementNotificationType.CatchUpOffline)
-        } else {
-            openPageIntent(type)
         }
 
         return notificationHelper.dailyRemindersChannelBuilder()
             .setSmallIcon(IR.drawable.notification)
             .setVisibility(NotificationCompat.VISIBILITY_PUBLIC)
-            .setContentTitle(contentTitle)
+            .setContentTitle(applicationContext.resources.getString(type.titleRes))
             .setContentText(contentText)
             .setColor(ContextCompat.getColor(applicationContext, R.color.notification_color))
-            .setContentIntent(pendingIntent)
+            .setContentIntent(openPageIntent(type))
     }
 
     private fun openPageIntent(type: NotificationType): PendingIntent {

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManager.kt
@@ -51,7 +51,7 @@ interface EpisodeManager {
     fun findDownloadedEpisodesRxFlowable(): Flowable<List<PodcastEpisode>>
     fun findStarredEpisodesRxFlowable(): Flowable<List<PodcastEpisode>>
     suspend fun findStarredEpisodes(): List<PodcastEpisode>
-    suspend fun downloadedEpisodesThatHaveNotBeenPlayedCountBlocking(): Int
+    suspend fun downloadedEpisodesThatHaveNotBeenPlayedCount(): Int
 
     /** Add methods  */
     fun addBlocking(episode: PodcastEpisode, downloadMetaData: Boolean): Boolean

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManager.kt
@@ -51,6 +51,7 @@ interface EpisodeManager {
     fun findDownloadedEpisodesRxFlowable(): Flowable<List<PodcastEpisode>>
     fun findStarredEpisodesRxFlowable(): Flowable<List<PodcastEpisode>>
     suspend fun findStarredEpisodes(): List<PodcastEpisode>
+    suspend fun downloadedEpisodesThatHaveNotBeenPlayedCountBlocking(): Int
 
     /** Add methods  */
     fun addBlocking(episode: PodcastEpisode, downloadMetaData: Boolean): Boolean

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManagerImpl.kt
@@ -802,6 +802,10 @@ class EpisodeManagerImpl @Inject constructor(
         return episodeDao.findDownloadedEpisodesRxFlowable()
     }
 
+    override suspend fun downloadedEpisodesThatHaveNotBeenPlayedCountBlocking(): Int {
+        return episodeDao.downloadedEpisodesThatHaveNotBeenPlayedCountBlocking()
+    }
+
     override fun findStarredEpisodesRxFlowable(): Flowable<List<PodcastEpisode>> {
         return episodeDao.findStarredEpisodesRxFlowable()
     }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManagerImpl.kt
@@ -802,8 +802,8 @@ class EpisodeManagerImpl @Inject constructor(
         return episodeDao.findDownloadedEpisodesRxFlowable()
     }
 
-    override suspend fun downloadedEpisodesThatHaveNotBeenPlayedCountBlocking(): Int {
-        return episodeDao.downloadedEpisodesThatHaveNotBeenPlayedCountBlocking()
+    override suspend fun downloadedEpisodesThatHaveNotBeenPlayedCount(): Int {
+        return episodeDao.downloadedEpisodesThatHaveNotBeenPlayedCount()
     }
 
     override fun findStarredEpisodesRxFlowable(): Flowable<List<PodcastEpisode>> {

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/notification/NotificationDelayCalculatorTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/notification/NotificationDelayCalculatorTest.kt
@@ -180,6 +180,30 @@ class NotificationDelayCalculatorTest {
         assertEquals(expectedDelay, delay)
     }
 
+    @Test
+    fun testReEngagementCheck_Before4PM() {
+        val fixedTime = getFixedTime(2025, Calendar.APRIL, 10, 15, 0)
+        val expectedDelay = 1 * HOUR_IN_MILLIS
+        val delay = calculator.calculateDelayForReEngagementCheck(fixedTime)
+        assertEquals(expectedDelay, delay)
+    }
+
+    @Test
+    fun testReEngagementCheck_Exactly4PM() {
+        val fixedTime = getFixedTime(2025, Calendar.APRIL, 10, 16, 0)
+        val expectedDelay = 24 * HOUR_IN_MILLIS
+        val delay = calculator.calculateDelayForReEngagementCheck(fixedTime)
+        assertEquals(expectedDelay, delay)
+    }
+
+    @Test
+    fun testReEngagementCheck_After4PM() {
+        val fixedTime = getFixedTime(2025, Calendar.APRIL, 10, 17, 0)
+        val expectedDelay = 23 * HOUR_IN_MILLIS
+        val delay = calculator.calculateDelayForReEngagementCheck(fixedTime)
+        assertEquals(expectedDelay, delay)
+    }
+
     private fun getFixedTime(
         year: Int,
         month: Int,

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/notification/NotificationDelayCalculatorTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/notification/NotificationDelayCalculatorTest.kt
@@ -1,221 +1,204 @@
 package au.com.shiftyjelly.pocketcasts.repositories.notification
 
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneOffset
 import java.util.Calendar
 import junit.framework.TestCase.assertEquals
 import org.junit.Test
 
 class NotificationDelayCalculatorTest {
 
-    private val calculator = NotificationDelayCalculator()
-
     companion object {
         private const val HOUR_IN_MILLIS = 60 * 60 * 1000L
+
+        private fun getFixedTime(
+            year: Int,
+            month: Int,
+            day: Int,
+            hour: Int,
+            minute: Int,
+            second: Int = 0,
+            millisecond: Int = 0,
+        ): Long {
+            return Calendar.getInstance().apply {
+                set(year, month, day, hour, minute, second)
+                set(Calendar.MILLISECOND, millisecond)
+            }.timeInMillis
+        }
+
+        private fun calculatorAt(fixedTime: Long): NotificationDelayCalculator {
+            val fixedInstant = Instant.ofEpochMilli(fixedTime)
+            val fixedClock = Clock.fixed(fixedInstant, ZoneOffset.UTC)
+            return NotificationDelayCalculator(fixedClock)
+        }
     }
 
-    @Test
-    fun testBefore10AM_Sync() {
-        val fixedTime = getFixedTime(2025, Calendar.APRIL, 10, 9, 0)
-        val expectedDelay = (1 + 0 * 24) * HOUR_IN_MILLIS // 1 hour
-        val delay = calculator.calculateDelayForOnboardingNotification(OnboardingNotificationType.Sync, fixedTime)
-        assertEquals(expectedDelay, delay)
+    @Test fun testBefore10AM_Sync() {
+        val t = getFixedTime(2025, Calendar.APRIL, 10, 9, 0)
+        val calc = calculatorAt(t)
+        val expected = (1 + 0 * 24) * HOUR_IN_MILLIS
+        assertEquals(expected, calc.calculateDelayForOnboardingNotification(OnboardingNotificationType.Sync))
     }
 
-    @Test
-    fun testBefore10AM_Import() {
-        val fixedTime = getFixedTime(2025, Calendar.APRIL, 10, 9, 0)
-        val expectedDelay = (1 + 1 * 24) * HOUR_IN_MILLIS // 25 hours
-        val delay = calculator.calculateDelayForOnboardingNotification(OnboardingNotificationType.Import, fixedTime)
-        assertEquals(expectedDelay, delay)
+    @Test fun testBefore10AM_Import() {
+        val t = getFixedTime(2025, Calendar.APRIL, 10, 9, 0)
+        val calc = calculatorAt(t)
+        val expected = (1 + 1 * 24) * HOUR_IN_MILLIS
+        assertEquals(expected, calc.calculateDelayForOnboardingNotification(OnboardingNotificationType.Import))
     }
 
-    @Test
-    fun testBefore10AM_UpNext() {
-        val fixedTime = getFixedTime(2025, Calendar.APRIL, 10, 9, 0)
-        val expectedDelay = (1 + 2 * 24) * HOUR_IN_MILLIS // 49 hours
-        val delay = calculator.calculateDelayForOnboardingNotification(OnboardingNotificationType.UpNext, fixedTime)
-        assertEquals(expectedDelay, delay)
+    @Test fun testBefore10AM_UpNext() {
+        val t = getFixedTime(2025, Calendar.APRIL, 10, 9, 0)
+        val calc = calculatorAt(t)
+        val expected = (1 + 2 * 24) * HOUR_IN_MILLIS
+        assertEquals(expected, calc.calculateDelayForOnboardingNotification(OnboardingNotificationType.UpNext))
     }
 
-    @Test
-    fun testBefore10AM_Filters() {
-        val fixedTime = getFixedTime(2025, Calendar.APRIL, 10, 9, 0)
-        val expectedDelay = (1 + 3 * 24) * HOUR_IN_MILLIS // 73 hours
-        val delay = calculator.calculateDelayForOnboardingNotification(OnboardingNotificationType.Filters, fixedTime)
-        assertEquals(expectedDelay, delay)
+    @Test fun testBefore10AM_Filters() {
+        val t = getFixedTime(2025, Calendar.APRIL, 10, 9, 0)
+        val calc = calculatorAt(t)
+        val expected = (1 + 3 * 24) * HOUR_IN_MILLIS
+        assertEquals(expected, calc.calculateDelayForOnboardingNotification(OnboardingNotificationType.Filters))
     }
 
-    @Test
-    fun testBefore10AM_Themes() {
-        val fixedTime = getFixedTime(2025, Calendar.APRIL, 10, 9, 0)
-        val expectedDelay = (1 + 4 * 24) * HOUR_IN_MILLIS // 97 hours
-        val delay = calculator.calculateDelayForOnboardingNotification(OnboardingNotificationType.Themes, fixedTime)
-        assertEquals(expectedDelay, delay)
+    @Test fun testBefore10AM_Themes() {
+        val t = getFixedTime(2025, Calendar.APRIL, 10, 9, 0)
+        val calc = calculatorAt(t)
+        val expected = (1 + 4 * 24) * HOUR_IN_MILLIS
+        assertEquals(expected, calc.calculateDelayForOnboardingNotification(OnboardingNotificationType.Themes))
     }
 
-    @Test
-    fun testBefore10AM_StaffPicks() {
-        val fixedTime = getFixedTime(2025, Calendar.APRIL, 10, 9, 0)
-        val expectedDelay = (1 + 5 * 24) * HOUR_IN_MILLIS // 121 hours
-        val delay = calculator.calculateDelayForOnboardingNotification(OnboardingNotificationType.StaffPicks, fixedTime)
-        assertEquals(expectedDelay, delay)
+    @Test fun testBefore10AM_StaffPicks() {
+        val t = getFixedTime(2025, Calendar.APRIL, 10, 9, 0)
+        val calc = calculatorAt(t)
+        val expected = (1 + 5 * 24) * HOUR_IN_MILLIS
+        assertEquals(expected, calc.calculateDelayForOnboardingNotification(OnboardingNotificationType.StaffPicks))
     }
 
-    @Test
-    fun testBefore10AM_PlusUpsell() {
-        val fixedTime = getFixedTime(2025, Calendar.APRIL, 10, 9, 0)
-        val expectedDelay = (1 + 6 * 24) * HOUR_IN_MILLIS // 145 hours
-        val delay = calculator.calculateDelayForOnboardingNotification(OnboardingNotificationType.PlusUpsell, fixedTime)
-        assertEquals(expectedDelay, delay)
+    @Test fun testBefore10AM_PlusUpsell() {
+        val t = getFixedTime(2025, Calendar.APRIL, 10, 9, 0)
+        val calc = calculatorAt(t)
+        val expected = (1 + 6 * 24) * HOUR_IN_MILLIS
+        assertEquals(expected, calc.calculateDelayForOnboardingNotification(OnboardingNotificationType.PlusUpsell))
     }
 
-    @Test
-    fun testExact10AM_Sync() {
-        val fixedTime = getFixedTime(2025, Calendar.APRIL, 10, 10, 0)
-        val expectedDelay = (24 + 0 * 24) * HOUR_IN_MILLIS // 24 hours
-        val delay = calculator.calculateDelayForOnboardingNotification(OnboardingNotificationType.Sync, fixedTime)
-        assertEquals(expectedDelay, delay)
+    @Test fun testExact10AM_Sync() {
+        val t = getFixedTime(2025, Calendar.APRIL, 10, 10, 0)
+        val calc = calculatorAt(t)
+        val expected = (24 + 0 * 24) * HOUR_IN_MILLIS
+        assertEquals(expected, calc.calculateDelayForOnboardingNotification(OnboardingNotificationType.Sync))
     }
 
-    @Test
-    fun testExact10AM_Import() {
-        val fixedTime = getFixedTime(2025, Calendar.APRIL, 10, 10, 0)
-        val expectedDelay = (24 + 1 * 24) * HOUR_IN_MILLIS // 48 hours
-        val delay = calculator.calculateDelayForOnboardingNotification(OnboardingNotificationType.Import, fixedTime)
-        assertEquals(expectedDelay, delay)
+    @Test fun testExact10AM_Import() {
+        val t = getFixedTime(2025, Calendar.APRIL, 10, 10, 0)
+        val calc = calculatorAt(t)
+        val expected = (24 + 1 * 24) * HOUR_IN_MILLIS
+        assertEquals(expected, calc.calculateDelayForOnboardingNotification(OnboardingNotificationType.Import))
     }
 
-    @Test
-    fun testExact10AM_UpNext() {
-        val fixedTime = getFixedTime(2025, Calendar.APRIL, 10, 10, 0)
-        val expectedDelay = (24 + 2 * 24) * HOUR_IN_MILLIS // 72 hours
-        val delay = calculator.calculateDelayForOnboardingNotification(OnboardingNotificationType.UpNext, fixedTime)
-        assertEquals(expectedDelay, delay)
+    @Test fun testExact10AM_UpNext() {
+        val t = getFixedTime(2025, Calendar.APRIL, 10, 10, 0)
+        val calc = calculatorAt(t)
+        val expected = (24 + 2 * 24) * HOUR_IN_MILLIS
+        assertEquals(expected, calc.calculateDelayForOnboardingNotification(OnboardingNotificationType.UpNext))
     }
 
-    @Test
-    fun testExact10AM_Filters() {
-        val fixedTime = getFixedTime(2025, Calendar.APRIL, 10, 10, 0)
-        val expectedDelay = (24 + 3 * 24) * HOUR_IN_MILLIS // 96 hours
-        val delay = calculator.calculateDelayForOnboardingNotification(OnboardingNotificationType.Filters, fixedTime)
-        assertEquals(expectedDelay, delay)
+    @Test fun testExact10AM_Filters() {
+        val t = getFixedTime(2025, Calendar.APRIL, 10, 10, 0)
+        val calc = calculatorAt(t)
+        val expected = (24 + 3 * 24) * HOUR_IN_MILLIS
+        assertEquals(expected, calc.calculateDelayForOnboardingNotification(OnboardingNotificationType.Filters))
     }
 
-    @Test
-    fun testExact10AM_Themes() {
-        val fixedTime = getFixedTime(2025, Calendar.APRIL, 10, 10, 0)
-        val expectedDelay = (24 + 4 * 24) * HOUR_IN_MILLIS // 120 hours
-        val delay = calculator.calculateDelayForOnboardingNotification(OnboardingNotificationType.Themes, fixedTime)
-        assertEquals(expectedDelay, delay)
+    @Test fun testExact10AM_Themes() {
+        val t = getFixedTime(2025, Calendar.APRIL, 10, 10, 0)
+        val calc = calculatorAt(t)
+        val expected = (24 + 4 * 24) * HOUR_IN_MILLIS
+        assertEquals(expected, calc.calculateDelayForOnboardingNotification(OnboardingNotificationType.Themes))
     }
 
-    @Test
-    fun testExact10AM_StaffPicks() {
-        val fixedTime = getFixedTime(2025, Calendar.APRIL, 10, 10, 0)
-        val expectedDelay = (24 + 5 * 24) * HOUR_IN_MILLIS // 144 hours
-        val delay = calculator.calculateDelayForOnboardingNotification(OnboardingNotificationType.StaffPicks, fixedTime)
-        assertEquals(expectedDelay, delay)
+    @Test fun testExact10AM_StaffPicks() {
+        val t = getFixedTime(2025, Calendar.APRIL, 10, 10, 0)
+        val calc = calculatorAt(t)
+        val expected = (24 + 5 * 24) * HOUR_IN_MILLIS
+        assertEquals(expected, calc.calculateDelayForOnboardingNotification(OnboardingNotificationType.StaffPicks))
     }
 
-    @Test
-    fun testExact10AM_PlusUpsell() {
-        val fixedTime = getFixedTime(2025, Calendar.APRIL, 10, 10, 0)
-        val expectedDelay = (24 + 6 * 24) * HOUR_IN_MILLIS // 168 hours
-        val delay = calculator.calculateDelayForOnboardingNotification(OnboardingNotificationType.PlusUpsell, fixedTime)
-        assertEquals(expectedDelay, delay)
+    @Test fun testExact10AM_PlusUpsell() {
+        val t = getFixedTime(2025, Calendar.APRIL, 10, 10, 0)
+        val calc = calculatorAt(t)
+        val expected = (24 + 6 * 24) * HOUR_IN_MILLIS
+        assertEquals(expected, calc.calculateDelayForOnboardingNotification(OnboardingNotificationType.PlusUpsell))
     }
 
-    @Test
-    fun testAfter10AM_Sync() {
-        val fixedTime = getFixedTime(2025, Calendar.APRIL, 10, 11, 0)
-        val expectedDelay = (23 + 0 * 24) * HOUR_IN_MILLIS // 23 hours
-        val delay = calculator.calculateDelayForOnboardingNotification(OnboardingNotificationType.Sync, fixedTime)
-        assertEquals(expectedDelay, delay)
+    @Test fun testAfter10AM_Sync() {
+        val t = getFixedTime(2025, Calendar.APRIL, 10, 11, 0)
+        val calc = calculatorAt(t)
+        val expected = (23 + 0 * 24) * HOUR_IN_MILLIS
+        assertEquals(expected, calc.calculateDelayForOnboardingNotification(OnboardingNotificationType.Sync))
     }
 
-    @Test
-    fun testAfter10AM_Import() {
-        val fixedTime = getFixedTime(2025, Calendar.APRIL, 10, 11, 0)
-        val expectedDelay = (23 + 1 * 24) * HOUR_IN_MILLIS // 47 hours
-        val delay = calculator.calculateDelayForOnboardingNotification(OnboardingNotificationType.Import, fixedTime)
-        assertEquals(expectedDelay, delay)
+    @Test fun testAfter10AM_Import() {
+        val t = getFixedTime(2025, Calendar.APRIL, 10, 11, 0)
+        val calc = calculatorAt(t)
+        val expected = (23 + 1 * 24) * HOUR_IN_MILLIS
+        assertEquals(expected, calc.calculateDelayForOnboardingNotification(OnboardingNotificationType.Import))
     }
 
-    @Test
-    fun testAfter10AM_UpNext() {
-        val fixedTime = getFixedTime(2025, Calendar.APRIL, 10, 11, 0)
-        val expectedDelay = (23 + 2 * 24) * HOUR_IN_MILLIS // 71 hours
-        val delay = calculator.calculateDelayForOnboardingNotification(OnboardingNotificationType.UpNext, fixedTime)
-        assertEquals(expectedDelay, delay)
+    @Test fun testAfter10AM_UpNext() {
+        val t = getFixedTime(2025, Calendar.APRIL, 10, 11, 0)
+        val calc = calculatorAt(t)
+        val expected = (23 + 2 * 24) * HOUR_IN_MILLIS
+        assertEquals(expected, calc.calculateDelayForOnboardingNotification(OnboardingNotificationType.UpNext))
     }
 
-    @Test
-    fun testAfter10AM_Filters() {
-        val fixedTime = getFixedTime(2025, Calendar.APRIL, 10, 11, 0)
-        val expectedDelay = (23 + 3 * 24) * HOUR_IN_MILLIS // 95 hours
-        val delay = calculator.calculateDelayForOnboardingNotification(OnboardingNotificationType.Filters, fixedTime)
-        assertEquals(expectedDelay, delay)
+    @Test fun testAfter10AM_Filters() {
+        val t = getFixedTime(2025, Calendar.APRIL, 10, 11, 0)
+        val calc = calculatorAt(t)
+        val expected = (23 + 3 * 24) * HOUR_IN_MILLIS
+        assertEquals(expected, calc.calculateDelayForOnboardingNotification(OnboardingNotificationType.Filters))
     }
 
-    @Test
-    fun testAfter10AM_Themes() {
-        val fixedTime = getFixedTime(2025, Calendar.APRIL, 10, 11, 0)
-        val expectedDelay = (23 + 4 * 24) * HOUR_IN_MILLIS // 119 hours
-        val delay = calculator.calculateDelayForOnboardingNotification(OnboardingNotificationType.Themes, fixedTime)
-        assertEquals(expectedDelay, delay)
+    @Test fun testAfter10AM_Themes() {
+        val t = getFixedTime(2025, Calendar.APRIL, 10, 11, 0)
+        val calc = calculatorAt(t)
+        val expected = (23 + 4 * 24) * HOUR_IN_MILLIS
+        assertEquals(expected, calc.calculateDelayForOnboardingNotification(OnboardingNotificationType.Themes))
     }
 
-    @Test
-    fun testAfter10AM_StaffPicks() {
-        val fixedTime = getFixedTime(2025, Calendar.APRIL, 10, 11, 0)
-        val expectedDelay = (23 + 5 * 24) * HOUR_IN_MILLIS // 143 hours
-        val delay = calculator.calculateDelayForOnboardingNotification(OnboardingNotificationType.StaffPicks, fixedTime)
-        assertEquals(expectedDelay, delay)
+    @Test fun testAfter10AM_StaffPicks() {
+        val t = getFixedTime(2025, Calendar.APRIL, 10, 11, 0)
+        val calc = calculatorAt(t)
+        val expected = (23 + 5 * 24) * HOUR_IN_MILLIS
+        assertEquals(expected, calc.calculateDelayForOnboardingNotification(OnboardingNotificationType.StaffPicks))
     }
 
-    @Test
-    fun testAfter10AM_PlusUpsell() {
-        val fixedTime = getFixedTime(2025, Calendar.APRIL, 10, 11, 0)
-        val expectedDelay = (23 + 6 * 24) * HOUR_IN_MILLIS // 167 hours
-        val delay = calculator.calculateDelayForOnboardingNotification(OnboardingNotificationType.PlusUpsell, fixedTime)
-        assertEquals(expectedDelay, delay)
+    @Test fun testAfter10AM_PlusUpsell() {
+        val t = getFixedTime(2025, Calendar.APRIL, 10, 11, 0)
+        val calc = calculatorAt(t)
+        val expected = (23 + 6 * 24) * HOUR_IN_MILLIS
+        assertEquals(expected, calc.calculateDelayForOnboardingNotification(OnboardingNotificationType.PlusUpsell))
     }
 
-    @Test
-    fun testReEngagementCheck_Before4PM() {
-        val fixedTime = getFixedTime(2025, Calendar.APRIL, 10, 15, 0)
-        val expectedDelay = 1 * HOUR_IN_MILLIS
-        val delay = calculator.calculateDelayForReEngagementCheck(fixedTime)
-        assertEquals(expectedDelay, delay)
+    @Test fun testReEngagementCheck_Before4PM() {
+        val t = getFixedTime(2025, Calendar.APRIL, 10, 15, 0)
+        val calc = calculatorAt(t)
+        val expected = 1 * HOUR_IN_MILLIS
+        assertEquals(expected, calc.calculateDelayForReEngagementCheck())
     }
 
-    @Test
-    fun testReEngagementCheck_Exactly4PM() {
-        val fixedTime = getFixedTime(2025, Calendar.APRIL, 10, 16, 0)
-        val expectedDelay = 24 * HOUR_IN_MILLIS
-        val delay = calculator.calculateDelayForReEngagementCheck(fixedTime)
-        assertEquals(expectedDelay, delay)
+    @Test fun testReEngagementCheck_Exactly4PM() {
+        val t = getFixedTime(2025, Calendar.APRIL, 10, 16, 0)
+        val calc = calculatorAt(t)
+        val expected = 24 * HOUR_IN_MILLIS
+        assertEquals(expected, calc.calculateDelayForReEngagementCheck())
     }
 
-    @Test
-    fun testReEngagementCheck_After4PM() {
-        val fixedTime = getFixedTime(2025, Calendar.APRIL, 10, 17, 0)
-        val expectedDelay = 23 * HOUR_IN_MILLIS
-        val delay = calculator.calculateDelayForReEngagementCheck(fixedTime)
-        assertEquals(expectedDelay, delay)
-    }
-
-    private fun getFixedTime(
-        year: Int,
-        month: Int,
-        day: Int,
-        hour: Int,
-        minute: Int,
-        second: Int = 0,
-        millisecond: Int = 0,
-    ): Long {
-        return Calendar.getInstance().apply {
-            set(year, month, day, hour, minute, second)
-            set(Calendar.MILLISECOND, millisecond)
-        }.timeInMillis
+    @Test fun testReEngagementCheck_After4PM() {
+        val t = getFixedTime(2025, Calendar.APRIL, 10, 17, 0)
+        val calc = calculatorAt(t)
+        val expected = 23 * HOUR_IN_MILLIS
+        assertEquals(expected, calc.calculateDelayForReEngagementCheck())
     }
 }

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/notification/NotificationManagerTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/notification/NotificationManagerTest.kt
@@ -67,6 +67,18 @@ class NotificationManagerTest {
     }
 
     @Test
+    fun `should update interacted_at when tracking user interaction feature passing id`() = runTest {
+        val id = 99
+
+        notificationManager.updateUserFeatureInteraction(id)
+
+        val idCaptor = argumentCaptor<Int>()
+        val timestampCaptor = argumentCaptor<Long>()
+        verify(userNotificationsDao).updateInteractedAt(idCaptor.capture(), timestampCaptor.capture())
+        assertEquals(id, idCaptor.firstValue)
+    }
+
+    @Test
     fun `should return false when user has not interacted with feature`() = runTest {
         val userNotification = UserNotifications(notificationId = Filters.notificationId, interactedAt = null)
         whenever(userNotificationsDao.getUserNotification(Filters.notificationId)).thenReturn(userNotification)

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/notification/NotificationManagerTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/notification/NotificationManagerTest.kt
@@ -110,7 +110,7 @@ class NotificationManagerTest {
         )
         whenever(userNotificationsDao.getUserNotification(Filters.notificationId)).thenReturn(initialUserNotification)
 
-        notificationManager.updateOnboardingNotificationSent(Filters)
+        notificationManager.updateNotificationSent(Filters)
 
         val userNotificationCaptor = argumentCaptor<UserNotifications>()
         verify(userNotificationsDao).update(userNotificationCaptor.capture())
@@ -122,7 +122,7 @@ class NotificationManagerTest {
 
     @Test
     fun `should not update notification sent when notification is null`() = runTest {
-        notificationManager.updateOnboardingNotificationSent(Filters)
+        notificationManager.updateNotificationSent(Filters)
 
         verify(userNotificationsDao, never()).update(any())
     }
@@ -131,7 +131,7 @@ class NotificationManagerTest {
     fun `should not update notification sent when user notification is null`() = runTest {
         whenever(userNotificationsDao.getUserNotification(4)).thenReturn(null)
 
-        notificationManager.updateOnboardingNotificationSent(Filters)
+        notificationManager.updateNotificationSent(Filters)
 
         verify(userNotificationsDao, never()).update(any())
     }

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/notification/NotificationManagerTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/notification/NotificationManagerTest.kt
@@ -3,6 +3,7 @@ package au.com.shiftyjelly.pocketcasts.repositories.notification
 import au.com.shiftyjelly.pocketcasts.models.db.dao.UserNotificationsDao
 import au.com.shiftyjelly.pocketcasts.models.entity.UserNotifications
 import au.com.shiftyjelly.pocketcasts.repositories.notification.OnboardingNotificationType.Filters
+import java.util.concurrent.TimeUnit
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -99,6 +100,57 @@ class NotificationManagerTest {
         val hasInteracted = notificationManager.hasUserInteractedWithFeature(Filters)
 
         assertTrue(hasInteracted)
+    }
+
+    @Test
+    fun `should return false when user interacted exactly 7 days ago`() = runTest {
+        val now = System.currentTimeMillis()
+        val sevenDaysInMillis = TimeUnit.DAYS.toMillis(7)
+
+        val userNotification = UserNotifications(
+            notificationId = ReEngagementNotificationType.WeMissYou.notificationId,
+            interactedAt = now - sevenDaysInMillis,
+        )
+        whenever(userNotificationsDao.getUserNotification(ReEngagementNotificationType.WeMissYou.notificationId))
+            .thenReturn(userNotification)
+
+        val hasInteracted = notificationManager.hasUserInteractedWithFeature(ReEngagementNotificationType.WeMissYou)
+
+        assertFalse(hasInteracted)
+    }
+
+    @Test
+    fun `should return true when user interacted just less than 7 days ago`() = runTest {
+        val now = System.currentTimeMillis()
+        val sevenDaysInMillis = TimeUnit.DAYS.toMillis(7)
+
+        val userNotification = UserNotifications(
+            notificationId = ReEngagementNotificationType.WeMissYou.notificationId,
+            interactedAt = now - sevenDaysInMillis + 1,
+        )
+        whenever(userNotificationsDao.getUserNotification(ReEngagementNotificationType.WeMissYou.notificationId))
+            .thenReturn(userNotification)
+
+        val hasInteracted = notificationManager.hasUserInteractedWithFeature(ReEngagementNotificationType.WeMissYou)
+
+        assertTrue(hasInteracted)
+    }
+
+    @Test
+    fun `should return false when user interacted more than 7 days ago`() = runTest {
+        val now = System.currentTimeMillis()
+        val sevenDaysInMillis = TimeUnit.DAYS.toMillis(7)
+
+        val userNotification = UserNotifications(
+            notificationId = ReEngagementNotificationType.WeMissYou.notificationId,
+            interactedAt = now - sevenDaysInMillis - 1,
+        )
+        whenever(userNotificationsDao.getUserNotification(ReEngagementNotificationType.WeMissYou.notificationId))
+            .thenReturn(userNotification)
+
+        val hasInteracted = notificationManager.hasUserInteractedWithFeature(ReEngagementNotificationType.WeMissYou)
+
+        assertFalse(hasInteracted)
     }
 
     @Test

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/notification/NotificationManagerTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/notification/NotificationManagerTest.kt
@@ -43,6 +43,20 @@ class NotificationManagerTest {
     }
 
     @Test
+    fun `should setup re-engagement notifications`() = runTest {
+        val insertedIds = ReEngagementNotificationType.values.map { it.notificationId }
+
+        notificationManager.setupReEngagementNotifications()
+
+        val userNotificationsCaptor = argumentCaptor<List<UserNotifications>>()
+        verify(userNotificationsDao).insert(userNotificationsCaptor.capture())
+        val capturedUserNotifications = userNotificationsCaptor.firstValue
+
+        val expectedUserNotifications = insertedIds.map { UserNotifications(notificationId = it.toInt()) }
+        assertEquals(expectedUserNotifications, capturedUserNotifications)
+    }
+
+    @Test
     fun `should update interacted_at when tracking user interaction feature`() = runTest {
         notificationManager.updateUserFeatureInteraction(Filters)
 

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/notification/NotificationManagerTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/notification/NotificationManagerTest.kt
@@ -3,13 +3,14 @@ package au.com.shiftyjelly.pocketcasts.repositories.notification
 import au.com.shiftyjelly.pocketcasts.models.db.dao.UserNotificationsDao
 import au.com.shiftyjelly.pocketcasts.models.entity.UserNotifications
 import au.com.shiftyjelly.pocketcasts.repositories.notification.OnboardingNotificationType.Filters
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneOffset
 import java.util.concurrent.TimeUnit
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
-import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertTrue
-import org.junit.Before
 import org.junit.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.argumentCaptor
@@ -20,171 +21,161 @@ import org.mockito.kotlin.whenever
 
 class NotificationManagerTest {
 
-    private lateinit var userNotificationsDao: UserNotificationsDao
-    private lateinit var notificationManager: NotificationManagerImpl
-
-    @Before
-    fun setUp() {
-        userNotificationsDao = mock()
-        notificationManager = NotificationManagerImpl(userNotificationsDao)
+    companion object {
+        private fun fixedManager(
+            dao: UserNotificationsDao,
+            fixedTime: Long,
+        ): NotificationManagerImpl {
+            val clock = Clock.fixed(Instant.ofEpochMilli(fixedTime), ZoneOffset.UTC)
+            return NotificationManagerImpl(dao, clock)
+        }
     }
 
-    @Test
-    fun `should setup onboarding notifications`() = runTest {
+    @Test fun `should setup onboarding notifications`() = runTest {
+        val dao = mock<UserNotificationsDao>()
+        val now = Instant.parse("2025-04-17T00:00:00Z").toEpochMilli()
+        val manager = fixedManager(dao, now)
+
         val insertedIds = OnboardingNotificationType.values.map { it.notificationId }
+        manager.setupOnboardingNotifications()
 
-        notificationManager.setupOnboardingNotifications()
-
-        val userNotificationsCaptor = argumentCaptor<List<UserNotifications>>()
-        verify(userNotificationsDao).insert(userNotificationsCaptor.capture())
-        val capturedUserNotifications = userNotificationsCaptor.firstValue
-
-        val expectedUserNotifications = insertedIds.map { UserNotifications(notificationId = it.toInt()) }
-        assertEquals(expectedUserNotifications, capturedUserNotifications)
+        val captor = argumentCaptor<List<UserNotifications>>()
+        verify(dao).insert(captor.capture())
+        val actual = captor.firstValue
+        val expected = insertedIds.map { UserNotifications(notificationId = it.toInt()) }
+        assertEquals(expected, actual)
     }
 
-    @Test
-    fun `should setup re-engagement notifications`() = runTest {
+    @Test fun `should setup re-engagement notifications`() = runTest {
+        val dao = mock<UserNotificationsDao>()
+        val now = Instant.parse("2025-04-17T00:00:00Z").toEpochMilli()
+        val manager = fixedManager(dao, now)
+
         val insertedIds = ReEngagementNotificationType.values.map { it.notificationId }
+        manager.setupReEngagementNotifications()
 
-        notificationManager.setupReEngagementNotifications()
-
-        val userNotificationsCaptor = argumentCaptor<List<UserNotifications>>()
-        verify(userNotificationsDao).insert(userNotificationsCaptor.capture())
-        val capturedUserNotifications = userNotificationsCaptor.firstValue
-
-        val expectedUserNotifications = insertedIds.map { UserNotifications(notificationId = it.toInt()) }
-        assertEquals(expectedUserNotifications, capturedUserNotifications)
+        val captor = argumentCaptor<List<UserNotifications>>()
+        verify(dao).insert(captor.capture())
+        val actual = captor.firstValue
+        val expected = insertedIds.map { UserNotifications(notificationId = it.toInt()) }
+        assertEquals(expected, actual)
     }
 
-    @Test
-    fun `should update interacted_at when tracking user interaction feature`() = runTest {
-        notificationManager.updateUserFeatureInteraction(Filters)
+    @Test fun `should update interacted_at when tracking user interaction feature`() = runTest {
+        val dao = mock<UserNotificationsDao>()
+        val now = 1_625_000_000_000L
+        val manager = fixedManager(dao, now)
 
-        val idCaptor = argumentCaptor<Int>()
-        val timestampCaptor = argumentCaptor<Long>()
-        verify(userNotificationsDao).updateInteractedAt(idCaptor.capture(), timestampCaptor.capture())
-        assertNotEquals(0, idCaptor.firstValue)
+        manager.updateUserFeatureInteraction(Filters)
+
+        val idCap = argumentCaptor<Int>()
+        val timeCap = argumentCaptor<Long>()
+        verify(dao).updateInteractedAt(idCap.capture(), timeCap.capture())
+        assertEquals(Filters.notificationId, idCap.firstValue)
+        assertEquals(now, timeCap.firstValue)
     }
 
-    @Test
-    fun `should update interacted_at when tracking user interaction feature passing id`() = runTest {
+    @Test fun `should update interacted_at when tracking user interaction feature passing id`() = runTest {
+        val dao = mock<UserNotificationsDao>()
+        val now = 1_625_000_000_000L
+        val manager = fixedManager(dao, now)
         val id = 99
 
-        notificationManager.updateUserFeatureInteraction(id)
+        manager.updateUserFeatureInteraction(id)
 
-        val idCaptor = argumentCaptor<Int>()
-        val timestampCaptor = argumentCaptor<Long>()
-        verify(userNotificationsDao).updateInteractedAt(idCaptor.capture(), timestampCaptor.capture())
-        assertEquals(id, idCaptor.firstValue)
+        val idCap = argumentCaptor<Int>()
+        val timeCap = argumentCaptor<Long>()
+        verify(dao).updateInteractedAt(idCap.capture(), timeCap.capture())
+        assertEquals(id, idCap.firstValue)
+        assertEquals(now, timeCap.firstValue)
     }
 
-    @Test
-    fun `should return false when user has not interacted with feature`() = runTest {
-        val userNotification = UserNotifications(notificationId = Filters.notificationId, interactedAt = null)
-        whenever(userNotificationsDao.getUserNotification(Filters.notificationId)).thenReturn(userNotification)
+    @Test fun `should return false when user has not interacted with feature`() = runTest {
+        val dao = mock<UserNotificationsDao>()
+        val now = 1_625_000_000_000L
+        val manager = fixedManager(dao, now)
+        whenever(dao.getUserNotification(Filters.notificationId))
+            .thenReturn(UserNotifications(Filters.notificationId, interactedAt = null))
 
-        val hasInteracted = notificationManager.hasUserInteractedWithFeature(Filters)
-
-        assertFalse(hasInteracted)
+        assertFalse(manager.hasUserInteractedWithFeature(Filters))
     }
 
-    @Test
-    fun `should return true when user has interacted with feature`() = runTest {
-        val userNotification = UserNotifications(
-            notificationId = Filters.notificationId,
-            interactedAt = System.currentTimeMillis(),
-        )
-        whenever(userNotificationsDao.getUserNotification(Filters.notificationId)).thenReturn(userNotification)
+    @Test fun `should return true when user has interacted with feature`() = runTest {
+        val dao = mock<UserNotificationsDao>()
+        val now = 1_625_000_000_000L
+        val manager = fixedManager(dao, now)
+        whenever(dao.getUserNotification(Filters.notificationId))
+            .thenReturn(UserNotifications(Filters.notificationId, interactedAt = now))
 
-        val hasInteracted = notificationManager.hasUserInteractedWithFeature(Filters)
-
-        assertTrue(hasInteracted)
+        assertTrue(manager.hasUserInteractedWithFeature(Filters))
     }
 
-    @Test
-    fun `should return false when user interacted exactly 7 days ago`() = runTest {
-        val now = System.currentTimeMillis()
-        val sevenDaysInMillis = TimeUnit.DAYS.toMillis(7)
+    @Test fun `should return false when user interacted exactly 7 days ago`() = runTest {
+        val dao = mock<UserNotificationsDao>()
+        val now = 1_625_000_000_000L
+        val sevenDays = TimeUnit.DAYS.toMillis(7)
+        val manager = fixedManager(dao, now)
+        whenever(dao.getUserNotification(ReEngagementNotificationType.WeMissYou.notificationId))
+            .thenReturn(UserNotifications(ReEngagementNotificationType.WeMissYou.notificationId, interactedAt = now - sevenDays))
 
-        val userNotification = UserNotifications(
-            notificationId = ReEngagementNotificationType.WeMissYou.notificationId,
-            interactedAt = now - sevenDaysInMillis,
-        )
-        whenever(userNotificationsDao.getUserNotification(ReEngagementNotificationType.WeMissYou.notificationId))
-            .thenReturn(userNotification)
-
-        val hasInteracted = notificationManager.hasUserInteractedWithFeature(ReEngagementNotificationType.WeMissYou)
-
-        assertFalse(hasInteracted)
+        assertFalse(manager.hasUserInteractedWithFeature(ReEngagementNotificationType.WeMissYou))
     }
 
-    @Test
-    fun `should return true when user interacted just less than 7 days ago`() = runTest {
-        val now = System.currentTimeMillis()
-        val sevenDaysInMillis = TimeUnit.DAYS.toMillis(7)
+    @Test fun `should return true when user interacted just less than 7 days ago`() = runTest {
+        val dao = mock<UserNotificationsDao>()
+        val now = 1_625_000_000_000L
+        val sevenDays = TimeUnit.DAYS.toMillis(7)
+        val manager = fixedManager(dao, now)
+        whenever(dao.getUserNotification(ReEngagementNotificationType.WeMissYou.notificationId))
+            .thenReturn(UserNotifications(ReEngagementNotificationType.WeMissYou.notificationId, interactedAt = now - sevenDays + 1))
 
-        val userNotification = UserNotifications(
-            notificationId = ReEngagementNotificationType.WeMissYou.notificationId,
-            interactedAt = now - sevenDaysInMillis + 1,
-        )
-        whenever(userNotificationsDao.getUserNotification(ReEngagementNotificationType.WeMissYou.notificationId))
-            .thenReturn(userNotification)
-
-        val hasInteracted = notificationManager.hasUserInteractedWithFeature(ReEngagementNotificationType.WeMissYou)
-
-        assertTrue(hasInteracted)
+        assertTrue(manager.hasUserInteractedWithFeature(ReEngagementNotificationType.WeMissYou))
     }
 
-    @Test
-    fun `should return false when user interacted more than 7 days ago`() = runTest {
-        val now = System.currentTimeMillis()
-        val sevenDaysInMillis = TimeUnit.DAYS.toMillis(7)
+    @Test fun `should return false when user interacted more than 7 days ago`() = runTest {
+        val dao = mock<UserNotificationsDao>()
+        val now = 1_625_000_000_000L
+        val sevenDays = TimeUnit.DAYS.toMillis(7)
+        val manager = fixedManager(dao, now)
+        whenever(dao.getUserNotification(ReEngagementNotificationType.WeMissYou.notificationId))
+            .thenReturn(UserNotifications(ReEngagementNotificationType.WeMissYou.notificationId, interactedAt = now - sevenDays - 1))
 
-        val userNotification = UserNotifications(
-            notificationId = ReEngagementNotificationType.WeMissYou.notificationId,
-            interactedAt = now - sevenDaysInMillis - 1,
-        )
-        whenever(userNotificationsDao.getUserNotification(ReEngagementNotificationType.WeMissYou.notificationId))
-            .thenReturn(userNotification)
-
-        val hasInteracted = notificationManager.hasUserInteractedWithFeature(ReEngagementNotificationType.WeMissYou)
-
-        assertFalse(hasInteracted)
+        assertFalse(manager.hasUserInteractedWithFeature(ReEngagementNotificationType.WeMissYou))
     }
 
-    @Test
-    fun `should update sentThisWeek and lastSentAt when tracking notification sent`() = runTest {
-        val initialUserNotification = UserNotifications(
-            notificationId = Filters.notificationId,
-            sentThisWeek = 0,
-            lastSentAt = 0,
-        )
-        whenever(userNotificationsDao.getUserNotification(Filters.notificationId)).thenReturn(initialUserNotification)
+    @Test fun `should update sentThisWeek and lastSentAt when tracking notification sent`() = runTest {
+        val dao = mock<UserNotificationsDao>()
+        val now = 1_625_000_000_000L
+        val manager = fixedManager(dao, now)
 
-        notificationManager.updateNotificationSent(Filters)
+        whenever(dao.getUserNotification(Filters.notificationId))
+            .thenReturn(UserNotifications(Filters.notificationId, sentThisWeek = 0, lastSentAt = 0))
 
-        val userNotificationCaptor = argumentCaptor<UserNotifications>()
-        verify(userNotificationsDao).update(userNotificationCaptor.capture())
-        val updatedUserNotification = userNotificationCaptor.firstValue
+        manager.updateNotificationSent(Filters)
 
-        assertEquals(1, updatedUserNotification.sentThisWeek)
-        assertTrue(updatedUserNotification.lastSentAt > 0)
+        val captor = argumentCaptor<UserNotifications>()
+        verify(dao).update(captor.capture())
+        val updated = captor.firstValue
+        assertEquals(1, updated.sentThisWeek)
+        assertEquals(now, updated.lastSentAt)
     }
 
-    @Test
-    fun `should not update notification sent when notification is null`() = runTest {
-        notificationManager.updateNotificationSent(Filters)
+    @Test fun `should not update notification sent when notification is null`() = runTest {
+        val dao = mock<UserNotificationsDao>()
+        val now = 1_625_000_000_000L
+        val manager = fixedManager(dao, now)
 
-        verify(userNotificationsDao, never()).update(any())
+        manager.updateNotificationSent(Filters)
+        verify(dao, never()).update(any())
     }
 
-    @Test
-    fun `should not update notification sent when user notification is null`() = runTest {
-        whenever(userNotificationsDao.getUserNotification(4)).thenReturn(null)
+    @Test fun `should not update notification sent when user notification is null`() = runTest {
+        val dao = mock<UserNotificationsDao>()
+        val now = 1_625_000_000_000L
+        val manager = fixedManager(dao, now)
 
-        notificationManager.updateNotificationSent(Filters)
-
-        verify(userNotificationsDao, never()).update(any())
+        whenever(dao.getUserNotification(4)).thenReturn(null)
+        manager.updateNotificationSent(Filters)
+        verify(dao, never()).update(any())
     }
 }


### PR DESCRIPTION
## Description
- This PR adds the new Re-engagement notifications group that will display notifications if the user does not open the app for more than 7 days and we will keep notifying them every week.
- To archive this, I schedule the notification worker to daily check this and send a notification
- Rules: hVHQ8RgGQf1afBWybZExD2-fi-35_552
  - For this PR, we have two types of re-engagement notifications: `WeMissYou` and `CatchUpOffline`
  - If the user downloaded episodes and did not play them, we will display the `CatchUpOffline` otherwise we will display the `WeMissYou` 

> [!NOTE]  
> WorkManager’s periodic work is inexact due to battery optimizations. The actual execution may be delayed (in my tests I observed up to ~2 minutes of drift).

## Testing Instructions

### Re-engagement notifications

#### Setup
- Apply this [re-engagement.patch](https://github.com/user-attachments/files/19783874/re-engagement.patch) so instead of wait for 7 days, you can wait for 60 seconds (or whatever the time you set)
- The rule is to run the WorkManager at 4pm, so you will have to modify the code bellow to run according to your expected time. 

https://github.com/Automattic/pocket-casts-android/blob/64d2e39f5b6e37f6ef50a4fbd02857029428c73b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/notification/NotificationDelayCalculator.kt#L52-L53

#### We miss you
1. Install the app
2. Grant notification permission
3. Close the app
4. Wait for the time you have set for the notification worker be triggered (this might have some delay)
5. Ensure you receive the we miss you notification ✅

#### Catch Up Offline
1. Install the app
2. Grant notification permission
3. Download an episode (do not play this episode)
4. Close the app
5. Wait for the time you have set for the notification worker be triggered (this might have some delay)
6. Ensure you receive the offline notification ✅

#### We miss you after playing the downloaded the episode
1. Repeat the tests from the test above, but play the downloaded episode
2. Ensure you receive the we miss you notification ✅

#### Not receive notification

1. Install the app
2. Grant notification permission
3. Close the app right before the time you have set.
For example, you can set for this something like 2 minutes

https://github.com/Automattic/pocket-casts-android/blob/64d2e39f5b6e37f6ef50a4fbd02857029428c73b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/notification/NotificationManagerImpl.kt#L36

4. and the close the app when it has 1 minute left before the time you have configured for the notification worker
5. Ensure you don't receive any notification ✅


### Regression test for onboarding notifications
Apply this [onboarding.patch](https://github.com/user-attachments/files/19784040/onboarding.patch)

1. Install the app
2. Grant notification permission
3. Wait for a notification every 10 seconds

## Screenshots or Screencast 

| Offline | We miss you |
|--------|--------|
| ![Screenshot_20250416_162850](https://github.com/user-attachments/assets/9b8426e2-d0e8-4985-af81-eebcb3b51ecb) | ![Screenshot_20250416_163517](https://github.com/user-attachments/assets/b2a8be42-2fdd-46a1-be38-4eb235b1bc00) | 


## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.