### PR TITLE
Rename payment types

### DIFF
--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/winback/AvailablePlansPage.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/winback/AvailablePlansPage.kt
@@ -59,7 +59,7 @@ import au.com.shiftyjelly.pocketcasts.compose.pocketRed
 import au.com.shiftyjelly.pocketcasts.compose.preview.ThemePreviewParameterProvider
 import au.com.shiftyjelly.pocketcasts.compose.theme
 import au.com.shiftyjelly.pocketcasts.payment.AcknowledgedSubscription
-import au.com.shiftyjelly.pocketcasts.payment.SubscriptionBillingCycle
+import au.com.shiftyjelly.pocketcasts.payment.BillingCycle
 import au.com.shiftyjelly.pocketcasts.payment.SubscriptionPlan
 import au.com.shiftyjelly.pocketcasts.payment.SubscriptionPlans
 import au.com.shiftyjelly.pocketcasts.payment.SubscriptionTier
@@ -355,7 +355,7 @@ private fun SubscriptionRow(
                     lineHeight = 21.sp,
                 )
             }
-            if (plan.billingCycle == SubscriptionBillingCycle.Yearly) {
+            if (plan.billingCycle == BillingCycle.Yearly) {
                 val currencyCode = plan.pricingPhase.price.currencyCode
                 TextP40(
                     text = if (currencyCode == "USD") {
@@ -371,7 +371,7 @@ private fun SubscriptionRow(
             }
         }
 
-        if (plan.tier == SubscriptionTier.Plus && plan.billingCycle == SubscriptionBillingCycle.Yearly) {
+        if (plan.tier == SubscriptionTier.Plus && plan.billingCycle == BillingCycle.Yearly) {
             Box(
                 modifier = Modifier
                     .align(Alignment.TopEnd)
@@ -443,8 +443,8 @@ private fun ManageSubscriptions(
 private val SubscriptionPlan.Base.pricePerWeek: Float
     get() {
         val pricePerWeek = when (billingCycle) {
-            SubscriptionBillingCycle.Monthly -> pricingPhase.price.amount * 12.toBigDecimal()
-            SubscriptionBillingCycle.Yearly -> pricingPhase.price.amount
+            BillingCycle.Monthly -> pricingPhase.price.amount * 12.toBigDecimal()
+            BillingCycle.Yearly -> pricingPhase.price.amount
         } / 52.toBigDecimal()
         return pricePerWeek.toFloat()
     }
@@ -452,8 +452,8 @@ private val SubscriptionPlan.Base.pricePerWeek: Float
 @Composable
 @ReadOnlyComposable
 private fun SubscriptionPlan.Base.price() = when (billingCycle) {
-    SubscriptionBillingCycle.Monthly -> stringResource(LR.string.plus_per_month, pricingPhase.price.formattedPrice)
-    SubscriptionBillingCycle.Yearly -> stringResource(LR.string.plus_per_year, pricingPhase.price.formattedPrice)
+    BillingCycle.Monthly -> stringResource(LR.string.plus_per_month, pricingPhase.price.formattedPrice)
+    BillingCycle.Yearly -> stringResource(LR.string.plus_per_year, pricingPhase.price.formattedPrice)
 }
 
 @Preview(device = Devices.PortraitRegular)
@@ -469,7 +469,7 @@ private fun AvailablePlansPagePreview(
                 currentSubscription = AcknowledgedSubscription(
                     orderId = "orderId",
                     tier = SubscriptionTier.Plus,
-                    billingCycle = SubscriptionBillingCycle.Yearly,
+                    billingCycle = BillingCycle.Yearly,
                     isAutoRenewing = true,
                 ),
                 subscriptionPlans = SubscriptionPlans.Preview,

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/winback/OfferClaimedPage.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/winback/OfferClaimedPage.kt
@@ -41,14 +41,14 @@ import au.com.shiftyjelly.pocketcasts.compose.buttons.RowButton
 import au.com.shiftyjelly.pocketcasts.compose.components.TextP30
 import au.com.shiftyjelly.pocketcasts.compose.preview.ThemePreviewParameterProvider
 import au.com.shiftyjelly.pocketcasts.compose.theme
-import au.com.shiftyjelly.pocketcasts.payment.SubscriptionBillingCycle
+import au.com.shiftyjelly.pocketcasts.payment.BillingCycle
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme.ThemeType
 import au.com.shiftyjelly.pocketcasts.images.R as IR
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 @Composable
 internal fun OfferClaimedPage(
-    billingCycle: SubscriptionBillingCycle,
+    billingCycle: BillingCycle,
     onConfirm: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -73,8 +73,8 @@ internal fun OfferClaimedPage(
         )
         Text(
             text = when (billingCycle) {
-                SubscriptionBillingCycle.Monthly -> stringResource(LR.string.winback_claimed_offer_message_1)
-                SubscriptionBillingCycle.Yearly -> stringResource(LR.string.winback_claimed_offer_message_3)
+                BillingCycle.Monthly -> stringResource(LR.string.winback_claimed_offer_message_1)
+                BillingCycle.Yearly -> stringResource(LR.string.winback_claimed_offer_message_3)
             },
             fontWeight = FontWeight.Bold,
             fontSize = 28.sp,
@@ -88,8 +88,8 @@ internal fun OfferClaimedPage(
         )
         TextP30(
             text = when (billingCycle) {
-                SubscriptionBillingCycle.Monthly -> stringResource(LR.string.winback_claimed_offer_message_2)
-                SubscriptionBillingCycle.Yearly -> stringResource(LR.string.winback_claimed_offer_message_4)
+                BillingCycle.Monthly -> stringResource(LR.string.winback_claimed_offer_message_2)
+                BillingCycle.Yearly -> stringResource(LR.string.winback_claimed_offer_message_4)
             },
             color = MaterialTheme.theme.colors.primaryText02,
             textAlign = TextAlign.Center,
@@ -198,7 +198,7 @@ private val graySparkle = Color(0xFFCCD6D9) to Color(0xFFE5F7FF)
 @Preview(device = Devices.PortraitRegular)
 @Composable
 private fun WinbackOfferPageBillingPeriodPreview(
-    @PreviewParameter(BillingPeriodParameterProvider::class) billingPeriod: SubscriptionBillingCycle,
+    @PreviewParameter(BillingPeriodParameterProvider::class) billingPeriod: BillingCycle,
 ) {
     AppThemeWithBackground(
         themeType = ThemeType.ROSE,
@@ -219,15 +219,15 @@ private fun WinbackOfferPageThemePreview(
         themeType = theme,
     ) {
         OfferClaimedPage(
-            billingCycle = SubscriptionBillingCycle.Monthly,
+            billingCycle = BillingCycle.Monthly,
             onConfirm = {},
         )
     }
 }
 
-private class BillingPeriodParameterProvider : PreviewParameterProvider<SubscriptionBillingCycle> {
+private class BillingPeriodParameterProvider : PreviewParameterProvider<BillingCycle> {
     override val values = sequenceOf(
-        SubscriptionBillingCycle.Monthly,
-        SubscriptionBillingCycle.Yearly,
+        BillingCycle.Monthly,
+        BillingCycle.Yearly,
     )
 }

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/winback/WinbackFragment.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/winback/WinbackFragment.kt
@@ -52,7 +52,7 @@ import au.com.shiftyjelly.pocketcasts.compose.CallOnce
 import au.com.shiftyjelly.pocketcasts.compose.components.ProgressDialog
 import au.com.shiftyjelly.pocketcasts.compose.components.TextH50
 import au.com.shiftyjelly.pocketcasts.compose.theme
-import au.com.shiftyjelly.pocketcasts.payment.SubscriptionBillingCycle
+import au.com.shiftyjelly.pocketcasts.payment.BillingCycle
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.settings.HelpPage
 import au.com.shiftyjelly.pocketcasts.settings.LogsPage
@@ -142,12 +142,12 @@ class WinbackFragment : BaseDialogFragment() {
                             WinbackNavRoutes.offerClaimedRoute(),
                             listOf(
                                 navArgument(WinbackNavRoutes.OfferClaimedBillingCycleArgument) {
-                                    type = NavType.EnumType(SubscriptionBillingCycle::class.java)
+                                    type = NavType.EnumType(BillingCycle::class.java)
                                 },
                             ),
                         ) { backStackEntry ->
                             val arguments = requireNotNull(backStackEntry.arguments) { "Missing back stack entry arguments" }
-                            val billingCycle = requireNotNull(BundleCompat.getSerializable(arguments, WinbackNavRoutes.OfferClaimedBillingCycleArgument, SubscriptionBillingCycle::class.java)) {
+                            val billingCycle = requireNotNull(BundleCompat.getSerializable(arguments, WinbackNavRoutes.OfferClaimedBillingCycleArgument, BillingCycle::class.java)) {
                                 "Missing billing cycle argument"
                             }
                             OfferClaimedPage(
@@ -386,7 +386,7 @@ private object WinbackNavRoutes {
 
     fun offerClaimedRoute() = "$OfferClaimed/{$OfferClaimedBillingCycleArgument}"
 
-    fun offerClaimedDestination(billingCycle: SubscriptionBillingCycle) = "$OfferClaimed/$billingCycle"
+    fun offerClaimedDestination(billingCycle: BillingCycle) = "$OfferClaimed/$billingCycle"
 }
 
 private val intOffsetAnimationSpec = tween<IntOffset>(350)

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/winback/WinbackOfferPage.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/winback/WinbackOfferPage.kt
@@ -47,7 +47,7 @@ import au.com.shiftyjelly.pocketcasts.compose.components.TextH30
 import au.com.shiftyjelly.pocketcasts.compose.components.TextP30
 import au.com.shiftyjelly.pocketcasts.compose.preview.ThemePreviewParameterProvider
 import au.com.shiftyjelly.pocketcasts.compose.theme
-import au.com.shiftyjelly.pocketcasts.payment.SubscriptionBillingCycle
+import au.com.shiftyjelly.pocketcasts.payment.BillingCycle
 import au.com.shiftyjelly.pocketcasts.payment.SubscriptionTier
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme.ThemeType
 import au.com.shiftyjelly.pocketcasts.images.R as IR
@@ -81,8 +81,8 @@ internal fun WinbackOfferPage(
         )
         Text(
             text = when (offer.billingCycle) {
-                SubscriptionBillingCycle.Monthly -> stringResource(LR.string.winback_offer_free_offer_title, offer.formattedPrice)
-                SubscriptionBillingCycle.Yearly -> stringResource(LR.string.winback_offer_free_offer_yearly_title, offer.formattedPrice)
+                BillingCycle.Monthly -> stringResource(LR.string.winback_offer_free_offer_title, offer.formattedPrice)
+                BillingCycle.Yearly -> stringResource(LR.string.winback_offer_free_offer_yearly_title, offer.formattedPrice)
             },
             fontWeight = FontWeight.Bold,
             fontSize = 28.sp,
@@ -96,8 +96,8 @@ internal fun WinbackOfferPage(
         )
         TextP30(
             text = when (offer.billingCycle) {
-                SubscriptionBillingCycle.Monthly -> stringResource(LR.string.winback_offer_free_offer_description, offer.formattedPrice)
-                SubscriptionBillingCycle.Yearly -> stringResource(LR.string.winback_offer_free_offer_yearly_description, offer.formattedPrice)
+                BillingCycle.Monthly -> stringResource(LR.string.winback_offer_free_offer_description, offer.formattedPrice)
+                BillingCycle.Yearly -> stringResource(LR.string.winback_offer_free_offer_yearly_description, offer.formattedPrice)
             },
             color = MaterialTheme.theme.colors.primaryText02,
             textAlign = TextAlign.Center,
@@ -261,7 +261,7 @@ private fun WinbackOfferPageThemePreview(
                 redeemCode = "",
                 formattedPrice = "\$3.99",
                 tier = SubscriptionTier.Plus,
-                billingCycle = SubscriptionBillingCycle.Monthly,
+                billingCycle = BillingCycle.Monthly,
             ),
         )
     }
@@ -273,13 +273,13 @@ private class WinbackOfferParameterProvider : PreviewParameterProvider<WinbackOf
             redeemCode = "",
             formattedPrice = "\$3.99",
             tier = SubscriptionTier.Plus,
-            billingCycle = SubscriptionBillingCycle.Monthly,
+            billingCycle = BillingCycle.Monthly,
         ),
         WinbackOffer(
             redeemCode = "",
             formattedPrice = "\$19.99",
             tier = SubscriptionTier.Plus,
-            billingCycle = SubscriptionBillingCycle.Yearly,
+            billingCycle = BillingCycle.Yearly,
         ),
     )
 }

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/winback/WinbackViewModel.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/winback/WinbackViewModel.kt
@@ -6,10 +6,10 @@ import androidx.lifecycle.viewModelScope
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTracker
 import au.com.shiftyjelly.pocketcasts.payment.AcknowledgedSubscription
+import au.com.shiftyjelly.pocketcasts.payment.BillingCycle
 import au.com.shiftyjelly.pocketcasts.payment.PaymentClient
 import au.com.shiftyjelly.pocketcasts.payment.PaymentResult
 import au.com.shiftyjelly.pocketcasts.payment.PurchaseResult
-import au.com.shiftyjelly.pocketcasts.payment.SubscriptionBillingCycle
 import au.com.shiftyjelly.pocketcasts.payment.SubscriptionOffer
 import au.com.shiftyjelly.pocketcasts.payment.SubscriptionPlan
 import au.com.shiftyjelly.pocketcasts.payment.SubscriptionPlans
@@ -252,8 +252,8 @@ class WinbackViewModel @Inject constructor(
         return WinbackOffer(
             redeemCode = redeemCode,
             formattedPrice = when (plan.billingCycle) {
-                SubscriptionBillingCycle.Monthly -> regularPhase.price.formattedPrice
-                SubscriptionBillingCycle.Yearly -> discountPhase.price.formattedPrice
+                BillingCycle.Monthly -> regularPhase.price.formattedPrice
+                BillingCycle.Yearly -> discountPhase.price.formattedPrice
             },
             tier = plan.tier,
             billingCycle = plan.billingCycle,
@@ -290,7 +290,7 @@ class WinbackViewModel @Inject constructor(
 
     private fun SubscriptionPlans.finMatchingWinbackPlan(offerId: String): SubscriptionPlan.WithOffer? {
         SubscriptionTier.entries.forEach { tier ->
-            SubscriptionBillingCycle.entries.forEach { billingCycle ->
+            BillingCycle.entries.forEach { billingCycle ->
                 val offer = findOfferPlan(tier, billingCycle, SubscriptionOffer.Winback).getOrNull()
                 if (offer != null && offer.offerId == offerId) {
                     return offer
@@ -449,10 +449,10 @@ internal sealed interface SubscriptionPlansState {
         val hasPlanChangeFailed: Boolean = false,
     ) : SubscriptionPlansState {
         val basePlans get() = listOf(
-            subscriptionPlans.getBasePlan(SubscriptionTier.Plus, SubscriptionBillingCycle.Monthly),
-            subscriptionPlans.getBasePlan(SubscriptionTier.Patron, SubscriptionBillingCycle.Monthly),
-            subscriptionPlans.getBasePlan(SubscriptionTier.Plus, SubscriptionBillingCycle.Yearly),
-            subscriptionPlans.getBasePlan(SubscriptionTier.Patron, SubscriptionBillingCycle.Yearly),
+            subscriptionPlans.getBasePlan(SubscriptionTier.Plus, BillingCycle.Monthly),
+            subscriptionPlans.getBasePlan(SubscriptionTier.Patron, BillingCycle.Monthly),
+            subscriptionPlans.getBasePlan(SubscriptionTier.Plus, BillingCycle.Yearly),
+            subscriptionPlans.getBasePlan(SubscriptionTier.Patron, BillingCycle.Yearly),
         )
     }
 }
@@ -461,7 +461,7 @@ internal data class WinbackOffer(
     val redeemCode: String,
     val formattedPrice: String,
     val tier: SubscriptionTier,
-    val billingCycle: SubscriptionBillingCycle,
+    val billingCycle: BillingCycle,
 ) {
     val productId get() = SubscriptionPlan.productId(tier, billingCycle)
 }

--- a/modules/features/profile/src/test/kotlin/au/com/shiftyjelly/pocketcasts/profile/winback/WinbackViewModelTest.kt
+++ b/modules/features/profile/src/test/kotlin/au/com/shiftyjelly/pocketcasts/profile/winback/WinbackViewModelTest.kt
@@ -9,12 +9,12 @@ import au.com.shiftyjelly.pocketcasts.analytics.Tracker
 import au.com.shiftyjelly.pocketcasts.analytics.TrackerType
 import au.com.shiftyjelly.pocketcasts.models.to.SubscriptionStatus
 import au.com.shiftyjelly.pocketcasts.payment.AcknowledgedSubscription
+import au.com.shiftyjelly.pocketcasts.payment.BillingCycle
 import au.com.shiftyjelly.pocketcasts.payment.FakePaymentDataSource
 import au.com.shiftyjelly.pocketcasts.payment.PaymentClient
 import au.com.shiftyjelly.pocketcasts.payment.PaymentResultCode
 import au.com.shiftyjelly.pocketcasts.payment.Purchase
 import au.com.shiftyjelly.pocketcasts.payment.PurchaseState
-import au.com.shiftyjelly.pocketcasts.payment.SubscriptionBillingCycle
 import au.com.shiftyjelly.pocketcasts.payment.SubscriptionOffer
 import au.com.shiftyjelly.pocketcasts.payment.SubscriptionPlan
 import au.com.shiftyjelly.pocketcasts.payment.SubscriptionTier
@@ -56,7 +56,7 @@ class WinbackViewModelTest {
         }
         whenever(settings.cachedSubscriptionStatus) doReturn subscriptionSettingMock
         wheneverBlocking { referralManager.getWinbackResponse() } doReturn createSuccessReferralResult(
-            offerId = SubscriptionOffer.Winback.offerId(SubscriptionTier.Plus, SubscriptionBillingCycle.Yearly)!!,
+            offerId = SubscriptionOffer.Winback.offerId(SubscriptionTier.Plus, BillingCycle.Yearly)!!,
         )
 
         viewModel = WinbackViewModel(
@@ -185,7 +185,7 @@ class WinbackViewModelTest {
             orderId = "new-order-id",
             productIds = listOf(SubscriptionPlan.PlusMonthlyProductId),
         )
-        val newSubscription = AcknowledgedSubscription("new-order-id", SubscriptionTier.Plus, SubscriptionBillingCycle.Monthly, isAutoRenewing = true)
+        val newSubscription = AcknowledgedSubscription("new-order-id", SubscriptionTier.Plus, BillingCycle.Monthly, isAutoRenewing = true)
 
         viewModel.loadWinbackData()
 
@@ -273,7 +273,7 @@ class WinbackViewModelTest {
             createPurchase(productIds = listOf(SubscriptionPlan.PlusMonthlyProductId)),
         )
         wheneverBlocking { referralManager.getWinbackResponse() } doReturn createSuccessReferralResult(
-            offerId = SubscriptionOffer.Winback.offerId(SubscriptionTier.Plus, SubscriptionBillingCycle.Monthly)!!,
+            offerId = SubscriptionOffer.Winback.offerId(SubscriptionTier.Plus, BillingCycle.Monthly)!!,
         )
 
         viewModel.loadWinbackData()
@@ -284,7 +284,7 @@ class WinbackViewModelTest {
                     redeemCode = "ABC",
                     formattedPrice = "$3.99",
                     tier = SubscriptionTier.Plus,
-                    billingCycle = SubscriptionBillingCycle.Monthly,
+                    billingCycle = BillingCycle.Monthly,
                 ),
                 awaitItem().winbackOfferState?.offer,
             )
@@ -301,7 +301,7 @@ class WinbackViewModelTest {
                     redeemCode = "ABC",
                     formattedPrice = "$20.00",
                     tier = SubscriptionTier.Plus,
-                    billingCycle = SubscriptionBillingCycle.Yearly,
+                    billingCycle = BillingCycle.Yearly,
                 ),
                 awaitItem().winbackOfferState?.offer,
             )
@@ -314,7 +314,7 @@ class WinbackViewModelTest {
             createPurchase(productIds = listOf(SubscriptionPlan.PatronMonthlyProductId)),
         )
         wheneverBlocking { referralManager.getWinbackResponse() } doReturn createSuccessReferralResult(
-            offerId = SubscriptionOffer.Winback.offerId(SubscriptionTier.Patron, SubscriptionBillingCycle.Monthly)!!,
+            offerId = SubscriptionOffer.Winback.offerId(SubscriptionTier.Patron, BillingCycle.Monthly)!!,
         )
 
         viewModel.loadWinbackData()
@@ -325,7 +325,7 @@ class WinbackViewModelTest {
                     redeemCode = "ABC",
                     formattedPrice = "$9.99",
                     tier = SubscriptionTier.Patron,
-                    billingCycle = SubscriptionBillingCycle.Monthly,
+                    billingCycle = BillingCycle.Monthly,
                 ),
                 awaitItem().winbackOfferState?.offer,
             )
@@ -338,7 +338,7 @@ class WinbackViewModelTest {
             createPurchase(productIds = listOf(SubscriptionPlan.PatronYearlyProductId)),
         )
         wheneverBlocking { referralManager.getWinbackResponse() } doReturn createSuccessReferralResult(
-            offerId = SubscriptionOffer.Winback.offerId(SubscriptionTier.Patron, SubscriptionBillingCycle.Yearly)!!,
+            offerId = SubscriptionOffer.Winback.offerId(SubscriptionTier.Patron, BillingCycle.Yearly)!!,
         )
 
         viewModel.loadWinbackData()
@@ -349,7 +349,7 @@ class WinbackViewModelTest {
                     redeemCode = "ABC",
                     formattedPrice = "$50.00",
                     tier = SubscriptionTier.Patron,
-                    billingCycle = SubscriptionBillingCycle.Yearly,
+                    billingCycle = BillingCycle.Yearly,
                 ),
                 awaitItem().winbackOfferState?.offer,
             )
@@ -373,13 +373,13 @@ class WinbackViewModelTest {
             orderId = "new-order-id",
             productIds = listOf(SubscriptionPlan.PatronYearlyProductId),
         )
-        val newSubscription = AcknowledgedSubscription("new-order-id", SubscriptionTier.Patron, SubscriptionBillingCycle.Yearly, isAutoRenewing = true)
+        val newSubscription = AcknowledgedSubscription("new-order-id", SubscriptionTier.Patron, BillingCycle.Yearly, isAutoRenewing = true)
 
         viewModel.loadWinbackData()
 
         paymentDataSource.loadedPurchases = listOf(newPurchase)
         wheneverBlocking { referralManager.getWinbackResponse() } doReturn createSuccessReferralResult(
-            offerId = SubscriptionOffer.Winback.offerId(SubscriptionTier.Patron, SubscriptionBillingCycle.Yearly)!!,
+            offerId = SubscriptionOffer.Winback.offerId(SubscriptionTier.Patron, BillingCycle.Yearly)!!,
         )
 
         viewModel.changePlan(SubscriptionPlan.PlusMonthlyPreview, mock<Activity>())
@@ -389,7 +389,7 @@ class WinbackViewModelTest {
                 redeemCode = "ABC",
                 formattedPrice = "$50.00",
                 tier = SubscriptionTier.Patron,
-                billingCycle = SubscriptionBillingCycle.Yearly,
+                billingCycle = BillingCycle.Yearly,
             ),
             viewModel.uiState.value.winbackOfferState?.offer,
         )
@@ -434,7 +434,7 @@ class WinbackViewModelTest {
             createPurchase(productIds = listOf(SubscriptionPlan.PlusYearlyProductId)),
         )
         wheneverBlocking { referralManager.getWinbackResponse() } doReturn createSuccessReferralResult(
-            offerId = SubscriptionOffer.Winback.offerId(SubscriptionTier.Plus, SubscriptionBillingCycle.Monthly)!!,
+            offerId = SubscriptionOffer.Winback.offerId(SubscriptionTier.Plus, BillingCycle.Monthly)!!,
         )
 
         viewModel.loadWinbackData()
@@ -454,7 +454,7 @@ class WinbackViewModelTest {
             product.copy(pricingPlans = newPricingPlans)
         }
         wheneverBlocking { referralManager.getWinbackResponse() } doReturn createSuccessReferralResult(
-            offerId = SubscriptionOffer.Winback.offerId(SubscriptionTier.Plus, SubscriptionBillingCycle.Monthly)!!,
+            offerId = SubscriptionOffer.Winback.offerId(SubscriptionTier.Plus, BillingCycle.Monthly)!!,
         )
 
         viewModel.loadWinbackData()
@@ -476,7 +476,7 @@ class WinbackViewModelTest {
             product.copy(pricingPlans = newPricingPlans)
         }
         wheneverBlocking { referralManager.getWinbackResponse() } doReturn createSuccessReferralResult(
-            offerId = SubscriptionOffer.Winback.offerId(SubscriptionTier.Plus, SubscriptionBillingCycle.Monthly)!!,
+            offerId = SubscriptionOffer.Winback.offerId(SubscriptionTier.Plus, BillingCycle.Monthly)!!,
         )
 
         viewModel.loadWinbackData()
@@ -491,7 +491,7 @@ class WinbackViewModelTest {
     @Test
     fun `claim winback offer successfully`() = runTest {
         wheneverBlocking { referralManager.getWinbackResponse() } doReturn createSuccessReferralResult(
-            offerId = SubscriptionOffer.Winback.offerId(SubscriptionTier.Plus, SubscriptionBillingCycle.Yearly)!!,
+            offerId = SubscriptionOffer.Winback.offerId(SubscriptionTier.Plus, BillingCycle.Yearly)!!,
         )
 
         viewModel.loadWinbackData()
@@ -827,7 +827,7 @@ private fun createPurchase(
 )
 
 private fun createSuccessReferralResult(
-    offerId: String = SubscriptionOffer.Winback.offerId(SubscriptionTier.Plus, SubscriptionBillingCycle.Yearly)!!,
+    offerId: String = SubscriptionOffer.Winback.offerId(SubscriptionTier.Plus, BillingCycle.Yearly)!!,
     code: String = "ABC",
 ) = ReferralResult.SuccessResult(
     winbackResponse {

--- a/modules/services/payment/src/main/kotlin/au/com/shiftyjelly/pocketcasts/payment/Data.kt
+++ b/modules/services/payment/src/main/kotlin/au/com/shiftyjelly/pocketcasts/payment/Data.kt
@@ -71,7 +71,7 @@ class SubscriptionPlans private constructor(
 ) {
     fun getBasePlan(
         tier: SubscriptionTier,
-        billingCycle: SubscriptionBillingCycle,
+        billingCycle: BillingCycle,
     ): SubscriptionPlan.Base {
         val key = SubscriptionPlan.Key(tier, billingCycle, offer = null)
         // This is a safe cast because constructor is private and we validate data in the create function
@@ -80,7 +80,7 @@ class SubscriptionPlans private constructor(
 
     fun findOfferPlan(
         tier: SubscriptionTier,
-        billingCycle: SubscriptionBillingCycle,
+        billingCycle: BillingCycle,
         offer: SubscriptionOffer,
     ): PaymentResult<SubscriptionPlan.WithOffer> {
         val key = SubscriptionPlan.Key(tier, billingCycle, offer)
@@ -99,13 +99,13 @@ class SubscriptionPlans private constructor(
         val Preview get() = SubscriptionPlans.create(FakePaymentDataSource.DefaultLoadedProducts).getOrNull()!!
 
         private val basePlanKeys = SubscriptionTier.entries.flatMap { tier ->
-            SubscriptionBillingCycle.entries.map { billingCycle ->
+            BillingCycle.entries.map { billingCycle ->
                 SubscriptionPlan.Key(tier, billingCycle, offer = null)
             }
         }
 
         private val offerPlanKeys = SubscriptionTier.entries.flatMap { tier ->
-            SubscriptionBillingCycle.entries.flatMap { billingCycle ->
+            BillingCycle.entries.flatMap { billingCycle ->
                 SubscriptionOffer.entries.map { offer ->
                     SubscriptionPlan.Key(tier, billingCycle, offer)
                 }
@@ -179,7 +179,7 @@ sealed interface SubscriptionPlan {
     val name: String
     val key: SubscriptionPlan.Key
     val tier: SubscriptionTier
-    val billingCycle: SubscriptionBillingCycle
+    val billingCycle: BillingCycle
     val offer: SubscriptionOffer?
 
     val productId get() = key.productId
@@ -189,7 +189,7 @@ sealed interface SubscriptionPlan {
     data class Base(
         override val name: String,
         override val tier: SubscriptionTier,
-        override val billingCycle: SubscriptionBillingCycle,
+        override val billingCycle: BillingCycle,
         val pricingPhase: PricingPhase,
     ) : SubscriptionPlan {
         override val offer get() = null
@@ -199,7 +199,7 @@ sealed interface SubscriptionPlan {
     data class WithOffer(
         override val name: String,
         override val tier: SubscriptionTier,
-        override val billingCycle: SubscriptionBillingCycle,
+        override val billingCycle: BillingCycle,
         override val offer: SubscriptionOffer,
         val pricingPhases: List<PricingPhase>,
     ) : SubscriptionPlan {
@@ -208,7 +208,7 @@ sealed interface SubscriptionPlan {
 
     data class Key(
         val tier: SubscriptionTier,
-        val billingCycle: SubscriptionBillingCycle,
+        val billingCycle: BillingCycle,
         val offer: SubscriptionOffer?,
     ) {
         val productId = SubscriptionPlan.productId(tier, billingCycle)
@@ -222,38 +222,38 @@ sealed interface SubscriptionPlan {
         const val PatronMonthlyProductId = "com.pocketcasts.monthly.patron"
         const val PatronYearlyProductId = "com.pocketcasts.yearly.patron"
 
-        val PlusMonthlyPreview get() = SubscriptionPlans.Preview.getBasePlan(SubscriptionTier.Plus, SubscriptionBillingCycle.Monthly)
-        val PlusYearlyPreview get() = SubscriptionPlans.Preview.getBasePlan(SubscriptionTier.Plus, SubscriptionBillingCycle.Yearly)
-        val PatronMonthlyPreview get() = SubscriptionPlans.Preview.getBasePlan(SubscriptionTier.Patron, SubscriptionBillingCycle.Monthly)
-        val PatronYearlyPreview get() = SubscriptionPlans.Preview.getBasePlan(SubscriptionTier.Patron, SubscriptionBillingCycle.Yearly)
+        val PlusMonthlyPreview get() = SubscriptionPlans.Preview.getBasePlan(SubscriptionTier.Plus, BillingCycle.Monthly)
+        val PlusYearlyPreview get() = SubscriptionPlans.Preview.getBasePlan(SubscriptionTier.Plus, BillingCycle.Yearly)
+        val PatronMonthlyPreview get() = SubscriptionPlans.Preview.getBasePlan(SubscriptionTier.Patron, BillingCycle.Monthly)
+        val PatronYearlyPreview get() = SubscriptionPlans.Preview.getBasePlan(SubscriptionTier.Patron, BillingCycle.Yearly)
 
         fun productId(
             tier: SubscriptionTier,
-            billingCycle: SubscriptionBillingCycle,
+            billingCycle: BillingCycle,
         ) = when (tier) {
             SubscriptionTier.Plus -> when (billingCycle) {
-                SubscriptionBillingCycle.Monthly -> PlusMonthlyProductId
-                SubscriptionBillingCycle.Yearly -> PlusYearlyProductId
+                BillingCycle.Monthly -> PlusMonthlyProductId
+                BillingCycle.Yearly -> PlusYearlyProductId
             }
 
             SubscriptionTier.Patron -> when (billingCycle) {
-                SubscriptionBillingCycle.Monthly -> PatronMonthlyProductId
-                SubscriptionBillingCycle.Yearly -> PatronYearlyProductId
+                BillingCycle.Monthly -> PatronMonthlyProductId
+                BillingCycle.Yearly -> PatronYearlyProductId
             }
         }
 
         fun basePlanId(
             tier: SubscriptionTier,
-            billingCycle: SubscriptionBillingCycle,
+            billingCycle: BillingCycle,
         ) = when (tier) {
             SubscriptionTier.Plus -> when (billingCycle) {
-                SubscriptionBillingCycle.Monthly -> "p1m"
-                SubscriptionBillingCycle.Yearly -> "p1y"
+                BillingCycle.Monthly -> "p1m"
+                BillingCycle.Yearly -> "p1y"
             }
 
             SubscriptionTier.Patron -> when (billingCycle) {
-                SubscriptionBillingCycle.Monthly -> "patron-monthly"
-                SubscriptionBillingCycle.Yearly -> "patron-yearly"
+                BillingCycle.Monthly -> "patron-monthly"
+                BillingCycle.Yearly -> "patron-yearly"
             }
         }
     }
@@ -270,7 +270,7 @@ enum class SubscriptionTier(
     ),
 }
 
-enum class SubscriptionBillingCycle(
+enum class BillingCycle(
     val analyticsValue: String,
 ) {
     Monthly(
@@ -289,12 +289,12 @@ enum class SubscriptionOffer {
 
     fun offerId(
         tier: SubscriptionTier,
-        billingCycle: SubscriptionBillingCycle,
+        billingCycle: BillingCycle,
     ) = when (this) {
         Trial -> when (tier) {
             SubscriptionTier.Plus -> when (billingCycle) {
-                SubscriptionBillingCycle.Monthly -> null
-                SubscriptionBillingCycle.Yearly -> "plus-yearly-trial-30days"
+                BillingCycle.Monthly -> null
+                BillingCycle.Yearly -> "plus-yearly-trial-30days"
             }
 
             SubscriptionTier.Patron -> null
@@ -302,8 +302,8 @@ enum class SubscriptionOffer {
 
         Referral -> when (tier) {
             SubscriptionTier.Plus -> when (billingCycle) {
-                SubscriptionBillingCycle.Monthly -> null
-                SubscriptionBillingCycle.Yearly -> "plus-yearly-referral-two-months-free"
+                BillingCycle.Monthly -> null
+                BillingCycle.Yearly -> "plus-yearly-referral-two-months-free"
             }
 
             SubscriptionTier.Patron -> null
@@ -311,13 +311,13 @@ enum class SubscriptionOffer {
 
         Winback -> when (tier) {
             SubscriptionTier.Plus -> when (billingCycle) {
-                SubscriptionBillingCycle.Monthly -> "plus-monthly-winback"
-                SubscriptionBillingCycle.Yearly -> "plus-yearly-winback"
+                BillingCycle.Monthly -> "plus-monthly-winback"
+                BillingCycle.Yearly -> "plus-yearly-winback"
             }
 
             SubscriptionTier.Patron -> when (billingCycle) {
-                SubscriptionBillingCycle.Monthly -> "patron-monthly-winback"
-                SubscriptionBillingCycle.Yearly -> "patron-yearly-winback"
+                BillingCycle.Monthly -> "patron-monthly-winback"
+                BillingCycle.Yearly -> "patron-yearly-winback"
             }
         }
     }
@@ -350,7 +350,7 @@ sealed interface PurchaseState {
 data class AcknowledgedSubscription(
     val orderId: String,
     val tier: SubscriptionTier,
-    val billingCycle: SubscriptionBillingCycle,
+    val billingCycle: BillingCycle,
     val isAutoRenewing: Boolean,
 ) {
     val productId get() = SubscriptionPlan.productId(tier, billingCycle)

--- a/modules/services/payment/src/main/kotlin/au/com/shiftyjelly/pocketcasts/payment/Data.kt
+++ b/modules/services/payment/src/main/kotlin/au/com/shiftyjelly/pocketcasts/payment/Data.kt
@@ -34,7 +34,7 @@ sealed interface PricingPlan {
 
 data class PricingPhase(
     val price: Price,
-    val billingPeriod: BillingPeriod,
+    val schedule: PricingSchedule,
 )
 
 data class Price(
@@ -43,34 +43,26 @@ data class Price(
     val formattedPrice: String,
 )
 
-data class BillingPeriod(
-    val cycle: BillingPeriod.Cycle,
-    val interval: BillingPeriod.Interval,
-    val intervalCount: Int,
+data class PricingSchedule(
+    val recurrenceMode: PricingSchedule.RecurrenceMode,
+    val period: PricingSchedule.Period,
+    val periodCount: Int,
 ) {
-    enum class Interval {
+    enum class Period {
         Weekly,
         Monthly,
         Yearly,
     }
 
-    sealed interface Cycle {
-        data object NonRecurring : Cycle
+    sealed interface RecurrenceMode {
+        data object NonRecurring : RecurrenceMode
 
         @JvmInline
         value class Recurring(
             val value: Int,
-        ) : Cycle
+        ) : RecurrenceMode
 
-        data object Infinite : Cycle
-    }
-
-    companion object {
-        val Preview = BillingPeriod(
-            cycle = BillingPeriod.Cycle.Infinite,
-            interval = BillingPeriod.Interval.Yearly,
-            intervalCount = 0,
-        )
+        data object Infinite : RecurrenceMode
     }
 }
 

--- a/modules/services/payment/src/main/kotlin/au/com/shiftyjelly/pocketcasts/payment/FakePaymentDataSource.kt
+++ b/modules/services/payment/src/main/kotlin/au/com/shiftyjelly/pocketcasts/payment/FakePaymentDataSource.kt
@@ -94,7 +94,7 @@ class FakePaymentDataSource : PaymentDataSource {
     companion object {
         val DefaultLoadedProducts
             get() = SubscriptionTier.entries.flatMap { tier ->
-                SubscriptionBillingCycle.entries.map { billingCycle ->
+                BillingCycle.entries.map { billingCycle ->
                     Product(
                         SubscriptionPlan.productId(tier, billingCycle),
                         productName(tier, billingCycle),
@@ -162,16 +162,16 @@ private val PatronYearlyPricingPhase
 
 private fun productName(
     tier: SubscriptionTier,
-    billingCycle: SubscriptionBillingCycle,
+    billingCycle: BillingCycle,
 ) = "$tier $billingCycle (Fake)"
 
 private fun pricingPhases(
     tier: SubscriptionTier,
-    billingCycle: SubscriptionBillingCycle,
+    billingCycle: BillingCycle,
     offer: SubscriptionOffer?,
 ): List<PricingPhase> = when (offer) {
     SubscriptionOffer.Trial -> when (billingCycle) {
-        SubscriptionBillingCycle.Yearly -> when (tier) {
+        BillingCycle.Yearly -> when (tier) {
             SubscriptionTier.Plus -> listOf(
                 PlusYearlyPricingPhase.withDiscount(priceFraction = 0.0),
                 PlusYearlyPricingPhase,
@@ -180,11 +180,11 @@ private fun pricingPhases(
             SubscriptionTier.Patron -> emptyList()
         }
 
-        SubscriptionBillingCycle.Monthly -> emptyList()
+        BillingCycle.Monthly -> emptyList()
     }
 
     SubscriptionOffer.Referral -> when (billingCycle) {
-        SubscriptionBillingCycle.Yearly -> when (tier) {
+        BillingCycle.Yearly -> when (tier) {
             SubscriptionTier.Plus -> listOf(
                 PlusYearlyPricingPhase.withDiscount(priceFraction = 0.0, intervalCount = 2),
                 PlusYearlyPricingPhase,
@@ -193,11 +193,11 @@ private fun pricingPhases(
             SubscriptionTier.Patron -> emptyList()
         }
 
-        SubscriptionBillingCycle.Monthly -> emptyList()
+        BillingCycle.Monthly -> emptyList()
     }
 
     SubscriptionOffer.Winback -> when (billingCycle) {
-        SubscriptionBillingCycle.Monthly -> when (tier) {
+        BillingCycle.Monthly -> when (tier) {
             SubscriptionTier.Plus -> listOf(
                 PlusMonthlyPricingPhase.withDiscount(priceFraction = 0.5),
                 PlusMonthlyPricingPhase,
@@ -209,7 +209,7 @@ private fun pricingPhases(
             )
         }
 
-        SubscriptionBillingCycle.Yearly -> when (tier) {
+        BillingCycle.Yearly -> when (tier) {
             SubscriptionTier.Plus -> listOf(
                 PlusYearlyPricingPhase.withDiscount(priceFraction = 0.5, period = PricingSchedule.Period.Yearly),
                 PlusYearlyPricingPhase,
@@ -223,12 +223,12 @@ private fun pricingPhases(
     }
 
     null -> when (billingCycle) {
-        SubscriptionBillingCycle.Monthly -> when (tier) {
+        BillingCycle.Monthly -> when (tier) {
             SubscriptionTier.Plus -> listOf(PlusMonthlyPricingPhase)
             SubscriptionTier.Patron -> listOf(PatronMonthlyPricingPhase)
         }
 
-        SubscriptionBillingCycle.Yearly -> when (tier) {
+        BillingCycle.Yearly -> when (tier) {
             SubscriptionTier.Plus -> listOf(PlusYearlyPricingPhase)
             SubscriptionTier.Patron -> listOf(PatronYearlyPricingPhase)
         }

--- a/modules/services/payment/src/main/kotlin/au/com/shiftyjelly/pocketcasts/payment/FakePaymentDataSource.kt
+++ b/modules/services/payment/src/main/kotlin/au/com/shiftyjelly/pocketcasts/payment/FakePaymentDataSource.kt
@@ -142,22 +142,22 @@ class FakePaymentDataSource : PaymentDataSource {
 private val PlusMonthlyPricingPhase
     get() = PricingPhase(
         Price(3.99.toBigDecimal(), "USD", "$3.99"),
-        BillingPeriod(BillingPeriod.Cycle.Infinite, BillingPeriod.Interval.Monthly, intervalCount = 0),
+        PricingSchedule(PricingSchedule.RecurrenceMode.Infinite, PricingSchedule.Period.Monthly, periodCount = 0),
     )
 private val PlusYearlyPricingPhase
     get() = PricingPhase(
         Price(39.99.toBigDecimal(), "USD", "$39.99"),
-        BillingPeriod(BillingPeriod.Cycle.Infinite, BillingPeriod.Interval.Monthly, intervalCount = 0),
+        PricingSchedule(PricingSchedule.RecurrenceMode.Infinite, PricingSchedule.Period.Monthly, periodCount = 0),
     )
 private val PatronMonthlyPricingPhase
     get() = PricingPhase(
         Price(9.99.toBigDecimal(), "USD", "$9.99"),
-        BillingPeriod(BillingPeriod.Cycle.Infinite, BillingPeriod.Interval.Monthly, intervalCount = 0),
+        PricingSchedule(PricingSchedule.RecurrenceMode.Infinite, PricingSchedule.Period.Monthly, periodCount = 0),
     )
 private val PatronYearlyPricingPhase
     get() = PricingPhase(
         Price(99.99.toBigDecimal(), "USD", "$99.99"),
-        BillingPeriod(BillingPeriod.Cycle.Infinite, BillingPeriod.Interval.Yearly, intervalCount = 0),
+        PricingSchedule(PricingSchedule.RecurrenceMode.Infinite, PricingSchedule.Period.Yearly, periodCount = 0),
     )
 
 private fun productName(
@@ -211,12 +211,12 @@ private fun pricingPhases(
 
         SubscriptionBillingCycle.Yearly -> when (tier) {
             SubscriptionTier.Plus -> listOf(
-                PlusYearlyPricingPhase.withDiscount(priceFraction = 0.5, interval = BillingPeriod.Interval.Yearly),
+                PlusYearlyPricingPhase.withDiscount(priceFraction = 0.5, period = PricingSchedule.Period.Yearly),
                 PlusYearlyPricingPhase,
             )
 
             SubscriptionTier.Patron -> listOf(
-                PatronYearlyPricingPhase.withDiscount(priceFraction = 0.5, interval = BillingPeriod.Interval.Yearly),
+                PatronYearlyPricingPhase.withDiscount(priceFraction = 0.5, period = PricingSchedule.Period.Yearly),
                 PatronYearlyPricingPhase,
             )
         }
@@ -237,14 +237,14 @@ private fun pricingPhases(
 
 private fun PricingPhase.withDiscount(
     priceFraction: Double,
-    cycle: BillingPeriod.Cycle = BillingPeriod.Cycle.Recurring(1),
-    interval: BillingPeriod.Interval = BillingPeriod.Interval.Monthly,
+    recurrenceMode: PricingSchedule.RecurrenceMode = PricingSchedule.RecurrenceMode.Recurring(1),
+    period: PricingSchedule.Period = PricingSchedule.Period.Monthly,
     intervalCount: Int = 1,
 ): PricingPhase {
     val newAmount = price.amount.times(priceFraction.coerceIn(0.0..1.0).toBigDecimal())
     val newFormattedPrice = if (newAmount == BigDecimal.ZERO) "Free" else "$%.2f".format(newAmount.toDouble())
     return copy(
         price = price.copy(amount = newAmount, formattedPrice = newFormattedPrice),
-        billingPeriod = BillingPeriod(cycle, interval, intervalCount),
+        schedule = PricingSchedule(recurrenceMode, period, intervalCount),
     )
 }

--- a/modules/services/payment/src/main/kotlin/au/com/shiftyjelly/pocketcasts/payment/PaymentClient.kt
+++ b/modules/services/payment/src/main/kotlin/au/com/shiftyjelly/pocketcasts/payment/PaymentClient.kt
@@ -155,7 +155,7 @@ class PaymentClient @Inject constructor(
 
     private fun findMatchingProductKey(productId: String): SubscriptionPlan.Key? {
         val keys = SubscriptionTier.entries.flatMap { tier ->
-            SubscriptionBillingCycle.entries.map { cycle ->
+            BillingCycle.entries.map { cycle ->
                 SubscriptionPlan.Key(tier, cycle, offer = null)
             }
         }

--- a/modules/services/payment/src/test/kotlin/au/com/shiftyjelly/pocketcasts/payment/PaymentClientTest.kt
+++ b/modules/services/payment/src/test/kotlin/au/com/shiftyjelly/pocketcasts/payment/PaymentClientTest.kt
@@ -18,7 +18,7 @@ class PaymentClientTest {
 
     private val client = PaymentClient(dataSource, approver, logger)
 
-    private val planKey = SubscriptionPlan.Key(SubscriptionTier.Plus, SubscriptionBillingCycle.Monthly, offer = null)
+    private val planKey = SubscriptionPlan.Key(SubscriptionTier.Plus, BillingCycle.Monthly, offer = null)
     private val purchase = Purchase(
         state = PurchaseState.Purchased("orderId"),
         token = "token",
@@ -76,10 +76,10 @@ class PaymentClientTest {
 
         assertEquals(
             listOf(
-                AcknowledgedSubscription("order-id-1", SubscriptionTier.Plus, SubscriptionBillingCycle.Monthly, isAutoRenewing = true),
-                AcknowledgedSubscription("order-id-2", SubscriptionTier.Plus, SubscriptionBillingCycle.Yearly, isAutoRenewing = true),
-                AcknowledgedSubscription("order-id-3", SubscriptionTier.Patron, SubscriptionBillingCycle.Monthly, isAutoRenewing = true),
-                AcknowledgedSubscription("order-id-4", SubscriptionTier.Patron, SubscriptionBillingCycle.Yearly, isAutoRenewing = false),
+                AcknowledgedSubscription("order-id-1", SubscriptionTier.Plus, BillingCycle.Monthly, isAutoRenewing = true),
+                AcknowledgedSubscription("order-id-2", SubscriptionTier.Plus, BillingCycle.Yearly, isAutoRenewing = true),
+                AcknowledgedSubscription("order-id-3", SubscriptionTier.Patron, BillingCycle.Monthly, isAutoRenewing = true),
+                AcknowledgedSubscription("order-id-4", SubscriptionTier.Patron, BillingCycle.Yearly, isAutoRenewing = false),
             ),
             subscriptions,
         )
@@ -161,7 +161,7 @@ class PaymentClientTest {
 
         assertEquals(
             listOf(
-                AcknowledgedSubscription("order-id", SubscriptionTier.Plus, SubscriptionBillingCycle.Monthly, isAutoRenewing = true),
+                AcknowledgedSubscription("order-id", SubscriptionTier.Plus, BillingCycle.Monthly, isAutoRenewing = true),
             ),
             subscriptions,
         )

--- a/modules/services/payment/src/test/kotlin/au/com/shiftyjelly/pocketcasts/payment/SubscriptionPlansTest.kt
+++ b/modules/services/payment/src/test/kotlin/au/com/shiftyjelly/pocketcasts/payment/SubscriptionPlansTest.kt
@@ -12,7 +12,7 @@ class SubscriptionPlansTest {
     )
 
     private val products = SubscriptionTier.entries.flatMap { tier ->
-        SubscriptionBillingCycle.entries.map { billingCycle ->
+        BillingCycle.entries.map { billingCycle ->
             Product(
                 id = SubscriptionPlan.productId(tier, billingCycle),
                 name = "$tier $billingCycle",
@@ -48,44 +48,44 @@ class SubscriptionPlansTest {
     fun `get plus monthly base plan`() {
         val plans = SubscriptionPlans.create(products).getOrNull()!!
 
-        val plan = plans.getBasePlan(SubscriptionTier.Plus, SubscriptionBillingCycle.Monthly)
+        val plan = plans.getBasePlan(SubscriptionTier.Plus, BillingCycle.Monthly)
 
         assertEquals("Plus Monthly", plan.name)
         assertEquals(SubscriptionTier.Plus, plan.tier)
-        assertEquals(SubscriptionBillingCycle.Monthly, plan.billingCycle)
+        assertEquals(BillingCycle.Monthly, plan.billingCycle)
     }
 
     @Test
     fun `get plus yearly base plan`() {
         val plans = SubscriptionPlans.create(products).getOrNull()!!
 
-        val plan = plans.getBasePlan(SubscriptionTier.Plus, SubscriptionBillingCycle.Yearly)
+        val plan = plans.getBasePlan(SubscriptionTier.Plus, BillingCycle.Yearly)
 
         assertEquals("Plus Yearly", plan.name)
         assertEquals(SubscriptionTier.Plus, plan.tier)
-        assertEquals(SubscriptionBillingCycle.Yearly, plan.billingCycle)
+        assertEquals(BillingCycle.Yearly, plan.billingCycle)
     }
 
     @Test
     fun `get patron monthly base plan`() {
         val plans = SubscriptionPlans.create(products).getOrNull()!!
 
-        val plan = plans.getBasePlan(SubscriptionTier.Patron, SubscriptionBillingCycle.Monthly)
+        val plan = plans.getBasePlan(SubscriptionTier.Patron, BillingCycle.Monthly)
 
         assertEquals("Patron Monthly", plan.name)
         assertEquals(SubscriptionTier.Patron, plan.tier)
-        assertEquals(SubscriptionBillingCycle.Monthly, plan.billingCycle)
+        assertEquals(BillingCycle.Monthly, plan.billingCycle)
     }
 
     @Test
     fun `get patron yearly base plan`() {
         val plans = SubscriptionPlans.create(products).getOrNull()!!
 
-        val plan = plans.getBasePlan(SubscriptionTier.Patron, SubscriptionBillingCycle.Yearly)
+        val plan = plans.getBasePlan(SubscriptionTier.Patron, BillingCycle.Yearly)
 
         assertEquals("Patron Yearly", plan.name)
         assertEquals(SubscriptionTier.Patron, plan.tier)
-        assertEquals(SubscriptionBillingCycle.Yearly, plan.billingCycle)
+        assertEquals(BillingCycle.Yearly, plan.billingCycle)
     }
 
     @Test
@@ -94,13 +94,13 @@ class SubscriptionPlansTest {
 
         val plan = plans.findOfferPlan(
             SubscriptionTier.Plus,
-            SubscriptionBillingCycle.Monthly,
+            BillingCycle.Monthly,
             SubscriptionOffer.Winback,
         ).getOrNull()!!
 
         assertEquals("Plus Monthly", plan.name)
         assertEquals(SubscriptionTier.Plus, plan.tier)
-        assertEquals(SubscriptionBillingCycle.Monthly, plan.billingCycle)
+        assertEquals(BillingCycle.Monthly, plan.billingCycle)
         assertEquals(SubscriptionOffer.Winback, plan.offer)
     }
 
@@ -110,13 +110,13 @@ class SubscriptionPlansTest {
 
         val plan = plans.findOfferPlan(
             SubscriptionTier.Plus,
-            SubscriptionBillingCycle.Yearly,
+            BillingCycle.Yearly,
             SubscriptionOffer.Winback,
         ).getOrNull()!!
 
         assertEquals("Plus Yearly", plan.name)
         assertEquals(SubscriptionTier.Plus, plan.tier)
-        assertEquals(SubscriptionBillingCycle.Yearly, plan.billingCycle)
+        assertEquals(BillingCycle.Yearly, plan.billingCycle)
         assertEquals(SubscriptionOffer.Winback, plan.offer)
     }
 
@@ -126,13 +126,13 @@ class SubscriptionPlansTest {
 
         val plan = plans.findOfferPlan(
             SubscriptionTier.Patron,
-            SubscriptionBillingCycle.Monthly,
+            BillingCycle.Monthly,
             SubscriptionOffer.Winback,
         ).getOrNull()!!
 
         assertEquals("Patron Monthly", plan.name)
         assertEquals(SubscriptionTier.Patron, plan.tier)
-        assertEquals(SubscriptionBillingCycle.Monthly, plan.billingCycle)
+        assertEquals(BillingCycle.Monthly, plan.billingCycle)
         assertEquals(SubscriptionOffer.Winback, plan.offer)
     }
 
@@ -142,13 +142,13 @@ class SubscriptionPlansTest {
 
         val plan = plans.findOfferPlan(
             SubscriptionTier.Patron,
-            SubscriptionBillingCycle.Yearly,
+            BillingCycle.Yearly,
             SubscriptionOffer.Winback,
         ).getOrNull()!!
 
         assertEquals("Patron Yearly", plan.name)
         assertEquals(SubscriptionTier.Patron, plan.tier)
-        assertEquals(SubscriptionBillingCycle.Yearly, plan.billingCycle)
+        assertEquals(BillingCycle.Yearly, plan.billingCycle)
         assertEquals(SubscriptionOffer.Winback, plan.offer)
     }
 
@@ -158,13 +158,13 @@ class SubscriptionPlansTest {
 
         val plan = plans.findOfferPlan(
             SubscriptionTier.Plus,
-            SubscriptionBillingCycle.Yearly,
+            BillingCycle.Yearly,
             SubscriptionOffer.Referral,
         ).getOrNull()!!
 
         assertEquals("Plus Yearly", plan.name)
         assertEquals(SubscriptionTier.Plus, plan.tier)
-        assertEquals(SubscriptionBillingCycle.Yearly, plan.billingCycle)
+        assertEquals(BillingCycle.Yearly, plan.billingCycle)
         assertEquals(SubscriptionOffer.Referral, plan.offer)
     }
 
@@ -174,13 +174,13 @@ class SubscriptionPlansTest {
 
         val plan = plans.findOfferPlan(
             SubscriptionTier.Plus,
-            SubscriptionBillingCycle.Yearly,
+            BillingCycle.Yearly,
             SubscriptionOffer.Trial,
         ).getOrNull()!!
 
         assertEquals("Plus Yearly", plan.name)
         assertEquals(SubscriptionTier.Plus, plan.tier)
-        assertEquals(SubscriptionBillingCycle.Yearly, plan.billingCycle)
+        assertEquals(BillingCycle.Yearly, plan.billingCycle)
         assertEquals(SubscriptionOffer.Trial, plan.offer)
     }
 
@@ -190,7 +190,7 @@ class SubscriptionPlansTest {
 
         val plan = plans.findOfferPlan(
             SubscriptionTier.Patron,
-            SubscriptionBillingCycle.Monthly,
+            BillingCycle.Monthly,
             SubscriptionOffer.Trial,
         ).getOrNull()
 
@@ -283,7 +283,7 @@ class SubscriptionPlansTest {
 
         val plan = plans.findOfferPlan(
             SubscriptionTier.Plus,
-            SubscriptionBillingCycle.Yearly,
+            BillingCycle.Yearly,
             SubscriptionOffer.Winback,
         ).getOrNull()
 

--- a/modules/services/payment/src/test/kotlin/au/com/shiftyjelly/pocketcasts/payment/SubscriptionPlansTest.kt
+++ b/modules/services/payment/src/test/kotlin/au/com/shiftyjelly/pocketcasts/payment/SubscriptionPlansTest.kt
@@ -8,7 +8,7 @@ import org.junit.Test
 class SubscriptionPlansTest {
     private val pricingPhase = PricingPhase(
         Price(100.toBigDecimal(), "USD", "$100.00"),
-        BillingPeriod(BillingPeriod.Cycle.Infinite, BillingPeriod.Interval.Yearly, intervalCount = 1),
+        PricingSchedule(PricingSchedule.RecurrenceMode.Infinite, PricingSchedule.Period.Yearly, periodCount = 1),
     )
 
     private val products = SubscriptionTier.entries.flatMap { tier ->

--- a/modules/services/payment/src/test/kotlin/au/com/shiftyjelly/pocketcasts/payment/billing/BillingPaymentMapperFlowParamsTest.kt
+++ b/modules/services/payment/src/test/kotlin/au/com/shiftyjelly/pocketcasts/payment/billing/BillingPaymentMapperFlowParamsTest.kt
@@ -1,6 +1,6 @@
 package au.com.shiftyjelly.pocketcasts.payment.billing
 
-import au.com.shiftyjelly.pocketcasts.payment.SubscriptionBillingCycle
+import au.com.shiftyjelly.pocketcasts.payment.BillingCycle
 import au.com.shiftyjelly.pocketcasts.payment.SubscriptionOffer
 import au.com.shiftyjelly.pocketcasts.payment.SubscriptionPlan
 import au.com.shiftyjelly.pocketcasts.payment.SubscriptionTier
@@ -29,7 +29,7 @@ class BillingPaymentMapperFlowParamsTest {
 
         @Test
         fun `create billing params`() {
-            val planKey = SubscriptionPlan.Key(SubscriptionTier.Plus, SubscriptionBillingCycle.Monthly, offer = null)
+            val planKey = SubscriptionPlan.Key(SubscriptionTier.Plus, BillingCycle.Monthly, offer = null)
             val product = GoogleProductDetails(
                 productId = planKey.productId,
                 subscriptionOfferDetails = listOf(
@@ -84,7 +84,7 @@ class BillingPaymentMapperFlowParamsTest {
                     isAutoRenewing = false,
                 ),
             )
-            val planKey = SubscriptionPlan.Key(SubscriptionTier.Plus, SubscriptionBillingCycle.Yearly, offer = null)
+            val planKey = SubscriptionPlan.Key(SubscriptionTier.Plus, BillingCycle.Yearly, offer = null)
             val product = GoogleProductDetails(
                 productId = planKey.productId,
                 subscriptionOfferDetails = listOf(
@@ -109,7 +109,7 @@ class BillingPaymentMapperFlowParamsTest {
 
         @Test
         fun `log too many matching products`() {
-            val planKey = SubscriptionPlan.Key(SubscriptionTier.Plus, SubscriptionBillingCycle.Monthly, offer = null)
+            val planKey = SubscriptionPlan.Key(SubscriptionTier.Plus, BillingCycle.Monthly, offer = null)
             val product = GoogleProductDetails(
                 productId = planKey.productId,
                 subscriptionOfferDetails = listOf(
@@ -130,7 +130,7 @@ class BillingPaymentMapperFlowParamsTest {
 
         @Test
         fun `log no matching products`() {
-            val planKey = SubscriptionPlan.Key(SubscriptionTier.Plus, SubscriptionBillingCycle.Monthly, offer = null)
+            val planKey = SubscriptionPlan.Key(SubscriptionTier.Plus, BillingCycle.Monthly, offer = null)
 
             mapper.toBillingFlowRequest(planKey, productDetails = emptyList(), purchases = emptyList())
 
@@ -141,7 +141,7 @@ class BillingPaymentMapperFlowParamsTest {
 
         @Test
         fun `log too many matching offers`() {
-            val planKey = SubscriptionPlan.Key(SubscriptionTier.Plus, SubscriptionBillingCycle.Monthly, offer = null)
+            val planKey = SubscriptionPlan.Key(SubscriptionTier.Plus, BillingCycle.Monthly, offer = null)
             val product = GoogleProductDetails(
                 productId = planKey.productId,
                 subscriptionOfferDetails = listOf(
@@ -167,7 +167,7 @@ class BillingPaymentMapperFlowParamsTest {
 
         @Test
         fun `log no matching offers`() {
-            val planKey = SubscriptionPlan.Key(SubscriptionTier.Plus, SubscriptionBillingCycle.Monthly, offer = null)
+            val planKey = SubscriptionPlan.Key(SubscriptionTier.Plus, BillingCycle.Monthly, offer = null)
             val product = GoogleProductDetails(
                 productId = planKey.productId,
                 subscriptionOfferDetails = emptyList(),
@@ -192,7 +192,7 @@ class BillingPaymentMapperFlowParamsTest {
                     productIds = listOf("product-id-2"),
                 ),
             )
-            val planKey = SubscriptionPlan.Key(SubscriptionTier.Plus, SubscriptionBillingCycle.Monthly, offer = null)
+            val planKey = SubscriptionPlan.Key(SubscriptionTier.Plus, BillingCycle.Monthly, offer = null)
             val product = GoogleProductDetails(
                 productId = planKey.productId,
                 subscriptionOfferDetails = listOf(
@@ -215,7 +215,7 @@ class BillingPaymentMapperFlowParamsTest {
                     productIds = listOf("product-id-1", "product-id-2"),
                 ),
             )
-            val planKey = SubscriptionPlan.Key(SubscriptionTier.Plus, SubscriptionBillingCycle.Monthly, offer = null)
+            val planKey = SubscriptionPlan.Key(SubscriptionTier.Plus, BillingCycle.Monthly, offer = null)
             val product = GoogleProductDetails(
                 productId = planKey.productId,
                 subscriptionOfferDetails = listOf(
@@ -232,7 +232,7 @@ class BillingPaymentMapperFlowParamsTest {
 
         @Test
         fun `do not log anything when mapped succesfully`() {
-            val planKey = SubscriptionPlan.Key(SubscriptionTier.Plus, SubscriptionBillingCycle.Monthly, offer = null)
+            val planKey = SubscriptionPlan.Key(SubscriptionTier.Plus, BillingCycle.Monthly, offer = null)
             val product = GoogleProductDetails(
                 productId = planKey.productId,
                 subscriptionOfferDetails = listOf(
@@ -250,7 +250,7 @@ class BillingPaymentMapperFlowParamsTest {
     @RunWith(ParameterizedRobolectricTestRunner::class)
     class WithoutActivePurchase(
         private val tier: SubscriptionTier,
-        private val billingCycle: SubscriptionBillingCycle,
+        private val billingCycle: BillingCycle,
     ) {
         private val mapper = BillingPaymentMapper(TestLogger())
 
@@ -327,10 +327,10 @@ class BillingPaymentMapperFlowParamsTest {
             @JvmStatic
             @ParameterizedRobolectricTestRunner.Parameters(name = "{0} {1}")
             fun params() = listOf(
-                arrayOf(SubscriptionTier.Plus, SubscriptionBillingCycle.Monthly),
-                arrayOf(SubscriptionTier.Plus, SubscriptionBillingCycle.Yearly),
-                arrayOf(SubscriptionTier.Patron, SubscriptionBillingCycle.Monthly),
-                arrayOf(SubscriptionTier.Patron, SubscriptionBillingCycle.Yearly),
+                arrayOf(SubscriptionTier.Plus, BillingCycle.Monthly),
+                arrayOf(SubscriptionTier.Plus, BillingCycle.Yearly),
+                arrayOf(SubscriptionTier.Patron, BillingCycle.Monthly),
+                arrayOf(SubscriptionTier.Patron, BillingCycle.Yearly),
             )
         }
     }
@@ -339,9 +339,9 @@ class BillingPaymentMapperFlowParamsTest {
     @RunWith(ParameterizedRobolectricTestRunner::class)
     class WithActivePurchase(
         private val fromTier: SubscriptionTier,
-        private val fromBillingCycle: SubscriptionBillingCycle,
+        private val fromBillingCycle: BillingCycle,
         private val toTier: SubscriptionTier,
-        private val toBillingCycle: SubscriptionBillingCycle,
+        private val toBillingCycle: BillingCycle,
         private val expectedReplacementMode: Int?,
     ) {
         private val mapper = BillingPaymentMapper(TestLogger())
@@ -385,7 +385,7 @@ class BillingPaymentMapperFlowParamsTest {
                 GooglePurchase(
                     purchaseToken = "purchase-token-2",
                     productIds = listOf(
-                        SubscriptionPlan.productId(SubscriptionTier.entries.random(), SubscriptionBillingCycle.entries.random()),
+                        SubscriptionPlan.productId(SubscriptionTier.entries.random(), BillingCycle.entries.random()),
                     ),
                 ),
             )
@@ -433,114 +433,114 @@ class BillingPaymentMapperFlowParamsTest {
             fun params() = listOf<Array<Any?>>(
                 arrayOf(
                     SubscriptionTier.Plus,
-                    SubscriptionBillingCycle.Monthly,
+                    BillingCycle.Monthly,
                     SubscriptionTier.Plus,
-                    SubscriptionBillingCycle.Monthly,
+                    BillingCycle.Monthly,
                     null,
                 ),
                 arrayOf(
                     SubscriptionTier.Plus,
-                    SubscriptionBillingCycle.Monthly,
+                    BillingCycle.Monthly,
                     SubscriptionTier.Plus,
-                    SubscriptionBillingCycle.Yearly,
+                    BillingCycle.Yearly,
                     ReplacementMode.CHARGE_FULL_PRICE,
                 ),
                 arrayOf(
                     SubscriptionTier.Plus,
-                    SubscriptionBillingCycle.Monthly,
+                    BillingCycle.Monthly,
                     SubscriptionTier.Patron,
-                    SubscriptionBillingCycle.Monthly,
+                    BillingCycle.Monthly,
                     ReplacementMode.CHARGE_PRORATED_PRICE,
                 ),
                 arrayOf(
                     SubscriptionTier.Plus,
-                    SubscriptionBillingCycle.Monthly,
+                    BillingCycle.Monthly,
                     SubscriptionTier.Patron,
-                    SubscriptionBillingCycle.Yearly,
+                    BillingCycle.Yearly,
                     ReplacementMode.CHARGE_FULL_PRICE,
                 ),
                 arrayOf(
                     SubscriptionTier.Plus,
-                    SubscriptionBillingCycle.Yearly,
+                    BillingCycle.Yearly,
                     SubscriptionTier.Plus,
-                    SubscriptionBillingCycle.Monthly,
+                    BillingCycle.Monthly,
                     ReplacementMode.WITH_TIME_PRORATION,
                 ),
                 arrayOf(
                     SubscriptionTier.Plus,
-                    SubscriptionBillingCycle.Yearly,
+                    BillingCycle.Yearly,
                     SubscriptionTier.Plus,
-                    SubscriptionBillingCycle.Yearly,
+                    BillingCycle.Yearly,
                     null,
                 ),
                 arrayOf(
                     SubscriptionTier.Plus,
-                    SubscriptionBillingCycle.Yearly,
+                    BillingCycle.Yearly,
                     SubscriptionTier.Patron,
-                    SubscriptionBillingCycle.Monthly,
+                    BillingCycle.Monthly,
                     ReplacementMode.WITH_TIME_PRORATION,
                 ),
                 arrayOf(
                     SubscriptionTier.Plus,
-                    SubscriptionBillingCycle.Yearly,
+                    BillingCycle.Yearly,
                     SubscriptionTier.Patron,
-                    SubscriptionBillingCycle.Yearly,
+                    BillingCycle.Yearly,
                     ReplacementMode.CHARGE_PRORATED_PRICE,
                 ),
                 arrayOf(
                     SubscriptionTier.Patron,
-                    SubscriptionBillingCycle.Monthly,
+                    BillingCycle.Monthly,
                     SubscriptionTier.Plus,
-                    SubscriptionBillingCycle.Monthly,
+                    BillingCycle.Monthly,
                     ReplacementMode.WITH_TIME_PRORATION,
                 ),
                 arrayOf(
                     SubscriptionTier.Patron,
-                    SubscriptionBillingCycle.Monthly,
+                    BillingCycle.Monthly,
                     SubscriptionTier.Plus,
-                    SubscriptionBillingCycle.Yearly,
+                    BillingCycle.Yearly,
                     ReplacementMode.CHARGE_FULL_PRICE,
                 ),
                 arrayOf(
                     SubscriptionTier.Patron,
-                    SubscriptionBillingCycle.Monthly,
+                    BillingCycle.Monthly,
                     SubscriptionTier.Patron,
-                    SubscriptionBillingCycle.Monthly,
+                    BillingCycle.Monthly,
                     null,
                 ),
                 arrayOf(
                     SubscriptionTier.Patron,
-                    SubscriptionBillingCycle.Monthly,
+                    BillingCycle.Monthly,
                     SubscriptionTier.Patron,
-                    SubscriptionBillingCycle.Yearly,
+                    BillingCycle.Yearly,
                     ReplacementMode.CHARGE_FULL_PRICE,
                 ),
                 arrayOf(
                     SubscriptionTier.Patron,
-                    SubscriptionBillingCycle.Yearly,
+                    BillingCycle.Yearly,
                     SubscriptionTier.Plus,
-                    SubscriptionBillingCycle.Monthly,
+                    BillingCycle.Monthly,
                     ReplacementMode.WITH_TIME_PRORATION,
                 ),
                 arrayOf(
                     SubscriptionTier.Patron,
-                    SubscriptionBillingCycle.Yearly,
+                    BillingCycle.Yearly,
                     SubscriptionTier.Plus,
-                    SubscriptionBillingCycle.Yearly,
+                    BillingCycle.Yearly,
                     ReplacementMode.WITH_TIME_PRORATION,
                 ),
                 arrayOf(
                     SubscriptionTier.Patron,
-                    SubscriptionBillingCycle.Yearly,
+                    BillingCycle.Yearly,
                     SubscriptionTier.Patron,
-                    SubscriptionBillingCycle.Monthly,
+                    BillingCycle.Monthly,
                     ReplacementMode.WITH_TIME_PRORATION,
                 ),
                 arrayOf(
                     SubscriptionTier.Patron,
-                    SubscriptionBillingCycle.Yearly,
+                    BillingCycle.Yearly,
                     SubscriptionTier.Patron,
-                    SubscriptionBillingCycle.Yearly,
+                    BillingCycle.Yearly,
                     null,
                 ),
             )

--- a/modules/services/payment/src/test/kotlin/au/com/shiftyjelly/pocketcasts/payment/billing/BillingPaymentMapperTest.kt
+++ b/modules/services/payment/src/test/kotlin/au/com/shiftyjelly/pocketcasts/payment/billing/BillingPaymentMapperTest.kt
@@ -379,9 +379,9 @@ class BillingPaymentMapperTest {
             "Missing billing period duration designator in {basePlanId=Base plan ID, productId=Product ID, rawDuration=D1M}",
             "Invalid billing period interval count '' in {basePlanId=Base plan ID, productId=Product ID, rawDuration=PM}",
             "Invalid billing period interval count '' in {basePlanId=Base plan ID, productId=Product ID, rawDuration=P-1M}",
-            "Unrecognized period designator 'U' in {basePlanId=Base plan ID, productId=Product ID, rawDuration=P1U}",
-            "Unrecognized period designator 'MY' in {basePlanId=Base plan ID, productId=Product ID, rawDuration=P1MY}",
-            "Unrecognized period designator '' in {basePlanId=Base plan ID, productId=Product ID, rawDuration=P1}",
+            "Unrecognized billing interval period designator 'U' in {basePlanId=Base plan ID, productId=Product ID, rawDuration=P1U}",
+            "Unrecognized billing interval period designator 'MY' in {basePlanId=Base plan ID, productId=Product ID, rawDuration=P1MY}",
+            "Unrecognized billing interval period designator '' in {basePlanId=Base plan ID, productId=Product ID, rawDuration=P1}",
         )
     }
 

--- a/modules/services/payment/src/test/kotlin/au/com/shiftyjelly/pocketcasts/payment/billing/BillingPaymentMapperTest.kt
+++ b/modules/services/payment/src/test/kotlin/au/com/shiftyjelly/pocketcasts/payment/billing/BillingPaymentMapperTest.kt
@@ -1,7 +1,7 @@
 package au.com.shiftyjelly.pocketcasts.payment.billing
 
-import au.com.shiftyjelly.pocketcasts.payment.BillingPeriod
 import au.com.shiftyjelly.pocketcasts.payment.Price
+import au.com.shiftyjelly.pocketcasts.payment.PricingSchedule
 import au.com.shiftyjelly.pocketcasts.payment.PurchaseState
 import au.com.shiftyjelly.pocketcasts.payment.TestLogger
 import com.android.billingclient.api.GoogleOfferDetails
@@ -83,8 +83,8 @@ class BillingPaymentMapperTest {
             pricingPhase.price,
         )
         assertEquals(
-            BillingPeriod(BillingPeriod.Cycle.Infinite, BillingPeriod.Interval.Monthly, intervalCount = 1),
-            pricingPhase.billingPeriod,
+            PricingSchedule(PricingSchedule.RecurrenceMode.Infinite, PricingSchedule.Period.Monthly, periodCount = 1),
+            pricingPhase.schedule,
         )
     }
 
@@ -154,7 +154,7 @@ class BillingPaymentMapperTest {
     }
 
     @Test
-    fun `map product billing intervals`() {
+    fun `map product pricing schedules`() {
         val googleProduct = GoogleProductDetails(
             subscriptionOfferDetails = listOf(
                 GoogleOfferDetails(offerId = null),
@@ -231,50 +231,50 @@ class BillingPaymentMapperTest {
             ),
         )
 
-        val billingPeriods = mapper.toProduct(googleProduct)!!.pricingPlans
+        val pricingSchedules = mapper.toProduct(googleProduct)!!.pricingPlans
             .offerPlans
             .flatMap { it.pricingPhases }
-            .map { it.billingPeriod }
+            .map { it.schedule }
 
         assertEquals(
             listOf(
-                BillingPeriod(
-                    intervalCount = 1,
-                    interval = BillingPeriod.Interval.Monthly,
-                    cycle = BillingPeriod.Cycle.Infinite,
+                PricingSchedule(
+                    periodCount = 1,
+                    period = PricingSchedule.Period.Monthly,
+                    recurrenceMode = PricingSchedule.RecurrenceMode.Infinite,
                 ),
-                BillingPeriod(
-                    intervalCount = 1,
-                    interval = BillingPeriod.Interval.Monthly,
-                    cycle = BillingPeriod.Cycle.NonRecurring,
+                PricingSchedule(
+                    periodCount = 1,
+                    period = PricingSchedule.Period.Monthly,
+                    recurrenceMode = PricingSchedule.RecurrenceMode.NonRecurring,
                 ),
-                BillingPeriod(
-                    intervalCount = 1,
-                    interval = BillingPeriod.Interval.Monthly,
-                    cycle = BillingPeriod.Cycle.Recurring(1),
+                PricingSchedule(
+                    periodCount = 1,
+                    period = PricingSchedule.Period.Monthly,
+                    recurrenceMode = PricingSchedule.RecurrenceMode.Recurring(1),
                 ),
-                BillingPeriod(
-                    intervalCount = 1,
-                    interval = BillingPeriod.Interval.Monthly,
-                    cycle = BillingPeriod.Cycle.Recurring(2),
+                PricingSchedule(
+                    periodCount = 1,
+                    period = PricingSchedule.Period.Monthly,
+                    recurrenceMode = PricingSchedule.RecurrenceMode.Recurring(2),
                 ),
-                BillingPeriod(
-                    intervalCount = 2,
-                    interval = BillingPeriod.Interval.Monthly,
-                    cycle = BillingPeriod.Cycle.Infinite,
+                PricingSchedule(
+                    periodCount = 2,
+                    period = PricingSchedule.Period.Monthly,
+                    recurrenceMode = PricingSchedule.RecurrenceMode.Infinite,
                 ),
-                BillingPeriod(
-                    intervalCount = 1,
-                    interval = BillingPeriod.Interval.Weekly,
-                    cycle = BillingPeriod.Cycle.Infinite,
+                PricingSchedule(
+                    periodCount = 1,
+                    period = PricingSchedule.Period.Weekly,
+                    recurrenceMode = PricingSchedule.RecurrenceMode.Infinite,
                 ),
-                BillingPeriod(
-                    intervalCount = 3,
-                    interval = BillingPeriod.Interval.Yearly,
-                    cycle = BillingPeriod.Cycle.Infinite,
+                PricingSchedule(
+                    periodCount = 3,
+                    period = PricingSchedule.Period.Yearly,
+                    recurrenceMode = PricingSchedule.RecurrenceMode.Infinite,
                 ),
             ),
-            billingPeriods,
+            pricingSchedules,
         )
     }
 
@@ -379,9 +379,9 @@ class BillingPaymentMapperTest {
             "Missing billing period duration designator in {basePlanId=Base plan ID, productId=Product ID, rawDuration=D1M}",
             "Invalid billing period interval count '' in {basePlanId=Base plan ID, productId=Product ID, rawDuration=PM}",
             "Invalid billing period interval count '' in {basePlanId=Base plan ID, productId=Product ID, rawDuration=P-1M}",
-            "Unrecognized billing interval period designator 'U' in {basePlanId=Base plan ID, productId=Product ID, rawDuration=P1U}",
-            "Unrecognized billing interval period designator 'MY' in {basePlanId=Base plan ID, productId=Product ID, rawDuration=P1MY}",
-            "Unrecognized billing interval period designator '' in {basePlanId=Base plan ID, productId=Product ID, rawDuration=P1}",
+            "Unrecognized period designator 'U' in {basePlanId=Base plan ID, productId=Product ID, rawDuration=P1U}",
+            "Unrecognized period designator 'MY' in {basePlanId=Base plan ID, productId=Product ID, rawDuration=P1MY}",
+            "Unrecognized period designator '' in {basePlanId=Base plan ID, productId=Product ID, rawDuration=P1}",
         )
     }
 


### PR DESCRIPTION
## Description

This PR rename `SubscriptionBillingCycle` to `BillingCycle`. It is a frequently use type so it makes it a bit easier to use it. The old `BillingCycle` got renamed to `PricingSchedule`. `PricingSchedule` is not really used anything other than determining `BillingCycle` and now it aligns more with naming from the Billing API.

## Testing Instructions

Code review the changes.

## Checklist
- [ ] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [ ] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [ ] ~Any jetpack compose components I added or changed are covered by compose previews~
- [ ] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~