### PR TITLE
Add loading state to podcasts page

### DIFF
--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcasts/PodcastsFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcasts/PodcastsFragment.kt
@@ -249,7 +249,7 @@ class PodcastsFragment :
                     adapter?.setFolderItems(uiState.items)
 
                     val isEmpty = uiState.items.isEmpty()
-                    binding.emptyView.isVisible = isEmpty
+                    binding.emptyView.isVisible = isEmpty && !uiState.isLoadingItems
                     binding.swipeRefreshLayout.isGone = isEmpty
                 }
             }

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/PodcastsViewModel.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/PodcastsViewModel.kt
@@ -56,7 +56,7 @@ class PodcastsViewModel @AssistedInject constructor(
     private val userManager: UserManager,
     @Assisted private val folderUuid: String?,
 ) : ViewModel() {
-    private val _uiState = MutableStateFlow(UiState())
+    private val _uiState = MutableStateFlow(UiState(isLoadingItems = true))
     val uiState = _uiState.asStateFlow()
 
     val areSuggestedFoldersAvailable = suggestedFoldersManager.observeSuggestedFolders()
@@ -322,6 +322,7 @@ class PodcastsViewModel @AssistedInject constructor(
     }
 
     data class UiState(
+        val isLoadingItems: Boolean = false,
         val items: List<FolderItem> = emptyList(),
         val folder: Folder? = null,
         val isSignedInAsPlusOrPatron: Boolean = false,


### PR DESCRIPTION
## Description

During rewrite of podcasts tab to coroutines the loading state got removed. This resulted in podcasts page showing empty state when podcasts were loading. Normally this isn't an issue but for a large amount of podcasts it can take some time before they are available. This PR fixes the problem by tracking if podcasts are loaded or not.

## Testing Instructions

1. Apply [this patch](https://github.com/user-attachments/files/20444002/empty-state.patch).
```
curl -L https://github.com/user-attachments/files/20444002/empty-state.patch | git apply
```
2. Open the app.
3. Go to the podcasts tab.
4. Close the app.
5. Open the app.
6. For the first 5 seconds you should not see the empty state message.
7. After 5 seconds you should see either the message or the podcasts you're subscribed to. 

## Checklist
- [ ] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] ~I have considered whether it makes sense to add tests for my changes~
- [ ] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [ ] ~Any jetpack compose components I added or changed are covered by compose previews~
- [ ] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~