### PR TITLE
Updates DataStore dependency to prevent crashes, attempt 2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
         ([#4024](https://github.com/Automattic/pocket-casts-android/pull/4024))
 *   Bug Fixes
     *   Updates datastore dependency to prevent crashes
-        ([#3982](https://github.com/Automattic/pocket-casts-android/pull/3982)
+        ([#4031](https://github.com/Automattic/pocket-casts-android/pull/4031)
 
 7.89
 -----

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
         ([#4006](https://github.com/Automattic/pocket-casts-android/pull/4006))
     *   Improve error handling when purchasing subscriptions.
         ([#4024](https://github.com/Automattic/pocket-casts-android/pull/4024))
+*   Bug Fixes
+    *   Updates datastore dependency to prevent crashes
+        ([#3982](https://github.com/Automattic/pocket-casts-android/pull/3982)
 
 7.89
 -----
@@ -23,6 +26,7 @@
         ([#3947](https://github.com/Automattic/pocket-casts-android/pull/3947))
     *   Fix issue with podcast description crashing the app
         ([#3994](https://github.com/Automattic/pocket-casts-android/pull/3994))
+
 
 7.88
 -----

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,6 @@
     *   Fix issue with podcast description crashing the app
         ([#3994](https://github.com/Automattic/pocket-casts-android/pull/3994))
 
-
 7.88
 -----
 *   New Features

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -70,6 +70,7 @@ dependencies {
     implementation(libs.coroutines.rx2)
     implementation(libs.dagger.hilt.android)
     implementation(libs.dagger.hilt.core)
+    implementation(libs.datastore)?.because("Force using the latest datastore version to stop the app crashing with Glance widgets. Glance and Horologist libraries both include this library. Pull request https://github.com/Automattic/pocket-casts-android/pull/3982.")
     implementation(libs.encryptedlogging)
     implementation(libs.firebase.config)
     implementation(libs.fragment.ktx)

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -70,7 +70,7 @@ dependencies {
     implementation(libs.coroutines.rx2)
     implementation(libs.dagger.hilt.android)
     implementation(libs.dagger.hilt.core)
-    implementation(libs.datastore)?.because("Force using the latest datastore version to stop the app crashing with Glance widgets. Glance and Horologist libraries both include this library. Pull request https://github.com/Automattic/pocket-casts-android/pull/3982.")
+    implementation(libs.datastore)?.because("Force using the latest datastore version to stop the app crashing with Glance widgets. Glance and Horologist libraries both include this library. Pull request https://github.com/Automattic/pocket-casts-android/pull/4031.")
     implementation(libs.encryptedlogging)
     implementation(libs.firebase.config)
     implementation(libs.fragment.ktx)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -21,10 +21,11 @@ android-gradle-plugin = "8.10.0"
 billing = "7.0.0"
 coil = "2.7.0"
 compose = "2024.10.00" # https://developer.android.com/jetpack/compose/bom/bom-mapping
+datastore = "1.1.7"
 dependency-analysis = "2.17.0"
 firebase = "33.13.0"
 fragment = "1.8.6"
-glance = "1.0.0"
+glance = "1.1.1"
 google-services = "4.4.2"
 hilt = "2.56.2"
 hilt-compiler = "1.2.0"
@@ -106,6 +107,9 @@ dagger-hilt-core = { module = "com.google.dagger:hilt-core", version.ref = "hilt
 hilt-compiler = { module = "androidx.hilt:hilt-compiler", version.ref = "hilt-compiler" }
 hilt-navigation-compose = "androidx.hilt:hilt-navigation-compose:1.2.0"
 hilt-work = "androidx.hilt:hilt-work:1.2.0"
+
+# Datastore
+datastore = { module = "androidx.datastore:datastore", version.ref = "datastore" }
 
 # Firebase
 firebase-bom = { module = "com.google.firebase:firebase-bom", version.ref = "firebase" }

--- a/wear/build.gradle.kts
+++ b/wear/build.gradle.kts
@@ -73,6 +73,7 @@ dependencies {
     implementation(libs.coroutines.rx2)
     implementation(libs.dagger.hilt.android)
     implementation(libs.dagger.hilt.core)
+    implementation(libs.datastore)?.because("Force using the latest datastore version to stop the app crashing with Glance widgets. Glance and Horologist libraries both include this library. Pull request https://github.com/Automattic/pocket-casts-android/pull/3982.")
     implementation(libs.encryptedlogging)
     implementation(libs.firebase.config)
     implementation(libs.guava)

--- a/wear/build.gradle.kts
+++ b/wear/build.gradle.kts
@@ -73,7 +73,7 @@ dependencies {
     implementation(libs.coroutines.rx2)
     implementation(libs.dagger.hilt.android)
     implementation(libs.dagger.hilt.core)
-    implementation(libs.datastore)?.because("Force using the latest datastore version to stop the app crashing with Glance widgets. Glance and Horologist libraries both include this library. Pull request https://github.com/Automattic/pocket-casts-android/pull/3982.")
+    implementation(libs.datastore)?.because("Force using the latest datastore version to stop the app crashing with Glance widgets. Glance and Horologist libraries both include this library. Pull request https://github.com/Automattic/pocket-casts-android/pull/4031.")
     implementation(libs.encryptedlogging)
     implementation(libs.firebase.config)
     implementation(libs.guava)


### PR DESCRIPTION
## Description

This change attempts to upgrade the DataStore library to prevent one of the app's most common crashes. We tried this with version 1.1.6 in the PR https://github.com/Automattic/pocket-casts-android/pull/3982 but it was later found that it crashes the release build. I have tested 1.1.7 with a release build and the release notes contain the following:

> Fixed missing Proguard rules issue in the Android artifact of datastore-preferences-core. ([3f3f6e](https://android-review.googlesource.com/#/q/3f3f6ecadb0f3beb755a27fb5859e238e81b7ea3), [b/413078297](https://issuetracker.google.com/issues/413078297))

## Testing Instructions
Although I haven’t been able to reproduce the crash, the issue appears related to the DataStore usage in the Glance widget and Horologist libraries. Please focus testing on widgets and Wear OS functionality.

📱 Widgets
1. Install the app from the main branch.
2. Add a few widgets to your home screen.
3. Install the app from this branch.
4. ✅ Confirm that the previously added widgets still appear and function as expected.
5. Add additional widgets.
6. ✅ Verify that all widgets (old and new) behave correctly.

⌚️ Wear OS
7. Install the Wear OS app from this branch.
8. ✅ Check that the Wear app installs successfully and all key functionality works as expected.

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 

