### PR TITLE
Add purchase APIs to the payment module

### DIFF
--- a/modules/services/payment/src/main/kotlin/au/com/shiftyjelly/pocketcasts/payment/Data.kt
+++ b/modules/services/payment/src/main/kotlin/au/com/shiftyjelly/pocketcasts/payment/Data.kt
@@ -134,8 +134,8 @@ class SubscriptionPlans private constructor(
                     },
                 )
 
-                0 -> PaymentResult.Failure("No matching product found for $key")
-                else -> PaymentResult.Failure("Multiple matching products found for $key. $matchingProducts")
+                0 -> PaymentResult.Failure(PaymentResultCode.DeveloperError, "No matching product found for $key")
+                else -> PaymentResult.Failure(PaymentResultCode.DeveloperError, "Multiple matching products found for $key. $matchingProducts")
             }
         }
 

--- a/modules/services/payment/src/main/kotlin/au/com/shiftyjelly/pocketcasts/payment/Data.kt
+++ b/modules/services/payment/src/main/kotlin/au/com/shiftyjelly/pocketcasts/payment/Data.kt
@@ -287,3 +287,27 @@ enum class SubscriptionOffer {
         }
     }
 }
+
+data class Purchase(
+    val state: PurchaseState,
+    val token: String,
+    val productIds: List<String>,
+    val isAcknowledged: Boolean,
+    val isAutoRenewing: Boolean,
+)
+
+sealed interface PurchaseState {
+    val orderId: String?
+
+    data object Pending : PurchaseState {
+        override val orderId get() = null
+    }
+
+    data class Purchased(
+        override val orderId: String,
+    ) : PurchaseState
+
+    data object Unspecified : PurchaseState {
+        override val orderId get() = null
+    }
+}

--- a/modules/services/payment/src/main/kotlin/au/com/shiftyjelly/pocketcasts/payment/PaymentClient.kt
+++ b/modules/services/payment/src/main/kotlin/au/com/shiftyjelly/pocketcasts/payment/PaymentClient.kt
@@ -12,6 +12,6 @@ class PaymentClient @Inject constructor(
             .loadProducts()
             .flatMap(SubscriptionPlans::create)
             .onSuccess { plans -> logger.info("Subscription plans loaded: $plans") }
-            .onFailure { message -> logger.warning("Failed to load subscription plans: $message") }
+            .onFailure { code, message -> logger.warning("Failed to load subscription plans. $code $message") }
     }
 }

--- a/modules/services/payment/src/main/kotlin/au/com/shiftyjelly/pocketcasts/payment/PaymentClient.kt
+++ b/modules/services/payment/src/main/kotlin/au/com/shiftyjelly/pocketcasts/payment/PaymentClient.kt
@@ -12,6 +12,6 @@ class PaymentClient @Inject constructor(
             .loadProducts()
             .flatMap(SubscriptionPlans::create)
             .onSuccess { plans -> logger.info("Subscription plans loaded: $plans") }
-            .onFailure { code, message -> logger.warning("Failed to load subscription plans. $code $message") }
+            .onFailure { code, message -> logger.warning("Failed to load subscription plans. $code, $message") }
     }
 }

--- a/modules/services/payment/src/main/kotlin/au/com/shiftyjelly/pocketcasts/payment/PaymentDataSource.kt
+++ b/modules/services/payment/src/main/kotlin/au/com/shiftyjelly/pocketcasts/payment/PaymentDataSource.kt
@@ -7,15 +7,21 @@ import com.android.billingclient.api.AcknowledgePurchaseParams
 import com.android.billingclient.api.BillingFlowParams
 import com.android.billingclient.api.BillingResult
 import com.android.billingclient.api.ProductDetails
-import com.android.billingclient.api.Purchase
 import com.android.billingclient.api.PurchaseHistoryRecord
 import com.android.billingclient.api.QueryProductDetailsParams
 import com.android.billingclient.api.QueryPurchaseHistoryParams
 import com.android.billingclient.api.QueryPurchasesParams
 import kotlinx.coroutines.flow.SharedFlow
+import com.android.billingclient.api.Purchase as GooglePurchase
 
 interface PaymentDataSource {
+    val purchaseResults: SharedFlow<PaymentResult<List<Purchase>>>
+
     suspend fun loadProducts(): PaymentResult<List<Product>>
+
+    suspend fun loadPurchases(): PaymentResult<List<Purchase>>
+
+    suspend fun acknowledgePurchase(purchase: Purchase): PaymentResult<Purchase>
 
     companion object {
         fun billing(
@@ -27,7 +33,7 @@ interface PaymentDataSource {
     }
 
     // <editor-fold desc="Temporarily extracted old interface">
-    val purchaseUpdates: SharedFlow<Pair<BillingResult, List<Purchase>>>
+    val purchaseUpdates: SharedFlow<Pair<BillingResult, List<GooglePurchase>>>
 
     suspend fun loadProducts(
         params: QueryProductDetailsParams,
@@ -39,7 +45,7 @@ interface PaymentDataSource {
 
     suspend fun loadPurchases(
         params: QueryPurchasesParams,
-    ): Pair<BillingResult, List<Purchase>>
+    ): Pair<BillingResult, List<GooglePurchase>>
 
     suspend fun acknowledgePurchase(
         params: AcknowledgePurchaseParams,

--- a/modules/services/payment/src/main/kotlin/au/com/shiftyjelly/pocketcasts/payment/PaymentResult.kt
+++ b/modules/services/payment/src/main/kotlin/au/com/shiftyjelly/pocketcasts/payment/PaymentResult.kt
@@ -1,30 +1,56 @@
 package au.com.shiftyjelly.pocketcasts.payment
 
 sealed interface PaymentResult<out T : Any> {
-    data class Success<out T : Any>(val value: T) : PaymentResult<T>
+    data class Success<out T : Any>(
+        val value: T,
+    ) : PaymentResult<T>
 
-    data class Failure(val message: String) : PaymentResult<Nothing>
+    data class Failure constructor(
+        val code: PaymentResultCode,
+        val message: String,
+    ) : PaymentResult<Nothing>
 }
 
-fun <T : Any, R : Any> PaymentResult<T>.map(block: (T) -> R) = when (this) {
+sealed interface PaymentResultCode {
+    data object Error : PaymentResultCode
+    data object FeatureNotSupported : PaymentResultCode
+    data object ServiceDisconnected : PaymentResultCode
+    data object Ok : PaymentResultCode
+    data object UserCancelled : PaymentResultCode
+    data object ServiceUnavailable : PaymentResultCode
+    data object BillingUnavailable : PaymentResultCode
+    data object ItemUnavailable : PaymentResultCode
+    data object DeveloperError : PaymentResultCode
+    data object ItemAlreadyOwned : PaymentResultCode
+    data object ItemNotOwned : PaymentResultCode
+    data object NetworkError : PaymentResultCode
+    data class Unknown(val code: Int) : PaymentResultCode
+}
+
+inline fun <T : Any, R : Any> PaymentResult<T>.map(block: (T) -> R) = when (this) {
     is PaymentResult.Success -> PaymentResult.Success(block(value))
     is PaymentResult.Failure -> this
 }
 
-fun <T : Any, R : Any> PaymentResult<T>.flatMap(block: (T) -> PaymentResult<R>) = when (this) {
+inline fun <T : Any, R : Any> PaymentResult<T>.flatMap(block: (T) -> PaymentResult<R>) = when (this) {
     is PaymentResult.Success -> block(value)
     is PaymentResult.Failure -> this
 }
 
-fun <T : Any> PaymentResult<T>.onSuccess(block: (T) -> Unit) = apply {
+inline fun <T : Any> PaymentResult<T>.recover(block: (PaymentResultCode, String) -> PaymentResult<T>) = when (this) {
+    is PaymentResult.Success -> this
+    is PaymentResult.Failure -> block(code, message)
+}
+
+inline fun <T : Any> PaymentResult<T>.onSuccess(block: (T) -> Unit) = apply {
     if (this is PaymentResult.Success) {
         block(value)
     }
 }
 
-fun <T : Any> PaymentResult<T>.onFailure(block: (String) -> Unit) = apply {
+inline fun <T : Any> PaymentResult<T>.onFailure(block: (PaymentResultCode, String) -> Unit) = apply {
     if (this is PaymentResult.Failure) {
-        block(message)
+        block(code, message)
     }
 }
 

--- a/modules/services/payment/src/main/kotlin/au/com/shiftyjelly/pocketcasts/payment/billing/BillingPaymentDataSource.kt
+++ b/modules/services/payment/src/main/kotlin/au/com/shiftyjelly/pocketcasts/payment/billing/BillingPaymentDataSource.kt
@@ -168,4 +168,29 @@ private fun ProductDetailsResult.toPaymentResult(): PaymentResult<List<ProductDe
     }
 }
 
-private fun BillingResult.toPaymentFailure() = PaymentResult.Failure("Response code: $responseCode, $debugMessage")
+private fun PurchasesResult.toPaymentResult(): PaymentResult<List<GooglePurchase>> {
+    return if (billingResult.isOk()) {
+        PaymentResult.Success(purchasesList.orEmpty())
+    } else {
+        billingResult.toPaymentFailure()
+    }
+}
+
+private fun BillingResult.toPaymentFailure() = PaymentResult.Failure(
+    when (responseCode) {
+        -2 -> PaymentResultCode.FeatureNotSupported
+        -1 -> PaymentResultCode.ServiceDisconnected
+        0 -> PaymentResultCode.Ok
+        1 -> PaymentResultCode.UserCancelled
+        2, -3 -> PaymentResultCode.ServiceUnavailable
+        3 -> PaymentResultCode.BillingUnavailable
+        4 -> PaymentResultCode.ItemUnavailable
+        5 -> PaymentResultCode.DeveloperError
+        6 -> PaymentResultCode.Error
+        7 -> PaymentResultCode.ItemAlreadyOwned
+        8 -> PaymentResultCode.ItemNotOwned
+        12 -> PaymentResultCode.NetworkError
+        else -> PaymentResultCode.Unknown(responseCode)
+    },
+    debugMessage,
+)

--- a/modules/services/payment/src/main/kotlin/au/com/shiftyjelly/pocketcasts/payment/billing/BillingPaymentDataSource.kt
+++ b/modules/services/payment/src/main/kotlin/au/com/shiftyjelly/pocketcasts/payment/billing/BillingPaymentDataSource.kt
@@ -5,7 +5,9 @@ import android.content.Context
 import au.com.shiftyjelly.pocketcasts.payment.Logger
 import au.com.shiftyjelly.pocketcasts.payment.PaymentDataSource
 import au.com.shiftyjelly.pocketcasts.payment.PaymentResult
+import au.com.shiftyjelly.pocketcasts.payment.PaymentResultCode
 import au.com.shiftyjelly.pocketcasts.payment.Product
+import au.com.shiftyjelly.pocketcasts.payment.Purchase
 import au.com.shiftyjelly.pocketcasts.payment.SubscriptionBillingCycle
 import au.com.shiftyjelly.pocketcasts.payment.SubscriptionPlan
 import au.com.shiftyjelly.pocketcasts.payment.SubscriptionTier
@@ -16,8 +18,8 @@ import com.android.billingclient.api.BillingFlowParams
 import com.android.billingclient.api.BillingResult
 import com.android.billingclient.api.ProductDetails
 import com.android.billingclient.api.ProductDetailsResult
-import com.android.billingclient.api.Purchase
 import com.android.billingclient.api.PurchaseHistoryRecord
+import com.android.billingclient.api.PurchasesResult
 import com.android.billingclient.api.PurchasesUpdatedListener
 import com.android.billingclient.api.QueryProductDetailsParams
 import com.android.billingclient.api.QueryPurchaseHistoryParams
@@ -28,21 +30,29 @@ import com.android.billingclient.api.queryPurchaseHistory
 import com.android.billingclient.api.queryPurchasesAsync
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.asSharedFlow
+import com.android.billingclient.api.Purchase as GooglePurchase
 
 internal class BillingPaymentDataSource(
     context: Context,
     private val logger: Logger,
 ) : PaymentDataSource {
-    private val _purchaseUpdates = MutableSharedFlow<Pair<BillingResult, List<Purchase>>>(
+    private val _purchaseUpdates = MutableSharedFlow<Pair<BillingResult, List<GooglePurchase>>>(
         extraBufferCapacity = 100, // Arbitrarily large number
     )
     override val purchaseUpdates = _purchaseUpdates.asSharedFlow()
 
     private val connection = ClientConnection(
         context,
-        listener = PurchasesUpdatedListener { billingResult, purchases ->
+        listener = PurchasesUpdatedListener { billingResult, googlePurchases ->
             logger.info("Purchase results updated")
-            _purchaseUpdates.tryEmit(billingResult to purchases.orEmpty())
+            _purchaseUpdates.tryEmit(billingResult to googlePurchases.orEmpty())
+
+            val result = if (billingResult.isOk()) {
+                PaymentResult.Success(googlePurchases?.map(mapper::toPurchase).orEmpty())
+            } else {
+                billingResult.toPaymentFailure()
+            }
+            _purchases.tryEmit(result)
         },
         logger = logger,
     )
@@ -79,7 +89,7 @@ internal class BillingPaymentDataSource(
 
     override suspend fun loadPurchases(
         params: QueryPurchasesParams,
-    ): Pair<BillingResult, List<Purchase>> {
+    ): Pair<BillingResult, List<GooglePurchase>> {
         logger.info("Loading purchases")
         return connection.withConnectedClient { client ->
             val result = client.queryPurchasesAsync(params)
@@ -126,12 +136,41 @@ internal class BillingPaymentDataSource(
     // <editor-fold desc="PaymentDataSource implementation in progress">
     private val mapper = BillingPaymentMapper(logger)
 
+    private val _purchases = MutableSharedFlow<PaymentResult<List<Purchase>>>(
+        extraBufferCapacity = 100, // Arbitrarily large number
+    )
+
+    override val purchaseResults = _purchases.asSharedFlow()
+
     override suspend fun loadProducts(): PaymentResult<List<Product>> {
         return connection.withConnectedClient { client ->
             client
                 .queryProductDetails(AllSubscriptionsQueryProductDetailsParams)
                 .toPaymentResult()
                 .map { productDetails -> productDetails.mapNotNull(mapper::toProduct) }
+        }
+    }
+
+    override suspend fun loadPurchases(): PaymentResult<List<Purchase>> {
+        return connection.withConnectedClient { client ->
+            client
+                .queryPurchasesAsync(SubscriptionsQueryPurchasesParams)
+                .toPaymentResult()
+                .map { googlePurchases -> googlePurchases.mapNotNull(mapper::toPurchase) }
+        }
+    }
+
+    override suspend fun acknowledgePurchase(purchase: Purchase): PaymentResult<Purchase> {
+        return connection.withConnectedClient { client ->
+            val params = AcknowledgePurchaseParams.newBuilder()
+                .setPurchaseToken(purchase.token)
+                .build()
+            val billingResult = client.acknowledgePurchase(params)
+            if (billingResult.isOk()) {
+                PaymentResult.Success(purchase.copy(isAcknowledged = true))
+            } else {
+                billingResult.toPaymentFailure()
+            }
         }
     }
     // </editor-fold>
@@ -158,6 +197,10 @@ private val AllSubscriptionsQueryProductDetailsParams = QueryProductDetailsParam
                 .build(),
         ),
     )
+    .build()
+
+private val SubscriptionsQueryPurchasesParams = QueryPurchasesParams.newBuilder()
+    .setProductType(BillingClient.ProductType.SUBS)
     .build()
 
 private fun ProductDetailsResult.toPaymentResult(): PaymentResult<List<ProductDetails>> {

--- a/modules/services/payment/src/main/kotlin/au/com/shiftyjelly/pocketcasts/payment/billing/BillingPaymentMapper.kt
+++ b/modules/services/payment/src/main/kotlin/au/com/shiftyjelly/pocketcasts/payment/billing/BillingPaymentMapper.kt
@@ -7,10 +7,14 @@ import au.com.shiftyjelly.pocketcasts.payment.PricingPhase
 import au.com.shiftyjelly.pocketcasts.payment.PricingPlan
 import au.com.shiftyjelly.pocketcasts.payment.PricingPlans
 import au.com.shiftyjelly.pocketcasts.payment.Product
+import au.com.shiftyjelly.pocketcasts.payment.Purchase
+import au.com.shiftyjelly.pocketcasts.payment.PurchaseState
 import com.android.billingclient.api.ProductDetails.RecurrenceMode
 import com.android.billingclient.api.ProductDetails as GoogleProduct
 import com.android.billingclient.api.ProductDetails.PricingPhase as GooglePricingPhase
 import com.android.billingclient.api.ProductDetails.SubscriptionOfferDetails as GoogleOfferDetails
+import com.android.billingclient.api.Purchase as GooglePurchase
+import com.android.billingclient.api.Purchase.PurchaseState as GooglePurchaseState
 
 internal class BillingPaymentMapper(
     val logger: Logger,
@@ -33,6 +37,20 @@ internal class BillingPaymentMapper(
             id = productDetails.productId,
             name = productDetails.name,
             pricingPlans = toPlans(offerDetails, mappingContext) ?: return null,
+        )
+    }
+
+    fun toPurchase(purchase: GooglePurchase): Purchase {
+        return Purchase(
+            state = when (purchase.purchaseState) {
+                GooglePurchaseState.PENDING -> PurchaseState.Pending
+                GooglePurchaseState.PURCHASED -> purchase.orderId?.let(PurchaseState::Purchased) ?: PurchaseState.Unspecified
+                else -> PurchaseState.Unspecified
+            },
+            token = purchase.purchaseToken,
+            productIds = purchase.products,
+            isAcknowledged = purchase.isAcknowledged,
+            isAutoRenewing = purchase.isAutoRenewing,
         )
     }
 

--- a/modules/services/payment/src/test/kotlin/au/com/shiftyjelly/pocketcasts/payment/PaymentClientTest.kt
+++ b/modules/services/payment/src/test/kotlin/au/com/shiftyjelly/pocketcasts/payment/PaymentClientTest.kt
@@ -43,6 +43,6 @@ class PaymentClientTest {
         client.loadSubscriptionPlans()
 
         logger.assertInfos("Load subscription plans")
-        logger.assertWarnings("Failed to load subscription plans: Test failure")
+        logger.assertWarnings("Failed to load subscription plans. Error, Test failure")
     }
 }

--- a/modules/services/payment/src/test/kotlin/au/com/shiftyjelly/pocketcasts/payment/PaymentClientTest.kt
+++ b/modules/services/payment/src/test/kotlin/au/com/shiftyjelly/pocketcasts/payment/PaymentClientTest.kt
@@ -19,7 +19,7 @@ class PaymentClientTest {
 
     @Test
     fun `load plans with failure`() = runTest {
-        dataSource.customProductsResult = PaymentResult.Failure("Test failure")
+        dataSource.customProductsResult = PaymentResult.Failure(PaymentResultCode.Error, "Test failure")
 
         val plans = client.loadSubscriptionPlans()
 
@@ -38,7 +38,7 @@ class PaymentClientTest {
 
     @Test
     fun `log loading plans with failure`() = runTest {
-        dataSource.customProductsResult = PaymentResult.Failure("Test failure")
+        dataSource.customProductsResult = PaymentResult.Failure(PaymentResultCode.Error, "Test failure")
 
         client.loadSubscriptionPlans()
 

--- a/modules/services/payment/src/test/kotlin/au/com/shiftyjelly/pocketcasts/payment/PaymentResultTest.kt
+++ b/modules/services/payment/src/test/kotlin/au/com/shiftyjelly/pocketcasts/payment/PaymentResultTest.kt
@@ -14,7 +14,7 @@ class PaymentResultTest {
 
     @Test
     fun `getOrNull for failure`() {
-        val result: PaymentResult<Int> = PaymentResult.Failure("Error")
+        val result: PaymentResult<Int> = PaymentResult.Failure(PaymentResultCode.Error, "Whoops!")
 
         assertNull(result.getOrNull())
     }
@@ -30,7 +30,7 @@ class PaymentResultTest {
 
     @Test
     fun `map for failure`() {
-        val result: PaymentResult<Int> = PaymentResult.Failure("Error")
+        val result: PaymentResult<Int> = PaymentResult.Failure(PaymentResultCode.Error, "Whoops!")
 
         val mapped = result.map { "${it * 2}" }
 
@@ -48,7 +48,7 @@ class PaymentResultTest {
 
     @Test
     fun `flatMap for failure`() {
-        val result: PaymentResult<Int> = PaymentResult.Failure("Error")
+        val result: PaymentResult<Int> = PaymentResult.Failure(PaymentResultCode.Error, "Whoops!")
 
         val mapped = result.flatMap { PaymentResult.Success("${it * 2}") }
 
@@ -67,7 +67,7 @@ class PaymentResultTest {
 
     @Test
     fun `onSuccess for failure`() {
-        val result: PaymentResult<Int> = PaymentResult.Failure("Error")
+        val result: PaymentResult<Int> = PaymentResult.Failure(PaymentResultCode.Error, "Whoops!")
         var value = "Hello"
 
         result.onSuccess { value = "${it * 2}" }
@@ -80,18 +80,36 @@ class PaymentResultTest {
         val result = PaymentResult.Success(10)
         var value = "Hello"
 
-        result.onFailure { value = it }
+        result.onFailure { code, message -> value = "$code $message" }
 
         assertEquals("Hello", value)
     }
 
     @Test
     fun `onFailure for failure`() {
-        val result: PaymentResult<Int> = PaymentResult.Failure("Error")
+        val result: PaymentResult<Int> = PaymentResult.Failure(PaymentResultCode.Error, "Whoops!")
         var value = "Hello"
 
-        result.onFailure { value = it }
+        result.onFailure { code, message -> value = "$code $message" }
 
-        assertEquals("Error", value)
+        assertEquals("Error Whoops!", value)
+    }
+
+    @Test
+    fun `recover for success`() {
+        val result = PaymentResult.Success(10)
+
+        val recovered = result.recover { code, message -> PaymentResult.Success(55) }
+
+        assertEquals(10, recovered.getOrNull())
+    }
+
+    @Test
+    fun `recover for failure`() {
+        val result: PaymentResult<Int> = PaymentResult.Failure(PaymentResultCode.Error, "Whoops!")
+
+        val recovered = result.recover { _, _ -> PaymentResult.Success(55) }
+
+        assertEquals(55, recovered.getOrNull())
     }
 }

--- a/modules/services/payment/src/test/kotlin/com/android/billingclient/api/ProductDetails.kt
+++ b/modules/services/payment/src/test/kotlin/com/android/billingclient/api/ProductDetails.kt
@@ -4,6 +4,7 @@ import com.android.billingclient.api.ProductDetails.PricingPhase
 import com.android.billingclient.api.ProductDetails.SubscriptionOfferDetails
 import org.json.JSONArray
 import org.json.JSONObject
+import com.android.billingclient.api.Purchase as GooglePurchase
 
 fun GoogleProductDetails(
     productId: String = "product-id",
@@ -55,6 +56,32 @@ fun GooglePricingPhase(
         .put("recurrenceMode", recurrenceMode)
         .put("billingCycleCount", billingCycleCount)
     return PricingPhase(json)
+}
+
+fun GooglePurchase(
+    orderId: String? = "order-id",
+    purchaseToken: String = "purchase-token",
+    productIds: List<String> = listOf("product-id"),
+    isAcknowledged: Boolean = true,
+    isAutoRenewing: Boolean = true,
+    isPurchased: Boolean = true,
+): GooglePurchase {
+    val quantity = productIds.size
+    val productsField: Any? = if (quantity > 1) {
+        JSONArray(productIds)
+    } else {
+        productIds.getOrNull(0)
+    }
+    val json = JSONObject()
+        .put("orderId", orderId)
+        .put("purchaseToken", purchaseToken)
+        .put("purchaseState", if (isPurchased) 1 else 4)
+        .put("quantity", quantity)
+        .put(if (quantity > 1) "productIds" else "productId", productsField)
+        .put("acknowledged", isAcknowledged)
+        .put("autoRenewing", isAutoRenewing)
+
+    return GooglePurchase(json.toString(), "")
 }
 
 private fun PricingPhase.toJson() = JSONObject()


### PR DESCRIPTION
## Description

Continuation of Billing APIs improvements. This PR adds purchase related types and integrations. I also added some improvements to the `PaymentResult` type. Failure type now has enumerated code to improve decision making and `recover()` method to map from failures to other results.

## Testing Instructions

Code review is enough as there's nothing to test yet.

## Checklist
- [ ] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [ ] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [ ] ~Any jetpack compose components I added or changed are covered by compose previews~
- [ ] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~