### PR TITLE
Fix issue with disappearing file image right after upload completes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 *   New Features
     *   Add account encouragement flow
         ([#3909](https://github.com/Automattic/pocket-casts-android/pull/3909))
+*   Bug Fixes
+    *   Fix issue with disappearing file image after upload completes
+        ([#3910](https://github.com/Automattic/pocket-casts-android/pull/3910))
 
 7.87
 -----

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/UserEpisodeManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/UserEpisodeManager.kt
@@ -283,7 +283,7 @@ class UserEpisodeManagerImpl @Inject constructor(
         }
     }
 
-    override suspend fun syncFiles(playbackManager: PlaybackManager) {
+    private suspend fun syncFiles(playbackManager: PlaybackManager, syncArtworkChanges: Boolean) {
         val episodesToSync = userEpisodeDao.findUserEpisodesToSyncBlocking()
         if (episodesToSync.isNotEmpty()) {
             val response = withContext(Dispatchers.IO) {
@@ -337,7 +337,7 @@ class UserEpisodeManagerImpl @Inject constructor(
                     didChange = true
                 }
 
-                if (existingFile.hasCustomImage != it.hasCustomImage) {
+                if (syncArtworkChanges && existingFile.hasCustomImage != it.hasCustomImage) {
                     existingFile.hasCustomImage = it.hasCustomImage
                     didChange = true
                 }
@@ -347,7 +347,7 @@ class UserEpisodeManagerImpl @Inject constructor(
                     didChange = true
                 }
 
-                if (existingFile.artworkUrl != it.imageUrl) {
+                if (syncArtworkChanges && existingFile.artworkUrl != it.imageUrl) {
                     existingFile.artworkUrl = it.imageUrl
                     didChange = true
                 }
@@ -412,6 +412,10 @@ class UserEpisodeManagerImpl @Inject constructor(
         }
     }
 
+    override suspend fun syncFiles(playbackManager: PlaybackManager) {
+        syncFiles(playbackManager = playbackManager, syncArtworkChanges = true)
+    }
+
     override fun uploadToServer(userEpisode: UserEpisode, waitForWifi: Boolean) {
         val networkType = if (waitForWifi) NetworkType.UNMETERED else NetworkType.CONNECTED
         val constraints = Constraints.Builder()
@@ -453,9 +457,6 @@ class UserEpisodeManagerImpl @Inject constructor(
         return userEpisodeDao.updateServerStatusRxCompletable(userEpisode.uuid, UserEpisodeServerStatus.UPLOADING)
             .andThen(userEpisodeDao.updateUploadErrorRxCompetable(userEpisode.uuid, null))
             .andThen(syncManager.uploadFileToServerRxCompletable(userEpisode))
-            .andThen(
-                userEpisodeDao.updateServerStatusRxCompletable(userEpisode.uuid, serverStatus = UserEpisodeServerStatus.UPLOADED),
-            )
             .andThen(imageUploadTask)
             // let the file upload report to upload to the api server
             .delay(1, TimeUnit.SECONDS)
@@ -477,9 +478,14 @@ class UserEpisodeManagerImpl @Inject constructor(
                     },
             )
             .andThen(
-                rxCompletable { syncFiles(playbackManager) }
-                    .doOnError { Timber.e(it) }
-                    .onErrorComplete(),
+                rxCompletable {
+                    syncFiles(
+                        playbackManager = playbackManager,
+                        syncArtworkChanges = false,
+                    )
+                }.doOnError {
+                    Timber.e(it)
+                }.onErrorComplete(),
             )
     }
 


### PR DESCRIPTION
## Description
<!-- Please include a summary of what this PR is changing and why these changes are needed. -->
As title says. 
During my investigation I discovered that the file upload process consits of multiple steps. To call out the most important ones:
- Upload the file itself
- Upload the image (when applicable). The image will be uploaded by using a URL that is unique to the previously uploaded file.
After the sequence completes, we sync files with the server. However at this point the server might not have `ServerFile.imageUrl` property. Image gets uploaded to an aws bucket, and I assume it requires some time until our backend gets notified about the image upload completion. We then overwrote our db record with the data we got from the server -- effectively erased the image from the records. If you refresh the files list after a few seconds, the server will send the image.
I modified the code and added a new argument to the `syncFiles` method that controls whether we should skip comparison on image-related properties when examining whether our local record needs to be updated or not.

Fixes #1631 

## Testing Instructions
1. Make sure you log in with a Plus account
2. Navigate to Profile
3. Select Files
4. Tap the + FAB
5. Browse a file and select an image to be uploaded
6. Tap Save
7. Tap the new file you've just created
8. On the bottom sheet, select Upload to cloud
9. Observe
- [ ] image remains the same after the upload completes
10. Wait for a few seconds (~5) and pull down to refresh file list
- [ ] image of the previously uploaded file flickers -- it indicates that the server now sends the `imageUrl` field that points to the aws file 


## Screenshots or Screencast 
<!-- if applicable -->


https://github.com/user-attachments/assets/8a663b52-6de6-4f03-aabd-035bc6d67645


## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
