### PR TITLE
Add subscription types to the payment module

### DIFF
--- a/modules/services/payment/src/main/kotlin/au/com/shiftyjelly/pocketcasts/payment/Data.kt
+++ b/modules/services/payment/src/main/kotlin/au/com/shiftyjelly/pocketcasts/payment/Data.kt
@@ -65,3 +65,216 @@ data class BillingPeriod(
         data object Infinite : Cycle
     }
 }
+
+class SubscriptionPlans private constructor(
+    private val plans: Map<Key, PaymentResult<SubscriptionPlan>>,
+) {
+    fun getBasePlan(
+        tier: SubscriptionTier,
+        billingCycle: SubscriptionBillingCycle,
+    ): SubscriptionPlan.Base {
+        val key = Key(tier, billingCycle, offer = null)
+        // This is a safe cast because constructor is private and we validate data in the create function
+        return plans.getValue(key).getOrNull() as SubscriptionPlan.Base
+    }
+
+    fun findOfferPlan(
+        tier: SubscriptionTier,
+        billingCycle: SubscriptionBillingCycle,
+        offer: SubscriptionOffer,
+    ): PaymentResult<SubscriptionPlan.WithOffer> {
+        val key = Key(tier, billingCycle, offer)
+        // This is a safe cast because constructor is private and we validate data in the create function
+        @Suppress("UNCHECKED_CAST")
+        return plans.getValue(key) as PaymentResult<SubscriptionPlan.WithOffer>
+    }
+
+    companion object {
+        private val basePlanKeys = SubscriptionTier.entries.flatMap { tier ->
+            SubscriptionBillingCycle.entries.map { billingCycle ->
+                Key(tier, billingCycle, offer = null)
+            }
+        }
+
+        private val offerPlanKeys = SubscriptionTier.entries.flatMap { tier ->
+            SubscriptionBillingCycle.entries.flatMap { billingCycle ->
+                SubscriptionOffer.entries.map { offer ->
+                    Key(tier, billingCycle, offer)
+                }
+            }
+        }
+
+
+        fun create(products: List<Product>): PaymentResult<SubscriptionPlans> {
+            val basePlans = basePlanKeys.associateWith { key -> products.findMatchingSubscriptionPlan(key) }
+            val basePlanFailure = basePlans.values
+                .filterIsInstance<PaymentResult.Failure>()
+                .firstOrNull()
+            if (basePlanFailure != null) {
+                return basePlanFailure
+            }
+            val offerPlans = offerPlanKeys.associateWith { key -> products.findMatchingSubscriptionPlan(key) }
+
+            return PaymentResult.Success(SubscriptionPlans(basePlans + offerPlans))
+        }
+
+        private fun List<Product>.findMatchingSubscriptionPlan(key: Key): PaymentResult<SubscriptionPlan> {
+            val matchingProducts = findMatchingProducts(key)
+            return when (matchingProducts.size) {
+                1 -> PaymentResult.Success(
+                    if (key.offer != null) {
+                        matchingProducts[0].toOfferSubscriptionPlan(key)
+                    } else {
+                        matchingProducts[0].toBaseSubscriptionPlan(key)
+                    },
+                )
+                0 -> PaymentResult.Failure("No matching product found for $key")
+                else -> PaymentResult.Failure("Multiple matching products found for $key. $matchingProducts")
+            }
+        }
+
+        private fun List<Product>.findMatchingProducts(key: Key): List<Product> {
+            return filter { product ->
+                val offerCondition = if (key.offer != null) {
+                    product.pricingPlans.offerPlans.singleOrNull { it.offerId == key.offerId } != null
+                } else {
+                    product.pricingPlans.basePlan.pricingPhases.size == 1
+                }
+                product.id == key.productId && product.pricingPlans.basePlan.planId == key.basePlanId && offerCondition
+            }
+        }
+
+        private fun Product.toBaseSubscriptionPlan(key: Key): SubscriptionPlan.Base {
+            return SubscriptionPlan.Base(
+                name,
+                key.tier,
+                key.billingCycle,
+                pricingPlans.basePlan.pricingPhases[0],
+            )
+        }
+
+        private fun Product.toOfferSubscriptionPlan(key: Key): SubscriptionPlan.WithOffer {
+            checkNotNull(key.offer)
+            val matchingPricingPhases = pricingPlans.offerPlans.single { it.offerId == key.offerId }.pricingPhases
+            return SubscriptionPlan.WithOffer(
+                name,
+                key.tier,
+                key.billingCycle,
+                key.offer,
+                matchingPricingPhases
+            )
+        }
+    }
+
+    private data class Key(
+        val tier: SubscriptionTier,
+        val billingCycle: SubscriptionBillingCycle,
+        val offer: SubscriptionOffer?,
+    ) {
+        val productId = SubscriptionPlan.productId(tier, billingCycle)
+        val basePlanId = SubscriptionPlan.basePlanId(tier, billingCycle)
+        val offerId = offer?.offerId(tier, billingCycle)
+    }
+}
+
+sealed interface SubscriptionPlan {
+    val name: String
+    val tier: SubscriptionTier
+    val billingCycle: SubscriptionBillingCycle
+
+    data class Base(
+        override val name: String,
+        override val tier: SubscriptionTier,
+        override val billingCycle: SubscriptionBillingCycle,
+        val pricingPhase: PricingPhase,
+    ) : SubscriptionPlan
+
+    data class WithOffer(
+        override val name: String,
+        override val tier: SubscriptionTier,
+        override val billingCycle: SubscriptionBillingCycle,
+        val offer: SubscriptionOffer,
+        val pricingPhases: List<PricingPhase>,
+    ) : SubscriptionPlan
+
+    companion object {
+        fun productId(
+            tier: SubscriptionTier,
+            billingCycle: SubscriptionBillingCycle,
+        ) = when (tier) {
+            SubscriptionTier.Plus -> when (billingCycle) {
+                SubscriptionBillingCycle.Monthly -> "com.pocketcasts.plus.monthly"
+                SubscriptionBillingCycle.Yearly -> "com.pocketcasts.plus.yearly"
+            }
+
+            SubscriptionTier.Patron -> when (billingCycle) {
+                SubscriptionBillingCycle.Monthly -> "com.pocketcasts.monthly.patron"
+                SubscriptionBillingCycle.Yearly -> "com.pocketcasts.yearly.patron"
+            }
+        }
+
+        fun basePlanId(
+            tier: SubscriptionTier,
+            billingCycle: SubscriptionBillingCycle,
+        ) = when (tier) {
+            SubscriptionTier.Plus -> when (billingCycle) {
+                SubscriptionBillingCycle.Monthly -> "p1m"
+                SubscriptionBillingCycle.Yearly -> "p1y"
+            }
+
+            SubscriptionTier.Patron -> when (billingCycle) {
+                SubscriptionBillingCycle.Monthly -> "patron-monthly"
+                SubscriptionBillingCycle.Yearly -> "patron-yearly"
+            }
+        }
+    }
+}
+
+enum class SubscriptionTier {
+    Plus,
+    Patron,
+}
+
+enum class SubscriptionBillingCycle {
+    Monthly,
+    Yearly,
+}
+
+enum class SubscriptionOffer {
+    Trial,
+    Referral,
+    Winback,
+    ;
+
+    fun offerId(tier: SubscriptionTier, billingCycle: SubscriptionBillingCycle) = when (this) {
+        Trial -> when (tier) {
+            SubscriptionTier.Plus -> when (billingCycle) {
+                SubscriptionBillingCycle.Monthly -> null
+                SubscriptionBillingCycle.Yearly -> "plus-yearly-trial-30days"
+            }
+
+            SubscriptionTier.Patron -> null
+        }
+
+        Referral -> when (tier) {
+            SubscriptionTier.Plus -> when (billingCycle) {
+                SubscriptionBillingCycle.Monthly -> null
+                SubscriptionBillingCycle.Yearly -> "plus-yearly-referral-two-months-free"
+            }
+
+            SubscriptionTier.Patron -> null
+        }
+
+        Winback -> when (tier) {
+            SubscriptionTier.Plus -> when (billingCycle) {
+                SubscriptionBillingCycle.Monthly -> "plus-monthly-winback"
+                SubscriptionBillingCycle.Yearly -> "plus-yearly-winback"
+            }
+
+            SubscriptionTier.Patron -> when (billingCycle) {
+                SubscriptionBillingCycle.Monthly -> "patron-monthly-winback"
+                SubscriptionBillingCycle.Yearly -> "patron-yearly-winback"
+            }
+        }
+    }
+}

--- a/modules/services/payment/src/main/kotlin/au/com/shiftyjelly/pocketcasts/payment/Data.kt
+++ b/modules/services/payment/src/main/kotlin/au/com/shiftyjelly/pocketcasts/payment/Data.kt
@@ -252,7 +252,10 @@ enum class SubscriptionOffer {
     Winback,
     ;
 
-    fun offerId(tier: SubscriptionTier, billingCycle: SubscriptionBillingCycle) = when (this) {
+    fun offerId(
+        tier: SubscriptionTier,
+        billingCycle: SubscriptionBillingCycle,
+    ) = when (this) {
         Trial -> when (tier) {
             SubscriptionTier.Plus -> when (billingCycle) {
                 SubscriptionBillingCycle.Monthly -> null

--- a/modules/services/payment/src/main/kotlin/au/com/shiftyjelly/pocketcasts/payment/Data.kt
+++ b/modules/services/payment/src/main/kotlin/au/com/shiftyjelly/pocketcasts/payment/Data.kt
@@ -89,6 +89,12 @@ class SubscriptionPlans private constructor(
         return plans.getValue(key) as PaymentResult<SubscriptionPlan.WithOffer>
     }
 
+    override fun equals(other: Any?) = (other === this) || (other is SubscriptionPlans && other.plans == this.plans)
+
+    override fun hashCode() = plans.hashCode()
+
+    override fun toString() = "SubscriptionPlans(plans=$plans)"
+
     companion object {
         private val basePlanKeys = SubscriptionTier.entries.flatMap { tier ->
             SubscriptionBillingCycle.entries.map { billingCycle ->
@@ -103,7 +109,6 @@ class SubscriptionPlans private constructor(
                 }
             }
         }
-
 
         fun create(products: List<Product>): PaymentResult<SubscriptionPlans> {
             val basePlans = basePlanKeys.associateWith { key -> products.findMatchingSubscriptionPlan(key) }
@@ -128,6 +133,7 @@ class SubscriptionPlans private constructor(
                         matchingProducts[0].toBaseSubscriptionPlan(key)
                     },
                 )
+
                 0 -> PaymentResult.Failure("No matching product found for $key")
                 else -> PaymentResult.Failure("Multiple matching products found for $key. $matchingProducts")
             }
@@ -161,7 +167,7 @@ class SubscriptionPlans private constructor(
                 key.tier,
                 key.billingCycle,
                 key.offer,
-                matchingPricingPhases
+                matchingPricingPhases,
             )
         }
     }

--- a/modules/services/payment/src/main/kotlin/au/com/shiftyjelly/pocketcasts/payment/PaymentResult.kt
+++ b/modules/services/payment/src/main/kotlin/au/com/shiftyjelly/pocketcasts/payment/PaymentResult.kt
@@ -1,0 +1,12 @@
+package au.com.shiftyjelly.pocketcasts.payment
+
+sealed interface PaymentResult<out T : Any> {
+    data class Success<out T : Any>(val value: T) : PaymentResult<T>
+
+    data class Failure(val message: String) : PaymentResult<Nothing>
+}
+
+fun <T : Any> PaymentResult<T>.getOrNull() = when (this) {
+    is PaymentResult.Success -> value
+    is PaymentResult.Failure -> null
+}

--- a/modules/services/payment/src/test/kotlin/au/com/shiftyjelly/pocketcasts/payment/PaymentResultTest.kt
+++ b/modules/services/payment/src/test/kotlin/au/com/shiftyjelly/pocketcasts/payment/PaymentResultTest.kt
@@ -1,0 +1,21 @@
+package au.com.shiftyjelly.pocketcasts.payment
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class PaymentResultTest {
+    @Test
+    fun `getOrNull for success`() {
+        val result = PaymentResult.Success(10)
+
+        assertEquals(10, result.getOrNull())
+    }
+
+    @Test
+    fun `getOrNull for failure`() {
+        val result: PaymentResult<Int> = PaymentResult.Failure("Error")
+
+        assertNull(result.getOrNull())
+    }
+}

--- a/modules/services/payment/src/test/kotlin/au/com/shiftyjelly/pocketcasts/payment/SubscriptionPlansTest.kt
+++ b/modules/services/payment/src/test/kotlin/au/com/shiftyjelly/pocketcasts/payment/SubscriptionPlansTest.kt
@@ -1,0 +1,292 @@
+package au.com.shiftyjelly.pocketcasts.payment
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class SubscriptionPlansTest {
+    private val pricingPhase = PricingPhase(
+        Price(100.toBigDecimal(), "USD", "$100.00"),
+        BillingPeriod(BillingPeriod.Cycle.Infinite, BillingPeriod.Interval.Yearly, intervalCount = 1),
+    )
+
+    private val products = SubscriptionTier.entries.flatMap { tier ->
+        SubscriptionBillingCycle.entries.map { billingCycle ->
+            Product(
+                id = SubscriptionPlan.productId(tier, billingCycle),
+                name = "$tier $billingCycle",
+                pricingPlans = PricingPlans(
+                    basePlan = PricingPlan.Base(
+                        planId = SubscriptionPlan.basePlanId(tier, billingCycle),
+                        pricingPhases = listOf(pricingPhase),
+                        tags = emptyList(),
+                    ),
+                    offerPlans = SubscriptionOffer.entries
+                        .mapNotNull { offer -> offer.offerId(tier, billingCycle) }
+                        .map { offerId ->
+                            PricingPlan.Offer(
+                                offerId = offerId,
+                                planId = SubscriptionPlan.basePlanId(tier, billingCycle),
+                                pricingPhases = listOf(pricingPhase, pricingPhase),
+                                tags = emptyList(),
+                            )
+                        },
+                ),
+            )
+        }
+    }
+
+    @Test
+    fun `create subscription plans`() {
+        val plans = SubscriptionPlans.create(products).getOrNull()
+
+        assertNotNull(plans)
+    }
+
+    @Test
+    fun `get plus monthly base plan`() {
+        val plans = SubscriptionPlans.create(products).getOrNull()!!
+
+        val plan = plans.getBasePlan(SubscriptionTier.Plus, SubscriptionBillingCycle.Monthly)
+
+        assertEquals("Plus Monthly", plan.name)
+        assertEquals(SubscriptionTier.Plus, plan.tier)
+        assertEquals(SubscriptionBillingCycle.Monthly, plan.billingCycle)
+    }
+
+    @Test
+    fun `get plus yearly base plan`() {
+        val plans = SubscriptionPlans.create(products).getOrNull()!!
+
+        val plan = plans.getBasePlan(SubscriptionTier.Plus, SubscriptionBillingCycle.Yearly)
+
+        assertEquals("Plus Yearly", plan.name)
+        assertEquals(SubscriptionTier.Plus, plan.tier)
+        assertEquals(SubscriptionBillingCycle.Yearly, plan.billingCycle)
+    }
+
+    @Test
+    fun `get patron monthly base plan`() {
+        val plans = SubscriptionPlans.create(products).getOrNull()!!
+
+        val plan = plans.getBasePlan(SubscriptionTier.Patron, SubscriptionBillingCycle.Monthly)
+
+        assertEquals("Patron Monthly", plan.name)
+        assertEquals(SubscriptionTier.Patron, plan.tier)
+        assertEquals(SubscriptionBillingCycle.Monthly, plan.billingCycle)
+    }
+
+    @Test
+    fun `get patron yearly base plan`() {
+        val plans = SubscriptionPlans.create(products).getOrNull()!!
+
+        val plan = plans.getBasePlan(SubscriptionTier.Patron, SubscriptionBillingCycle.Yearly)
+
+        assertEquals("Patron Yearly", plan.name)
+        assertEquals(SubscriptionTier.Patron, plan.tier)
+        assertEquals(SubscriptionBillingCycle.Yearly, plan.billingCycle)
+    }
+
+    @Test
+    fun `find plus monthly winback plan`() {
+        val plans = SubscriptionPlans.create(products).getOrNull()!!
+
+        val plan = plans.findOfferPlan(
+            SubscriptionTier.Plus,
+            SubscriptionBillingCycle.Monthly,
+            SubscriptionOffer.Winback,
+        ).getOrNull()!!
+
+        assertEquals("Plus Monthly", plan.name)
+        assertEquals(SubscriptionTier.Plus, plan.tier)
+        assertEquals(SubscriptionBillingCycle.Monthly, plan.billingCycle)
+        assertEquals(SubscriptionOffer.Winback, plan.offer)
+    }
+
+    @Test
+    fun `find plus yearly winback plan`() {
+        val plans = SubscriptionPlans.create(products).getOrNull()!!
+
+        val plan = plans.findOfferPlan(
+            SubscriptionTier.Plus,
+            SubscriptionBillingCycle.Yearly,
+            SubscriptionOffer.Winback,
+        ).getOrNull()!!
+
+        assertEquals("Plus Yearly", plan.name)
+        assertEquals(SubscriptionTier.Plus, plan.tier)
+        assertEquals(SubscriptionBillingCycle.Yearly, plan.billingCycle)
+        assertEquals(SubscriptionOffer.Winback, plan.offer)
+    }
+
+    @Test
+    fun `find patron monthly winback plan`() {
+        val plans = SubscriptionPlans.create(products).getOrNull()!!
+
+        val plan = plans.findOfferPlan(
+            SubscriptionTier.Patron,
+            SubscriptionBillingCycle.Monthly,
+            SubscriptionOffer.Winback,
+        ).getOrNull()!!
+
+        assertEquals("Patron Monthly", plan.name)
+        assertEquals(SubscriptionTier.Patron, plan.tier)
+        assertEquals(SubscriptionBillingCycle.Monthly, plan.billingCycle)
+        assertEquals(SubscriptionOffer.Winback, plan.offer)
+    }
+
+    @Test
+    fun `find patron yearly winback plan`() {
+        val plans = SubscriptionPlans.create(products).getOrNull()!!
+
+        val plan = plans.findOfferPlan(
+            SubscriptionTier.Patron,
+            SubscriptionBillingCycle.Yearly,
+            SubscriptionOffer.Winback,
+        ).getOrNull()!!
+
+        assertEquals("Patron Yearly", plan.name)
+        assertEquals(SubscriptionTier.Patron, plan.tier)
+        assertEquals(SubscriptionBillingCycle.Yearly, plan.billingCycle)
+        assertEquals(SubscriptionOffer.Winback, plan.offer)
+    }
+
+    @Test
+    fun `find plus yearly referral plan`() {
+        val plans = SubscriptionPlans.create(products).getOrNull()!!
+
+        val plan = plans.findOfferPlan(
+            SubscriptionTier.Plus,
+            SubscriptionBillingCycle.Yearly,
+            SubscriptionOffer.Referral,
+        ).getOrNull()!!
+
+        assertEquals("Plus Yearly", plan.name)
+        assertEquals(SubscriptionTier.Plus, plan.tier)
+        assertEquals(SubscriptionBillingCycle.Yearly, plan.billingCycle)
+        assertEquals(SubscriptionOffer.Referral, plan.offer)
+    }
+
+    @Test
+    fun `find plus yearly trial plan`() {
+        val plans = SubscriptionPlans.create(products).getOrNull()!!
+
+        val plan = plans.findOfferPlan(
+            SubscriptionTier.Plus,
+            SubscriptionBillingCycle.Yearly,
+            SubscriptionOffer.Trial,
+        ).getOrNull()!!
+
+        assertEquals("Plus Yearly", plan.name)
+        assertEquals(SubscriptionTier.Plus, plan.tier)
+        assertEquals(SubscriptionBillingCycle.Yearly, plan.billingCycle)
+        assertEquals(SubscriptionOffer.Trial, plan.offer)
+    }
+
+    @Test
+    fun `do not find unknown offer plan`() {
+        val plans = SubscriptionPlans.create(products).getOrNull()!!
+
+        val plan = plans.findOfferPlan(
+            SubscriptionTier.Patron,
+            SubscriptionBillingCycle.Monthly,
+            SubscriptionOffer.Trial,
+        ).getOrNull()
+
+        assertNull(plan)
+    }
+
+    @Test
+    fun `do not create plans when plus monthly product is missing`() {
+        val products = products.filter { it.id != SubscriptionPlan.productId(SubscriptionTier.Plus, SubscriptionBillingCycle.Monthly) }
+
+        val plans = SubscriptionPlans.create(products).getOrNull()
+
+        assertNull(plans)
+    }
+
+    @Test
+    fun `do not create plans when plus yearly product is missing`() {
+        val products = products.filter { it.id != SubscriptionPlan.productId(SubscriptionTier.Plus, SubscriptionBillingCycle.Yearly) }
+
+        val plans = SubscriptionPlans.create(products).getOrNull()
+
+        assertNull(plans)
+    }
+
+    @Test
+    fun `do not create plans when patron monthly product is missing`() {
+        val products = products.filter { it.id != SubscriptionPlan.productId(SubscriptionTier.Patron, SubscriptionBillingCycle.Monthly) }
+
+        val plans = SubscriptionPlans.create(products).getOrNull()
+
+        assertNull(plans)
+    }
+
+    @Test
+    fun `do not create plans when patron yearly product is missing`() {
+        val products = products.filter { it.id != SubscriptionPlan.productId(SubscriptionTier.Patron, SubscriptionBillingCycle.Yearly) }
+
+        val plans = SubscriptionPlans.create(products).getOrNull()
+
+        assertNull(plans)
+    }
+
+    @Test
+    fun `do not create plans when base plan has multiple pricing phases`() {
+        val products = products.map { product ->
+            if (product.id == SubscriptionPlan.productId(SubscriptionTier.Patron, SubscriptionBillingCycle.Yearly)) {
+                val basePlan = product.pricingPlans.basePlan.copy(pricingPhases = listOf(pricingPhase, pricingPhase))
+                val pricingPlans = product.pricingPlans.copy(basePlan = basePlan)
+                product.copy(pricingPlans = pricingPlans)
+            } else {
+                product
+            }
+        }
+
+        val plans = SubscriptionPlans.create(products).getOrNull()
+
+        assertNull(plans)
+    }
+
+    @Test
+    fun `do not create plans when base plan has multiple matching products`() {
+        val products = products + products[0]
+
+        val plans = SubscriptionPlans.create(products).getOrNull()
+
+        assertNull(plans)
+    }
+
+    @Test
+    fun `create plans when offer plan has multiple matching products`() {
+        val products = products.map { product ->
+            val offerPlans = product.pricingPlans.offerPlans
+            val pricingPlans = product.pricingPlans.copy(offerPlans = offerPlans + offerPlans)
+            product.copy(pricingPlans = pricingPlans)
+        }
+
+        val plans = SubscriptionPlans.create(products).getOrNull()
+
+        assertNotNull(plans)
+    }
+
+    @Test
+    fun `do not find offers when ther are multiple matching ones`() {
+        val products = products.map { product ->
+            val offerPlans = product.pricingPlans.offerPlans
+            val pricingPlans = product.pricingPlans.copy(offerPlans = offerPlans + offerPlans)
+            product.copy(pricingPlans = pricingPlans)
+        }
+        val plans = SubscriptionPlans.create(products).getOrNull()!!
+
+        val plan = plans.findOfferPlan(
+            SubscriptionTier.Plus,
+            SubscriptionBillingCycle.Yearly,
+            SubscriptionOffer.Winback,
+        ).getOrNull()
+
+        assertNull(plan)
+    }
+}


### PR DESCRIPTION
## Description

This PR adds data models for Pocket Casts-specific subscription types. There are a few key assumptions:

1. All base plans (Plus Monthly, Plus Yearly, Patron Monthly, Patron Yearly) must be present.
2. A base plan has only a single pricing phase.

Our current code already somewhat assumes this, but it's not explicitly modeled in the types, which makes it harder to manage. The proposed approach makes these assumptions explicit.

I considered creating specific types for offer subscriptions. For example, we expect that Winback offers consist of a single discounted pricing phase followed by the base one. However, I don't believe that's the right approach. I think such specific handling should live in repositories or view models that deal with offer logic. This way, all subscription offers can be modeled using a single type, which helps reduce the API surface and minimizes code churn in the payment module.

One oddity you might notice is the `PaymentResult` type. It currently has only the `getOrNull()` function. This type will be expanded with functions like `map()`, `flatMap()`, etc., as the payment module evolves. For now, it's a simple container to provide a uniform API across payment-related methods. Ideally, I’d use [Arrow’s `Either` type](https://arrow-kt.io/learn/typed-errors/either-and-ior/), which is more generic. But I’m not sure if everyone is comfortable with adding it. If people are on board, we should probably introduce it in a separate step and then replace `PaymentResult`, which shouldn't be too difficult.

## Testing Instructions

Code review the API.

## Checklist
- [ ] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] ~I have considered whether it makes sense to add tests for my changes~
- [ ] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [ ] ~Any jetpack compose components I added or changed are covered by compose previews~
- [ ] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~