### PR TITLE
Position tooltip correctly based on its tip

### DIFF
--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/Tooltip.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/Tooltip.kt
@@ -55,8 +55,9 @@ fun TooltipPopup(
     onClick: (() -> Unit)? = null,
     onClickOutside: (() -> Unit)? = null,
 ) {
+    val elevationPadding = elevation * 1.5f
     Popup(
-        popupPositionProvider = rememberTooltipPositionProvider(tipPosition, anchorOffset, elevation),
+        popupPositionProvider = rememberTooltipPositionProvider(tipPosition, anchorOffset, elevationPadding),
         properties = properties,
         onDismissRequest = onClickOutside,
     ) {
@@ -64,7 +65,7 @@ fun TooltipPopup(
             visible = show,
             enter = fadeIn(),
             exit = fadeOut(),
-            modifier = Modifier.padding(elevation),
+            modifier = Modifier.padding(elevationPadding),
         ) {
             Tooltip(
                 title = title,

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/Tooltip.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/Tooltip.kt
@@ -197,10 +197,9 @@ private class TooltipPositionProvider(
         layoutDirection: LayoutDirection,
         popupContentSize: IntSize,
     ): IntOffset {
-        val normalizedTipPosition = tipPosition.normalize(layoutDirection)
         val elevationPx = density.run { elevation.roundToPx() }
 
-        return anchorOffset + when (normalizedTipPosition) {
+        return anchorOffset + when (tipPosition.normalize(layoutDirection)) {
             TipPosition.TopStart -> {
                 val elevationOffset = IntOffset(elevationPx, elevationPx)
                 val tipOffset = IntOffset(density.run { CornerTipPeakPosition.roundToPx() }, 0)
@@ -410,7 +409,6 @@ private val TipHeight = 13.dp
 private val CornerTipWidth = 40.dp
 private val CornerTipPeakPosition = 16.5.dp
 private val CenterTipWidth = 47.dp
-private val CenterPeakPosition = 23.5.dp
 private val CornerRadius = 10.dp
 
 @Preview

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/Tooltip.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/Tooltip.kt
@@ -196,19 +196,48 @@ private class TooltipPositionProvider(
         layoutDirection: LayoutDirection,
         popupContentSize: IntSize,
     ): IntOffset {
+        val normalizedTipPosition = tipPosition.normalize(layoutDirection)
         val elevationPx = density.run { elevation.roundToPx() }
-        return anchorOffset + when (tipPosition.normalize(layoutDirection)) {
+
+        return anchorOffset + when (normalizedTipPosition) {
             TipPosition.TopStart -> {
-                val tipOffset = IntOffset(density.run { CornerTipPeakPosition.roundToPx() }, 0)
                 val elevationOffset = IntOffset(elevationPx, elevationPx)
+                val tipOffset = IntOffset(density.run { CornerTipPeakPosition.roundToPx() }, 0)
                 anchorBounds.bottomCenter - elevationOffset - tipOffset
             }
 
-            TipPosition.TopCenter -> anchorBounds.bottomCenter
-            TipPosition.TopEnd -> anchorBounds.topCenter
-            TipPosition.BottomStart -> anchorBounds.topCenter
-            TipPosition.BottomCenter -> anchorBounds.topCenter
-            TipPosition.BottomEnd -> anchorBounds.topCenter
+            TipPosition.TopCenter -> {
+                val elevationOffset = IntOffset(0, elevationPx)
+                val contentOffset = IntOffset(popupContentSize.width / 2, 0)
+                anchorBounds.bottomCenter - elevationOffset - contentOffset
+            }
+
+            TipPosition.TopEnd -> {
+                val elevationOffset = IntOffset(-elevationPx, elevationPx)
+                val contentOffset = IntOffset(popupContentSize.width, 0)
+                val tipOffset = IntOffset(density.run { CornerTipPeakPosition.roundToPx() }, 0)
+                anchorBounds.bottomCenter - elevationOffset - contentOffset + tipOffset
+            }
+
+            TipPosition.BottomStart -> {
+                val elevationOffset = IntOffset(elevationPx, -elevationPx)
+                val contentOffset = IntOffset(0, popupContentSize.height)
+                val tipOffset = IntOffset(density.run { CornerTipPeakPosition.roundToPx() }, 0)
+                anchorBounds.topCenter - elevationOffset - contentOffset - tipOffset
+            }
+
+            TipPosition.BottomCenter -> {
+                val elevationOffset = IntOffset(0, -elevationPx)
+                val contentOffset = IntOffset(popupContentSize.width / 2, popupContentSize.height)
+                anchorBounds.topCenter - elevationOffset - contentOffset
+            }
+
+            TipPosition.BottomEnd -> {
+                val elevationOffset = IntOffset(elevationPx, elevationPx)
+                val contentOffset = IntOffset(popupContentSize.width, popupContentSize.height)
+                val tipOffset = IntOffset(density.run { CornerTipPeakPosition.roundToPx() }, 0)
+                anchorBounds.topCenter + elevationOffset - contentOffset + tipOffset
+            }
         }
     }
 }
@@ -380,11 +409,12 @@ private val TipHeight = 13.dp
 private val CornerTipWidth = 40.dp
 private val CornerTipPeakPosition = 16.5.dp
 private val CenterTipWidth = 47.dp
+private val CenterPeakPosition = 23.5.dp
 private val CornerRadius = 10.dp
 
 @Preview
 @Composable
-private fun Tooltip2ThemePreview(
+private fun TooltipThemePreview(
     @PreviewParameter(ThemePreviewParameterProvider::class) themeType: Theme.ThemeType,
 ) {
     AppThemeWithBackground(themeType) {
@@ -403,7 +433,7 @@ private fun Tooltip2ThemePreview(
 
 @Preview
 @Composable
-private fun Tooltip2TipPreview(
+private fun TooltipTipPreview(
     @PreviewParameter(TipPositionParameterProvider::class) tipPosition: TipPosition,
 ) {
     AppThemeWithBackground(Theme.ThemeType.LIGHT) {

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/Tooltip.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/Tooltip.kt
@@ -55,6 +55,8 @@ fun TooltipPopup(
     onClick: (() -> Unit)? = null,
     onClickOutside: (() -> Unit)? = null,
 ) {
+    // We're adding additional padding to the popup box in order to prevent shadow clipping.
+    // There's no API to determine how much padding is needed. We just eyeball it to 150%.
     val elevationPadding = elevation * 1.5f
     Popup(
         popupPositionProvider = rememberTooltipPositionProvider(tipPosition, anchorOffset, elevationPadding),


### PR DESCRIPTION
## Description

This fixes tooltip positioning around the anchor. In the last PR I only did it for the `TopStart` position and forgot to do it for the other ones.

## Testing Instructions

1. Apply [this patch](https://github.com/user-attachments/files/20281992/tooltip-playground.patch).
```
curl -L https://github.com/user-attachments/files/20281992/tooltip-playground.patch | git apply
```
2. Go to the Settings.
3. Tap the Developer row.
4. You should see the tooltip playground.
5. Move sliders to change the anchor size.
6. Select option to change the tip position of the tooltip.
7. At all times tooltip should be centered around the anchor.

## Checklist
- [ ] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] ~I have considered whether it makes sense to add tests for my changes~
- [ ] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [ ] ~Any jetpack compose components I added or changed are covered by compose previews~
- [ ] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~