### PR TITLE
Refactor recommendations handling in PodcastViewModel

### DIFF
--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastFragment.kt
@@ -1055,7 +1055,6 @@ class PodcastFragment : BaseFragment() {
         viewModel.tintColor.observe(viewLifecycleOwner) { tintColor ->
             adapter?.setTint(tintColor)
         }
-
         viewModel.uiState.observe(viewLifecycleOwner) { state ->
             when (state) {
                 is PodcastViewModel.UiState.Loading -> {

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastFragment.kt
@@ -1055,6 +1055,7 @@ class PodcastFragment : BaseFragment() {
         viewModel.tintColor.observe(viewLifecycleOwner) { tintColor ->
             adapter?.setTint(tintColor)
         }
+
         viewModel.uiState.observe(viewLifecycleOwner) { state ->
             when (state) {
                 is PodcastViewModel.UiState.Loading -> {

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/podcast/RecommendationsHandler.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/podcast/RecommendationsHandler.kt
@@ -1,6 +1,5 @@
 package au.com.shiftyjelly.pocketcasts.podcasts.viewmodel.podcast
 
-import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.repositories.lists.ListRepository
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
@@ -35,7 +34,7 @@ class RecommendationsHandler @Inject constructor(
         }
     }
 
-    fun getRecommendationsFlowable(podcast: Podcast): Flowable<RecommendationsResult> {
+    fun getRecommendationsFlowable(podcastUuid: String): Flowable<RecommendationsResult> {
         return Flowable
             .combineLatest(
                 enabledObservable.toFlowable(BackpressureStrategy.LATEST).distinctUntilChanged(),
@@ -43,7 +42,7 @@ class RecommendationsHandler @Inject constructor(
             ) { enabled, _ -> enabled }
             .switchMap { enabled ->
                 if (enabled) {
-                    getRecommendationsMaybe(podcast)
+                    getRecommendationsMaybe(podcastUuid)
                         .toFlowable()
                         .addSubscribedStatusFlowable()
                         .map { listFeed ->
@@ -60,12 +59,12 @@ class RecommendationsHandler @Inject constructor(
                 } else {
                     Flowable.just(RecommendationsResult.Empty)
                 }
-            }
+            }.startWith(RecommendationsResult.Loading)
     }
 
-    private fun getRecommendationsMaybe(podcast: Podcast): Maybe<ListFeed> = rxMaybe {
+    private fun getRecommendationsMaybe(podcastUuid: String): Maybe<ListFeed> = rxMaybe {
         listRepository.getPodcastRecommendations(
-            podcastUuid = podcast.uuid,
+            podcastUuid = podcastUuid,
             countryCode = settings.discoverCountryCode.value,
         )
     }


### PR DESCRIPTION
## Description

This resolves the issue of the podcast page search not functioning when there was a problem with the recommendations list. This problem was seen when the call to retrieve the recommendation list was timing out, and since this occurred after the search and before the UI state update, it caused the page updates to take a long time. This change separates the recommendations list call so that any changes to the page, such as the episode search or toggling the podcast to show or hide archived episodes, do not depend on the recommendations. 

## Testing Instructions

Check that the logic is separate from the recommendations list do the following: 

1. Filter logcat by `/recommendations/podcast/`
2. Open a podcast page 
3. ✅ Verify there is a server call to get the list
4. Tap the "Show archived" button
5. ✅ Confirm there isn't another server call to recommendations

Also check if the podcast that was reported by the user is working:

6. Add the private podcast here p1747563011773809/1747335264.669609-slack-C02A333D8LQ
7. Go to the podcast page
8. Enter an episode search
9. ✅ Verify the episodes are filtered

## Screencast

https://github.com/user-attachments/assets/47a2f929-5290-4ef7-8c19-d6b11d566e26

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack