### PR TITLE
Refactors Discover feed loading to use coroutines

### DIFF
--- a/automotive/src/main/java/au/com/shiftyjelly/pocketcasts/AutoPlaybackService.kt
+++ b/automotive/src/main/java/au/com/shiftyjelly/pocketcasts/AutoPlaybackService.kt
@@ -165,7 +165,7 @@ class AutoPlaybackService : PlaybackService() {
         Log.d(Settings.LOG_TAG_AUTO, "Loading discover root")
         val discoverFeed: Discover
         try {
-            discoverFeed = listSource.getDiscoverFeedSuspend()
+            discoverFeed = listSource.getDiscoverFeed()
         } catch (e: Exception) {
             Log.e(Settings.LOG_TAG_AUTO, "Error loading discover", e)
             return emptyList()
@@ -181,7 +181,7 @@ class AutoPlaybackService : PlaybackService() {
             .filter { it.type is ListType.PodcastList && it.displayStyle !is DisplayStyle.CollectionList && !it.sponsored && it.displayStyle !is DisplayStyle.SinglePodcast }
             .map { discoverItem ->
                 Log.d(Settings.LOG_TAG_AUTO, "Loading discover feed ${discoverItem.source}")
-                val listFeed = listSource.getListFeedSuspend(discoverItem.source)
+                val listFeed = listSource.getListFeed(discoverItem.source)
                 Pair(discoverItem.title, listFeed.podcasts?.take(6) ?: emptyList())
             }
             .flatMap { (title, podcasts) ->

--- a/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/viewmodel/PodcastListViewModel.kt
+++ b/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/viewmodel/PodcastListViewModel.kt
@@ -25,6 +25,7 @@ import io.reactivex.rxkotlin.subscribeBy
 import io.reactivex.schedulers.Schedulers
 import javax.inject.Inject
 import kotlinx.coroutines.rx2.rxMaybe
+import kotlinx.coroutines.rx2.rxSingle
 import timber.log.Timber
 
 @HiltViewModel
@@ -54,7 +55,9 @@ class PodcastListViewModel @Inject constructor(
             return
         }
 
-        listRepository.getListFeed(sourceUrl)
+        rxSingle { listRepository.getListFeed(sourceUrl) }
+            .subscribeOn(Schedulers.io())
+            .observeOn(AndroidSchedulers.mainThread())
             .flatMap {
                 return@flatMap if (listStyle is ExpandedStyle.RankedList) {
                     addColorsToFeed(it)

--- a/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/worker/CuratedPodcastsCrawler.kt
+++ b/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/worker/CuratedPodcastsCrawler.kt
@@ -23,7 +23,7 @@ class CuratedPodcastsCrawler(
     ) : this(service, BuildConfig.SERVER_STATIC_URL)
 
     suspend fun crawl(platform: String): Result<List<CuratedPodcast>> = coroutineScope {
-        runCatching { service.getDiscoverFeedSuspend(platform) }.mapCatching { discover ->
+        runCatching { service.getDiscoverFeed(platform) }.mapCatching { discover ->
             val feeds = discover.layout
                 .filterDisplayablePodcasts()
                 .mapNotNull { row -> row.id?.let { id -> fetchFeed(id, row.source) } }
@@ -68,6 +68,6 @@ class CuratedPodcastsCrawler(
         } else {
             url
         }
-        return async { runCatching { service.getListFeedSuspend(engageUrl) } }
+        return async { runCatching { service.getListFeed(engageUrl) } }
     }
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/categories/CategoriesManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/categories/CategoriesManager.kt
@@ -18,7 +18,6 @@ import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.rx2.await
 import timber.log.Timber
 
 @Singleton
@@ -66,7 +65,7 @@ class CategoriesManager @Inject constructor(
         if (discoverCategories.value.isEmpty() || areCategoriesStale()) {
             scope.launch {
                 try {
-                    discoverCategories.value = listRepository.getCategoriesList(url).await()
+                    discoverCategories.value = listRepository.getCategoriesList(url)
                     lastUpdate = TimeSource.Monotonic.markNow()
                 } catch (e: Throwable) {
                     Timber.e(e, "Failed to fetch categories under $url")

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/server/ListRepository.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/server/ListRepository.kt
@@ -3,35 +3,18 @@ package au.com.shiftyjelly.pocketcasts.servers.server
 import au.com.shiftyjelly.pocketcasts.servers.model.Discover
 import au.com.shiftyjelly.pocketcasts.servers.model.DiscoverCategory
 import au.com.shiftyjelly.pocketcasts.servers.model.ListFeed
-import io.reactivex.Single
-import io.reactivex.android.schedulers.AndroidSchedulers
-import io.reactivex.schedulers.Schedulers
 
 class ListRepository(private val listWebService: ListWebService, private val platform: String) {
 
-    fun getDiscoverFeed(): Single<Discover> {
+    suspend fun getDiscoverFeed(): Discover {
         return listWebService.getDiscoverFeed(platform)
-            .subscribeOn(Schedulers.io())
-            .observeOn(AndroidSchedulers.mainThread())
     }
 
-    suspend fun getDiscoverFeedSuspend(): Discover {
-        return listWebService.getDiscoverFeedSuspend(platform)
-    }
-
-    fun getListFeed(url: String): Single<ListFeed> {
+    suspend fun getListFeed(url: String): ListFeed {
         return listWebService.getListFeed(url)
-            .subscribeOn(Schedulers.io())
-            .observeOn(AndroidSchedulers.mainThread())
     }
 
-    suspend fun getListFeedSuspend(url: String): ListFeed {
-        return listWebService.getListFeedSuspend(url)
-    }
-
-    fun getCategoriesList(url: String): Single<List<DiscoverCategory>> {
+    suspend fun getCategoriesList(url: String): List<DiscoverCategory> {
         return listWebService.getCategoriesList(url)
-            .subscribeOn(Schedulers.io())
-            .observeOn(AndroidSchedulers.mainThread())
     }
 }

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/server/ListWebService.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/server/ListWebService.kt
@@ -3,24 +3,17 @@ package au.com.shiftyjelly.pocketcasts.servers.server
 import au.com.shiftyjelly.pocketcasts.servers.model.Discover
 import au.com.shiftyjelly.pocketcasts.servers.model.DiscoverCategory
 import au.com.shiftyjelly.pocketcasts.servers.model.ListFeed
-import io.reactivex.Single
 import retrofit2.http.GET
 import retrofit2.http.Path
 import retrofit2.http.Url
 
 interface ListWebService {
     @GET("/discover/{platform}/content_v2.json")
-    fun getDiscoverFeed(@Path("platform") platform: String): Single<Discover>
-
-    @GET("/discover/{platform}/content_v2.json")
-    suspend fun getDiscoverFeedSuspend(@Path("platform") platform: String): Discover
+    suspend fun getDiscoverFeed(@Path("platform") platform: String): Discover
 
     @GET
-    fun getListFeed(@Url url: String): Single<ListFeed>
+    suspend fun getListFeed(@Url url: String): ListFeed
 
     @GET
-    suspend fun getListFeedSuspend(@Url url: String): ListFeed
-
-    @GET
-    fun getCategoriesList(@Url url: String): Single<List<DiscoverCategory>>
+    suspend fun getCategoriesList(@Url url: String): List<DiscoverCategory>
 }


### PR DESCRIPTION
## Description

Before raising the recommendations change, I have done a small cleanup so I'm not changing multiple methods, for example, an Rx and Coroutine version. 

## Testing Instructions

1. Clean install the app
2. Open the Discover section
3. ✅ Verify the lists load
4. Tap one of the category pills
5. ✅ Verify the page loads
6. Subscribe to podcast
7. Open the podcast page
8. Tap on the Bookmarks tab
9. Tap the Get Bookmarks buton
10. Tap the Upgrade to Plus button
11. Sign up with a new account
12. ✅ Verify the onboarding recommendation lists load
13. Install the Automotive app
14. ✅ Verify the Discover section loads.

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.

