### PR TITLE
Load subscriptions plans

### DIFF
--- a/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
+++ b/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
@@ -92,6 +92,7 @@ import au.com.shiftyjelly.pocketcasts.models.type.EpisodeViewSource
 import au.com.shiftyjelly.pocketcasts.navigation.BottomNavigator
 import au.com.shiftyjelly.pocketcasts.navigation.FragmentInfo
 import au.com.shiftyjelly.pocketcasts.navigation.NavigatorAction
+import au.com.shiftyjelly.pocketcasts.payment.PaymentClient
 import au.com.shiftyjelly.pocketcasts.player.view.PlayerBottomSheet
 import au.com.shiftyjelly.pocketcasts.player.view.PlayerContainerFragment
 import au.com.shiftyjelly.pocketcasts.player.view.UpNextFragment
@@ -245,6 +246,8 @@ class MainActivity :
     lateinit var applicationScope: CoroutineScope
 
     @Inject lateinit var crashLogging: CrashLogging
+
+    @Inject lateinit var paymentClient: PaymentClient
 
     private val viewModel: MainActivityViewModel by viewModels()
     private val disposables = CompositeDisposable()
@@ -483,6 +486,13 @@ class MainActivity :
         ThemeSettingObserver(this, theme, settings.themeReconfigurationEvents).observeThemeChanges()
 
         encourageAccountCreation()
+
+        if (BuildConfig.DEBUG) {
+            lifecycleScope.launch {
+                delay(5000)
+                paymentClient.loadSubscriptionPlans()
+            }
+        }
     }
 
     private fun resetEoYBadgeIfNeeded() {

--- a/modules/services/payment/build.gradle.kts
+++ b/modules/services/payment/build.gradle.kts
@@ -1,6 +1,8 @@
 plugins {
     alias(libs.plugins.android.library)
     alias(libs.plugins.kotlin.android)
+    alias(libs.plugins.ksp)
+    alias(libs.plugins.hilt)
 }
 
 android {
@@ -12,8 +14,12 @@ android {
 }
 
 dependencies {
+    ksp(libs.dagger.hilt.compiler)
+    ksp(libs.hilt.compiler)
+
     api(libs.billing.ktx)
     api(libs.coroutines.core)
+    api(libs.dagger.hilt.android)
 
     testImplementation(libs.coroutines.test)
     testImplementation(libs.junit)

--- a/modules/services/payment/build.gradle.kts
+++ b/modules/services/payment/build.gradle.kts
@@ -15,6 +15,7 @@ dependencies {
     api(libs.billing.ktx)
     api(libs.coroutines.core)
 
+    testImplementation(libs.coroutines.test)
     testImplementation(libs.junit)
     testImplementation(libs.robolectric)
 }

--- a/modules/services/payment/src/main/kotlin/au/com/shiftyjelly/pocketcasts/payment/FakePaymentDataSource.kt
+++ b/modules/services/payment/src/main/kotlin/au/com/shiftyjelly/pocketcasts/payment/FakePaymentDataSource.kt
@@ -1,0 +1,143 @@
+package au.com.shiftyjelly.pocketcasts.payment
+
+import java.math.BigDecimal
+
+class FakePaymentDataSource : PaymentDataSource {
+    var customProductsResult: PaymentResult<List<Product>>? = null
+
+    override suspend fun loadProducts(): PaymentResult<List<Product>> {
+        return customProductsResult ?: PaymentResult.Success(KnownProducts)
+    }
+}
+
+private val KnownProducts = SubscriptionTier.entries.flatMap { tier ->
+    SubscriptionBillingCycle.entries.map { billingCycle ->
+        Product(
+            SubscriptionPlan.productId(tier, billingCycle),
+            productName(tier, billingCycle),
+            PricingPlans(
+                PricingPlan.Base(
+                    SubscriptionPlan.basePlanId(tier, billingCycle),
+                    pricingPhases(tier, billingCycle, offer = null),
+                    emptyList(),
+                ),
+                SubscriptionOffer.entries
+                    .mapNotNull { offer -> offer.offerId(tier, billingCycle)?.let { offer to it } }
+                    .map { (offer, offerId) ->
+                        PricingPlan.Offer(
+                            offerId,
+                            SubscriptionPlan.basePlanId(tier, billingCycle),
+                            pricingPhases(tier, billingCycle, offer),
+                            emptyList(),
+                        )
+                    },
+            ),
+        )
+    }
+}
+
+private fun productName(
+    tier: SubscriptionTier,
+    billingCycle: SubscriptionBillingCycle,
+) = "$tier $billingCycle (Fake)"
+
+private fun pricingPhases(
+    tier: SubscriptionTier,
+    billingCycle: SubscriptionBillingCycle,
+    offer: SubscriptionOffer?,
+): List<PricingPhase> = when (offer) {
+    SubscriptionOffer.Trial -> when (billingCycle) {
+        SubscriptionBillingCycle.Yearly -> when (tier) {
+            SubscriptionTier.Plus -> listOf(
+                PlusYearlyPricingPhase.withDiscount(priceFraction = 0.0),
+                PlusYearlyPricingPhase,
+            )
+
+            SubscriptionTier.Patron -> emptyList()
+        }
+
+        SubscriptionBillingCycle.Monthly -> emptyList()
+    }
+
+    SubscriptionOffer.Referral -> when (billingCycle) {
+        SubscriptionBillingCycle.Yearly -> when (tier) {
+            SubscriptionTier.Plus -> listOf(
+                PlusYearlyPricingPhase.withDiscount(priceFraction = 0.0, intervalCount = 2),
+                PlusYearlyPricingPhase,
+            )
+
+            SubscriptionTier.Patron -> emptyList()
+        }
+
+        SubscriptionBillingCycle.Monthly -> emptyList()
+    }
+
+    SubscriptionOffer.Winback -> when (billingCycle) {
+        SubscriptionBillingCycle.Monthly -> when (tier) {
+            SubscriptionTier.Plus -> listOf(
+                PlusMonthlyPricingPhase.withDiscount(priceFraction = 0.5),
+                PlusMonthlyPricingPhase,
+            )
+
+            SubscriptionTier.Patron -> listOf(
+                PatronMonthlyPricingPhase.withDiscount(priceFraction = 0.5),
+                PatronMonthlyPricingPhase,
+            )
+        }
+
+        SubscriptionBillingCycle.Yearly -> when (tier) {
+            SubscriptionTier.Plus -> listOf(
+                PlusYearlyPricingPhase.withDiscount(priceFraction = 0.5, interval = BillingPeriod.Interval.Yearly),
+                PlusYearlyPricingPhase,
+            )
+
+            SubscriptionTier.Patron -> listOf(
+                PatronYearlyPricingPhase.withDiscount(priceFraction = 0.5, interval = BillingPeriod.Interval.Yearly),
+                PatronYearlyPricingPhase,
+            )
+        }
+    }
+
+    null -> when (billingCycle) {
+        SubscriptionBillingCycle.Monthly -> when (tier) {
+            SubscriptionTier.Plus -> listOf(PlusMonthlyPricingPhase)
+            SubscriptionTier.Patron -> listOf(PatronMonthlyPricingPhase)
+        }
+
+        SubscriptionBillingCycle.Yearly -> when (tier) {
+            SubscriptionTier.Plus -> listOf(PlusYearlyPricingPhase)
+            SubscriptionTier.Patron -> listOf(PatronYearlyPricingPhase)
+        }
+    }
+}
+
+private val PlusMonthlyPricingPhase = PricingPhase(
+    Price(3.99.toBigDecimal(), "USD", "$3.99"),
+    BillingPeriod(BillingPeriod.Cycle.Infinite, BillingPeriod.Interval.Monthly, intervalCount = 0),
+)
+private val PlusYearlyPricingPhase = PricingPhase(
+    Price(39.99.toBigDecimal(), "USD", "$39.99"),
+    BillingPeriod(BillingPeriod.Cycle.Infinite, BillingPeriod.Interval.Monthly, intervalCount = 0),
+)
+private val PatronMonthlyPricingPhase = PricingPhase(
+    Price(9.99.toBigDecimal(), "USD", "$9.99"),
+    BillingPeriod(BillingPeriod.Cycle.Infinite, BillingPeriod.Interval.Monthly, intervalCount = 0),
+)
+private val PatronYearlyPricingPhase = PricingPhase(
+    Price(99.99.toBigDecimal(), "USD", "$99.99"),
+    BillingPeriod(BillingPeriod.Cycle.Infinite, BillingPeriod.Interval.Yearly, intervalCount = 0),
+)
+
+private fun PricingPhase.withDiscount(
+    priceFraction: Double,
+    cycle: BillingPeriod.Cycle = BillingPeriod.Cycle.Recurring(1),
+    interval: BillingPeriod.Interval = BillingPeriod.Interval.Monthly,
+    intervalCount: Int = 1,
+): PricingPhase {
+    val newAmount = price.amount.times(priceFraction.coerceIn(0.0..1.0).toBigDecimal())
+    val newFormattedPrice = if (newAmount == BigDecimal.ZERO) "Free" else "$%.2f".format(newAmount.toDouble())
+    return copy(
+        price = price.copy(amount = newAmount, formattedPrice = newFormattedPrice),
+        billingPeriod = BillingPeriod(cycle, interval, intervalCount),
+    )
+}

--- a/modules/services/payment/src/main/kotlin/au/com/shiftyjelly/pocketcasts/payment/FakePaymentDataSource.kt
+++ b/modules/services/payment/src/main/kotlin/au/com/shiftyjelly/pocketcasts/payment/FakePaymentDataSource.kt
@@ -1,6 +1,18 @@
 package au.com.shiftyjelly.pocketcasts.payment
 
+import android.app.Activity
+import com.android.billingclient.api.AcknowledgePurchaseParams
+import com.android.billingclient.api.BillingFlowParams
+import com.android.billingclient.api.BillingResult
+import com.android.billingclient.api.ProductDetails
+import com.android.billingclient.api.Purchase
+import com.android.billingclient.api.PurchaseHistoryRecord
+import com.android.billingclient.api.QueryProductDetailsParams
+import com.android.billingclient.api.QueryPurchaseHistoryParams
+import com.android.billingclient.api.QueryPurchasesParams
 import java.math.BigDecimal
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.SharedFlow
 
 class FakePaymentDataSource : PaymentDataSource {
     var customProductsResult: PaymentResult<List<Product>>? = null
@@ -8,6 +20,31 @@ class FakePaymentDataSource : PaymentDataSource {
     override suspend fun loadProducts(): PaymentResult<List<Product>> {
         return customProductsResult ?: PaymentResult.Success(KnownProducts)
     }
+
+    // <editor-fold desc="Temporarily extracted old interface">
+    override val purchaseUpdates: SharedFlow<Pair<BillingResult, List<Purchase>>> = MutableSharedFlow()
+
+    override suspend fun loadProducts(
+        params: QueryProductDetailsParams,
+    ): Pair<BillingResult, List<ProductDetails>> = BillingResult.newBuilder().build() to emptyList()
+
+    override suspend fun loadPurchaseHistory(
+        params: QueryPurchaseHistoryParams,
+    ): Pair<BillingResult, List<PurchaseHistoryRecord>> = BillingResult.newBuilder().build() to emptyList()
+
+    override suspend fun loadPurchases(
+        params: QueryPurchasesParams,
+    ): Pair<BillingResult, List<Purchase>> = BillingResult.newBuilder().build() to emptyList()
+
+    override suspend fun acknowledgePurchase(
+        params: AcknowledgePurchaseParams,
+    ): BillingResult = BillingResult.newBuilder().build()
+
+    override suspend fun launchBillingFlow(
+        activity: Activity,
+        params: BillingFlowParams,
+    ): BillingResult = BillingResult.newBuilder().build()
+    // </editor-fold>
 }
 
 private val KnownProducts get() = SubscriptionTier.entries.flatMap { tier ->

--- a/modules/services/payment/src/main/kotlin/au/com/shiftyjelly/pocketcasts/payment/FakePaymentDataSource.kt
+++ b/modules/services/payment/src/main/kotlin/au/com/shiftyjelly/pocketcasts/payment/FakePaymentDataSource.kt
@@ -10,7 +10,7 @@ class FakePaymentDataSource : PaymentDataSource {
     }
 }
 
-private val KnownProducts = SubscriptionTier.entries.flatMap { tier ->
+private val KnownProducts get() = SubscriptionTier.entries.flatMap { tier ->
     SubscriptionBillingCycle.entries.map { billingCycle ->
         Product(
             SubscriptionPlan.productId(tier, billingCycle),
@@ -35,6 +35,23 @@ private val KnownProducts = SubscriptionTier.entries.flatMap { tier ->
         )
     }
 }
+
+private val PlusMonthlyPricingPhase get() = PricingPhase(
+    Price(3.99.toBigDecimal(), "USD", "$3.99"),
+    BillingPeriod(BillingPeriod.Cycle.Infinite, BillingPeriod.Interval.Monthly, intervalCount = 0),
+)
+private val PlusYearlyPricingPhase get() = PricingPhase(
+    Price(39.99.toBigDecimal(), "USD", "$39.99"),
+    BillingPeriod(BillingPeriod.Cycle.Infinite, BillingPeriod.Interval.Monthly, intervalCount = 0),
+)
+private val PatronMonthlyPricingPhase get() = PricingPhase(
+    Price(9.99.toBigDecimal(), "USD", "$9.99"),
+    BillingPeriod(BillingPeriod.Cycle.Infinite, BillingPeriod.Interval.Monthly, intervalCount = 0),
+)
+private val PatronYearlyPricingPhase get() = PricingPhase(
+    Price(99.99.toBigDecimal(), "USD", "$99.99"),
+    BillingPeriod(BillingPeriod.Cycle.Infinite, BillingPeriod.Interval.Yearly, intervalCount = 0),
+)
 
 private fun productName(
     tier: SubscriptionTier,
@@ -110,23 +127,6 @@ private fun pricingPhases(
         }
     }
 }
-
-private val PlusMonthlyPricingPhase = PricingPhase(
-    Price(3.99.toBigDecimal(), "USD", "$3.99"),
-    BillingPeriod(BillingPeriod.Cycle.Infinite, BillingPeriod.Interval.Monthly, intervalCount = 0),
-)
-private val PlusYearlyPricingPhase = PricingPhase(
-    Price(39.99.toBigDecimal(), "USD", "$39.99"),
-    BillingPeriod(BillingPeriod.Cycle.Infinite, BillingPeriod.Interval.Monthly, intervalCount = 0),
-)
-private val PatronMonthlyPricingPhase = PricingPhase(
-    Price(9.99.toBigDecimal(), "USD", "$9.99"),
-    BillingPeriod(BillingPeriod.Cycle.Infinite, BillingPeriod.Interval.Monthly, intervalCount = 0),
-)
-private val PatronYearlyPricingPhase = PricingPhase(
-    Price(99.99.toBigDecimal(), "USD", "$99.99"),
-    BillingPeriod(BillingPeriod.Cycle.Infinite, BillingPeriod.Interval.Yearly, intervalCount = 0),
-)
 
 private fun PricingPhase.withDiscount(
     priceFraction: Double,

--- a/modules/services/payment/src/main/kotlin/au/com/shiftyjelly/pocketcasts/payment/PaymentClient.kt
+++ b/modules/services/payment/src/main/kotlin/au/com/shiftyjelly/pocketcasts/payment/PaymentClient.kt
@@ -1,0 +1,15 @@
+package au.com.shiftyjelly.pocketcasts.payment
+
+class PaymentClient(
+    private val dataSource: PaymentDataSource,
+    private val logger: Logger,
+) {
+    suspend fun loadSubscriptionPlans(): PaymentResult<SubscriptionPlans> {
+        logger.info("Load subscription plans")
+        return dataSource
+            .loadProducts()
+            .flatMap(SubscriptionPlans::create)
+            .onSuccess { plans -> logger.info("Subscription plans loaded: $plans") }
+            .onFailure { message -> logger.warning("Failed to load subscription plans: $message") }
+    }
+}

--- a/modules/services/payment/src/main/kotlin/au/com/shiftyjelly/pocketcasts/payment/PaymentClient.kt
+++ b/modules/services/payment/src/main/kotlin/au/com/shiftyjelly/pocketcasts/payment/PaymentClient.kt
@@ -1,6 +1,8 @@
 package au.com.shiftyjelly.pocketcasts.payment
 
-class PaymentClient(
+import javax.inject.Inject
+
+class PaymentClient @Inject constructor(
     private val dataSource: PaymentDataSource,
     private val logger: Logger,
 ) {

--- a/modules/services/payment/src/main/kotlin/au/com/shiftyjelly/pocketcasts/payment/PaymentDataSource.kt
+++ b/modules/services/payment/src/main/kotlin/au/com/shiftyjelly/pocketcasts/payment/PaymentDataSource.kt
@@ -1,9 +1,17 @@
 package au.com.shiftyjelly.pocketcasts.payment
 
+import android.content.Context
+import au.com.shiftyjelly.pocketcasts.payment.billing.BillingPaymentDataSource
+
 interface PaymentDataSource {
     suspend fun loadProducts(): PaymentResult<List<Product>>
 
     companion object {
+        fun billing(
+            context: Context,
+            logger: Logger,
+        ): PaymentDataSource = BillingPaymentDataSource(context, logger)
+
         fun fake() = FakePaymentDataSource()
     }
 }

--- a/modules/services/payment/src/main/kotlin/au/com/shiftyjelly/pocketcasts/payment/PaymentDataSource.kt
+++ b/modules/services/payment/src/main/kotlin/au/com/shiftyjelly/pocketcasts/payment/PaymentDataSource.kt
@@ -1,0 +1,9 @@
+package au.com.shiftyjelly.pocketcasts.payment
+
+interface PaymentDataSource {
+    suspend fun loadProducts(): PaymentResult<List<Product>>
+
+    companion object {
+        fun fake() = FakePaymentDataSource()
+    }
+}

--- a/modules/services/payment/src/main/kotlin/au/com/shiftyjelly/pocketcasts/payment/PaymentDataSource.kt
+++ b/modules/services/payment/src/main/kotlin/au/com/shiftyjelly/pocketcasts/payment/PaymentDataSource.kt
@@ -1,7 +1,18 @@
 package au.com.shiftyjelly.pocketcasts.payment
 
+import android.app.Activity
 import android.content.Context
 import au.com.shiftyjelly.pocketcasts.payment.billing.BillingPaymentDataSource
+import com.android.billingclient.api.AcknowledgePurchaseParams
+import com.android.billingclient.api.BillingFlowParams
+import com.android.billingclient.api.BillingResult
+import com.android.billingclient.api.ProductDetails
+import com.android.billingclient.api.Purchase
+import com.android.billingclient.api.PurchaseHistoryRecord
+import com.android.billingclient.api.QueryProductDetailsParams
+import com.android.billingclient.api.QueryPurchaseHistoryParams
+import com.android.billingclient.api.QueryPurchasesParams
+import kotlinx.coroutines.flow.SharedFlow
 
 interface PaymentDataSource {
     suspend fun loadProducts(): PaymentResult<List<Product>>
@@ -14,4 +25,29 @@ interface PaymentDataSource {
 
         fun fake() = FakePaymentDataSource()
     }
+
+    // <editor-fold desc="Temporarily extracted old interface">
+    val purchaseUpdates: SharedFlow<Pair<BillingResult, List<Purchase>>>
+
+    suspend fun loadProducts(
+        params: QueryProductDetailsParams,
+    ): Pair<BillingResult, List<ProductDetails>>
+
+    suspend fun loadPurchaseHistory(
+        params: QueryPurchaseHistoryParams,
+    ): Pair<BillingResult, List<PurchaseHistoryRecord>>
+
+    suspend fun loadPurchases(
+        params: QueryPurchasesParams,
+    ): Pair<BillingResult, List<Purchase>>
+
+    suspend fun acknowledgePurchase(
+        params: AcknowledgePurchaseParams,
+    ): BillingResult
+
+    suspend fun launchBillingFlow(
+        activity: Activity,
+        params: BillingFlowParams,
+    ): BillingResult
+    // </editor-fold>
 }

--- a/modules/services/payment/src/main/kotlin/au/com/shiftyjelly/pocketcasts/payment/PaymentResult.kt
+++ b/modules/services/payment/src/main/kotlin/au/com/shiftyjelly/pocketcasts/payment/PaymentResult.kt
@@ -6,6 +6,28 @@ sealed interface PaymentResult<out T : Any> {
     data class Failure(val message: String) : PaymentResult<Nothing>
 }
 
+fun <T : Any, R : Any> PaymentResult<T>.map(block: (T) -> R) = when (this) {
+    is PaymentResult.Success -> PaymentResult.Success(block(value))
+    is PaymentResult.Failure -> this
+}
+
+fun <T : Any, R : Any> PaymentResult<T>.flatMap(block: (T) -> PaymentResult<R>) = when (this) {
+    is PaymentResult.Success -> block(value)
+    is PaymentResult.Failure -> this
+}
+
+fun <T : Any> PaymentResult<T>.onSuccess(block: (T) -> Unit) = apply {
+    if (this is PaymentResult.Success) {
+        block(value)
+    }
+}
+
+fun <T : Any> PaymentResult<T>.onFailure(block: (String) -> Unit) = apply {
+    if (this is PaymentResult.Failure) {
+        block(message)
+    }
+}
+
 fun <T : Any> PaymentResult<T>.getOrNull() = when (this) {
     is PaymentResult.Success -> value
     is PaymentResult.Failure -> null

--- a/modules/services/payment/src/main/kotlin/au/com/shiftyjelly/pocketcasts/payment/billing/BillingPaymentDataSource.kt
+++ b/modules/services/payment/src/main/kotlin/au/com/shiftyjelly/pocketcasts/payment/billing/BillingPaymentDataSource.kt
@@ -29,14 +29,14 @@ import com.android.billingclient.api.queryPurchasesAsync
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.asSharedFlow
 
-class BillingPaymentDataSource(
+internal class BillingPaymentDataSource(
     context: Context,
     private val logger: Logger,
 ) : PaymentDataSource {
     private val _purchaseUpdates = MutableSharedFlow<Pair<BillingResult, List<Purchase>>>(
         extraBufferCapacity = 100, // Arbitrarily large number
     )
-    val purchaseUpdates = _purchaseUpdates.asSharedFlow()
+    override val purchaseUpdates = _purchaseUpdates.asSharedFlow()
 
     private val connection = ClientConnection(
         context,
@@ -47,7 +47,7 @@ class BillingPaymentDataSource(
         logger = logger,
     )
 
-    suspend fun loadProducts(
+    override suspend fun loadProducts(
         params: QueryProductDetailsParams,
     ): Pair<BillingResult, List<ProductDetails>> {
         logger.info("Loading products")
@@ -62,7 +62,7 @@ class BillingPaymentDataSource(
         }
     }
 
-    suspend fun loadPurchaseHistory(
+    override suspend fun loadPurchaseHistory(
         params: QueryPurchaseHistoryParams,
     ): Pair<BillingResult, List<PurchaseHistoryRecord>> {
         logger.info("Loading purchase history")
@@ -77,7 +77,7 @@ class BillingPaymentDataSource(
         }
     }
 
-    suspend fun loadPurchases(
+    override suspend fun loadPurchases(
         params: QueryPurchasesParams,
     ): Pair<BillingResult, List<Purchase>> {
         logger.info("Loading purchases")
@@ -92,7 +92,7 @@ class BillingPaymentDataSource(
         }
     }
 
-    suspend fun acknowledgePurchase(
+    override suspend fun acknowledgePurchase(
         params: AcknowledgePurchaseParams,
     ): BillingResult {
         logger.info("Acknowledging purchase: ${params.purchaseToken}")
@@ -107,7 +107,7 @@ class BillingPaymentDataSource(
         }
     }
 
-    suspend fun launchBillingFlow(
+    override suspend fun launchBillingFlow(
         activity: Activity,
         params: BillingFlowParams,
     ): BillingResult {

--- a/modules/services/payment/src/test/kotlin/au/com/shiftyjelly/pocketcasts/payment/PaymentClientTest.kt
+++ b/modules/services/payment/src/test/kotlin/au/com/shiftyjelly/pocketcasts/payment/PaymentClientTest.kt
@@ -1,0 +1,48 @@
+package au.com.shiftyjelly.pocketcasts.payment
+
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class PaymentClientTest {
+    private val dataSource = PaymentDataSource.fake()
+    private val logger = TestLogger()
+    private val client = PaymentClient(dataSource, logger)
+
+    @Test
+    fun `load plans successfully`() = runTest {
+        val plans = client.loadSubscriptionPlans()
+
+        assertNotNull(plans.getOrNull())
+    }
+
+    @Test
+    fun `load plans with failure`() = runTest {
+        dataSource.customProductsResult = PaymentResult.Failure("Test failure")
+
+        val plans = client.loadSubscriptionPlans()
+
+        assertNull(plans.getOrNull())
+    }
+
+    @Test
+    fun `log loading plans successfully`() = runTest {
+        val plans = client.loadSubscriptionPlans()
+
+        logger.assertInfos(
+            "Load subscription plans",
+            "Subscription plans loaded: ${plans.getOrNull()}",
+        )
+    }
+
+    @Test
+    fun `log loading plans with failure`() = runTest {
+        dataSource.customProductsResult = PaymentResult.Failure("Test failure")
+
+        client.loadSubscriptionPlans()
+
+        logger.assertInfos("Load subscription plans")
+        logger.assertWarnings("Failed to load subscription plans: Test failure")
+    }
+}

--- a/modules/services/payment/src/test/kotlin/au/com/shiftyjelly/pocketcasts/payment/PaymentResultTest.kt
+++ b/modules/services/payment/src/test/kotlin/au/com/shiftyjelly/pocketcasts/payment/PaymentResultTest.kt
@@ -18,4 +18,80 @@ class PaymentResultTest {
 
         assertNull(result.getOrNull())
     }
+
+    @Test
+    fun `map for success`() {
+        val result = PaymentResult.Success(10)
+
+        val mapped = result.map { "${it * 2}" }
+
+        assertEquals("20", mapped.getOrNull())
+    }
+
+    @Test
+    fun `map for failure`() {
+        val result: PaymentResult<Int> = PaymentResult.Failure("Error")
+
+        val mapped = result.map { "${it * 2}" }
+
+        assertNull(mapped.getOrNull())
+    }
+
+    @Test
+    fun `flatMap for success`() {
+        val result = PaymentResult.Success(10)
+
+        val mapped = result.flatMap { PaymentResult.Success("${it * 2}") }
+
+        assertEquals("20", mapped.getOrNull())
+    }
+
+    @Test
+    fun `flatMap for failure`() {
+        val result: PaymentResult<Int> = PaymentResult.Failure("Error")
+
+        val mapped = result.flatMap { PaymentResult.Success("${it * 2}") }
+
+        assertNull(mapped.getOrNull())
+    }
+
+    @Test
+    fun `onSuccess for success`() {
+        val result = PaymentResult.Success(10)
+        var value = "Hello"
+
+        result.onSuccess { value = "${it * 2}" }
+
+        assertEquals("20", value)
+    }
+
+    @Test
+    fun `onSuccess for failure`() {
+        val result: PaymentResult<Int> = PaymentResult.Failure("Error")
+        var value = "Hello"
+
+        result.onSuccess { value = "${it * 2}" }
+
+        assertEquals("Hello", value)
+    }
+
+    @Test
+    fun `onFailure for success`() {
+        val result = PaymentResult.Success(10)
+        var value = "Hello"
+
+        result.onFailure { value = it }
+
+        assertEquals("Hello", value)
+    }
+
+    @Test
+    fun `onFailure for failure`() {
+        val result: PaymentResult<Int> = PaymentResult.Failure("Error")
+        var value = "Hello"
+
+        result.onFailure { value = it }
+
+        assertEquals("Error", value)
+    }
 }

--- a/modules/services/payment/src/test/kotlin/au/com/shiftyjelly/pocketcasts/payment/TestLogger.kt
+++ b/modules/services/payment/src/test/kotlin/au/com/shiftyjelly/pocketcasts/payment/TestLogger.kt
@@ -17,6 +17,11 @@ class TestLogger : Logger {
         logs += LogEntry(LogLevel.Error, message)
     }
 
+    fun assertInfos(vararg messages: String) {
+        val infoLogs = logs.filter { it.level == LogLevel.Info }.map { it.message }
+        assertEquals(messages.toList(), infoLogs)
+    }
+
     fun assertWarnings(vararg messages: String) {
         val warningLogs = logs.filter { it.level == LogLevel.Warning }.map { it.message }
         assertEquals(messages.toList(), warningLogs)

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/di/RepositoryProviderModule.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/di/RepositoryProviderModule.kt
@@ -5,7 +5,7 @@ import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.ProcessLifecycleOwner
 import au.com.shiftyjelly.pocketcasts.crashlogging.di.ProvideApplicationScope
 import au.com.shiftyjelly.pocketcasts.payment.Logger
-import au.com.shiftyjelly.pocketcasts.payment.billing.PaymentDataSource
+import au.com.shiftyjelly.pocketcasts.payment.billing.BillingPaymentDataSource
 import au.com.shiftyjelly.pocketcasts.repositories.lists.ListRepository
 import au.com.shiftyjelly.pocketcasts.repositories.sync.SyncAccountManager
 import au.com.shiftyjelly.pocketcasts.repositories.sync.SyncManager
@@ -52,7 +52,7 @@ class RepositoryProviderModule {
     @Singleton
     fun providePaymentDataSource(
         @ApplicationContext context: Context,
-    ) = PaymentDataSource(
+    ) = BillingPaymentDataSource(
         context = context,
         logger = object : Logger {
             override fun info(message: String) {

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/di/RepositoryProviderModule.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/di/RepositoryProviderModule.kt
@@ -6,7 +6,6 @@ import androidx.lifecycle.ProcessLifecycleOwner
 import au.com.shiftyjelly.pocketcasts.crashlogging.di.ProvideApplicationScope
 import au.com.shiftyjelly.pocketcasts.payment.Logger
 import au.com.shiftyjelly.pocketcasts.payment.PaymentDataSource
-import au.com.shiftyjelly.pocketcasts.payment.billing.BillingPaymentDataSource
 import au.com.shiftyjelly.pocketcasts.repositories.lists.ListRepository
 import au.com.shiftyjelly.pocketcasts.repositories.sync.SyncAccountManager
 import au.com.shiftyjelly.pocketcasts.repositories.sync.SyncManager
@@ -70,35 +69,12 @@ class RepositoryProviderModule {
 
     @Provides
     @Singleton
-    fun provideBillingPaymentDataSource(
-        @ApplicationContext context: Context,
-    ) = BillingPaymentDataSource(
-        context = context,
-        logger = object : Logger {
-            override fun info(message: String) {
-                Timber.tag(LogBuffer.TAG_SUBSCRIPTIONS).i(message)
-            }
-
-            override fun warning(message: String) {
-                Timber.tag(LogBuffer.TAG_SUBSCRIPTIONS).w(message)
-                LogBuffer.w(LogBuffer.TAG_SUBSCRIPTIONS, message)
-            }
-
-            override fun error(message: String, exception: Throwable) {
-                Timber.tag(LogBuffer.TAG_SUBSCRIPTIONS).e(exception, message)
-                LogBuffer.e(LogBuffer.TAG_SUBSCRIPTIONS, exception, message)
-            }
-        }
-    )
-
-    @Provides
-    @Singleton
     fun providePaymentDataSource(
         @ApplicationContext context: Context,
         logger: Logger,
     ): PaymentDataSource {
         return if (context.packageName == "au.com.shiftyjelly.pocketcasts") {
-            BillingPaymentDataSource(context, logger)
+            PaymentDataSource.billing(context, logger)
         } else {
             PaymentDataSource.fake()
         }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/subscription/SubscriptionManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/subscription/SubscriptionManagerImpl.kt
@@ -14,7 +14,7 @@ import au.com.shiftyjelly.pocketcasts.models.type.SubscriptionMapper
 import au.com.shiftyjelly.pocketcasts.models.type.SubscriptionPlatform
 import au.com.shiftyjelly.pocketcasts.models.type.SubscriptionPricingPhase
 import au.com.shiftyjelly.pocketcasts.models.type.SubscriptionTier
-import au.com.shiftyjelly.pocketcasts.payment.billing.BillingPaymentDataSource
+import au.com.shiftyjelly.pocketcasts.payment.PaymentDataSource
 import au.com.shiftyjelly.pocketcasts.payment.billing.isOk
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.repositories.sync.SyncManager
@@ -57,7 +57,7 @@ import kotlinx.coroutines.rx2.rxSingle
 
 @Singleton
 class SubscriptionManagerImpl @Inject constructor(
-    private val paymentDataSource: BillingPaymentDataSource,
+    private val paymentDataSource: PaymentDataSource,
     private val subscriptionMapper: SubscriptionMapper,
     private val syncManager: SyncManager,
     private val settings: Settings,

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/subscription/SubscriptionManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/subscription/SubscriptionManagerImpl.kt
@@ -14,7 +14,7 @@ import au.com.shiftyjelly.pocketcasts.models.type.SubscriptionMapper
 import au.com.shiftyjelly.pocketcasts.models.type.SubscriptionPlatform
 import au.com.shiftyjelly.pocketcasts.models.type.SubscriptionPricingPhase
 import au.com.shiftyjelly.pocketcasts.models.type.SubscriptionTier
-import au.com.shiftyjelly.pocketcasts.payment.billing.PaymentDataSource
+import au.com.shiftyjelly.pocketcasts.payment.billing.BillingPaymentDataSource
 import au.com.shiftyjelly.pocketcasts.payment.billing.isOk
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.repositories.sync.SyncManager
@@ -57,7 +57,7 @@ import kotlinx.coroutines.rx2.rxSingle
 
 @Singleton
 class SubscriptionManagerImpl @Inject constructor(
-    private val paymentDataSource: PaymentDataSource,
+    private val paymentDataSource: BillingPaymentDataSource,
     private val subscriptionMapper: SubscriptionMapper,
     private val syncManager: SyncManager,
     private val settings: Settings,


### PR DESCRIPTION
## Description

This PR connects the basic logic of loading subscription plans with the app. Currently, it is only enabled for debug builds to allow testing and verification.

The `PaymentDataSource` interface is an abstraction that, in the real implementation, communicates with the Billing APIs. However, for tests and debug builds, we can use `FakePaymentDataSource` to verify feature interactions.

To simplify the dependency injection logic, I temporarily extracted the public API of the old `BillingClientWrapper` into `PaymentDataSource`. I will remove these methods one by one as I migrate functionality to use the new code.

## Testing Instructions

### Fake data source

1. Install `debug` or `debugProd` variant.
2. Open the app.
3. Wait 10 seconds.
4. Check Logcat and filter by `Payments` log tag.
5. You should see fake subscriptions plans. You can recognize them by word "Fake" in their names.

### Real data source.

1. Apply [this patch](https://github.com/user-attachments/files/19896662/debug-as-prod.patch).
2. Install `debugProd` variant.
3. Open the app.
4. Wait 10 seconds.
5. Check Logcat and filter by `Payments` log tag.
6. You should see real subscriptions plans.

## Checklist
- [ ] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [ ] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [ ] ~Any jetpack compose components I added or changed are covered by compose previews~
- [ ] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~