### PR TITLE
Reverts datastore dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,9 +14,6 @@
         ([#3942](https://github.com/Automattic/pocket-casts-android/pull/3942))
     *   Improve Accessibility on the Upgrade page
         ([#3947](https://github.com/Automattic/pocket-casts-android/pull/3947))
-*   Bug Fixes
-    *   Updates datastore dependency to prevent crashes
-        ([#3982](https://github.com/Automattic/pocket-casts-android/pull/3982)
 
 7.88
 -----

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -70,7 +70,6 @@ dependencies {
     implementation(libs.coroutines.rx2)
     implementation(libs.dagger.hilt.android)
     implementation(libs.dagger.hilt.core)
-    implementation(libs.datastore) // Force using the latest datastore version to stop the app crashing with Glance widgets. Glance and Horologist libraries both include this library. Pull request https://github.com/Automattic/pocket-casts-android/pull/3982.
     implementation(libs.encryptedlogging)
     implementation(libs.firebase.config)
     implementation(libs.fragment.ktx)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -21,11 +21,10 @@ android-gradle-plugin = "8.9.2"
 billing = "7.0.0"
 coil = "2.7.0"
 compose = "2024.10.00" # https://developer.android.com/jetpack/compose/bom/bom-mapping
-datastore = "1.1.6"
 dependency-analysis = "2.17.0"
 firebase = "33.13.0"
 fragment = "1.8.6"
-glance = "1.1.1"
+glance = "1.0.0"
 google-services = "4.4.2"
 hilt = "2.56.2"
 hilt-compiler = "1.2.0"
@@ -107,9 +106,6 @@ dagger-hilt-core = { module = "com.google.dagger:hilt-core", version.ref = "hilt
 hilt-compiler = { module = "androidx.hilt:hilt-compiler", version.ref = "hilt-compiler" }
 hilt-navigation-compose = "androidx.hilt:hilt-navigation-compose:1.2.0"
 hilt-work = "androidx.hilt:hilt-work:1.2.0"
-
-# Datastore
-datastore = { module = "androidx.datastore:datastore", version.ref = "datastore" }
 
 # Firebase
 firebase-bom = { module = "com.google.firebase:firebase-bom", version.ref = "firebase" }

--- a/wear/build.gradle.kts
+++ b/wear/build.gradle.kts
@@ -73,7 +73,6 @@ dependencies {
     implementation(libs.coroutines.rx2)
     implementation(libs.dagger.hilt.android)
     implementation(libs.dagger.hilt.core)
-    implementation(libs.datastore)?.because("Force using the latest datastore version to stop the app crashing with Glance widgets. Glance and Horologist libraries both include this library. Pull request https://github.com/Automattic/pocket-casts-android/pull/3982.")
     implementation(libs.encryptedlogging)
     implementation(libs.firebase.config)
     implementation(libs.guava)


### PR DESCRIPTION
## Description

The Datastore library upgrade causes the release build of the app to crash. This change reverts the library change. 

## Testing Instructions

1. Create a release build
2. Try to open the app

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x]  Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 