### PR TITLE
Fix displaying podroll podcasts when it's the only recommendation

### DIFF
--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastAdapter.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastAdapter.kt
@@ -626,11 +626,11 @@ class PodcastAdapter(
                     )
                 }
                 is RecommendationsResult.Success -> {
+                    val resources = context.resources
                     val list = result.listFeed
                     // Podroll
                     val podroll = list.podroll
                     if (!podroll.isNullOrEmpty()) {
-                        val resources = context.resources
                         add(
                             DividerSubTitleRow(
                                 icon = IR.drawable.ic_author_small,
@@ -649,26 +649,28 @@ class PodcastAdapter(
                             )
                         }
                         add(PaddingRow(12.dp))
+                    }
+                    // Recommended "You might like" podcasts
+                    val podcasts = list.podcasts
+                    if (!podcasts.isNullOrEmpty()) {
                         add(
                             DividerSubTitleRow(
                                 icon = IR.drawable.ic_duplicate,
                                 title = resources.getString(LR.string.similar_shows_to, podcast.title),
                             ),
                         )
+                        podcasts.forEachIndexed { index, podcast ->
+                            add(
+                                RecommendedPodcast(
+                                    listDate = list.date ?: "",
+                                    podcast = podcast,
+                                    onRowClick = onRecommendedPodcastClicked,
+                                    onSubscribeClick = onRecommendedPodcastSubscribeClicked,
+                                ),
+                            )
+                        }
+                        add(PaddingRow(12.dp))
                     }
-                    // Recommended "You might like" podcasts
-                    val podcasts = list.podcasts
-                    podcasts?.forEachIndexed { index, podcast ->
-                        add(
-                            RecommendedPodcast(
-                                listDate = list.date ?: "",
-                                podcast = podcast,
-                                onRowClick = onRecommendedPodcastClicked,
-                                onSubscribeClick = onRecommendedPodcastSubscribeClicked,
-                            ),
-                        )
-                    }
-                    add(PaddingRow(12.dp))
                 }
             }
         }

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/podcast/RecommendationsHandler.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/podcast/RecommendationsHandler.kt
@@ -47,7 +47,7 @@ class RecommendationsHandler @Inject constructor(
                         .removePodcast(podcastUuid)
                         .addSubscribedStatusFlowable()
                         .map { listFeed ->
-                            if (listFeed.podcasts.isNullOrEmpty()) {
+                            if (listFeed.podcasts.isNullOrEmpty() && listFeed.podroll.isNullOrEmpty()) {
                                 RecommendationsResult.Empty
                             } else {
                                 RecommendationsResult.Success(listFeed)

--- a/modules/features/podcasts/src/test/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/podcast/RecommendationsHandlerTest.kt
+++ b/modules/features/podcasts/src/test/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/podcast/RecommendationsHandlerTest.kt
@@ -19,6 +19,7 @@ import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
+import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 
@@ -33,6 +34,7 @@ class RecommendationsHandlerTest {
     private lateinit var testPodcastUuid: String
     private lateinit var testListFeed: ListFeed
     private lateinit var testDiscoverPodcasts: List<DiscoverPodcast>
+    private lateinit var testPodrollPodcasts: List<DiscoverPodcast>
 
     @Before
     fun setup() {
@@ -52,15 +54,20 @@ class RecommendationsHandlerTest {
             DiscoverPodcast(uuid = UUID.randomUUID().toString(), title = "Test Podcast 1", url = null, author = null, category = null, description = null, language = null, mediaType = null),
             DiscoverPodcast(uuid = UUID.randomUUID().toString(), title = "Test Podcast 2", url = null, author = null, category = null, description = null, language = null, mediaType = null),
         )
-        testListFeed = ListFeed(title = "Test List Feed", podcasts = testDiscoverPodcasts, subtitle = null, description = null, date = null, episodes = null, collectionImageUrl = null, featureImage = null, headerImageUrl = null, tintColors = null, collageImages = null, webLinkUrl = null, webLinkTitle = null, promotion = null, podroll = null)
+        testPodrollPodcasts = listOf(
+            DiscoverPodcast(uuid = UUID.randomUUID().toString(), title = "Test Podcast 3", url = null, author = null, category = null, description = null, language = null, mediaType = null),
+            DiscoverPodcast(uuid = UUID.randomUUID().toString(), title = "Test Podcast 4", url = null, author = null, category = null, description = null, language = null, mediaType = null),
+        )
+        testListFeed = ListFeed(title = "Test List Feed", podcasts = testDiscoverPodcasts, podroll = testPodrollPodcasts, subtitle = null, description = null, date = null, episodes = null, collectionImageUrl = null, featureImage = null, headerImageUrl = null, tintColors = null, collageImages = null, webLinkUrl = null, webLinkTitle = null, promotion = null)
     }
 
     @Test
-    fun testFeatureFlagDisabledNoPodcastsFetched() {
+    fun `do not load recommendations when feature flag is disabled`() = runTest {
         // feature flag is disabled
         FeatureFlag.setEnabled(feature = Feature.RECOMMENDATIONS, enabled = false)
-
         recommendations.setEnabled(true)
+
+        whenever(listWebService.getListFeed(any())).thenReturn(testListFeed)
 
         val values = recommendations.getRecommendationsFlowable(testPodcastUuid)
             .test()
@@ -74,18 +81,37 @@ class RecommendationsHandlerTest {
     }
 
     @Test
-    fun testEnabledAndFeatureFlagOnPodcastsFetched() = runTest {
+    fun `do not load recommendations when recommendations are disabled`() = runTest {
+        // feature flag is disabled
+        FeatureFlag.setEnabled(feature = Feature.RECOMMENDATIONS, enabled = true)
+        recommendations.setEnabled(false)
+
+        whenever(listWebService.getListFeed(any())).thenReturn(testListFeed)
+
+        val values = recommendations.getRecommendationsFlowable(testPodcastUuid)
+            .test()
+            .awaitCount(2)
+            .assertNoErrors()
+            .values()
+
+        // no podcasts should be found
+        assertTrue(values[0] is RecommendationsResult.Loading)
+        assertTrue(values[1] is RecommendationsResult.Empty)
+    }
+
+    @Test
+    fun `load recommendations when podcasts are available`() = runTest {
         FeatureFlag.setEnabled(feature = Feature.RECOMMENDATIONS, enabled = true)
         recommendations.setEnabled(true)
 
         // expected URL for the list recommendation
         val listUrl = "${Settings.SERVER_API_URL}/recommendations/podcast/$testPodcastUuid?country=us"
-        whenever(listWebService.getListFeed(listUrl)).thenReturn(testListFeed)
+        whenever(listWebService.getListFeed(listUrl)).thenReturn(testListFeed.copy(podroll = null))
 
         // mark the first podcast as subscribed
         val subscribedUuid = testDiscoverPodcasts.first().uuid
         whenever(podcastManager.getSubscribedPodcastUuidsRxSingle()).thenReturn(Single.just(listOf(subscribedUuid)))
-        whenever(podcastManager.podcastSubscriptionsRxFlowable()).thenReturn(Flowable.just(emptyList()))
+        whenever(podcastManager.podcastSubscriptionsRxFlowable()).thenReturn(Flowable.empty())
 
         // call the method to test
         val values = recommendations.getRecommendationsFlowable(testPodcastUuid)
@@ -99,7 +125,7 @@ class RecommendationsHandlerTest {
         assertTrue(values[1] is RecommendationsResult.Success)
 
         val podcasts = (values[1] as RecommendationsResult.Success).listFeed.podcasts
-        assertEquals(testListFeed.podcasts?.size, podcasts?.size)
+        assertEquals(2, podcasts?.size)
 
         // check that the subscribed status is set correctly
         val subscribedPodcast = podcasts?.find { it.uuid == subscribedUuid }
@@ -107,5 +133,65 @@ class RecommendationsHandlerTest {
 
         assertTrue(subscribedPodcast?.isSubscribed == true)
         assertTrue(unsubscribedPodcast?.isSubscribed == false)
+    }
+
+    @Test
+    fun `load recommendations when podroll is available`() = runTest {
+        FeatureFlag.setEnabled(feature = Feature.RECOMMENDATIONS, enabled = true)
+        recommendations.setEnabled(true)
+
+        // expected URL for the list recommendation
+        val listUrl = "${Settings.SERVER_API_URL}/recommendations/podcast/$testPodcastUuid?country=us"
+        whenever(listWebService.getListFeed(listUrl)).thenReturn(testListFeed.copy(podcasts = null))
+
+        // mark the first podcast as subscribed
+        val subscribedUuid = testPodrollPodcasts.first().uuid
+        whenever(podcastManager.getSubscribedPodcastUuidsRxSingle()).thenReturn(Single.just(listOf(subscribedUuid)))
+        whenever(podcastManager.podcastSubscriptionsRxFlowable()).thenReturn(Flowable.empty())
+
+        // call the method to test
+        val values = recommendations.getRecommendationsFlowable(testPodcastUuid)
+            .test()
+            .awaitCount(2)
+            .assertNoErrors()
+            .values()
+
+        // check that the podcasts are fetched correctly
+        assertTrue(values[0] is RecommendationsResult.Loading)
+        assertTrue(values[1] is RecommendationsResult.Success)
+
+        val podcasts = (values[1] as RecommendationsResult.Success).listFeed.podroll
+        assertEquals(2, podcasts?.size)
+
+        // check that the subscribed status is set correctly
+        val subscribedPodcast = podcasts?.find { it.uuid == subscribedUuid }
+        val unsubscribedPodcast = podcasts?.find { it.uuid != subscribedUuid }
+
+        assertTrue(subscribedPodcast?.isSubscribed == true)
+        assertTrue(unsubscribedPodcast?.isSubscribed == false)
+    }
+
+    @Test
+    fun `do not load recommendations when neither podcasts or podroll are available`() = runTest {
+        FeatureFlag.setEnabled(feature = Feature.RECOMMENDATIONS, enabled = true)
+        recommendations.setEnabled(true)
+
+        // expected URL for the list recommendation
+        val listUrl = "${Settings.SERVER_API_URL}/recommendations/podcast/$testPodcastUuid?country=us"
+        whenever(listWebService.getListFeed(listUrl)).thenReturn(testListFeed.copy(podroll = null, podcasts = null))
+
+        whenever(podcastManager.getSubscribedPodcastUuidsRxSingle()).thenReturn(Single.just(emptyList()))
+        whenever(podcastManager.podcastSubscriptionsRxFlowable()).thenReturn(Flowable.just(emptyList()))
+
+        // call the method to test
+        val values = recommendations.getRecommendationsFlowable(testPodcastUuid)
+            .test()
+            .awaitCount(2)
+            .assertNoErrors()
+            .values()
+
+        // no podcasts should be found
+        assertTrue(values[0] is RecommendationsResult.Loading)
+        assertTrue(values[1] is RecommendationsResult.Empty)
     }
 }


### PR DESCRIPTION
## Description

Podroll recommendations were ignored when they were the only recommendations.

Internal ref: p1748447347766299-slack-C028JAG44VD

## Testing Instructions

1. Open [Podcasting 2.0 podcast](https://pca.st/s7qtomm0).
2. Go to "You might like" tab.
3. You should see its Podroll.

## Checklist
- [ ] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [ ] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [ ] ~Any jetpack compose components I added or changed are covered by compose previews~
- [ ] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~