### PR TITLE
Simplify payment client testing

### DIFF
--- a/modules/services/payment/src/main/kotlin/au/com/shiftyjelly/pocketcasts/payment/FakePaymentDataSource.kt
+++ b/modules/services/payment/src/main/kotlin/au/com/shiftyjelly/pocketcasts/payment/FakePaymentDataSource.kt
@@ -36,7 +36,7 @@ class FakePaymentDataSource : PaymentDataSource {
         return if (loadedProductsResultCode == PaymentResultCode.Ok) {
             PaymentResult.Success(loadedProducts)
         } else {
-            PaymentResult.Failure(loadedProductsResultCode, "Error message")
+            PaymentResult.Failure(loadedProductsResultCode, "Load products error")
         }
     }
 
@@ -44,7 +44,7 @@ class FakePaymentDataSource : PaymentDataSource {
         return if (loadedPurchasesResultCode == PaymentResultCode.Ok) {
             PaymentResult.Success(loadedPurchases)
         } else {
-            PaymentResult.Failure(loadedPurchasesResultCode, "Error message")
+            PaymentResult.Failure(loadedPurchasesResultCode, "Load purchases error")
         }
     }
 
@@ -54,12 +54,12 @@ class FakePaymentDataSource : PaymentDataSource {
             val purchaseResult = if (purchasedProductsResultCode == PaymentResultCode.Ok) {
                 PaymentResult.Success(purchasedProducts)
             } else {
-                PaymentResult.Failure(purchasedProductsResultCode, "Error message")
+                PaymentResult.Failure(purchasedProductsResultCode, "Purchase product error")
             }
             _purchaseResults.emit(purchaseResult)
             billingResult
         } else {
-            PaymentResult.Failure(billingFlowResultCode, "Error message")
+            PaymentResult.Failure(billingFlowResultCode, "Launch billing error")
         }
     }
 
@@ -68,7 +68,7 @@ class FakePaymentDataSource : PaymentDataSource {
         return if (acknowledgePurchaseResultCode == PaymentResultCode.Ok) {
             PaymentResult.Success(purchase.copy(isAcknowledged = true))
         } else {
-            PaymentResult.Failure(acknowledgePurchaseResultCode, "Error message")
+            PaymentResult.Failure(acknowledgePurchaseResultCode, "Acknowledge purchase error")
         }
     }
 

--- a/modules/services/payment/src/main/kotlin/au/com/shiftyjelly/pocketcasts/payment/FakePaymentDataSource.kt
+++ b/modules/services/payment/src/main/kotlin/au/com/shiftyjelly/pocketcasts/payment/FakePaymentDataSource.kt
@@ -10,48 +10,65 @@ import com.android.billingclient.api.QueryPurchaseHistoryParams
 import com.android.billingclient.api.QueryPurchasesParams
 import java.math.BigDecimal
 import kotlinx.coroutines.flow.MutableSharedFlow
-import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.asSharedFlow
 import com.android.billingclient.api.Purchase as GooglePurchase
 
 class FakePaymentDataSource : PaymentDataSource {
-    var customProductsResult: PaymentResult<List<Product>>? = null
-    var customPurchasesResult: PaymentResult<List<Purchase>>? = null
-    var launchBillingFlowResultCode: PaymentResultCode = PaymentResultCode.Ok
+    var loadedProducts: List<Product> = DefaultLoadedProducts
+    var loadedProductsResultCode: PaymentResultCode = PaymentResultCode.Ok
 
+    var loadedPurchases: List<Purchase> = listOf(DefaultLoadedPurchase)
+    var loadedPurchasesResultCode: PaymentResultCode = PaymentResultCode.Ok
+
+    var billingFlowResultCode: PaymentResultCode = PaymentResultCode.Ok
+    var purchasedProducts: List<Purchase> = listOf(DefaultPurchasedProduct)
+    var purchasedProductsResultCode: PaymentResultCode = PaymentResultCode.Ok
+
+    var acknowledgePurchaseResultCode: PaymentResultCode = PaymentResultCode.Ok
     var receivedPurchases = emptyList<Purchase>()
         private set
 
-    private val acknowledgeFlow = MutableSharedFlow<PaymentResultCode>()
+    private val _purchaseResults = MutableSharedFlow<PaymentResult<List<Purchase>>>()
 
-    override val purchaseResults = MutableSharedFlow<PaymentResult<List<Purchase>>>()
+    override val purchaseResults = _purchaseResults.asSharedFlow()
 
     override suspend fun loadProducts(): PaymentResult<List<Product>> {
-        return customProductsResult ?: PaymentResult.Success(KnownProducts)
+        return if (loadedProductsResultCode == PaymentResultCode.Ok) {
+            PaymentResult.Success(loadedProducts)
+        } else {
+            PaymentResult.Failure(loadedProductsResultCode, "Error message")
+        }
     }
 
     override suspend fun loadPurchases(): PaymentResult<List<Purchase>> {
-        return customPurchasesResult ?: PaymentResult.Success(DefaultPurchases)
+        return if (loadedPurchasesResultCode == PaymentResultCode.Ok) {
+            PaymentResult.Success(loadedPurchases)
+        } else {
+            PaymentResult.Failure(loadedPurchasesResultCode, "Error message")
+        }
+    }
+
+    override suspend fun launchBillingFlow(key: SubscriptionPlan.Key, activity: Activity): PaymentResult<Unit> {
+        return if (billingFlowResultCode == PaymentResultCode.Ok) {
+            val billingResult = PaymentResult.Success(Unit)
+            val purchaseResult = if (purchasedProductsResultCode == PaymentResultCode.Ok) {
+                PaymentResult.Success(purchasedProducts)
+            } else {
+                PaymentResult.Failure(purchasedProductsResultCode, "Error message")
+            }
+            _purchaseResults.emit(purchaseResult)
+            billingResult
+        } else {
+            PaymentResult.Failure(billingFlowResultCode, "Error message")
+        }
     }
 
     override suspend fun acknowledgePurchase(purchase: Purchase): PaymentResult<Purchase> {
         receivedPurchases += purchase
-        val resultCode = acknowledgeFlow.first()
-        return if (resultCode is PaymentResultCode.Ok) {
+        return if (acknowledgePurchaseResultCode == PaymentResultCode.Ok) {
             PaymentResult.Success(purchase.copy(isAcknowledged = true))
         } else {
-            PaymentResult.Failure(resultCode, "Error")
-        }
-    }
-
-    suspend fun emitAcknowledgeResponse(code: PaymentResultCode) {
-        acknowledgeFlow.emit(code)
-    }
-
-    override suspend fun launchBillingFlow(key: SubscriptionPlan.Key, activity: Activity): PaymentResult<Unit> {
-        return if (launchBillingFlowResultCode is PaymentResultCode.Ok) {
-            PaymentResult.Success(Unit)
-        } else {
-            PaymentResult.Failure(launchBillingFlowResultCode, "Error")
+            PaymentResult.Failure(acknowledgePurchaseResultCode, "Error message")
         }
     }
 
@@ -73,31 +90,52 @@ class FakePaymentDataSource : PaymentDataSource {
         params: BillingFlowParams,
     ): BillingResult = BillingResult.newBuilder().build()
     // </editor-fold>
-}
 
-private val KnownProducts get() = SubscriptionTier.entries.flatMap { tier ->
-    SubscriptionBillingCycle.entries.map { billingCycle ->
-        Product(
-            SubscriptionPlan.productId(tier, billingCycle),
-            productName(tier, billingCycle),
-            PricingPlans(
-                PricingPlan.Base(
-                    SubscriptionPlan.basePlanId(tier, billingCycle),
-                    pricingPhases(tier, billingCycle, offer = null),
-                    emptyList(),
-                ),
-                SubscriptionOffer.entries
-                    .mapNotNull { offer -> offer.offerId(tier, billingCycle)?.let { offer to it } }
-                    .map { (offer, offerId) ->
-                        PricingPlan.Offer(
-                            offerId,
-                            SubscriptionPlan.basePlanId(tier, billingCycle),
-                            pricingPhases(tier, billingCycle, offer),
-                            emptyList(),
-                        )
-                    },
-            ),
-        )
+    companion object {
+        val DefaultLoadedProducts
+            get() = SubscriptionTier.entries.flatMap { tier ->
+                SubscriptionBillingCycle.entries.map { billingCycle ->
+                    Product(
+                        SubscriptionPlan.productId(tier, billingCycle),
+                        productName(tier, billingCycle),
+                        PricingPlans(
+                            PricingPlan.Base(
+                                SubscriptionPlan.basePlanId(tier, billingCycle),
+                                pricingPhases(tier, billingCycle, offer = null),
+                                emptyList(),
+                            ),
+                            SubscriptionOffer.entries
+                                .mapNotNull { offer -> offer.offerId(tier, billingCycle)?.let { offer to it } }
+                                .map { (offer, offerId) ->
+                                    PricingPlan.Offer(
+                                        offerId,
+                                        SubscriptionPlan.basePlanId(tier, billingCycle),
+                                        pricingPhases(tier, billingCycle, offer),
+                                        emptyList(),
+                                    )
+                                },
+                        ),
+                    )
+                }
+            }
+
+        val DefaultLoadedPurchase
+            get() = Purchase(
+                state = PurchaseState.Purchased("order-id"),
+                token = "purchase-token",
+                productIds = listOf(SubscriptionPlan.productId(SubscriptionTier.Plus, SubscriptionBillingCycle.Yearly)),
+                isAcknowledged = true,
+                isAutoRenewing = true,
+            )
+
+        val DefaultPurchasedProduct
+            get() = Purchase(
+                state = PurchaseState.Purchased("order-id"),
+                token = "purchase-token",
+                productIds = listOf(SubscriptionPlan.productId(SubscriptionTier.Plus, SubscriptionBillingCycle.Yearly)),
+                isAcknowledged = false,
+                isAutoRenewing = true,
+            )
     }
 }
 
@@ -116,16 +154,6 @@ private val PatronMonthlyPricingPhase get() = PricingPhase(
 private val PatronYearlyPricingPhase get() = PricingPhase(
     Price(99.99.toBigDecimal(), "USD", "$99.99"),
     BillingPeriod(BillingPeriod.Cycle.Infinite, BillingPeriod.Interval.Yearly, intervalCount = 0),
-)
-
-private val DefaultPurchases get() = listOf(
-    Purchase(
-        state = PurchaseState.Purchased("order-id"),
-        token = "purchase-token",
-        productIds = listOf(SubscriptionPlan.productId(SubscriptionTier.Plus, SubscriptionBillingCycle.Yearly)),
-        isAcknowledged = true,
-        isAutoRenewing = true,
-    ),
 )
 
 private fun productName(

--- a/modules/services/payment/src/main/kotlin/au/com/shiftyjelly/pocketcasts/payment/PaymentDataSource.kt
+++ b/modules/services/payment/src/main/kotlin/au/com/shiftyjelly/pocketcasts/payment/PaymentDataSource.kt
@@ -20,9 +20,9 @@ interface PaymentDataSource {
 
     suspend fun loadPurchases(): PaymentResult<List<Purchase>>
 
-    suspend fun acknowledgePurchase(purchase: Purchase): PaymentResult<Purchase>
-
     suspend fun launchBillingFlow(key: SubscriptionPlan.Key, activity: Activity): PaymentResult<Unit>
+
+    suspend fun acknowledgePurchase(purchase: Purchase): PaymentResult<Purchase>
 
     companion object {
         fun billing(

--- a/modules/services/payment/src/main/kotlin/au/com/shiftyjelly/pocketcasts/payment/billing/BillingPaymentDataSource.kt
+++ b/modules/services/payment/src/main/kotlin/au/com/shiftyjelly/pocketcasts/payment/billing/BillingPaymentDataSource.kt
@@ -140,20 +140,6 @@ internal class BillingPaymentDataSource(
         }
     }
 
-    override suspend fun acknowledgePurchase(purchase: Purchase): PaymentResult<Purchase> {
-        return connection.withConnectedClient { client ->
-            val params = AcknowledgePurchaseParams.newBuilder()
-                .setPurchaseToken(purchase.token)
-                .build()
-            val billingResult = client.acknowledgePurchase(params)
-            if (billingResult.isOk()) {
-                PaymentResult.Success(purchase.copy(isAcknowledged = true))
-            } else {
-                billingResult.toPaymentFailure()
-            }
-        }
-    }
-
     override suspend fun launchBillingFlow(
         key: SubscriptionPlan.Key,
         activity: Activity,
@@ -179,6 +165,20 @@ internal class BillingPaymentDataSource(
                         }
                     }
                 }
+        }
+    }
+
+    override suspend fun acknowledgePurchase(purchase: Purchase): PaymentResult<Purchase> {
+        return connection.withConnectedClient { client ->
+            val params = AcknowledgePurchaseParams.newBuilder()
+                .setPurchaseToken(purchase.token)
+                .build()
+            val billingResult = client.acknowledgePurchase(params)
+            if (billingResult.isOk()) {
+                PaymentResult.Success(purchase.copy(isAcknowledged = true))
+            } else {
+                billingResult.toPaymentFailure()
+            }
         }
     }
     // </editor-fold>

--- a/modules/services/payment/src/test/kotlin/au/com/shiftyjelly/pocketcasts/payment/PaymentClientTest.kt
+++ b/modules/services/payment/src/test/kotlin/au/com/shiftyjelly/pocketcasts/payment/PaymentClientTest.kt
@@ -296,7 +296,7 @@ class PaymentClientTest {
         client.loadSubscriptionPlans()
 
         logger.assertInfos("Load subscription plans")
-        logger.assertWarnings("Failed to load subscription plans. Error, Error message")
+        logger.assertWarnings("Failed to load subscription plans. Error, Load products error")
     }
 
     @Test
@@ -316,7 +316,7 @@ class PaymentClientTest {
         client.loadAcknowledgedSubscriptions()
 
         logger.assertInfos("Loading acknowledged subscriptions")
-        logger.assertWarnings("Failed to load acknowledged subscriptions. Error, Error message")
+        logger.assertWarnings("Failed to load acknowledged subscriptions. Error, Load purchases error")
     }
 
     @Test
@@ -390,7 +390,7 @@ class PaymentClientTest {
         client.purchaseSubscriptionPlan(planKey, mock<Activity>())
 
         logger.assertWarnings(
-            "Purchase failure: ServiceDisconnected, Error message",
+            "Purchase failure: ServiceDisconnected, Purchase product error",
         )
     }
 
@@ -401,7 +401,7 @@ class PaymentClientTest {
         client.purchaseSubscriptionPlan(planKey, mock<Activity>())
 
         logger.assertWarnings(
-            "Launching billing flow failed: DeveloperError, Error message",
+            "Launching billing flow failed: DeveloperError, Launch billing error",
         )
     }
 }

--- a/modules/services/payment/src/test/kotlin/au/com/shiftyjelly/pocketcasts/payment/PaymentClientTest.kt
+++ b/modules/services/payment/src/test/kotlin/au/com/shiftyjelly/pocketcasts/payment/PaymentClientTest.kt
@@ -1,10 +1,7 @@
 package au.com.shiftyjelly.pocketcasts.payment
 
 import android.app.Activity
-import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.async
-import kotlinx.coroutines.launch
-import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.yield
 import org.junit.Assert.assertEquals
@@ -39,7 +36,7 @@ class PaymentClientTest {
 
     @Test
     fun `load plans with failure`() = runTest {
-        dataSource.customProductsResult = PaymentResult.Failure(PaymentResultCode.Error, "Test failure")
+        dataSource.loadedProductsResultCode = PaymentResultCode.Error
 
         val plans = client.loadSubscriptionPlans()
 
@@ -48,32 +45,30 @@ class PaymentClientTest {
 
     @Test
     fun `load acknowledged subscribtion purchases`() = runTest {
-        dataSource.customPurchasesResult = PaymentResult.Success(
-            listOf(
-                purchase.copy(
-                    state = PurchaseState.Purchased("order-id-1"),
-                    productIds = listOf(SubscriptionPlan.productId(SubscriptionTier.Plus, SubscriptionBillingCycle.Monthly)),
-                    isAcknowledged = true,
-                    isAutoRenewing = true,
-                ),
-                purchase.copy(
-                    state = PurchaseState.Purchased("order-id-2"),
-                    productIds = listOf(SubscriptionPlan.productId(SubscriptionTier.Plus, SubscriptionBillingCycle.Yearly)),
-                    isAcknowledged = true,
-                    isAutoRenewing = true,
-                ),
-                purchase.copy(
-                    state = PurchaseState.Purchased("order-id-3"),
-                    productIds = listOf(SubscriptionPlan.productId(SubscriptionTier.Patron, SubscriptionBillingCycle.Monthly)),
-                    isAcknowledged = true,
-                    isAutoRenewing = true,
-                ),
-                purchase.copy(
-                    state = PurchaseState.Purchased("order-id-4"),
-                    productIds = listOf(SubscriptionPlan.productId(SubscriptionTier.Patron, SubscriptionBillingCycle.Yearly)),
-                    isAcknowledged = true,
-                    isAutoRenewing = false,
-                ),
+        dataSource.loadedPurchases = listOf(
+            purchase.copy(
+                state = PurchaseState.Purchased("order-id-1"),
+                productIds = listOf(SubscriptionPlan.productId(SubscriptionTier.Plus, SubscriptionBillingCycle.Monthly)),
+                isAcknowledged = true,
+                isAutoRenewing = true,
+            ),
+            purchase.copy(
+                state = PurchaseState.Purchased("order-id-2"),
+                productIds = listOf(SubscriptionPlan.productId(SubscriptionTier.Plus, SubscriptionBillingCycle.Yearly)),
+                isAcknowledged = true,
+                isAutoRenewing = true,
+            ),
+            purchase.copy(
+                state = PurchaseState.Purchased("order-id-3"),
+                productIds = listOf(SubscriptionPlan.productId(SubscriptionTier.Patron, SubscriptionBillingCycle.Monthly)),
+                isAcknowledged = true,
+                isAutoRenewing = true,
+            ),
+            purchase.copy(
+                state = PurchaseState.Purchased("order-id-4"),
+                productIds = listOf(SubscriptionPlan.productId(SubscriptionTier.Patron, SubscriptionBillingCycle.Yearly)),
+                isAcknowledged = true,
+                isAutoRenewing = false,
             ),
         )
 
@@ -92,20 +87,18 @@ class PaymentClientTest {
 
     @Test
     fun `do not load unconfirmed subscription purchases`() = runTest {
-        dataSource.customPurchasesResult = PaymentResult.Success(
-            listOf(
-                purchase.copy(
-                    state = PurchaseState.Pending,
-                    isAcknowledged = true,
-                ),
-                purchase.copy(
-                    state = PurchaseState.Unspecified,
-                    isAcknowledged = false,
-                ),
-                purchase.copy(
-                    state = PurchaseState.Purchased("order-id-3"),
-                    isAcknowledged = false,
-                ),
+        dataSource.loadedPurchases = listOf(
+            purchase.copy(
+                state = PurchaseState.Pending,
+                isAcknowledged = true,
+            ),
+            purchase.copy(
+                state = PurchaseState.Unspecified,
+                isAcknowledged = false,
+            ),
+            purchase.copy(
+                state = PurchaseState.Purchased("order-id-3"),
+                isAcknowledged = false,
             ),
         )
 
@@ -116,13 +109,11 @@ class PaymentClientTest {
 
     @Test
     fun `do not load acknowledged subscription purchases without any products`() = runTest {
-        dataSource.customPurchasesResult = PaymentResult.Success(
-            listOf(
-                purchase.copy(
-                    productIds = listOf(
-                        SubscriptionPlan.productId(SubscriptionTier.Plus, SubscriptionBillingCycle.Monthly),
-                        SubscriptionPlan.productId(SubscriptionTier.Plus, SubscriptionBillingCycle.Yearly),
-                    ),
+        dataSource.loadedPurchases = listOf(
+            purchase.copy(
+                productIds = listOf(
+                    SubscriptionPlan.productId(SubscriptionTier.Plus, SubscriptionBillingCycle.Monthly),
+                    SubscriptionPlan.productId(SubscriptionTier.Plus, SubscriptionBillingCycle.Yearly),
                 ),
             ),
         )
@@ -134,8 +125,8 @@ class PaymentClientTest {
 
     @Test
     fun `do not load acknowledged subscription purchases with unknown products`() = runTest {
-        dataSource.customPurchasesResult = PaymentResult.Success(
-            listOf(purchase.copy(productIds = listOf("some-unknown-product"))),
+        dataSource.loadedPurchases = listOf(
+            purchase.copy(productIds = listOf("some-unknown-product")),
         )
 
         val subscriptions = client.loadAcknowledgedSubscriptions().getOrNull()!!
@@ -145,8 +136,8 @@ class PaymentClientTest {
 
     @Test
     fun `do not load acknowledged subscription purchases without multiple products`() = runTest {
-        dataSource.customPurchasesResult = PaymentResult.Success(
-            listOf(purchase.copy(productIds = emptyList())),
+        dataSource.loadedPurchases = listOf(
+            purchase.copy(productIds = emptyList()),
         )
 
         val subscriptions = client.loadAcknowledgedSubscriptions().getOrNull()!!
@@ -156,16 +147,14 @@ class PaymentClientTest {
 
     @Test
     fun `ignore invalid purchases when loading acknowledged subscription purchases`() = runTest {
-        dataSource.customPurchasesResult = PaymentResult.Success(
-            listOf(
-                purchase.copy(
-                    state = PurchaseState.Purchased("order-id"),
-                    productIds = listOf(SubscriptionPlan.productId(SubscriptionTier.Plus, SubscriptionBillingCycle.Monthly)),
-                    isAcknowledged = true,
-                    isAutoRenewing = true,
-                ),
-                purchase.copy(productIds = emptyList()),
+        dataSource.loadedPurchases = listOf(
+            purchase.copy(
+                state = PurchaseState.Purchased("order-id"),
+                productIds = listOf(SubscriptionPlan.productId(SubscriptionTier.Plus, SubscriptionBillingCycle.Monthly)),
+                isAcknowledged = true,
+                isAutoRenewing = true,
             ),
+            purchase.copy(productIds = emptyList()),
         )
 
         val subscriptions = client.loadAcknowledgedSubscriptions().getOrNull()!!
@@ -180,7 +169,7 @@ class PaymentClientTest {
 
     @Test
     fun `load acknowledged subscriptions with failure`() = runTest {
-        dataSource.customPurchasesResult = PaymentResult.Failure(PaymentResultCode.Error, "Test error")
+        dataSource.loadedPurchasesResultCode = PaymentResultCode.Error
 
         val subscriptions = client.loadAcknowledgedSubscriptions()
 
@@ -188,133 +177,102 @@ class PaymentClientTest {
     }
 
     @Test
-    fun `purchase subscription`() = monitoredTest {
-        val purchaseResult = purchaseSubscription()
+    fun `purchase subscription`() = runTest {
+        val purchaseResult = client.purchaseSubscriptionPlan(planKey, mock<Activity>())
 
-        dataSource.purchaseResults.emit(PaymentResult.Success(listOf(purchase)))
-        approver.emitApproveResponse(PaymentResultCode.Ok)
-        dataSource.emitAcknowledgeResponse(PaymentResultCode.Ok)
-
-        assertEquals(PurchaseResult.Purchased, purchaseResult.await())
+        assertEquals(PurchaseResult.Purchased, purchaseResult)
     }
 
     @Test
-    fun `do not purchase subscription when billing result is failure`() = monitoredTest {
-        dataSource.launchBillingFlowResultCode = PaymentResultCode.FeatureNotSupported
+    fun `do not purchase subscription when billing result is failure`() = runTest {
+        dataSource.billingFlowResultCode = PaymentResultCode.FeatureNotSupported
 
-        val purchaseResult = purchaseSubscription()
+        val purchaseResult = client.purchaseSubscriptionPlan(planKey, mock<Activity>())
 
-        assertEquals(PurchaseResult.Failure(PaymentResultCode.FeatureNotSupported), purchaseResult.await())
+        assertEquals(PurchaseResult.Failure(PaymentResultCode.FeatureNotSupported), purchaseResult)
     }
 
     @Test
-    fun `do not purchase subscription when purchase result is failure`() = monitoredTest {
-        val purchaseResult = purchaseSubscription()
+    fun `do not purchase subscription when purchase result is failure`() = runTest {
+        dataSource.purchasedProductsResultCode = PaymentResultCode.Error
 
-        dataSource.purchaseResults.emit(PaymentResult.Failure(PaymentResultCode.BillingUnavailable, "Error"))
+        val purchaseResult = client.purchaseSubscriptionPlan(planKey, mock<Activity>())
 
-        assertEquals(PurchaseResult.Failure(PaymentResultCode.BillingUnavailable), purchaseResult.await())
+        assertEquals(PurchaseResult.Failure(PaymentResultCode.Error), purchaseResult)
     }
 
     @Test
-    fun `cancel purchase subscription when purchase result is cancelled`() = monitoredTest {
-        val purchaseResult = purchaseSubscription()
+    fun `cancel purchase subscription when purchase result is cancelled`() = runTest {
+        dataSource.purchasedProductsResultCode = PaymentResultCode.UserCancelled
 
-        dataSource.purchaseResults.emit(PaymentResult.Failure(PaymentResultCode.UserCancelled, "Error"))
+        val purchaseResult = client.purchaseSubscriptionPlan(planKey, mock<Activity>())
 
-        assertEquals(PurchaseResult.Cancelled, purchaseResult.await())
+        assertEquals(PurchaseResult.Cancelled, purchaseResult)
     }
 
     @Test
-    fun `do not purchase subscription when approving fails`() = monitoredTest {
-        val purchaseResult = purchaseSubscription()
+    fun `do not purchase subscription when approving fails`() = runTest {
+        approver.approveResultCode = PaymentResultCode.Error
 
-        dataSource.purchaseResults.emit(PaymentResult.Success(listOf(purchase)))
-        approver.emitApproveResponse(PaymentResultCode.Error)
+        val purchaseResult = client.purchaseSubscriptionPlan(planKey, mock<Activity>())
 
-        assertEquals(PurchaseResult.Failure(PaymentResultCode.Error), purchaseResult.await())
+        assertEquals(PurchaseResult.Failure(PaymentResultCode.Error), purchaseResult)
     }
 
     @Test
-    fun `do not purchase subscription when acknowledging fails`() = monitoredTest {
-        val purchaseResult = purchaseSubscription()
+    fun `do not purchase subscription when acknowledging fails`() = runTest {
+        dataSource.acknowledgePurchaseResultCode = PaymentResultCode.Error
 
-        dataSource.purchaseResults.emit(PaymentResult.Success(listOf(purchase)))
-        approver.emitApproveResponse(PaymentResultCode.Ok)
-        dataSource.emitAcknowledgeResponse(PaymentResultCode.Error)
+        val purchaseResult = client.purchaseSubscriptionPlan(planKey, mock<Activity>())
 
-        assertEquals(PurchaseResult.Failure(PaymentResultCode.Error), purchaseResult.await())
+        assertEquals(PurchaseResult.Failure(PaymentResultCode.Error), purchaseResult)
     }
 
     @Test
-    fun `cancel purchase subscription when acknowledging is cancelled`() = monitoredTest {
-        val purchaseResult = purchaseSubscription()
+    fun `cancel purchase subscription when acknowledging is cancelled`() = runTest {
+        dataSource.acknowledgePurchaseResultCode = PaymentResultCode.UserCancelled
 
-        dataSource.purchaseResults.emit(PaymentResult.Success(listOf(purchase)))
-        approver.emitApproveResponse(PaymentResultCode.Ok)
-        dataSource.emitAcknowledgeResponse(PaymentResultCode.UserCancelled)
+        val purchaseResult = client.purchaseSubscriptionPlan(planKey, mock<Activity>())
 
-        assertEquals(PurchaseResult.Cancelled, purchaseResult.await())
+        assertEquals(PurchaseResult.Cancelled, purchaseResult)
     }
 
     @Test
-    fun `wait for all purchases to be confirmed before finalizing purchase`() = monitoredTest {
-        val purchaseResult = purchaseSubscription()
+    fun `do not finalize non confirmed purchases`() = runTest {
+        dataSource.purchasedProducts = listOf(
+            purchase.copy(state = PurchaseState.Pending),
+        )
 
-        dataSource.purchaseResults.emit(PaymentResult.Success(listOf(purchase, purchase)))
-        approver.emitApproveResponse(PaymentResultCode.Ok)
-        dataSource.emitAcknowledgeResponse(PaymentResultCode.Ok)
-
+        val purchaseResult = backgroundScope.async { client.purchaseSubscriptionPlan(planKey, mock<Activity>()) }
         yield() // Yield to make sure the job didn't cancel
-        assertTrue(purchaseResult.isActive)
 
-        approver.emitApproveResponse(PaymentResultCode.Ok)
-        dataSource.emitAcknowledgeResponse(PaymentResultCode.Ok)
-
-        assertEquals(PurchaseResult.Purchased, purchaseResult.await())
-    }
-
-    @Test
-    fun `do not finalize non confirmed purchases`() = monitoredTest {
-        val purchaseResult = purchaseSubscription()
-
-        dataSource.purchaseResults.emit(PaymentResult.Success(listOf(purchase.copy(state = PurchaseState.Pending))))
-        approver.emitApproveResponse(PaymentResultCode.Ok)
-        dataSource.emitAcknowledgeResponse(PaymentResultCode.Ok)
-
-        yield() // Yield to make sure the job didn't cancel
         assertTrue(purchaseResult.isActive)
         assertTrue(approver.receivedPurchases.isEmpty())
     }
 
     @Test
-    fun `do not acknowledge purchases that are already acknowledged`() = monitoredTest {
-        val purchaseResult = purchaseSubscription()
+    fun `do not acknowledge purchases that are already acknowledged`() = runTest {
+        dataSource.purchasedProducts = listOf(
+            purchase.copy(isAcknowledged = true),
+        )
 
-        dataSource.purchaseResults.emit(PaymentResult.Success(listOf(purchase.copy(isAcknowledged = true))))
-        approver.emitApproveResponse(PaymentResultCode.Ok)
+        val purchaseResult = client.purchaseSubscriptionPlan(planKey, mock<Activity>())
 
         assertTrue(dataSource.receivedPurchases.isEmpty())
-        assertEquals(PurchaseResult.Purchased, purchaseResult.await())
+        assertEquals(PurchaseResult.Purchased, purchaseResult)
     }
 
     @Test
-    fun `acknowledge lingering purchases when monitoring starts`() = runTest {
+    fun `acknowledge lingering purchases`() = runTest {
         val purchases = listOf(
             purchase.copy(state = PurchaseState.Purchased("order-id-1")),
             purchase.copy(isAcknowledged = true),
             purchase.copy(state = PurchaseState.Pending),
             purchase.copy(state = PurchaseState.Purchased("order-id-2")),
         )
-        dataSource.customPurchasesResult = PaymentResult.Success(purchases)
+        dataSource.loadedPurchases = purchases
 
-        backgroundScope.launch(start = CoroutineStart.UNDISPATCHED) { client.monitorPurchaseUpdates() }
-        yield() // Yield due to starting internal job inside monitorPurchaseUpdates()
-
-        approver.emitApproveResponse(PaymentResultCode.Ok)
-        dataSource.emitAcknowledgeResponse(PaymentResultCode.Ok)
-        approver.emitApproveResponse(PaymentResultCode.Ok)
-        dataSource.emitAcknowledgeResponse(PaymentResultCode.Ok)
+        client.acknowledgePendingPurchases()
 
         val expectedPurchases = listOf(purchases[0], purchases[3])
         assertEquals(expectedPurchases, approver.receivedPurchases)
@@ -333,12 +291,12 @@ class PaymentClientTest {
 
     @Test
     fun `log loading plans with failure`() = runTest {
-        dataSource.customProductsResult = PaymentResult.Failure(PaymentResultCode.Error, "Test failure")
+        dataSource.loadedProductsResultCode = PaymentResultCode.Error
 
         client.loadSubscriptionPlans()
 
         logger.assertInfos("Load subscription plans")
-        logger.assertWarnings("Failed to load subscription plans. Error, Test failure")
+        logger.assertWarnings("Failed to load subscription plans. Error, Error message")
     }
 
     @Test
@@ -353,41 +311,39 @@ class PaymentClientTest {
 
     @Test
     fun `log loading acknowledged subscription with failure`() = runTest {
-        dataSource.customPurchasesResult = PaymentResult.Failure(PaymentResultCode.Error, "Test failure")
+        dataSource.loadedPurchasesResultCode = PaymentResultCode.Error
 
         client.loadAcknowledgedSubscriptions()
 
         logger.assertInfos("Loading acknowledged subscriptions")
-        logger.assertWarnings("Failed to load acknowledged subscriptions. Error, Test failure")
+        logger.assertWarnings("Failed to load acknowledged subscriptions. Error, Error message")
     }
 
     @Test
     fun `log issues with invalid acknowledged subscription purchases`() = runTest {
-        dataSource.customPurchasesResult = PaymentResult.Success(
-            listOf(
-                purchase.copy(
-                    state = PurchaseState.Pending,
-                    isAcknowledged = true,
-                ),
-                purchase.copy(
-                    state = PurchaseState.Purchased(orderId = "order-id-1"),
-                    isAcknowledged = false,
-                ),
-                purchase.copy(
-                    state = PurchaseState.Purchased(orderId = "order-id-2"),
-                    isAcknowledged = true,
-                    productIds = emptyList(),
-                ),
-                purchase.copy(
-                    state = PurchaseState.Purchased(orderId = "order-id-3"),
-                    isAcknowledged = true,
-                    productIds = listOf("product-id-1", "product-id-2"),
-                ),
-                purchase.copy(
-                    state = PurchaseState.Purchased(orderId = "order-id-4"),
-                    isAcknowledged = true,
-                    productIds = listOf("unknown-product-id"),
-                ),
+        dataSource.loadedPurchases = listOf(
+            purchase.copy(
+                state = PurchaseState.Pending,
+                isAcknowledged = true,
+            ),
+            purchase.copy(
+                state = PurchaseState.Purchased(orderId = "order-id-1"),
+                isAcknowledged = false,
+            ),
+            purchase.copy(
+                state = PurchaseState.Purchased(orderId = "order-id-2"),
+                productIds = emptyList(),
+                isAcknowledged = true,
+            ),
+            purchase.copy(
+                state = PurchaseState.Purchased(orderId = "order-id-3"),
+                productIds = listOf("product-id-1", "product-id-2"),
+                isAcknowledged = true,
+            ),
+            purchase.copy(
+                state = PurchaseState.Purchased(orderId = "order-id-4"),
+                productIds = listOf("unknown-product-id"),
+                isAcknowledged = true,
             ),
         )
 
@@ -401,13 +357,10 @@ class PaymentClientTest {
     }
 
     @Test
-    fun `log confirming purchase`() = monitoredTest {
-        val purchaseResult = purchaseSubscription()
+    fun `log confirming purchase`() = runTest {
+        dataSource.purchasedProducts = listOf(purchase)
 
-        dataSource.purchaseResults.emit(PaymentResult.Success(listOf(purchase)))
-        approver.emitApproveResponse(PaymentResultCode.Ok)
-        dataSource.emitAcknowledgeResponse(PaymentResultCode.Ok)
-        purchaseResult.await()
+        client.purchaseSubscriptionPlan(planKey, mock<Activity>())
 
         logger.assertInfos(
             "Confirm purchase: $purchase",
@@ -416,50 +369,39 @@ class PaymentClientTest {
     }
 
     @Test
-    fun `log confirming purchase failure`() = monitoredTest {
-        val purchaseResult = purchaseSubscription()
+    fun `log confirming purchase failure`() = runTest {
+        dataSource.purchasedProducts = listOf(purchase)
+        approver.approveResultCode = PaymentResultCode.DeveloperError
 
-        dataSource.purchaseResults.emit(PaymentResult.Success(listOf(purchase)))
-        approver.emitApproveResponse(PaymentResultCode.DeveloperError)
-        purchaseResult.await()
+        client.purchaseSubscriptionPlan(planKey, mock<Activity>())
 
         logger.assertInfos(
             "Confirm purchase: $purchase",
         )
         logger.assertWarnings(
-            "Failed to confirm purchase: $purchase. DeveloperError Error",
+            "Failed to confirm purchase: $purchase. DeveloperError, Error message",
         )
     }
 
     @Test
-    fun `log purchase result failure`() = monitoredTest {
-        val purchaseResult = purchaseSubscription()
+    fun `log purchase result failure`() = runTest {
+        dataSource.purchasedProductsResultCode = PaymentResultCode.ServiceDisconnected
 
-        dataSource.purchaseResults.emit(PaymentResult.Failure(PaymentResultCode.ServiceDisconnected, "Whoops!"))
-        purchaseResult.await()
+        client.purchaseSubscriptionPlan(planKey, mock<Activity>())
 
         logger.assertWarnings(
-            "Purchase failure: ServiceDisconnected Whoops!",
+            "Purchase failure: ServiceDisconnected, Error message",
         )
     }
 
     @Test
-    fun `log billing result failure`() = monitoredTest {
-        dataSource.launchBillingFlowResultCode = PaymentResultCode.DeveloperError
+    fun `log billing result failure`() = runTest {
+        dataSource.billingFlowResultCode = PaymentResultCode.DeveloperError
 
-        purchaseSubscription()
+        client.purchaseSubscriptionPlan(planKey, mock<Activity>())
 
         logger.assertWarnings(
-            "Launching billing flow failed: DeveloperError Error",
+            "Launching billing flow failed: DeveloperError, Error message",
         )
     }
-
-    private fun monitoredTest(testBody: suspend TestScope.() -> Unit) = runTest {
-        backgroundScope.launch(start = CoroutineStart.UNDISPATCHED) { client.monitorPurchaseUpdates() }
-        testBody()
-    }
-
-    private fun TestScope.purchaseSubscription(
-        key: SubscriptionPlan.Key = planKey,
-    ) = backgroundScope.async(start = CoroutineStart.UNDISPATCHED) { client.purchaseSubscriptionPlan(key, mock<Activity>()) }
 }

--- a/modules/services/payment/src/test/kotlin/au/com/shiftyjelly/pocketcasts/payment/TestPurchaseApprover.kt
+++ b/modules/services/payment/src/test/kotlin/au/com/shiftyjelly/pocketcasts/payment/TestPurchaseApprover.kt
@@ -1,25 +1,17 @@
 package au.com.shiftyjelly.pocketcasts.payment
 
-import kotlinx.coroutines.flow.MutableSharedFlow
-import kotlinx.coroutines.flow.first
-
 class TestPurchaseApprover : PurchaseApprover {
+    var approveResultCode: PaymentResultCode = PaymentResultCode.Ok
+
     var receivedPurchases = emptyList<Purchase>()
         private set
 
-    private val approveFlow = MutableSharedFlow<PaymentResultCode>()
-
-    suspend fun emitApproveResponse(code: PaymentResultCode) {
-        approveFlow.emit(code)
-    }
-
     override suspend fun approve(purchase: Purchase): PaymentResult<Purchase> {
         receivedPurchases += purchase
-        val errorCode = approveFlow.first()
-        return if (errorCode == PaymentResultCode.Ok) {
+        return if (approveResultCode == PaymentResultCode.Ok) {
             PaymentResult.Success(purchase)
         } else {
-            PaymentResult.Failure(errorCode, "Error")
+            PaymentResult.Failure(approveResultCode, "Error message")
         }
     }
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/subscription/SubscriptionManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/subscription/SubscriptionManagerImpl.kt
@@ -129,7 +129,7 @@ class SubscriptionManagerImpl @Inject constructor(
     }
 
     override suspend fun initializeBillingConnection(): Nothing = coroutineScope {
-        launch { paymentClient.monitorPurchaseUpdates() }
+        launch { paymentClient.listenToPurchaseUpdates() }
         paymentClient.purchaseEvents.collect(purchaseEvents::accept)
     }
 


### PR DESCRIPTION
## Description

This simplifies the testing logic of `PaymentClient`. Previously, it was designed to emulate real behavior: we had to launch the purchase flow asynchronously, and while the task was running, we had to emit a set of events like receiving or acknowledging manually. I realized that the previous approach isn't what we really wanted as it would put too much burden on higher-level tests without any real benefit.

This change automates those emissions. While we lose some flexibility in testing, it significantly simplifies the process. We no longer need to spin up a background job to monitor purchases or explicitly emit events. If we want to simulate a failure, we can simply set the appropriate `PaymentResultCode` properties before launching the purchase. By default, without setting anything, we now get a happy-path scenario.

In the future, if we want to have more control, we could change the implementation from a constant response to a queue of responses that gets depleted 1 by 1.

## Testing Instructions

Verify the code.

## Checklist
- [ ] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [ ] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [ ] ~Any jetpack compose components I added or changed are covered by compose previews~
- [ ] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~