### PR TITLE
Empty state tweaks

### DIFF
--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeFeaturesPage.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeFeaturesPage.kt
@@ -80,8 +80,8 @@ import au.com.shiftyjelly.pocketcasts.compose.CallOnce
 import au.com.shiftyjelly.pocketcasts.compose.bars.NavigationIconButton
 import au.com.shiftyjelly.pocketcasts.compose.bars.SystemBarsStyles
 import au.com.shiftyjelly.pocketcasts.compose.components.AutoResizeText
-import au.com.shiftyjelly.pocketcasts.compose.components.NoContentBanner
 import au.com.shiftyjelly.pocketcasts.compose.components.HorizontalPagerWrapper
+import au.com.shiftyjelly.pocketcasts.compose.components.NoContentBanner
 import au.com.shiftyjelly.pocketcasts.compose.components.SegmentedTabBar
 import au.com.shiftyjelly.pocketcasts.compose.components.TextH30
 import au.com.shiftyjelly.pocketcasts.compose.components.TextH60

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeFeaturesPage.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeFeaturesPage.kt
@@ -80,7 +80,7 @@ import au.com.shiftyjelly.pocketcasts.compose.CallOnce
 import au.com.shiftyjelly.pocketcasts.compose.bars.NavigationIconButton
 import au.com.shiftyjelly.pocketcasts.compose.bars.SystemBarsStyles
 import au.com.shiftyjelly.pocketcasts.compose.components.AutoResizeText
-import au.com.shiftyjelly.pocketcasts.compose.components.EmptyState
+import au.com.shiftyjelly.pocketcasts.compose.components.NoContentBanner
 import au.com.shiftyjelly.pocketcasts.compose.components.HorizontalPagerWrapper
 import au.com.shiftyjelly.pocketcasts.compose.components.SegmentedTabBar
 import au.com.shiftyjelly.pocketcasts.compose.components.TextH30
@@ -575,7 +575,7 @@ fun NoSubscriptionsLayout(
         }
         Spacer(modifier = Modifier.weight(1f))
 
-        EmptyState(
+        NoContentBanner(
             title = stringResource(LR.string.onboarding_upgrade_no_plans_found_title),
             subtitle = stringResource(LR.string.onboarding_upgrade_no_plans_found_body),
             iconResourceId = IR.drawable.ic_warning,

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeFeaturesPage.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeFeaturesPage.kt
@@ -577,7 +577,7 @@ fun NoSubscriptionsLayout(
 
         NoContentBanner(
             title = stringResource(LR.string.onboarding_upgrade_no_plans_found_title),
-            subtitle = stringResource(LR.string.onboarding_upgrade_no_plans_found_body),
+            body = stringResource(LR.string.onboarding_upgrade_no_plans_found_body),
             iconResourceId = IR.drawable.ic_warning,
             primaryButtonText = stringResource(LR.string.try_again),
             onPrimaryButtonClick = onTryAgain,

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/UpNextAdapter.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/UpNextAdapter.kt
@@ -186,7 +186,7 @@ class UpNextAdapter(
                 binding.emptyUpNextComposeView.setContentWithViewCompositionStrategy {
                     AppTheme(theme) {
                         if (header.episodePlaying && header.episodeCount == 0) {
-                            UpNextEmptyState(
+                            UpNextNoContentBanner(
                                 onDiscoverTapped = listener::onDiscoverTapped,
                                 modifier = Modifier.padding(top = 24.dp),
                             )

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/UpNextFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/UpNextFragment.kt
@@ -220,7 +220,7 @@ class UpNextFragment :
                         verticalArrangement = Arrangement.Center,
                         modifier = Modifier.verticalScroll(rememberScrollState()),
                     ) {
-                        UpNextEmptyState(
+                        UpNextNoContentBanner(
                             onDiscoverTapped = ::onDiscoverTapped,
                             modifier = Modifier.padding(vertical = 24.dp),
                         )

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/UpNextNoContentBanner.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/UpNextNoContentBanner.kt
@@ -4,16 +4,16 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
-import au.com.shiftyjelly.pocketcasts.compose.components.EmptyState
+import au.com.shiftyjelly.pocketcasts.compose.components.NoContentBanner
 import au.com.shiftyjelly.pocketcasts.player.R
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 @Composable
-fun UpNextEmptyState(
+fun UpNextNoContentBanner(
     onDiscoverTapped: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    EmptyState(
+    NoContentBanner(
         title = stringResource(LR.string.player_up_next_empty_title),
         subtitle = stringResource(LR.string.player_up_next_empty_subtitle),
         iconResourceId = R.drawable.mini_player_upnext,
@@ -25,8 +25,8 @@ fun UpNextEmptyState(
 
 @Preview(showBackground = true)
 @Composable
-private fun UpNextEmptyStatePreview() {
-    UpNextEmptyState(
+private fun UpNextNoContentBannerPreview() {
+    UpNextNoContentBanner(
         onDiscoverTapped = {},
     )
 }

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/UpNextNoContentBanner.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/UpNextNoContentBanner.kt
@@ -15,7 +15,7 @@ fun UpNextNoContentBanner(
 ) {
     NoContentBanner(
         title = stringResource(LR.string.player_up_next_empty_title),
-        subtitle = stringResource(LR.string.player_up_next_empty_subtitle),
+        body = stringResource(LR.string.player_up_next_empty_subtitle),
         iconResourceId = R.drawable.mini_player_upnext,
         primaryButtonText = stringResource(LR.string.go_to_discover),
         onPrimaryButtonClick = onDiscoverTapped,

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/bookmark/BookmarksPage.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/bookmark/BookmarksPage.kt
@@ -172,7 +172,7 @@ private fun Content(
             ) {
                 NoContentBanner(
                     title = stringResource(LR.string.bookmarks_empty_state_title),
-                    subtitle = stringResource(LR.string.bookmarks_paid_user_empty_state_message),
+                    body = stringResource(LR.string.bookmarks_paid_user_empty_state_message),
                     iconResourceId = IR.drawable.ic_bookmark,
                     primaryButtonText = stringResource(LR.string.bookmarks_headphone_settings),
                     onPrimaryButtonClick = {
@@ -186,7 +186,7 @@ private fun Content(
             ) {
                 NoContentBanner(
                     title = stringResource(LR.string.bookmarks_empty_state_title),
-                    subtitle = stringResource(LR.string.bookmarks_free_user_empty_state_message),
+                    body = stringResource(LR.string.bookmarks_free_user_empty_state_message),
                     iconResourceId = IR.drawable.ic_bookmark,
                     primaryButtonText = stringResource(LR.string.bookmarks_free_user_empty_state_button),
                     onPrimaryButtonClick = onUpgradeClicked,

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/bookmark/BookmarksPage.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/bookmark/BookmarksPage.kt
@@ -35,14 +35,14 @@ import au.com.shiftyjelly.pocketcasts.analytics.SourceView
 import au.com.shiftyjelly.pocketcasts.compose.AppTheme
 import au.com.shiftyjelly.pocketcasts.compose.bookmark.BookmarkRow
 import au.com.shiftyjelly.pocketcasts.compose.buttons.TimePlayButtonColors
-import au.com.shiftyjelly.pocketcasts.compose.components.EmptyState
+import au.com.shiftyjelly.pocketcasts.compose.components.NoContentBanner
 import au.com.shiftyjelly.pocketcasts.compose.components.SearchBar
 import au.com.shiftyjelly.pocketcasts.compose.loading.LoadingView
 import au.com.shiftyjelly.pocketcasts.models.entity.Bookmark
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.models.type.SyncStatus
 import au.com.shiftyjelly.pocketcasts.player.view.bookmark.components.HeaderRow
-import au.com.shiftyjelly.pocketcasts.player.view.bookmark.components.NoMatchingBookmarks
+import au.com.shiftyjelly.pocketcasts.player.view.bookmark.components.NoMatchingBookmarksBanner
 import au.com.shiftyjelly.pocketcasts.player.viewmodel.BookmarksViewModel
 import au.com.shiftyjelly.pocketcasts.player.viewmodel.BookmarksViewModel.BookmarkMessage
 import au.com.shiftyjelly.pocketcasts.player.viewmodel.BookmarksViewModel.UiState
@@ -170,7 +170,7 @@ private fun Content(
             is UiState.Empty -> Column(
                 modifier = Modifier.verticalScroll(rememberScrollState()),
             ) {
-                EmptyState(
+                NoContentBanner(
                     title = stringResource(LR.string.bookmarks_empty_state_title),
                     subtitle = stringResource(LR.string.bookmarks_paid_user_empty_state_message),
                     iconResourceId = IR.drawable.ic_bookmark,
@@ -184,7 +184,7 @@ private fun Content(
             is UiState.Upsell -> Column(
                 modifier = Modifier.verticalScroll(rememberScrollState()),
             ) {
-                EmptyState(
+                NoContentBanner(
                     title = stringResource(LR.string.bookmarks_empty_state_title),
                     subtitle = stringResource(LR.string.bookmarks_free_user_empty_state_message),
                     iconResourceId = IR.drawable.ic_bookmark,
@@ -235,7 +235,7 @@ private fun BookmarksView(
             state.bookmarks.isEmpty()
         ) {
             item {
-                NoMatchingBookmarks(
+                NoMatchingBookmarksBanner(
                     modifier = Modifier.padding(top = 24.dp),
                 )
             }

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/bookmark/components/NoMatchingBookmarksBanner.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/bookmark/components/NoMatchingBookmarksBanner.kt
@@ -16,7 +16,7 @@ fun NoMatchingBookmarksBanner(
 ) {
     NoContentBanner(
         title = stringResource(LR.string.podcast_no_bookmarks_found),
-        subtitle = stringResource(LR.string.bookmarks_search_results_not_found),
+        body = stringResource(LR.string.bookmarks_search_results_not_found),
         iconResourceId = R.drawable.ic_bookmark,
         modifier = modifier,
     )

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/bookmark/components/NoMatchingBookmarksBanner.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/bookmark/components/NoMatchingBookmarksBanner.kt
@@ -5,16 +5,16 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import au.com.shiftyjelly.pocketcasts.compose.AppTheme
-import au.com.shiftyjelly.pocketcasts.compose.components.EmptyState
+import au.com.shiftyjelly.pocketcasts.compose.components.NoContentBanner
 import au.com.shiftyjelly.pocketcasts.images.R
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 @Composable
-fun NoMatchingBookmarks(
+fun NoMatchingBookmarksBanner(
     modifier: Modifier = Modifier,
 ) {
-    EmptyState(
+    NoContentBanner(
         title = stringResource(LR.string.podcast_no_bookmarks_found),
         subtitle = stringResource(LR.string.bookmarks_search_results_not_found),
         iconResourceId = R.drawable.ic_bookmark,
@@ -24,8 +24,8 @@ fun NoMatchingBookmarks(
 
 @Preview
 @Composable
-private fun NoMatchingBookmarksPreview() {
+private fun NoMatchingBookmarksBannerPreview() {
     AppTheme(themeType = Theme.ThemeType.LIGHT) {
-        NoMatchingBookmarks()
+        NoMatchingBookmarksBanner()
     }
 }

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/ProfileEpisodeListFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/ProfileEpisodeListFragment.kt
@@ -484,7 +484,7 @@ class ProfileEpisodeListFragment : BaseFragment(), Toolbar.OnMenuItemClickListen
                     ) {
                         NoContentBanner(
                             title = stringResource(state.titleRes),
-                            subtitle = stringResource(state.summaryRes),
+                            body = stringResource(state.summaryRes),
                             iconResourceId = state.iconRes,
                             primaryButtonText = buttonText,
                             onPrimaryButtonClick = {

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/ProfileEpisodeListFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/ProfileEpisodeListFragment.kt
@@ -37,7 +37,7 @@ import au.com.shiftyjelly.pocketcasts.analytics.SourceView
 import au.com.shiftyjelly.pocketcasts.compose.AppTheme
 import au.com.shiftyjelly.pocketcasts.compose.CallOnce
 import au.com.shiftyjelly.pocketcasts.compose.components.Banner
-import au.com.shiftyjelly.pocketcasts.compose.components.EmptyState
+import au.com.shiftyjelly.pocketcasts.compose.components.NoContentBanner
 import au.com.shiftyjelly.pocketcasts.compose.extensions.setContentWithViewCompositionStrategy
 import au.com.shiftyjelly.pocketcasts.compose.theme
 import au.com.shiftyjelly.pocketcasts.models.entity.BaseEpisode
@@ -482,7 +482,7 @@ class ProfileEpisodeListFragment : BaseFragment(), Toolbar.OnMenuItemClickListen
                             .fillMaxWidth()
                             .verticalScroll(rememberScrollState()),
                     ) {
-                        EmptyState(
+                        NoContentBanner(
                             title = stringResource(state.titleRes),
                             subtitle = stringResource(state.summaryRes),
                             iconResourceId = state.iconRes,

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/adapter/BookmarkUpsellViewHolder.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/adapter/BookmarkUpsellViewHolder.kt
@@ -28,7 +28,7 @@ class BookmarkUpsellViewHolder(
                 val context = LocalContext.current
                 NoContentBanner(
                     title = stringResource(LR.string.bookmarks_empty_state_title),
-                    subtitle = stringResource(LR.string.bookmarks_free_user_empty_state_message),
+                    body = stringResource(LR.string.bookmarks_free_user_empty_state_message),
                     iconResourceId = IR.drawable.ic_bookmark,
                     primaryButtonText = stringResource(LR.string.bookmarks_free_user_empty_state_button),
                     onPrimaryButtonClick = {

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/adapter/BookmarkUpsellViewHolder.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/adapter/BookmarkUpsellViewHolder.kt
@@ -8,7 +8,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.recyclerview.widget.RecyclerView
 import au.com.shiftyjelly.pocketcasts.compose.AppTheme
-import au.com.shiftyjelly.pocketcasts.compose.components.EmptyState
+import au.com.shiftyjelly.pocketcasts.compose.components.NoContentBanner
 import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingFlow
 import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingLauncher
 import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingUpgradeSource
@@ -26,7 +26,7 @@ class BookmarkUpsellViewHolder(
         composeView.setContent {
             AppTheme(theme.activeTheme) {
                 val context = LocalContext.current
-                EmptyState(
+                NoContentBanner(
                     title = stringResource(LR.string.bookmarks_empty_state_title),
                     subtitle = stringResource(LR.string.bookmarks_free_user_empty_state_message),
                     iconResourceId = IR.drawable.ic_bookmark,

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/adapter/EmptyListViewHolder.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/adapter/EmptyListViewHolder.kt
@@ -9,7 +9,7 @@ import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.unit.dp
 import androidx.recyclerview.widget.RecyclerView
 import au.com.shiftyjelly.pocketcasts.compose.AppTheme
-import au.com.shiftyjelly.pocketcasts.compose.components.EmptyState
+import au.com.shiftyjelly.pocketcasts.compose.components.NoContentBanner
 import au.com.shiftyjelly.pocketcasts.compose.extensions.setContentWithViewCompositionStrategy
 import au.com.shiftyjelly.pocketcasts.podcasts.view.podcast.PodcastAdapter
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
@@ -25,7 +25,7 @@ class EmptyListViewHolder(
                     contentAlignment = Alignment.Center,
                     modifier = Modifier.fillMaxWidth(),
                 ) {
-                    EmptyState(
+                    NoContentBanner(
                         title = emptyList.title,
                         subtitle = emptyList.subtitle,
                         iconResourceId = emptyList.iconResourceId,

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/adapter/EmptyListViewHolder.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/adapter/EmptyListViewHolder.kt
@@ -27,7 +27,7 @@ class EmptyListViewHolder(
                 ) {
                     NoContentBanner(
                         title = emptyList.title,
-                        subtitle = emptyList.subtitle,
+                        body = emptyList.subtitle,
                         iconResourceId = emptyList.iconResourceId,
                         primaryButtonText = emptyList.buttonText,
                         onPrimaryButtonClick = emptyList.onButtonClick,

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcasts/PodcastsFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcasts/PodcastsFragment.kt
@@ -53,7 +53,7 @@ import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTracker
 import au.com.shiftyjelly.pocketcasts.analytics.SourceView
 import au.com.shiftyjelly.pocketcasts.compose.AppTheme
 import au.com.shiftyjelly.pocketcasts.compose.CallOnce
-import au.com.shiftyjelly.pocketcasts.compose.components.EmptyState
+import au.com.shiftyjelly.pocketcasts.compose.components.NoContentBanner
 import au.com.shiftyjelly.pocketcasts.compose.components.TipPosition
 import au.com.shiftyjelly.pocketcasts.compose.components.Tooltip
 import au.com.shiftyjelly.pocketcasts.compose.extensions.setContentWithViewCompositionStrategy
@@ -451,7 +451,7 @@ class PodcastsFragment :
                     modifier = Modifier.verticalScroll(rememberScrollState()),
                 ) {
                     if (isFolder) {
-                        FoldersEmptyState(
+                        NoFolderPodcastsBanner(
                             onClickButton = {
                                 viewModel.folder?.let { folder ->
                                     FolderEditPodcastsFragment.newInstance(folderUuid = folder.uuid).show(parentFragmentManager, "add_podcasts_card")
@@ -459,7 +459,7 @@ class PodcastsFragment :
                             },
                         )
                     } else {
-                        PodcastsEmptyState(
+                        NoPodcastsBanner(
                             onClickButton = {
                                 analyticsTracker.track(AnalyticsEvent.PODCASTS_LIST_DISCOVER_BUTTON_TAPPED)
                                 (activity as FragmentHostListener).openTab(VR.id.navigation_discover)
@@ -593,10 +593,10 @@ class PodcastsFragment :
 }
 
 @Composable
-private fun PodcastsEmptyState(
+private fun NoPodcastsBanner(
     onClickButton: () -> Unit,
 ) {
-    EmptyState(
+    NoContentBanner(
         title = stringResource(LR.string.podcasts_time_to_add_some_podcasts),
         subtitle = stringResource(LR.string.podcasts_time_to_add_some_podcasts_summary),
         iconResourceId = IR.drawable.ic_podcasts,
@@ -606,10 +606,10 @@ private fun PodcastsEmptyState(
 }
 
 @Composable
-private fun FoldersEmptyState(
+private fun NoFolderPodcastsBanner(
     onClickButton: () -> Unit,
 ) {
-    EmptyState(
+    NoContentBanner(
         title = stringResource(LR.string.podcasts_empty_folder),
         subtitle = stringResource(LR.string.podcasts_empty_folder_summary),
         iconResourceId = IR.drawable.ic_folder,

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcasts/PodcastsFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcasts/PodcastsFragment.kt
@@ -598,7 +598,7 @@ private fun NoPodcastsBanner(
 ) {
     NoContentBanner(
         title = stringResource(LR.string.podcasts_time_to_add_some_podcasts),
-        subtitle = stringResource(LR.string.podcasts_time_to_add_some_podcasts_summary),
+        body = stringResource(LR.string.podcasts_time_to_add_some_podcasts_summary),
         iconResourceId = IR.drawable.ic_podcasts,
         primaryButtonText = stringResource(LR.string.podcasts_discover),
         onPrimaryButtonClick = onClickButton,
@@ -611,7 +611,7 @@ private fun NoFolderPodcastsBanner(
 ) {
     NoContentBanner(
         title = stringResource(LR.string.podcasts_empty_folder),
-        subtitle = stringResource(LR.string.podcasts_empty_folder_summary),
+        body = stringResource(LR.string.podcasts_empty_folder_summary),
         iconResourceId = IR.drawable.ic_folder,
         primaryButtonText = stringResource(LR.string.add_podcasts),
         onPrimaryButtonClick = onClickButton,

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/cloud/CloudFilesFragment.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/cloud/CloudFilesFragment.kt
@@ -31,7 +31,7 @@ import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTracker
 import au.com.shiftyjelly.pocketcasts.analytics.SourceView
 import au.com.shiftyjelly.pocketcasts.compose.AppTheme
-import au.com.shiftyjelly.pocketcasts.compose.components.EmptyState
+import au.com.shiftyjelly.pocketcasts.compose.components.NoContentBanner
 import au.com.shiftyjelly.pocketcasts.compose.extensions.setContentWithViewCompositionStrategy
 import au.com.shiftyjelly.pocketcasts.models.entity.BaseEpisode
 import au.com.shiftyjelly.pocketcasts.models.type.EpisodeViewSource
@@ -185,7 +185,7 @@ class CloudFilesFragment : BaseFragment(), Toolbar.OnMenuItemClickListener {
                         .fillMaxWidth()
                         .verticalScroll(rememberScrollState()),
                 ) {
-                    EmptyState(
+                    NoContentBanner(
                         title = stringResource(LR.string.profile_files_empty_title),
                         subtitle = stringResource(LR.string.profile_files_empty_summary),
                         iconResourceId = IR.drawable.ic_file,

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/cloud/CloudFilesFragment.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/cloud/CloudFilesFragment.kt
@@ -187,7 +187,7 @@ class CloudFilesFragment : BaseFragment(), Toolbar.OnMenuItemClickListener {
                 ) {
                     NoContentBanner(
                         title = stringResource(LR.string.profile_files_empty_title),
-                        subtitle = stringResource(LR.string.profile_files_empty_summary),
+                        body = stringResource(LR.string.profile_files_empty_summary),
                         iconResourceId = IR.drawable.ic_file,
                         modifier = Modifier.padding(vertical = 24.dp),
                     )

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/NoContentBanner.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/NoContentBanner.kt
@@ -42,7 +42,7 @@ import au.com.shiftyjelly.pocketcasts.images.R as IR
 @Composable
 fun NoContentBanner(
     title: String,
-    subtitle: String,
+    body: String,
     @DrawableRes iconResourceId: Int,
     modifier: Modifier = Modifier,
     primaryButtonText: String? = null,
@@ -77,9 +77,9 @@ fun NoContentBanner(
             fontWeight = FontWeight.W500,
         )
 
-        if (subtitle.isNotEmpty()) {
+        if (body.isNotEmpty()) {
             TextP40(
-                text = subtitle,
+                text = body,
                 textAlign = TextAlign.Center,
                 color = MaterialTheme.theme.colors.primaryText02,
                 fontSize = 15.sp,
@@ -154,7 +154,7 @@ private fun UpNextNoContentBannerPreview(
     AppThemeWithBackground(themeType = themeType) {
         NoContentBanner(
             title = "Time to add some podcasts",
-            subtitle = "Discover and subscribe to your favorite podcasts.",
+            body = "Discover and subscribe to your favorite podcasts.",
             iconResourceId = IR.drawable.ic_podcasts,
             primaryButtonText = "Discover",
             secondaryButtonText = "How do I do that?",
@@ -168,7 +168,7 @@ private fun UpNextNoContentBannerWithoutSubtitlePreview() {
     AppThemeWithBackground(themeType = Theme.ThemeType.LIGHT) {
         NoContentBanner(
             title = "Time to add some podcasts",
-            subtitle = "",
+            body = "",
             iconResourceId = IR.drawable.ic_podcasts,
             primaryButtonText = "Discover",
             secondaryButtonText = "How do I do that?",
@@ -182,7 +182,7 @@ private fun UpNextNoContentBannerWithoutPrimaryButtonPreview() {
     AppThemeWithBackground(themeType = Theme.ThemeType.LIGHT) {
         NoContentBanner(
             title = "Time to add some podcasts",
-            subtitle = "Discover and subscribe to your favorite podcasts.",
+            body = "Discover and subscribe to your favorite podcasts.",
             iconResourceId = IR.drawable.ic_podcasts,
             secondaryButtonText = "How do I do that?",
         )
@@ -195,7 +195,7 @@ private fun UpNextNoContentBannerWithoutSecondaryButtonPreview() {
     AppThemeWithBackground(themeType = Theme.ThemeType.LIGHT) {
         NoContentBanner(
             title = "Time to add some podcasts",
-            subtitle = "Discover and subscribe to your favorite podcasts.",
+            body = "Discover and subscribe to your favorite podcasts.",
             iconResourceId = IR.drawable.ic_podcasts,
             primaryButtonText = "Discover",
         )

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/NoContentBanner.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/NoContentBanner.kt
@@ -14,9 +14,14 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.ButtonDefaults
+import androidx.compose.material.ExperimentalMaterialApi
+import androidx.compose.material.LocalRippleConfiguration
 import androidx.compose.material.MaterialTheme
+import androidx.compose.material.RippleConfiguration
 import androidx.compose.material.ripple
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -96,6 +101,7 @@ fun NoContentBanner(
     }
 }
 
+@OptIn(ExperimentalMaterialApi::class)
 @Composable
 private fun EmptyStateButtons(
     primaryButtonText: String? = null,
@@ -110,25 +116,30 @@ private fun EmptyStateButtons(
             modifier = Modifier.fillMaxWidth(),
         ) {
             if (primaryButtonText != null) {
-                RowButton(
-                    text = primaryButtonText,
-                    onClick = { onPrimaryButtonClick?.invoke() },
-                    includePadding = false,
-                    textColor = MaterialTheme.theme.colors.primaryInteractive02,
-                    colors = ButtonDefaults.buttonColors(
-                        backgroundColor = MaterialTheme.theme.colors.primaryInteractive01,
-                    ),
-                )
+                CompositionLocalProvider(
+                    LocalRippleConfiguration provides RippleConfiguration(MaterialTheme.theme.colors.primaryUi01),
+                ) {
+                    RowButton(
+                        text = primaryButtonText,
+                        onClick = { onPrimaryButtonClick?.invoke() },
+                        includePadding = false,
+                        textColor = MaterialTheme.theme.colors.primaryInteractive02,
+                        colors = ButtonDefaults.buttonColors(
+                            backgroundColor = MaterialTheme.theme.colors.primaryInteractive01,
+                        ),
+                    )
+                }
             }
 
             if (secondaryButtonText != null) {
+                val rippleColors = MaterialTheme.theme.colors.primaryInteractive01
                 Box(
                     contentAlignment = Alignment.Center,
                     modifier = Modifier
                         .heightIn(min = 48.dp)
                         .clip(RoundedCornerShape(12.dp))
                         .clickable(
-                            indication = ripple(color = MaterialTheme.theme.colors.primaryInteractive01),
+                            indication = remember(rippleColors) { ripple(color = rippleColors) },
                             interactionSource = null,
                             role = Role.Button,
                             onClick = { onSecondaryButtonClick?.invoke() },

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/NoContentBanner.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/NoContentBanner.kt
@@ -30,7 +30,6 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.max
 import androidx.compose.ui.unit.sp
 import au.com.shiftyjelly.pocketcasts.compose.AppThemeWithBackground
 import au.com.shiftyjelly.pocketcasts.compose.buttons.RowButton
@@ -41,7 +40,7 @@ import au.com.shiftyjelly.pocketcasts.utils.Util
 import au.com.shiftyjelly.pocketcasts.images.R as IR
 
 @Composable
-fun EmptyState(
+fun NoContentBanner(
     title: String,
     subtitle: String,
     @DrawableRes iconResourceId: Int,
@@ -149,11 +148,11 @@ private fun EmptyStateButtons(
 
 @Preview
 @Composable
-private fun EmptyStatePreview(
+private fun UpNextNoContentBannerPreview(
     @PreviewParameter(ThemePreviewParameterProvider::class) themeType: Theme.ThemeType,
 ) {
     AppThemeWithBackground(themeType = themeType) {
-        EmptyState(
+        NoContentBanner(
             title = "Time to add some podcasts",
             subtitle = "Discover and subscribe to your favorite podcasts.",
             iconResourceId = IR.drawable.ic_podcasts,
@@ -165,9 +164,9 @@ private fun EmptyStatePreview(
 
 @Preview
 @Composable
-private fun EmptyStateNoSubtitlePreview() {
+private fun UpNextNoContentBannerWithoutSubtitlePreview() {
     AppThemeWithBackground(themeType = Theme.ThemeType.LIGHT) {
-        EmptyState(
+        NoContentBanner(
             title = "Time to add some podcasts",
             subtitle = "",
             iconResourceId = IR.drawable.ic_podcasts,
@@ -179,9 +178,9 @@ private fun EmptyStateNoSubtitlePreview() {
 
 @Preview
 @Composable
-private fun EmptyStateNoPrimaryButtonPreview() {
+private fun UpNextNoContentBannerWithoutPrimaryButtonPreview() {
     AppThemeWithBackground(themeType = Theme.ThemeType.LIGHT) {
-        EmptyState(
+        NoContentBanner(
             title = "Time to add some podcasts",
             subtitle = "Discover and subscribe to your favorite podcasts.",
             iconResourceId = IR.drawable.ic_podcasts,
@@ -192,9 +191,9 @@ private fun EmptyStateNoPrimaryButtonPreview() {
 
 @Preview
 @Composable
-private fun EmptyStateNoSecondaryButtonPreview() {
+private fun UpNextNoContentBannerWithoutSecondaryButtonPreview() {
     AppThemeWithBackground(themeType = Theme.ThemeType.LIGHT) {
-        EmptyState(
+        NoContentBanner(
             title = "Time to add some podcasts",
             subtitle = "Discover and subscribe to your favorite podcasts.",
             iconResourceId = IR.drawable.ic_podcasts,

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -165,7 +165,7 @@
     <string name="episodes">Episodes</string>
     <string name="none">None</string>
     <string name="expand_details">Expand details</string>
-    <string name="add_podcasts">Add podcasts</string>
+    <string name="add_podcasts">Add Podcasts</string>
     <string name="please_try_again">Please try again</string>
     <string name="next">Next</string>
     <string name="select_podcasts">Select podcasts</string>


### PR DESCRIPTION
## Description

Small tweaks to the empty state:
- Rename `EmptyState` to `NoContentBanner`. I think using "state" for the UI component is misleading as state types are typically data types.
- Rename subtitle parameter to body to align with Figma designs.
- Improve ripple color to make it visible in contrast themes.
- Capitalize "podcast" string to match other action buttons.

## Testing Instructions

Code review should be enough.

## Checklist
- [ ] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] ~I have considered whether it makes sense to add tests for my changes~
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [ ] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [ ] ~with a landscape orientation~
- [ ] ~with the device set to have a large display and font size~
- [ ] ~for accessibility with TalkBack~
