### PR TITLE
Add billing flow parameters mapping

### DIFF
--- a/modules/services/payment/src/main/kotlin/au/com/shiftyjelly/pocketcasts/payment/Data.kt
+++ b/modules/services/payment/src/main/kotlin/au/com/shiftyjelly/pocketcasts/payment/Data.kt
@@ -187,19 +187,26 @@ sealed interface SubscriptionPlan {
     val name: String
     val tier: SubscriptionTier
     val billingCycle: SubscriptionBillingCycle
+    val offer: SubscriptionOffer?
+
+    val productId get() = SubscriptionPlan.productId(tier, billingCycle)
+    val basePlanId get() = SubscriptionPlan.basePlanId(tier, billingCycle)
+    val offerId get() = offer?.offerId(tier, billingCycle)
 
     data class Base(
         override val name: String,
         override val tier: SubscriptionTier,
         override val billingCycle: SubscriptionBillingCycle,
         val pricingPhase: PricingPhase,
-    ) : SubscriptionPlan
+    ) : SubscriptionPlan {
+        override val offer get() = null
+    }
 
     data class WithOffer(
         override val name: String,
         override val tier: SubscriptionTier,
         override val billingCycle: SubscriptionBillingCycle,
-        val offer: SubscriptionOffer,
+        override val offer: SubscriptionOffer,
         val pricingPhases: List<PricingPhase>,
     ) : SubscriptionPlan
 

--- a/modules/services/payment/src/main/kotlin/au/com/shiftyjelly/pocketcasts/payment/FakePaymentDataSource.kt
+++ b/modules/services/payment/src/main/kotlin/au/com/shiftyjelly/pocketcasts/payment/FakePaymentDataSource.kt
@@ -18,6 +18,7 @@ class FakePaymentDataSource : PaymentDataSource {
     var customProductsResult: PaymentResult<List<Product>>? = null
     var customPurchases: PaymentResult<List<Purchase>>? = null
     var acknowledgePurchaseResultCode: PaymentResultCode = PaymentResultCode.Ok
+    var launchBillingFlowResultCode: PaymentResultCode = PaymentResultCode.Ok
 
     override val purchaseResults = MutableSharedFlow<PaymentResult<List<Purchase>>>()
 
@@ -32,6 +33,14 @@ class FakePaymentDataSource : PaymentDataSource {
     override suspend fun acknowledgePurchase(purchase: Purchase): PaymentResult<Purchase> {
         return if (acknowledgePurchaseResultCode is PaymentResultCode.Ok) {
             PaymentResult.Success(purchase.copy(isAcknowledged = true))
+        } else {
+            PaymentResult.Failure(acknowledgePurchaseResultCode, "Error")
+        }
+    }
+
+    override suspend fun launchBillingFlow(plan: SubscriptionPlan, activity: Activity): PaymentResult<Unit> {
+        return if (launchBillingFlowResultCode is PaymentResultCode.Ok) {
+            PaymentResult.Success(Unit)
         } else {
             PaymentResult.Failure(acknowledgePurchaseResultCode, "Error")
         }

--- a/modules/services/payment/src/main/kotlin/au/com/shiftyjelly/pocketcasts/payment/PaymentDataSource.kt
+++ b/modules/services/payment/src/main/kotlin/au/com/shiftyjelly/pocketcasts/payment/PaymentDataSource.kt
@@ -23,6 +23,8 @@ interface PaymentDataSource {
 
     suspend fun acknowledgePurchase(purchase: Purchase): PaymentResult<Purchase>
 
+    suspend fun launchBillingFlow(plan: SubscriptionPlan, activity: Activity): PaymentResult<Unit>
+
     companion object {
         fun billing(
             context: Context,

--- a/modules/services/payment/src/main/kotlin/au/com/shiftyjelly/pocketcasts/payment/billing/BillingFlowRequest.kt
+++ b/modules/services/payment/src/main/kotlin/au/com/shiftyjelly/pocketcasts/payment/billing/BillingFlowRequest.kt
@@ -1,0 +1,42 @@
+package au.com.shiftyjelly.pocketcasts.payment.billing
+
+import com.android.billingclient.api.BillingFlowParams
+import com.android.billingclient.api.ProductDetails
+
+internal data class BillingFlowRequest(
+    val productQuery: ProductQuery,
+    val subscriptionUpdateQuery: SubscriptionUpdateQuery?,
+) {
+    fun toGoogleParams(): BillingFlowParams {
+        val productParams = BillingFlowParams.ProductDetailsParams.newBuilder()
+            .setProductDetails(productQuery.product)
+            .setOfferToken(productQuery.offerToken)
+            .build()
+        val subscriptionUpdateParams = subscriptionUpdateQuery?.let { query ->
+            BillingFlowParams.SubscriptionUpdateParams.newBuilder()
+                .setOldPurchaseToken(query.purchaseToken)
+                .setSubscriptionReplacementMode(query.replacementMode)
+                .build()
+        }
+        return BillingFlowParams.newBuilder()
+            .setProductDetailsParamsList(listOf(productParams))
+            .let { builder ->
+                if (subscriptionUpdateParams != null) {
+                    builder.setSubscriptionUpdateParams(subscriptionUpdateParams)
+                } else {
+                    builder
+                }
+            }
+            .build()
+    }
+
+    data class ProductQuery(
+        val product: ProductDetails,
+        val offerToken: String,
+    )
+
+    data class SubscriptionUpdateQuery(
+        val purchaseToken: String,
+        val replacementMode: Int,
+    )
+}

--- a/modules/services/payment/src/test/kotlin/au/com/shiftyjelly/pocketcasts/payment/billing/BillingPaymentMapperFlowParamsTest.kt
+++ b/modules/services/payment/src/test/kotlin/au/com/shiftyjelly/pocketcasts/payment/billing/BillingPaymentMapperFlowParamsTest.kt
@@ -1,0 +1,577 @@
+package au.com.shiftyjelly.pocketcasts.payment.billing
+
+import au.com.shiftyjelly.pocketcasts.payment.BillingPeriod
+import au.com.shiftyjelly.pocketcasts.payment.Price
+import au.com.shiftyjelly.pocketcasts.payment.PricingPhase
+import au.com.shiftyjelly.pocketcasts.payment.SubscriptionBillingCycle
+import au.com.shiftyjelly.pocketcasts.payment.SubscriptionOffer
+import au.com.shiftyjelly.pocketcasts.payment.SubscriptionPlan
+import au.com.shiftyjelly.pocketcasts.payment.SubscriptionTier
+import au.com.shiftyjelly.pocketcasts.payment.TestLogger
+import com.android.billingclient.api.BillingFlowParams.SubscriptionUpdateParams.ReplacementMode
+import com.android.billingclient.api.GoogleOfferDetails
+import com.android.billingclient.api.GoogleProductDetails
+import com.android.billingclient.api.GooglePurchase
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Test
+import org.junit.experimental.runners.Enclosed
+import org.junit.runner.RunWith
+import org.robolectric.ParameterizedRobolectricTestRunner
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(Enclosed::class)
+class BillingPaymentMapperFlowParamsTest {
+    @Config(manifest = Config.NONE)
+    @RunWith(RobolectricTestRunner::class)
+    class GeneralBehavior {
+        private val logger = TestLogger()
+        private val mapper = BillingPaymentMapper(logger)
+
+        @Test
+        fun `create billing params`() {
+            val plan = creatMockPlan(SubscriptionTier.Plus, SubscriptionBillingCycle.Monthly)
+            val product = GoogleProductDetails(
+                productId = plan.productId,
+                subscriptionOfferDetails = listOf(
+                    GoogleOfferDetails(
+                        basePlanId = plan.basePlanId,
+                        offerId = plan.offerId,
+                        offerIdToken = "offer-token",
+                    ),
+                ),
+            )
+
+            val request = mapper.toBillingFlowRequest(plan, listOf(product), purchases = emptyList())
+
+            assertEquals(
+                BillingFlowRequest(
+                    BillingFlowRequest.ProductQuery(product, "offer-token"),
+                    subscriptionUpdateQuery = null,
+                ),
+                request,
+            )
+        }
+
+        @Test
+        fun `create billing params with only single active purchase`() {
+            val currentPurchases = listOf(
+                GooglePurchase(
+                    orderId = "order-id-1",
+                    purchaseToken = "purchase-token-1",
+                    productIds = listOf(
+                        SubscriptionPlan.productId(SubscriptionTier.Plus, SubscriptionBillingCycle.Monthly),
+                    ),
+                    isAcknowledged = true,
+                    isAutoRenewing = true,
+                ),
+                GooglePurchase(
+                    orderId = "order-id-2",
+                    purchaseToken = "purchase-token-2",
+                    productIds = listOf(
+                        SubscriptionPlan.productId(SubscriptionTier.Plus, SubscriptionBillingCycle.Monthly),
+                    ),
+                    isAcknowledged = true,
+                    isAutoRenewing = false,
+                ),
+                GooglePurchase(
+                    orderId = "order-id-2",
+                    purchaseToken = "purchase-token-3",
+                    productIds = listOf(
+                        SubscriptionPlan.productId(SubscriptionTier.Plus, SubscriptionBillingCycle.Monthly),
+                    ),
+                    isAcknowledged = false,
+                    isAutoRenewing = true,
+                ),
+                GooglePurchase(
+                    orderId = "order-id-2",
+                    purchaseToken = "purchase-token-3",
+                    productIds = listOf(
+                        SubscriptionPlan.productId(SubscriptionTier.Plus, SubscriptionBillingCycle.Monthly),
+                    ),
+                    isAcknowledged = false,
+                    isAutoRenewing = false,
+                ),
+            )
+            val plan = creatMockPlan(SubscriptionTier.Plus, SubscriptionBillingCycle.Yearly)
+            val product = GoogleProductDetails(
+                productId = plan.productId,
+                subscriptionOfferDetails = listOf(
+                    GoogleOfferDetails(
+                        basePlanId = plan.basePlanId,
+                        offerId = plan.offerId,
+                        offerIdToken = "offer-token",
+                    ),
+                ),
+            )
+
+            val request = mapper.toBillingFlowRequest(plan, listOf(product), currentPurchases)
+
+            assertEquals(
+                BillingFlowRequest(
+                    BillingFlowRequest.ProductQuery(product, "offer-token"),
+                    BillingFlowRequest.SubscriptionUpdateQuery("purchase-token-1", ReplacementMode.CHARGE_FULL_PRICE),
+                ),
+                request,
+            )
+        }
+
+        @Test
+        fun `log too many matching products`() {
+            val plan = creatMockPlan(SubscriptionTier.Plus, SubscriptionBillingCycle.Monthly)
+            val product = GoogleProductDetails(
+                productId = plan.productId,
+                subscriptionOfferDetails = listOf(
+                    GoogleOfferDetails(
+                        basePlanId = plan.basePlanId,
+                        offerId = plan.offerId,
+                        offerIdToken = "${plan.name}-offer-token",
+                    ),
+                ),
+            )
+
+            mapper.toBillingFlowRequest(plan, listOf(product, product), purchases = emptyList())
+
+            logger.assertWarnings(
+                "Found multiple matching products in {billingCycle=Monthly, offer=null, tier=Plus}",
+            )
+        }
+
+        @Test
+        fun `log no matching products`() {
+            val plan = creatMockPlan(SubscriptionTier.Plus, SubscriptionBillingCycle.Monthly)
+
+            mapper.toBillingFlowRequest(plan, productDetails = emptyList(), purchases = emptyList())
+
+            logger.assertWarnings(
+                "Found no matching products in {billingCycle=Monthly, offer=null, tier=Plus}",
+            )
+        }
+
+        @Test
+        fun `log too many matching offers`() {
+            val plan = creatMockPlan(SubscriptionTier.Plus, SubscriptionBillingCycle.Monthly)
+            val product = GoogleProductDetails(
+                productId = plan.productId,
+                subscriptionOfferDetails = listOf(
+                    GoogleOfferDetails(
+                        basePlanId = plan.basePlanId,
+                        offerId = plan.offerId,
+                        offerIdToken = "token-1",
+                    ),
+                    GoogleOfferDetails(
+                        basePlanId = plan.basePlanId,
+                        offerId = plan.offerId,
+                        offerIdToken = "token-2",
+                    ),
+                ),
+            )
+
+            mapper.toBillingFlowRequest(plan, listOf(product), purchases = emptyList())
+
+            logger.assertWarnings(
+                "Found multiple matching offers in {billingCycle=Monthly, offer=null, tier=Plus}",
+            )
+        }
+
+        @Test
+        fun `log no matching offers`() {
+            val plan = creatMockPlan(SubscriptionTier.Plus, SubscriptionBillingCycle.Monthly)
+            val product = GoogleProductDetails(
+                productId = plan.productId,
+                subscriptionOfferDetails = emptyList(),
+            )
+
+            mapper.toBillingFlowRequest(plan, listOf(product), purchases = emptyList())
+
+            logger.assertWarnings(
+                "Found no matching offers in {billingCycle=Monthly, offer=null, tier=Plus}",
+            )
+        }
+
+        @Test
+        fun `log too many active purchases`() {
+            val currentPurchases = listOf(
+                GooglePurchase(
+                    orderId = "order-id-1",
+                    productIds = listOf("product-id-1"),
+                ),
+                GooglePurchase(
+                    orderId = "order-id-2",
+                    productIds = listOf("product-id-2"),
+                ),
+            )
+            val plan = creatMockPlan(SubscriptionTier.Plus, SubscriptionBillingCycle.Monthly)
+            val product = GoogleProductDetails(
+                productId = plan.productId,
+                subscriptionOfferDetails = listOf(
+                    GoogleOfferDetails(basePlanId = plan.basePlanId, offerId = plan.offerId),
+                ),
+            )
+
+            mapper.toBillingFlowRequest(plan, listOf(product), currentPurchases)
+
+            logger.assertWarnings(
+                "Found more than one active purchase in {purchases=order-id-1: [product-id-1], order-id-2: [product-id-2]}",
+            )
+        }
+
+        @Test
+        fun `log too many products in a a purchase`() {
+            val currentPurchases = listOf(
+                GooglePurchase(
+                    orderId = "order-id",
+                    productIds = listOf("product-id-1", "product-id-2"),
+                ),
+            )
+            val plan = creatMockPlan(SubscriptionTier.Plus, SubscriptionBillingCycle.Monthly)
+            val product = GoogleProductDetails(
+                productId = plan.productId,
+                subscriptionOfferDetails = listOf(
+                    GoogleOfferDetails(basePlanId = plan.basePlanId, offerId = plan.offerId),
+                ),
+            )
+
+            mapper.toBillingFlowRequest(plan, listOf(product), currentPurchases)
+
+            logger.assertWarnings(
+                "Active purchase should have only a single product in {orderId=order-id, products=[product-id-1, product-id-2]}",
+            )
+        }
+
+        @Test
+        fun `do not log anything when mapped succesfully`() {
+            val plan = creatMockPlan(SubscriptionTier.Plus, SubscriptionBillingCycle.Monthly)
+            val product = GoogleProductDetails(
+                productId = plan.productId,
+                subscriptionOfferDetails = listOf(
+                    GoogleOfferDetails(basePlanId = plan.basePlanId, offerId = plan.offerId),
+                ),
+            )
+
+            mapper.toBillingFlowRequest(plan, listOf(product), purchases = emptyList())
+
+            logger.assertNoLogs()
+        }
+    }
+
+    @Config(manifest = Config.NONE)
+    @RunWith(ParameterizedRobolectricTestRunner::class)
+    class WithoutActivePurchase(
+        private val tier: SubscriptionTier,
+        private val billingCycle: SubscriptionBillingCycle,
+    ) {
+        private val mapper = BillingPaymentMapper(TestLogger())
+
+        @Test
+        fun `map base plan to billing flow request`() {
+            val plan = creatMockPlan(tier, billingCycle)
+            val product = GoogleProductDetails(
+                productId = plan.productId,
+                subscriptionOfferDetails = listOf(
+                    GoogleOfferDetails(
+                        basePlanId = plan.basePlanId,
+                        offerId = plan.offerId,
+                        offerIdToken = "${plan.name}-offer-token",
+                    ),
+                    GoogleOfferDetails(
+                        basePlanId = plan.basePlanId,
+                        offerId = "random-offer-id-${plan.name}",
+                        offerIdToken = "random-offer-token-1-${plan.name}",
+                    ),
+                    GoogleOfferDetails(
+                        basePlanId = "random-base-plan-id-${plan.name}",
+                        offerId = plan.offerId,
+                        offerIdToken = "random-offer-token-2-${plan.name}",
+                    ),
+                ),
+            )
+
+            val request = mapper.toBillingFlowRequest(plan, listOf(product), purchases = emptyList())
+
+            assertEquals(
+                BillingFlowRequest(
+                    productQuery = BillingFlowRequest.ProductQuery(
+                        product = product,
+                        offerToken = "${plan.name}-offer-token",
+                    ),
+                    subscriptionUpdateQuery = null,
+                ),
+                request,
+            )
+        }
+
+        @Test
+        fun `do not map base plan to billing flow request with multiple matching products`() {
+            val plan = creatMockPlan(tier, billingCycle)
+            val product = GoogleProductDetails(
+                productId = plan.productId,
+                subscriptionOfferDetails = listOf(
+                    GoogleOfferDetails(basePlanId = plan.basePlanId, offerId = plan.offerId),
+                ),
+            )
+
+            val request = mapper.toBillingFlowRequest(plan, listOf(product, product), purchases = emptyList())
+
+            assertNull(request)
+        }
+
+        @Test
+        fun `do not map base plan to billing flow request with multiple matching offers`() {
+            val plan = creatMockPlan(tier, billingCycle)
+            val product = GoogleProductDetails(
+                productId = plan.productId,
+                subscriptionOfferDetails = listOf(
+                    GoogleOfferDetails(basePlanId = plan.basePlanId, offerId = plan.offerId),
+                    GoogleOfferDetails(basePlanId = plan.basePlanId, offerId = plan.offerId),
+                ),
+            )
+
+            val request = mapper.toBillingFlowRequest(plan, listOf(product), purchases = emptyList())
+
+            assertNull(request)
+        }
+
+        companion object {
+            @JvmStatic
+            @ParameterizedRobolectricTestRunner.Parameters(name = "{0} {1}")
+            fun params() = listOf(
+                arrayOf(SubscriptionTier.Plus, SubscriptionBillingCycle.Monthly),
+                arrayOf(SubscriptionTier.Plus, SubscriptionBillingCycle.Yearly),
+                arrayOf(SubscriptionTier.Patron, SubscriptionBillingCycle.Monthly),
+                arrayOf(SubscriptionTier.Patron, SubscriptionBillingCycle.Yearly),
+            )
+        }
+    }
+
+    @Config(manifest = Config.NONE)
+    @RunWith(ParameterizedRobolectricTestRunner::class)
+    class WithActivePurchase(
+        private val fromTier: SubscriptionTier,
+        private val fromBillingCycle: SubscriptionBillingCycle,
+        private val toTier: SubscriptionTier,
+        private val toBillingCycle: SubscriptionBillingCycle,
+        private val expectedReplacementMode: Int?,
+    ) {
+        private val mapper = BillingPaymentMapper(TestLogger())
+
+        @Test
+        fun `create billing request with correct replacement mode`() {
+            val currentPurchase = GooglePurchase(
+                purchaseToken = "purchase-token",
+                productIds = listOf(SubscriptionPlan.productId(fromTier, fromBillingCycle)),
+            )
+            val newPlan = creatMockPlan(toTier, toBillingCycle)
+            val product = GoogleProductDetails(
+                productId = newPlan.productId,
+                subscriptionOfferDetails = listOf(
+                    GoogleOfferDetails(basePlanId = newPlan.basePlanId, offerId = newPlan.offerId),
+                ),
+            )
+
+            val request = mapper.toBillingFlowRequest(newPlan, listOf(product), listOf(currentPurchase))
+
+            if (expectedReplacementMode == null) {
+                assertNotNull(request)
+                assertNull(request?.subscriptionUpdateQuery)
+            } else {
+                assertEquals(
+                    BillingFlowRequest.SubscriptionUpdateQuery("purchase-token", expectedReplacementMode),
+                    request?.subscriptionUpdateQuery,
+                )
+            }
+        }
+
+        @Test
+        fun `create billing request with no replacement mode when there are multiple active purchases`() {
+            val currentPurchases = listOf(
+                GooglePurchase(
+                    purchaseToken = "purchase-token-1",
+                    productIds = listOf(
+                        SubscriptionPlan.productId(fromTier, fromBillingCycle),
+                    ),
+                ),
+                GooglePurchase(
+                    purchaseToken = "purchase-token-2",
+                    productIds = listOf(
+                        SubscriptionPlan.productId(SubscriptionTier.entries.random(), SubscriptionBillingCycle.entries.random()),
+                    ),
+                ),
+            )
+            val newPlan = creatMockPlan(toTier, toBillingCycle)
+            val product = GoogleProductDetails(
+                productId = newPlan.productId,
+                subscriptionOfferDetails = listOf(
+                    GoogleOfferDetails(basePlanId = newPlan.basePlanId, offerId = newPlan.offerId),
+                ),
+            )
+
+            val request = mapper.toBillingFlowRequest(newPlan, listOf(product), currentPurchases)
+
+            assertNotNull(request)
+            assertNull(request?.subscriptionUpdateQuery)
+        }
+
+        @Test
+        fun `craete billing request with full price replacement mode for offers`() {
+            SubscriptionOffer.entries.forEach { offer ->
+                val currentPurchase = GooglePurchase(
+                    purchaseToken = "purchase-token",
+                    productIds = listOf(SubscriptionPlan.productId(fromTier, fromBillingCycle)),
+                )
+                val newPlan = creatMockPlan(toTier, toBillingCycle, offer)
+                val product = GoogleProductDetails(
+                    productId = newPlan.productId,
+                    subscriptionOfferDetails = listOf(
+                        GoogleOfferDetails(basePlanId = newPlan.basePlanId, offerId = newPlan.offerId),
+                    ),
+                )
+
+                val request = mapper.toBillingFlowRequest(newPlan, listOf(product), listOf(currentPurchase))
+
+                assertEquals(
+                    BillingFlowRequest.SubscriptionUpdateQuery("purchase-token", ReplacementMode.CHARGE_FULL_PRICE),
+                    request?.subscriptionUpdateQuery,
+                )
+            }
+        }
+
+        companion object {
+            @JvmStatic
+            @ParameterizedRobolectricTestRunner.Parameters(name = "From: {0} {1}, To: {2} {3}")
+            fun params() = listOf<Array<Any?>>(
+                arrayOf(
+                    SubscriptionTier.Plus,
+                    SubscriptionBillingCycle.Monthly,
+                    SubscriptionTier.Plus,
+                    SubscriptionBillingCycle.Monthly,
+                    null,
+                ),
+                arrayOf(
+                    SubscriptionTier.Plus,
+                    SubscriptionBillingCycle.Monthly,
+                    SubscriptionTier.Plus,
+                    SubscriptionBillingCycle.Yearly,
+                    ReplacementMode.CHARGE_FULL_PRICE,
+                ),
+                arrayOf(
+                    SubscriptionTier.Plus,
+                    SubscriptionBillingCycle.Monthly,
+                    SubscriptionTier.Patron,
+                    SubscriptionBillingCycle.Monthly,
+                    ReplacementMode.CHARGE_PRORATED_PRICE,
+                ),
+                arrayOf(
+                    SubscriptionTier.Plus,
+                    SubscriptionBillingCycle.Monthly,
+                    SubscriptionTier.Patron,
+                    SubscriptionBillingCycle.Yearly,
+                    ReplacementMode.CHARGE_FULL_PRICE,
+                ),
+                arrayOf(
+                    SubscriptionTier.Plus,
+                    SubscriptionBillingCycle.Yearly,
+                    SubscriptionTier.Plus,
+                    SubscriptionBillingCycle.Monthly,
+                    ReplacementMode.WITH_TIME_PRORATION,
+                ),
+                arrayOf(
+                    SubscriptionTier.Plus,
+                    SubscriptionBillingCycle.Yearly,
+                    SubscriptionTier.Plus,
+                    SubscriptionBillingCycle.Yearly,
+                    null,
+                ),
+                arrayOf(
+                    SubscriptionTier.Plus,
+                    SubscriptionBillingCycle.Yearly,
+                    SubscriptionTier.Patron,
+                    SubscriptionBillingCycle.Monthly,
+                    ReplacementMode.WITH_TIME_PRORATION,
+                ),
+                arrayOf(
+                    SubscriptionTier.Plus,
+                    SubscriptionBillingCycle.Yearly,
+                    SubscriptionTier.Patron,
+                    SubscriptionBillingCycle.Yearly,
+                    ReplacementMode.CHARGE_PRORATED_PRICE,
+                ),
+                arrayOf(
+                    SubscriptionTier.Patron,
+                    SubscriptionBillingCycle.Monthly,
+                    SubscriptionTier.Plus,
+                    SubscriptionBillingCycle.Monthly,
+                    ReplacementMode.WITH_TIME_PRORATION,
+                ),
+                arrayOf(
+                    SubscriptionTier.Patron,
+                    SubscriptionBillingCycle.Monthly,
+                    SubscriptionTier.Plus,
+                    SubscriptionBillingCycle.Yearly,
+                    ReplacementMode.CHARGE_FULL_PRICE,
+                ),
+                arrayOf(
+                    SubscriptionTier.Patron,
+                    SubscriptionBillingCycle.Monthly,
+                    SubscriptionTier.Patron,
+                    SubscriptionBillingCycle.Monthly,
+                    null,
+                ),
+                arrayOf(
+                    SubscriptionTier.Patron,
+                    SubscriptionBillingCycle.Monthly,
+                    SubscriptionTier.Patron,
+                    SubscriptionBillingCycle.Yearly,
+                    ReplacementMode.CHARGE_FULL_PRICE,
+                ),
+                arrayOf(
+                    SubscriptionTier.Patron,
+                    SubscriptionBillingCycle.Yearly,
+                    SubscriptionTier.Plus,
+                    SubscriptionBillingCycle.Monthly,
+                    ReplacementMode.WITH_TIME_PRORATION,
+                ),
+                arrayOf(
+                    SubscriptionTier.Patron,
+                    SubscriptionBillingCycle.Yearly,
+                    SubscriptionTier.Plus,
+                    SubscriptionBillingCycle.Yearly,
+                    ReplacementMode.WITH_TIME_PRORATION,
+                ),
+                arrayOf(
+                    SubscriptionTier.Patron,
+                    SubscriptionBillingCycle.Yearly,
+                    SubscriptionTier.Patron,
+                    SubscriptionBillingCycle.Monthly,
+                    ReplacementMode.WITH_TIME_PRORATION,
+                ),
+                arrayOf(
+                    SubscriptionTier.Patron,
+                    SubscriptionBillingCycle.Yearly,
+                    SubscriptionTier.Patron,
+                    SubscriptionBillingCycle.Yearly,
+                    null,
+                ),
+            )
+        }
+    }
+}
+
+private fun creatMockPlan(
+    tier: SubscriptionTier,
+    billingCycle: SubscriptionBillingCycle,
+    offer: SubscriptionOffer? = null,
+): SubscriptionPlan {
+    val anyPricingPhase = PricingPhase(
+        price = Price(10.toBigDecimal(), "USD", "$10.00"),
+        billingPeriod = BillingPeriod(BillingPeriod.Cycle.Infinite, BillingPeriod.Interval.Monthly, intervalCount = 0),
+    )
+
+    return if (offer == null) {
+        SubscriptionPlan.Base("Plan", tier, billingCycle, anyPricingPhase)
+    } else {
+        SubscriptionPlan.WithOffer("Plan", tier, SubscriptionBillingCycle.Monthly, offer, listOf(anyPricingPhase, anyPricingPhase))
+    }
+}


### PR DESCRIPTION
## Description

This PR adds support for finding the correct Billing flow parameters when making purchases through the new APIs. Because `BillingFlowParams` type doesn't implement equality methods I created intermediate `BillingFlowRequest` type. This let me write tests for different scenarios.

There are some assumptions in the code. For example a single purchase doesn't contain more than one products. Also users can have only a single active purchase. This makes sense for our app since we operate only on subscriptions and you should have only a single active one.

## Testing Instructions

Code review the API and tests.

## Checklist
- [ ] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [ ] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [ ] ~Any jetpack compose components I added or changed are covered by compose previews~
- [ ] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~