### PR TITLE
Fall back to the top level tier when mapping subscriptions

### DIFF
--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/SubscriptionModel.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/SubscriptionModel.kt
@@ -40,9 +40,16 @@ fun SubscriptionStatusResponse.toSubscription(): Subscription? {
     }
 
     val subscriptionResponse = subscriptions?.getOrNull(index) ?: fallbackSubscription
+    // Some older accounts use an empty string for the subscription tier inside their subscriptions.
+    // In these cases, the correct tier is only available at the top-level subscription status object.
+    //
+    // Therefore, we need to explicitly fall back to the top level object.
+    val tier = subscriptionResponse.tier
+        ?.takeUnless(String::isNullOrBlank)
+        ?: fallbackSubscription.tier
 
     return Subscription(
-        tier = when (subscriptionResponse.tier?.lowercase()) {
+        tier = when (tier?.lowercase()) {
             "plus" -> SubscriptionTier.Plus
             "patron" -> SubscriptionTier.Patron
             else -> return null


### PR DESCRIPTION
## Description

We had a report that Champion users do not see their subscription correctly in the app. It didn't come up in testing because when using the Admin Panel we create new gifts so the accounts aren't in a state when the bug can happen. It turns out that for the very old subscriptions the tier is missing for some reason.

Internal ref: p1748269270411719-slack-C028JAG44VD

## Testing Instructions

There isn't really a good way to test it. I worked on this bug directly with a user affected by it and they confirm that things are fixed now.

## Checklist
- [ ] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] ~I have considered whether it makes sense to add tests for my changes~
- [ ] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [ ] ~Any jetpack compose components I added or changed are covered by compose previews~
- [ ] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~