### PR TITLE
Podcast UI tweaks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 -----
 *   Updates
     *   Add dropshadow to the podcast artwork and move it below toolbar.
-        ([#3800](https://github.com/Automattic/pocket-casts-android/pull/3800))
+        ([#4006](https://github.com/Automattic/pocket-casts-android/pull/4006))
 
 7.89
 -----

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 7.90
 -----
-
+*   Updates
+    *   Add dropshadow to the podcast artwork and move it below toolbar.
+        ([#3800](https://github.com/Automattic/pocket-casts-android/pull/3800))
 
 7.89
 -----

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastAdapter.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastAdapter.kt
@@ -826,7 +826,7 @@ class PodcastAdapter(
                         isHeaderExpanded = podcast.isHeaderExpanded,
                         isDescriptionExpanded = isDescriptionExpanded,
                         contentPadding = PaddingValues(
-                            top = statusBarPadding + 40.dp, // Eyeball the position inside app bar
+                            top = statusBarPadding + 56.dp, // Eyeball the position below app bar
                             start = 16.dp,
                             end = 16.dp,
                             bottom = 16.dp,

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastHeader.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastHeader.kt
@@ -177,6 +177,7 @@ internal fun PodcastHeader(
             PodcastImage(
                 uuid = uuid,
                 cornerSize = 8.dp,
+                elevation = 16.dp,
                 modifier = Modifier
                     .size(coverSize)
                     .combinedClickable(


### PR DESCRIPTION
## Description

Small changes to the podcast page.

See: p1747286334037309-slack-C08DPN79CN8

## Testing Instructions

1. Open any podcast.
2. Verify that there is larger elevation of the podcast image.
3. Verify that the podcast image is below toolbar.

## Screenshots or Screencast 

| Before | After |
| - | - |
| ![Screenshot_20250515-122936](https://github.com/user-attachments/assets/3fa93842-c57d-41c5-a569-ee8dcaf262aa) | ![a](https://github.com/user-attachments/assets/a5aa0ee6-f716-4476-99b7-383f227680b3) |

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] ~I have considered whether it makes sense to add tests for my changes~
- [ ] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [ ] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~