### PR TITLE
Fix upselling to paid accounts

### DIFF
--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/AccountFragment.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/AccountFragment.kt
@@ -91,7 +91,7 @@ class AccountFragment : BaseFragment() {
                         flow = null,
                         fontSize = dimensionResource(CR.dimen.car_body2_size).value.sp,
                         includePadding = false,
-                        onComplete = { activity?.finish() },
+                        onComplete = { _, _ -> activity?.finish() },
                     )
                 }
             }

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/OnboardingFlowComposable.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/OnboardingFlowComposable.kt
@@ -24,6 +24,7 @@ import au.com.shiftyjelly.pocketcasts.compose.AppThemeWithBackground
 import au.com.shiftyjelly.pocketcasts.compose.CallOnce
 import au.com.shiftyjelly.pocketcasts.compose.bars.SystemBarsStyles
 import au.com.shiftyjelly.pocketcasts.models.type.SignInState
+import au.com.shiftyjelly.pocketcasts.models.type.Subscription
 import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingExitInfo
 import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingFlow
 import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingUpgradeSource
@@ -217,11 +218,11 @@ private fun Content(
                 },
                 onSignUpClicked = { navController.navigate(OnboardingNavRoute.createFreeAccount) },
                 onLoginClicked = { navController.navigate(OnboardingNavRoute.logIn) },
-                onContinueWithGoogleComplete = { state ->
+                onContinueWithGoogleComplete = { state, subscription ->
                     if (state.isNewAccount) {
                         onAccountCreated()
                     } else {
-                        onLoginToExistingAccount(flow, exitOnboarding, navController)
+                        onLoginToExistingAccount(flow, subscription, exitOnboarding, navController)
                     }
                 },
                 onUpdateSystemBars = onUpdateSystemBars,
@@ -241,8 +242,8 @@ private fun Content(
             OnboardingLoginPage(
                 theme = theme,
                 onBackPressed = { navController.popBackStack() },
-                onLoginComplete = {
-                    onLoginToExistingAccount(flow, exitOnboarding, navController)
+                onLoginComplete = { subscription ->
+                    onLoginToExistingAccount(flow, subscription, exitOnboarding, navController)
                 },
                 onForgotPasswordTapped = { navController.navigate(OnboardingNavRoute.forgotPassword) },
                 onUpdateSystemBars = onUpdateSystemBars,
@@ -366,6 +367,7 @@ private fun Content(
 
 private fun onLoginToExistingAccount(
     flow: OnboardingFlow,
+    subscription: Subscription?,
     exitOnboarding: (OnboardingExitInfo) -> Unit,
     navController: NavHostController,
 ) {
@@ -385,9 +387,15 @@ private fun onLoginToExistingAccount(
         is OnboardingFlow.PatronAccountUpgrade,
         is OnboardingFlow.PlusAccountUpgradeNeedsLogin,
         is OnboardingFlow.Upsell,
-        -> navController.navigate(OnboardingNavRoute.PlusUpgrade.routeWithSource(OnboardingUpgradeSource.LOGIN)) {
-            // clear backstack after successful login
-            popUpTo(OnboardingNavRoute.logInOrSignUp) { inclusive = true }
+        -> {
+            if (subscription == null) {
+                navController.navigate(OnboardingNavRoute.PlusUpgrade.routeWithSource(OnboardingUpgradeSource.LOGIN)) {
+                    // clear backstack after successful login
+                    popUpTo(OnboardingNavRoute.logInOrSignUp) { inclusive = true }
+                }
+            } else {
+                exitOnboarding(OnboardingExitInfo())
+            }
         }
     }
 }

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/OnboardingLoginOrSignUpPage.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/OnboardingLoginOrSignUpPage.kt
@@ -63,6 +63,7 @@ import au.com.shiftyjelly.pocketcasts.compose.images.HorizontalLogo
 import au.com.shiftyjelly.pocketcasts.compose.preview.ThemePreviewParameterProvider
 import au.com.shiftyjelly.pocketcasts.compose.theme
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
+import au.com.shiftyjelly.pocketcasts.models.type.Subscription
 import au.com.shiftyjelly.pocketcasts.settings.consent.TrackingConsentDialog
 import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingFlow
 import au.com.shiftyjelly.pocketcasts.ui.extensions.inLandscape
@@ -78,7 +79,7 @@ internal fun OnboardingLoginOrSignUpPage(
     onDismiss: () -> Unit,
     onSignUpClicked: () -> Unit,
     onLoginClicked: () -> Unit,
-    onContinueWithGoogleComplete: (GoogleSignInState) -> Unit,
+    onContinueWithGoogleComplete: (GoogleSignInState, Subscription?) -> Unit,
     onUpdateSystemBars: (SystemBarsStyles) -> Unit,
     viewModel: OnboardingLoginOrSignUpViewModel = hiltViewModel(),
 ) {
@@ -134,7 +135,7 @@ private fun Content(
     onNavigationClick: () -> Unit,
     onSignUpClicked: () -> Unit,
     onLoginClicked: () -> Unit,
-    onContinueWithGoogleComplete: (GoogleSignInState) -> Unit,
+    onContinueWithGoogleComplete: (GoogleSignInState, Subscription?) -> Unit,
     onUpdateTrackingConsent: (Boolean) -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -348,7 +349,7 @@ private fun OnboardingLoginOrSignUpPagePreview(@PreviewParameter(ThemePreviewPar
             onDismiss = {},
             onSignUpClicked = {},
             onLoginClicked = {},
-            onContinueWithGoogleComplete = {},
+            onContinueWithGoogleComplete = { _, _ -> },
             onUpdateSystemBars = {},
         )
     }

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/OnboardingLoginPage.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/OnboardingLoginPage.kt
@@ -42,6 +42,7 @@ import au.com.shiftyjelly.pocketcasts.compose.components.TextH40
 import au.com.shiftyjelly.pocketcasts.compose.components.TextP40
 import au.com.shiftyjelly.pocketcasts.compose.preview.ThemePreviewParameterProvider
 import au.com.shiftyjelly.pocketcasts.compose.theme
+import au.com.shiftyjelly.pocketcasts.models.type.Subscription
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import au.com.shiftyjelly.pocketcasts.views.helper.UiUtil
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
@@ -50,7 +51,7 @@ import au.com.shiftyjelly.pocketcasts.localization.R as LR
 internal fun OnboardingLoginPage(
     theme: Theme.ThemeType,
     onBackPressed: () -> Unit,
-    onLoginComplete: () -> Unit,
+    onLoginComplete: (Subscription?) -> Unit,
     onForgotPasswordTapped: () -> Unit,
     onUpdateSystemBars: (SystemBarsStyles) -> Unit,
 ) {
@@ -77,9 +78,9 @@ internal fun OnboardingLoginPage(
     val view = LocalView.current
 
     @Suppress("NAME_SHADOWING")
-    val onLoginComplete = {
+    val onLoginComplete = { subscription: Subscription? ->
         UiUtil.hideKeyboard(view)
-        onLoginComplete()
+        onLoginComplete(subscription)
     }
 
     Column(

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/components/ContinueWithGoogleButton.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/components/ContinueWithGoogleButton.kt
@@ -17,6 +17,7 @@ import au.com.shiftyjelly.pocketcasts.account.viewmodel.GoogleSignInButtonViewMo
 import au.com.shiftyjelly.pocketcasts.account.viewmodel.GoogleSignInState
 import au.com.shiftyjelly.pocketcasts.compose.buttons.RowOutlinedButton
 import au.com.shiftyjelly.pocketcasts.compose.theme
+import au.com.shiftyjelly.pocketcasts.models.type.Subscription
 import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingFlow
 import au.com.shiftyjelly.pocketcasts.utils.Network
 import au.com.shiftyjelly.pocketcasts.images.R as IR
@@ -31,7 +32,7 @@ fun ContinueWithGoogleButton(
     flow: OnboardingFlow?,
     fontSize: TextUnit? = null,
     includePadding: Boolean = true,
-    onComplete: (GoogleSignInState) -> Unit,
+    onComplete: (GoogleSignInState, Subscription?) -> Unit,
 ) {
     val viewModel = hiltViewModel<GoogleSignInButtonViewModel>()
     val context = LocalContext.current

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/OnboardingLogInViewModel.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/OnboardingLogInViewModel.kt
@@ -7,6 +7,7 @@ import androidx.lifecycle.viewModelScope
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTracker
 import au.com.shiftyjelly.pocketcasts.analytics.experiments.ExperimentProvider
+import au.com.shiftyjelly.pocketcasts.models.type.Subscription
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
 import au.com.shiftyjelly.pocketcasts.repositories.subscription.SubscriptionManager
 import au.com.shiftyjelly.pocketcasts.repositories.sync.LoginResult
@@ -53,7 +54,7 @@ class OnboardingLogInViewModel @Inject constructor(
         _state.update { it.copy(password = password) }
     }
 
-    fun logIn(onSuccessfulLogin: () -> Unit) {
+    fun logIn(onSuccessfulLogin: (Subscription?) -> Unit) {
         _state.update { it.copy(hasAttemptedLogIn = true, isNetworkAvailable = Network.isConnected(getApplication())) }
 
         val state = state.value
@@ -80,7 +81,7 @@ class OnboardingLogInViewModel @Inject constructor(
                 is LoginResult.Success -> {
                     podcastManager.refreshPodcastsAfterSignIn()
                     experiments.refreshExperiments()
-                    onSuccessfulLogin()
+                    onSuccessfulLogin(subscriptionManager.fetchFreshSubscription())
                 }
 
                 is LoginResult.Failed -> {


### PR DESCRIPTION
## Description

When signing it to a paid account during the upsell flow we redirected users back to the plans screen instead of finishing the flow.

## Testing Instructions

1. Apply the patch from below.
```
curl -L https://github.com/user-attachments/files/20201283/debug-as-prod.patch | git apply
```
2. Install the app.
3. Open the app but don't sign in.
4. Go to the podcasts screen.
5. Tap on the folder icon.
6. During the onboarding flow sign in with a paid account.
7. After you sign in you should not see the subscription plans paywall.
8. Sign out.
9. Go to the podcasts screen.
10. Tap on the folder icon.
11. During the onboarding flow sign in with a free account.
12. After you sign in you should see the subscription plans paywall.

## Screenshots or Screencast 

https://github.com/user-attachments/assets/e28de879-7b1b-4218-86a4-bba0bdb0ab4b

## Checklist
- [ ] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] ~I have considered whether it makes sense to add tests for my changes~
- [ ] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [ ] ~Any jetpack compose components I added or changed are covered by compose previews~
- [ ] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~