### PR TITLE
Do not skip CI checks when only Gradle changes are present

### DIFF
--- a/.buildkite/commands/should-skip-job.sh
+++ b/.buildkite/commands/should-skip-job.sh
@@ -23,7 +23,6 @@ COMMON_PATTERNS=(
   "fastlane/**"
   "Gemfile"
   "Gemfile.lock"
-  "gradle/**"
   "version.properties"
 )
 


### PR DESCRIPTION
We should run build checks in cases of Gradle wrapper or dependencies changes.