### PR TITLE
Don't post showTooltip task

### DIFF
--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcasts/PodcastsFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcasts/PodcastsFragment.kt
@@ -199,9 +199,7 @@ class PodcastsFragment :
 
         viewLifecycleOwner.lifecycleScope.launch {
             if (viewModel.shouldShowTooltip()) {
-                binding.toolbar.post {
-                    showTooltip()
-                }
+                showTooltip()
             }
         }
 


### PR DESCRIPTION
## Description
In the latest beta `7.90-rc-2` I noticed a crash on `PodcastsFragment.showTooltip`:
https://a8c.sentry.io/issues/6634171842/?project=6711064&query=release%3Aau.com.shiftyjelly.pocketcasts%407.90-rc-2%2B9342&referrer=release-issue-stream
It seems like a timing issue, posting a `Runnable` to invoke `showTooltip` on the `binding.toolbar` may be called after `onDestroy` so the `realBinding` reference is cleared.
I have removed the `post` call because we're on the main thread anyways.

Fixes #4057 

## Testing Instructions
1. Apply this patch  [show_tooltip.patch](https://github.com/user-attachments/files/20503340/show_tooltip.patch)
2. Build and install the app
3. Select the podcasts tab
- [x] tooltip is displayed and app didn't crash


## Screenshots or Screencast 
<img width="1007" alt="Screenshot 2025-05-29 at 13 05 28" src="https://github.com/user-attachments/assets/3770d821-cfbc-4bb8-b95b-fc5ee6ee7728" />


## Checklist
- ~[ ] If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- ~[ ] I have considered whether it makes sense to add tests for my changes~
- ~[ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- ~[ ] Any jetpack compose components I added or changed are covered by compose previews~
- ~[ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- ~[ ] with different themes~
- ~[ ] with a landscape orientation~
- ~[ ] with the device set to have a large display and font size~
- ~[ ] for accessibility with TalkBack~
