### PR TITLE
Fix podcasts drag & drop

### DIFF
--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/PodcastsViewModel.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/PodcastsViewModel.kt
@@ -106,7 +106,9 @@ class PodcastsViewModel @AssistedInject constructor(
             userManager.getSignInState().asFlow(),
         ) { podcasts, folders, sortType, signInState ->
             withContext(Dispatchers.Default) {
-                buildUiState(podcasts, folders, sortType, signInState)
+                val state = buildUiState(podcasts, folders, sortType, signInState)
+                adapterState = state.items.toMutableList()
+                state
             }
         }
     }


### PR DESCRIPTION
## Description

During coroutines migration I didn't account for the drag & drop state which is kept separately from the UI state. This fixes it by applying the previous solution of updating the `adapterState` with each new UI state. Ideally this would be a part of the UI state but I don't want to make too many changes in a beta fix.

## Testing Instructions

1. Follow some podcasts.
2. Go to the podcasts tab.
3. Ordering podcasts by drag & drop should work.

## Checklist
- [ ] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] ~I have considered whether it makes sense to add tests for my changes~
- [ ] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [ ] ~Any jetpack compose components I added or changed are covered by compose previews~
- [ ] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~