### PR TITLE
Handles podcast subscription race condition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
     *   Add account encouragement flow
         ([#3909](https://github.com/Automattic/pocket-casts-android/pull/3909))
 *   Bug Fixes
+    *   Fix podcast follow in the Discover tab not always working
+        ([#3922](https://github.com/Automattic/pocket-casts-android/pull/3922))
     *   Fix issue with disappearing file image after upload completes
         ([#3910](https://github.com/Automattic/pocket-casts-android/pull/3910))
 

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/PodcastViewModel.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/PodcastViewModel.kt
@@ -782,7 +782,7 @@ private fun Maybe<Podcast>.downloadMissingPodcast(uuid: String, podcastManager: 
     return this.switchIfEmpty(
         Single.defer {
             LogBuffer.i(LogBuffer.TAG_BACKGROUND_TASKS, "Podcast $uuid not found in database")
-            podcastManager.findOrDownloadPodcastRxSingle(uuid)
+            podcastManager.findOrDownloadPodcastRxSingle(podcastUuid = uuid, waitForSubscribe = true)
         },
     )
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PodcastManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PodcastManager.kt
@@ -61,7 +61,7 @@ interface PodcastManager {
     fun subscribeToPodcast(podcastUuid: String, sync: Boolean, shouldAutoDownload: Boolean = true)
 
     fun subscribeToPodcastRxSingle(podcastUuid: String, sync: Boolean = false, shouldAutoDownload: Boolean = true): Single<Podcast>
-    fun findOrDownloadPodcastRxSingle(podcastUuid: String): Single<Podcast>
+    fun findOrDownloadPodcastRxSingle(podcastUuid: String, waitForSubscribe: Boolean = false): Single<Podcast>
     fun isSubscribingToPodcasts(): Boolean
     fun getSubscribedPodcastUuidsRxSingle(): Single<List<String>>
     fun isSubscribingToPodcast(podcastUuid: String): Boolean

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PodcastManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PodcastManagerImpl.kt
@@ -134,8 +134,14 @@ class PodcastManagerImpl @Inject constructor(
     /**
      * If the podcast isn't already in the database add it as unsubscribed.
      */
-    override fun findOrDownloadPodcastRxSingle(podcastUuid: String): Single<Podcast> {
-        return rxMaybe { findPodcastOrWaitForSubscribe(podcastUuid) }
+    override fun findOrDownloadPodcastRxSingle(podcastUuid: String, waitForSubscribe: Boolean): Single<Podcast> {
+        return rxMaybe {
+            if (waitForSubscribe) {
+                findPodcastOrWaitForSubscribe(podcastUuid)
+            } else {
+                findPodcastByUuid(podcastUuid)
+            }
+        }
             .switchIfEmpty(subscribeManager.addPodcastRxSingle(podcastUuid, sync = false, subscribed = false, shouldAutoDownload = false).toMaybe())
             .toSingle()
     }


### PR DESCRIPTION
## Description

While testing the Discover section I found an issue that if you tap on the subscribe button on the artwork and then quickly tap the artwork to open the podcast, it can open the podcast page with the podcast as not being followed. After looking into the issue it seems like in the `SubscribeManager` the podcast is being added as followed and unfollowed at the same time. 

I'm really not sure of the best approach to solve this issue. My solution does not download and add the podcast to the database on the podcast page if it is already being subscribed to. It will wait for a second and retry that five times. Please let me know if you have a better solution. 

## Testing Instructions

1. Fresh install the app
2. Go to the Discover tab
3. Scroll down to a podcast large list
4. Tap the subscribe button on the artwork and then quickly tap the artwork
5. ✅ Verify the podcast is marked as followed on the podcast page

## Video

Before

https://github.com/user-attachments/assets/84a47bfb-4c4a-4589-85f4-e463c164dd61

After

https://github.com/user-attachments/assets/eba94036-f5ae-4496-800f-9af7c33f12aa

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
