### PR TITLE
Respect orientation when laying out artwork and player controls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 *   Bug Fixes
     *   Fix issue with disappearing file image after upload completes
         ([#3910](https://github.com/Automattic/pocket-casts-android/pull/3910))
+    *   Fix missing fullscreen player controls in landscape mode
+        ([#3917](https://github.com/Automattic/pocket-casts-android/pull/3917))
 
 7.87
 -----

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/nowplaying/ArtworkSection.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/nowplaying/ArtworkSection.kt
@@ -106,9 +106,9 @@ private fun Content(
         // As it turned out, there is a very narrow section of phones that are classified as WindowHeightSizeClass.Medium in landscape orientation.
         // These conditions are meant to relax the rule of 480dp by adding a tolerance of +5% in order to treat them as phones in landscape mode.
         if (
-            orientation == Configuration.ORIENTATION_LANDSCAPE
-            && windowSize.heightSizeClass != WindowHeightSizeClass.Compact
-            && LocalConfiguration.current.screenHeightDp.dp <= LANDSCAPE_COMPACT_HEIGHT_BREAKPOINT * PHONE_LANDSCAPE_HEIGHT_CLASS_TOLERANCE
+            orientation == Configuration.ORIENTATION_LANDSCAPE &&
+            windowSize.heightSizeClass != WindowHeightSizeClass.Compact &&
+            LocalConfiguration.current.screenHeightDp.dp <= LANDSCAPE_COMPACT_HEIGHT_BREAKPOINT * PHONE_LANDSCAPE_HEIGHT_CLASS_TOLERANCE
         ) {
             WindowHeightSizeClass.Compact
         } else {

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/nowplaying/ArtworkSection.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/nowplaying/ArtworkSection.kt
@@ -94,9 +94,8 @@ private fun Content(
 ) {
     val activity = LocalContext.current.getActivity()
     val windowSize = activity?.let { calculateWindowSizeClass(it) }
-    val heightSizeClass = if (LocalInspectionMode.current) {
-        val orientation = LocalConfiguration.current.orientation
-        if (orientation == Configuration.ORIENTATION_LANDSCAPE) WindowHeightSizeClass.Compact else WindowHeightSizeClass.Medium
+    val heightSizeClass = if (LocalConfiguration.current.orientation == Configuration.ORIENTATION_LANDSCAPE) {
+        WindowHeightSizeClass.Compact
     } else {
         windowSize?.heightSizeClass ?: return
     }


### PR DESCRIPTION
## Description
<!-- Please include a summary of what this PR is changing and why these changes are needed. -->
It's been reported that the expanded player won't display player controls while the phone is in landscape.
I traced down the issue to `ArtworkSection` composable, there was a piece of code that incorrectly selected orientation and hence layout configuration. 
The original conditions made sure to select the proper configuration for previews, but since we are running the app on a real device, that code path was never selected.


Fixes #3901 

## Testing Instructions
1. Install and run app on your phone
2. Optional: Connect to headless auto emulator
3. Start playing a podcast episode while your phone is in portrait mode
4. Rotate your phone to landscape (and make sure you've turned off 'lock to portrait' in settings)
- [ ] Player controls appear as expected

## Screenshots or Screencast 
| Before | After |
| --- | --- |
| ![Screenshot_20250421_142531](https://github.com/user-attachments/assets/6a462705-3d7b-4289-a0c2-ffba85002d7b) | ![Screenshot_20250421_153520](https://github.com/user-attachments/assets/d690978c-1813-4ef2-8c9e-e2ab40f01da4) |


## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
