### PR TITLE
Fixes podcast description crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
         ([#3942](https://github.com/Automattic/pocket-casts-android/pull/3942))
     *   Improve Accessibility on the Upgrade page
         ([#3947](https://github.com/Automattic/pocket-casts-android/pull/3947))
+    *   Fix issue with podcast description crashing the app
+        ([#3994](https://github.com/Automattic/pocket-casts-android/pull/3994))
 
 7.88
 -----

--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/compose/text/ExtensionTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/compose/text/ExtensionTest.kt
@@ -1,0 +1,28 @@
+package au.com.shiftyjelly.pocketcasts.compose.text
+
+import android.graphics.Color
+import androidx.core.text.HtmlCompat
+import androidx.core.text.toSpannable
+import org.junit.Test
+
+class ExtensionTest {
+
+    @Test
+    fun toAnnotatedString() {
+        val string = "<h3><br /></h3><h3>The</h3><h3>Podcast</h3>"
+        val html = HtmlCompat.fromHtml(
+            string,
+            HtmlCompat.FROM_HTML_MODE_COMPACT and
+                HtmlCompat.FROM_HTML_SEPARATOR_LINE_BREAK_PARAGRAPH.inv(),
+        )
+        val annotatedString = html.toSpannable().toAnnotatedString(urlColor = Color.RED)
+        annotatedString.spanStyles.forEach { spanStyle ->
+            assert(spanStyle.end > spanStyle.start) { "Span end is not greater than start: ${spanStyle.end} <= ${spanStyle.start}" }
+            val length = spanStyle.toString().length
+            assert(spanStyle.start <= length) { "Span start is greater than length: ${spanStyle.start} > $length" }
+            assert(spanStyle.end <= length) { "Span end is greater than length: ${spanStyle.end} > $length" }
+            assert(spanStyle.start >= 0) { "Span start is negative: ${spanStyle.start}" }
+            assert(spanStyle.end >= 0) { "Span end is negative: ${spanStyle.end}" }
+        }
+    }
+}

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/text/Extension.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/text/Extension.kt
@@ -33,8 +33,12 @@ fun Spanned.toAnnotatedString(urlColor: Int? = null): AnnotatedString = buildAnn
     append(trimmedText)
     // Step 3: Go through each span
     getSpans(0, length, Any::class.java).forEach { span ->
-        val start = getSpanStart(span) - startOffset
-        val end = (getSpanEnd(span) - startOffset).coerceAtMost(length)
+        val start = (getSpanStart(span) - startOffset).coerceIn(0, length)
+        val end = (getSpanEnd(span) - startOffset).coerceIn(0, length)
+        if (start >= end) {
+            // Skip if the span is invalid
+            return@forEach
+        }
         when (span) {
             // Bold, Italic, Bold-Italic
             is StyleSpan -> {


### PR DESCRIPTION
## Description

There's an HTML description that causes the podcast page to crash. It happens because the start of the description has a BR tag that causes the front of the string to have a new line character. 

Fixes https://github.com/Automattic/pocket-casts-android/issues/3993

## Testing Instructions

1. Use the debug variant
2. Search for https://pcast.pocketcasts.net/yap4gwzx
3. Tap on the artwork to open the podcast page
4. ✅ Verify the page doesn't crash
5. Search for https://pcast.pocketcasts.net/embd
6. Tap on the artwork to open the podcast page
4. ✅ Verify the page doesn't crash

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
