### PR TITLE
Add billing flow API

### DIFF
--- a/modules/services/payment/build.gradle.kts
+++ b/modules/services/payment/build.gradle.kts
@@ -23,5 +23,7 @@ dependencies {
 
     testImplementation(libs.coroutines.test)
     testImplementation(libs.junit)
+    testImplementation(libs.mockito.core)
+    testImplementation(libs.mockito.kotlin)
     testImplementation(libs.robolectric)
 }

--- a/modules/services/payment/src/main/kotlin/au/com/shiftyjelly/pocketcasts/payment/Data.kt
+++ b/modules/services/payment/src/main/kotlin/au/com/shiftyjelly/pocketcasts/payment/Data.kt
@@ -67,13 +67,13 @@ data class BillingPeriod(
 }
 
 class SubscriptionPlans private constructor(
-    private val plans: Map<Key, PaymentResult<SubscriptionPlan>>,
+    private val plans: Map<SubscriptionPlan.Key, PaymentResult<SubscriptionPlan>>,
 ) {
     fun getBasePlan(
         tier: SubscriptionTier,
         billingCycle: SubscriptionBillingCycle,
     ): SubscriptionPlan.Base {
-        val key = Key(tier, billingCycle, offer = null)
+        val key = SubscriptionPlan.Key(tier, billingCycle, offer = null)
         // This is a safe cast because constructor is private and we validate data in the create function
         return plans.getValue(key).getOrNull() as SubscriptionPlan.Base
     }
@@ -83,7 +83,7 @@ class SubscriptionPlans private constructor(
         billingCycle: SubscriptionBillingCycle,
         offer: SubscriptionOffer,
     ): PaymentResult<SubscriptionPlan.WithOffer> {
-        val key = Key(tier, billingCycle, offer)
+        val key = SubscriptionPlan.Key(tier, billingCycle, offer)
         // This is a safe cast because constructor is private and we validate data in the create function
         @Suppress("UNCHECKED_CAST")
         return plans.getValue(key) as PaymentResult<SubscriptionPlan.WithOffer>
@@ -98,14 +98,14 @@ class SubscriptionPlans private constructor(
     companion object {
         private val basePlanKeys = SubscriptionTier.entries.flatMap { tier ->
             SubscriptionBillingCycle.entries.map { billingCycle ->
-                Key(tier, billingCycle, offer = null)
+                SubscriptionPlan.Key(tier, billingCycle, offer = null)
             }
         }
 
         private val offerPlanKeys = SubscriptionTier.entries.flatMap { tier ->
             SubscriptionBillingCycle.entries.flatMap { billingCycle ->
                 SubscriptionOffer.entries.map { offer ->
-                    Key(tier, billingCycle, offer)
+                    SubscriptionPlan.Key(tier, billingCycle, offer)
                 }
             }
         }
@@ -123,7 +123,7 @@ class SubscriptionPlans private constructor(
             return PaymentResult.Success(SubscriptionPlans(basePlans + offerPlans))
         }
 
-        private fun List<Product>.findMatchingSubscriptionPlan(key: Key): PaymentResult<SubscriptionPlan> {
+        private fun List<Product>.findMatchingSubscriptionPlan(key: SubscriptionPlan.Key): PaymentResult<SubscriptionPlan> {
             val matchingProducts = findMatchingProducts(key)
             return when (matchingProducts.size) {
                 1 -> PaymentResult.Success(
@@ -139,7 +139,7 @@ class SubscriptionPlans private constructor(
             }
         }
 
-        private fun List<Product>.findMatchingProducts(key: Key): List<Product> {
+        private fun List<Product>.findMatchingProducts(key: SubscriptionPlan.Key): List<Product> {
             return filter { product ->
                 val offerCondition = if (key.offer != null) {
                     product.pricingPlans.offerPlans.singleOrNull { it.offerId == key.offerId } != null
@@ -150,7 +150,7 @@ class SubscriptionPlans private constructor(
             }
         }
 
-        private fun Product.toBaseSubscriptionPlan(key: Key): SubscriptionPlan.Base {
+        private fun Product.toBaseSubscriptionPlan(key: SubscriptionPlan.Key): SubscriptionPlan.Base {
             return SubscriptionPlan.Base(
                 name,
                 key.tier,
@@ -159,7 +159,7 @@ class SubscriptionPlans private constructor(
             )
         }
 
-        private fun Product.toOfferSubscriptionPlan(key: Key): SubscriptionPlan.WithOffer {
+        private fun Product.toOfferSubscriptionPlan(key: SubscriptionPlan.Key): SubscriptionPlan.WithOffer {
             checkNotNull(key.offer)
             val matchingPricingPhases = pricingPlans.offerPlans.single { it.offerId == key.offerId }.pricingPhases
             return SubscriptionPlan.WithOffer(
@@ -171,27 +171,18 @@ class SubscriptionPlans private constructor(
             )
         }
     }
-
-    private data class Key(
-        val tier: SubscriptionTier,
-        val billingCycle: SubscriptionBillingCycle,
-        val offer: SubscriptionOffer?,
-    ) {
-        val productId = SubscriptionPlan.productId(tier, billingCycle)
-        val basePlanId = SubscriptionPlan.basePlanId(tier, billingCycle)
-        val offerId = offer?.offerId(tier, billingCycle)
-    }
 }
 
 sealed interface SubscriptionPlan {
     val name: String
+    val key: SubscriptionPlan.Key
     val tier: SubscriptionTier
     val billingCycle: SubscriptionBillingCycle
     val offer: SubscriptionOffer?
 
-    val productId get() = SubscriptionPlan.productId(tier, billingCycle)
-    val basePlanId get() = SubscriptionPlan.basePlanId(tier, billingCycle)
-    val offerId get() = offer?.offerId(tier, billingCycle)
+    val productId get() = key.productId
+    val basePlanId get() = key.basePlanId
+    val offerId get() = key.offerId
 
     data class Base(
         override val name: String,
@@ -200,6 +191,7 @@ sealed interface SubscriptionPlan {
         val pricingPhase: PricingPhase,
     ) : SubscriptionPlan {
         override val offer get() = null
+        override val key get() = SubscriptionPlan.Key(tier, billingCycle, offer = null)
     }
 
     data class WithOffer(
@@ -208,7 +200,19 @@ sealed interface SubscriptionPlan {
         override val billingCycle: SubscriptionBillingCycle,
         override val offer: SubscriptionOffer,
         val pricingPhases: List<PricingPhase>,
-    ) : SubscriptionPlan
+    ) : SubscriptionPlan {
+        override val key get() = SubscriptionPlan.Key(tier, billingCycle, offer)
+    }
+
+    data class Key(
+        val tier: SubscriptionTier,
+        val billingCycle: SubscriptionBillingCycle,
+        val offer: SubscriptionOffer?,
+    ) {
+        val productId = SubscriptionPlan.productId(tier, billingCycle)
+        val basePlanId = SubscriptionPlan.basePlanId(tier, billingCycle)
+        val offerId = offer?.offerId(tier, billingCycle)
+    }
 
     companion object {
         fun productId(

--- a/modules/services/payment/src/main/kotlin/au/com/shiftyjelly/pocketcasts/payment/FakePaymentDataSource.kt
+++ b/modules/services/payment/src/main/kotlin/au/com/shiftyjelly/pocketcasts/payment/FakePaymentDataSource.kt
@@ -38,7 +38,7 @@ class FakePaymentDataSource : PaymentDataSource {
         }
     }
 
-    override suspend fun launchBillingFlow(plan: SubscriptionPlan, activity: Activity): PaymentResult<Unit> {
+    override suspend fun launchBillingFlow(key: SubscriptionPlan.Key, activity: Activity): PaymentResult<Unit> {
         return if (launchBillingFlowResultCode is PaymentResultCode.Ok) {
             PaymentResult.Success(Unit)
         } else {

--- a/modules/services/payment/src/main/kotlin/au/com/shiftyjelly/pocketcasts/payment/FakePaymentDataSource.kt
+++ b/modules/services/payment/src/main/kotlin/au/com/shiftyjelly/pocketcasts/payment/FakePaymentDataSource.kt
@@ -12,13 +12,18 @@ import com.android.billingclient.api.QueryPurchasesParams
 import java.math.BigDecimal
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.first
 import com.android.billingclient.api.Purchase as GooglePurchase
 
 class FakePaymentDataSource : PaymentDataSource {
     var customProductsResult: PaymentResult<List<Product>>? = null
     var customPurchases: PaymentResult<List<Purchase>>? = null
-    var acknowledgePurchaseResultCode: PaymentResultCode = PaymentResultCode.Ok
     var launchBillingFlowResultCode: PaymentResultCode = PaymentResultCode.Ok
+
+    var receivedPurchases = emptyList<Purchase>()
+        private set
+
+    private val acknowledgeFlow = MutableSharedFlow<PaymentResultCode>()
 
     override val purchaseResults = MutableSharedFlow<PaymentResult<List<Purchase>>>()
 
@@ -31,18 +36,24 @@ class FakePaymentDataSource : PaymentDataSource {
     }
 
     override suspend fun acknowledgePurchase(purchase: Purchase): PaymentResult<Purchase> {
-        return if (acknowledgePurchaseResultCode is PaymentResultCode.Ok) {
+        receivedPurchases += purchase
+        val resultCode = acknowledgeFlow.first()
+        return if (resultCode is PaymentResultCode.Ok) {
             PaymentResult.Success(purchase.copy(isAcknowledged = true))
         } else {
-            PaymentResult.Failure(acknowledgePurchaseResultCode, "Error")
+            PaymentResult.Failure(resultCode, "Error")
         }
+    }
+
+    suspend fun emitAcknowledgeResponse(code: PaymentResultCode) {
+        acknowledgeFlow.emit(code)
     }
 
     override suspend fun launchBillingFlow(key: SubscriptionPlan.Key, activity: Activity): PaymentResult<Unit> {
         return if (launchBillingFlowResultCode is PaymentResultCode.Ok) {
             PaymentResult.Success(Unit)
         } else {
-            PaymentResult.Failure(acknowledgePurchaseResultCode, "Error")
+            PaymentResult.Failure(launchBillingFlowResultCode, "Error")
         }
     }
 

--- a/modules/services/payment/src/main/kotlin/au/com/shiftyjelly/pocketcasts/payment/PaymentClient.kt
+++ b/modules/services/payment/src/main/kotlin/au/com/shiftyjelly/pocketcasts/payment/PaymentClient.kt
@@ -1,11 +1,30 @@
 package au.com.shiftyjelly.pocketcasts.payment
 
+import android.app.Activity
+import java.util.Collections
+import java.util.concurrent.ConcurrentHashMap
 import javax.inject.Inject
+import javax.inject.Singleton
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
 
+@Singleton
 class PaymentClient @Inject constructor(
     private val dataSource: PaymentDataSource,
+    private val purchaseApprover: PurchaseApprover,
     private val logger: Logger,
 ) {
+    private val purchaseEvents = MutableSharedFlow<PurchaseResult>()
+    private val pendingPurchases = Collections.newSetFromMap(ConcurrentHashMap<String, Boolean>())
+
+    suspend fun monitorPurchaseUpdates(): Nothing = coroutineScope {
+        launch { loadAndAcknowledgePurchases() }
+        listenToPurchaseUpdates()
+    }
+
     suspend fun loadSubscriptionPlans(): PaymentResult<SubscriptionPlans> {
         logger.info("Load subscription plans")
         return dataSource
@@ -13,5 +32,88 @@ class PaymentClient @Inject constructor(
             .flatMap(SubscriptionPlans::create)
             .onSuccess { plans -> logger.info("Subscription plans loaded: $plans") }
             .onFailure { code, message -> logger.warning("Failed to load subscription plans. $code, $message") }
+    }
+
+    suspend fun purchaseSubscriptionPlan(
+        key: SubscriptionPlan.Key,
+        activity: Activity,
+    ): PurchaseResult = coroutineScope {
+        val purchaseConfirmationDeferred = async { purchaseEvents.first() }
+        val billingResult = dataSource.launchBillingFlow(key, activity)
+        when (billingResult) {
+            is PaymentResult.Success -> {
+                purchaseConfirmationDeferred.await()
+            }
+
+            is PaymentResult.Failure -> {
+                logger.warning("Launching billing flow failed: ${billingResult.code} ${billingResult.message}")
+                purchaseConfirmationDeferred.cancel()
+                billingResult.toPurchaseResult()
+            }
+        }
+    }
+
+    private suspend fun loadAndAcknowledgePurchases() {
+        dataSource.loadPurchases().onSuccess { purchases ->
+            purchases
+                .filter { purchase -> !purchase.isAcknowledged }
+                .forEach { confirmPurchase(it, dispatchConfirmation = false) }
+        }
+    }
+
+    private suspend fun listenToPurchaseUpdates(): Nothing {
+        dataSource.purchaseResults.collect { result ->
+            val recoveredResult = result.recover { code, message ->
+                when (code) {
+                    PaymentResultCode.ItemAlreadyOwned -> dataSource.loadPurchases()
+                    else -> PaymentResult.Failure(code, message)
+                }
+            }
+            when (recoveredResult) {
+                is PaymentResult.Success -> {
+                    val purchases = recoveredResult.value
+                    purchases.forEachIndexed { index, purchase ->
+                        confirmPurchase(purchase, dispatchConfirmation = index == purchases.lastIndex)
+                    }
+                }
+
+                is PaymentResult.Failure -> {
+                    logger.warning("Purchase failure: ${recoveredResult.code} ${recoveredResult.message}")
+                    purchaseEvents.emit(recoveredResult.toPurchaseResult())
+                }
+            }
+        }
+    }
+
+    private suspend fun confirmPurchase(
+        purchase: Purchase,
+        dispatchConfirmation: Boolean,
+    ) {
+        if (purchase.state is PurchaseState.Purchased && pendingPurchases.add(purchase.state.orderId)) {
+            logger.info("Confirm purchase: $purchase")
+
+            val confirmResult = purchaseApprover.approve(purchase)
+                .flatMap { approvedPurchase ->
+                    if (!approvedPurchase.isAcknowledged) {
+                        dataSource.acknowledgePurchase(approvedPurchase)
+                    } else {
+                        PaymentResult.Success(approvedPurchase)
+                    }
+                }
+                .onSuccess { logger.info("Purchase confirmed: $it") }
+                .onFailure { code, message -> logger.warning("Failed to confirm purchase: $purchase. $code $message") }
+            if (dispatchConfirmation) {
+                purchaseEvents.emit(confirmResult.toPurchaseResult())
+            }
+            pendingPurchases.remove(purchase.state.orderId)
+        }
+    }
+}
+
+private fun PaymentResult<*>.toPurchaseResult() = when (this) {
+    is PaymentResult.Success -> PurchaseResult.Purchased
+    is PaymentResult.Failure -> when (code) {
+        PaymentResultCode.UserCancelled -> PurchaseResult.Cancelled
+        else -> PurchaseResult.Failure(code)
     }
 }

--- a/modules/services/payment/src/main/kotlin/au/com/shiftyjelly/pocketcasts/payment/PaymentDataSource.kt
+++ b/modules/services/payment/src/main/kotlin/au/com/shiftyjelly/pocketcasts/payment/PaymentDataSource.kt
@@ -23,7 +23,7 @@ interface PaymentDataSource {
 
     suspend fun acknowledgePurchase(purchase: Purchase): PaymentResult<Purchase>
 
-    suspend fun launchBillingFlow(plan: SubscriptionPlan, activity: Activity): PaymentResult<Unit>
+    suspend fun launchBillingFlow(key: SubscriptionPlan.Key, activity: Activity): PaymentResult<Unit>
 
     companion object {
         fun billing(

--- a/modules/services/payment/src/main/kotlin/au/com/shiftyjelly/pocketcasts/payment/PaymentResult.kt
+++ b/modules/services/payment/src/main/kotlin/au/com/shiftyjelly/pocketcasts/payment/PaymentResult.kt
@@ -58,3 +58,9 @@ fun <T : Any> PaymentResult<T>.getOrNull() = when (this) {
     is PaymentResult.Success -> value
     is PaymentResult.Failure -> null
 }
+
+sealed interface PurchaseResult {
+    data object Purchased : PurchaseResult
+    data object Cancelled : PurchaseResult
+    data class Failure(val code: PaymentResultCode) : PurchaseResult
+}

--- a/modules/services/payment/src/main/kotlin/au/com/shiftyjelly/pocketcasts/payment/PurchaseApprover.kt
+++ b/modules/services/payment/src/main/kotlin/au/com/shiftyjelly/pocketcasts/payment/PurchaseApprover.kt
@@ -1,0 +1,5 @@
+package au.com.shiftyjelly.pocketcasts.payment
+
+interface PurchaseApprover {
+    suspend fun approve(purchase: Purchase): PaymentResult<Purchase>
+}

--- a/modules/services/payment/src/main/kotlin/au/com/shiftyjelly/pocketcasts/payment/billing/BillingPaymentDataSource.kt
+++ b/modules/services/payment/src/main/kotlin/au/com/shiftyjelly/pocketcasts/payment/billing/BillingPaymentDataSource.kt
@@ -176,7 +176,7 @@ internal class BillingPaymentDataSource(
     }
 
     override suspend fun launchBillingFlow(
-        plan: SubscriptionPlan,
+        key: SubscriptionPlan.Key,
         activity: Activity,
     ): PaymentResult<Unit> {
         return connection.withConnectedClient { client ->
@@ -188,7 +188,7 @@ internal class BillingPaymentDataSource(
                         .map { purchases -> productDetails to purchases }
                 }
                 .flatMap { (productDetails, purchases) ->
-                    val params = mapper.toBillingFlowRequest(plan, productDetails, purchases)?.toGoogleParams()
+                    val params = mapper.toBillingFlowRequest(key, productDetails, purchases)?.toGoogleParams()
                     if (params == null) {
                         PaymentResult.Failure(PaymentResultCode.DeveloperError, "Couldn't create billing flow params")
                     } else {

--- a/modules/services/payment/src/test/kotlin/au/com/shiftyjelly/pocketcasts/payment/PaymentClientTest.kt
+++ b/modules/services/payment/src/test/kotlin/au/com/shiftyjelly/pocketcasts/payment/PaymentClientTest.kt
@@ -1,14 +1,34 @@
 package au.com.shiftyjelly.pocketcasts.payment
 
+import android.app.Activity
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.async
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.yield
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Test
+import org.mockito.kotlin.mock
 
 class PaymentClientTest {
     private val dataSource = PaymentDataSource.fake()
+    private val approver = TestPurchaseApprover()
     private val logger = TestLogger()
-    private val client = PaymentClient(dataSource, logger)
+
+    private val client = PaymentClient(dataSource, approver, logger)
+
+    private val planKey = SubscriptionPlan.Key(SubscriptionTier.Plus, SubscriptionBillingCycle.Monthly, offer = null)
+    private val purchase = Purchase(
+        state = PurchaseState.Purchased("orderId"),
+        token = "token",
+        productIds = listOf(planKey.productId),
+        isAcknowledged = false,
+        isAutoRenewing = false,
+    )
 
     @Test
     fun `load plans successfully`() = runTest {
@@ -24,6 +44,140 @@ class PaymentClientTest {
         val plans = client.loadSubscriptionPlans()
 
         assertNull(plans.getOrNull())
+    }
+
+    @Test
+    fun `purchase subscription`() = monitoredTest {
+        val purchaseResult = purchaseSubscription()
+
+        dataSource.purchaseResults.emit(PaymentResult.Success(listOf(purchase)))
+        approver.emitApproveResponse(PaymentResultCode.Ok)
+        dataSource.emitAcknowledgeResponse(PaymentResultCode.Ok)
+
+        assertEquals(PurchaseResult.Purchased, purchaseResult.await())
+    }
+
+    @Test
+    fun `do not purchase subscription when billing result is failure`() = monitoredTest {
+        dataSource.launchBillingFlowResultCode = PaymentResultCode.FeatureNotSupported
+
+        val purchaseResult = purchaseSubscription()
+
+        assertEquals(PurchaseResult.Failure(PaymentResultCode.FeatureNotSupported), purchaseResult.await())
+    }
+
+    @Test
+    fun `do not purchase subscription when purchase result is failure`() = monitoredTest {
+        val purchaseResult = purchaseSubscription()
+
+        dataSource.purchaseResults.emit(PaymentResult.Failure(PaymentResultCode.BillingUnavailable, "Error"))
+
+        assertEquals(PurchaseResult.Failure(PaymentResultCode.BillingUnavailable), purchaseResult.await())
+    }
+
+    @Test
+    fun `cancel purchase subscription when purchase result is cancelled`() = monitoredTest {
+        val purchaseResult = purchaseSubscription()
+
+        dataSource.purchaseResults.emit(PaymentResult.Failure(PaymentResultCode.UserCancelled, "Error"))
+
+        assertEquals(PurchaseResult.Cancelled, purchaseResult.await())
+    }
+
+    @Test
+    fun `do not purchase subscription when approving fails`() = monitoredTest {
+        val purchaseResult = purchaseSubscription()
+
+        dataSource.purchaseResults.emit(PaymentResult.Success(listOf(purchase)))
+        approver.emitApproveResponse(PaymentResultCode.Error)
+
+        assertEquals(PurchaseResult.Failure(PaymentResultCode.Error), purchaseResult.await())
+    }
+
+    @Test
+    fun `do not purchase subscription when acknowledging fails`() = monitoredTest {
+        val purchaseResult = purchaseSubscription()
+
+        dataSource.purchaseResults.emit(PaymentResult.Success(listOf(purchase)))
+        approver.emitApproveResponse(PaymentResultCode.Ok)
+        dataSource.emitAcknowledgeResponse(PaymentResultCode.Error)
+
+        assertEquals(PurchaseResult.Failure(PaymentResultCode.Error), purchaseResult.await())
+    }
+
+    @Test
+    fun `cancel purchase subscription when acknowledging is cancelled`() = monitoredTest {
+        val purchaseResult = purchaseSubscription()
+
+        dataSource.purchaseResults.emit(PaymentResult.Success(listOf(purchase)))
+        approver.emitApproveResponse(PaymentResultCode.Ok)
+        dataSource.emitAcknowledgeResponse(PaymentResultCode.UserCancelled)
+
+        assertEquals(PurchaseResult.Cancelled, purchaseResult.await())
+    }
+
+    @Test
+    fun `wait for all purchases to be confirmed before finalizing purchase`() = monitoredTest {
+        val purchaseResult = purchaseSubscription()
+
+        dataSource.purchaseResults.emit(PaymentResult.Success(listOf(purchase, purchase)))
+        approver.emitApproveResponse(PaymentResultCode.Ok)
+        dataSource.emitAcknowledgeResponse(PaymentResultCode.Ok)
+
+        yield() // Yield to make sure the job didn't cancel
+        assertTrue(purchaseResult.isActive)
+
+        approver.emitApproveResponse(PaymentResultCode.Ok)
+        dataSource.emitAcknowledgeResponse(PaymentResultCode.Ok)
+
+        assertEquals(PurchaseResult.Purchased, purchaseResult.await())
+    }
+
+    @Test
+    fun `do not finalize non confirmed purchases`() = monitoredTest {
+        val purchaseResult = purchaseSubscription()
+
+        dataSource.purchaseResults.emit(PaymentResult.Success(listOf(purchase.copy(state = PurchaseState.Pending))))
+        approver.emitApproveResponse(PaymentResultCode.Ok)
+        dataSource.emitAcknowledgeResponse(PaymentResultCode.Ok)
+
+        yield() // Yield to make sure the job didn't cancel
+        assertTrue(purchaseResult.isActive)
+        assertTrue(approver.receivedPurchases.isEmpty())
+    }
+
+    @Test
+    fun `do not acknowledge purchases that are already acknowledged`() = monitoredTest {
+        val purchaseResult = purchaseSubscription()
+
+        dataSource.purchaseResults.emit(PaymentResult.Success(listOf(purchase.copy(isAcknowledged = true))))
+        approver.emitApproveResponse(PaymentResultCode.Ok)
+
+        assertTrue(dataSource.receivedPurchases.isEmpty())
+        assertEquals(PurchaseResult.Purchased, purchaseResult.await())
+    }
+
+    @Test
+    fun `acknowledge lingering purchases when monitoring starts`() = runTest {
+        val purchases = listOf(
+            purchase.copy(state = PurchaseState.Purchased("order-id-1")),
+            purchase.copy(isAcknowledged = true),
+            purchase.copy(state = PurchaseState.Pending),
+            purchase.copy(state = PurchaseState.Purchased("order-id-2")),
+        )
+        dataSource.customPurchases = PaymentResult.Success(purchases)
+
+        backgroundScope.launch(start = CoroutineStart.UNDISPATCHED) { client.monitorPurchaseUpdates() }
+        yield() // Yield due to starting internal job inside monitorPurchaseUpdates()
+
+        approver.emitApproveResponse(PaymentResultCode.Ok)
+        dataSource.emitAcknowledgeResponse(PaymentResultCode.Ok)
+        approver.emitApproveResponse(PaymentResultCode.Ok)
+        dataSource.emitAcknowledgeResponse(PaymentResultCode.Ok)
+
+        val expectedPurchases = listOf(purchases[0], purchases[3])
+        assertEquals(expectedPurchases, approver.receivedPurchases)
+        assertEquals(expectedPurchases, dataSource.receivedPurchases)
     }
 
     @Test
@@ -45,4 +199,67 @@ class PaymentClientTest {
         logger.assertInfos("Load subscription plans")
         logger.assertWarnings("Failed to load subscription plans. Error, Test failure")
     }
+
+    @Test
+    fun `log confirming purchase`() = monitoredTest {
+        val purchaseResult = purchaseSubscription()
+
+        dataSource.purchaseResults.emit(PaymentResult.Success(listOf(purchase)))
+        approver.emitApproveResponse(PaymentResultCode.Ok)
+        dataSource.emitAcknowledgeResponse(PaymentResultCode.Ok)
+        purchaseResult.await()
+
+        logger.assertInfos(
+            "Confirm purchase: $purchase",
+            "Purchase confirmed: ${purchase.copy(isAcknowledged = true)}",
+        )
+    }
+
+    @Test
+    fun `log confirming purchase failure`() = monitoredTest {
+        val purchaseResult = purchaseSubscription()
+
+        dataSource.purchaseResults.emit(PaymentResult.Success(listOf(purchase)))
+        approver.emitApproveResponse(PaymentResultCode.DeveloperError)
+        purchaseResult.await()
+
+        logger.assertInfos(
+            "Confirm purchase: $purchase",
+        )
+        logger.assertWarnings(
+            "Failed to confirm purchase: $purchase. DeveloperError Error",
+        )
+    }
+
+    @Test
+    fun `log purchase result failure`() = monitoredTest {
+        val purchaseResult = purchaseSubscription()
+
+        dataSource.purchaseResults.emit(PaymentResult.Failure(PaymentResultCode.ServiceDisconnected, "Whoops!"))
+        purchaseResult.await()
+
+        logger.assertWarnings(
+            "Purchase failure: ServiceDisconnected Whoops!",
+        )
+    }
+
+    @Test
+    fun `log billing result failure`() = monitoredTest {
+        dataSource.launchBillingFlowResultCode = PaymentResultCode.DeveloperError
+
+        purchaseSubscription()
+
+        logger.assertWarnings(
+            "Launching billing flow failed: DeveloperError Error",
+        )
+    }
+
+    private fun monitoredTest(testBody: suspend TestScope.() -> Unit) = runTest {
+        backgroundScope.launch(start = CoroutineStart.UNDISPATCHED) { client.monitorPurchaseUpdates() }
+        testBody()
+    }
+
+    private fun TestScope.purchaseSubscription(
+        key: SubscriptionPlan.Key = planKey,
+    ) = backgroundScope.async(start = CoroutineStart.UNDISPATCHED) { client.purchaseSubscriptionPlan(key, mock<Activity>()) }
 }

--- a/modules/services/payment/src/test/kotlin/au/com/shiftyjelly/pocketcasts/payment/TestPurchaseApprover.kt
+++ b/modules/services/payment/src/test/kotlin/au/com/shiftyjelly/pocketcasts/payment/TestPurchaseApprover.kt
@@ -1,0 +1,25 @@
+package au.com.shiftyjelly.pocketcasts.payment
+
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.first
+
+class TestPurchaseApprover : PurchaseApprover {
+    var receivedPurchases = emptyList<Purchase>()
+        private set
+
+    private val approveFlow = MutableSharedFlow<PaymentResultCode>()
+
+    suspend fun emitApproveResponse(code: PaymentResultCode) {
+        approveFlow.emit(code)
+    }
+
+    override suspend fun approve(purchase: Purchase): PaymentResult<Purchase> {
+        receivedPurchases += purchase
+        val errorCode = approveFlow.first()
+        return if (errorCode == PaymentResultCode.Ok) {
+            PaymentResult.Success(purchase)
+        } else {
+            PaymentResult.Failure(errorCode, "Error")
+        }
+    }
+}

--- a/modules/services/payment/src/test/kotlin/au/com/shiftyjelly/pocketcasts/payment/billing/BillingPaymentMapperFlowParamsTest.kt
+++ b/modules/services/payment/src/test/kotlin/au/com/shiftyjelly/pocketcasts/payment/billing/BillingPaymentMapperFlowParamsTest.kt
@@ -1,8 +1,5 @@
 package au.com.shiftyjelly.pocketcasts.payment.billing
 
-import au.com.shiftyjelly.pocketcasts.payment.BillingPeriod
-import au.com.shiftyjelly.pocketcasts.payment.Price
-import au.com.shiftyjelly.pocketcasts.payment.PricingPhase
 import au.com.shiftyjelly.pocketcasts.payment.SubscriptionBillingCycle
 import au.com.shiftyjelly.pocketcasts.payment.SubscriptionOffer
 import au.com.shiftyjelly.pocketcasts.payment.SubscriptionPlan
@@ -32,19 +29,19 @@ class BillingPaymentMapperFlowParamsTest {
 
         @Test
         fun `create billing params`() {
-            val plan = creatMockPlan(SubscriptionTier.Plus, SubscriptionBillingCycle.Monthly)
+            val planKey = SubscriptionPlan.Key(SubscriptionTier.Plus, SubscriptionBillingCycle.Monthly, offer = null)
             val product = GoogleProductDetails(
-                productId = plan.productId,
+                productId = planKey.productId,
                 subscriptionOfferDetails = listOf(
                     GoogleOfferDetails(
-                        basePlanId = plan.basePlanId,
-                        offerId = plan.offerId,
+                        basePlanId = planKey.basePlanId,
+                        offerId = planKey.offerId,
                         offerIdToken = "offer-token",
                     ),
                 ),
             )
 
-            val request = mapper.toBillingFlowRequest(plan, listOf(product), purchases = emptyList())
+            val request = mapper.toBillingFlowRequest(planKey, listOf(product), purchases = emptyList())
 
             assertEquals(
                 BillingFlowRequest(
@@ -95,19 +92,19 @@ class BillingPaymentMapperFlowParamsTest {
                     isAutoRenewing = false,
                 ),
             )
-            val plan = creatMockPlan(SubscriptionTier.Plus, SubscriptionBillingCycle.Yearly)
+            val planKey = SubscriptionPlan.Key(SubscriptionTier.Plus, SubscriptionBillingCycle.Yearly, offer = null)
             val product = GoogleProductDetails(
-                productId = plan.productId,
+                productId = planKey.productId,
                 subscriptionOfferDetails = listOf(
                     GoogleOfferDetails(
-                        basePlanId = plan.basePlanId,
-                        offerId = plan.offerId,
+                        basePlanId = planKey.basePlanId,
+                        offerId = planKey.offerId,
                         offerIdToken = "offer-token",
                     ),
                 ),
             )
 
-            val request = mapper.toBillingFlowRequest(plan, listOf(product), currentPurchases)
+            val request = mapper.toBillingFlowRequest(planKey, listOf(product), currentPurchases)
 
             assertEquals(
                 BillingFlowRequest(
@@ -120,19 +117,19 @@ class BillingPaymentMapperFlowParamsTest {
 
         @Test
         fun `log too many matching products`() {
-            val plan = creatMockPlan(SubscriptionTier.Plus, SubscriptionBillingCycle.Monthly)
+            val planKey = SubscriptionPlan.Key(SubscriptionTier.Plus, SubscriptionBillingCycle.Monthly, offer = null)
             val product = GoogleProductDetails(
-                productId = plan.productId,
+                productId = planKey.productId,
                 subscriptionOfferDetails = listOf(
                     GoogleOfferDetails(
-                        basePlanId = plan.basePlanId,
-                        offerId = plan.offerId,
-                        offerIdToken = "${plan.name}-offer-token",
+                        basePlanId = planKey.basePlanId,
+                        offerId = planKey.offerId,
+                        offerIdToken = "${planKey.name}-offer-token",
                     ),
                 ),
             )
 
-            mapper.toBillingFlowRequest(plan, listOf(product, product), purchases = emptyList())
+            mapper.toBillingFlowRequest(planKey, listOf(product, product), purchases = emptyList())
 
             logger.assertWarnings(
                 "Found multiple matching products in {billingCycle=Monthly, offer=null, tier=Plus}",
@@ -141,9 +138,9 @@ class BillingPaymentMapperFlowParamsTest {
 
         @Test
         fun `log no matching products`() {
-            val plan = creatMockPlan(SubscriptionTier.Plus, SubscriptionBillingCycle.Monthly)
+            val planKey = SubscriptionPlan.Key(SubscriptionTier.Plus, SubscriptionBillingCycle.Monthly, offer = null)
 
-            mapper.toBillingFlowRequest(plan, productDetails = emptyList(), purchases = emptyList())
+            mapper.toBillingFlowRequest(planKey, productDetails = emptyList(), purchases = emptyList())
 
             logger.assertWarnings(
                 "Found no matching products in {billingCycle=Monthly, offer=null, tier=Plus}",
@@ -152,24 +149,24 @@ class BillingPaymentMapperFlowParamsTest {
 
         @Test
         fun `log too many matching offers`() {
-            val plan = creatMockPlan(SubscriptionTier.Plus, SubscriptionBillingCycle.Monthly)
+            val planKey = SubscriptionPlan.Key(SubscriptionTier.Plus, SubscriptionBillingCycle.Monthly, offer = null)
             val product = GoogleProductDetails(
-                productId = plan.productId,
+                productId = planKey.productId,
                 subscriptionOfferDetails = listOf(
                     GoogleOfferDetails(
-                        basePlanId = plan.basePlanId,
-                        offerId = plan.offerId,
+                        basePlanId = planKey.basePlanId,
+                        offerId = planKey.offerId,
                         offerIdToken = "token-1",
                     ),
                     GoogleOfferDetails(
-                        basePlanId = plan.basePlanId,
-                        offerId = plan.offerId,
+                        basePlanId = planKey.basePlanId,
+                        offerId = planKey.offerId,
                         offerIdToken = "token-2",
                     ),
                 ),
             )
 
-            mapper.toBillingFlowRequest(plan, listOf(product), purchases = emptyList())
+            mapper.toBillingFlowRequest(planKey, listOf(product), purchases = emptyList())
 
             logger.assertWarnings(
                 "Found multiple matching offers in {billingCycle=Monthly, offer=null, tier=Plus}",
@@ -178,13 +175,13 @@ class BillingPaymentMapperFlowParamsTest {
 
         @Test
         fun `log no matching offers`() {
-            val plan = creatMockPlan(SubscriptionTier.Plus, SubscriptionBillingCycle.Monthly)
+            val planKey = SubscriptionPlan.Key(SubscriptionTier.Plus, SubscriptionBillingCycle.Monthly, offer = null)
             val product = GoogleProductDetails(
-                productId = plan.productId,
+                productId = planKey.productId,
                 subscriptionOfferDetails = emptyList(),
             )
 
-            mapper.toBillingFlowRequest(plan, listOf(product), purchases = emptyList())
+            mapper.toBillingFlowRequest(planKey, listOf(product), purchases = emptyList())
 
             logger.assertWarnings(
                 "Found no matching offers in {billingCycle=Monthly, offer=null, tier=Plus}",
@@ -203,15 +200,15 @@ class BillingPaymentMapperFlowParamsTest {
                     productIds = listOf("product-id-2"),
                 ),
             )
-            val plan = creatMockPlan(SubscriptionTier.Plus, SubscriptionBillingCycle.Monthly)
+            val planKey = SubscriptionPlan.Key(SubscriptionTier.Plus, SubscriptionBillingCycle.Monthly, offer = null)
             val product = GoogleProductDetails(
-                productId = plan.productId,
+                productId = planKey.productId,
                 subscriptionOfferDetails = listOf(
-                    GoogleOfferDetails(basePlanId = plan.basePlanId, offerId = plan.offerId),
+                    GoogleOfferDetails(basePlanId = planKey.basePlanId, offerId = planKey.offerId),
                 ),
             )
 
-            mapper.toBillingFlowRequest(plan, listOf(product), currentPurchases)
+            mapper.toBillingFlowRequest(planKey, listOf(product), currentPurchases)
 
             logger.assertWarnings(
                 "Found more than one active purchase in {purchases=order-id-1: [product-id-1], order-id-2: [product-id-2]}",
@@ -226,15 +223,15 @@ class BillingPaymentMapperFlowParamsTest {
                     productIds = listOf("product-id-1", "product-id-2"),
                 ),
             )
-            val plan = creatMockPlan(SubscriptionTier.Plus, SubscriptionBillingCycle.Monthly)
+            val planKey = SubscriptionPlan.Key(SubscriptionTier.Plus, SubscriptionBillingCycle.Monthly, offer = null)
             val product = GoogleProductDetails(
-                productId = plan.productId,
+                productId = planKey.productId,
                 subscriptionOfferDetails = listOf(
-                    GoogleOfferDetails(basePlanId = plan.basePlanId, offerId = plan.offerId),
+                    GoogleOfferDetails(basePlanId = planKey.basePlanId, offerId = planKey.offerId),
                 ),
             )
 
-            mapper.toBillingFlowRequest(plan, listOf(product), currentPurchases)
+            mapper.toBillingFlowRequest(planKey, listOf(product), currentPurchases)
 
             logger.assertWarnings(
                 "Active purchase should have only a single product in {orderId=order-id, products=[product-id-1, product-id-2]}",
@@ -243,15 +240,15 @@ class BillingPaymentMapperFlowParamsTest {
 
         @Test
         fun `do not log anything when mapped succesfully`() {
-            val plan = creatMockPlan(SubscriptionTier.Plus, SubscriptionBillingCycle.Monthly)
+            val planKey = SubscriptionPlan.Key(SubscriptionTier.Plus, SubscriptionBillingCycle.Monthly, offer = null)
             val product = GoogleProductDetails(
-                productId = plan.productId,
+                productId = planKey.productId,
                 subscriptionOfferDetails = listOf(
-                    GoogleOfferDetails(basePlanId = plan.basePlanId, offerId = plan.offerId),
+                    GoogleOfferDetails(basePlanId = planKey.basePlanId, offerId = planKey.offerId),
                 ),
             )
 
-            mapper.toBillingFlowRequest(plan, listOf(product), purchases = emptyList())
+            mapper.toBillingFlowRequest(planKey, listOf(product), purchases = emptyList())
 
             logger.assertNoLogs()
         }
@@ -267,35 +264,35 @@ class BillingPaymentMapperFlowParamsTest {
 
         @Test
         fun `map base plan to billing flow request`() {
-            val plan = creatMockPlan(tier, billingCycle)
+            val planKey = SubscriptionPlan.Key(tier, billingCycle, offer = null)
             val product = GoogleProductDetails(
-                productId = plan.productId,
+                productId = planKey.productId,
                 subscriptionOfferDetails = listOf(
                     GoogleOfferDetails(
-                        basePlanId = plan.basePlanId,
-                        offerId = plan.offerId,
-                        offerIdToken = "${plan.name}-offer-token",
+                        basePlanId = planKey.basePlanId,
+                        offerId = planKey.offerId,
+                        offerIdToken = "${planKey.name}-offer-token",
                     ),
                     GoogleOfferDetails(
-                        basePlanId = plan.basePlanId,
-                        offerId = "random-offer-id-${plan.name}",
-                        offerIdToken = "random-offer-token-1-${plan.name}",
+                        basePlanId = planKey.basePlanId,
+                        offerId = "random-offer-id-${planKey.name}",
+                        offerIdToken = "random-offer-token-1-${planKey.name}",
                     ),
                     GoogleOfferDetails(
-                        basePlanId = "random-base-plan-id-${plan.name}",
-                        offerId = plan.offerId,
-                        offerIdToken = "random-offer-token-2-${plan.name}",
+                        basePlanId = "random-base-plan-id-${planKey.name}",
+                        offerId = planKey.offerId,
+                        offerIdToken = "random-offer-token-2-${planKey.name}",
                     ),
                 ),
             )
 
-            val request = mapper.toBillingFlowRequest(plan, listOf(product), purchases = emptyList())
+            val request = mapper.toBillingFlowRequest(planKey, listOf(product), purchases = emptyList())
 
             assertEquals(
                 BillingFlowRequest(
                     productQuery = BillingFlowRequest.ProductQuery(
                         product = product,
-                        offerToken = "${plan.name}-offer-token",
+                        offerToken = "${planKey.name}-offer-token",
                     ),
                     subscriptionUpdateQuery = null,
                 ),
@@ -305,31 +302,31 @@ class BillingPaymentMapperFlowParamsTest {
 
         @Test
         fun `do not map base plan to billing flow request with multiple matching products`() {
-            val plan = creatMockPlan(tier, billingCycle)
+            val planKey = SubscriptionPlan.Key(tier, billingCycle, offer = null)
             val product = GoogleProductDetails(
-                productId = plan.productId,
+                productId = planKey.productId,
                 subscriptionOfferDetails = listOf(
-                    GoogleOfferDetails(basePlanId = plan.basePlanId, offerId = plan.offerId),
+                    GoogleOfferDetails(basePlanId = planKey.basePlanId, offerId = planKey.offerId),
                 ),
             )
 
-            val request = mapper.toBillingFlowRequest(plan, listOf(product, product), purchases = emptyList())
+            val request = mapper.toBillingFlowRequest(planKey, listOf(product, product), purchases = emptyList())
 
             assertNull(request)
         }
 
         @Test
         fun `do not map base plan to billing flow request with multiple matching offers`() {
-            val plan = creatMockPlan(tier, billingCycle)
+            val planKey = SubscriptionPlan.Key(tier, billingCycle, offer = null)
             val product = GoogleProductDetails(
-                productId = plan.productId,
+                productId = planKey.productId,
                 subscriptionOfferDetails = listOf(
-                    GoogleOfferDetails(basePlanId = plan.basePlanId, offerId = plan.offerId),
-                    GoogleOfferDetails(basePlanId = plan.basePlanId, offerId = plan.offerId),
+                    GoogleOfferDetails(basePlanId = planKey.basePlanId, offerId = planKey.offerId),
+                    GoogleOfferDetails(basePlanId = planKey.basePlanId, offerId = planKey.offerId),
                 ),
             )
 
-            val request = mapper.toBillingFlowRequest(plan, listOf(product), purchases = emptyList())
+            val request = mapper.toBillingFlowRequest(planKey, listOf(product), purchases = emptyList())
 
             assertNull(request)
         }
@@ -363,15 +360,15 @@ class BillingPaymentMapperFlowParamsTest {
                 purchaseToken = "purchase-token",
                 productIds = listOf(SubscriptionPlan.productId(fromTier, fromBillingCycle)),
             )
-            val newPlan = creatMockPlan(toTier, toBillingCycle)
+            val newPlanKey = SubscriptionPlan.Key(toTier, toBillingCycle, offer = null)
             val product = GoogleProductDetails(
-                productId = newPlan.productId,
+                productId = newPlanKey.productId,
                 subscriptionOfferDetails = listOf(
-                    GoogleOfferDetails(basePlanId = newPlan.basePlanId, offerId = newPlan.offerId),
+                    GoogleOfferDetails(basePlanId = newPlanKey.basePlanId, offerId = newPlanKey.offerId),
                 ),
             )
 
-            val request = mapper.toBillingFlowRequest(newPlan, listOf(product), listOf(currentPurchase))
+            val request = mapper.toBillingFlowRequest(newPlanKey, listOf(product), listOf(currentPurchase))
 
             if (expectedReplacementMode == null) {
                 assertNotNull(request)
@@ -400,15 +397,15 @@ class BillingPaymentMapperFlowParamsTest {
                     ),
                 ),
             )
-            val newPlan = creatMockPlan(toTier, toBillingCycle)
+            val newPlanKey = SubscriptionPlan.Key(toTier, toBillingCycle, offer = null)
             val product = GoogleProductDetails(
-                productId = newPlan.productId,
+                productId = newPlanKey.productId,
                 subscriptionOfferDetails = listOf(
-                    GoogleOfferDetails(basePlanId = newPlan.basePlanId, offerId = newPlan.offerId),
+                    GoogleOfferDetails(basePlanId = newPlanKey.basePlanId, offerId = newPlanKey.offerId),
                 ),
             )
 
-            val request = mapper.toBillingFlowRequest(newPlan, listOf(product), currentPurchases)
+            val request = mapper.toBillingFlowRequest(newPlanKey, listOf(product), currentPurchases)
 
             assertNotNull(request)
             assertNull(request?.subscriptionUpdateQuery)
@@ -421,15 +418,15 @@ class BillingPaymentMapperFlowParamsTest {
                     purchaseToken = "purchase-token",
                     productIds = listOf(SubscriptionPlan.productId(fromTier, fromBillingCycle)),
                 )
-                val newPlan = creatMockPlan(toTier, toBillingCycle, offer)
+                val newPlanKey = SubscriptionPlan.Key(toTier, toBillingCycle, offer)
                 val product = GoogleProductDetails(
-                    productId = newPlan.productId,
+                    productId = newPlanKey.productId,
                     subscriptionOfferDetails = listOf(
-                        GoogleOfferDetails(basePlanId = newPlan.basePlanId, offerId = newPlan.offerId),
+                        GoogleOfferDetails(basePlanId = newPlanKey.basePlanId, offerId = newPlanKey.offerId),
                     ),
                 )
 
-                val request = mapper.toBillingFlowRequest(newPlan, listOf(product), listOf(currentPurchase))
+                val request = mapper.toBillingFlowRequest(newPlanKey, listOf(product), listOf(currentPurchase))
 
                 assertEquals(
                     BillingFlowRequest.SubscriptionUpdateQuery("purchase-token", ReplacementMode.CHARGE_FULL_PRICE),
@@ -559,19 +556,12 @@ class BillingPaymentMapperFlowParamsTest {
     }
 }
 
-private fun creatMockPlan(
-    tier: SubscriptionTier,
-    billingCycle: SubscriptionBillingCycle,
-    offer: SubscriptionOffer? = null,
-): SubscriptionPlan {
-    val anyPricingPhase = PricingPhase(
-        price = Price(10.toBigDecimal(), "USD", "$10.00"),
-        billingPeriod = BillingPeriod(BillingPeriod.Cycle.Infinite, BillingPeriod.Interval.Monthly, intervalCount = 0),
-    )
-
-    return if (offer == null) {
-        SubscriptionPlan.Base("Plan", tier, billingCycle, anyPricingPhase)
-    } else {
-        SubscriptionPlan.WithOffer("Plan", tier, SubscriptionBillingCycle.Monthly, offer, listOf(anyPricingPhase, anyPricingPhase))
+private val SubscriptionPlan.Key.name get() = buildString {
+    append(tier)
+    append(' ')
+    append(billingCycle)
+    if (offer != null) {
+        append(' ')
+        append(offer)
     }
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/di/RepositoryModule.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/di/RepositoryModule.kt
@@ -4,6 +4,7 @@ import androidx.work.WorkerFactory
 import au.com.shiftyjelly.pocketcasts.analytics.AccountStatusInfo
 import au.com.shiftyjelly.pocketcasts.crashlogging.CrashReportPermissionCheck
 import au.com.shiftyjelly.pocketcasts.crashlogging.ObserveUser
+import au.com.shiftyjelly.pocketcasts.payment.PurchaseApprover
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.preferences.SettingsImpl
 import au.com.shiftyjelly.pocketcasts.repositories.bookmark.BookmarkManager
@@ -48,6 +49,7 @@ import au.com.shiftyjelly.pocketcasts.repositories.referrals.ReferralManager
 import au.com.shiftyjelly.pocketcasts.repositories.referrals.ReferralManagerImpl
 import au.com.shiftyjelly.pocketcasts.repositories.searchhistory.SearchHistoryManager
 import au.com.shiftyjelly.pocketcasts.repositories.searchhistory.SearchHistoryManagerImpl
+import au.com.shiftyjelly.pocketcasts.repositories.subscription.ServerPurchaseApprover
 import au.com.shiftyjelly.pocketcasts.repositories.subscription.SubscriptionManager
 import au.com.shiftyjelly.pocketcasts.repositories.subscription.SubscriptionManagerImpl
 import au.com.shiftyjelly.pocketcasts.repositories.sync.AccountManagerStatusInfo
@@ -196,4 +198,7 @@ abstract class RepositoryModule {
 
     @Binds
     abstract fun provideUpNextHistoryManager(upNextHistoryManagerImpl: UpNextHistoryManagerImpl): UpNextHistoryManager
+
+    @Binds
+    abstract fun providePurchaseApprover(approver: ServerPurchaseApprover): PurchaseApprover
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/subscription/ServerPurchaseApprover.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/subscription/ServerPurchaseApprover.kt
@@ -1,0 +1,26 @@
+package au.com.shiftyjelly.pocketcasts.repositories.subscription
+
+import au.com.shiftyjelly.pocketcasts.payment.PaymentResult
+import au.com.shiftyjelly.pocketcasts.payment.PaymentResultCode
+import au.com.shiftyjelly.pocketcasts.payment.Purchase
+import au.com.shiftyjelly.pocketcasts.payment.PurchaseApprover
+import au.com.shiftyjelly.pocketcasts.repositories.sync.SyncManager
+import au.com.shiftyjelly.pocketcasts.servers.sync.SubscriptionPurchaseRequest
+import javax.inject.Inject
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.rx2.await
+
+class ServerPurchaseApprover @Inject constructor(
+    private val syncManager: SyncManager,
+) : PurchaseApprover {
+    override suspend fun approve(purchase: Purchase): PaymentResult<Purchase> {
+        return try {
+            val request = SubscriptionPurchaseRequest(purchase.token, purchase.productIds.first())
+            syncManager.subscriptionPurchaseRxSingle(request).await()
+            PaymentResult.Success(purchase)
+        } catch (e: Throwable) {
+            if (e is CancellationException) throw e
+            PaymentResult.Failure(PaymentResultCode.Unknown(0), e.message ?: "Server confirmation error")
+        }
+    }
+}


### PR DESCRIPTION
## Description

This is the last major PR before I can begin integrating the new APIs with the existing code. It adds support for launching the billing flow. I retained all of the logic from the current `SubscriptionManagerImpl`, with a few small improvements:

- The purchase event is dispatched only after all purchases are confirmed. While this doesn't affect us much—since our purchases can only contain one item. It is generally safer.
- In some edge cases, there were no purchase confirmations. These events will now be present.
- Pre-existing purchases no longer trigger purchase confirmation events.

## Testing Instructions

Code review the changes.

## Checklist
- [ ] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [ ] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [ ] ~Any jetpack compose components I added or changed are covered by compose previews~
- [ ] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~