### PR TITLE
Centralize purchase tracking

### DIFF
--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/winback/WinbackViewModel.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/winback/WinbackViewModel.kt
@@ -100,7 +100,7 @@ class WinbackViewModel @Inject constructor(
             _uiState.value = _uiState.value.withLoadedSubscriptionPlans { plans ->
                 plans.copy(isChangingPlan = true)
             }
-            when (paymentClient.purchaseSubscriptionPlan(newPlan.key, activity)) {
+            when (paymentClient.purchaseSubscriptionPlan(newPlan.key, purchaseSource = "winback", activity)) {
                 is PurchaseResult.Cancelled -> {
                     _uiState.value = _uiState.value.withLoadedSubscriptionPlans { plans ->
                         plans.copy(isChangingPlan = false)
@@ -173,7 +173,7 @@ class WinbackViewModel @Inject constructor(
                 loadedState.currentSubscription.billingCycle,
                 SubscriptionOffer.Winback,
             )
-            when (paymentClient.purchaseSubscriptionPlan(newPlanKey, activity)) {
+            when (paymentClient.purchaseSubscriptionPlan(newPlanKey, purchaseSource = "winback", activity)) {
                 is PurchaseResult.Purchased -> {
                     referralManager.redeemReferralCode(winbackState.offer.redeemCode)
                     _uiState.value = _uiState.value.withOfferState { state ->

--- a/modules/features/referrals/src/main/kotlin/au/com/shiftyjelly/pocketcasts/referrals/ReferralsClaimGuestPassViewModel.kt
+++ b/modules/features/referrals/src/main/kotlin/au/com/shiftyjelly/pocketcasts/referrals/ReferralsClaimGuestPassViewModel.kt
@@ -120,7 +120,7 @@ class ReferralsClaimGuestPassViewModel @Inject constructor(
     ) {
         analyticsTracker.track(AnalyticsEvent.REFERRAL_PURCHASE_SHOWN)
         viewModelScope.launch {
-            val purchaseResult = paymentClient.purchaseSubscriptionPlan(referralPlan.key, activity)
+            val purchaseResult = paymentClient.purchaseSubscriptionPlan(referralPlan.key, purchaseSource = "referrals", activity)
             when (purchaseResult) {
                 PurchaseResult.Purchased -> {
                     analyticsTracker.track(AnalyticsEvent.REFERRAL_PURCHASE_SUCCESS)

--- a/modules/services/payment/src/main/kotlin/au/com/shiftyjelly/pocketcasts/payment/PaymentClient.kt
+++ b/modules/services/payment/src/main/kotlin/au/com/shiftyjelly/pocketcasts/payment/PaymentClient.kt
@@ -40,6 +40,7 @@ class PaymentClient @Inject constructor(
 
     suspend fun purchaseSubscriptionPlan(
         key: SubscriptionPlan.Key,
+        purchaseSource: String,
         activity: Activity,
     ): PurchaseResult = coroutineScope {
         forEachListener { onPurchaseSubscriptionPlan(key) }
@@ -58,7 +59,7 @@ class PaymentClient @Inject constructor(
             }
         }
         purchaseUpdatesJob.cancelAndJoin()
-        forEachListener { onSubscriptionPurchased(key, purchaseResult) }
+        forEachListener { onSubscriptionPurchased(key, purchaseSource, purchaseResult) }
         purchaseResult
     }
 
@@ -172,7 +173,7 @@ class PaymentClient @Inject constructor(
 
         fun onPurchaseSubscriptionPlan(key: SubscriptionPlan.Key) = Unit
 
-        fun onSubscriptionPurchased(key: SubscriptionPlan.Key, result: PurchaseResult) = Unit
+        fun onSubscriptionPurchased(key: SubscriptionPlan.Key, purchaseSource: String, result: PurchaseResult) = Unit
 
         fun onConfirmPurchase(purchase: Purchase) = Unit
 

--- a/modules/services/payment/src/test/kotlin/au/com/shiftyjelly/pocketcasts/payment/PaymentClientTest.kt
+++ b/modules/services/payment/src/test/kotlin/au/com/shiftyjelly/pocketcasts/payment/PaymentClientTest.kt
@@ -179,7 +179,7 @@ class PaymentClientTest {
 
     @Test
     fun `purchase subscription`() = runTest {
-        val purchaseResult = client.purchaseSubscriptionPlan(planKey, mock<Activity>())
+        val purchaseResult = client.purchaseSubscriptionPlan(planKey)
 
         assertEquals(PurchaseResult.Purchased, purchaseResult)
     }
@@ -188,7 +188,7 @@ class PaymentClientTest {
     fun `do not purchase subscription when billing result is failure`() = runTest {
         dataSource.billingFlowResultCode = PaymentResultCode.FeatureNotSupported
 
-        val purchaseResult = client.purchaseSubscriptionPlan(planKey, mock<Activity>())
+        val purchaseResult = client.purchaseSubscriptionPlan(planKey)
 
         assertEquals(PurchaseResult.Failure(PaymentResultCode.FeatureNotSupported), purchaseResult)
     }
@@ -197,7 +197,7 @@ class PaymentClientTest {
     fun `do not purchase subscription when purchase result is failure`() = runTest {
         dataSource.purchasedProductsResultCode = PaymentResultCode.Error
 
-        val purchaseResult = client.purchaseSubscriptionPlan(planKey, mock<Activity>())
+        val purchaseResult = client.purchaseSubscriptionPlan(planKey)
 
         assertEquals(PurchaseResult.Failure(PaymentResultCode.Error), purchaseResult)
     }
@@ -206,7 +206,7 @@ class PaymentClientTest {
     fun `cancel purchase subscription when purchase result is cancelled`() = runTest {
         dataSource.purchasedProductsResultCode = PaymentResultCode.UserCancelled
 
-        val purchaseResult = client.purchaseSubscriptionPlan(planKey, mock<Activity>())
+        val purchaseResult = client.purchaseSubscriptionPlan(planKey)
 
         assertEquals(PurchaseResult.Cancelled, purchaseResult)
     }
@@ -215,7 +215,7 @@ class PaymentClientTest {
     fun `do not purchase subscription when approving fails`() = runTest {
         approver.approveResultCode = PaymentResultCode.Error
 
-        val purchaseResult = client.purchaseSubscriptionPlan(planKey, mock<Activity>())
+        val purchaseResult = client.purchaseSubscriptionPlan(planKey)
 
         assertEquals(PurchaseResult.Failure(PaymentResultCode.Error), purchaseResult)
     }
@@ -224,7 +224,7 @@ class PaymentClientTest {
     fun `do not purchase subscription when acknowledging fails`() = runTest {
         dataSource.acknowledgePurchaseResultCode = PaymentResultCode.Error
 
-        val purchaseResult = client.purchaseSubscriptionPlan(planKey, mock<Activity>())
+        val purchaseResult = client.purchaseSubscriptionPlan(planKey)
 
         assertEquals(PurchaseResult.Failure(PaymentResultCode.Error), purchaseResult)
     }
@@ -233,7 +233,7 @@ class PaymentClientTest {
     fun `cancel purchase subscription when acknowledging is cancelled`() = runTest {
         dataSource.acknowledgePurchaseResultCode = PaymentResultCode.UserCancelled
 
-        val purchaseResult = client.purchaseSubscriptionPlan(planKey, mock<Activity>())
+        val purchaseResult = client.purchaseSubscriptionPlan(planKey)
 
         assertEquals(PurchaseResult.Cancelled, purchaseResult)
     }
@@ -244,7 +244,7 @@ class PaymentClientTest {
             purchase.copy(state = PurchaseState.Pending),
         )
 
-        val purchaseResult = backgroundScope.async { client.purchaseSubscriptionPlan(planKey, mock<Activity>()) }
+        val purchaseResult = backgroundScope.async { client.purchaseSubscriptionPlan(planKey) }
         yield() // Yield to make sure the job didn't cancel
 
         assertTrue(purchaseResult.isActive)
@@ -257,7 +257,7 @@ class PaymentClientTest {
             purchase.copy(isAcknowledged = true),
         )
 
-        val purchaseResult = client.purchaseSubscriptionPlan(planKey, mock<Activity>())
+        val purchaseResult = client.purchaseSubscriptionPlan(planKey)
 
         assertTrue(dataSource.receivedPurchases.isEmpty())
         assertEquals(PurchaseResult.Purchased, purchaseResult)
@@ -363,7 +363,7 @@ class PaymentClientTest {
 
     @Test
     fun `dispatch purchase result success`() = runTest {
-        client.purchaseSubscriptionPlan(planKey, mock<Activity>())
+        client.purchaseSubscriptionPlan(planKey)
 
         listener.assertEvents(
             Event.PurchaseSubscriptionPlan,
@@ -377,7 +377,7 @@ class PaymentClientTest {
     fun `dispatch purchase result cancellation`() = runTest {
         dataSource.purchasedProductsResultCode = PaymentResultCode.UserCancelled
 
-        client.purchaseSubscriptionPlan(planKey, mock<Activity>())
+        client.purchaseSubscriptionPlan(planKey)
 
         listener.assertEvents(
             Event.PurchaseSubscriptionPlan,
@@ -389,7 +389,7 @@ class PaymentClientTest {
     fun `dispatch purchase result failure`() = runTest {
         dataSource.purchasedProductsResultCode = PaymentResultCode.ServiceDisconnected
 
-        client.purchaseSubscriptionPlan(planKey, mock<Activity>())
+        client.purchaseSubscriptionPlan(planKey)
 
         listener.assertEvents(
             Event.PurchaseSubscriptionPlan,
@@ -401,7 +401,7 @@ class PaymentClientTest {
     fun `dispatch billing result failure`() = runTest {
         dataSource.billingFlowResultCode = PaymentResultCode.DeveloperError
 
-        client.purchaseSubscriptionPlan(planKey, mock<Activity>())
+        client.purchaseSubscriptionPlan(planKey)
 
         listener.assertEvents(
             Event.PurchaseSubscriptionPlan,
@@ -413,7 +413,7 @@ class PaymentClientTest {
     fun `dispatch confirm pruchase result failure`() = runTest {
         approver.approveResultCode = PaymentResultCode.DeveloperError
 
-        client.purchaseSubscriptionPlan(planKey, mock<Activity>())
+        client.purchaseSubscriptionPlan(planKey)
 
         listener.assertEvents(
             Event.PurchaseSubscriptionPlan,
@@ -421,5 +421,9 @@ class PaymentClientTest {
             Event.ConfirmPurchaseFailure,
             Event.PurchaseSubscriptionPlanFailure,
         )
+    }
+
+    private suspend fun PaymentClient.purchaseSubscriptionPlan(key: SubscriptionPlan.Key): PurchaseResult {
+        return purchaseSubscriptionPlan(key, purchaseSource = "source", mock<Activity>())
     }
 }

--- a/modules/services/payment/src/test/kotlin/au/com/shiftyjelly/pocketcasts/payment/TestListener.kt
+++ b/modules/services/payment/src/test/kotlin/au/com/shiftyjelly/pocketcasts/payment/TestListener.kt
@@ -32,7 +32,7 @@ class TestListener : PaymentClient.Listener {
         events += Event.PurchaseSubscriptionPlan
     }
 
-    override fun onSubscriptionPurchased(key: SubscriptionPlan.Key, result: PurchaseResult) {
+    override fun onSubscriptionPurchased(key: SubscriptionPlan.Key, purchaseSource: String, result: PurchaseResult) {
         events += when (result) {
             is PurchaseResult.Purchased -> Event.PurchaseSubscriptionPlanSuccess
             is PurchaseResult.Cancelled -> Event.PurchaseSubscriptionPlanCancelled

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/di/RepositoryProviderModule.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/di/RepositoryProviderModule.kt
@@ -3,10 +3,12 @@ package au.com.shiftyjelly.pocketcasts.repositories.di
 import android.content.Context
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.ProcessLifecycleOwner
+import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTracker
 import au.com.shiftyjelly.pocketcasts.crashlogging.di.ProvideApplicationScope
 import au.com.shiftyjelly.pocketcasts.payment.PaymentClient
 import au.com.shiftyjelly.pocketcasts.payment.PaymentDataSource
 import au.com.shiftyjelly.pocketcasts.repositories.lists.ListRepository
+import au.com.shiftyjelly.pocketcasts.repositories.payment.AnalyticsPaymentListener
 import au.com.shiftyjelly.pocketcasts.repositories.payment.LoggingPaymentListener
 import au.com.shiftyjelly.pocketcasts.repositories.sync.SyncAccountManager
 import au.com.shiftyjelly.pocketcasts.repositories.sync.SyncManager
@@ -52,6 +54,12 @@ class RepositoryProviderModule {
     @IntoSet
     fun provideLoggingListener(): PaymentClient.Listener {
         return LoggingPaymentListener()
+    }
+
+    @Provides
+    @IntoSet
+    fun provideAnalyticsListener(tracker: AnalyticsTracker): PaymentClient.Listener {
+        return AnalyticsPaymentListener(tracker)
     }
 
     @Provides

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/payment/AnalyticsPaymentListener.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/payment/AnalyticsPaymentListener.kt
@@ -1,0 +1,44 @@
+package au.com.shiftyjelly.pocketcasts.repositories.payment
+
+import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
+import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTracker
+import au.com.shiftyjelly.pocketcasts.payment.PaymentClient
+import au.com.shiftyjelly.pocketcasts.payment.PaymentResultCode
+import au.com.shiftyjelly.pocketcasts.payment.PurchaseResult
+import au.com.shiftyjelly.pocketcasts.payment.SubscriptionPlan
+
+internal class AnalyticsPaymentListener(
+    private val tracker: AnalyticsTracker,
+) : PaymentClient.Listener {
+    override fun onSubscriptionPurchased(key: SubscriptionPlan.Key, purchaseSource: String, result: PurchaseResult) {
+        val baseProperties = mutableMapOf(
+            "tier" to key.tier.analyticsValue,
+            "frequency" to key.billingCycle.analyticsValue,
+            "offer_type" to (key.offer?.analyticsValue ?: "none"),
+            "source" to "",
+        )
+        val (event, properties) = when (result) {
+            is PurchaseResult.Purchased -> {
+                AnalyticsEvent.PURCHASE_SUCCESSFUL to baseProperties
+            }
+
+            is PurchaseResult.Cancelled -> {
+                val properties = baseProperties + PaymentResultCode.UserCancelled.analyticProperties()
+                AnalyticsEvent.PURCHASE_CANCELLED to baseProperties + properties
+            }
+
+            is PurchaseResult.Failure -> {
+                val properties = baseProperties + result.code.analyticProperties()
+                AnalyticsEvent.PURCHASE_FAILED to properties
+            }
+        }
+        tracker.track(event, properties)
+    }
+
+    private fun PaymentResultCode.analyticProperties() = buildMap {
+        put("error", analyticsValue)
+        if (this@analyticProperties is PaymentResultCode.Unknown) {
+            put("error_code", code)
+        }
+    }
+}

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/payment/AnalyticsPaymentListener.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/payment/AnalyticsPaymentListener.kt
@@ -15,7 +15,7 @@ internal class AnalyticsPaymentListener(
             "tier" to key.tier.analyticsValue,
             "frequency" to key.billingCycle.analyticsValue,
             "offer_type" to (key.offer?.analyticsValue ?: "none"),
-            "source" to "",
+            "source" to purchaseSource,
         )
         val (event, properties) = when (result) {
             is PurchaseResult.Purchased -> {

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/payment/LoggingPaymentListener.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/payment/LoggingPaymentListener.kt
@@ -38,7 +38,7 @@ internal class LoggingPaymentListener : PaymentClient.Listener {
         log("Purchasing subscrition plan: $key")
     }
 
-    override fun onSubscriptionPurchased(key: SubscriptionPlan.Key, result: PurchaseResult) {
+    override fun onSubscriptionPurchased(key: SubscriptionPlan.Key, purchaseSource: String, result: PurchaseResult) {
         val message = when (result) {
             is PurchaseResult.Purchased -> "Purchased subscription plan: $key"
             is PurchaseResult.Cancelled -> "Cancelled subscription plan purchase: $key"

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/payment/AnalyticsPaymentListenerTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/payment/AnalyticsPaymentListenerTest.kt
@@ -1,0 +1,116 @@
+package au.com.shiftyjelly.pocketcasts.repositories.payment
+
+import android.app.Activity
+import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
+import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTracker
+import au.com.shiftyjelly.pocketcasts.analytics.Tracker
+import au.com.shiftyjelly.pocketcasts.analytics.TrackerType
+import au.com.shiftyjelly.pocketcasts.payment.FakePaymentDataSource
+import au.com.shiftyjelly.pocketcasts.payment.PaymentClient
+import au.com.shiftyjelly.pocketcasts.payment.PaymentResultCode
+import au.com.shiftyjelly.pocketcasts.payment.SubscriptionOffer
+import au.com.shiftyjelly.pocketcasts.payment.SubscriptionPlan
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.mockito.kotlin.mock
+
+class AnalyticsPaymentListenerTest {
+    private val tracker = TestTracker()
+
+    private val dataSource = FakePaymentDataSource()
+    private val paymentClient = PaymentClient.test(
+        dataSource,
+        AnalyticsPaymentListener(AnalyticsTracker.test(tracker, isFirstPartyEnabled = true)),
+    )
+
+    @Test
+    fun `successfull purchase`() = runTest {
+        val key = SubscriptionPlan.PlusYearlyPreview.key
+
+        paymentClient.purchaseSubscriptionPlan(key, "purchase_source", mock<Activity>())
+
+        val event = tracker.events.first()
+        event.assertType(AnalyticsEvent.PURCHASE_SUCCESSFUL)
+        event.assertProperties(
+            mapOf(
+                "tier" to "plus",
+                "frequency" to "yearly",
+                "offer_type" to "none",
+                "source" to "purchase_source",
+            ),
+        )
+    }
+
+    @Test
+    fun `cancelled purchase`() = runTest {
+        val key = SubscriptionPlan.PatronMonthlyPreview.key.copy(offer = SubscriptionOffer.Referral)
+
+        dataSource.purchasedProductsResultCode = PaymentResultCode.UserCancelled
+        paymentClient.purchaseSubscriptionPlan(key, "purchase_source", mock<Activity>())
+
+        val event = tracker.events.first()
+        event.assertType(AnalyticsEvent.PURCHASE_CANCELLED)
+        event.assertProperties(
+            mapOf(
+                "tier" to "patron",
+                "frequency" to "monthly",
+                "offer_type" to "referral",
+                "source" to "purchase_source",
+                "error" to "user_cancelled",
+            ),
+        )
+    }
+
+    @Test
+    fun `failure purchase`() = runTest {
+        val key = SubscriptionPlan.PlusYearlyPreview.key
+
+        dataSource.purchasedProductsResultCode = PaymentResultCode.Unknown(404)
+        paymentClient.purchaseSubscriptionPlan(key, "purchase_source", mock<Activity>())
+
+        val event = tracker.events.first()
+        event.assertType(AnalyticsEvent.PURCHASE_FAILED)
+        event.assertProperties(
+            mapOf(
+                "tier" to "plus",
+                "frequency" to "yearly",
+                "offer_type" to "none",
+                "source" to "purchase_source",
+                "error" to "unknown",
+                "error_code" to 404,
+            ),
+        )
+    }
+}
+
+private class TestTracker : Tracker {
+    private val _events = mutableListOf<TrackEvent>()
+
+    val events get() = _events.toList()
+
+    override fun track(event: AnalyticsEvent, properties: Map<String, Any>) {
+        _events += TrackEvent(event, properties)
+    }
+
+    override fun getTrackerType() = TrackerType.FirstParty
+
+    override fun refreshMetadata() = Unit
+
+    override fun flush() = Unit
+
+    override fun clearAllData() = Unit
+}
+
+private data class TrackEvent(
+    val type: AnalyticsEvent,
+    val properties: Map<String, Any>,
+) {
+    fun assertType(type: AnalyticsEvent) {
+        assertEquals(type, this.type)
+    }
+
+    fun assertProperties(properties: Map<String, Any>) {
+        assertEquals(properties, this.properties)
+    }
+}


### PR DESCRIPTION
## Description

This PR moves tracking purchase events to a `PaymentClient.Listener`.

Closes #4000

## Testing Instructions

1. Apply this patch.
```
curl -L https://github.com/user-attachments/files/20201283/debug-as-prod.patch | git apply
```
2. Install the app.
3. Start purchase flow.
4. Verify `purchase_cancelled` event by dismissing the Play Store confirmation sheet.
5. Verify `purchase_failed` event by using error test purchase card.
6. Verify `purchase_successful` event by completing a purchase.

<img width="1295" alt="Screenshot 2025-05-15 at 15 57 22" src="https://github.com/user-attachments/assets/53b9cb65-2294-4ca6-88ee-cae458147b75" />

## Checklist
- [ ] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [ ] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [ ] ~Any jetpack compose components I added or changed are covered by compose previews~
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.