### PR TITLE
[Tooling] Skip jobs if there are no relevant code changes

### DIFF
--- a/.buildkite/commands/assemble-release-apk.sh
+++ b/.buildkite/commands/assemble-release-apk.sh
@@ -1,5 +1,9 @@
 #!/bin/bash -eu
 
+if .buildkite/commands/should-skip-job.sh --job-type build; then
+  exit 0
+fi
+
 "$(dirname "${BASH_SOURCE[0]}")/restore-cache.sh"
 
 echo "--- :rubygems: Setting up Gems"

--- a/.buildkite/commands/assemble-release-apk.sh
+++ b/.buildkite/commands/assemble-release-apk.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -eu
 
-if .buildkite/commands/should-skip-job.sh --job-type build; then
+if "$(dirname "${BASH_SOURCE[0]}")/should-skip-job.sh" --job-type build; then
   exit 0
 fi
 

--- a/.buildkite/commands/diff-merged-manifest.sh
+++ b/.buildkite/commands/diff-merged-manifest.sh
@@ -1,6 +1,8 @@
-#!/bin/bash
+#!/bin/bash -eu
 
-set -euo pipefail
+if .buildkite/commands/should-skip-job.sh --job-type validation; then
+  exit 0
+fi
 
 "$(dirname "${BASH_SOURCE[0]}")/restore-cache.sh"
 

--- a/.buildkite/commands/diff-merged-manifest.sh
+++ b/.buildkite/commands/diff-merged-manifest.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -eu
 
-if .buildkite/commands/should-skip-job.sh --job-type validation; then
+if "$(dirname "${BASH_SOURCE[0]}")/should-skip-job.sh" --job-type validation; then
   exit 0
 fi
 

--- a/.buildkite/commands/lint.sh
+++ b/.buildkite/commands/lint.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -eu
 
-if .buildkite/commands/should-skip-job.sh --job-type lint; then
+if "$(dirname "${BASH_SOURCE[0]}")/should-skip-job.sh" --job-type lint; then
   exit 0
 fi
 

--- a/.buildkite/commands/lint.sh
+++ b/.buildkite/commands/lint.sh
@@ -1,4 +1,8 @@
-#!/bin/bash -u
+#!/bin/bash -eu
+
+if .buildkite/commands/should-skip-job.sh --job-type lint; then
+  exit 0
+fi
 
 "$(dirname "${BASH_SOURCE[0]}")/restore-cache.sh"
 

--- a/.buildkite/commands/prototype-build.sh
+++ b/.buildkite/commands/prototype-build.sh
@@ -1,5 +1,9 @@
 #!/bin/bash -eu
 
+if .buildkite/commands/should-skip-job.sh --job-type build; then
+  exit 0
+fi
+
 "$(dirname "${BASH_SOURCE[0]}")/restore-cache.sh"
 
 echo "--- :rubygems: Setting up Gems"

--- a/.buildkite/commands/prototype-build.sh
+++ b/.buildkite/commands/prototype-build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -eu
 
-if .buildkite/commands/should-skip-job.sh --job-type build; then
+if "$(dirname "${BASH_SOURCE[0]}")/should-skip-job.sh" --job-type build; then
   exit 0
 fi
 

--- a/.buildkite/commands/run-instrumented-tests.sh
+++ b/.buildkite/commands/run-instrumented-tests.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -eu
 
-if .buildkite/commands/should-skip-job.sh --job-type validation; then
+if "$(dirname "${BASH_SOURCE[0]}")/should-skip-job.sh" --job-type validation; then
   exit 0
 fi
 

--- a/.buildkite/commands/run-instrumented-tests.sh
+++ b/.buildkite/commands/run-instrumented-tests.sh
@@ -1,5 +1,9 @@
 #!/bin/bash -eu
 
+if .buildkite/commands/should-skip-job.sh --job-type validation; then
+  exit 0
+fi
+
 "$(dirname "${BASH_SOURCE[0]}")/restore-cache.sh"
 
 echo "--- :rubygems: Setting up Gems"

--- a/.buildkite/commands/run-unit-tests.sh
+++ b/.buildkite/commands/run-unit-tests.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -eu
 
-if .buildkite/commands/should-skip-job.sh --job-type validation; then
+if "$(dirname "${BASH_SOURCE[0]}")/should-skip-job.sh" --job-type validation; then
   exit 0
 fi
 

--- a/.buildkite/commands/run-unit-tests.sh
+++ b/.buildkite/commands/run-unit-tests.sh
@@ -1,5 +1,9 @@
 #!/bin/bash -eu
 
+if .buildkite/commands/should-skip-job.sh --job-type validation; then
+  exit 0
+fi
+
 "$(dirname "${BASH_SOURCE[0]}")/restore-cache.sh"
 
 echo "--- 🧪 Testing"

--- a/.buildkite/commands/should-skip-job.sh
+++ b/.buildkite/commands/should-skip-job.sh
@@ -37,9 +37,9 @@ fi
 # Function to display skip message and create annotation
 show_skip_message() {
   local job_type=$1
-  local message="Skipping ${BUILDKITE_LABEL:-Job} - no relevant files changed"
+  local message="Skipped ${BUILDKITE_LABEL:-Job} - no relevant files changed"
   local context="skip-$(echo "${BUILDKITE_LABEL:-$job_type}" | sed -E -e 's/[^[:alnum:]]+/-/g' | tr A-Z a-z)"
-  
+
   echo "$message" | buildkite-agent annotate --style "info" --context "$context"
   echo "$message"
 }

--- a/.buildkite/commands/should-skip-job.sh
+++ b/.buildkite/commands/should-skip-job.sh
@@ -1,0 +1,73 @@
+#!/bin/bash -eu
+
+# Usage: should-skip-job.sh --job-type [validation|build|lint]
+# --job-type validation: For jobs like unit/instrumented tests, manifest validation…
+#     Skip when changes are limited to documentation, tooling, non-code files, and localization files
+# --job-type lint: For jobs doing linting, especially ones that might include linting of localization files
+#     Skip when changes are limited to documentation, tooling, and non-code files.
+#     Does not skip if localization files changed (so that linter can run to report translation inconsistencies)
+# --job-type build: For jobs building an apk binary, e.g. Assemble, Prototype Builds…
+#     Skip when changes are limited to documentation, tooling, and non-code files
+#
+# Return codes:
+# 0 - Job should be skipped (script also handles displaying the message and annotation)
+# 1 - Job should not be skipped
+# 15 - Error in script parameters
+
+COMMON_PATTERNS=(
+  "*.md"
+  "*.pot"
+  "*.txt"
+  ".gitignore"
+  "config/**"
+  "fastlane/**"
+  "Gemfile"
+  "Gemfile.lock"
+  "gradle/**"
+  "version.properties"
+)
+
+# Check if arguments are valid
+if [ -z "${1:-}" ] || [ "$1" != "--job-type" ] || [ -z "${2:-}" ]; then
+  echo "Error: Must specify --job-type [validation|build|lint]"
+  buildkite-agent step cancel
+  exit 15
+fi
+
+# Function to display skip message and create annotation
+show_skip_message() {
+  local job_type=$1
+  local message="Skipping ${BUILDKITE_LABEL:-Job} - no relevant files changed"
+  local context="skip-$(echo "${BUILDKITE_LABEL:-$job_type}" | sed -E -e 's/[^[:alnum:]]+/-/g' | tr A-Z a-z)"
+  
+  echo "$message" | buildkite-agent annotate --style "info" --context "$context"
+  echo "$message"
+}
+
+job_type="$2"
+case "$job_type" in
+  "validation")
+    # We should skip if changes are limited to documentation, tooling, non-code files, and localization files
+    PATTERNS=("${COMMON_PATTERNS[@]}" "**/strings.xml")
+    if pr_changed_files --all-match "${PATTERNS[@]}"; then
+      show_skip_message "$job_type"
+      exit 0
+    fi
+    exit 1
+    ;;
+  "build"|"lint")
+    # We should skip if changes are limited to documentation, tooling, and non-code files
+    # We'll let the job run (won't skip) if PR includes changes in localization files though
+    PATTERNS=("${COMMON_PATTERNS[@]}")
+    if pr_changed_files --all-match "${PATTERNS[@]}"; then
+      show_skip_message "$job_type"
+      exit 0
+    fi
+    exit 1
+    ;;
+  *)
+    echo "Error: Job type must be either 'validation', 'build', or 'lint'"
+    buildkite-agent step cancel
+    exit 15
+    ;;
+esac

--- a/.buildkite/commands/should-skip-job.sh
+++ b/.buildkite/commands/should-skip-job.sh
@@ -27,9 +27,14 @@ COMMON_PATTERNS=(
   "version.properties"
 )
 
+# Define constants for job types
+VALIDATION="validation"
+BUILD="build"
+LINT="lint"
+
 # Check if arguments are valid
 if [ -z "${1:-}" ] || [ "$1" != "--job-type" ] || [ -z "${2:-}" ]; then
-  echo "Error: Must specify --job-type [validation|build|lint]"
+  echo "Error: Must specify --job-type [$VALIDATION|$BUILD|$LINT]"
   buildkite-agent step cancel
   exit 15
 fi
@@ -46,7 +51,7 @@ show_skip_message() {
 
 job_type="$2"
 case "$job_type" in
-  "validation")
+  $VALIDATION)
     # We should skip if changes are limited to documentation, tooling, non-code files, and localization files
     PATTERNS=("${COMMON_PATTERNS[@]}" "**/strings.xml")
     if pr_changed_files --all-match "${PATTERNS[@]}"; then
@@ -55,7 +60,7 @@ case "$job_type" in
     fi
     exit 1
     ;;
-  "build"|"lint")
+  $BUILD|$LINT)
     # We should skip if changes are limited to documentation, tooling, and non-code files
     # We'll let the job run (won't skip) if PR includes changes in localization files though
     PATTERNS=("${COMMON_PATTERNS[@]}")
@@ -66,7 +71,7 @@ case "$job_type" in
     exit 1
     ;;
   *)
-    echo "Error: Job type must be either 'validation', 'build', or 'lint'"
+    echo "Error: Job type must be either '$VALIDATION', '$BUILD', or '$LINT'"
     buildkite-agent step cancel
     exit 15
     ;;

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -25,7 +25,7 @@ steps:
         agents:
           queue: "linter"
 
-      - label: 'Android Lint'
+      - label: 'Lint'
         command: ".buildkite/commands/lint.sh"
         plugins: [$CI_TOOLKIT]
         artifact_paths:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -25,7 +25,7 @@ steps:
         agents:
           queue: "linter"
 
-      - label: 'Lint'
+      - label: 'Android Lint'
         command: ".buildkite/commands/lint.sh"
         plugins: [$CI_TOOLKIT]
         artifact_paths:
@@ -53,6 +53,10 @@ steps:
 
   - label: 'Spotless formatting check'
     command: |
+      if .buildkite/commands/should-skip-job.sh --job-type validation; then
+        exit 0
+      fi
+
       echo "--- 🔎 Checking formatting with Spotless"
       ./gradlew spotlessCheck
     plugins: [$CI_TOOLKIT]

--- a/.buildkite/shared-pipeline-vars
+++ b/.buildkite/shared-pipeline-vars
@@ -3,4 +3,4 @@
 # This file is `source`'d before calling `buildkite-agent pipeline upload`, and can be used
 # to set up some variables that will be interpolated in the `.yml` pipeline before uploading it.
 
-export CI_TOOLKIT="automattic/a8c-ci-toolkit#5.1.3"
+export CI_TOOLKIT="automattic/a8c-ci-toolkit#5.3.1"


### PR DESCRIPTION
Internal reference: paaHJt-7Ss-p2

The main goal of this PR is to optimize the wait time for PRs with minor, non-code related changes, specially the ones related to the release process.

I've updated the original script to cover build, validation and localization jobs:
- `should-skip-job.sh --job-type [build|lint]`: skips if the changes are limited to documentation, tooling, metadata, etc
- `should-skip-job.sh --job-type validation`: same as above, but also skip on localization changes. The idea is that it can be valuable to run things as a Prototype build when localization changes

## Testing
I've created the PR https://github.com/Automattic/pocket-casts-android/pull/4009 to test a few scenarios skipping jobs:
- App version bump: https://buildkite.com/automattic/pocket-casts-android/builds/11842
- ++ Localization update: https://buildkite.com/automattic/pocket-casts-android/builds/11843
- ++ Metadata update: https://buildkite.com/automattic/pocket-casts-android/builds/11844