### PR TITLE
Enables Recently Played sorting option for podcasts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 7.90
 -----
+*   New Features
+    *   Add Recently Played sorting option for podcasts
+        ([#3816](https://github.com/Automattic/pocket-casts-android/pull/3816)) 
 *   Updates
     *   Add dropshadow to the podcast artwork and move it below toolbar.
         ([#4006](https://github.com/Automattic/pocket-casts-android/pull/4006))

--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/Feature.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/Feature.kt
@@ -165,9 +165,9 @@ enum class Feature(
     PODCASTS_SORT_CHANGES(
         key = "podcasts_sort_changes",
         title = "Podcasts Sort Changes",
-        defaultValue = BuildConfig.DEBUG,
+        defaultValue = true,
         tier = FeatureTier.Free,
-        hasFirebaseRemoteFlag = false,
+        hasFirebaseRemoteFlag = true,
         hasDevToggle = true,
     ),
     GUEST_LISTS_NETWORK_HIGHLIGHTS_REDESIGN(


### PR DESCRIPTION
## Description

This pull request enables the new sorting option for podcasts "Recently played".

## Testing Instructions

1. Install the release variant
```
./gradlew app:assembleRelease
adb install -r app/build/outputs/apk/release/app-release.apk
```  
2. Go to the Podcasts tab
3. ✅ Check the new "Sort by" option "Recently played" is visible and works

## Screenshots 

<img  width="300" src="https://github.com/user-attachments/assets/aa93f592-2bfd-443d-a13c-dd747e5cdc46" /> 

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack
