### PR TITLE
Add Onboarding launch intent

### DIFF
--- a/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
+++ b/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
@@ -519,8 +519,12 @@ class MainActivity :
         }
     }
 
+    override fun launchIntent(onboardingFlow: OnboardingFlow): Intent {
+        return OnboardingActivity.newInstance(this, onboardingFlow)
+    }
+
     override fun openOnboardingFlow(onboardingFlow: OnboardingFlow) {
-        onboardingLauncher.launch(OnboardingActivity.newInstance(this, onboardingFlow))
+        onboardingLauncher.launch(launchIntent(onboardingFlow))
     }
 
     override fun onStart() {

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/PlayerHeaderFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/PlayerHeaderFragment.kt
@@ -498,7 +498,7 @@ class PlayerHeaderFragment : BaseFragment(), PlayerClickListener {
         val onboardingFlow = OnboardingFlow.Upsell(
             source = source,
         )
-        OnboardingLauncher.openOnboardingFlow(activity, onboardingFlow)
+        OnboardingLauncher.openOnboardingFlow(requireActivity(), onboardingFlow)
     }
 
     override fun onClosePlayer() {

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/UpNextAdapter.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/UpNextAdapter.kt
@@ -212,7 +212,10 @@ class UpNextAdapter(
 
                         settings.upNextShuffle.set(newValue, updateModifiedAt = false)
                     } else {
-                        OnboardingLauncher.openOnboardingFlow(root.context.getActivity(), OnboardingFlow.Upsell(OnboardingUpgradeSource.UP_NEXT_SHUFFLE))
+                        OnboardingLauncher.openOnboardingFlow(
+                            requireNotNull(root.context.getActivity()),
+                            OnboardingFlow.Upsell(OnboardingUpgradeSource.UP_NEXT_SHUFFLE),
+                        )
                     }
 
                     shuffle.updateShuffleButton()

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/bookmark/BookmarksFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/bookmark/BookmarksFragment.kt
@@ -247,7 +247,7 @@ class BookmarksFragment : BaseFragment() {
         val onboardingFlow = OnboardingFlow.Upsell(
             source = OnboardingUpgradeSource.BOOKMARKS,
         )
-        OnboardingLauncher.openOnboardingFlow(activity, onboardingFlow)
+        OnboardingLauncher.openOnboardingFlow(requireActivity(), onboardingFlow)
     }
 
     fun onPlayerOpen() {

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/folders/SuggestedFoldersFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/folders/SuggestedFoldersFragment.kt
@@ -187,7 +187,7 @@ class SuggestedFoldersFragment : BaseDialogFragment() {
                 .show(parentFragmentManager, "create_folder_card")
             finalizeAndDismiss()
         } else {
-            OnboardingLauncher.openOnboardingFlow(activity, OnboardingFlow.Upsell(OnboardingUpgradeSource.SUGGESTED_FOLDERS))
+            OnboardingLauncher.openOnboardingFlow(requireActivity(), OnboardingFlow.Upsell(OnboardingUpgradeSource.SUGGESTED_FOLDERS))
         }
     }
 
@@ -205,7 +205,7 @@ class SuggestedFoldersFragment : BaseDialogFragment() {
             }
         } else {
             viewModel.trackUseSuggestedFoldersTapped()
-            OnboardingLauncher.openOnboardingFlow(activity, OnboardingFlow.Upsell(OnboardingUpgradeSource.SUGGESTED_FOLDERS))
+            OnboardingLauncher.openOnboardingFlow(requireActivity(), OnboardingFlow.Upsell(OnboardingUpgradeSource.SUGGESTED_FOLDERS))
         }
     }
 

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastFragment.kt
@@ -556,7 +556,7 @@ class PodcastFragment : BaseFragment() {
             analyticsTracker.track(AnalyticsEvent.PODCAST_SCREEN_FOLDER_TAPPED)
             val isSignedInAsPlusOrPatron = viewModel.signInState.value?.isSignedInAsPlusOrPatron == true
             if (!isSignedInAsPlusOrPatron) {
-                OnboardingLauncher.openOnboardingFlow(activity, OnboardingFlow.Upsell(OnboardingUpgradeSource.FOLDERS_PODCAST_SCREEN))
+                OnboardingLauncher.openOnboardingFlow(requireActivity(), OnboardingFlow.Upsell(OnboardingUpgradeSource.FOLDERS_PODCAST_SCREEN))
                 return@launch
             }
             val folder = viewModel.getFolder()

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/adapter/BookmarkUpsellViewHolder.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/adapter/BookmarkUpsellViewHolder.kt
@@ -36,7 +36,7 @@ class BookmarkUpsellViewHolder(
                         val onboardingFlow = OnboardingFlow.Upsell(
                             source = OnboardingUpgradeSource.BOOKMARKS,
                         )
-                        OnboardingLauncher.openOnboardingFlow(context.getActivity(), onboardingFlow)
+                        OnboardingLauncher.openOnboardingFlow(requireNotNull(context.getActivity()), onboardingFlow)
                     },
                     modifier = Modifier.padding(vertical = 24.dp),
                 )

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcasts/PodcastsFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcasts/PodcastsFragment.kt
@@ -174,7 +174,7 @@ class PodcastsFragment :
                 val state = viewModel.suggestedFoldersState.value
                 when (state) {
                     is SuggestedFoldersState.Empty -> {
-                        OnboardingLauncher.openOnboardingFlow(activity, OnboardingFlow.Upsell(OnboardingUpgradeSource.FOLDERS))
+                        OnboardingLauncher.openOnboardingFlow(requireActivity(), OnboardingFlow.Upsell(OnboardingUpgradeSource.FOLDERS))
                     }
 
                     is SuggestedFoldersState.Available -> {
@@ -182,7 +182,7 @@ class PodcastsFragment :
                     }
                 }
             } else {
-                OnboardingLauncher.openOnboardingFlow(activity, OnboardingFlow.Upsell(OnboardingUpgradeSource.FOLDERS))
+                OnboardingLauncher.openOnboardingFlow(requireActivity(), OnboardingFlow.Upsell(OnboardingUpgradeSource.FOLDERS))
             }
             true
         }

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/AccountDetailsFragment.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/AccountDetailsFragment.kt
@@ -120,7 +120,7 @@ class AccountDetailsFragment : BaseFragment() {
                 analyticsTracker.track(AnalyticsEvent.PLUS_PROMOTION_UPGRADE_BUTTON_TAPPED)
                 val source = OnboardingUpgradeSource.PROFILE
                 val onboardingFlow = OnboardingFlow.PlusAccountUpgrade(source, planKey.tier, planKey.billingCycle)
-                OnboardingLauncher.openOnboardingFlow(activity, onboardingFlow)
+                OnboardingLauncher.openOnboardingFlow(requireActivity(), onboardingFlow)
             },
             onChangeFeatureCard = { planKey ->
                 analyticsTracker.track(AnalyticsEvent.PLUS_PROMOTION_SUBSCRIPTION_TIER_CHANGED, mapOf("value" to planKey.tier.analyticsValue))
@@ -140,7 +140,7 @@ class AccountDetailsFragment : BaseFragment() {
             onUpgradeToPatron = {
                 val source = OnboardingUpgradeSource.ACCOUNT_DETAILS
                 val onboardingFlow = OnboardingFlow.PatronAccountUpgrade(source)
-                OnboardingLauncher.openOnboardingFlow(activity, onboardingFlow)
+                OnboardingLauncher.openOnboardingFlow(requireActivity(), onboardingFlow)
             },
             onCancelSubscription = { winbackParams ->
                 analyticsTracker.track(AnalyticsEvent.ACCOUNT_DETAILS_CANCEL_TAPPED)

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/cloud/AddFileActivity.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/cloud/AddFileActivity.kt
@@ -323,12 +323,16 @@ class AddFileActivity :
         openOnboardingFlow(OnboardingFlow.Upsell(OnboardingUpgradeSource.FILES))
     }
 
+    override fun launchIntent(onboardingFlow: OnboardingFlow): Intent {
+        return OnboardingActivity.newInstance(this, onboardingFlow)
+    }
+
     override fun openOnboardingFlow(onboardingFlow: OnboardingFlow) {
         // Just starting the activity without registering for a result because
         // we don't need the result since we don't want to break the user's flow
         // by sending them back to the Discover screen with an
         // OnboardingFinish.DoneGoToDiscover result.
-        startActivity(OnboardingActivity.newInstance(this, onboardingFlow))
+        startActivity(launchIntent(onboardingFlow))
     }
 
     @UnstableApi

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/cloud/CloudFileBottomSheetFragment.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/cloud/CloudFileBottomSheetFragment.kt
@@ -296,7 +296,7 @@ class CloudFileBottomSheetFragment : BottomSheetDialogFragment() {
                 binding.layoutLockedCloud.setOnClickListener {
                     viewModel.trackOptionTapped(UPLOAD_UPGRADE_REQUIRED)
                     OnboardingLauncher.openOnboardingFlow(
-                        activity,
+                        requireActivity(),
                         OnboardingFlow.Upsell(OnboardingUpgradeSource.FILES),
                     )
                 }

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/cloud/CloudSettingsFragment.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/cloud/CloudSettingsFragment.kt
@@ -147,7 +147,7 @@ class CloudSettingsFragment : BaseFragment() {
 
     private fun openUpgradeSheet() {
         OnboardingLauncher.openOnboardingFlow(
-            activity,
+            requireActivity(),
             OnboardingFlow.Upsell(OnboardingUpgradeSource.FILES),
         )
     }

--- a/modules/features/referrals/src/main/kotlin/au/com/shiftyjelly/pocketcasts/referrals/ReferralsClaimGuestPassPage.kt
+++ b/modules/features/referrals/src/main/kotlin/au/com/shiftyjelly/pocketcasts/referrals/ReferralsClaimGuestPassPage.kt
@@ -114,22 +114,20 @@ fun ReferralsClaimGuestPassPage(
                     }
 
                     NavigationEvent.LoginOrSignup -> openOnboardingFlow(
-                        activity = activity,
+                        activity = requireNotNull(activity),
                         onboardingFlow = OnboardingFlow.ReferralLoginOrSignUp,
                     )
 
                     is NavigationEvent.LaunchBillingFlow -> {
-                        activity?.let {
-                            viewModel.launchBillingFlow(
-                                activity = activity,
-                                referralPlan = navigationEvent.plan,
-                            )
-                        }
+                        viewModel.launchBillingFlow(
+                            activity = requireNotNull(activity),
+                            referralPlan = navigationEvent.plan,
+                        )
                     }
 
                     NavigationEvent.Close -> { onDismiss() }
                     NavigationEvent.Welcome -> openOnboardingFlow(
-                        activity = activity,
+                        activity = requireNotNull(activity),
                         onboardingFlow = OnboardingFlow.Welcome,
                     )
                 }

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/AppearanceSettingsFragment.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/AppearanceSettingsFragment.kt
@@ -246,7 +246,7 @@ class AppearanceSettingsFragment : BaseFragment() {
         val onboardingFlow = tier?.takeIf { tier == SubscriptionTier.Patron }?.let {
             OnboardingFlow.Upsell(source = source)
         } ?: OnboardingFlow.Upsell(source)
-        OnboardingLauncher.openOnboardingFlow(activity, onboardingFlow)
+        OnboardingLauncher.openOnboardingFlow(requireActivity(), onboardingFlow)
     }
 
     private fun scrollToCurrentTheme() {

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/HeadphoneControlsSettingsFragment.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/HeadphoneControlsSettingsFragment.kt
@@ -281,7 +281,7 @@ class HeadphoneControlsSettingsFragment : BaseFragment() {
         val onboardingFlow = OnboardingFlow.Upsell(
             source = OnboardingUpgradeSource.HEADPHONE_CONTROLS_SETTINGS,
         )
-        OnboardingLauncher.openOnboardingFlow(activity, onboardingFlow)
+        OnboardingLauncher.openOnboardingFlow(requireActivity(), onboardingFlow)
     }
 
     @StringRes

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/SettingsFragmentPage.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/SettingsFragmentPage.kt
@@ -80,7 +80,7 @@ fun SettingsFragmentPage(
                 item {
                     PlusRow(onClick = {
                         OnboardingLauncher.openOnboardingFlow(
-                            context.getActivity(),
+                            requireNotNull(context.getActivity()),
                             OnboardingFlow.Upsell(
                                 OnboardingUpgradeSource.SETTINGS,
                             ),

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/onboarding/OnboardingLauncher.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/onboarding/OnboardingLauncher.kt
@@ -1,17 +1,26 @@
 package au.com.shiftyjelly.pocketcasts.settings.onboarding
 
 import android.app.Activity
+import android.content.Intent
 
 interface OnboardingLauncher {
+    fun launchIntent(onboardingFlow: OnboardingFlow): Intent
+
     fun openOnboardingFlow(onboardingFlow: OnboardingFlow)
 
     companion object {
-        fun openOnboardingFlow(activity: Activity?, onboardingFlow: OnboardingFlow) {
-            if (activity is OnboardingLauncher) {
-                (activity as OnboardingLauncher).openOnboardingFlow(onboardingFlow)
-            } else {
-                throw IllegalStateException("Unable to launch onboarding flow because the activity is not an ${OnboardingLauncher::class.simpleName}")
+        fun launchIntent(activity: Activity, onboardingFlow: OnboardingFlow): Intent {
+            require(activity is OnboardingLauncher) {
+                "Unable to launch onboarding flow because the activity is not an ${OnboardingLauncher::class.simpleName}"
             }
+            return activity.launchIntent(onboardingFlow)
+        }
+
+        fun openOnboardingFlow(activity: Activity, onboardingFlow: OnboardingFlow) {
+            require(activity is OnboardingLauncher) {
+                "Unable to launch onboarding flow because the activity is not an ${OnboardingLauncher::class.simpleName}"
+            }
+            activity.openOnboardingFlow(onboardingFlow)
         }
     }
 }

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/whatsnew/WhatsNewFragment.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/whatsnew/WhatsNewFragment.kt
@@ -97,7 +97,7 @@ class WhatsNewFragment : BaseFragment() {
         val onboardingFlow = OnboardingFlow.Upsell(
             source = source,
         )
-        OnboardingLauncher.openOnboardingFlow(activity, onboardingFlow)
+        OnboardingLauncher.openOnboardingFlow(requireActivity(), onboardingFlow)
     }
 
     companion object {


### PR DESCRIPTION
## Description

While working on streamlining Smart Folders after Onboarding I had to launch the Onboarding for result from a fragment. However, we don't have any APIs to do that. While closing #3967 requires more work I wanted to add this change to minimize future PR.

## Testing Instructions

Smoke test creating an account.

## Checklist
- [ ] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] ~I have considered whether it makes sense to add tests for my changes~
- [ ] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [ ] ~Any jetpack compose components I added or changed are covered by compose previews~
- [ ] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~