### PR TITLE
Recommendation run analytics

### DIFF
--- a/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/CarouselListRowAdapter.kt
+++ b/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/CarouselListRowAdapter.kt
@@ -32,7 +32,7 @@ private val differ: DiffUtil.ItemCallback<Any> = object : DiffUtil.ItemCallback<
     }
 }
 
-internal class CarouselListRowAdapter(var pillText: String?, val theme: Theme, val onPodcastClicked: ((DiscoverPodcast, String?, Boolean) -> Unit), val onPodcastSubscribe: ((DiscoverPodcast, String?) -> Unit), private val analyticsTracker: AnalyticsTracker) : ListAdapter<Any, CarouselItemViewHolder>(differ) {
+internal class CarouselListRowAdapter(var pillText: String?, val theme: Theme, val onPodcastClicked: ((DiscoverPodcast, String?, String?, Boolean) -> Unit), val onPodcastSubscribe: ((DiscoverPodcast, String?) -> Unit), private val analyticsTracker: AnalyticsTracker) : ListAdapter<Any, CarouselItemViewHolder>(differ) {
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): CarouselItemViewHolder {
         val view = LayoutInflater.from(parent.context).inflate(R.layout.item_carousel, parent, false)
         return CarouselItemViewHolder(theme, view)
@@ -52,7 +52,7 @@ internal class CarouselListRowAdapter(var pillText: String?, val theme: Theme, v
             holder.setTaglineText(tagLineText)
             holder.itemView.setOnClickListener {
                 val isFeatured = podcast.isSponsored || podcast.listId == null
-                onPodcastClicked(podcast, podcast.listId, isFeatured)
+                onPodcastClicked(podcast, podcast.listId, null, isFeatured)
 
                 if (podcast.listId != null) {
                     val listId = podcast.listId as String

--- a/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/CarouselListRowAdapter.kt
+++ b/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/CarouselListRowAdapter.kt
@@ -32,7 +32,13 @@ private val differ: DiffUtil.ItemCallback<Any> = object : DiffUtil.ItemCallback<
     }
 }
 
-internal class CarouselListRowAdapter(var pillText: String?, val theme: Theme, val onPodcastClicked: ((DiscoverPodcast, String?, String?, Boolean) -> Unit), val onPodcastSubscribe: ((DiscoverPodcast, String?) -> Unit), private val analyticsTracker: AnalyticsTracker) : ListAdapter<Any, CarouselItemViewHolder>(differ) {
+internal class CarouselListRowAdapter(
+    var pillText: String?,
+    val theme: Theme,
+    val onPodcastClicked: ((DiscoverPodcast, String?, String?, Boolean) -> Unit),
+    val onPodcastSubscribe: ((DiscoverPodcast, String?) -> Unit),
+    private val analyticsTracker: AnalyticsTracker,
+) : ListAdapter<Any, CarouselItemViewHolder>(differ) {
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): CarouselItemViewHolder {
         val view = LayoutInflater.from(parent.context).inflate(R.layout.item_carousel, parent, false)
         return CarouselItemViewHolder(theme, view)

--- a/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/DiscoverFragment.kt
+++ b/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/DiscoverFragment.kt
@@ -71,7 +71,7 @@ class DiscoverFragment :
     }
 
     override fun onPodcastClicked(podcast: DiscoverPodcast, listUuid: String?, listDate: String?, isFeatured: Boolean) {
-        val fragment = PodcastFragment.newInstance(podcastUuid = podcast.uuid, fromListUuid = listUuid, sourceView = SourceView.DISCOVER, featuredPodcast = isFeatured)
+        val fragment = PodcastFragment.newInstance(podcastUuid = podcast.uuid, fromListUuid = listUuid, fromListDate = listDate, sourceView = SourceView.DISCOVER, featuredPodcast = isFeatured)
         (activity as FragmentHostListener).addFragment(fragment)
     }
 

--- a/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/DiscoverFragment.kt
+++ b/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/DiscoverFragment.kt
@@ -71,7 +71,13 @@ class DiscoverFragment :
     }
 
     override fun onPodcastClicked(podcast: DiscoverPodcast, listUuid: String?, listDate: String?, isFeatured: Boolean) {
-        val fragment = PodcastFragment.newInstance(podcastUuid = podcast.uuid, fromListUuid = listUuid, fromListDate = listDate, sourceView = SourceView.DISCOVER, featuredPodcast = isFeatured)
+        val fragment = PodcastFragment.newInstance(
+            podcastUuid = podcast.uuid,
+            fromListUuid = listUuid,
+            fromListDate = listDate,
+            sourceView = SourceView.DISCOVER,
+            featuredPodcast = isFeatured,
+        )
         (activity as FragmentHostListener).addFragment(fragment)
     }
 

--- a/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/PodcastGridListFragment.kt
+++ b/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/PodcastGridListFragment.kt
@@ -14,6 +14,8 @@ import androidx.fragment.app.viewModels
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTracker
 import au.com.shiftyjelly.pocketcasts.analytics.SourceView
+import au.com.shiftyjelly.pocketcasts.analytics.discoverListPodcastSubscribed
+import au.com.shiftyjelly.pocketcasts.analytics.discoverListPodcastTapped
 import au.com.shiftyjelly.pocketcasts.discover.R
 import au.com.shiftyjelly.pocketcasts.discover.view.DiscoverFragment.Companion.EPISODE_UUID_KEY
 import au.com.shiftyjelly.pocketcasts.discover.view.DiscoverFragment.Companion.LIST_ID_KEY
@@ -118,22 +120,19 @@ open class PodcastGridListFragment : BaseFragment(), Toolbar.OnMenuItemClickList
     protected val viewModel: PodcastListViewModel by viewModels()
 
     val onPodcastClicked: (DiscoverPodcast) -> Unit = { podcast ->
-        listUuid?.let {
-            analyticsTracker.track(AnalyticsEvent.DISCOVER_LIST_PODCAST_TAPPED, mapOf(LIST_ID_KEY to it, PODCAST_UUID_KEY to podcast.uuid))
-        }
+        val listDate = viewModel.listFeed?.date
+        analyticsTracker.discoverListPodcastTapped(podcastUuid = podcast.uuid, listId = listUuid, listDate = listDate)
         val sourceView = when (expandedStyle) {
             is ExpandedStyle.RankedList -> SourceView.DISCOVER_RANKED_LIST
             is ExpandedStyle.PlainList -> SourceView.DISCOVER_PLAIN_LIST
             else -> SourceView.DISCOVER
         }
-        val fragment = PodcastFragment.newInstance(podcastUuid = podcast.uuid, fromListUuid = listUuid, sourceView = sourceView)
+        val fragment = PodcastFragment.newInstance(podcastUuid = podcast.uuid, fromListUuid = listUuid, fromListDate = listDate, sourceView = sourceView)
         (activity as FragmentHostListener).addFragment(fragment)
     }
 
     val onPodcastSubscribe: (String) -> Unit = { podcastUuid ->
-        listUuid?.let {
-            analyticsTracker.track(AnalyticsEvent.DISCOVER_LIST_PODCAST_SUBSCRIBED, mapOf(LIST_ID_KEY to it, PODCAST_UUID_KEY to podcastUuid))
-        }
+        analyticsTracker.discoverListPodcastSubscribed(podcastUuid = podcastUuid, listId = listUuid, listDate = viewModel.listFeed?.date)
         var podcastSubscribedSource = SourceView.DISCOVER
         if (expandedStyle is ExpandedStyle.RankedList) {
             podcastSubscribedSource = SourceView.DISCOVER_RANKED_LIST

--- a/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/PodcastGridListFragment.kt
+++ b/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/PodcastGridListFragment.kt
@@ -127,7 +127,12 @@ open class PodcastGridListFragment : BaseFragment(), Toolbar.OnMenuItemClickList
             is ExpandedStyle.PlainList -> SourceView.DISCOVER_PLAIN_LIST
             else -> SourceView.DISCOVER
         }
-        val fragment = PodcastFragment.newInstance(podcastUuid = podcast.uuid, fromListUuid = listUuid, fromListDate = listDate, sourceView = sourceView)
+        val fragment = PodcastFragment.newInstance(
+            podcastUuid = podcast.uuid,
+            fromListUuid = listUuid,
+            fromListDate = listDate,
+            sourceView = sourceView,
+        )
         (activity as FragmentHostListener).addFragment(fragment)
     }
 

--- a/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/viewmodel/DiscoverViewModel.kt
+++ b/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/viewmodel/DiscoverViewModel.kt
@@ -166,6 +166,7 @@ class DiscoverViewModel @Inject constructor(
                     tintColors = it.tintColors,
                     images = it.collageImages,
                     listId = it.listId,
+                    date = it.date,
                 )
             }
             .flatMapPublisher { addSubscriptionStateToPodcasts(it) }
@@ -402,6 +403,7 @@ data class PodcastList(
     val tintColors: DiscoverFeedTintColors?,
     val images: List<DiscoverFeedImage>?,
     val listId: String? = null,
+    val date: String? = null,
 )
 
 data class CarouselSponsoredPodcast(

--- a/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/viewmodel/PodcastListViewModel.kt
+++ b/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/viewmodel/PodcastListViewModel.kt
@@ -39,6 +39,9 @@ class PodcastListViewModel @Inject constructor(
     val state: MutableLiveData<PodcastListViewState> = MutableLiveData()
     val disposables: CompositeDisposable = CompositeDisposable()
 
+    val listFeed: ListFeed?
+        get() = (state.value as? PodcastListViewState.ListLoaded)?.feed
+
     init {
         state.value = PodcastListViewState.Loading()
     }

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastFragment.kt
@@ -38,6 +38,7 @@ import androidx.recyclerview.widget.SimpleItemAnimator
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTracker
 import au.com.shiftyjelly.pocketcasts.analytics.SourceView
+import au.com.shiftyjelly.pocketcasts.analytics.discoverListPodcastSubscribed
 import au.com.shiftyjelly.pocketcasts.compose.AppTheme
 import au.com.shiftyjelly.pocketcasts.localization.extensions.getStringPlural
 import au.com.shiftyjelly.pocketcasts.models.entity.BaseEpisode
@@ -137,6 +138,7 @@ class PodcastFragment : BaseFragment() {
             podcastUuid: String,
             sourceView: SourceView,
             fromListUuid: String? = null,
+            fromListDate: String? = null,
             featuredPodcast: Boolean = false,
         ): PodcastFragment = PodcastFragment().apply {
             arguments = bundleOf(
@@ -144,6 +146,7 @@ class PodcastFragment : BaseFragment() {
                     podcastUuid = podcastUuid,
                     sourceView = sourceView,
                     fromListUuid = fromListUuid,
+                    fromListDate = fromListDate,
                     featuredPodcast = featuredPodcast,
                 ),
             )
@@ -287,9 +290,7 @@ class PodcastFragment : BaseFragment() {
     }
 
     private val onSubscribeClicked: () -> Unit = {
-        fromListUuid?.let {
-            analyticsTracker.track(AnalyticsEvent.DISCOVER_LIST_PODCAST_SUBSCRIBED, mapOf(LIST_ID_KEY to it, PODCAST_UUID_KEY to podcastUuid))
-        }
+        analyticsTracker.discoverListPodcastSubscribed(podcastUuid = podcastUuid, listId = fromListUuid, listDate = fromListDate)
         if (featuredPodcast) {
             viewModel.podcast.value?.uuid?.let { podcastUuid ->
                 analyticsTracker.track(AnalyticsEvent.DISCOVER_FEATURED_PODCAST_SUBSCRIBED, mapOf(PODCAST_UUID_KEY to podcastUuid))
@@ -679,6 +680,9 @@ class PodcastFragment : BaseFragment() {
 
     private val fromListUuid: String?
         get() = args.fromListUuid
+
+    private val fromListDate: String
+        get() = args.fromListDate.orEmpty()
 
     private var lastSearchTerm: String? = null
 
@@ -1306,6 +1310,7 @@ class PodcastFragment : BaseFragment() {
         val podcastUuid: String,
         val sourceView: SourceView,
         val fromListUuid: String?,
+        val fromListDate: String?,
         val featuredPodcast: Boolean,
     ) : Parcelable
 }

--- a/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsParameter.kt
+++ b/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsParameter.kt
@@ -1,0 +1,8 @@
+package au.com.shiftyjelly.pocketcasts.analytics
+
+object AnalyticsParameter {
+
+    const val listId = "list_id"
+    const val listDate = "list_datetime"
+    const val podcastUuid = "podcast_uuid"
+}

--- a/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsTrackerExtensions.kt
+++ b/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsTrackerExtensions.kt
@@ -53,7 +53,7 @@ private fun AnalyticsTracker.discoverListPodcastEvent(analyticsEvent: AnalyticsE
         properties = mapOf(
             AnalyticsParameter.podcastUuid to podcastUuid,
             AnalyticsParameter.listId to listId,
-            AnalyticsParameter.listDate to (listDate ?: ""),
+            AnalyticsParameter.listDate to listDate.orEmpty(),
         ),
     )
 }

--- a/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsTrackerExtensions.kt
+++ b/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsTrackerExtensions.kt
@@ -1,0 +1,59 @@
+package au.com.shiftyjelly.pocketcasts.analytics
+
+fun AnalyticsTracker.discoverListShowAllTapped(listId: String, listDate: String) {
+    discoverListEvent(
+        analyticsEvent = AnalyticsEvent.DISCOVER_LIST_SHOW_ALL_TAPPED,
+        listId = listId,
+        listDate = listDate,
+    )
+}
+
+fun AnalyticsTracker.discoverShowAllTapped(listId: String, listDate: String) {
+    discoverListEvent(
+        analyticsEvent = AnalyticsEvent.DISCOVER_SHOW_ALL_TAPPED,
+        listId = listId,
+        listDate = listDate,
+    )
+}
+
+private fun AnalyticsTracker.discoverListEvent(analyticsEvent: AnalyticsEvent, listId: String, listDate: String) {
+    track(
+        event = analyticsEvent,
+        properties = mapOf(
+            AnalyticsParameter.listId to listId,
+            AnalyticsParameter.listDate to listDate,
+        ),
+    )
+}
+
+fun AnalyticsTracker.discoverListPodcastTapped(podcastUuid: String, listId: String?, listDate: String?) {
+    discoverListPodcastEvent(
+        analyticsEvent = AnalyticsEvent.DISCOVER_LIST_PODCAST_TAPPED,
+        podcastUuid = podcastUuid,
+        listId = listId,
+        listDate = listDate,
+    )
+}
+
+fun AnalyticsTracker.discoverListPodcastSubscribed(podcastUuid: String, listId: String?, listDate: String?) {
+    discoverListPodcastEvent(
+        analyticsEvent = AnalyticsEvent.DISCOVER_LIST_PODCAST_SUBSCRIBED,
+        podcastUuid = podcastUuid,
+        listId = listId,
+        listDate = listDate,
+    )
+}
+
+private fun AnalyticsTracker.discoverListPodcastEvent(analyticsEvent: AnalyticsEvent, podcastUuid: String, listId: String?, listDate: String?) {
+    if (listId == null) {
+        return
+    }
+    track(
+        event = analyticsEvent,
+        properties = mapOf(
+            AnalyticsParameter.podcastUuid to podcastUuid,
+            AnalyticsParameter.listId to listId,
+            AnalyticsParameter.listDate to (listDate ?: ""),
+        ),
+    )
+}


### PR DESCRIPTION
## Description

To help improve the recommendations, this change includes the list date in the analytics. We are using the date of the recommendation lists as a version so we can tell if changes are helping. 

## Testing Instructions
- Filter logcat by `list_datetime`
- Login with a Pocket Casts account that you have history on so you get recommendations
- Go to the Discover tab
- Scroll down to "You Might Like"
- Tap on the artwork follow button 
- ✅ Verify the event `discover_list_podcast_subscribed` with the properties `list_id`, `list_datetime`, and `podcast_uuid`
- Tap on the artwork to open the podcast page
- ✅ Verify the event `discover_list_podcast_tapped` with the properties `list_id`, `list_datetime`, and `podcast_uuid`
- Tap the follow button
- ✅ Verify the event `discover_list_podcast_subscribed` with the properties `list_id`, `list_datetime`, and `podcast_uuid`
- Go back to the Discover tab
- Tap the "Show all" button
- ✅ Verify the event `discover_list_show_all_tapped` with the properties `list_id` and `list_datetime`
- Tap on the row follow button 
- ✅ Verify the event `discover_list_podcast_subscribed` with the properties `list_id`, `list_datetime`, and `podcast_uuid`
- Tap on the row
- ✅ Verify the event `discover_list_podcast_tapped` with the properties `list_id`, `list_datetime`, and `podcast_uuid`

Repeat the same as above with the recommendation list "Because you like".

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack
