### PR TITLE
TalkBack improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 *   Updates
     *   Improve contrast of secondary texts on Upgrade page
         ([#3942](https://github.com/Automattic/pocket-casts-android/pull/3942))
+    *   Improve Accessibility on the Upgrade page
+        ([#3947](https://github.com/Automattic/pocket-casts-android/pull/3947))
 
 7.88
 -----

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/components/ProductAmountVerticalText.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/components/ProductAmountVerticalText.kt
@@ -10,6 +10,8 @@ import androidx.compose.material.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.style.TextDecoration
@@ -71,6 +73,7 @@ fun ProductAmountHorizontalText(
     verticalAlignment: Alignment.Vertical = Alignment.CenterVertically,
     secondaryTextColor: Color = MaterialTheme.theme.colors.primaryText02,
     isFocusable: Boolean = false,
+    focusRequester: FocusRequester? = null,
 ) {
     Row(
         modifier = modifier,
@@ -86,9 +89,15 @@ fun ProductAmountHorizontalText(
                     } else {
                         MaterialTheme.theme.colors.primaryText01
                     },
-                modifier = if (isFocusable) {
-                    Modifier.focusable()
-                } else Modifier,
+                modifier = if (focusRequester != null) {
+                    Modifier.focusRequester(focusRequester)
+                } else {
+                    Modifier
+                }.then(
+                    if (isFocusable) {
+                        Modifier.focusable()
+                    } else Modifier
+                ),
             )
         }
 

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/components/ProductAmountVerticalText.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/components/ProductAmountVerticalText.kt
@@ -84,11 +84,11 @@ fun ProductAmountHorizontalText(
                 text = price,
                 fontSize = priceTextFontSize,
                 color =
-                    if (hasBackgroundAlwaysWhite) {
-                        Color.Black
-                    } else {
-                        MaterialTheme.theme.colors.primaryText01
-                    },
+                if (hasBackgroundAlwaysWhite) {
+                    Color.Black
+                } else {
+                    MaterialTheme.theme.colors.primaryText01
+                },
                 modifier = if (focusRequester != null) {
                     Modifier.focusRequester(focusRequester)
                 } else {
@@ -96,7 +96,9 @@ fun ProductAmountHorizontalText(
                 }.then(
                     if (isFocusable) {
                         Modifier.focusable()
-                    } else Modifier
+                    } else {
+                        Modifier
+                    },
                 ),
             )
         }

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/components/ProductAmountVerticalText.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/components/ProductAmountVerticalText.kt
@@ -10,8 +10,6 @@ import androidx.compose.material.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.focus.FocusRequester
-import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.style.TextDecoration
@@ -73,7 +71,6 @@ fun ProductAmountHorizontalText(
     verticalAlignment: Alignment.Vertical = Alignment.CenterVertically,
     secondaryTextColor: Color = MaterialTheme.theme.colors.primaryText02,
     isFocusable: Boolean = false,
-    focusRequester: FocusRequester? = null,
 ) {
     Row(
         modifier = modifier,
@@ -83,23 +80,16 @@ fun ProductAmountHorizontalText(
             TextH30(
                 text = price,
                 fontSize = priceTextFontSize,
-                color =
-                if (hasBackgroundAlwaysWhite) {
+                color = if (hasBackgroundAlwaysWhite) {
                     Color.Black
                 } else {
                     MaterialTheme.theme.colors.primaryText01
                 },
-                modifier = if (focusRequester != null) {
-                    Modifier.focusRequester(focusRequester)
+                modifier = if (isFocusable) {
+                    Modifier.focusable()
                 } else {
                     Modifier
-                }.then(
-                    if (isFocusable) {
-                        Modifier.focusable()
-                    } else {
-                        Modifier
-                    },
-                ),
+                },
             )
         }
 

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/components/ProductAmountVerticalText.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/components/ProductAmountVerticalText.kt
@@ -1,5 +1,6 @@
 package au.com.shiftyjelly.pocketcasts.account.components
 
+import androidx.compose.foundation.focusable
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -69,6 +70,7 @@ fun ProductAmountHorizontalText(
     hasBackgroundAlwaysWhite: Boolean = false,
     verticalAlignment: Alignment.Vertical = Alignment.CenterVertically,
     secondaryTextColor: Color = MaterialTheme.theme.colors.primaryText02,
+    isFocusable: Boolean = false,
 ) {
     Row(
         modifier = modifier,
@@ -79,11 +81,14 @@ fun ProductAmountHorizontalText(
                 text = price,
                 fontSize = priceTextFontSize,
                 color =
-                if (hasBackgroundAlwaysWhite) {
-                    Color.Black
-                } else {
-                    MaterialTheme.theme.colors.primaryText01
-                },
+                    if (hasBackgroundAlwaysWhite) {
+                        Color.Black
+                    } else {
+                        MaterialTheme.theme.colors.primaryText01
+                    },
+                modifier = if (isFocusable) {
+                    Modifier.focusable()
+                } else Modifier,
             )
         }
 

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeFeaturesPage.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeFeaturesPage.kt
@@ -6,6 +6,8 @@ import androidx.compose.animation.core.tween
 import androidx.compose.foundation.ScrollState
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.focusGroup
+import androidx.compose.foundation.focusable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
@@ -48,6 +50,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.drawWithCache
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusProperties
+import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.graphics.BlendMode
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
@@ -297,7 +300,7 @@ fun FeatureCards(
         showPageIndicator = featureCardsState.showPageIndicator,
         pageSize = PageSize.Fixed(LocalConfiguration.current.screenWidthDp.dp - 64.dp),
         contentPadding = PaddingValues(horizontal = 32.dp),
-    ) { index, pagerHeight ->
+    ) { index, pagerHeight, focusRequester ->
         FeatureCard(
             subscription = state.currentSubscription,
             card = featureCardsState.featureCards[index],
@@ -309,7 +312,9 @@ fun FeatureCards(
                 Modifier.height(pagerHeight.pxToDp(LocalContext.current).dp)
             } else {
                 Modifier
-            },
+            }.then(
+                Modifier.focusRequester(focusRequester)
+            ),
         )
     }
 }
@@ -398,7 +403,9 @@ private fun FeatureCard(
                 }
             }
 
-            Column {
+            Column(
+                modifier = Modifier.focusGroup()
+            ) {
                 SubscriptionProductAmountHorizontal(
                     isFocusable = true,
                     subscription = subscription,
@@ -409,10 +416,13 @@ private fun FeatureCard(
                 Spacer(modifier = Modifier.padding(vertical = 4.dp))
 
                 card.featureItems(subscriptionFrequency).forEach {
-                    UpgradeFeatureItem(it)
+                    UpgradeFeatureItem(
+                        item = it,
+                    )
                 }
                 Spacer(modifier = Modifier.weight(1f))
                 OnboardingUpgradeHelper.PrivacyPolicy(
+                    modifier = Modifier.focusable(),
                     color = secondaryTextColor,
                     textAlign = TextAlign.Start,
                     lineHeight = 18.sp,

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeFeaturesPage.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeFeaturesPage.kt
@@ -6,8 +6,6 @@ import androidx.compose.animation.core.tween
 import androidx.compose.foundation.ScrollState
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.focusGroup
-import androidx.compose.foundation.focusable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
@@ -50,7 +48,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.drawWithCache
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusProperties
-import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.graphics.BlendMode
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
@@ -181,8 +178,6 @@ private fun UpgradeLayout(
                 tier = state.currentFeatureCard.subscriptionTier,
                 backgroundGlowsRes = state.currentFeatureCard.backgroundGlowsRes,
             ) {
-                val (titleFocus, tabsFocus, pagerFocus) = remember { FocusRequester.createRefs() }
-
                 Column(
                     Modifier
                         .windowInsetsPadding(WindowInsets.statusBars)
@@ -202,10 +197,7 @@ private fun UpgradeLayout(
                             iconColor = Color.White,
                             modifier = Modifier
                                 .height(48.dp)
-                                .width(48.dp)
-                                .focusProperties {
-                                    down = titleFocus
-                                },
+                                .width(48.dp),
                         )
                         if (state.showNotNow) {
                             TextH30(
@@ -223,12 +215,7 @@ private fun UpgradeLayout(
                     Column {
                         Box(
                             modifier = Modifier
-                                .heightIn(min = 70.dp)
-                                .focusGroup()
-                                .focusRequester(titleFocus)
-                                .focusProperties {
-                                    down = tabsFocus
-                                },
+                                .heightIn(min = 70.dp),
                             contentAlignment = Alignment.Center,
                         ) {
                             AutoResizeText(
@@ -251,12 +238,6 @@ private fun UpgradeLayout(
                         Box(
                             modifier = Modifier
                                 .fillMaxWidth()
-                                .focusRequester(tabsFocus)
-                                .focusGroup()
-                                .focusProperties {
-                                    up = titleFocus
-                                    down = pagerFocus
-                                }
                                 .padding(bottom = 24.dp),
                             contentAlignment = Alignment.Center,
                         ) {
@@ -275,12 +256,6 @@ private fun UpgradeLayout(
                         }
 
                         FeatureCards(
-                            modifier = Modifier
-                                .focusRequester(pagerFocus)
-                                .focusGroup()
-                                .focusProperties {
-                                    up = tabsFocus
-                                },
                             state = state,
                             upgradeButton = state.currentUpgradeButton,
                             onFeatureCardChanged = onFeatureCardChanged,
@@ -357,8 +332,7 @@ private fun FeatureCard(
         backgroundColor = Color.White,
         modifier = modifier
             .padding(8.dp)
-            .fillMaxWidth()
-            .focusGroup(),
+            .fillMaxWidth(),
     ) {
         Column(
             modifier = Modifier.padding(24.dp),
@@ -465,7 +439,6 @@ internal fun UpgradeButton(
         contentAlignment = Alignment.BottomCenter,
         modifier = Modifier
             .fadeBackground()
-            .focusGroup()
             .focusProperties {
                 down = FocusRequester.Cancel
                 left = FocusRequester.Cancel

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeFeaturesPage.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeFeaturesPage.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.ScrollState
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.focusGroup
+import androidx.compose.foundation.focusable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
@@ -49,6 +50,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.drawWithCache
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusProperties
+import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.graphics.BlendMode
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
@@ -159,10 +161,10 @@ private fun UpgradeLayout(
     onSubscriptionFrequencyChanged: (SubscriptionFrequency) -> Unit,
     onFeatureCardChanged: (Int) -> Unit,
     onClickSubscribe: () -> Unit,
+    modifier: Modifier = Modifier,
     onPrivacyPolicyClick: () -> Unit = {},
     onTermsAndConditionsClick: () -> Unit = {},
     canUpgrade: Boolean,
-    modifier: Modifier = Modifier,
 ) {
     Box(
         modifier = modifier.fillMaxHeight(),
@@ -179,6 +181,9 @@ private fun UpgradeLayout(
                 tier = state.currentFeatureCard.subscriptionTier,
                 backgroundGlowsRes = state.currentFeatureCard.backgroundGlowsRes,
             ) {
+
+                val (titleFocus, tabsFocus, pagerFocus) = remember { FocusRequester.createRefs() }
+
                 Column(
                     Modifier
                         .windowInsetsPadding(WindowInsets.statusBars)
@@ -198,7 +203,10 @@ private fun UpgradeLayout(
                             iconColor = Color.White,
                             modifier = Modifier
                                 .height(48.dp)
-                                .width(48.dp),
+                                .width(48.dp)
+                                .focusProperties {
+                                    down = titleFocus
+                                },
                         )
                         if (state.showNotNow) {
                             TextH30(
@@ -215,7 +223,13 @@ private fun UpgradeLayout(
 
                     Column {
                         Box(
-                            modifier = Modifier.heightIn(min = 70.dp),
+                            modifier = Modifier
+                                .heightIn(min = 70.dp)
+                                .focusGroup()
+                                .focusRequester(titleFocus)
+                                .focusProperties {
+                                    down = tabsFocus
+                                },
                             contentAlignment = Alignment.Center,
                         ) {
                             AutoResizeText(
@@ -226,6 +240,7 @@ private fun UpgradeLayout(
                                 fontWeight = FontWeight.W700,
                                 maxLines = 2,
                                 textAlign = TextAlign.Center,
+                                isFocusable = true,
                                 modifier = Modifier
                                     .padding(horizontal = 24.dp)
                                     .fillMaxWidth(),
@@ -237,6 +252,12 @@ private fun UpgradeLayout(
                         Box(
                             modifier = Modifier
                                 .fillMaxWidth()
+                                .focusRequester(tabsFocus)
+                                .focusGroup()
+                                .focusProperties {
+                                    up = titleFocus
+                                    down = pagerFocus
+                                }
                                 .padding(bottom = 24.dp),
                             contentAlignment = Alignment.Center,
                         ) {
@@ -255,6 +276,12 @@ private fun UpgradeLayout(
                         }
 
                         FeatureCards(
+                            modifier = Modifier
+                                .focusRequester(pagerFocus)
+                                .focusGroup()
+                                .focusProperties {
+                                    up = tabsFocus
+                                },
                             state = state,
                             upgradeButton = state.currentUpgradeButton,
                             onFeatureCardChanged = onFeatureCardChanged,
@@ -282,12 +309,14 @@ fun FeatureCards(
     state: OnboardingUpgradeFeaturesState.Loaded,
     upgradeButton: UpgradeButton,
     onFeatureCardChanged: (Int) -> Unit,
+    modifier: Modifier = Modifier,
     onPrivacyPolicyClick: () -> Unit = {},
     onTermsAndConditionsClick: () -> Unit = {},
 ) {
     val featureCardsState = state.featureCardsState
     val currentSubscriptionFrequency = state.currentSubscriptionFrequency
     HorizontalPagerWrapper(
+        modifier = modifier,
         pageCount = featureCardsState.featureCards.size,
         initialPage = featureCardsState.featureCards.indexOf(state.currentFeatureCard),
         onPageChanged = onFeatureCardChanged,
@@ -433,7 +462,8 @@ internal fun UpgradeButton(
 
     Box(
         contentAlignment = Alignment.BottomCenter,
-        modifier = Modifier.fadeBackground()
+        modifier = Modifier
+            .fadeBackground()
             .focusGroup()
             .focusProperties {
                 down = FocusRequester.Cancel

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeFeaturesPage.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeFeaturesPage.kt
@@ -170,6 +170,9 @@ private fun UpgradeLayout(
         modifier = modifier.fillMaxHeight(),
         contentAlignment = Alignment.BottomCenter,
     ) {
+
+        val focusPager = remember { FocusRequester() }
+
         // Need this BoxWithConstraints so we can force the inner column to fill the screen with vertical scroll enabled
         BoxWithConstraints(
             Modifier
@@ -259,6 +262,7 @@ private fun UpgradeLayout(
                         }
 
                         FeatureCards(
+                            modifier = Modifier.focusRequester(focusPager),
                             state = state,
                             upgradeButton = state.currentUpgradeButton,
                             onFeatureCardChanged = onFeatureCardChanged,
@@ -274,6 +278,7 @@ private fun UpgradeLayout(
 
         if (canUpgrade) {
             UpgradeButton(
+                upFocusRequester = focusPager,
                 button = state.currentUpgradeButton,
                 onClickSubscribe = onClickSubscribe,
             )
@@ -439,6 +444,7 @@ private fun FeatureCard(
 internal fun UpgradeButton(
     button: UpgradeButton,
     onClickSubscribe: () -> Unit,
+    upFocusRequester: FocusRequester
 ) {
     val resources = LocalContext.current.resources
     val shortName = resources.getString(button.shortNameRes)
@@ -450,6 +456,7 @@ internal fun UpgradeButton(
         modifier = Modifier
             .fadeBackground()
             .focusProperties {
+                up = upFocusRequester
                 down = FocusRequester.Cancel
                 left = FocusRequester.Cancel
                 right = FocusRequester.Cancel

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeFeaturesPage.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeFeaturesPage.kt
@@ -170,7 +170,6 @@ private fun UpgradeLayout(
         modifier = modifier.fillMaxHeight(),
         contentAlignment = Alignment.BottomCenter,
     ) {
-
         val focusPager = remember { FocusRequester() }
 
         // Need this BoxWithConstraints so we can force the inner column to fill the screen with vertical scroll enabled
@@ -318,7 +317,7 @@ fun FeatureCards(
             } else {
                 Modifier
             }.then(
-                Modifier.focusRequester(focusRequester)
+                Modifier.focusRequester(focusRequester),
             ),
         )
     }
@@ -409,7 +408,7 @@ private fun FeatureCard(
             }
 
             Column(
-                modifier = Modifier.focusGroup()
+                modifier = Modifier.focusGroup(),
             ) {
                 SubscriptionProductAmountHorizontal(
                     isFocusable = true,
@@ -444,7 +443,7 @@ private fun FeatureCard(
 internal fun UpgradeButton(
     button: UpgradeButton,
     onClickSubscribe: () -> Unit,
-    upFocusRequester: FocusRequester
+    upFocusRequester: FocusRequester,
 ) {
     val resources = LocalContext.current.resources
     val shortName = resources.getString(button.shortNameRes)

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeFeaturesPage.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeFeaturesPage.kt
@@ -41,7 +41,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
@@ -181,7 +181,6 @@ private fun UpgradeLayout(
                 tier = state.currentFeatureCard.subscriptionTier,
                 backgroundGlowsRes = state.currentFeatureCard.backgroundGlowsRes,
             ) {
-
                 val (titleFocus, tabsFocus, pagerFocus) = remember { FocusRequester.createRefs() }
 
                 Column(
@@ -358,12 +357,13 @@ private fun FeatureCard(
         backgroundColor = Color.White,
         modifier = modifier
             .padding(8.dp)
-            .fillMaxWidth(),
+            .fillMaxWidth()
+            .focusGroup(),
     ) {
         Column(
             modifier = Modifier.padding(24.dp),
         ) {
-            var offerBadgeTextLength by remember { mutableStateOf(MAX_OFFER_BADGE_TEXT_LENGTH) }
+            var offerBadgeTextLength by remember { mutableIntStateOf(MAX_OFFER_BADGE_TEXT_LENGTH) }
             val screenWidth = LocalConfiguration.current.screenWidthDp
             val displayInHorizontal = screenWidth >= MIN_SCREEN_WIDTH_FOR_HORIZONTAL_DISPLAY && offerBadgeTextLength <= MAX_OFFER_BADGE_TEXT_LENGTH
 
@@ -426,6 +426,7 @@ private fun FeatureCard(
 
             Column {
                 SubscriptionProductAmountHorizontal(
+                    isFocusable = true,
                     subscription = subscription,
                     hasBackgroundAlwaysWhite = true,
                     secondaryTextColor = secondaryTextColor,

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeFeaturesPage.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeFeaturesPage.kt
@@ -6,6 +6,7 @@ import androidx.compose.animation.core.tween
 import androidx.compose.foundation.ScrollState
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.focusGroup
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
@@ -43,8 +44,11 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
+import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.drawWithCache
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusProperties
 import androidx.compose.ui.graphics.BlendMode
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
@@ -416,6 +420,7 @@ private fun FeatureCard(
     }
 }
 
+@OptIn(ExperimentalComposeUiApi::class)
 @Composable
 internal fun UpgradeButton(
     button: UpgradeButton,
@@ -428,7 +433,13 @@ internal fun UpgradeButton(
 
     Box(
         contentAlignment = Alignment.BottomCenter,
-        modifier = Modifier.fadeBackground(),
+        modifier = Modifier.fadeBackground()
+            .focusGroup()
+            .focusProperties {
+                down = FocusRequester.Cancel
+                left = FocusRequester.Cancel
+                right = FocusRequester.Cancel
+            },
     ) {
         Column {
             UpgradeRowButton(

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/ProfileUpgradeBanner.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/ProfileUpgradeBanner.kt
@@ -59,7 +59,7 @@ fun ProfileUpgradeBanner(
             showPageIndicator = featureCardsState.showPageIndicator,
             pageIndicatorColor = MaterialTheme.theme.colors.primaryText01,
             modifier = modifier,
-        ) { index, pagerHeight ->
+        ) { index, pagerHeight, _ ->
             val currentTier = featureCardsState.featureCards[index].subscriptionTier
             FeatureCard(
                 card = featureCardsState.featureCards[index],

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/SubscriptionProductAmountHorizontal.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/SubscriptionProductAmountHorizontal.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.material.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
@@ -19,6 +20,7 @@ fun SubscriptionProductAmountHorizontal(
     hasBackgroundAlwaysWhite: Boolean = false,
     secondaryTextColor: Color = MaterialTheme.theme.colors.primaryText02,
     isFocusable: Boolean = false,
+    focusRequester: FocusRequester? = null,
 ) {
     if (subscription is Subscription.WithOffer) {
         if (subscription is Subscription.Intro) {
@@ -28,7 +30,8 @@ fun SubscriptionProductAmountHorizontal(
                 period = subscription.offerPricingPhase.slashPeriod(LocalContext.current.resources),
                 originalPrice = subscription.recurringPricingPhase.priceSlashPeriod(LocalContext.current.resources),
                 hasBackgroundAlwaysWhite = hasBackgroundAlwaysWhite,
-                isFocusable = isFocusable
+                isFocusable = isFocusable,
+                focusRequester = focusRequester,
             )
         } else if (subscription is Subscription.Trial) {
             ProductAmountHorizontalText(
@@ -37,7 +40,8 @@ fun SubscriptionProductAmountHorizontal(
                 originalPrice = subscription.recurringPricingPhase.slashPeriod(LocalContext.current.resources),
                 lineThroughOriginalPrice = false,
                 hasBackgroundAlwaysWhite = hasBackgroundAlwaysWhite,
-                isFocusable = isFocusable
+                isFocusable = isFocusable,
+                focusRequester = focusRequester,
             )
         }
 
@@ -49,7 +53,8 @@ fun SubscriptionProductAmountHorizontal(
             originalPrice = subscription.recurringPricingPhase.slashPeriod(LocalContext.current.resources),
             lineThroughOriginalPrice = false,
             hasBackgroundAlwaysWhite = hasBackgroundAlwaysWhite,
-            isFocusable = isFocusable
+            isFocusable = isFocusable,
+            focusRequester = focusRequester,
         )
     }
 }

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/SubscriptionProductAmountHorizontal.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/SubscriptionProductAmountHorizontal.kt
@@ -5,7 +5,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.material.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
@@ -20,7 +19,6 @@ fun SubscriptionProductAmountHorizontal(
     hasBackgroundAlwaysWhite: Boolean = false,
     secondaryTextColor: Color = MaterialTheme.theme.colors.primaryText02,
     isFocusable: Boolean = false,
-    focusRequester: FocusRequester? = null,
 ) {
     if (subscription is Subscription.WithOffer) {
         if (subscription is Subscription.Intro) {
@@ -31,7 +29,6 @@ fun SubscriptionProductAmountHorizontal(
                 originalPrice = subscription.recurringPricingPhase.priceSlashPeriod(LocalContext.current.resources),
                 hasBackgroundAlwaysWhite = hasBackgroundAlwaysWhite,
                 isFocusable = isFocusable,
-                focusRequester = focusRequester,
             )
         } else if (subscription is Subscription.Trial) {
             ProductAmountHorizontalText(
@@ -41,7 +38,6 @@ fun SubscriptionProductAmountHorizontal(
                 lineThroughOriginalPrice = false,
                 hasBackgroundAlwaysWhite = hasBackgroundAlwaysWhite,
                 isFocusable = isFocusable,
-                focusRequester = focusRequester,
             )
         }
 
@@ -54,7 +50,6 @@ fun SubscriptionProductAmountHorizontal(
             lineThroughOriginalPrice = false,
             hasBackgroundAlwaysWhite = hasBackgroundAlwaysWhite,
             isFocusable = isFocusable,
-            focusRequester = focusRequester,
         )
     }
 }

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/SubscriptionProductAmountHorizontal.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/SubscriptionProductAmountHorizontal.kt
@@ -18,6 +18,7 @@ fun SubscriptionProductAmountHorizontal(
     modifier: Modifier = Modifier,
     hasBackgroundAlwaysWhite: Boolean = false,
     secondaryTextColor: Color = MaterialTheme.theme.colors.primaryText02,
+    isFocusable: Boolean = false,
 ) {
     if (subscription is Subscription.WithOffer) {
         if (subscription is Subscription.Intro) {
@@ -27,6 +28,7 @@ fun SubscriptionProductAmountHorizontal(
                 period = subscription.offerPricingPhase.slashPeriod(LocalContext.current.resources),
                 originalPrice = subscription.recurringPricingPhase.priceSlashPeriod(LocalContext.current.resources),
                 hasBackgroundAlwaysWhite = hasBackgroundAlwaysWhite,
+                isFocusable = isFocusable
             )
         } else if (subscription is Subscription.Trial) {
             ProductAmountHorizontalText(
@@ -35,6 +37,7 @@ fun SubscriptionProductAmountHorizontal(
                 originalPrice = subscription.recurringPricingPhase.slashPeriod(LocalContext.current.resources),
                 lineThroughOriginalPrice = false,
                 hasBackgroundAlwaysWhite = hasBackgroundAlwaysWhite,
+                isFocusable = isFocusable
             )
         }
 
@@ -46,6 +49,7 @@ fun SubscriptionProductAmountHorizontal(
             originalPrice = subscription.recurringPricingPhase.slashPeriod(LocalContext.current.resources),
             lineThroughOriginalPrice = false,
             hasBackgroundAlwaysWhite = hasBackgroundAlwaysWhite,
+            isFocusable = isFocusable
         )
     }
 }

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/AutoResizeText.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/AutoResizeText.kt
@@ -1,5 +1,6 @@
 package au.com.shiftyjelly.pocketcasts.compose.components
 
+import androidx.compose.foundation.focusable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.requiredHeight
@@ -56,6 +57,7 @@ fun AutoResizeText(
     onTextLayout: (TextLayoutResult) -> Unit = {},
     style: TextStyle = LocalTextStyle.current,
     heightFactor: Float? = null,
+    isFocusable: Boolean = false
 ) {
     val alignment = contentAlignment ?: when (textAlign) {
         TextAlign.Left -> Alignment.TopStart
@@ -66,7 +68,10 @@ fun AutoResizeText(
         TextAlign.End -> Alignment.TopEnd
         else -> Alignment.TopStart
     }
-    BoxWithConstraints(modifier = modifier, contentAlignment = alignment) {
+    BoxWithConstraints(
+        modifier = modifier,
+        contentAlignment = alignment
+    ) {
         var shrunkFontSize = if (maxFontSize.isSpecified) maxFontSize else 100.sp
 
         val calculateIntrinsics = @Composable {
@@ -158,7 +163,13 @@ fun AutoResizeText(
             onTextLayout = onTextLayout,
             maxLines = maxLines,
             style = style,
-            modifier = heightModifier,
+            modifier = heightModifier.then(
+                if (isFocusable) {
+                    Modifier.focusable()
+                } else {
+                    Modifier
+                }
+            ),
         )
     }
 }

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/AutoResizeText.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/AutoResizeText.kt
@@ -57,7 +57,7 @@ fun AutoResizeText(
     onTextLayout: (TextLayoutResult) -> Unit = {},
     style: TextStyle = LocalTextStyle.current,
     heightFactor: Float? = null,
-    isFocusable: Boolean = false
+    isFocusable: Boolean = false,
 ) {
     val alignment = contentAlignment ?: when (textAlign) {
         TextAlign.Left -> Alignment.TopStart
@@ -70,7 +70,7 @@ fun AutoResizeText(
     }
     BoxWithConstraints(
         modifier = modifier,
-        contentAlignment = alignment
+        contentAlignment = alignment,
     ) {
         var shrunkFontSize = if (maxFontSize.isSpecified) maxFontSize else 100.sp
 
@@ -168,7 +168,7 @@ fun AutoResizeText(
                     Modifier.focusable()
                 } else {
                     Modifier
-                }
+                },
             ),
         )
     }

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/ClickableTextHelper.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/ClickableTextHelper.kt
@@ -7,12 +7,12 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.LinkAnnotation
 import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.TextLinkStyles
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextDecoration
-import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.TextUnit
 import androidx.compose.ui.unit.sp
 import au.com.shiftyjelly.pocketcasts.compose.theme
@@ -92,15 +92,13 @@ fun ClickableTextHelper(
                         linkInteractionListener = { _ ->
                             linkTextData.onClick?.invoke(linkTextData.data)
                         },
+                        styles = TextLinkStyles(
+                            style = SpanStyle(textDecoration = TextDecoration.Underline),
+                            focusedStyle = SpanStyle(background = MaterialTheme.theme.colors.primaryInteractive01),
+                        ),
                     ),
                 )
-                withStyle(
-                    style = SpanStyle(
-                        textDecoration = TextDecoration.Underline,
-                    ),
-                ) {
-                    append(linkTextData.text)
-                }
+                append(linkTextData.text)
                 pop()
             } else {
                 append(linkTextData.text)

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/HorizontalPagerWrapper.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/HorizontalPagerWrapper.kt
@@ -32,6 +32,8 @@ import androidx.compose.ui.input.key.type
 import androidx.compose.ui.layout.layout
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.launch
 
@@ -73,6 +75,9 @@ fun HorizontalPagerWrapper(
             var pageHeight by remember { mutableIntStateOf(0) }
             Box(
                 Modifier
+                    .semantics {
+                        contentDescription = "Page ${index + 1} of $pageCount"
+                    }
                     .fillMaxWidth()
                     .layout { measurable, constraints ->
                         /* https://github.com/google/accompanist/issues/1050#issuecomment-1097483476 */

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/HorizontalPagerWrapper.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/HorizontalPagerWrapper.kt
@@ -140,7 +140,7 @@ fun HorizontalPagerWrapper(
                         } else {
                             false
                         }
-                    }
+                    },
             ) {
                 content(index, pagerHeight, subContentFocusRequesters[index])
             }

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/HorizontalPagerWrapper.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/HorizontalPagerWrapper.kt
@@ -62,8 +62,8 @@ fun HorizontalPagerWrapper(
     }
 
     val coroutineScope = rememberCoroutineScope()
-    val focusRequesters = remember { List(pageCount) { FocusRequester() } }
-    val subContentFocusRequesters = remember { List(pageCount) { FocusRequester() } }
+    val focusRequesters = remember(pageCount) { List(pageCount) { FocusRequester() } }
+    val subContentFocusRequesters = remember(pageCount) { List(pageCount) { FocusRequester() } }
 
     var pagerHeight by remember { mutableIntStateOf(0) }
     Column(


### PR DESCRIPTION
## Description
This PR attempts to address the issues listed in #3931 
- vertical focus order is mostly correct, you can vertically traverse the main screen elements - title, period selector, subscription tier selector, cta.
- title is now focusable
- CTA focus issues have been adressed

~~However there are still 2 major issues open:~~
~~- Feature card items cannot be selected via keyboard arrows~~
~~- Dislaimer text (with the PP and TNC links) is not selectable~~

Fixes #3931 

## Testing Instructions
1. Open the upgrade screen (Profile -> Settings -> Upgrade to Plus)
2. Enable TalkBack (System Settings -> Accessbility -> TalkBack)
3. Start navigating up and down using the keyboard 

## Screenshots or Screencast 

https://github.com/user-attachments/assets/e2ca384a-934c-45c1-be9b-258ef1b57512



## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
~~- [ ] I have considered whether it makes sense to add tests for my changes~~
~~- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~~
- [x] Any jetpack compose components I added or changed are covered by compose previews
~~- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~~
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack
