### PR TITLE
Redirect free users to e-mail support

### DIFF
--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/HelpPage.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/HelpPage.kt
@@ -7,7 +7,6 @@ import android.content.Intent
 import android.net.Uri
 import android.webkit.WebResourceRequest
 import android.webkit.WebView
-import androidx.appcompat.app.AlertDialog
 import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.core.Spring
@@ -44,7 +43,6 @@ import androidx.compose.material.MaterialTheme
 import androidx.compose.material.ripple
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -99,7 +97,6 @@ fun HelpPage(
     onWebViewDisposed: (WebView) -> Unit = {},
 ) {
     val scope = rememberCoroutineScope()
-    val state by viewModel.uiState.collectAsState()
     var isExportingDatabase by remember { mutableStateOf(false) }
 
     Box(
@@ -118,24 +115,13 @@ fun HelpPage(
                 }
             },
             onContactSupport = {
-                if (state.subscriptionTier.isPaid) {
-                    scope.launch {
-                        val intent = viewModel.getSupportIntent(activity)
-                        try {
-                            activity.startActivity(intent)
-                        } catch (_: ActivityNotFoundException) {
-                            UiUtil.displayDialogNoEmailApp(activity)
-                        }
+                scope.launch {
+                    val intent = viewModel.getSupportIntent(activity)
+                    try {
+                        activity.startActivity(intent)
+                    } catch (_: ActivityNotFoundException) {
+                        UiUtil.displayDialogNoEmailApp(activity)
                     }
-                } else {
-                    val forumUrl = "https://forums.pocketcasts.com/"
-                    AlertDialog.Builder(activity)
-                        .setTitle(LR.string.settings_forums)
-                        .setMessage(activity.getString(LR.string.settings_forums_description, forumUrl))
-                        .setPositiveButton(LR.string.settings_take_me_there) { _, _ ->
-                            activity.startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(forumUrl)))
-                        }
-                        .show()
                 }
             },
             onTapUri = { uri ->

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/viewmodel/HelpViewModel.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/viewmodel/HelpViewModel.kt
@@ -3,40 +3,20 @@ package au.com.shiftyjelly.pocketcasts.settings.viewmodel
 import android.app.Activity
 import android.content.Intent
 import androidx.lifecycle.ViewModel
-import androidx.lifecycle.viewModelScope
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTracker
-import au.com.shiftyjelly.pocketcasts.models.type.SubscriptionTier
-import au.com.shiftyjelly.pocketcasts.repositories.subscription.SubscriptionManager
 import au.com.shiftyjelly.pocketcasts.repositories.support.DatabaseExportHelper
 import au.com.shiftyjelly.pocketcasts.repositories.support.Support
 import dagger.hilt.android.lifecycle.HiltViewModel
 import java.io.File
 import javax.inject.Inject
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.collect
-import kotlinx.coroutines.flow.update
-import kotlinx.coroutines.launch
 
 @HiltViewModel
 class HelpViewModel @Inject constructor(
     private val analyticsTracker: AnalyticsTracker,
-    private val subscriptionManager: SubscriptionManager,
     private val support: Support,
     private val databaseExportHelper: DatabaseExportHelper,
 ) : ViewModel() {
-    private val _uiState = MutableStateFlow(UiState())
-    val uiState: StateFlow<UiState> = _uiState
-
-    init {
-        viewModelScope.launch {
-            subscriptionManager.subscriptionTier().collect { tier ->
-                _uiState.update { it.copy(subscriptionTier = tier) }
-            }
-        }
-    }
-
     suspend fun exportDatabase(): File? {
         return databaseExportHelper.getExportFile()
     }
@@ -45,7 +25,7 @@ class HelpViewModel @Inject constructor(
         analyticsTracker.track(AnalyticsEvent.SETTINGS_LEAVE_FEEDBACK)
         return support.shareLogs(
             subject = "Android feedback.",
-            intro = "It's a great app, but it really needs...",
+            intro = "It's a great app, but it really needs…",
             emailSupport = true,
             context = activity,
         )
@@ -55,13 +35,9 @@ class HelpViewModel @Inject constructor(
         analyticsTracker.track(AnalyticsEvent.SETTINGS_GET_SUPPORT)
         return support.shareLogs(
             subject = "Android support.",
-            intro = "Hi there, just needed help with something....",
+            intro = "Hi there, just needed help with something…",
             emailSupport = true,
             context = activity,
         )
     }
-
-    data class UiState(
-        val subscriptionTier: SubscriptionTier = SubscriptionTier.NONE,
-    )
 }


### PR DESCRIPTION
## Description

This PR removes the forums barrier when contacting us as a free user.

See: pdzxoO-E7-p2#comment-630

## Testing Instructions

1. Open the app as an unsigned or a free user.
2. Go to the `Help & feedback` page.
3. Scroll down.
4. Tap `Get in touch` button.
5. Tap `Get support` button.
6. You should be able to send an email.

## Screenshots or Screencast 

https://github.com/user-attachments/assets/0eb74518-7f69-4366-9158-f27feb6c040a

## Checklist
- [ ] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] ~I have considered whether it makes sense to add tests for my changes~
- [ ] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [ ] ~Any jetpack compose components I added or changed are covered by compose previews~
- [ ] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~