### PR TITLE
Add data types to the payment module

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -285,6 +285,7 @@ play-cast = "com.google.android.gms:play-services-cast-framework:22.0.0"
 play-review = "com.google.android.play:review-ktx:2.0.2"
 play-wearable = "com.google.android.gms:play-services-wearable:19.0.0"
 reorderable = "sh.calvin.reorderable:reorderable:2.4.3"
+robolectric = "org.robolectric:robolectric:4.14"
 security-lint = { module = "com.android.security.lint:lint", version.ref = "security-lint" }
 timber = "com.jakewharton.timber:timber:5.0.1"
 turbine = "app.cash.turbine:turbine:1.2.0"

--- a/modules/services/payment/build.gradle.kts
+++ b/modules/services/payment/build.gradle.kts
@@ -14,4 +14,7 @@ android {
 dependencies {
     api(libs.billing.ktx)
     api(libs.coroutines.core)
+
+    testImplementation(libs.junit)
+    testImplementation(libs.robolectric)
 }

--- a/modules/services/payment/src/main/kotlin/au/com/shiftyjelly/pocketcasts/payment/Data.kt
+++ b/modules/services/payment/src/main/kotlin/au/com/shiftyjelly/pocketcasts/payment/Data.kt
@@ -1,0 +1,67 @@
+package au.com.shiftyjelly.pocketcasts.payment
+
+import java.math.BigDecimal
+
+data class Product(
+    val id: String,
+    val name: String,
+    val plans: Plans,
+)
+
+data class Plans(
+    val offerPlans: List<Plan.Offer>,
+    val basePlan: Plan.Base,
+)
+
+sealed interface Plan {
+    val planId: String
+    val pricingPhases: List<PricingPhase>
+    val tags: List<String>
+
+    data class Base(
+        override val planId: String,
+        override val pricingPhases: List<PricingPhase>,
+        override val tags: List<String>,
+    ) : Plan
+
+    data class Offer(
+        val offerId: String,
+        override val planId: String,
+        override val pricingPhases: List<PricingPhase>,
+        override val tags: List<String>,
+    ) : Plan
+}
+
+data class PricingPhase(
+    val price: Price,
+    val billingPeriod: BillingPeriod,
+)
+
+data class Price(
+    val amount: BigDecimal,
+    val currencyCode: String,
+    val formattedPrice: String,
+)
+
+data class BillingPeriod(
+    val cycle: BillingPeriod.Cycle,
+    val interval: BillingPeriod.Interval,
+    val intervalCount: Int,
+) {
+    enum class Interval {
+        Weekly,
+        Monthly,
+        Yearly,
+    }
+
+    sealed interface Cycle {
+        data object NonRecurring : Cycle
+
+        @JvmInline
+        value class Recurring(
+            val value: Int,
+        ) : Cycle
+
+        data object Infinite : Cycle
+    }
+}

--- a/modules/services/payment/src/main/kotlin/au/com/shiftyjelly/pocketcasts/payment/billing/ProductDetailsMapper.kt
+++ b/modules/services/payment/src/main/kotlin/au/com/shiftyjelly/pocketcasts/payment/billing/ProductDetailsMapper.kt
@@ -1,0 +1,186 @@
+package au.com.shiftyjelly.pocketcasts.payment.billing
+
+import au.com.shiftyjelly.pocketcasts.payment.BillingPeriod
+import au.com.shiftyjelly.pocketcasts.payment.Logger
+import au.com.shiftyjelly.pocketcasts.payment.Plan
+import au.com.shiftyjelly.pocketcasts.payment.Plans
+import au.com.shiftyjelly.pocketcasts.payment.Price
+import au.com.shiftyjelly.pocketcasts.payment.PricingPhase
+import au.com.shiftyjelly.pocketcasts.payment.Product
+import com.android.billingclient.api.ProductDetails.RecurrenceMode
+import com.android.billingclient.api.ProductDetails as GoogleProduct
+import com.android.billingclient.api.ProductDetails.PricingPhase as GooglePricingPhase
+import com.android.billingclient.api.ProductDetails.SubscriptionOfferDetails as GoogleOfferDetails
+
+internal class ProductDetailsMapper(
+    val logger: Logger,
+) {
+    fun toProduct(productDetails: GoogleProduct): Product? {
+        val mappingContext = mapOf("productId" to productDetails.productId)
+
+        if (productDetails.productType != SubscriptionType) {
+            logWarning("Unrecognized product type '${productDetails.productType}'", mappingContext)
+            return null
+        }
+
+        val offerDetails = productDetails.subscriptionOfferDetails
+        if (offerDetails.isNullOrEmpty()) {
+            logWarning("No subscription offers", mappingContext)
+            return null
+        }
+
+        return Product(
+            id = productDetails.productId,
+            name = productDetails.name,
+            plans = toPlans(offerDetails, mappingContext) ?: return null,
+        )
+    }
+
+    private fun toPlans(
+        offerDetails: List<GoogleOfferDetails>,
+        mappingContext: Map<String, Any?>,
+    ): Plans? {
+        return Plans(
+            offerPlans = toOfferPlans(offerDetails, mappingContext) ?: return null,
+            basePlan = toBasePlan(offerDetails, mappingContext) ?: return null,
+        )
+    }
+
+    private fun toBasePlan(
+        offerDetails: List<GoogleOfferDetails>,
+        mappingContext: Map<String, Any?>,
+    ): Plan.Base? {
+        val noOfferDetails = offerDetails.singleOrNull { it.offerId == null }
+        if (noOfferDetails == null) {
+            logWarning("No single base offer", mappingContext)
+            return null
+        }
+
+        return Plan.Base(
+            planId = noOfferDetails.basePlanId,
+            pricingPhases = toPricingPhases(
+                pricingPhases = noOfferDetails.pricingPhases.pricingPhaseList,
+                mappingContext = mappingContext + mapOf(
+                    "basePlanId" to noOfferDetails.basePlanId,
+                ),
+            ) ?: return null,
+            tags = noOfferDetails.offerTags,
+        )
+    }
+
+    private fun toOfferPlans(
+        offerDetails: List<GoogleOfferDetails>,
+        mappingContext: Map<String, Any?>,
+    ): List<Plan.Offer>? {
+        val withOfferDetails = offerDetails.filter { it.offerId != null }
+        val mappedPlans = withOfferDetails.mapNotNull { toOfferPlan(it, mappingContext) }
+
+        return if (withOfferDetails.size != mappedPlans.size) {
+            return null
+        } else {
+            mappedPlans
+        }
+    }
+
+    private fun toOfferPlan(
+        offerDetails: GoogleOfferDetails,
+        mappingContext: Map<String, Any?>,
+    ): Plan.Offer? {
+        return Plan.Offer(
+            offerId = requireNotNull(offerDetails.offerId),
+            planId = offerDetails.basePlanId,
+            pricingPhases = toPricingPhases(
+                pricingPhases = offerDetails.pricingPhases.pricingPhaseList,
+                mappingContext = mappingContext + mapOf(
+                    "basePlanId" to offerDetails.basePlanId,
+                    "offerId" to offerDetails.offerId,
+                ),
+            ) ?: return null,
+            tags = offerDetails.offerTags,
+        )
+    }
+
+    private fun toPricingPhases(
+        pricingPhases: List<GooglePricingPhase>,
+        mappingContext: Map<String, Any?>,
+    ): List<PricingPhase>? {
+        val mappedPhases = pricingPhases.mapNotNull { toPricingPhase(it, mappingContext) }
+
+        return if (pricingPhases.size != mappedPhases.size) {
+            return null
+        } else {
+            mappedPhases
+        }
+    }
+
+    private fun toPricingPhase(
+        pricingPhase: GooglePricingPhase,
+        mappingContext: Map<String, Any?>,
+    ): PricingPhase? {
+        val (count, interval) = toBillingDuration(pricingPhase.billingPeriod, mappingContext) ?: return null
+
+        return PricingPhase(
+            price = Price(
+                amount = pricingPhase.priceAmountMicros.toBigDecimal().movePointLeft(6),
+                currencyCode = pricingPhase.priceCurrencyCode,
+                formattedPrice = pricingPhase.formattedPrice,
+            ),
+            billingPeriod = BillingPeriod(
+                intervalCount = count,
+                interval = interval,
+                cycle = when (pricingPhase.recurrenceMode) {
+                    RecurrenceMode.NON_RECURRING -> BillingPeriod.Cycle.NonRecurring
+                    RecurrenceMode.FINITE_RECURRING -> BillingPeriod.Cycle.Recurring(
+                        value = pricingPhase.billingCycleCount,
+                    )
+                    RecurrenceMode.INFINITE_RECURRING -> BillingPeriod.Cycle.Infinite
+                    else -> {
+                        logWarning("Unrecognized recurrence mode '${pricingPhase.recurrenceMode}'", mappingContext)
+                        return null
+                    }
+                },
+            ),
+        )
+    }
+
+    private fun toBillingDuration(
+        iso8601Duration: String,
+        mappingContext: Map<String, Any?>,
+    ): Pair<Int, BillingPeriod.Interval>? {
+        val context = mappingContext + mapOf("rawDuration" to iso8601Duration)
+
+        val designator = iso8601Duration[0]
+        if (designator != 'P') {
+            logWarning("Missing billing period duration designator", context)
+            return null
+        }
+        val valuePart = iso8601Duration.drop(1)
+
+        val rawCount = valuePart.takeWhile(Char::isDigit)
+        val count = rawCount.toIntOrNull()
+        if (count == null) {
+            logWarning("Invalid billing period interval count '$count'", context)
+            return null
+        }
+
+        val rawInterval = valuePart.drop(rawCount.length)
+        val interval = when (rawInterval) {
+            "W" -> BillingPeriod.Interval.Weekly
+            "M" -> BillingPeriod.Interval.Monthly
+            "Y" -> BillingPeriod.Interval.Yearly
+            else -> null
+        }
+        if (interval == null) {
+            logWarning("Unrecognized billing interval period designator '$rawInterval'", context)
+            return null
+        }
+
+        return count to interval
+    }
+
+    private fun logWarning(message: String, context: Map<String, Any?>) {
+        logger.warning("$message in ${context.toSortedMap()}")
+    }
+}
+
+private const val SubscriptionType = "subs"

--- a/modules/services/payment/src/test/kotlin/au/com/shiftyjelly/pocketcasts/payment/TestLogger.kt
+++ b/modules/services/payment/src/test/kotlin/au/com/shiftyjelly/pocketcasts/payment/TestLogger.kt
@@ -1,0 +1,39 @@
+package au.com.shiftyjelly.pocketcasts.payment
+
+import org.junit.Assert.assertEquals
+
+class TestLogger : Logger {
+    private val logs = mutableListOf<LogEntry>()
+
+    override fun info(message: String) {
+        logs += LogEntry(LogLevel.Info, message)
+    }
+
+    override fun warning(message: String) {
+        logs += LogEntry(LogLevel.Warning, message)
+    }
+
+    override fun error(message: String, exception: Throwable) {
+        logs += LogEntry(LogLevel.Error, message)
+    }
+
+    fun assertWarnings(vararg messages: String) {
+        val warningLogs = logs.filter { it.level == LogLevel.Warning }.map { it.message }
+        assertEquals(messages.toList(), warningLogs)
+    }
+
+    fun assertNoLogs() {
+        assertEquals(emptyList<LogEntry>(), logs)
+    }
+}
+
+private data class LogEntry(
+    val level: LogLevel,
+    val message: String,
+)
+
+private enum class LogLevel {
+    Info,
+    Warning,
+    Error,
+}

--- a/modules/services/payment/src/test/kotlin/au/com/shiftyjelly/pocketcasts/payment/billing/ProductDetailsMapperTest.kt
+++ b/modules/services/payment/src/test/kotlin/au/com/shiftyjelly/pocketcasts/payment/billing/ProductDetailsMapperTest.kt
@@ -1,0 +1,385 @@
+package au.com.shiftyjelly.pocketcasts.payment.billing
+
+import au.com.shiftyjelly.pocketcasts.payment.BillingPeriod
+import au.com.shiftyjelly.pocketcasts.payment.Price
+import au.com.shiftyjelly.pocketcasts.payment.TestLogger
+import com.android.billingclient.api.GoogleOfferDetails
+import com.android.billingclient.api.GooglePricingPhase
+import com.android.billingclient.api.GoogleProductDetails
+import com.android.billingclient.api.ProductDetails.RecurrenceMode
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@Config(manifest = Config.NONE)
+@RunWith(RobolectricTestRunner::class)
+class ProductDetailsMapperTest {
+    private val logger = TestLogger()
+    private val mapper = ProductDetailsMapper(logger)
+
+    @Test
+    fun `map product`() {
+        assertNotNull(mapper.toProduct(GoogleProductDetails()))
+    }
+
+    @Test
+    fun `no errors are logged when mapped successfully`() {
+        mapper.toProduct(GoogleProductDetails())
+
+        logger.assertNoLogs()
+    }
+
+    @Test
+    fun `map base product properties`() {
+        val googleProduct = GoogleProductDetails(
+            productId = "ID 1234",
+            name = "Cool product",
+        )
+
+        val product = mapper.toProduct(googleProduct)!!
+
+        assertEquals("ID 1234", product.id)
+        assertEquals("Cool product", product.name)
+    }
+
+    @Test
+    fun `map product without offers`() {
+        val googleProduct = GoogleProductDetails(
+            subscriptionOfferDetails = listOf(
+                GoogleOfferDetails(
+                    basePlanId = "Base plan ID",
+                    offerId = null,
+                    pricingPhases = listOf(
+                        GooglePricingPhase(
+                            priceAmountMicros = 200_500_000,
+                            priceCurrencyCode = "AUD",
+                            formattedPrice = "$200.50",
+                            billingPeriod = "P1M",
+                            recurrenceMode = RecurrenceMode.INFINITE_RECURRING,
+                            billingCycleCount = 0,
+                        ),
+
+                    ),
+                    offerTags = listOf("Tag", "Another tag"),
+                ),
+            ),
+        )
+
+        val basePlan = mapper.toProduct(googleProduct)!!.plans.basePlan
+
+        assertEquals("Base plan ID", basePlan.planId)
+        assertEquals(listOf("Tag", "Another tag"), basePlan.tags)
+        assertEquals(1, basePlan.pricingPhases.size)
+
+        val pricingPhase = basePlan.pricingPhases[0]
+        assertEquals(
+            Price(200.5.toBigDecimal().setScale(6), "AUD", "$200.50"),
+            pricingPhase.price,
+        )
+        assertEquals(
+            BillingPeriod(BillingPeriod.Cycle.Infinite, BillingPeriod.Interval.Monthly, intervalCount = 1),
+            pricingPhase.billingPeriod,
+        )
+    }
+
+    @Test
+    fun `map product with offers`() {
+        val googleProduct = GoogleProductDetails(
+            subscriptionOfferDetails = listOf(
+                GoogleOfferDetails(offerId = null),
+                GoogleOfferDetails(
+                    basePlanId = "Offer base plan ID",
+                    offerId = "Offer ID",
+                    offerTags = listOf("Offer Tag", "Another offer tag"),
+                ),
+            ),
+        )
+
+        val offerPlans = mapper.toProduct(googleProduct)!!.plans.offerPlans
+        assertEquals(1, offerPlans.size)
+        val offerPlan = offerPlans[0]
+
+        assertEquals("Offer base plan ID", offerPlan.planId)
+        assertEquals("Offer ID", offerPlan.offerId)
+        assertEquals(listOf("Offer Tag", "Another offer tag"), offerPlan.tags)
+    }
+
+    @Test
+    fun `map product prices`() {
+        val googleProduct = GoogleProductDetails(
+            subscriptionOfferDetails = listOf(
+                GoogleOfferDetails(offerId = null),
+                GoogleOfferDetails(
+                    offerId = "ID",
+                    pricingPhases = listOf(
+                        GooglePricingPhase(
+                            priceAmountMicros = 10_000_000,
+                            priceCurrencyCode = "USD",
+                            formattedPrice = "$10.00",
+                        ),
+                        GooglePricingPhase(
+                            priceAmountMicros = 15_000_000,
+                            priceCurrencyCode = "EUR",
+                            formattedPrice = "15.00 €",
+                        ),
+                        GooglePricingPhase(
+                            priceAmountMicros = 20_000_000,
+                            priceCurrencyCode = "PLN",
+                            formattedPrice = "20.00 zł",
+                        ),
+                    ),
+                ),
+            ),
+        )
+
+        val prices = mapper.toProduct(googleProduct)!!.plans
+            .offerPlans
+            .flatMap { it.pricingPhases }
+            .map { it.price }
+
+        assertEquals(
+            listOf(
+                Price(10.toBigDecimal().setScale(6), "USD", "$10.00"),
+                Price(15.toBigDecimal().setScale(6), "EUR", "15.00 €"),
+                Price(20.toBigDecimal().setScale(6), "PLN", "20.00 zł"),
+            ),
+            prices,
+        )
+    }
+
+    @Test
+    fun `map product billing intervals`() {
+        val googleProduct = GoogleProductDetails(
+            subscriptionOfferDetails = listOf(
+                GoogleOfferDetails(offerId = null),
+                GoogleOfferDetails(
+                    offerId = "ID",
+                    pricingPhases = listOf(
+                        GooglePricingPhase(
+                            billingPeriod = "P1M",
+                            billingCycleCount = 0,
+                            recurrenceMode = RecurrenceMode.INFINITE_RECURRING,
+                        ),
+                    ),
+                ),
+                GoogleOfferDetails(
+                    offerId = "ID",
+                    pricingPhases = listOf(
+                        GooglePricingPhase(
+                            billingPeriod = "P1M",
+                            billingCycleCount = 0,
+                            recurrenceMode = RecurrenceMode.NON_RECURRING,
+                        ),
+                    ),
+                ),
+                GoogleOfferDetails(
+                    offerId = "ID",
+                    pricingPhases = listOf(
+                        GooglePricingPhase(
+                            billingPeriod = "P1M",
+                            billingCycleCount = 1,
+                            recurrenceMode = RecurrenceMode.FINITE_RECURRING,
+                        ),
+                    ),
+                ),
+                GoogleOfferDetails(
+                    offerId = "ID",
+                    pricingPhases = listOf(
+                        GooglePricingPhase(
+                            billingPeriod = "P1M",
+                            billingCycleCount = 2,
+                            recurrenceMode = RecurrenceMode.FINITE_RECURRING,
+                        ),
+                    ),
+                ),
+                GoogleOfferDetails(
+                    offerId = "ID",
+                    pricingPhases = listOf(
+                        GooglePricingPhase(
+                            billingPeriod = "P2M",
+                            billingCycleCount = 0,
+                            recurrenceMode = RecurrenceMode.INFINITE_RECURRING,
+                        ),
+                    ),
+                ),
+                GoogleOfferDetails(
+                    offerId = "ID",
+                    pricingPhases = listOf(
+                        GooglePricingPhase(
+                            billingPeriod = "P1W",
+                            billingCycleCount = 0,
+                            recurrenceMode = RecurrenceMode.INFINITE_RECURRING,
+                        ),
+                    ),
+                ),
+                GoogleOfferDetails(
+                    offerId = "ID",
+                    pricingPhases = listOf(
+                        GooglePricingPhase(
+                            billingPeriod = "P3Y",
+                            billingCycleCount = 0,
+                            recurrenceMode = RecurrenceMode.INFINITE_RECURRING,
+                        ),
+                    ),
+                ),
+            ),
+        )
+
+        val billingPeriods = mapper.toProduct(googleProduct)!!.plans
+            .offerPlans
+            .flatMap { it.pricingPhases }
+            .map { it.billingPeriod }
+
+        assertEquals(
+            listOf(
+                BillingPeriod(
+                    intervalCount = 1,
+                    interval = BillingPeriod.Interval.Monthly,
+                    cycle = BillingPeriod.Cycle.Infinite,
+                ),
+                BillingPeriod(
+                    intervalCount = 1,
+                    interval = BillingPeriod.Interval.Monthly,
+                    cycle = BillingPeriod.Cycle.NonRecurring,
+                ),
+                BillingPeriod(
+                    intervalCount = 1,
+                    interval = BillingPeriod.Interval.Monthly,
+                    cycle = BillingPeriod.Cycle.Recurring(1),
+                ),
+                BillingPeriod(
+                    intervalCount = 1,
+                    interval = BillingPeriod.Interval.Monthly,
+                    cycle = BillingPeriod.Cycle.Recurring(2),
+                ),
+                BillingPeriod(
+                    intervalCount = 2,
+                    interval = BillingPeriod.Interval.Monthly,
+                    cycle = BillingPeriod.Cycle.Infinite,
+                ),
+                BillingPeriod(
+                    intervalCount = 1,
+                    interval = BillingPeriod.Interval.Weekly,
+                    cycle = BillingPeriod.Cycle.Infinite,
+                ),
+                BillingPeriod(
+                    intervalCount = 3,
+                    interval = BillingPeriod.Interval.Yearly,
+                    cycle = BillingPeriod.Cycle.Infinite,
+                ),
+            ),
+            billingPeriods,
+        )
+    }
+
+    @Test
+    fun `do not map product with unknown type`() {
+        val googleProduct = GoogleProductDetails(
+            productId = "Product ID",
+            type = "foo",
+        )
+
+        assertNull(mapper.toProduct(googleProduct))
+        logger.assertWarnings("Unrecognized product type 'foo' in {productId=Product ID}")
+    }
+
+    @Test
+    fun `do not map product with no subscription offers`() {
+        val googleProduct = GoogleProductDetails(
+            productId = "Product ID",
+            subscriptionOfferDetails = null,
+        )
+
+        assertNull(mapper.toProduct(googleProduct))
+        logger.assertWarnings("No subscription offers in {productId=Product ID}")
+    }
+
+    @Test
+    fun `do not map product with empty subscription offers`() {
+        val googleProduct = GoogleProductDetails(
+            productId = "Product ID",
+            subscriptionOfferDetails = emptyList(),
+        )
+
+        assertNull(mapper.toProduct(googleProduct))
+        logger.assertWarnings("No subscription offers in {productId=Product ID}")
+    }
+
+    @Test
+    fun `do not map product with no base offer`() {
+        val googleProduct = GoogleProductDetails(
+            productId = "Product ID",
+            subscriptionOfferDetails = listOf(
+                GoogleOfferDetails(offerId = "Offer ID"),
+            ),
+        )
+
+        assertNull(mapper.toProduct(googleProduct))
+        logger.assertWarnings("No single base offer in {productId=Product ID}")
+    }
+
+    @Test
+    fun `do not map product with multiple base offer`() {
+        val googleProduct = GoogleProductDetails(
+            productId = "Product ID",
+            subscriptionOfferDetails = listOf(
+                GoogleOfferDetails(),
+                GoogleOfferDetails(),
+            ),
+        )
+
+        assertNull(mapper.toProduct(googleProduct))
+        logger.assertWarnings("No single base offer in {productId=Product ID}")
+    }
+
+    @Test
+    fun `do not map product with unknown recurrence mode`() {
+        val googleProduct = GoogleProductDetails(
+            productId = "Product ID",
+            subscriptionOfferDetails = listOf(
+                GoogleOfferDetails(),
+                GoogleOfferDetails(
+                    basePlanId = "Base plan ID",
+                    offerId = "Offer ID",
+                    pricingPhases = listOf(GooglePricingPhase(recurrenceMode = -100)),
+                ),
+            ),
+        )
+
+        assertNull(mapper.toProduct(googleProduct))
+        logger.assertWarnings("Unrecognized recurrence mode '-100' in {basePlanId=Base plan ID, offerId=Offer ID, productId=Product ID}")
+    }
+
+    @Test
+    fun `do not map product with invalid billing duration`() {
+        val durations = listOf("1M", "D1M", "PM", "P-1M", "P1U", "P1MY")
+        val googleProducts = durations.map { duration ->
+            GoogleProductDetails(
+                productId = "Product ID",
+                subscriptionOfferDetails = listOf(
+                    GoogleOfferDetails(
+                        basePlanId = "Base plan ID",
+                        pricingPhases = listOf(GooglePricingPhase(billingPeriod = duration)),
+                    ),
+                ),
+            )
+        }
+
+        val products = googleProducts.map(mapper::toProduct)
+
+        assertTrue(products.all { it == null })
+        logger.assertWarnings(
+            "Missing billing period duration designator in {basePlanId=Base plan ID, productId=Product ID, rawDuration=1M}",
+            "Missing billing period duration designator in {basePlanId=Base plan ID, productId=Product ID, rawDuration=D1M}",
+            "Invalid billing period interval count 'null' in {basePlanId=Base plan ID, productId=Product ID, rawDuration=PM}",
+            "Invalid billing period interval count 'null' in {basePlanId=Base plan ID, productId=Product ID, rawDuration=P-1M}",
+            "Unrecognized billing interval period designator 'U' in {basePlanId=Base plan ID, productId=Product ID, rawDuration=P1U}",
+            "Unrecognized billing interval period designator 'MY' in {basePlanId=Base plan ID, productId=Product ID, rawDuration=P1MY}",
+        )
+    }
+}

--- a/modules/services/payment/src/test/kotlin/com/android/billingclient/api/ProductDetails.kt
+++ b/modules/services/payment/src/test/kotlin/com/android/billingclient/api/ProductDetails.kt
@@ -1,0 +1,73 @@
+package com.android.billingclient.api
+
+import com.android.billingclient.api.ProductDetails.PricingPhase
+import com.android.billingclient.api.ProductDetails.SubscriptionOfferDetails
+import org.json.JSONArray
+import org.json.JSONObject
+
+fun GoogleProductDetails(
+    productId: String = "product-id",
+    type: String = "subs",
+    title: String = "title",
+    name: String = "name",
+    skuDetailsToken: String = "sku-details-token",
+    subscriptionOfferDetails: List<SubscriptionOfferDetails>? = listOf(GoogleOfferDetails()),
+): ProductDetails {
+    val json = JSONObject()
+        .put("productId", productId)
+        .put("type", type)
+        .put("title", title)
+        .put("name", name)
+        .put("skuDetailsToken", skuDetailsToken)
+        .putOpt("subscriptionOfferDetails", subscriptionOfferDetails?.map(SubscriptionOfferDetails::toJson)?.let(::JSONArray))
+    return ProductDetails(json.toString())
+}
+
+fun GoogleOfferDetails(
+    basePlanId: String = "base-plan-id",
+    offerId: String? = null,
+    offerIdToken: String = "offer-id-token",
+    pricingPhases: List<PricingPhase> = listOf(GooglePricingPhase()),
+    offerTags: List<String> = emptyList(),
+): SubscriptionOfferDetails {
+    val json = JSONObject()
+        .put("basePlanId", basePlanId)
+        .putOpt("offerId", offerId)
+        .put("offerIdToken", offerIdToken)
+        .put("pricingPhases", JSONArray(pricingPhases.map(PricingPhase::toJson)))
+        .put("offerTags", JSONArray(offerTags))
+    return SubscriptionOfferDetails(json)
+}
+
+fun GooglePricingPhase(
+    priceAmountMicros: Long = 100_000_000,
+    priceCurrencyCode: String = "USD",
+    formattedPrice: String = "$100.00",
+    billingPeriod: String = "P1M",
+    recurrenceMode: Int = 1,
+    billingCycleCount: Int = 0,
+): PricingPhase {
+    val json = JSONObject()
+        .put("priceAmountMicros", priceAmountMicros)
+        .put("priceCurrencyCode", priceCurrencyCode)
+        .put("formattedPrice", formattedPrice)
+        .put("billingPeriod", billingPeriod)
+        .put("recurrenceMode", recurrenceMode)
+        .put("billingCycleCount", billingCycleCount)
+    return PricingPhase(json)
+}
+
+private fun PricingPhase.toJson() = JSONObject()
+    .put("priceAmountMicros", priceAmountMicros)
+    .put("priceCurrencyCode", priceCurrencyCode)
+    .put("formattedPrice", formattedPrice)
+    .put("billingPeriod", billingPeriod)
+    .put("recurrenceMode", recurrenceMode)
+    .put("billingCycleCount", billingCycleCount)
+
+private fun SubscriptionOfferDetails.toJson() = JSONObject()
+    .put("basePlanId", basePlanId)
+    .putOpt("offerId", offerId)
+    .put("offerIdToken", offerToken)
+    .put("pricingPhases", JSONArray(pricingPhases.pricingPhaseList.map(PricingPhase::toJson)))
+    .put("offerTags", JSONArray(offerTags))


### PR DESCRIPTION
## Description

This PR adds data layer to the payment module and mapping from Google's Billing types to it. There are 2 main decisions that I made. If there's disagreement we can discuss them and work out whether they should be changed.

1. I map only subscription types and skip one-time purchases. We don't have any in the app and adding them would be represented better as a separate type with something like a `sealed interface` hierarchy for both subscriptions and one-time purchases.
2. Apart from monthly and yearly billing intervals, I added support for weekly ones as well While we don't have anything like that in the app I think it's important to keep. Our domain specific offers like Plus Monthly, Plus Yearly, etc., shouldn't affect the payment module too heavily. While I'm fine skipping the whole category of data like on-time purchases doing this for something like a billing period feels wrong. I think it is unlikely that we'll have one-time purchases but it's not unreasonable to imagine that our plans or some free trial periods might be based in weeks.

## Testing Instructions

There's nothing to test. Code review the API and consider whether it makes sense to you.

## Checklist
- [ ] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [ ] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [ ] ~Any jetpack compose components I added or changed are covered by compose previews~
- [ ] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~