### PR TITLE
Add missing analytics property

### DIFF
--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/payment/AnalyticsPaymentListener.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/payment/AnalyticsPaymentListener.kt
@@ -6,6 +6,7 @@ import au.com.shiftyjelly.pocketcasts.payment.PaymentClient
 import au.com.shiftyjelly.pocketcasts.payment.PaymentResultCode
 import au.com.shiftyjelly.pocketcasts.payment.PurchaseResult
 import au.com.shiftyjelly.pocketcasts.payment.SubscriptionPlan
+import au.com.shiftyjelly.pocketcasts.payment.SubscriptionTier
 
 internal class AnalyticsPaymentListener(
     private val tracker: AnalyticsTracker,
@@ -15,6 +16,7 @@ internal class AnalyticsPaymentListener(
             "tier" to key.tier.analyticsValue,
             "frequency" to key.billingCycle.analyticsValue,
             "offer_type" to (key.offer?.analyticsValue ?: "none"),
+            "product" to key.productLegacyAnalyticsValue(),
             "source" to purchaseSource,
         )
         val (event, properties) = when (result) {
@@ -40,5 +42,10 @@ internal class AnalyticsPaymentListener(
         if (this@analyticProperties is PaymentResultCode.Unknown) {
             put("error_code", code)
         }
+    }
+
+    private fun SubscriptionPlan.Key.productLegacyAnalyticsValue() = when (tier) {
+        SubscriptionTier.Plus -> billingCycle.analyticsValue
+        SubscriptionTier.Patron -> productId
     }
 }

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/payment/AnalyticsPaymentListenerTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/payment/AnalyticsPaymentListenerTest.kt
@@ -37,6 +37,7 @@ class AnalyticsPaymentListenerTest {
                 "tier" to "plus",
                 "frequency" to "yearly",
                 "offer_type" to "none",
+                "product" to "yearly",
                 "source" to "purchase_source",
             ),
         )
@@ -56,6 +57,7 @@ class AnalyticsPaymentListenerTest {
                 "tier" to "patron",
                 "frequency" to "monthly",
                 "offer_type" to "referral",
+                "product" to "com.pocketcasts.monthly.patron",
                 "source" to "purchase_source",
                 "error" to "user_cancelled",
             ),
@@ -76,10 +78,36 @@ class AnalyticsPaymentListenerTest {
                 "tier" to "plus",
                 "frequency" to "yearly",
                 "offer_type" to "none",
+                "product" to "yearly",
                 "source" to "purchase_source",
                 "error" to "unknown",
                 "error_code" to 404,
             ),
+        )
+    }
+
+    @Test
+    fun `legacy product property`() = runTest {
+        val keys = listOf(
+            SubscriptionPlan.PlusMonthlyPreview.key,
+            SubscriptionPlan.PlusYearlyPreview.key,
+            SubscriptionPlan.PatronMonthlyPreview.key,
+            SubscriptionPlan.PatronYearlyPreview.key,
+        )
+
+        for (key in keys) {
+            paymentClient.purchaseSubscriptionPlan(key, "purchase_source", mock<Activity>())
+        }
+
+        val productProperties = tracker.events.map { it.properties["product"] }
+        assertEquals(
+            listOf(
+                "monthly",
+                "yearly",
+                "com.pocketcasts.monthly.patron",
+                "com.pocketcasts.yearly.patron",
+            ),
+            productProperties,
         )
     }
 }


### PR DESCRIPTION
## Description

In #4000 I forgot to add legacy analytics properties to purchase events. It might be important to keep them because they might be used in some dashboards and such.

## Testing Instructions

Test purchasing different subscription plans and verify that the `product` analytics property is present. It might be with the debug app since we're only interested in analytics here.

## Checklist
- [ ] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [ ] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [ ] ~Any jetpack compose components I added or changed are covered by compose previews~
- [ ] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~