### PR TITLE
Increase contrast on Upgrade screen for better readability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 7.89
 -----
-
+*   Updates
+    *   Improve contrast of secondary texts on Upgrade page
+        ([#3942](https://github.com/Automattic/pocket-casts-android/pull/3942))
 
 7.88
 -----

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/components/ProductAmountVerticalText.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/components/ProductAmountVerticalText.kt
@@ -28,8 +28,8 @@ import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 @Composable
 fun ProductAmountVerticalText(
     primaryText: String,
-    secondaryText: String? = null,
     modifier: Modifier = Modifier,
+    secondaryText: String? = null,
     horizontalAlignment: Alignment.Horizontal = Alignment.End,
     emphasized: Boolean = true,
 ) {
@@ -59,6 +59,7 @@ fun ProductAmountVerticalText(
 
 @Composable
 fun ProductAmountHorizontalText(
+    modifier: Modifier = Modifier,
     price: String? = null,
     priceTextFontSize: TextUnit = 22.sp,
     originalPrice: String? = null,
@@ -67,7 +68,6 @@ fun ProductAmountHorizontalText(
     lineThroughOriginalPrice: Boolean = true,
     hasBackgroundAlwaysWhite: Boolean = false,
     verticalAlignment: Alignment.Vertical = Alignment.CenterVertically,
-    modifier: Modifier = Modifier,
 ) {
     Row(
         modifier = modifier,
@@ -78,11 +78,11 @@ fun ProductAmountHorizontalText(
                 text = price,
                 fontSize = priceTextFontSize,
                 color =
-                if (hasBackgroundAlwaysWhite) {
-                    Color.Black
-                } else {
-                    MaterialTheme.theme.colors.primaryText01
-                },
+                    if (hasBackgroundAlwaysWhite) {
+                        Color.Black
+                    } else {
+                        MaterialTheme.theme.colors.primaryText01
+                    },
             )
         }
 
@@ -119,6 +119,33 @@ private fun ProductAmountPreview(
         ProductAmountVerticalText(
             primaryText = "4 days free",
             secondaryText = "then $0.99 / month",
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun ProductAmountPreviewHorizontal(
+    @PreviewParameter(ThemePreviewParameterProvider::class) themeType: Theme.ThemeType,
+) {
+    AppTheme(themeType) {
+        ProductAmountHorizontalText(
+            price = "$0.99",
+            period = "/year"
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun ProductAmountPreviewHorizontalDiscount(
+    @PreviewParameter(ThemePreviewParameterProvider::class) themeType: Theme.ThemeType,
+) {
+    AppTheme(themeType) {
+        ProductAmountHorizontalText(
+            price = "$0.99",
+            originalPrice = "$1.29",
+            period = "/year"
         )
     }
 }

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/components/ProductAmountVerticalText.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/components/ProductAmountVerticalText.kt
@@ -68,6 +68,7 @@ fun ProductAmountHorizontalText(
     lineThroughOriginalPrice: Boolean = true,
     hasBackgroundAlwaysWhite: Boolean = false,
     verticalAlignment: Alignment.Vertical = Alignment.CenterVertically,
+    secondaryTextColor: Color = MaterialTheme.theme.colors.primaryText02,
 ) {
     Row(
         modifier = modifier,
@@ -78,11 +79,11 @@ fun ProductAmountHorizontalText(
                 text = price,
                 fontSize = priceTextFontSize,
                 color =
-                    if (hasBackgroundAlwaysWhite) {
-                        Color.Black
-                    } else {
-                        MaterialTheme.theme.colors.primaryText01
-                    },
+                if (hasBackgroundAlwaysWhite) {
+                    Color.Black
+                } else {
+                    MaterialTheme.theme.colors.primaryText01
+                },
             )
         }
 
@@ -90,7 +91,7 @@ fun ProductAmountHorizontalText(
             TextP60(
                 text = period,
                 fontSize = originalPriceFontSize,
-                color = MaterialTheme.theme.colors.primaryText02,
+                color = secondaryTextColor,
                 modifier = modifier.padding(start = 4.dp),
             )
         }
@@ -101,7 +102,7 @@ fun ProductAmountHorizontalText(
             TextP60(
                 text = originalPrice,
                 fontSize = originalPriceFontSize,
-                color = MaterialTheme.theme.colors.primaryText02,
+                color = secondaryTextColor,
                 style = TextStyle(
                     textDecoration = if (lineThroughOriginalPrice) TextDecoration.LineThrough else TextDecoration.None,
                 ),
@@ -131,7 +132,7 @@ private fun ProductAmountPreviewHorizontal(
     AppTheme(themeType) {
         ProductAmountHorizontalText(
             price = "$0.99",
-            period = "/year"
+            period = "/year",
         )
     }
 }
@@ -145,7 +146,7 @@ private fun ProductAmountPreviewHorizontalDiscount(
         ProductAmountHorizontalText(
             price = "$0.99",
             originalPrice = "$1.29",
-            period = "/year"
+            period = "/year",
         )
     }
 }

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeFeaturesPage.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeFeaturesPage.kt
@@ -134,6 +134,7 @@ internal fun OnboardingUpgradeFeaturesPage(
                 onTermsAndConditionsClick = { viewModel.onTermsAndConditionsPressed() },
             )
         }
+
         is OnboardingUpgradeFeaturesState.NoSubscriptions -> {
             NoSubscriptionsLayout(
                 showNotNow = (state as OnboardingUpgradeFeaturesState.NoSubscriptions).showNotNow,
@@ -306,6 +307,8 @@ fun FeatureCards(
     }
 }
 
+private val secondaryTextColor = Color(0xFF6F7580)
+
 @Composable
 private fun FeatureCard(
     card: UpgradeFeatureCard,
@@ -389,7 +392,11 @@ private fun FeatureCard(
             }
 
             Column {
-                SubscriptionProductAmountHorizontal(subscription, hasBackgroundAlwaysWhite = true)
+                SubscriptionProductAmountHorizontal(
+                    subscription = subscription,
+                    hasBackgroundAlwaysWhite = true,
+                    secondaryTextColor = secondaryTextColor,
+                )
 
                 Spacer(modifier = Modifier.padding(vertical = 4.dp))
 
@@ -398,7 +405,7 @@ private fun FeatureCard(
                 }
                 Spacer(modifier = Modifier.weight(1f))
                 OnboardingUpgradeHelper.PrivacyPolicy(
-                    color = Color.Black.copy(alpha = .5f),
+                    color = secondaryTextColor,
                     textAlign = TextAlign.Start,
                     lineHeight = 18.sp,
                     onPrivacyPolicyClick = onPrivacyPolicyClick,

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/SubscriptionProductAmountHorizontal.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/SubscriptionProductAmountHorizontal.kt
@@ -2,11 +2,14 @@ package au.com.shiftyjelly.pocketcasts.account.onboarding.upgrade
 
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.padding
+import androidx.compose.material.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 import au.com.shiftyjelly.pocketcasts.account.components.ProductAmountHorizontalText
+import au.com.shiftyjelly.pocketcasts.compose.theme
 import au.com.shiftyjelly.pocketcasts.models.type.Subscription
 
 @Composable
@@ -14,10 +17,12 @@ fun SubscriptionProductAmountHorizontal(
     subscription: Subscription,
     modifier: Modifier = Modifier,
     hasBackgroundAlwaysWhite: Boolean = false,
+    secondaryTextColor: Color = MaterialTheme.theme.colors.primaryText02,
 ) {
     if (subscription is Subscription.WithOffer) {
         if (subscription is Subscription.Intro) {
             ProductAmountHorizontalText(
+                secondaryTextColor = secondaryTextColor,
                 price = subscription.offerPricingPhase.pricingPhase.formattedPrice,
                 period = subscription.offerPricingPhase.slashPeriod(LocalContext.current.resources),
                 originalPrice = subscription.recurringPricingPhase.priceSlashPeriod(LocalContext.current.resources),
@@ -25,6 +30,7 @@ fun SubscriptionProductAmountHorizontal(
             )
         } else if (subscription is Subscription.Trial) {
             ProductAmountHorizontalText(
+                secondaryTextColor = secondaryTextColor,
                 price = subscription.recurringPricingPhase.formattedPrice,
                 originalPrice = subscription.recurringPricingPhase.slashPeriod(LocalContext.current.resources),
                 lineThroughOriginalPrice = false,
@@ -35,6 +41,7 @@ fun SubscriptionProductAmountHorizontal(
         Spacer(modifier = modifier.padding(vertical = 4.dp))
     } else if (subscription is Subscription.Simple) {
         ProductAmountHorizontalText(
+            secondaryTextColor = secondaryTextColor,
             price = subscription.recurringPricingPhase.formattedPrice,
             originalPrice = subscription.recurringPricingPhase.slashPeriod(LocalContext.current.resources),
             lineThroughOriginalPrice = false,


### PR DESCRIPTION
This PR delivers the first batch of accessibility updates on the Upgrade screen - now secondary texts have better contrast against the background.
[We had a discussion](https://pocketcastsp2.wordpress.com/2025/04/25/eu-accessibility-act-tasks/#comment-7481) on the implementation whether it should be introduced as a local change exclusive to the Upgrade screen or change themes across the app. We ultimatetly agreed on the former one.


Closes #3930 

## Testing Instructions
Just check the code please.

## Screenshots or Screencast 
| Before | After |
| --- | --- |
| ![Screenshot_20250429_111533](https://github.com/user-attachments/assets/0e7bc874-d0e9-4376-99f0-1bbcbafe093b) | ![Screenshot_20250429_111433](https://github.com/user-attachments/assets/8b148dc7-89a7-497b-947e-21269891c20b) |


## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- ~[ ] I have considered whether it makes sense to add tests for my changes~
- ~[ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [x] Any jetpack compose components I added or changed are covered by compose previews
- ~[ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~
 
