### PR TITLE
Use payment logic in subscription manager

### DIFF
--- a/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
+++ b/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
@@ -92,7 +92,6 @@ import au.com.shiftyjelly.pocketcasts.models.type.EpisodeViewSource
 import au.com.shiftyjelly.pocketcasts.navigation.BottomNavigator
 import au.com.shiftyjelly.pocketcasts.navigation.FragmentInfo
 import au.com.shiftyjelly.pocketcasts.navigation.NavigatorAction
-import au.com.shiftyjelly.pocketcasts.payment.PaymentClient
 import au.com.shiftyjelly.pocketcasts.player.view.PlayerBottomSheet
 import au.com.shiftyjelly.pocketcasts.player.view.PlayerContainerFragment
 import au.com.shiftyjelly.pocketcasts.player.view.UpNextFragment
@@ -246,8 +245,6 @@ class MainActivity :
     lateinit var applicationScope: CoroutineScope
 
     @Inject lateinit var crashLogging: CrashLogging
-
-    @Inject lateinit var paymentClient: PaymentClient
 
     private val viewModel: MainActivityViewModel by viewModels()
     private val disposables = CompositeDisposable()
@@ -486,13 +483,6 @@ class MainActivity :
         ThemeSettingObserver(this, theme, settings.themeReconfigurationEvents).observeThemeChanges()
 
         encourageAccountCreation()
-
-        if (BuildConfig.DEBUG) {
-            lifecycleScope.launch {
-                delay(5000)
-                paymentClient.loadSubscriptionPlans()
-            }
-        }
     }
 
     private fun resetEoYBadgeIfNeeded() {

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/CreateAccountViewModel.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/CreateAccountViewModel.kt
@@ -8,9 +8,10 @@ import au.com.shiftyjelly.pocketcasts.analytics.TracksAnalyticsTracker
 import au.com.shiftyjelly.pocketcasts.models.type.Subscription
 import au.com.shiftyjelly.pocketcasts.models.type.Subscription.Companion.PLUS_MONTHLY_PRODUCT_ID
 import au.com.shiftyjelly.pocketcasts.models.type.Subscription.Companion.PLUS_YEARLY_PRODUCT_ID
+import au.com.shiftyjelly.pocketcasts.payment.PaymentResultCode
+import au.com.shiftyjelly.pocketcasts.payment.PurchaseResult
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
-import au.com.shiftyjelly.pocketcasts.repositories.subscription.PurchaseEvent
 import au.com.shiftyjelly.pocketcasts.repositories.subscription.SubscriptionManager
 import au.com.shiftyjelly.pocketcasts.repositories.sync.LoginResult
 import au.com.shiftyjelly.pocketcasts.repositories.sync.SyncManager
@@ -38,7 +39,8 @@ class CreateAccountViewModel
     private val disposables = CompositeDisposable()
     var defaultSubscriptionType = SubscriptionType.FREE
 
-    @Inject lateinit var subscriptionManager: SubscriptionManager
+    @Inject
+    lateinit var subscriptionManager: SubscriptionManager
 
     companion object {
         private const val PRODUCT_KEY = "product"
@@ -46,11 +48,12 @@ class CreateAccountViewModel
         private const val OFFER_TYPE_NONE = "none"
         private const val OFFER_TYPE_FREE_TRIAL = "free_trial"
         private const val OFFER_TYPE_INTRO_OFFER = "intro_offer"
+        private const val ERROR_KEY = "error"
         private const val ERROR_CODE_KEY = "error_code"
         private const val SOURCE_KEY = "source"
         private const val ENABLED_KEY = "enabled"
 
-        fun trackPurchaseEvent(subscription: Subscription?, purchaseEvent: PurchaseEvent, analyticsTracker: AnalyticsTracker) {
+        fun trackPurchaseEvent(subscription: Subscription?, purchaseResult: PurchaseResult, analyticsTracker: AnalyticsTracker) {
             val productKey = subscription?.productDetails?.productId?.let {
                 if (it in listOf(PLUS_MONTHLY_PRODUCT_ID, PLUS_YEARLY_PRODUCT_ID)) {
                     // retain short product id for plus subscriptions
@@ -71,23 +74,73 @@ class CreateAccountViewModel
                 OFFER_TYPE_KEY to offerType,
             )
 
-            when (purchaseEvent) {
-                is PurchaseEvent.Success -> analyticsTracker.track(AnalyticsEvent.PURCHASE_SUCCESSFUL, analyticsProperties)
+            when (purchaseResult) {
+                is PurchaseResult.Purchased -> analyticsTracker.track(AnalyticsEvent.PURCHASE_SUCCESSFUL, analyticsProperties)
 
-                is PurchaseEvent.Cancelled -> analyticsTracker.track(
-                    AnalyticsEvent.PURCHASE_CANCELLED,
-                    analyticsProperties.plus(ERROR_CODE_KEY to purchaseEvent.responseCode),
-                )
+                is PurchaseResult.Cancelled -> analyticsTracker.track(AnalyticsEvent.PURCHASE_CANCELLED)
 
-                is PurchaseEvent.Failure -> {
-                    // Exclude error_code property if we do not have a responseCode
-                    val properties = purchaseEvent.responseCode?.let {
-                        analyticsProperties.plus(ERROR_CODE_KEY to it)
-                    } ?: analyticsProperties
-
-                    analyticsTracker.track(AnalyticsEvent.PURCHASE_FAILED, properties)
+                is PurchaseResult.Failure -> {
+                    analyticsTracker.track(
+                        AnalyticsEvent.PURCHASE_FAILED,
+                        analyticsProperties + purchaseResult.code.analyticProperties(),
+                    )
                 }
             }
+        }
+
+        private fun PaymentResultCode.analyticProperties() = when (this) {
+            is PaymentResultCode.BillingUnavailable -> mapOf(
+                ERROR_KEY to "billing_unavailable",
+            )
+
+            is PaymentResultCode.DeveloperError -> mapOf(
+                ERROR_KEY to "developer_error",
+            )
+
+            is PaymentResultCode.Error -> mapOf(
+                ERROR_KEY to "error",
+            )
+
+            is PaymentResultCode.FeatureNotSupported -> mapOf(
+                ERROR_KEY to "feature_not_supported",
+            )
+
+            is PaymentResultCode.ItemAlreadyOwned -> mapOf(
+                ERROR_KEY to "item_already_woned",
+            )
+
+            is PaymentResultCode.ItemNotOwned -> mapOf(
+                ERROR_KEY to "item_not_owned",
+            )
+
+            is PaymentResultCode.ItemUnavailable -> mapOf(
+                ERROR_KEY to "item_unavailable",
+            )
+
+            is PaymentResultCode.NetworkError -> mapOf(
+                ERROR_KEY to "network_error",
+            )
+
+            is PaymentResultCode.Ok -> mapOf(
+                ERROR_KEY to "ok",
+            )
+
+            is PaymentResultCode.ServiceDisconnected -> mapOf(
+                ERROR_KEY to "service_disconnected",
+            )
+
+            is PaymentResultCode.ServiceUnavailable -> mapOf(
+                ERROR_KEY to "service_unavailable",
+            )
+
+            is PaymentResultCode.Unknown -> mapOf(
+                ERROR_KEY to "unknown",
+                ERROR_CODE_KEY to code,
+            )
+
+            is PaymentResultCode.UserCancelled -> mapOf(
+                ERROR_KEY to "user_cancelled",
+            )
         }
     }
 
@@ -97,6 +150,7 @@ class CreateAccountViewModel
             is CreateAccountState.Failure -> {
                 errors.addAll(existingState.errors)
             }
+
             else -> {}
         }
         if (add) errors.add(error) else errors.remove(error)
@@ -167,6 +221,7 @@ class CreateAccountViewModel
             is CreateAccountState.Failure -> {
                 return state.errors.contains(error)
             }
+
             else -> {}
         }
         return false
@@ -188,6 +243,7 @@ class CreateAccountViewModel
                     podcastManager.refreshPodcastsAfterSignIn()
                     createAccountState.postValue(CreateAccountState.AccountCreated)
                 }
+
                 is LoginResult.Failed -> {
                     val message = result.message
                     val errors = mutableSetOf(CreateAccountError.CANNOT_CREATE_ACCOUNT)

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/CreateAccountViewModel.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/CreateAccountViewModel.kt
@@ -88,59 +88,11 @@ class CreateAccountViewModel
             }
         }
 
-        private fun PaymentResultCode.analyticProperties() = when (this) {
-            is PaymentResultCode.BillingUnavailable -> mapOf(
-                ERROR_KEY to "billing_unavailable",
-            )
-
-            is PaymentResultCode.DeveloperError -> mapOf(
-                ERROR_KEY to "developer_error",
-            )
-
-            is PaymentResultCode.Error -> mapOf(
-                ERROR_KEY to "error",
-            )
-
-            is PaymentResultCode.FeatureNotSupported -> mapOf(
-                ERROR_KEY to "feature_not_supported",
-            )
-
-            is PaymentResultCode.ItemAlreadyOwned -> mapOf(
-                ERROR_KEY to "item_already_woned",
-            )
-
-            is PaymentResultCode.ItemNotOwned -> mapOf(
-                ERROR_KEY to "item_not_owned",
-            )
-
-            is PaymentResultCode.ItemUnavailable -> mapOf(
-                ERROR_KEY to "item_unavailable",
-            )
-
-            is PaymentResultCode.NetworkError -> mapOf(
-                ERROR_KEY to "network_error",
-            )
-
-            is PaymentResultCode.Ok -> mapOf(
-                ERROR_KEY to "ok",
-            )
-
-            is PaymentResultCode.ServiceDisconnected -> mapOf(
-                ERROR_KEY to "service_disconnected",
-            )
-
-            is PaymentResultCode.ServiceUnavailable -> mapOf(
-                ERROR_KEY to "service_unavailable",
-            )
-
-            is PaymentResultCode.Unknown -> mapOf(
-                ERROR_KEY to "unknown",
-                ERROR_CODE_KEY to code,
-            )
-
-            is PaymentResultCode.UserCancelled -> mapOf(
-                ERROR_KEY to "user_cancelled",
-            )
+        private fun PaymentResultCode.analyticProperties() = buildMap {
+            put(ERROR_KEY, analyticsValue)
+            if (this@analyticProperties is PaymentResultCode.Unknown) {
+                put(ERROR_CODE_KEY, code)
+            }
         }
     }
 

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/OnboardingUpgradeBottomSheetViewModel.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/OnboardingUpgradeBottomSheetViewModel.kt
@@ -14,9 +14,9 @@ import au.com.shiftyjelly.pocketcasts.models.type.OfferSubscriptionPricingPhase
 import au.com.shiftyjelly.pocketcasts.models.type.Subscription
 import au.com.shiftyjelly.pocketcasts.models.type.SubscriptionMapper
 import au.com.shiftyjelly.pocketcasts.models.type.SubscriptionTier
+import au.com.shiftyjelly.pocketcasts.payment.PurchaseResult
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.repositories.subscription.ProductDetailsState
-import au.com.shiftyjelly.pocketcasts.repositories.subscription.PurchaseEvent
 import au.com.shiftyjelly.pocketcasts.repositories.subscription.SubscriptionManager
 import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingFlow
 import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingUpgradeSource
@@ -120,19 +120,19 @@ class OnboardingUpgradeBottomSheetViewModel @Inject constructor(
             )
 
             viewModelScope.launch {
-                val purchaseEvent = subscriptionManager
+                val purchaseResult = subscriptionManager
                     .observePurchaseEvents()
                     .asFlow()
                     .firstOrNull()
 
-                when (purchaseEvent) {
-                    PurchaseEvent.Success -> {
+                when (purchaseResult) {
+                    PurchaseResult.Purchased -> {
                         onComplete()
                     }
-                    is PurchaseEvent.Cancelled -> {
+                    is PurchaseResult.Cancelled -> {
                         // User cancelled subscription creation. Do nothing.
                     }
-                    is PurchaseEvent.Failure -> {
+                    is PurchaseResult.Failure -> {
                         _state.update { loadedState.copy(purchaseFailed = true) }
                     }
                     null -> {
@@ -140,8 +140,8 @@ class OnboardingUpgradeBottomSheetViewModel @Inject constructor(
                     }
                 }
 
-                if (purchaseEvent != null) {
-                    CreateAccountViewModel.trackPurchaseEvent(subscription, purchaseEvent, analyticsTracker)
+                if (purchaseResult != null) {
+                    CreateAccountViewModel.trackPurchaseEvent(subscription, purchaseResult, analyticsTracker)
                 }
             }
             subscriptionManager.launchBillingFlow(

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/OnboardingUpgradeFeaturesViewModel.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/OnboardingUpgradeFeaturesViewModel.kt
@@ -16,9 +16,9 @@ import au.com.shiftyjelly.pocketcasts.models.type.Subscription
 import au.com.shiftyjelly.pocketcasts.models.type.SubscriptionFrequency
 import au.com.shiftyjelly.pocketcasts.models.type.SubscriptionMapper
 import au.com.shiftyjelly.pocketcasts.models.type.SubscriptionTier
+import au.com.shiftyjelly.pocketcasts.payment.PurchaseResult
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.repositories.subscription.ProductDetailsState
-import au.com.shiftyjelly.pocketcasts.repositories.subscription.PurchaseEvent
 import au.com.shiftyjelly.pocketcasts.repositories.subscription.SubscriptionManager
 import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingFlow
 import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingUpgradeSource
@@ -198,21 +198,21 @@ class OnboardingUpgradeFeaturesViewModel @Inject constructor(
                 )
 
                 viewModelScope.launch {
-                    val purchaseEvent = subscriptionManager
+                    val purchaseResult = subscriptionManager
                         .observePurchaseEvents()
                         .asFlow()
                         .firstOrNull()
 
-                    when (purchaseEvent) {
-                        PurchaseEvent.Success -> {
+                    when (purchaseResult) {
+                        PurchaseResult.Purchased -> {
                             onComplete()
                         }
 
-                        is PurchaseEvent.Cancelled -> {
+                        is PurchaseResult.Cancelled -> {
                             // User cancelled subscription creation. Do nothing.
                         }
 
-                        is PurchaseEvent.Failure -> {
+                        is PurchaseResult.Failure -> {
                             _state.update { loadedState.copy(purchaseFailed = true) }
                         }
 
@@ -221,10 +221,10 @@ class OnboardingUpgradeFeaturesViewModel @Inject constructor(
                         }
                     }
 
-                    if (purchaseEvent != null) {
+                    if (purchaseResult != null) {
                         CreateAccountViewModel.trackPurchaseEvent(
                             subscription,
-                            purchaseEvent,
+                            purchaseResult,
                             analyticsTracker,
                         )
                     }

--- a/modules/features/referrals/src/main/kotlin/au/com/shiftyjelly/pocketcasts/referrals/ReferralsClaimGuestPassViewModel.kt
+++ b/modules/features/referrals/src/main/kotlin/au/com/shiftyjelly/pocketcasts/referrals/ReferralsClaimGuestPassViewModel.kt
@@ -8,11 +8,11 @@ import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTracker
 import au.com.shiftyjelly.pocketcasts.models.type.ReferralsOfferInfo
 import au.com.shiftyjelly.pocketcasts.models.type.ReferralsOfferInfoPlayStore
 import au.com.shiftyjelly.pocketcasts.models.type.Subscription
+import au.com.shiftyjelly.pocketcasts.payment.PurchaseResult
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.repositories.referrals.ReferralManager
 import au.com.shiftyjelly.pocketcasts.repositories.referrals.ReferralManager.ReferralResult
 import au.com.shiftyjelly.pocketcasts.repositories.referrals.ReferralOfferInfoProvider
-import au.com.shiftyjelly.pocketcasts.repositories.subscription.PurchaseEvent
 import au.com.shiftyjelly.pocketcasts.repositories.subscription.SubscriptionManager
 import au.com.shiftyjelly.pocketcasts.repositories.user.UserManager
 import au.com.shiftyjelly.pocketcasts.utils.exception.NoNetworkException
@@ -120,23 +120,23 @@ class ReferralsClaimGuestPassViewModel @Inject constructor(
     ) {
         _navigationEvent.emit(NavigationEvent.LaunchBillingFlow(subscriptionWithOffer))
 
-        val purchaseEvent = subscriptionManager
+        val purchaseResult = subscriptionManager
             .observePurchaseEvents()
             .asFlow()
             .firstOrNull()
 
-        when (purchaseEvent) {
-            PurchaseEvent.Success -> {
+        when (purchaseResult) {
+            PurchaseResult.Purchased -> {
                 analyticsTracker.track(AnalyticsEvent.REFERRAL_PURCHASE_SUCCESS)
                 redeemReferralCode(settings.referralClaimCode.value)
             }
 
-            is PurchaseEvent.Cancelled -> {
+            is PurchaseResult.Cancelled -> {
                 LogBuffer.e(LogBuffer.TAG_INVALID_STATE, "PurchaseEvent.Cancelled")
                 // User cancelled subscription creation. Do nothing.
             }
 
-            is PurchaseEvent.Failure -> {
+            is PurchaseResult.Failure -> {
                 _snackBarEvent.emit(SnackbarEvent.PurchaseFailed)
             }
 

--- a/modules/features/referrals/src/test/kotlin/au/com/shiftyjelly/pocketcasts/referrals/ReferralsClaimGuestPassViewModelTest.kt
+++ b/modules/features/referrals/src/test/kotlin/au/com/shiftyjelly/pocketcasts/referrals/ReferralsClaimGuestPassViewModelTest.kt
@@ -7,6 +7,8 @@ import au.com.shiftyjelly.pocketcasts.models.to.SubscriptionStatus
 import au.com.shiftyjelly.pocketcasts.models.type.ReferralsOfferInfo
 import au.com.shiftyjelly.pocketcasts.models.type.ReferralsOfferInfoPlayStore
 import au.com.shiftyjelly.pocketcasts.models.type.Subscription
+import au.com.shiftyjelly.pocketcasts.payment.PaymentResultCode
+import au.com.shiftyjelly.pocketcasts.payment.PurchaseResult
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.preferences.UserSetting
 import au.com.shiftyjelly.pocketcasts.referrals.ReferralsClaimGuestPassViewModel.NavigationEvent
@@ -17,7 +19,6 @@ import au.com.shiftyjelly.pocketcasts.repositories.referrals.ReferralManager.Ref
 import au.com.shiftyjelly.pocketcasts.repositories.referrals.ReferralManager.ReferralResult.ErrorResult
 import au.com.shiftyjelly.pocketcasts.repositories.referrals.ReferralManager.ReferralResult.SuccessResult
 import au.com.shiftyjelly.pocketcasts.repositories.referrals.ReferralOfferInfoProvider
-import au.com.shiftyjelly.pocketcasts.repositories.subscription.PurchaseEvent
 import au.com.shiftyjelly.pocketcasts.repositories.subscription.SubscriptionManager
 import au.com.shiftyjelly.pocketcasts.repositories.user.UserManager
 import au.com.shiftyjelly.pocketcasts.sharedtest.MainCoroutineRule
@@ -162,7 +163,7 @@ class ReferralsClaimGuestPassViewModelTest {
             offerInfo = referralOfferInfo,
             signInState = SignInState.SignedIn("email", SubscriptionStatus.Free()),
             referralValidationResult = SuccessResult(mock()),
-            purchaseEvent = PurchaseEvent.Success,
+            purchaseResult = PurchaseResult.Purchased,
         )
         viewModel.onActivatePassClick()
 
@@ -176,7 +177,7 @@ class ReferralsClaimGuestPassViewModelTest {
             offerInfo = referralOfferInfo,
             signInState = SignInState.SignedIn("email", SubscriptionStatus.Free()),
             referralValidationResult = SuccessResult(mock()),
-            purchaseEvent = PurchaseEvent.Failure(errorMessage = "", responseCode = 0),
+            purchaseResult = PurchaseResult.Failure(PaymentResultCode.Error),
         )
 
         viewModel.snackBarEvent.test {
@@ -260,10 +261,10 @@ class ReferralsClaimGuestPassViewModelTest {
         offerInfo: ReferralsOfferInfo? = referralOfferInfo,
         signInState: SignInState = SignInState.SignedOut,
         referralValidationResult: ReferralManager.ReferralResult<ReferralValidationResponse> = SuccessResult(mock()),
-        purchaseEvent: PurchaseEvent = PurchaseEvent.Success,
+        purchaseResult: PurchaseResult = PurchaseResult.Purchased,
         showWelcomeSetting: UserSetting<Boolean> = UserSetting.Mock(false, mock()),
     ) {
-        whenever(subscriptionManager.observePurchaseEvents()).thenReturn(Flowable.just(purchaseEvent))
+        whenever(subscriptionManager.observePurchaseEvents()).thenReturn(Flowable.just(purchaseResult))
         whenever(referralOfferInfoProvider.referralOfferInfo()).thenReturn(offerInfo)
         whenever(settings.referralClaimCode).thenReturn(UserSetting.Mock(referralCode, mock()))
         whenever(settings.showReferralWelcome).thenReturn(showWelcomeSetting)

--- a/modules/services/payment/src/main/kotlin/au/com/shiftyjelly/pocketcasts/payment/FakePaymentDataSource.kt
+++ b/modules/services/payment/src/main/kotlin/au/com/shiftyjelly/pocketcasts/payment/FakePaymentDataSource.kt
@@ -1,7 +1,6 @@
 package au.com.shiftyjelly.pocketcasts.payment
 
 import android.app.Activity
-import com.android.billingclient.api.AcknowledgePurchaseParams
 import com.android.billingclient.api.BillingFlowParams
 import com.android.billingclient.api.BillingResult
 import com.android.billingclient.api.ProductDetails
@@ -11,7 +10,6 @@ import com.android.billingclient.api.QueryPurchaseHistoryParams
 import com.android.billingclient.api.QueryPurchasesParams
 import java.math.BigDecimal
 import kotlinx.coroutines.flow.MutableSharedFlow
-import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.first
 import com.android.billingclient.api.Purchase as GooglePurchase
 
@@ -58,8 +56,6 @@ class FakePaymentDataSource : PaymentDataSource {
     }
 
     // <editor-fold desc="Temporarily extracted old interface">
-    override val purchaseUpdates: SharedFlow<Pair<BillingResult, List<GooglePurchase>>> = MutableSharedFlow()
-
     override suspend fun loadProducts(
         params: QueryProductDetailsParams,
     ): Pair<BillingResult, List<ProductDetails>> = BillingResult.newBuilder().build() to emptyList()
@@ -71,10 +67,6 @@ class FakePaymentDataSource : PaymentDataSource {
     override suspend fun loadPurchases(
         params: QueryPurchasesParams,
     ): Pair<BillingResult, List<GooglePurchase>> = BillingResult.newBuilder().build() to emptyList()
-
-    override suspend fun acknowledgePurchase(
-        params: AcknowledgePurchaseParams,
-    ): BillingResult = BillingResult.newBuilder().build()
 
     override suspend fun launchBillingFlow(
         activity: Activity,

--- a/modules/services/payment/src/main/kotlin/au/com/shiftyjelly/pocketcasts/payment/PaymentDataSource.kt
+++ b/modules/services/payment/src/main/kotlin/au/com/shiftyjelly/pocketcasts/payment/PaymentDataSource.kt
@@ -3,7 +3,6 @@ package au.com.shiftyjelly.pocketcasts.payment
 import android.app.Activity
 import android.content.Context
 import au.com.shiftyjelly.pocketcasts.payment.billing.BillingPaymentDataSource
-import com.android.billingclient.api.AcknowledgePurchaseParams
 import com.android.billingclient.api.BillingFlowParams
 import com.android.billingclient.api.BillingResult
 import com.android.billingclient.api.ProductDetails
@@ -35,8 +34,6 @@ interface PaymentDataSource {
     }
 
     // <editor-fold desc="Temporarily extracted old interface">
-    val purchaseUpdates: SharedFlow<Pair<BillingResult, List<GooglePurchase>>>
-
     suspend fun loadProducts(
         params: QueryProductDetailsParams,
     ): Pair<BillingResult, List<ProductDetails>>
@@ -48,10 +45,6 @@ interface PaymentDataSource {
     suspend fun loadPurchases(
         params: QueryPurchasesParams,
     ): Pair<BillingResult, List<GooglePurchase>>
-
-    suspend fun acknowledgePurchase(
-        params: AcknowledgePurchaseParams,
-    ): BillingResult
 
     suspend fun launchBillingFlow(
         activity: Activity,

--- a/modules/services/payment/src/main/kotlin/au/com/shiftyjelly/pocketcasts/payment/PaymentResult.kt
+++ b/modules/services/payment/src/main/kotlin/au/com/shiftyjelly/pocketcasts/payment/PaymentResult.kt
@@ -12,19 +12,47 @@ sealed interface PaymentResult<out T : Any> {
 }
 
 sealed interface PaymentResultCode {
-    data object Error : PaymentResultCode
-    data object FeatureNotSupported : PaymentResultCode
-    data object ServiceDisconnected : PaymentResultCode
-    data object Ok : PaymentResultCode
-    data object UserCancelled : PaymentResultCode
-    data object ServiceUnavailable : PaymentResultCode
-    data object BillingUnavailable : PaymentResultCode
-    data object ItemUnavailable : PaymentResultCode
-    data object DeveloperError : PaymentResultCode
-    data object ItemAlreadyOwned : PaymentResultCode
-    data object ItemNotOwned : PaymentResultCode
-    data object NetworkError : PaymentResultCode
-    data class Unknown(val code: Int) : PaymentResultCode
+    val analyticsValue: String
+
+    data object Error : PaymentResultCode {
+        override val analyticsValue get() = "error"
+    }
+    data object FeatureNotSupported : PaymentResultCode {
+        override val analyticsValue get() = "feature_not_suported"
+    }
+    data object ServiceDisconnected : PaymentResultCode {
+        override val analyticsValue get() = "service_disconnected"
+    }
+    data object Ok : PaymentResultCode {
+        override val analyticsValue get() = "ok"
+    }
+    data object UserCancelled : PaymentResultCode {
+        override val analyticsValue get() = "user_cancelled"
+    }
+    data object ServiceUnavailable : PaymentResultCode {
+        override val analyticsValue get() = "service_unavailable"
+    }
+    data object BillingUnavailable : PaymentResultCode {
+        override val analyticsValue get() = "billing_unavailable"
+    }
+    data object ItemUnavailable : PaymentResultCode {
+        override val analyticsValue get() = "item_unavailable"
+    }
+    data object DeveloperError : PaymentResultCode {
+        override val analyticsValue get() = "developer_error"
+    }
+    data object ItemAlreadyOwned : PaymentResultCode {
+        override val analyticsValue get() = "item_already_owned"
+    }
+    data object ItemNotOwned : PaymentResultCode {
+        override val analyticsValue get() = "item_not_owned"
+    }
+    data object NetworkError : PaymentResultCode {
+        override val analyticsValue get() = "network_error"
+    }
+    data class Unknown(val code: Int) : PaymentResultCode {
+        override val analyticsValue get() = "unknown"
+    }
 }
 
 inline fun <T : Any, R : Any> PaymentResult<T>.map(block: (T) -> R) = when (this) {

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/subscription/ServerPurchaseApprover.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/subscription/ServerPurchaseApprover.kt
@@ -4,19 +4,23 @@ import au.com.shiftyjelly.pocketcasts.payment.PaymentResult
 import au.com.shiftyjelly.pocketcasts.payment.PaymentResultCode
 import au.com.shiftyjelly.pocketcasts.payment.Purchase
 import au.com.shiftyjelly.pocketcasts.payment.PurchaseApprover
+import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.repositories.sync.SyncManager
 import au.com.shiftyjelly.pocketcasts.servers.sync.SubscriptionPurchaseRequest
+import au.com.shiftyjelly.pocketcasts.servers.sync.toStatus
 import javax.inject.Inject
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.rx2.await
 
 class ServerPurchaseApprover @Inject constructor(
     private val syncManager: SyncManager,
+    private val settings: Settings,
 ) : PurchaseApprover {
     override suspend fun approve(purchase: Purchase): PaymentResult<Purchase> {
         return runCatching {
             val request = SubscriptionPurchaseRequest(purchase.token, purchase.productIds.first())
-            syncManager.subscriptionPurchaseRxSingle(request).await()
+            val response = syncManager.subscriptionPurchaseRxSingle(request).await()
+            settings.cachedSubscriptionStatus.set(response.toStatus(), updateModifiedAt = false)
             PaymentResult.Success(purchase)
         }.getOrElse { error ->
             if (error is CancellationException) {

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/subscription/SubscriptionManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/subscription/SubscriptionManager.kt
@@ -6,6 +6,7 @@ import au.com.shiftyjelly.pocketcasts.models.to.SubscriptionStatus
 import au.com.shiftyjelly.pocketcasts.models.type.Subscription
 import au.com.shiftyjelly.pocketcasts.models.type.SubscriptionFrequency
 import au.com.shiftyjelly.pocketcasts.models.type.SubscriptionTier
+import au.com.shiftyjelly.pocketcasts.payment.PurchaseResult
 import au.com.shiftyjelly.pocketcasts.utils.Optional
 import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
 import com.android.billingclient.api.BillingResult
@@ -13,9 +14,7 @@ import com.android.billingclient.api.ProductDetails
 import com.android.billingclient.api.Purchase
 import io.reactivex.Flowable
 import io.reactivex.Single
-import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.launch
 import timber.log.Timber
 
 interface SubscriptionManager {
@@ -27,11 +26,7 @@ interface SubscriptionManager {
 
     suspend fun loadPurchaseHistory(): PurchaseHistoryState
 
-    suspend fun refresh() = coroutineScope {
-        launch { loadProducts() }
-        launch { loadPurchases() }
-        launch { loadPurchaseHistory() }
-    }
+    suspend fun refresh()
 
     fun launchBillingFlow(activity: AppCompatActivity, productDetails: ProductDetails, offerToken: String)
 
@@ -53,7 +48,7 @@ interface SubscriptionManager {
     fun signOut()
 
     fun observeProductDetails(): Flowable<ProductDetailsState>
-    fun observePurchaseEvents(): Flowable<PurchaseEvent>
+    fun observePurchaseEvents(): Flowable<PurchaseResult>
     fun observeSubscriptionStatus(): Flowable<Optional<SubscriptionStatus>>
     fun subscriptionTier(): Flow<SubscriptionTier>
     fun getSubscriptionStatusRxSingle(allowCache: Boolean = true): Single<SubscriptionStatus>
@@ -71,16 +66,7 @@ interface SubscriptionManager {
     fun freeTrialForSubscriptionTierFlow(subscriptionTier: SubscriptionTier): Flow<FreeTrial>
 }
 
-internal fun logSubscriptionInfo(message: String) {
-    Timber.tag(LogBuffer.TAG_SUBSCRIPTIONS).i(message)
-}
-
 internal fun logSubscriptionWarning(message: String) {
     Timber.tag(LogBuffer.TAG_SUBSCRIPTIONS).w(message)
     LogBuffer.w(LogBuffer.TAG_SUBSCRIPTIONS, message)
-}
-
-internal fun logSubscriptionError(e: Throwable, message: String) {
-    Timber.tag(LogBuffer.TAG_SUBSCRIPTIONS).e(e, message)
-    LogBuffer.e(LogBuffer.TAG_SUBSCRIPTIONS, e, message)
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/winback/WinbackManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/winback/WinbackManager.kt
@@ -1,8 +1,8 @@
 package au.com.shiftyjelly.pocketcasts.repositories.winback
 
 import android.app.Activity
+import au.com.shiftyjelly.pocketcasts.payment.PurchaseResult
 import au.com.shiftyjelly.pocketcasts.repositories.subscription.ProductDetailsState
-import au.com.shiftyjelly.pocketcasts.repositories.subscription.PurchaseEvent
 import au.com.shiftyjelly.pocketcasts.repositories.subscription.PurchasesState
 import com.android.billingclient.api.ProductDetails
 import com.android.billingclient.api.Purchase
@@ -19,7 +19,7 @@ interface WinbackManager {
         newProduct: ProductDetails,
         newProductOfferToken: String,
         activity: Activity,
-    ): PurchaseEvent
+    ): PurchaseResult
 
     suspend fun getWinbackOffer(): WinbackResponse?
 
@@ -29,5 +29,5 @@ interface WinbackManager {
         winbackOfferToken: String,
         winbackClaimCode: String,
         activity: Activity,
-    ): PurchaseEvent
+    ): PurchaseResult
 }

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/SubscriptionModel.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/SubscriptionModel.kt
@@ -1,5 +1,9 @@
 package au.com.shiftyjelly.pocketcasts.servers.sync
 
+import au.com.shiftyjelly.pocketcasts.models.to.SubscriptionStatus
+import au.com.shiftyjelly.pocketcasts.models.type.SubscriptionFrequency
+import au.com.shiftyjelly.pocketcasts.models.type.SubscriptionPlatform
+import au.com.shiftyjelly.pocketcasts.models.type.SubscriptionTier
 import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
 import java.util.Date
@@ -27,3 +31,23 @@ data class SubscriptionResponse(
     @field:Json(name = "autoRenewing") val autoRenewing: Boolean,
     @field:Json(name = "updateUrl") val updateUrl: String?,
 )
+
+fun SubscriptionStatusResponse.toStatus(): SubscriptionStatus {
+    val originalPlatform = SubscriptionPlatform.entries.getOrNull(platform) ?: SubscriptionPlatform.NONE
+
+    return if (paid == 0) {
+        SubscriptionStatus.Free(expiryDate, giftDays, originalPlatform)
+    } else {
+        val subs = subscriptions?.map { it.toSubscription() } ?: emptyList()
+        subs.getOrNull(index)?.isPrimarySubscription = true // Mark the subscription that the server says is the main one
+        val freq = SubscriptionFrequency.entries.getOrNull(frequency) ?: SubscriptionFrequency.NONE
+        val enumTier = SubscriptionTier.fromString(tier)
+        SubscriptionStatus.Paid(expiryDate ?: Date(), autoRenewing, giftDays, freq, originalPlatform, subs, enumTier, index)
+    }
+}
+
+private fun SubscriptionResponse.toSubscription(): SubscriptionStatus.Subscription {
+    val enumTier = SubscriptionTier.fromString(tier)
+    val freq = SubscriptionFrequency.entries.getOrNull(frequency) ?: SubscriptionFrequency.NONE
+    return SubscriptionStatus.Subscription(enumTier, freq, expiryDate, autoRenewing, updateUrl)
+}


### PR DESCRIPTION
## Description

This PR replaces the purchase confirmation logic in `SubscriptionManagerImpl` with the new implementation from `PaymentClient`. This isn't the final form, as I plan to remove `Flowable<PurchaseResult>` entirely, but for migration and review simplicity, it's implemented this way for now.

## Testing Instructions

> [!note]
> Apply [this patch](https://github.com/user-attachments/files/20036518/debug-as-prod.patch) when testing.

Test that subscriptions work as expected in the following scenarios:
* Subscribing while creating an account.
* Subscribing with a free account from the account details screen.
* Subscribing from a paid feature.
* Changing the plan during the winback flow — see a [sample test](https://github.com/Automattic/pocket-casts-android/pull/3466).
* Applying the winback flow — this must be tested in the staging environment (`debug` variant). See a [sample test](https://github.com/Automattic/pocket-casts-android/pull/3905).

Test the following scenarios:
* Successful purchase.
* Failed purchase — use the "Test card, always declines" option when the Billing bottom sheet appears.
* Cancelled purchase — dismiss the Billing bottom sheet.

## Checklist
- [ ] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [ ] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [ ] ~Any jetpack compose components I added or changed are covered by compose previews~
- [ ] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~