### PR TITLE
Add "Pocket Casts" User-Agent to image requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@
     *   Fix issue with disappearing file image after upload completes
         ([#3910](https://github.com/Automattic/pocket-casts-android/pull/3910))
     *   Fix issue with image artwork not loading in some cases
-        ([#3910](https://github.com/Automattic/pocket-casts-android/pull/3910))
+        ([#3970](https://github.com/Automattic/pocket-casts-android/pull/3970))
 
 7.87
 -----

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@
         ([#3917](https://github.com/Automattic/pocket-casts-android/pull/3917))
     *   Fix issue with disappearing file image after upload completes
         ([#3910](https://github.com/Automattic/pocket-casts-android/pull/3910))
+    *   Fix issue with image artwork not loading in some cases
+        ([#3910](https://github.com/Automattic/pocket-casts-android/pull/3910))
 
 7.87
 -----

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/CleanAndRetryInterceptor.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/CleanAndRetryInterceptor.kt
@@ -9,7 +9,9 @@ internal class CleanAndRetryInterceptor(
     override fun intercept(chain: Interceptor.Chain): Response {
         val originalRequest = chain.request()
         val response = chain.proceed(originalRequest)
-        return if (response.isSuccessful || response.isRedirect) {
+        // response.isRedirect returns true only when redirecting to different resources
+        // It doesn't work here as it doesn't account for 304
+        return if (response.code in 200..399) {
             response
         } else {
             response.close()

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/di/InterceptorModule.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/di/InterceptorModule.kt
@@ -227,4 +227,21 @@ object InterceptorModule {
             }
         }
     }
+
+    @Provides
+    @Artwork
+    fun provideArtworkInterceptors(): List<OkHttpInterceptor> {
+        return buildList {
+            add(publicUserAgentInterceptor.toClientInterceptor())
+            add(crashLoggingInterceptor.toClientInterceptor())
+            add(cleanAndRetryInterceptor)
+
+            if (BuildConfig.DEBUG) {
+                val loggingInterceptor = HttpLoggingInterceptor().apply {
+                    level = HttpLoggingInterceptor.Level.HEADERS
+                }
+                add(loggingInterceptor.toClientInterceptor())
+            }
+        }
+    }
 }

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/di/ServersModule.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/di/ServersModule.kt
@@ -200,6 +200,18 @@ class ServersModule {
     }
 
     @Provides
+    @Singleton
+    @Artwork
+    fun provideArtworkClient(
+        @Raw client: OkHttpClient,
+        @Artwork interceptors: List<@JvmSuppressWildcards OkHttpInterceptor>,
+    ): OkHttpClient {
+        return client.newBuilder()
+            .addInterceptors(interceptors)
+            .build()
+    }
+
+    @Provides
     @SyncServiceRetrofit
     @Singleton
     internal fun provideApiRetrofit(@Cached okHttpClient: OkHttpClient, moshi: Moshi): Retrofit {
@@ -321,6 +333,10 @@ annotation class Transcripts
 @Qualifier
 @Retention(AnnotationRetention.BINARY)
 annotation class Player
+
+@Qualifier
+@Retention(AnnotationRetention.BINARY)
+annotation class Artwork
 
 @Qualifier
 @Retention(AnnotationRetention.BINARY)

--- a/modules/services/servers/src/test/kotlin/au/com/shiftyjelly/pocketcasts/servers/CleanAndRetryInterceptorTest.kt
+++ b/modules/services/servers/src/test/kotlin/au/com/shiftyjelly/pocketcasts/servers/CleanAndRetryInterceptorTest.kt
@@ -34,6 +34,24 @@ class CleanAndRetryInterceptorTest {
     }
 
     @Test
+    fun `do not remove header from request if response is 304`() {
+        val client = OkHttpClient.Builder()
+            .addInterceptor(CleanAndRetryInterceptor(headersToRemove = listOf("x-custom")))
+            .build()
+        val request = Request.Builder()
+            .url(url)
+            .header("x-custom", "value")
+            .build()
+
+        server.enqueue(MockResponse().setResponseCode(304))
+        client.newCall(request).execute()
+
+        val serverRequest = server.takeRequest()
+
+        assertEquals("value", serverRequest.getHeader("X-custom"))
+    }
+
+    @Test
     fun `remove header from request if response is error`() {
         val client = OkHttpClient.Builder()
             .addInterceptor(CleanAndRetryInterceptor(headersToRemove = listOf("x-custom")))

--- a/modules/services/ui/build.gradle.kts
+++ b/modules/services/ui/build.gradle.kts
@@ -26,6 +26,7 @@ dependencies {
     api(projects.modules.services.model)
     api(projects.modules.services.preferences)
     api(projects.modules.services.repositories)
+    api(projects.modules.services.servers)
 
     implementation(platform(libs.compose.bom))
 

--- a/modules/services/ui/src/main/java/au/com/shiftyjelly/pocketcasts/ui/di/UiModule.kt
+++ b/modules/services/ui/src/main/java/au/com/shiftyjelly/pocketcasts/ui/di/UiModule.kt
@@ -1,6 +1,7 @@
 package au.com.shiftyjelly.pocketcasts.ui.di
 
 import android.content.Context
+import au.com.shiftyjelly.pocketcasts.servers.di.Artwork
 import coil.ImageLoader
 import coil.disk.DiskCache
 import dagger.Module
@@ -9,6 +10,7 @@ import dagger.hilt.InstallIn
 import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
 import javax.inject.Singleton
+import okhttp3.OkHttpClient
 
 @Module
 @InstallIn(SingletonComponent::class)
@@ -16,9 +18,13 @@ class UiModule {
 
     @Provides
     @Singleton
-    internal fun provideCoilImageLoader(@ApplicationContext context: Context): ImageLoader {
+    internal fun provideCoilImageLoader(
+        @ApplicationContext context: Context,
+        @Artwork client: OkHttpClient,
+    ): ImageLoader {
         return ImageLoader.Builder(context)
             .crossfade(true)
+            .okHttpClient(client)
             .diskCache {
                 DiskCache.Builder()
                     .directory(context.cacheDir.resolve("ImageCache"))


### PR DESCRIPTION
## Description

We started getting 403s when fetching Buzzsprout images. Our `User-Agent` header was missing. I also fixed an issue in the retry interceptor that didn't account for 304 response codes.

Context: p1746686650407509-slack-C02A333D8LQ

## Testing Instructions

1. Enable in the appearance settings episode artwork.
2. Check that the artwork for [this podcast](https://nodeweb.pocketcasts.com/admin/podcasts/5422321) works.

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [ ] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [ ] ~Any jetpack compose components I added or changed are covered by compose previews~
- [ ] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~