### PR TITLE
Attempt to fix NoSuchElementException crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,14 @@
     *   Add account encouragement flow
         ([#3909](https://github.com/Automattic/pocket-casts-android/pull/3909))
 *   Bug Fixes
+    *   Fix crash when updating playlist
+        ([#3929](https://github.com/Automattic/pocket-casts-android/pull/3929))
     *   Fix podcast follow in the Discover tab not always working
         ([#3922](https://github.com/Automattic/pocket-casts-android/pull/3922))
-    *   Fix issue with disappearing file image after upload completes
-        ([#3910](https://github.com/Automattic/pocket-casts-android/pull/3910))
     *   Fix missing fullscreen player controls in landscape mode
         ([#3917](https://github.com/Automattic/pocket-casts-android/pull/3917))
+    *   Fix issue with disappearing file image after upload completes
+        ([#3910](https://github.com/Automattic/pocket-casts-android/pull/3910))
 
 7.87
 -----

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/UpNextDao.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/UpNextDao.kt
@@ -149,7 +149,7 @@ abstract class UpNextDao {
         val idToPosition = upNextEpisodes.associate { it.episodeUuid to it.position }
         val podcastEpisodes = findPodcastEpisodes(idToPosition.keys)
         val userEpisodes = if (podcastEpisodes.size != upNextEpisodes.size) findUserEpisodes(idToPosition.keys) else emptyList()
-        return (podcastEpisodes + userEpisodes).sortedBy { idToPosition[it.uuid] }
+        return (podcastEpisodes + userEpisodes).sortedBy { idToPosition.getOrDefault(it.uuid, null) }
     }
 
     @Query("SELECT * FROM up_next_episodes ORDER BY position ASC LIMIT :limit")


### PR DESCRIPTION
## Description
This PR attemts to fix the crash that a user has reported. See [slack](https://a8c.slack.com/archives/C02A333D8LQ/p1745423604825769)

I never managed to reproduce the issue on my end, and to be honest it made me scratch my head.
The reported stack trace looked like this:
```
java.util.NoSuchElementException: Cannot find value for key 87
	at androidx.collection.MutableLongIntMap.androidx.collection.LongIntMap.get(SourceFile:122)
                                          c0.MutableLongIntMap.get
	at au.com.shiftyjelly.pocketcasts.models.db.dao.UpNextDao$getUpNextBaseEpisodes$suspendImpl$$inlined$sortedBy$1.androidx.compose.foundation.text.selection.SelectionManager$getSelectionLayout-Wko1d7g$$inlined$compareBy$1.compare(SourceFile:45)
```

Checked our code and the `sortedBy` clause had this: `idToPosition[it.uuid]`. The brackets are translated to `operator fun Collection.get(key: K): V?` (notice that the return type is nullable)
`sortedBy` also accepts null values.
However the stackTrace was explicit on this:  `NoSuchElementException at androidx.collection.MutableLongIntMap.androidx.collection.LongIntMap.get`
I believe when we build a prod version of the app, the compiler optimises the code and the actual type of `idToPosition` map will be `MutableLongIntMap` since that's the most efficient collection to store this type of data.
But then the `get` method of this collection throws `NoSuchElementException` when there's no value for the given key [docs](https://developer.android.com/reference/kotlin/androidx/collection/LongIntMap#get(kotlin.Long))

Anyways, I changed the operator fun invocation to `Collections.getOrDefault(key: K, defaultValue: V?): V?` hoping that will behave as expected.

## Testing Instructions
1. Start playing some episodes, add some more to the up next queue
2. Kill and relaunch app
- [x] app doesn't crash at any point


## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 