### PR TITLE
Recommendation list title improvements and remove current podcast

### DIFF
--- a/modules/features/discover/src/main/res/layout/row_podcast_large_list_with_podcast.xml
+++ b/modules/features/discover/src/main/res/layout/row_podcast_large_list_with_podcast.xml
@@ -53,9 +53,9 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 tools:text="The Daily"
-                style="@style/H20"
+                style="@style/H30"
                 android:includeFontPadding="false"
-                android:maxLines="2"
+                android:maxLines="1"
                 android:ellipsize="end"
                 android:textColor="?attr/primary_text_01"/>
 

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastFragment.kt
@@ -1055,7 +1055,6 @@ class PodcastFragment : BaseFragment() {
         viewModel.tintColor.observe(viewLifecycleOwner) { tintColor ->
             adapter?.setTint(tintColor)
         }
-
         viewModel.uiState.observe(viewLifecycleOwner) { state ->
             when (state) {
                 is PodcastViewModel.UiState.Loading -> {

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastFragment.kt
@@ -1055,6 +1055,7 @@ class PodcastFragment : BaseFragment() {
         viewModel.tintColor.observe(viewLifecycleOwner) { tintColor ->
             adapter?.setTint(tintColor)
         }
+
         viewModel.uiState.observe(viewLifecycleOwner) { state ->
             when (state) {
                 is PodcastViewModel.UiState.Loading -> {

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/podcast/RecommendationsHandler.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/podcast/RecommendationsHandler.kt
@@ -44,6 +44,7 @@ class RecommendationsHandler @Inject constructor(
                 if (enabled) {
                     getRecommendationsMaybe(podcastUuid)
                         .toFlowable()
+                        .removePodcast(podcastUuid)
                         .addSubscribedStatusFlowable()
                         .map { listFeed ->
                             if (listFeed.podcasts.isNullOrEmpty()) {
@@ -67,6 +68,13 @@ class RecommendationsHandler @Inject constructor(
             podcastUuid = podcastUuid,
             countryCode = settings.discoverCountryCode.value,
         )
+    }
+
+    private fun Flowable<ListFeed>.removePodcast(podcastUuid: String): Flowable<ListFeed> {
+        return map { list ->
+            val filteredPodcasts = list.podcasts?.filter { it.uuid != podcastUuid }
+            list.copy(podcasts = filteredPodcasts)
+        }
     }
 
     private fun Flowable<ListFeed>.addSubscribedStatusFlowable(): Flowable<ListFeed> {

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/podcast/RecommendationsHandler.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/podcast/RecommendationsHandler.kt
@@ -1,6 +1,5 @@
 package au.com.shiftyjelly.pocketcasts.podcasts.viewmodel.podcast
 
-import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.repositories.lists.ListRepository
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
@@ -35,7 +34,7 @@ class RecommendationsHandler @Inject constructor(
         }
     }
 
-    fun getRecommendationsFlowable(podcast: Podcast): Flowable<RecommendationsResult> {
+    fun getRecommendationsFlowable(podcastUuid: String): Flowable<RecommendationsResult> {
         return Flowable
             .combineLatest(
                 enabledObservable.toFlowable(BackpressureStrategy.LATEST).distinctUntilChanged(),
@@ -43,7 +42,7 @@ class RecommendationsHandler @Inject constructor(
             ) { enabled, _ -> enabled }
             .switchMap { enabled ->
                 if (enabled) {
-                    getRecommendationsMaybe(podcast)
+                    getRecommendationsMaybe(podcastUuid)
                         .toFlowable()
                         .addSubscribedStatusFlowable()
                         .map { listFeed ->
@@ -60,12 +59,12 @@ class RecommendationsHandler @Inject constructor(
                 } else {
                     Flowable.just(RecommendationsResult.Empty)
                 }
-            }
+            }.startWith(RecommendationsResult.Loading)
     }
 
-    private fun getRecommendationsMaybe(podcast: Podcast): Maybe<ListFeed> = rxMaybe {
+    private fun getRecommendationsMaybe(podcastUuid: String): Maybe<ListFeed> = rxMaybe {
         listRepository.getPodcastRecommendations(
-            podcastUuid = podcast.uuid,
+            podcastUuid = podcastUuid,
             countryCode = settings.discoverCountryCode.value,
         )
     }

--- a/modules/services/localization/src/main/java/au/com/shiftyjelly/pocketcasts/localization/helper/LocaliseHelper.kt
+++ b/modules/services/localization/src/main/java/au/com/shiftyjelly/pocketcasts/localization/helper/LocaliseHelper.kt
@@ -82,7 +82,7 @@ object LocaliseHelper {
         "popular in [regionname]" to R.string.discover_popular_in,
         "most popular in [category]" to R.string.discover_most_popular_in,
         "loved by listeners of" to R.string.recommendations_loved_by_listeners,
-        "if you like" to R.string.recommendations_if_you_like,
+        "because you like" to R.string.recommendations_because_you_like,
     )
 
     private val serverMessageIdToStringId = mapOf(

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -1793,7 +1793,7 @@
     <string name="discover_select_categories">Select a category</string>
     <string name="discover_show_all_categories">Show all categories</string>
     <string name="discover_dismiss_selected_category">Dismiss selected category</string>
-    <string name="recommendations_if_you_like">If you like</string>
+    <string name="recommendations_because_you_like">Because you like</string>
     <string name="recommendations_loved_by_listeners">Loved by listeners of</string>
     <string name="recommended_by_creator">Recommended shows by the creator</string>
     <string name="similar_shows_to">Shows similar to \"%s\"</string>


### PR DESCRIPTION
## Description

This pull request includes the following changes:

1. On the podcast page, if the category list is used, then the current podcast is filtered. 
        p1747280739738859/1747280730.317709-slack-C08FYE3MUGN
2. Changes translation from "If you like" text to "Because you follow". 
        p1747212809024149/1747207915.288179-slack-C08FYE3MUGN
3. Keeps the list title to one line and makes sure it doesn't overlap the show all button.
        p1747275520818429/1747207676.004529-slack-C08FYE3MUGN

## Testing Instructions

Testing number 1.

1. Use the variant "debugProd"
2. Change the region on the Discover page to "Australian"
3. Open the [Mushroom Case Daily](https://pca.st/mushroom) podcast page
4. Tap the "You might like" tab
5. ✅ Verify the podcast doesn't appear in the recommendations

Testing number 2 and 3.

Apply [this patch](https://github.com/user-attachments/files/20275685/podcast-title.patch) to have a long podcast title and a translation for "Because you follow".

```
curl -L https://github.com/user-attachments/files/20275685/podcast-title.patch | git apply
```

1. Change the phone language to French
1. Sign into a Pocket Casts account you use, so it has recommendations
2. On the Discover tab scroll down
3. ✅ Verify the "Because you follow" is translated to "Parce que tu aimes"
4. ✅ Verify the podcast title is only on one line and not overlaying the show all button

## Screenshots 

Change 1:

| Before | After |
| --- | --- |
| ![Screenshot_20250519_093444](https://github.com/user-attachments/assets/eefb5a62-ae11-4996-8406-20a07e5cdcfb) | ![Screenshot_20250519_092507](https://github.com/user-attachments/assets/83b39061-6877-44d8-9a99-43ffcc081cf0) | 

Change 2:

<img  width="300" src="https://github.com/user-attachments/assets/ab6b325f-6bd9-4f5d-9e14-29d4ba5178d3" /> 

Change 3:

| Before | After |
| --- | --- |
| ![Screenshot_20250519_093534](https://github.com/user-attachments/assets/092a827d-49a5-4d98-89c0-1e06cdbcf97b) | ![Screenshot_20250519_090248](https://github.com/user-attachments/assets/58c39263-b795-4ae0-8247-c9fd3b73ceb3) | 

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack
