### PR TITLE
Streamline Smart Folders onboarding flow

### DIFF
--- a/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
+++ b/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
@@ -281,22 +281,22 @@ class MainActivity :
 
     private val onboardingLauncher: ActivityResultLauncher<Intent> = registerForActivityResult(OnboardingActivityContract()) { result ->
         when (result) {
-            OnboardingFinish.Done -> {
+            is OnboardingFinish.Done -> {
                 settings.setHasDoneInitialOnboarding()
             }
-            OnboardingFinish.DoneGoToDiscover -> {
+            is OnboardingFinish.DoneGoToDiscover -> {
                 settings.setHasDoneInitialOnboarding()
                 openTab(VR.id.navigation_discover)
             }
-            OnboardingFinish.DoneShowPlusPromotion -> {
+            is OnboardingFinish.DoneShowPlusPromotion -> {
                 settings.setHasDoneInitialOnboarding()
                 OnboardingLauncher.openOnboardingFlow(this, OnboardingFlow.Upsell(OnboardingUpgradeSource.LOGIN_PLUS_PROMOTION))
             }
-            OnboardingFinish.DoneShowWelcomeInReferralFlow -> {
+            is OnboardingFinish.DoneShowWelcomeInReferralFlow -> {
                 settings.showReferralWelcome.set(true, updateModifiedAt = false)
             }
-            null -> {
-                Timber.e("Unexpected null result from onboarding activity")
+            is OnboardingFinish.DoneApplySuggestedFolders, null -> {
+                Timber.e("Unexpected result $result from onboarding activity")
             }
         }
     }

--- a/modules/features/account/build.gradle.kts
+++ b/modules/features/account/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     alias(libs.plugins.android.library)
     alias(libs.plugins.kotlin.android)
+    alias(libs.plugins.kotlin.parcelize)
     alias(libs.plugins.ksp)
     alias(libs.plugins.hilt)
     alias(libs.plugins.compose.compiler)

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/OnboardingActivityContract.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/OnboardingActivityContract.kt
@@ -2,26 +2,37 @@ package au.com.shiftyjelly.pocketcasts.account.onboarding
 
 import android.content.Context
 import android.content.Intent
-import android.os.Build
+import android.os.Parcelable
 import androidx.activity.result.contract.ActivityResultContract
+import androidx.core.content.IntentCompat
+import au.com.shiftyjelly.pocketcasts.settings.onboarding.SuggestedFoldersAction
+import kotlinx.parcelize.Parcelize
 
 class OnboardingActivityContract : ActivityResultContract<Intent, OnboardingActivityContract.OnboardingFinish?>() {
 
     override fun createIntent(context: Context, input: Intent): Intent = input
 
-    override fun parseResult(resultCode: Int, intent: Intent?): OnboardingFinish? =
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-            intent?.getSerializableExtra(FINISH_KEY, OnboardingFinish::class.java)
-        } else {
-            @Suppress("DEPRECATION")
-            intent?.getSerializableExtra(FINISH_KEY) as? OnboardingFinish
-        }
+    override fun parseResult(resultCode: Int, intent: Intent?): OnboardingFinish? {
+        return intent?.let { IntentCompat.getParcelableExtra(it, FINISH_KEY, OnboardingFinish::class.java) }
+    }
 
-    enum class OnboardingFinish {
-        Done,
-        DoneGoToDiscover,
-        DoneShowPlusPromotion,
-        DoneShowWelcomeInReferralFlow,
+    sealed interface OnboardingFinish : Parcelable {
+        @Parcelize
+        data object Done : OnboardingFinish
+
+        @Parcelize
+        data object DoneGoToDiscover : OnboardingFinish
+
+        @Parcelize
+        data object DoneShowPlusPromotion : OnboardingFinish
+
+        @Parcelize
+        data object DoneShowWelcomeInReferralFlow : OnboardingFinish
+
+        @Parcelize
+        data class DoneApplySuggestedFolders(
+            val action: SuggestedFoldersAction,
+        ) : OnboardingFinish
     }
 
     companion object {

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/OnboardingActivityViewModel.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/OnboardingActivityViewModel.kt
@@ -42,6 +42,7 @@ class OnboardingActivityViewModel @Inject constructor(
                                 _finishState.emit(OnboardingFinish.DoneShowPlusPromotion)
                             }
                         }
+
                         is SignInState.SignedOut -> Unit
                     }
                 }
@@ -50,14 +51,27 @@ class OnboardingActivityViewModel @Inject constructor(
     }
 
     fun onExitOnboarding(exitInfo: OnboardingExitInfo) {
-        when {
-            exitInfo.showPlusPromotionForFreeUser -> showPlusPromotionForFreeUserFlow.value = true
-            exitInfo.showWelcomeInReferralFlow -> viewModelScope.launch {
-                _finishState.emit(OnboardingFinish.DoneShowWelcomeInReferralFlow)
+        when (exitInfo) {
+            is OnboardingExitInfo.Simple -> {
+                viewModelScope.launch {
+                    _finishState.emit(OnboardingFinish.Done)
+                }
             }
 
-            else -> viewModelScope.launch {
-                _finishState.emit(OnboardingFinish.Done)
+            is OnboardingExitInfo.ShowPlusPromotion -> {
+                showPlusPromotionForFreeUserFlow.value = true
+            }
+
+            is OnboardingExitInfo.ShowReferralWelcome -> {
+                viewModelScope.launch {
+                    _finishState.emit(OnboardingFinish.DoneShowWelcomeInReferralFlow)
+                }
+            }
+
+            is OnboardingExitInfo.ApplySuggestedFolders -> {
+                viewModelScope.launch {
+                    _finishState.emit(OnboardingFinish.DoneApplySuggestedFolders(exitInfo.action))
+                }
             }
         }
     }

--- a/modules/features/account/src/test/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/OnboardingActivityViewModelTest.kt
+++ b/modules/features/account/src/test/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/OnboardingActivityViewModelTest.kt
@@ -9,6 +9,7 @@ import au.com.shiftyjelly.pocketcasts.payment.BillingCycle
 import au.com.shiftyjelly.pocketcasts.payment.SubscriptionTier
 import au.com.shiftyjelly.pocketcasts.repositories.user.UserManager
 import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingExitInfo
+import au.com.shiftyjelly.pocketcasts.settings.onboarding.SuggestedFoldersAction
 import au.com.shiftyjelly.pocketcasts.sharedtest.MainCoroutineRule
 import io.reactivex.Flowable
 import java.time.Instant
@@ -42,42 +43,52 @@ class OnboardingActivityViewModelTest {
     )
 
     @Test
-    fun `given showPlusPromotionForFreeUser is false, when exit onboarding, then finish with Done`() = runTest {
+    fun `given simple exit info, when exit onboarding, then finish with Done`() = runTest {
         initViewModel(subscription = null)
 
         viewModel.finishState.test {
-            viewModel.onExitOnboarding(OnboardingExitInfo(showPlusPromotionForFreeUser = false))
+            viewModel.onExitOnboarding(OnboardingExitInfo.Simple)
             assert(awaitItem() == OnboardingFinish.Done)
         }
     }
 
     @Test
-    fun `given showPlusPromotionForFreeUser is true and free user, when exit onboarding, then finish with DoneShowPlusPromotion`() = runTest {
+    fun `given plus promtion exit info for free user, when exit onboarding, then finish with DoneShowPlusPromotion`() = runTest {
         initViewModel(subscription = null)
 
         viewModel.finishState.test {
-            viewModel.onExitOnboarding(OnboardingExitInfo(showPlusPromotionForFreeUser = true))
+            viewModel.onExitOnboarding(OnboardingExitInfo.ShowPlusPromotion)
             assert(awaitItem() == OnboardingFinish.DoneShowPlusPromotion)
         }
     }
 
     @Test
-    fun `given showPlusPromotionForFreeUser is true and paid user, when exit onboarding, then finish with Done`() = runTest {
+    fun `given plus promtion exit info for paid user, when exit onboarding, then finish with Done`() = runTest {
         initViewModel(subscription)
 
         viewModel.finishState.test {
-            viewModel.onExitOnboarding(OnboardingExitInfo(showPlusPromotionForFreeUser = true))
+            viewModel.onExitOnboarding(OnboardingExitInfo.ShowPlusPromotion)
             assert(awaitItem() == OnboardingFinish.Done)
         }
     }
 
     @Test
-    fun `given showWelcomeInReferralFlow is true, when exit onboarding, then finish with DoneShowWelcomeInReferralFlow`() = runTest {
+    fun `given referral exit info, when exit onboarding, then finish with DoneShowWelcomeInReferralFlow`() = runTest {
         initViewModel(subscription = null)
 
         viewModel.finishState.test {
-            viewModel.onExitOnboarding(OnboardingExitInfo(showWelcomeInReferralFlow = true))
+            viewModel.onExitOnboarding(OnboardingExitInfo.ShowReferralWelcome)
             assert(awaitItem() == OnboardingFinish.DoneShowWelcomeInReferralFlow)
+        }
+    }
+
+    @Test
+    fun `given suggested folders exit info, when exit onboarding, then finish with DoneShowWelcomeInReferralFlow`() = runTest {
+        initViewModel(subscription)
+
+        viewModel.finishState.test {
+            viewModel.onExitOnboarding(OnboardingExitInfo.ApplySuggestedFolders(SuggestedFoldersAction.UseSuggestion))
+            assert(awaitItem() == OnboardingFinish.DoneApplySuggestedFolders(SuggestedFoldersAction.UseSuggestion))
         }
     }
 

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/StoriesActivity.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/StoriesActivity.kt
@@ -87,18 +87,18 @@ class StoriesActivity : ComponentActivity() {
 
     private val onboardingLauncher: ActivityResultLauncher<Intent> = registerForActivityResult(OnboardingActivityContract()) { result ->
         when (result) {
-            OnboardingFinish.Done, OnboardingFinish.DoneGoToDiscover -> {
+            is OnboardingFinish.Done, is OnboardingFinish.DoneGoToDiscover -> {
                 settings.setHasDoneInitialOnboarding()
             }
-            OnboardingFinish.DoneShowPlusPromotion -> {
+            is OnboardingFinish.DoneShowPlusPromotion -> {
                 settings.setHasDoneInitialOnboarding()
                 OnboardingLauncher.openOnboardingFlow(this, OnboardingFlow.Upsell(OnboardingUpgradeSource.LOGIN_PLUS_PROMOTION))
             }
-            OnboardingFinish.DoneShowWelcomeInReferralFlow -> {
+            is OnboardingFinish.DoneShowWelcomeInReferralFlow -> {
                 settings.showReferralWelcome.set(true, updateModifiedAt = false)
             }
-            null -> {
-                Timber.e("Unexpected null result from onboarding activity")
+            is OnboardingFinish.DoneApplySuggestedFolders, null -> {
+                Timber.e("Unexpected result $result from onboarding activity")
             }
         }
     }

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/folders/SuggestedFoldersFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/folders/SuggestedFoldersFragment.kt
@@ -32,6 +32,8 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 import androidx.navigation.navArgument
+import au.com.shiftyjelly.pocketcasts.account.onboarding.OnboardingActivityContract
+import au.com.shiftyjelly.pocketcasts.account.onboarding.OnboardingActivityContract.OnboardingFinish
 import au.com.shiftyjelly.pocketcasts.compose.AppThemeWithBackground
 import au.com.shiftyjelly.pocketcasts.compose.CallOnce
 import au.com.shiftyjelly.pocketcasts.compose.extensions.slideInToEnd
@@ -41,12 +43,13 @@ import au.com.shiftyjelly.pocketcasts.compose.extensions.slideOutToStart
 import au.com.shiftyjelly.pocketcasts.podcasts.view.folders.SuggestedFoldersViewModel.UseFoldersState.Applied
 import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingFlow
 import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingLauncher
-import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingUpgradeSource
+import au.com.shiftyjelly.pocketcasts.settings.onboarding.SuggestedFoldersAction
 import au.com.shiftyjelly.pocketcasts.views.dialog.ConfirmationDialog
 import au.com.shiftyjelly.pocketcasts.views.fragments.BaseDialogFragment
 import dagger.hilt.android.AndroidEntryPoint
 import dagger.hilt.android.lifecycle.withCreationCallback
 import kotlinx.parcelize.Parcelize
+import timber.log.Timber
 import au.com.shiftyjelly.pocketcasts.images.R as VR
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 import au.com.shiftyjelly.pocketcasts.ui.R as UR
@@ -80,6 +83,24 @@ class SuggestedFoldersFragment : BaseDialogFragment() {
             }
         },
     )
+
+    private val onboardingLauncher = registerForActivityResult(OnboardingActivityContract()) { result ->
+        when (result) {
+            is OnboardingFinish.DoneApplySuggestedFolders -> {
+                resolveSuggestedFolders(result)
+            }
+
+            is OnboardingFinish.Done -> Unit
+
+            is OnboardingFinish.DoneGoToDiscover,
+            is OnboardingFinish.DoneShowPlusPromotion,
+            is OnboardingFinish.DoneShowWelcomeInReferralFlow,
+            null,
+            -> {
+                Timber.w("Unexpected onboarding result: $result")
+            }
+        }
+    }
 
     private var isFinalizingActionUsed = false
 
@@ -187,7 +208,7 @@ class SuggestedFoldersFragment : BaseDialogFragment() {
                 .show(parentFragmentManager, "create_folder_card")
             finalizeAndDismiss()
         } else {
-            OnboardingLauncher.openOnboardingFlow(requireActivity(), OnboardingFlow.Upsell(OnboardingUpgradeSource.SUGGESTED_FOLDERS))
+            launchOnboarding(SuggestedFoldersAction.CreateCustom)
         }
     }
 
@@ -198,6 +219,7 @@ class SuggestedFoldersFragment : BaseDialogFragment() {
                     viewModel.trackUseSuggestedFoldersTapped()
                     viewModel.useSuggestedFolders()
                 }
+
                 SuggestedAction.ReplaceFolders -> {
                     viewModel.trackReplaceFolderTapped()
                     showConfirmationDialog()
@@ -205,8 +227,14 @@ class SuggestedFoldersFragment : BaseDialogFragment() {
             }
         } else {
             viewModel.trackUseSuggestedFoldersTapped()
-            OnboardingLauncher.openOnboardingFlow(requireActivity(), OnboardingFlow.Upsell(OnboardingUpgradeSource.SUGGESTED_FOLDERS))
+            launchOnboarding(SuggestedFoldersAction.UseSuggestion)
         }
+    }
+
+    private fun launchOnboarding(action: SuggestedFoldersAction) {
+        val launchFlow = OnboardingFlow.UpsellSuggestedFolder(action)
+        val launchIntent = OnboardingLauncher.launchIntent(requireActivity(), launchFlow)
+        onboardingLauncher.launch(launchIntent)
     }
 
     private fun showConfirmationDialog() {
@@ -221,6 +249,23 @@ class SuggestedFoldersFragment : BaseDialogFragment() {
             .setIconId(VR.drawable.ic_replace)
             .setIconTint(UR.attr.primary_interactive_01)
             .show(childFragmentManager, "suggested-folders-confirmation-dialog")
+    }
+
+    private fun resolveSuggestedFolders(result: OnboardingFinish.DoneApplySuggestedFolders) {
+        when (result.action) {
+            SuggestedFoldersAction.UseSuggestion -> {
+                val suggestedAction = viewModel.state.value.action
+                if (suggestedAction != null) {
+                    handleSuggestedAction(suggestedAction, isUserPlusOrPatreon = true)
+                } else {
+                    Timber.w("Missing suggested action after onboarding process")
+                }
+            }
+
+            SuggestedFoldersAction.CreateCustom -> {
+                handleCustomFolderCreation(isUserPlusOrPatreon = true)
+            }
+        }
     }
 
     enum class Source(

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/onboarding/OnboardingExitInfo.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/onboarding/OnboardingExitInfo.kt
@@ -1,6 +1,13 @@
 package au.com.shiftyjelly.pocketcasts.settings.onboarding
 
-data class OnboardingExitInfo(
-    val showPlusPromotionForFreeUser: Boolean = false,
-    val showWelcomeInReferralFlow: Boolean = false,
-)
+sealed interface OnboardingExitInfo {
+    data object Simple : OnboardingExitInfo
+
+    data object ShowPlusPromotion : OnboardingExitInfo
+
+    data object ShowReferralWelcome : OnboardingExitInfo
+
+    data class ApplySuggestedFolders(
+        val action: SuggestedFoldersAction,
+    ) : OnboardingExitInfo
+}

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/onboarding/OnboardingFlow.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/onboarding/OnboardingFlow.kt
@@ -54,6 +54,14 @@ sealed interface OnboardingFlow : Parcelable {
     }
 
     @Parcelize
+    data class UpsellSuggestedFolder(
+        val action: SuggestedFoldersAction,
+    ) : OnboardingFlow {
+        override val analyticsValue get() = "suggested_folders"
+        override val source get() = OnboardingUpgradeSource.SUGGESTED_FOLDERS
+    }
+
+    @Parcelize
     data class PatronAccountUpgrade(
         override val source: OnboardingUpgradeSource,
     ) : OnboardingFlow {
@@ -69,4 +77,9 @@ sealed interface OnboardingFlow : Parcelable {
     data object AccountEncouragement : OnboardingFlow {
         override val analyticsValue get() = "account_encouragement"
     }
+}
+
+enum class SuggestedFoldersAction {
+    UseSuggestion,
+    CreateCustom,
 }


### PR DESCRIPTION
## Description

This change removes the need to tap the Smart Folders action after completing the onboarding flow.

There are some existing issues you might encounter that are unrelated to these changes but pertain to applying Smart Folders in general:

- When a user who already has folders signs in, Smart Folders may not apply due to a race condition between account sync and new folder creation.
- When a user who already follows some podcasts signs in, podcasts they previously followed but that are not recognized locally won’t be added to folders. This happens because the Smart Folders flow is not dynamic. New podcasts may appear after sign-in that weren't accounted for during the initial flow launch.

Closes: #3967

## Testing Instructions

> [!note]
> I recommended to start each test with a fresh installation / cleared data to avoid issues related to Suggested Folders hash caching, etc.

### Apply Folders Flow

1. Apply this patch.
```
curl -L https://github.com/user-attachments/files/20201283/debug-as-prod.patch | git apply
```
2. Follow at least 8 podcasts.
3. Go to the Podcasts tab.
4. You should see the Smart Folders bottom sheet.
5. Tap "Use these folders."
6. Complete the onboarding flow. Possible flows include:
   - Signing in with a free email account.
   - Signing in with a paid email account.
   - Signing up with email.
   - Signing in with a free Google account.
   - Signing in with a paid Google account.
   - Signing up with a Google account.
7. Completing any of these flows should apply Smart Folders automatically, without needing to tap the button again. If you sign in with a paid account that already has folders, you may see a "Replace folders" confirmation.

### Create New Folder Flow

1. Apply this patch.
```
curl -L https://github.com/user-attachments/files/20201283/debug-as-prod.patch | git apply
```
2. Follow at least 8 podcasts.
3. Go to the Podcasts tab.
4. You should see the Smart Folders bottom sheet.
5. Tap "Create custom folder."
6. Finish the onboarding flow with any type of account.
7. You should see the new folders flow.

### No Subscription Flow

1. Apply this patch.
```
curl -L https://github.com/user-attachments/files/20201283/debug-as-prod.patch | git apply
```
2. Follow at least 8 podcasts.
3. Go to the Podcasts tab.
4. You should see the Smart Folders bottom sheet.
5. Tap "Use these folders."
6. Sign up with a new account.
7. When prompted for payment, cancel it and exit the onboarding flow.
8. You should still see the Smart Folders bottom sheet.

## Screenshots or Screencast 

https://github.com/user-attachments/assets/914bf931-610c-4086-916a-fcffd84df77d

## Checklist
- [ ] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [ ] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [ ] ~Any jetpack compose components I added or changed are covered by compose previews~
- [ ] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~