### PR TITLE
Add missing intro offer configuration

### DIFF
--- a/modules/services/payment/src/main/kotlin/au/com/shiftyjelly/pocketcasts/payment/Data.kt
+++ b/modules/services/payment/src/main/kotlin/au/com/shiftyjelly/pocketcasts/payment/Data.kt
@@ -49,6 +49,7 @@ data class PricingSchedule(
     val periodCount: Int,
 ) {
     enum class Period {
+        Daily,
         Weekly,
         Monthly,
         Yearly,

--- a/modules/services/payment/src/main/kotlin/au/com/shiftyjelly/pocketcasts/payment/Data.kt
+++ b/modules/services/payment/src/main/kotlin/au/com/shiftyjelly/pocketcasts/payment/Data.kt
@@ -282,6 +282,7 @@ enum class BillingCycle(
 }
 
 enum class SubscriptionOffer {
+    IntroOffer,
     Trial,
     Referral,
     Winback,
@@ -291,6 +292,14 @@ enum class SubscriptionOffer {
         tier: SubscriptionTier,
         billingCycle: BillingCycle,
     ) = when (this) {
+        IntroOffer -> when (tier) {
+            SubscriptionTier.Plus -> when (billingCycle) {
+                BillingCycle.Monthly -> null
+                BillingCycle.Yearly -> "plus-yearly-intro-50percent"
+            }
+
+            SubscriptionTier.Patron -> null
+        }
         Trial -> when (tier) {
             SubscriptionTier.Plus -> when (billingCycle) {
                 BillingCycle.Monthly -> null

--- a/modules/services/payment/src/main/kotlin/au/com/shiftyjelly/pocketcasts/payment/FakePaymentDataSource.kt
+++ b/modules/services/payment/src/main/kotlin/au/com/shiftyjelly/pocketcasts/payment/FakePaymentDataSource.kt
@@ -147,7 +147,7 @@ private val PlusMonthlyPricingPhase
 private val PlusYearlyPricingPhase
     get() = PricingPhase(
         Price(39.99.toBigDecimal(), "USD", "$39.99"),
-        PricingSchedule(PricingSchedule.RecurrenceMode.Infinite, PricingSchedule.Period.Monthly, periodCount = 0),
+        PricingSchedule(PricingSchedule.RecurrenceMode.Infinite, PricingSchedule.Period.Yearly, periodCount = 0),
     )
 private val PatronMonthlyPricingPhase
     get() = PricingPhase(
@@ -170,6 +170,19 @@ private fun pricingPhases(
     billingCycle: BillingCycle,
     offer: SubscriptionOffer?,
 ): List<PricingPhase> = when (offer) {
+    SubscriptionOffer.IntroOffer -> when (billingCycle) {
+        BillingCycle.Yearly -> when (tier) {
+            SubscriptionTier.Plus -> listOf(
+                PlusYearlyPricingPhase.withDiscount(priceFraction = 0.5, period = PricingSchedule.Period.Yearly),
+                PlusYearlyPricingPhase,
+            )
+
+            SubscriptionTier.Patron -> emptyList()
+        }
+
+        BillingCycle.Monthly -> emptyList()
+    }
+
     SubscriptionOffer.Trial -> when (billingCycle) {
         BillingCycle.Yearly -> when (tier) {
             SubscriptionTier.Plus -> listOf(

--- a/modules/services/payment/src/main/kotlin/au/com/shiftyjelly/pocketcasts/payment/billing/BillingPaymentMapper.kt
+++ b/modules/services/payment/src/main/kotlin/au/com/shiftyjelly/pocketcasts/payment/billing/BillingPaymentMapper.kt
@@ -336,6 +336,7 @@ internal class BillingPaymentMapper(
 
             else -> null
         }
+        SubscriptionOffer.IntroOffer -> ReplacementMode.CHARGE_FULL_PRICE
         SubscriptionOffer.Trial -> ReplacementMode.CHARGE_FULL_PRICE
         SubscriptionOffer.Referral -> ReplacementMode.CHARGE_FULL_PRICE
         SubscriptionOffer.Winback -> ReplacementMode.CHARGE_FULL_PRICE

--- a/modules/services/payment/src/main/kotlin/au/com/shiftyjelly/pocketcasts/payment/billing/BillingPaymentMapper.kt
+++ b/modules/services/payment/src/main/kotlin/au/com/shiftyjelly/pocketcasts/payment/billing/BillingPaymentMapper.kt
@@ -203,6 +203,7 @@ internal class BillingPaymentMapper(
 
         val rawInterval = valuePart.drop(rawCount.length)
         val period = when (rawInterval) {
+            "D" -> PricingSchedule.Period.Daily
             "W" -> PricingSchedule.Period.Weekly
             "M" -> PricingSchedule.Period.Monthly
             "Y" -> PricingSchedule.Period.Yearly

--- a/modules/services/payment/src/test/kotlin/au/com/shiftyjelly/pocketcasts/payment/SubscriptionPlansTest.kt
+++ b/modules/services/payment/src/test/kotlin/au/com/shiftyjelly/pocketcasts/payment/SubscriptionPlansTest.kt
@@ -185,6 +185,22 @@ class SubscriptionPlansTest {
     }
 
     @Test
+    fun `find plus yearly intro offer plan`() {
+        val plans = SubscriptionPlans.create(products).getOrNull()!!
+
+        val plan = plans.findOfferPlan(
+            SubscriptionTier.Plus,
+            BillingCycle.Yearly,
+            SubscriptionOffer.IntroOffer,
+        ).getOrNull()!!
+
+        assertEquals("Plus Yearly", plan.name)
+        assertEquals(SubscriptionTier.Plus, plan.tier)
+        assertEquals(BillingCycle.Yearly, plan.billingCycle)
+        assertEquals(SubscriptionOffer.IntroOffer, plan.offer)
+    }
+
+    @Test
     fun `do not find unknown offer plan`() {
         val plans = SubscriptionPlans.create(products).getOrNull()!!
 

--- a/modules/services/payment/src/test/kotlin/au/com/shiftyjelly/pocketcasts/payment/billing/BillingPaymentMapperTest.kt
+++ b/modules/services/payment/src/test/kotlin/au/com/shiftyjelly/pocketcasts/payment/billing/BillingPaymentMapperTest.kt
@@ -228,6 +228,16 @@ class BillingPaymentMapperTest {
                         ),
                     ),
                 ),
+                GoogleOfferDetails(
+                    offerId = "ID",
+                    pricingPhases = listOf(
+                        GooglePricingPhase(
+                            billingPeriod = "P2D",
+                            billingCycleCount = 0,
+                            recurrenceMode = RecurrenceMode.INFINITE_RECURRING,
+                        ),
+                    ),
+                ),
             ),
         )
 
@@ -271,6 +281,11 @@ class BillingPaymentMapperTest {
                 PricingSchedule(
                     periodCount = 3,
                     period = PricingSchedule.Period.Yearly,
+                    recurrenceMode = PricingSchedule.RecurrenceMode.Infinite,
+                ),
+                PricingSchedule(
+                    periodCount = 2,
+                    period = PricingSchedule.Period.Daily,
                     recurrenceMode = PricingSchedule.RecurrenceMode.Infinite,
                 ),
             ),


### PR DESCRIPTION
## Description

This PR adds the intro offer that we have configured in the Play Console. I didn't add it earlier because it is at the moment deactivated but it is still used in the existing code and we might switch back to it.

## Testing Instructions

Code review is enough.

## Screenshots or Screencast 

N/A

## Checklist
- [ ] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [ ] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [ ] ~Any jetpack compose components I added or changed are covered by compose previews~
- [ ] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~