### PR TITLE
Adds source property to purchase analytic

### DIFF
--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/CreateAccountViewModel.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/CreateAccountViewModel.kt
@@ -14,6 +14,7 @@ import au.com.shiftyjelly.pocketcasts.repositories.subscription.PurchaseEvent
 import au.com.shiftyjelly.pocketcasts.repositories.subscription.SubscriptionManager
 import au.com.shiftyjelly.pocketcasts.repositories.sync.LoginResult
 import au.com.shiftyjelly.pocketcasts.repositories.sync.SyncManager
+import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingUpgradeSource
 import au.com.shiftyjelly.pocketcasts.utils.Util
 import dagger.hilt.android.lifecycle.HiltViewModel
 import io.reactivex.disposables.CompositeDisposable
@@ -50,7 +51,7 @@ class CreateAccountViewModel
         private const val SOURCE_KEY = "source"
         private const val ENABLED_KEY = "enabled"
 
-        fun trackPurchaseEvent(subscription: Subscription?, purchaseEvent: PurchaseEvent, analyticsTracker: AnalyticsTracker) {
+        fun trackPurchaseEvent(subscription: Subscription?, purchaseEvent: PurchaseEvent, source: OnboardingUpgradeSource, analyticsTracker: AnalyticsTracker) {
             val productKey = subscription?.productDetails?.productId?.let {
                 if (it in listOf(PLUS_MONTHLY_PRODUCT_ID, PLUS_YEARLY_PRODUCT_ID)) {
                     // retain short product id for plus subscriptions
@@ -69,6 +70,7 @@ class CreateAccountViewModel
             val analyticsProperties = mapOf(
                 PRODUCT_KEY to productKey,
                 OFFER_TYPE_KEY to offerType,
+                SOURCE_KEY to source.analyticsValue,
             )
 
             when (purchaseEvent) {

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/OnboardingUpgradeBottomSheetViewModel.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/OnboardingUpgradeBottomSheetViewModel.kt
@@ -141,7 +141,7 @@ class OnboardingUpgradeBottomSheetViewModel @Inject constructor(
                 }
 
                 if (purchaseEvent != null) {
-                    CreateAccountViewModel.trackPurchaseEvent(subscription, purchaseEvent, analyticsTracker)
+                    CreateAccountViewModel.trackPurchaseEvent(subscription, purchaseEvent, source, analyticsTracker)
                 }
             }
             subscriptionManager.launchBillingFlow(

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/OnboardingUpgradeFeaturesViewModel.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/OnboardingUpgradeFeaturesViewModel.kt
@@ -225,6 +225,7 @@ class OnboardingUpgradeFeaturesViewModel @Inject constructor(
                         CreateAccountViewModel.trackPurchaseEvent(
                             subscription,
                             purchaseEvent,
+                            source,
                             analyticsTracker,
                         )
                     }


### PR DESCRIPTION
## Description

This PR adds the `source` property to the Analytics events `purchase_*`.

Internal discussion: p1745971854757569-slack-C06EHRAPW12

## Testing Instructions

1. Use a real device
2. Use the debugProd variant
3. Apply the Git patch file [purchase-test.patch](https://github.com/user-attachments/files/19996212/purchase-test.patch)
4. Sign in with your Google account on your phone that can do test purchases, in the "Google Play - License testing" list
5. Change your phone Pocket Casts account to free
6. Find a place to upgrade, for example settings -> Appearance -> Plus theme
7. Tap "Upgrade to Plus"
8. ✅ Verify the `purchase_successful` event is shown in the logs with the property `"source":"themes"`

## Screencast 

https://github.com/user-attachments/assets/0ce76f28-4436-4056-9a52-d17df4c6386c

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack