### PR TITLE
Add secondary button to the empty state.

### DIFF
--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/UpNextAdapter.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/UpNextAdapter.kt
@@ -9,6 +9,9 @@ import android.view.ViewGroup
 import android.widget.ImageButton
 import androidx.annotation.ColorInt
 import androidx.appcompat.widget.TooltipCompat
+import androidx.compose.foundation.layout.padding
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
 import androidx.core.view.isVisible
 import androidx.fragment.app.FragmentManager
 import androidx.recyclerview.widget.DiffUtil
@@ -183,7 +186,10 @@ class UpNextAdapter(
                 binding.emptyUpNextComposeView.setContentWithViewCompositionStrategy {
                     AppTheme(theme) {
                         if (header.episodePlaying && header.episodeCount == 0) {
-                            UpNextEmptyState(onDiscoverTapped = { listener.onDiscoverTapped() })
+                            UpNextEmptyState(
+                                onDiscoverTapped = listener::onDiscoverTapped,
+                                modifier = Modifier.padding(top = 24.dp),
+                            )
                         }
                     }
                 }

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/UpNextEmptyState.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/UpNextEmptyState.kt
@@ -17,10 +17,8 @@ fun UpNextEmptyState(
         title = stringResource(LR.string.player_up_next_empty_title),
         subtitle = stringResource(LR.string.player_up_next_empty_subtitle),
         iconResourceId = R.drawable.mini_player_upnext,
-        buttonText = stringResource(LR.string.go_to_discover),
-        onButtonClick = {
-            onDiscoverTapped()
-        },
+        primaryButtonText = stringResource(LR.string.go_to_discover),
+        onPrimaryButtonClick = onDiscoverTapped,
         modifier = modifier,
     )
 }

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/UpNextFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/UpNextFragment.kt
@@ -10,7 +10,6 @@ import android.view.ViewGroup
 import androidx.appcompat.widget.Toolbar
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
-import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.core.os.bundleOf
 import androidx.core.view.isVisible
 import androidx.core.view.updatePadding
@@ -29,6 +28,7 @@ import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTracker
 import au.com.shiftyjelly.pocketcasts.analytics.SourceView
 import au.com.shiftyjelly.pocketcasts.compose.AppTheme
+import au.com.shiftyjelly.pocketcasts.compose.extensions.setContentWithViewCompositionStrategy
 import au.com.shiftyjelly.pocketcasts.models.entity.BaseEpisode
 import au.com.shiftyjelly.pocketcasts.models.type.EpisodeViewSource
 import au.com.shiftyjelly.pocketcasts.player.R
@@ -203,16 +203,14 @@ class UpNextFragment :
             analyticsTracker.track(AnalyticsEvent.UP_NEXT_SHOWN, mapOf("source" to "tab_bar"))
         }
 
-        binding.emptyUpNextView.apply {
-            setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
-            setContent {
-                val upNextState by remember {
-                    playerViewModel.upNextStateObservable.asFlow()
-                }.collectAsStateWithLifecycle(null)
-                AppTheme(theme.activeTheme) {
-                    if (upNextState is UpNextQueue.State.Empty) {
-                        UpNextEmptyState(onDiscoverTapped = ::onDiscoverTapped)
-                    }
+        binding.emptyUpNextView.setContentWithViewCompositionStrategy {
+            val upNextState by remember {
+                playerViewModel.upNextStateObservable.asFlow()
+            }.collectAsStateWithLifecycle(null)
+
+            AppTheme(theme.activeTheme) {
+                if (upNextState is UpNextQueue.State.Empty) {
+                    UpNextEmptyState(onDiscoverTapped = ::onDiscoverTapped)
                 }
             }
         }

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/bookmark/BookmarksPage.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/bookmark/BookmarksPage.kt
@@ -11,8 +11,6 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
-import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -151,6 +149,7 @@ private fun Content(
     Box(
         contentAlignment = Alignment.Center,
         modifier = Modifier
+            .fillMaxSize()
             .background(color = backgroundColor)
             .padding(bottom = if (sourceView == SourceView.PROFILE) 0.dp else 28.dp),
     ) {
@@ -173,22 +172,18 @@ private fun Content(
                 title = stringResource(LR.string.bookmarks_empty_state_title),
                 subtitle = stringResource(LR.string.bookmarks_paid_user_empty_state_message),
                 iconResourceId = IR.drawable.ic_bookmark,
-                buttonText = stringResource(LR.string.bookmarks_headphone_settings),
-                onButtonClick = {
+                primaryButtonText = stringResource(LR.string.bookmarks_headphone_settings),
+                onPrimaryButtonClick = {
                     onHeadphoneControlsButtonTapped()
                     openFragment(HeadphoneControlsSettingsFragment())
                 },
-                modifier = Modifier.verticalScroll(rememberScrollState()),
             )
             is UiState.Upsell -> EmptyState(
                 title = stringResource(LR.string.bookmarks_empty_state_title),
                 subtitle = stringResource(LR.string.bookmarks_free_user_empty_state_message),
                 iconResourceId = IR.drawable.ic_bookmark,
-                buttonText = stringResource(LR.string.bookmarks_free_user_empty_state_button),
-                onButtonClick = {
-                    onUpgradeClicked.invoke()
-                },
-                modifier = Modifier.verticalScroll(rememberScrollState()),
+                primaryButtonText = stringResource(LR.string.bookmarks_free_user_empty_state_button),
+                onPrimaryButtonClick = onUpgradeClicked,
             )
         }
     }

--- a/modules/features/player/src/main/res/layout/fragment_upnext.xml
+++ b/modules/features/player/src/main/res/layout/fragment_upnext.xml
@@ -44,7 +44,7 @@
     <androidx.compose.ui.platform.ComposeView
         android:id="@+id/emptyUpNextView"
         android:layout_width="0dp"
-        android:layout_height="0dp"
+        android:layout_height="wrap_content"
         app:layout_constraintTop_toBottomOf="@id/appBarLayout"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintStart_toStartOf="parent"

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/ProfileEpisodeListFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/ProfileEpisodeListFragment.kt
@@ -12,8 +12,6 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.MaterialTheme
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
@@ -64,7 +62,6 @@ import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingLauncher
 import au.com.shiftyjelly.pocketcasts.settings.viewmodel.ManualCleanupViewModel
 import au.com.shiftyjelly.pocketcasts.ui.extensions.themed
 import au.com.shiftyjelly.pocketcasts.ui.helper.FragmentHostListener
-import au.com.shiftyjelly.pocketcasts.utils.extensions.combine
 import au.com.shiftyjelly.pocketcasts.utils.extensions.dpToPx
 import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
 import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
@@ -479,12 +476,11 @@ class ProfileEpisodeListFragment : BaseFragment(), Toolbar.OnMenuItemClickListen
                         title = stringResource(state.titleRes),
                         subtitle = stringResource(state.summaryRes),
                         iconResourceId = state.iconRes,
-                        buttonText = buttonText,
-                        onButtonClick = {
+                        primaryButtonText = buttonText,
+                        onPrimaryButtonClick = {
                             analyticsTracker.track(AnalyticsEvent.LISTENING_HISTORY_DISCOVER_BUTTON_TAPPED)
                             (activity as FragmentHostListener).openTab(VR.id.navigation_discover)
                         },
-                        modifier = Modifier.verticalScroll(rememberScrollState()),
                     )
                 }
             }

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/adapter/BookmarkUpsellViewHolder.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/adapter/BookmarkUpsellViewHolder.kt
@@ -30,15 +30,15 @@ class BookmarkUpsellViewHolder(
                     title = stringResource(LR.string.bookmarks_empty_state_title),
                     subtitle = stringResource(LR.string.bookmarks_free_user_empty_state_message),
                     iconResourceId = IR.drawable.ic_bookmark,
-                    buttonText = stringResource(LR.string.bookmarks_free_user_empty_state_button),
-                    onButtonClick = {
+                    primaryButtonText = stringResource(LR.string.bookmarks_free_user_empty_state_button),
+                    onPrimaryButtonClick = {
                         onGetBookmarksClicked()
                         val onboardingFlow = OnboardingFlow.Upsell(
                             source = OnboardingUpgradeSource.BOOKMARKS,
                         )
                         OnboardingLauncher.openOnboardingFlow(requireNotNull(context.getActivity()), onboardingFlow)
                     },
-                    modifier = Modifier.padding(vertical = 24.dp),
+                    modifier = Modifier.padding(top = 56.dp),
                 )
             }
         }

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/adapter/EmptyListViewHolder.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/adapter/EmptyListViewHolder.kt
@@ -21,9 +21,9 @@ class EmptyListViewHolder(
                     title = emptyList.title,
                     subtitle = emptyList.subtitle,
                     iconResourceId = emptyList.iconResourceId,
-                    buttonText = emptyList.buttonText,
-                    onButtonClick = emptyList.onButtonClick,
-                    modifier = Modifier.padding(vertical = 36.dp),
+                    primaryButtonText = emptyList.buttonText,
+                    onPrimaryButtonClick = emptyList.onButtonClick,
+                    modifier = Modifier.padding(top = 56.dp),
                 )
             }
         }

--- a/modules/features/podcasts/src/main/res/layout/fragment_profile_episode_list.xml
+++ b/modules/features/podcasts/src/main/res/layout/fragment_profile_episode_list.xml
@@ -67,7 +67,7 @@
     <androidx.compose.ui.platform.ComposeView
         android:id="@+id/emptyLayout"
         android:layout_width="match_parent"
-        android:layout_height="0dp"
+        android:layout_height="wrap_content"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/toolbarBarrier" />
 

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/cloud/CloudFilesFragment.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/cloud/CloudFilesFragment.kt
@@ -7,9 +7,6 @@ import android.view.MenuItem
 import android.view.View
 import android.view.ViewGroup
 import androidx.appcompat.widget.Toolbar
-import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.verticalScroll
-import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.core.view.isVisible
 import androidx.core.view.updateLayoutParams
@@ -178,7 +175,6 @@ class CloudFilesFragment : BaseFragment(), Toolbar.OnMenuItemClickListener {
                     title = stringResource(LR.string.profile_files_empty_title),
                     subtitle = stringResource(LR.string.profile_files_empty_summary),
                     iconResourceId = IR.drawable.ic_file,
-                    modifier = Modifier.verticalScroll(rememberScrollState()),
                 )
             }
         }

--- a/modules/features/profile/src/main/res/layout/fragment_cloud_files.xml
+++ b/modules/features/profile/src/main/res/layout/fragment_cloud_files.xml
@@ -107,13 +107,6 @@
                 android:layout_height="@dimen/divider_height"
                 android:background="?attr/primary_ui_05" />
 
-            <androidx.compose.ui.platform.ComposeView
-                android:id="@+id/emptyLayout"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginBottom="4dp"
-                />
-
             <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
                 android:id="@+id/swipeRefreshLayout"
                 android:layout_width="match_parent"
@@ -128,6 +121,12 @@
                     android:paddingBottom="64dp" />
             </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
         </LinearLayout>
+
+        <androidx.compose.ui.platform.ComposeView
+            android:id="@+id/emptyLayout"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center" />
 
         <com.google.android.material.floatingactionbutton.FloatingActionButton
             android:id="@+id/fab"

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/EmptyState.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/EmptyState.kt
@@ -1,24 +1,30 @@
 package au.com.shiftyjelly.pocketcasts.compose.components
 
 import android.content.res.Configuration
+import androidx.annotation.DrawableRes
 import androidx.compose.foundation.Image
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.ButtonDefaults
 import androidx.compose.material.MaterialTheme
+import androidx.compose.material.ripple
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
@@ -37,24 +43,26 @@ import au.com.shiftyjelly.pocketcasts.images.R as IR
 fun EmptyState(
     title: String,
     subtitle: String,
-    iconResourceId: Int,
+    @DrawableRes iconResourceId: Int,
     modifier: Modifier = Modifier,
-    buttonText: String? = null,
-    onButtonClick: () -> Unit = {},
+    primaryButtonText: String? = null,
+    onPrimaryButtonClick: (() -> Unit)? = null,
+    secondaryButtonText: String? = null,
+    onSecondaryButtonClick: (() -> Unit)? = null,
 ) {
     val isLandscape = LocalConfiguration.current.orientation == Configuration.ORIENTATION_LANDSCAPE
     val isTablet = Util.isTablet(LocalContext.current)
     val isPortraitOrTablet = isTablet || !isLandscape
-    val heightPadding = if (isPortraitOrTablet) 16.dp else 8.dp
+    val itemSpaceHeight = if (isPortraitOrTablet) 16.dp else 8.dp
 
     Column(
         horizontalAlignment = Alignment.CenterHorizontally,
-        verticalArrangement = Arrangement.Center,
-        modifier = modifier.fillMaxWidth().padding(horizontal = 32.dp),
+        verticalArrangement = Arrangement.spacedBy(itemSpaceHeight),
+        modifier = modifier
+            .padding(horizontal = 32.dp)
+            .widthIn(max = 330.dp),
     ) {
         if (isPortraitOrTablet) {
-            Spacer(Modifier.height(heightPadding))
-
             Image(
                 painter = painterResource(id = iconResourceId),
                 contentDescription = null,
@@ -63,8 +71,6 @@ fun EmptyState(
             )
         }
 
-        Spacer(Modifier.height(heightPadding))
-
         TextH30(
             text = title,
             textAlign = TextAlign.Center,
@@ -72,40 +78,77 @@ fun EmptyState(
         )
 
         if (subtitle.isNotEmpty()) {
-            Spacer(Modifier.height(heightPadding))
-
             TextP40(
                 text = subtitle,
                 textAlign = TextAlign.Center,
                 color = MaterialTheme.theme.colors.primaryText02,
                 fontSize = 15.sp,
                 fontWeight = FontWeight.W400,
-                modifier = Modifier.widthIn(max = 330.dp),
             )
         }
 
-        buttonText?.let {
-            Spacer(Modifier.height(heightPadding))
-
-            RowButton(
-                text = it,
-                onClick = { onButtonClick() },
-                includePadding = false,
-                textColor = MaterialTheme.theme.colors.primaryInteractive02,
-                colors = ButtonDefaults.buttonColors(
-                    backgroundColor = MaterialTheme.theme.colors.primaryInteractive01,
-                ),
-                modifier = Modifier.widthIn(max = 330.dp),
-            )
-        }
-
-        Spacer(Modifier.height(heightPadding))
+        EmptyStateButtons(
+            primaryButtonText = primaryButtonText,
+            onPrimaryButtonClick = onPrimaryButtonClick,
+            secondaryButtonText = secondaryButtonText,
+            onSecondaryButtonClick = onSecondaryButtonClick,
+        )
     }
 }
 
-@Preview(showBackground = true)
 @Composable
-fun EmptyStatePreview(
+private fun EmptyStateButtons(
+    primaryButtonText: String? = null,
+    onPrimaryButtonClick: (() -> Unit)? = null,
+    secondaryButtonText: String? = null,
+    onSecondaryButtonClick: (() -> Unit)? = null,
+) {
+    if (primaryButtonText != null || secondaryButtonText != null) {
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(4.dp),
+            modifier = Modifier.fillMaxWidth(),
+        ) {
+            if (primaryButtonText != null) {
+                RowButton(
+                    text = primaryButtonText,
+                    onClick = { onPrimaryButtonClick?.invoke() },
+                    includePadding = false,
+                    textColor = MaterialTheme.theme.colors.primaryInteractive02,
+                    colors = ButtonDefaults.buttonColors(
+                        backgroundColor = MaterialTheme.theme.colors.primaryInteractive01,
+                    ),
+                )
+            }
+
+            if (secondaryButtonText != null) {
+                Box(
+                    contentAlignment = Alignment.Center,
+                    modifier = Modifier
+                        .heightIn(min = 48.dp)
+                        .clip(RoundedCornerShape(12.dp))
+                        .clickable(
+                            indication = ripple(color = MaterialTheme.theme.colors.primaryInteractive01),
+                            interactionSource = null,
+                            role = Role.Button,
+                            onClick = { onSecondaryButtonClick?.invoke() },
+                        )
+                        .padding(horizontal = 16.dp),
+                ) {
+                    TextP40(
+                        text = secondaryButtonText,
+                        fontSize = 17.sp,
+                        color = MaterialTheme.theme.colors.primaryInteractive01,
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun EmptyStatePreview(
     @PreviewParameter(ThemePreviewParameterProvider::class) themeType: Theme.ThemeType,
 ) {
     AppThemeWithBackground(themeType = themeType) {
@@ -113,8 +156,48 @@ fun EmptyStatePreview(
             title = "Time to add some podcasts",
             subtitle = "Discover and subscribe to your favorite podcasts.",
             iconResourceId = IR.drawable.ic_podcasts,
-            buttonText = "Discover",
-            onButtonClick = { },
+            primaryButtonText = "Discover",
+            secondaryButtonText = "How do I do that?",
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun EmptyStateNoSubtitlePreview() {
+    AppThemeWithBackground(themeType = Theme.ThemeType.LIGHT) {
+        EmptyState(
+            title = "Time to add some podcasts",
+            subtitle = "",
+            iconResourceId = IR.drawable.ic_podcasts,
+            primaryButtonText = "Discover",
+            secondaryButtonText = "How do I do that?",
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun EmptyStateNoPrimaryButtonPreview() {
+    AppThemeWithBackground(themeType = Theme.ThemeType.LIGHT) {
+        EmptyState(
+            title = "Time to add some podcasts",
+            subtitle = "Discover and subscribe to your favorite podcasts.",
+            iconResourceId = IR.drawable.ic_podcasts,
+            secondaryButtonText = "How do I do that?",
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun EmptyStateNoSecondaryButtonPreview() {
+    AppThemeWithBackground(themeType = Theme.ThemeType.LIGHT) {
+        EmptyState(
+            title = "Time to add some podcasts",
+            subtitle = "Discover and subscribe to your favorite podcasts.",
+            iconResourceId = IR.drawable.ic_podcasts,
+            primaryButtonText = "Discover",
         )
     }
 }


### PR DESCRIPTION
## Description

This PR adds a secondary CTA to the empty state component and cleans things up a little bit. I removed embedded vertical padding from the component itself. Having it there makes it more difficult to position it correctly.

Design: 2MA6Bz3Vi36BOhuR9pitCU-fi-50_7563

This also includes some updates to the empty states of the Cloud Files and Bookmarks screens. On the Cloud Files screen, I centered the empty state. On the Bookmarks page, I made some minor improvements to the background colors and positioning. It’s not ideal, but I can't do a full overhaul of the Bookmarks page at the moment.

## Testing Instructions

Check the component preview and verify it with the designs.

## Screenshots or Screencast

| Bookmarks before | Bookmarks after | Files before | Files after |
| - | - | - | - |
| ![bb](https://github.com/user-attachments/assets/87e7d07f-f077-436b-addd-e63c3d7b9f67) | ![ba](https://github.com/user-attachments/assets/b2833972-360d-4850-8b3c-ef734cc00762) | ![fb](https://github.com/user-attachments/assets/ba56ab44-be29-4877-a335-b6ec0444f9b0) | ![fa](https://github.com/user-attachments/assets/563fa2eb-3aca-4215-8418-b6bab993fe16) |

## Checklist
- [ ] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [ ] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [ ] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [ ] ~for accessibility with TalkBack~