### PR TITLE
Updates datastore dependency to prevent crashes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@
         ([#3942](https://github.com/Automattic/pocket-casts-android/pull/3942))
     *   Improve Accessibility on the Upgrade page
         ([#3947](https://github.com/Automattic/pocket-casts-android/pull/3947))
+*   Bug Fixes
+    *   Updates datastore dependency to prevent crashes
+        ([#3982](https://github.com/Automattic/pocket-casts-android/pull/3982)
 
 7.88
 -----

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -70,6 +70,7 @@ dependencies {
     implementation(libs.coroutines.rx2)
     implementation(libs.dagger.hilt.android)
     implementation(libs.dagger.hilt.core)
+    implementation(libs.datastore) // Force using the latest datastore version to stop the app crashing with Glance widgets. Glance and Horologist libraries both include this library. Google Play Console issue 63d0f64987c33fcdff73fc0092b45936.
     implementation(libs.encryptedlogging)
     implementation(libs.firebase.config)
     implementation(libs.fragment.ktx)

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -70,7 +70,7 @@ dependencies {
     implementation(libs.coroutines.rx2)
     implementation(libs.dagger.hilt.android)
     implementation(libs.dagger.hilt.core)
-    implementation(libs.datastore) // Force using the latest datastore version to stop the app crashing with Glance widgets. Glance and Horologist libraries both include this library. Google Play Console issue 63d0f64987c33fcdff73fc0092b45936.
+    implementation(libs.datastore) // Force using the latest datastore version to stop the app crashing with Glance widgets. Glance and Horologist libraries both include this library. Pull request https://github.com/Automattic/pocket-casts-android/pull/3982.
     implementation(libs.encryptedlogging)
     implementation(libs.firebase.config)
     implementation(libs.fragment.ktx)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -21,10 +21,11 @@ android-gradle-plugin = "8.9.2"
 billing = "7.0.0"
 coil = "2.7.0"
 compose = "2024.10.00" # https://developer.android.com/jetpack/compose/bom/bom-mapping
+datastore = "1.1.6"
 dependency-analysis = "2.17.0"
 firebase = "33.13.0"
 fragment = "1.8.6"
-glance = "1.0.0"
+glance = "1.1.1"
 google-services = "4.4.2"
 hilt = "2.56.2"
 hilt-compiler = "1.2.0"
@@ -106,6 +107,9 @@ dagger-hilt-core = { module = "com.google.dagger:hilt-core", version.ref = "hilt
 hilt-compiler = { module = "androidx.hilt:hilt-compiler", version.ref = "hilt-compiler" }
 hilt-navigation-compose = "androidx.hilt:hilt-navigation-compose:1.2.0"
 hilt-work = "androidx.hilt:hilt-work:1.2.0"
+
+# Datastore
+datastore = { module = "androidx.datastore:datastore", version.ref = "datastore" }
 
 # Firebase
 firebase-bom = { module = "com.google.firebase:firebase-bom", version.ref = "firebase" }

--- a/wear/build.gradle.kts
+++ b/wear/build.gradle.kts
@@ -73,7 +73,7 @@ dependencies {
     implementation(libs.coroutines.rx2)
     implementation(libs.dagger.hilt.android)
     implementation(libs.dagger.hilt.core)
-    implementation(libs.datastore) // Force using the latest datastore version to stop the app crashing with Glance widgets. Glance and Horologist libraries both include this library. Google Play Console issue 63d0f64987c33fcdff73fc0092b45936.
+    implementation(libs.datastore) // Force using the latest datastore version to stop the app crashing with Glance widgets. Glance and Horologist libraries both include this library. Pull request https://github.com/Automattic/pocket-casts-android/pull/3982.
     implementation(libs.encryptedlogging)
     implementation(libs.firebase.config)
     implementation(libs.guava)

--- a/wear/build.gradle.kts
+++ b/wear/build.gradle.kts
@@ -73,6 +73,7 @@ dependencies {
     implementation(libs.coroutines.rx2)
     implementation(libs.dagger.hilt.android)
     implementation(libs.dagger.hilt.core)
+    implementation(libs.datastore) // Force using the latest datastore version to stop the app crashing with Glance widgets. Glance and Horologist libraries both include this library. Google Play Console issue 63d0f64987c33fcdff73fc0092b45936.
     implementation(libs.encryptedlogging)
     implementation(libs.firebase.config)
     implementation(libs.guava)

--- a/wear/build.gradle.kts
+++ b/wear/build.gradle.kts
@@ -73,7 +73,7 @@ dependencies {
     implementation(libs.coroutines.rx2)
     implementation(libs.dagger.hilt.android)
     implementation(libs.dagger.hilt.core)
-    implementation(libs.datastore) // Force using the latest datastore version to stop the app crashing with Glance widgets. Glance and Horologist libraries both include this library. Pull request https://github.com/Automattic/pocket-casts-android/pull/3982.
+    implementation(libs.datastore)?.because("Force using the latest datastore version to stop the app crashing with Glance widgets. Glance and Horologist libraries both include this library. Pull request https://github.com/Automattic/pocket-casts-android/pull/3982.")
     implementation(libs.encryptedlogging)
     implementation(libs.firebase.config)
     implementation(libs.guava)


### PR DESCRIPTION
## Description

Force the use of the latest Datastore library version to address a crash. The issue is the Google Play Console:

`androidx.datastore.preferences.protobuf.InvalidProtocolBufferException.<init>`
<details><summary>Stacktrace</summary>
<p>

```
Exception d5.c: Unable to parse preferences proto.
  at androidx.datastore.core.CorruptionException.<init> (CorruptionException.java:25)
  at androidx.datastore.preferences.PreferencesMapCompat$Companion.readFrom (PreferencesMapCompat.java:34)
  at androidx.datastore.preferences.core.PreferencesSerializer.readFrom (PreferencesSerializer.java:46)
  at androidx.datastore.core.okio.OkioReadScope.readData$suspendImpl (OkioStorage.kt:180)
  at androidx.datastore.core.okio.OkioReadScope.readData (OkioStorage.kt:1)
  at androidx.datastore.core.StorageConnectionKt$readData$2.invokeSuspend (StorageConnection.kt:74)
  at androidx.datastore.core.StorageConnectionKt$readData$2.invoke (StorageConnection.kt:26)
  at androidx.datastore.core.StorageConnectionKt$readData$2.invoke (StorageConnection.kt:26)
  at androidx.datastore.core.okio.OkioStorageConnection.readScope (OkioStorage.kt:113)
  at androidx.datastore.core.StorageConnectionKt.readData (StorageConnection.kt:74)
  at androidx.datastore.core.DataStoreImpl.readDataFromFileOrDefault (DataStoreImpl.kt:331)
  at androidx.datastore.core.DataStoreImpl.readDataOrHandleCorruption (DataStoreImpl.kt:373)
  at androidx.datastore.core.DataStoreImpl.access$readDataOrHandleCorruption (DataStoreImpl.kt:53)
  at androidx.datastore.core.DataStoreImpl$InitDataStore$doRun$initData$1.invokeSuspend (DataStoreImpl.kt:445)
  at androidx.datastore.core.DataStoreImpl$InitDataStore$doRun$initData$1.invoke (DataStoreImpl.kt:11)
  at androidx.datastore.core.DataStoreImpl$InitDataStore$doRun$initData$1.invoke (DataStoreImpl.kt:11)
  at androidx.datastore.core.SingleProcessCoordinator.lock (SingleProcessCoordinator.kt:41)
  at androidx.datastore.core.DataStoreImpl$InitDataStore.doRun (DataStoreImpl.java:442)
  at androidx.datastore.core.RunOnce.runIfNeeded (RunOnce.java:505)
  at androidx.datastore.core.DataStoreImpl.readAndInitOrPropagateAndThrowFailure (DataStoreImpl.kt:274)
  at androidx.datastore.core.DataStoreImpl.handleUpdate (DataStoreImpl.kt:251)
  at androidx.datastore.core.DataStoreImpl.access$handleUpdate (DataStoreImpl.kt:53)
  at androidx.datastore.core.DataStoreImpl$writeActor$3.invokeSuspend (DataStoreImpl.kt:215)
  at androidx.datastore.core.DataStoreImpl$writeActor$3.invoke (DataStoreImpl.kt:13)
  at androidx.datastore.core.DataStoreImpl$writeActor$3.invoke (DataStoreImpl.kt:13)
  at androidx.datastore.core.SimpleActor$offer$2.invokeSuspend (SimpleActor.kt:121)
  at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith (ContinuationImpl.kt:33)
  at kotlinx.coroutines.DispatchedTask.run (DispatchedTask.kt:100)
  at kotlinx.coroutines.internal.LimitedDispatcher$Worker.run (LimitedDispatcher.java:113)
  at kotlinx.coroutines.scheduling.TaskImpl.run (Tasks.kt:89)
  at kotlinx.coroutines.scheduling.CoroutineScheduler.runSafely (CoroutineScheduler.java:586)
  at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.executeTask (CoroutineScheduler.kt:820)
  at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.runWorker (CoroutineScheduler.kt:717)
  at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.run (CoroutineScheduler.kt:704)
Caused by androidx.datastore.preferences.protobuf.a0: Protocol message contained an invalid tag (zero).
  at androidx.datastore.preferences.protobuf.InvalidProtocolBufferException.<init> (InvalidProtocolBufferException.java:47)
  at androidx.datastore.preferences.protobuf.InvalidProtocolBufferException.invalidTag (InvalidProtocolBufferException.java:133)
  at androidx.datastore.preferences.protobuf.CodedInputStream$StreamDecoder.readTag (CodedInputStream.java:2107)
  at androidx.datastore.preferences.protobuf.CodedInputStreamReader.getFieldNumber (CodedInputStreamReader.java:82)
  at androidx.datastore.preferences.protobuf.MessageSchema.mergeFromHelper (MessageSchema.java:3913)
  at androidx.datastore.preferences.protobuf.MessageSchema.mergeFrom (MessageSchema.java:3895)
  at androidx.datastore.preferences.protobuf.GeneratedMessageLite.parsePartialFrom (GeneratedMessageLite.java:1648)
  at androidx.datastore.preferences.protobuf.GeneratedMessageLite.parseFrom (GeneratedMessageLite.java:1784)
  at androidx.datastore.preferences.PreferencesProto$PreferenceMap.parseFrom (PreferencesProto.java:196)
  at androidx.datastore.preferences.PreferencesMapCompat$Companion.readFrom (PreferencesMapCompat.java:32)
  at androidx.datastore.preferences.core.PreferencesSerializer.readFrom (PreferencesSerializer.java:46)
```

</p>
</details> 

By explicitly adding the Glance library in the root of the project it looks like it uses the higher version.

```
+|    +--- androidx.glance:glance-appwidget:1.1.1
+|    |    +--- androidx.datastore:datastore:1.0.0 -> 1.1.6 (*)
+|    |    +--- androidx.datastore:datastore-core:1.0.0 -> 1.1.6 (*)
+|    |    +--- androidx.datastore:datastore-preferences:1.0.0 -> 1.1.6 (*)
+|    |    +--- androidx.datastore:datastore-preferences-core:1.0.0 -> 1.1.6 (*)
+|    |    +--- androidx.glance:glance:1.1.1
+|    |    |    +--- androidx.datastore:datastore-core:1.0.0 -> 1.1.6 (*)
+|    |    |    +--- androidx.datastore:datastore-preferences:1.0.0 -> 1.1.6 (*)
+|    |    |    +--- androidx.datastore:datastore-preferences-core:1.0.0 -> 1.1.6 (*)
```

There was an [issue upgrading](https://github.com/Automattic/pocket-casts-android/pull/2786) from Glance 1.0.0 to 1.1.0 so we will have to watch the beta a new crash. Unfortunately, the Sentry link doesn't work in the previous revert PR, so we can't see the exact crash. But checking previous Slack conversations, it's this Google issue. https://issuetracker.google.com/u/1/issues/360756889
p1725428337727999/1725279372.448629-slack-C028JAG44VD

```
1. Okio__JvmOkioKt.source, android.system.ErrnoException - open failed: EACCES (Permission denied):
Fatal Exception: java.io.FileNotFoundException
/data/user/0/.../files/datastore/GlanceAppWidgetManager.preferences_pb: open failed: ENOENT (No such file or directory)
          Caused by android.system.ErrnoException: open failed: ENOENT (No such file or directory)
```

Fixes https://github.com/Automattic/pocket-casts-android/issues/3958

## Testing Instructions

Although I haven’t been able to reproduce the crash, the issue appears related to the DataStore usage in the Glance widget and Horologist libraries. Please focus testing on widgets and Wear OS functionality.

📱 Widgets
	1.	Install the app from the main branch.
	2.	Add a few widgets to your home screen.
	3.	Install the app from this branch.
	4.	✅ Confirm that the previously added widgets still appear and function as expected.
	5.	Add additional widgets.
	6.	✅ Verify that all widgets (old and new) behave correctly.

⌚️ Wear OS
	7.	Install the Wear OS app from this branch.
	8.	✅ Check that the Wear app installs successfully and all key functionality works as expected.

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.