### PR TITLE
Add weekly price to yearly offers during winback flow

### DIFF
--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/winback/AvailablePlansPage.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/winback/AvailablePlansPage.kt
@@ -12,8 +12,10 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -49,6 +51,7 @@ import au.com.shiftyjelly.pocketcasts.compose.bars.BottomSheetAppBar
 import au.com.shiftyjelly.pocketcasts.compose.components.ProgressDialog
 import au.com.shiftyjelly.pocketcasts.compose.components.TextH30
 import au.com.shiftyjelly.pocketcasts.compose.components.TextH40
+import au.com.shiftyjelly.pocketcasts.compose.components.TextH50
 import au.com.shiftyjelly.pocketcasts.compose.components.TextP40
 import au.com.shiftyjelly.pocketcasts.compose.components.TextP50
 import au.com.shiftyjelly.pocketcasts.compose.components.rememberViewInteropNestedScrollConnection
@@ -56,6 +59,7 @@ import au.com.shiftyjelly.pocketcasts.compose.pocketRed
 import au.com.shiftyjelly.pocketcasts.compose.preview.ThemePreviewParameterProvider
 import au.com.shiftyjelly.pocketcasts.compose.theme
 import au.com.shiftyjelly.pocketcasts.models.type.BillingPeriod
+import au.com.shiftyjelly.pocketcasts.models.type.Subscription
 import au.com.shiftyjelly.pocketcasts.profile.winback.FailureReason.Default
 import au.com.shiftyjelly.pocketcasts.profile.winback.FailureReason.NoOrderId
 import au.com.shiftyjelly.pocketcasts.profile.winback.FailureReason.NoProducts
@@ -301,47 +305,86 @@ private fun SubscriptionRow(
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    Row(
-        modifier = modifier
-            .fillMaxWidth()
-            .clip(RoundedCornerShape(8.dp))
-            .background(MaterialTheme.theme.colors.primaryUi01Active)
-            .then(
-                if (isSelected) {
-                    Modifier.border(
-                        width = 2.dp,
-                        color = MaterialTheme.theme.colors.primaryField03Active,
-                        shape = RoundedCornerShape(8.dp),
-                    )
-                } else {
-                    Modifier
-                },
-            )
-            .clickable(
-                enabled = !isSelected,
-                onClick = onClick,
-                role = Role.Button,
-                indication = ripple(color = MaterialTheme.theme.colors.primaryIcon01),
-                interactionSource = null,
-            )
-            .padding(start = 20.dp, end = 10.dp, top = 10.dp, bottom = 10.dp),
+    Box(
+        modifier = modifier.fillMaxWidth(),
     ) {
-        Column(
-            modifier = Modifier.weight(1f),
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .clip(RoundedCornerShape(8.dp))
+                .background(MaterialTheme.theme.colors.primaryUi01Active)
+                .then(
+                    if (isSelected) {
+                        Modifier.border(
+                            width = 2.dp,
+                            color = MaterialTheme.theme.colors.primaryField03Active,
+                            shape = RoundedCornerShape(8.dp),
+                        )
+                    } else {
+                        Modifier
+                    },
+                )
+                .clickable(
+                    enabled = !isSelected,
+                    onClick = onClick,
+                    role = Role.Button,
+                    indication = ripple(color = MaterialTheme.theme.colors.primaryIcon01),
+                    interactionSource = null,
+                )
+                .padding(start = 20.dp, end = 10.dp, top = 10.dp, bottom = 10.dp),
         ) {
-            TextH30(
-                text = plan.title,
+            CheckMark(
+                isSelected = isSelected,
+                modifier = Modifier
+                    .align(Alignment.CenterVertically)
+                    .size(22.dp),
             )
-            TextP40(
-                text = plan.price(),
-                fontSize = 15.sp,
-                lineHeight = 21.sp,
+            Spacer(
+                modifier = Modifier.width(16.dp),
             )
+            Column(
+                modifier = Modifier.weight(1f),
+            ) {
+                TextH30(
+                    text = plan.title,
+                )
+                TextP40(
+                    text = plan.price(),
+                    color = MaterialTheme.theme.colors.primaryText02,
+                    fontSize = 15.sp,
+                    lineHeight = 21.sp,
+                )
+            }
+            if (plan.billingPeriod == BillingPeriod.Yearly) {
+                TextP40(
+                    text = if (plan.currencyCode == "USD") {
+                        stringResource(LR.string.price_per_week_usd, plan.pricePerWeek)
+                    } else {
+                        stringResource(LR.string.price_per_week, plan.pricePerWeek, plan.currencyCode)
+                    },
+                    color = MaterialTheme.theme.colors.primaryText02,
+                    fontSize = 15.sp,
+                    lineHeight = 21.sp,
+                    modifier = Modifier.align(Alignment.CenterVertically),
+                )
+            }
         }
-        CheckMark(
-            isSelected = isSelected,
-            modifier = Modifier.size(22.dp),
-        )
+
+        if (plan.productId == Subscription.PLUS_YEARLY_PRODUCT_ID) {
+            Box(
+                modifier = Modifier
+                    .align(Alignment.TopEnd)
+                    .offset(x = -10.dp, y = -10.dp)
+                    .background(MaterialTheme.theme.colors.primaryField03Active, CircleShape)
+                    .padding(horizontal = 12.dp, vertical = 2.dp),
+            ) {
+                TextH50(
+                    text = "Best Value",
+                    color = MaterialTheme.theme.colors.primaryUi01,
+                    disableAutoScale = true,
+                )
+            }
+        }
     }
 }
 
@@ -415,44 +458,44 @@ private fun AvailablePlansPagePreview(
             plansState = SubscriptionPlansState.Loaded(
                 activePurchase = ActivePurchase(
                     orderId = "orderId",
-                    productId = "plus.monthly",
+                    productId = Subscription.PLUS_MONTHLY_PRODUCT_ID,
                 ),
                 plans = listOf(
                     SubscriptionPlan(
-                        productId = "plus.monthly",
+                        productId = Subscription.PLUS_MONTHLY_PRODUCT_ID,
                         offerToken = "",
                         title = "Plus Monthly",
                         formattedPrice = "$3.99",
                         billingPeriod = BillingPeriod.Monthly,
-                        basePrice = 100.toBigDecimal(),
+                        basePrice = 3.99.toBigDecimal(),
                         currencyCode = "USD",
                     ),
                     SubscriptionPlan(
-                        productId = "patron.monthly",
+                        productId = Subscription.PATRON_MONTHLY_PRODUCT_ID,
                         offerToken = "",
                         title = "Patron Monthly",
                         formattedPrice = "$9.99",
                         billingPeriod = BillingPeriod.Monthly,
-                        basePrice = 200.toBigDecimal(),
+                        basePrice = 9.99.toBigDecimal(),
                         currencyCode = "USD",
                     ),
                     SubscriptionPlan(
-                        productId = "plus.yearly",
+                        productId = Subscription.PLUS_YEARLY_PRODUCT_ID,
                         offerToken = "",
                         title = "Plus Yearly",
                         formattedPrice = "$39.99",
                         billingPeriod = BillingPeriod.Yearly,
-                        basePrice = 300.toBigDecimal(),
+                        basePrice = 39.99.toBigDecimal(),
                         currencyCode = "USD",
                     ),
                     SubscriptionPlan(
-                        productId = "patron.yearly",
+                        productId = Subscription.PATRON_YEARLY_PRODUCT_ID,
                         offerToken = "",
-                        title = "Plus Yearly",
+                        title = "Patron Yearly",
                         formattedPrice = "$99.99",
                         billingPeriod = BillingPeriod.Yearly,
-                        basePrice = 400.toBigDecimal(),
-                        currencyCode = "USD",
+                        basePrice = 99.99.toBigDecimal(),
+                        currencyCode = "PLN",
                     ),
                 ),
             ),

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/winback/AvailablePlansPage.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/winback/AvailablePlansPage.kt
@@ -424,6 +424,8 @@ private fun AvailablePlansPagePreview(
                         title = "Plus Monthly",
                         formattedPrice = "$3.99",
                         billingPeriod = BillingPeriod.Monthly,
+                        basePrice = 100.toBigDecimal(),
+                        currencyCode = "USD",
                     ),
                     SubscriptionPlan(
                         productId = "patron.monthly",
@@ -431,6 +433,8 @@ private fun AvailablePlansPagePreview(
                         title = "Patron Monthly",
                         formattedPrice = "$9.99",
                         billingPeriod = BillingPeriod.Monthly,
+                        basePrice = 200.toBigDecimal(),
+                        currencyCode = "USD",
                     ),
                     SubscriptionPlan(
                         productId = "plus.yearly",
@@ -438,6 +442,8 @@ private fun AvailablePlansPagePreview(
                         title = "Plus Yearly",
                         formattedPrice = "$39.99",
                         billingPeriod = BillingPeriod.Yearly,
+                        basePrice = 300.toBigDecimal(),
+                        currencyCode = "USD",
                     ),
                     SubscriptionPlan(
                         productId = "patron.yearly",
@@ -445,6 +451,8 @@ private fun AvailablePlansPagePreview(
                         title = "Plus Yearly",
                         formattedPrice = "$99.99",
                         billingPeriod = BillingPeriod.Yearly,
+                        basePrice = 400.toBigDecimal(),
+                        currencyCode = "USD",
                     ),
                 ),
             ),

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/winback/WinbackViewModel.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/winback/WinbackViewModel.kt
@@ -516,11 +516,10 @@ internal data class SubscriptionPlan(
 ) {
     val pricePerWeek = basePrice
         .let { price ->
-            val weeksCount = when (billingPeriod) {
-                BillingPeriod.Monthly -> 4
-                BillingPeriod.Yearly -> 52
-            }.toBigDecimal()
-            price.divide(weeksCount, 2, RoundingMode.HALF_UP)
+            when (billingPeriod) {
+                BillingPeriod.Monthly -> price.times(12.toBigDecimal())
+                BillingPeriod.Yearly -> price
+            }.divide(52.toBigDecimal(), 2, RoundingMode.HALF_UP)
         }
         .toFloat()
 }
@@ -529,17 +528,19 @@ internal data class ActivePurchase(
     val orderId: String,
     val productId: String,
 ) {
-    val tier get() = when (productId) {
-        Subscription.PLUS_MONTHLY_PRODUCT_ID, Subscription.PLUS_YEARLY_PRODUCT_ID -> "plus"
-        Subscription.PATRON_MONTHLY_PRODUCT_ID, Subscription.PATRON_YEARLY_PRODUCT_ID -> "patron"
-        else -> null
-    }
+    val tier
+        get() = when (productId) {
+            Subscription.PLUS_MONTHLY_PRODUCT_ID, Subscription.PLUS_YEARLY_PRODUCT_ID -> "plus"
+            Subscription.PATRON_MONTHLY_PRODUCT_ID, Subscription.PATRON_YEARLY_PRODUCT_ID -> "patron"
+            else -> null
+        }
 
-    val frequency get() = when (productId) {
-        Subscription.PLUS_MONTHLY_PRODUCT_ID, Subscription.PATRON_MONTHLY_PRODUCT_ID -> "monthly"
-        Subscription.PLUS_YEARLY_PRODUCT_ID, Subscription.PATRON_YEARLY_PRODUCT_ID -> "yearly"
-        else -> null
-    }
+    val frequency
+        get() = when (productId) {
+            Subscription.PLUS_MONTHLY_PRODUCT_ID, Subscription.PATRON_MONTHLY_PRODUCT_ID -> "monthly"
+            Subscription.PLUS_YEARLY_PRODUCT_ID, Subscription.PATRON_YEARLY_PRODUCT_ID -> "yearly"
+            else -> null
+        }
 }
 
 internal enum class FailureReason {

--- a/modules/features/profile/src/test/kotlin/au/com/shiftyjelly/pocketcasts/profile/winback/WinbackViewModelTest.kt
+++ b/modules/features/profile/src/test/kotlin/au/com/shiftyjelly/pocketcasts/profile/winback/WinbackViewModelTest.kt
@@ -59,6 +59,8 @@ class WinbackViewModelTest {
         title = "title",
         formattedPrice = "price",
         billingPeriod = BillingPeriod.Yearly,
+        basePrice = 100.toBigDecimal(),
+        currencyCode = "USD",
     )
 
     private val winbackResponse = winbackResponse {

--- a/modules/features/profile/src/test/kotlin/au/com/shiftyjelly/pocketcasts/profile/winback/WinbackViewModelTest.kt
+++ b/modules/features/profile/src/test/kotlin/au/com/shiftyjelly/pocketcasts/profile/winback/WinbackViewModelTest.kt
@@ -553,6 +553,8 @@ class WinbackViewModelTest {
                         on { formattedPrice } doReturn "price"
                         on { billingPeriod } doReturn BillingPeriod.Monthly.value
                         on { recurrenceMode } doReturn RecurrenceMode.INFINITE_RECURRING
+                        on { priceAmountMicros } doReturn 100L
+                        on { priceCurrencyCode } doReturn "USD"
                     }
                 },
             ),
@@ -998,12 +1000,16 @@ private fun createProductDetails(
         on { formattedPrice } doReturn "base-price-$id"
         on { billingPeriod } doReturn period.value
         on { recurrenceMode } doReturn RecurrenceMode.INFINITE_RECURRING
+        on { priceAmountMicros } doReturn 100L
+        on { priceCurrencyCode } doReturn "USD"
     }
     val offerPricingPhase = bonusOfferId?.let {
         mock<PricingPhase> {
             on { formattedPrice } doReturn "offer-price-$id"
             on { billingPeriod } doReturn period.value
             on { recurrenceMode } doReturn RecurrenceMode.INFINITE_RECURRING
+            on { priceAmountMicros } doReturn 100L
+            on { priceCurrencyCode } doReturn "USD"
         }
     }
     val basePricingPhases = mock<PricingPhases> {

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -196,6 +196,10 @@
     <string name="move_down">Move down</string>
     <string name="see_more">See more</string>
     <string name="maybe_later">Maybe later</string>
+    <!-- %1$.2f is price with 2 decimal points precision, %1$s is the currency -->
+    <string name="price_per_week">%1$.2f %2$s/week</string>
+    <!-- %1$.2f is price with 2 decimal points precision, \u0024 is a dollar sign -->
+    <string name="price_per_week_usd">\u0024%1$.2f/week</string>
 
     <string name="multiselect_actions_shown">Shortcut in toolbar</string>
     <string name="multiselect_actions_hidden">In overflow</string>


### PR DESCRIPTION
## Description

This PR adds weekly price to the offers.

Designs: G22KfZwL1Gv5yyxdTheF9H-fi-1075_9457

## Testing Instructions

> [!note]
> Test this with the debug variant and [this patch](https://github.com/user-attachments/files/19793722/winback.patch) applied.

1. Create a new account and subscribe to any plan.  
2. Go to your account details.  
3. Tap on the cancellation row.  
4. Check available plans.
5. Notice that yearly offers have per week value.
6. Notice that yearly Plus has the best value sticker.

## Screenshots or Screencast 

| Before | After |
| - | - |
| ![b](https://github.com/user-attachments/assets/fc602434-ffa6-43af-90d9-568b537a9b25) | ![a](https://github.com/user-attachments/assets/23ff3544-7308-45ac-b7ba-479a13297f0d) |

## Checklist
- [ ] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] ~I have considered whether it makes sense to add tests for my changes~
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [ ] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack