### PR TITLE
Adds deep link support for podcast URLs at pocketcasts.com

### DIFF
--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/deeplink/DeepLinkFactoryTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/deeplink/DeepLinkFactoryTest.kt
@@ -752,6 +752,17 @@ class DeepLinkFactoryTest {
     }
 
     @Test
+    fun webBaseSharePodcast() {
+        val intent = Intent()
+            .setAction(ACTION_VIEW)
+            .setData(Uri.parse("https://pocketcasts.com/podcasts/podcast-id?source_view=source"))
+
+        val deepLink = factory.create(intent)
+
+        assertEquals(ShowPodcastDeepLink("podcast-id", sourceView = "source"), deepLink)
+    }
+
+    @Test
     fun webPlayerShareEpisode() {
         val intent = Intent()
             .setAction(ACTION_VIEW)

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -139,6 +139,24 @@
                 <category android:name="android.intent.category.DEFAULT"/>
                 <category android:name="android.intent.category.BROWSABLE"/>
                 <data
+                    android:host="pocketcasts.com"
+                    android:scheme="https"
+                    android:pathPrefix="/podcasts/" />
+            </intent-filter>
+            <intent-filter android:autoVerify="true">
+                <action android:name="android.intent.action.VIEW"/>
+                <category android:name="android.intent.category.DEFAULT"/>
+                <category android:name="android.intent.category.BROWSABLE"/>
+                <data
+                    android:host="pocketcasts.net"
+                    android:scheme="https"
+                    android:pathPrefix="/podcasts/" />
+            </intent-filter>
+            <intent-filter android:autoVerify="true">
+                <action android:name="android.intent.action.VIEW"/>
+                <category android:name="android.intent.category.DEFAULT"/>
+                <category android:name="android.intent.category.BROWSABLE"/>
+                <data
                     android:host="pocket-casts-main-development.mystagingwebsite.com"
                     android:scheme="https"
                     android:pathPrefix="/redeem" />

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -292,7 +292,7 @@ subprojects {
                     buildConfigField("String", "SERVER_SHORT_URL", "\"https://pcast.pocketcasts.net\"")
                     buildConfigField("String", "SERVER_SHORT_HOST", "\"pcast.pocketcasts.net\"")
                     buildConfigField("String", "SERVER_WEB_PLAYER_HOST", "\"play.pocketcasts.net\"")
-                    buildConfigField("String", "WEB_BASE_HOST", "\"pocket-casts-main-development.mystagingwebsite.com\"")
+                    buildConfigField("String", "WEB_BASE_HOST", "\"pocketcasts.net\"")
                     buildConfigField("String", "SERVER_LIST_URL", "\"https://lists.pocketcasts.net\"")
                     buildConfigField("String", "SERVER_LIST_HOST", "\"lists.pocketcasts.net\"")
 

--- a/modules/services/deeplink/src/main/kotlin/au/com/shiftyjelly/pocketcasts/deeplink/DeepLinkFactory.kt
+++ b/modules/services/deeplink/src/main/kotlin/au/com/shiftyjelly/pocketcasts/deeplink/DeepLinkFactory.kt
@@ -57,7 +57,7 @@ class DeepLinkFactory(
         ShareLinkNativeAdapter(),
         SignInAdapter(shareHost),
         ShareLinkAdapter(shareHost),
-        WebPlayerShareLinkAdapter(webPlayerHost),
+        WebPlayerShareLinkAdapter(webBaseHost = webBaseHost, webPlayerHost = webPlayerHost),
         OpmlAdapter(listOf(listHost, shareHost)),
         PodcastUrlSchemeAdapter(listOf(listHost, shareHost, webBaseHost)),
         PlayFromSearchAdapter(),
@@ -430,6 +430,7 @@ private class ShareLinkAdapter(
 }
 
 private class WebPlayerShareLinkAdapter(
+    private val webBaseHost: String,
     private val webPlayerHost: String,
 ) : DeepLinkAdapter {
     private val timestampParser = SharingUrlTimestampParser()
@@ -441,7 +442,7 @@ private class WebPlayerShareLinkAdapter(
 
         if (intent.action != ACTION_VIEW ||
             scheme !in listOf("http", "https") ||
-            host != webPlayerHost ||
+            (host != webBaseHost && host != webPlayerHost) ||
             uriData.pathSegments.size <= 1 ||
             uriData.pathSegments.first() != "podcasts"
         ) {


### PR DESCRIPTION
## Description

As the Web Player is migrating to our marketing site, the Web Player share pages are now at pocketcasts.com instead of play.pocketcasts.com. This change fixes it so these pages open the Android app.

## Testing Instructions
1. Open this PR in Chrome and click this link https://pocketcasts.net/podcasts/e6d1eff0-244e-012e-04d4-00163e1b201c
2. ✅ Verify it opens "The Book Review" podcast page

## Screencast 

https://github.com/user-attachments/assets/38002e6d-e358-4cf3-b5ea-3b59e679a4a1

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 