### PR TITLE
Add acknowledged purchases API

### DIFF
--- a/modules/services/payment/src/main/kotlin/au/com/shiftyjelly/pocketcasts/payment/Data.kt
+++ b/modules/services/payment/src/main/kotlin/au/com/shiftyjelly/pocketcasts/payment/Data.kt
@@ -322,3 +322,12 @@ sealed interface PurchaseState {
         override val orderId get() = null
     }
 }
+
+data class AcknowledgedSubscription(
+    val orderId: String,
+    val tier: SubscriptionTier,
+    val billingCycle: SubscriptionBillingCycle,
+    val isAutoRenewing: Boolean,
+) {
+    val productId get() = SubscriptionPlan.productId(tier, billingCycle)
+}

--- a/modules/services/payment/src/main/kotlin/au/com/shiftyjelly/pocketcasts/payment/FakePaymentDataSource.kt
+++ b/modules/services/payment/src/main/kotlin/au/com/shiftyjelly/pocketcasts/payment/FakePaymentDataSource.kt
@@ -15,7 +15,7 @@ import com.android.billingclient.api.Purchase as GooglePurchase
 
 class FakePaymentDataSource : PaymentDataSource {
     var customProductsResult: PaymentResult<List<Product>>? = null
-    var customPurchases: PaymentResult<List<Purchase>>? = null
+    var customPurchasesResult: PaymentResult<List<Purchase>>? = null
     var launchBillingFlowResultCode: PaymentResultCode = PaymentResultCode.Ok
 
     var receivedPurchases = emptyList<Purchase>()
@@ -30,7 +30,7 @@ class FakePaymentDataSource : PaymentDataSource {
     }
 
     override suspend fun loadPurchases(): PaymentResult<List<Purchase>> {
-        return customPurchases ?: PaymentResult.Success(emptyList())
+        return customPurchasesResult ?: PaymentResult.Success(DefaultPurchases)
     }
 
     override suspend fun acknowledgePurchase(purchase: Purchase): PaymentResult<Purchase> {
@@ -116,6 +116,16 @@ private val PatronMonthlyPricingPhase get() = PricingPhase(
 private val PatronYearlyPricingPhase get() = PricingPhase(
     Price(99.99.toBigDecimal(), "USD", "$99.99"),
     BillingPeriod(BillingPeriod.Cycle.Infinite, BillingPeriod.Interval.Yearly, intervalCount = 0),
+)
+
+private val DefaultPurchases get() = listOf(
+    Purchase(
+        state = PurchaseState.Purchased("order-id"),
+        token = "purchase-token",
+        productIds = listOf(SubscriptionPlan.productId(SubscriptionTier.Plus, SubscriptionBillingCycle.Yearly)),
+        isAcknowledged = true,
+        isAutoRenewing = true,
+    ),
 )
 
 private fun productName(

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/subscription/SubscriptionManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/subscription/SubscriptionManagerImpl.kt
@@ -41,7 +41,6 @@ import javax.inject.Singleton
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.transformLatest
@@ -126,7 +125,7 @@ class SubscriptionManagerImpl @Inject constructor(
     override suspend fun refresh() {
         loadProducts()
         loadPurchaseHistory()
-        paymentClient.loadAndAcknowledgePurchases()
+        paymentClient.acknowledgePendingPurchases()
     }
 
     override suspend fun initializeBillingConnection(): Nothing = coroutineScope {


### PR DESCRIPTION
## Description

This PR adds the `AcknowledgedSubscription` type to the API. These represent purchases that have been confirmed by both the Billing API and our backend. The main motivation for introducing this type is that the `Purchase` type can include multiple associated products, making it difficult to determine which active subscription a user has. The mapping logic from `Purchase` to `AcknowledgedSubscription` resolves this by filtering out items with multiple products. This is safe in our case because, as the [documentation states](https://developer.android.com/reference/com/android/billingclient/api/Purchase#getQuantity()):

> `public int getQuantity()`
> 
> Returns the quantity of the purchased product.
> Always returns 1 for `SkuType#SUBS` items; could be greater than 1 for `INAPP` items.

## Testing Instructions

Code review the API.

## Checklist
- [ ] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [ ] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [ ] ~Any jetpack compose components I added or changed are covered by compose previews~
- [ ] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~