### PR TITLE
[Notifications Revamp] Missing pieces and changes

### DIFF
--- a/app/src/main/java/au/com/shiftyjelly/pocketcasts/PocketCastsApplication.kt
+++ b/app/src/main/java/au/com/shiftyjelly/pocketcasts/PocketCastsApplication.kt
@@ -21,7 +21,6 @@ import au.com.shiftyjelly.pocketcasts.repositories.file.StorageOptions
 import au.com.shiftyjelly.pocketcasts.repositories.jobs.VersionMigrationsWorker
 import au.com.shiftyjelly.pocketcasts.repositories.notification.NotificationHelper
 import au.com.shiftyjelly.pocketcasts.repositories.notification.NotificationManager
-import au.com.shiftyjelly.pocketcasts.repositories.notification.ReEngagementNotificationType
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
 import au.com.shiftyjelly.pocketcasts.repositories.playback.SleepTimerRestartWhenShakingDevice
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager

--- a/app/src/main/java/au/com/shiftyjelly/pocketcasts/PocketCastsApplication.kt
+++ b/app/src/main/java/au/com/shiftyjelly/pocketcasts/PocketCastsApplication.kt
@@ -188,7 +188,8 @@ class PocketCastsApplication : Application(), Configuration.Provider {
             notificationManager.setupOnboardingNotifications()
             notificationManager.setupReEngagementNotifications()
             notificationManager.setupTrendingAndRecommendationsNotifications()
-            notificationManager.updateUserFeatureInteraction(ReEngagementNotificationType.notificationId)
+            notificationManager.setupNewFeaturesNotifications()
+            notificationManager.setupOffersNotifications()
             appLifecycleObserver.setup()
 
             Coil.setImageLoader(coilImageLoader)

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/notifications/NotificationsSettingsFragment.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/notifications/NotificationsSettingsFragment.kt
@@ -101,6 +101,7 @@ internal class NotificationsSettingsFragment : BaseFragment(), PodcastSelectFrag
                     onSelectRingtoneClicked = ::showRingtoneSelector,
                     onSelectPodcastsClicked = ::showPodcastSelector,
                     onSystemNotificationsSettingsClicked = {
+                        viewModel.reportSystemNotificationsSettingsOpened()
                         notificationHelper.openNotificationSettings(requireActivity())
                     },
                 )

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/notifications/NotificationsSettingsViewModel.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/notifications/NotificationsSettingsViewModel.kt
@@ -207,6 +207,10 @@ internal class NotificationsSettingsViewModel @Inject constructor(
         }
     }
 
+    internal fun reportSystemNotificationsSettingsOpened() {
+        analyticsTracker.track(AnalyticsEvent.SETTINGS_NOTIFICATIONS_PERMISSION_OPEN_SYSTEM_SETTINGS)
+    }
+
     internal suspend fun getSelectedPodcastIds(): List<String> = withContext(Dispatchers.IO) {
         val uuids = podcastManager.findSubscribedBlocking().filter { it.isShowNotifications }.map { it.uuid }
         uuids

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/notifications/NotificationsSettingsViewModel.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/notifications/NotificationsSettingsViewModel.kt
@@ -120,8 +120,10 @@ internal class NotificationsSettingsViewModel @Inject constructor(
                     )
                     if (preference.isEnabled) {
                         notificationScheduler.setupOnboardingNotifications()
+                        notificationScheduler.setupReEngagementNotification()
                     } else {
                         notificationScheduler.cancelScheduledOnboardingNotifications()
+                        notificationScheduler.cancelScheduledReEngagementNotifications()
                     }
                 }
 

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/notifications/data/NotificationsPreferencesRepositoryImpl.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/notifications/data/NotificationsPreferencesRepositoryImpl.kt
@@ -89,28 +89,6 @@ internal class NotificationsPreferencesRepositoryImpl @Inject constructor(
             if (notificationFeaturesProvider.isRevampFeatureEnabled) {
                 add(
                     NotificationPreferenceCategory(
-                        title = TextResource.fromStringId(LR.string.settings_notification_daily_reminders),
-                        preferences = buildList {
-                            add(
-                                NotificationPreferenceType.EnableDailyReminders(
-                                    title = TextResource.fromStringId(LR.string.settings_notification_notify_me),
-                                    isEnabled = settings.dailyRemindersNotification.value,
-                                ),
-                            )
-                            if (settings.dailyRemindersNotification.value && notificationFeaturesProvider.hasNotificationChannels) {
-                                add(
-                                    NotificationPreferenceType.DailyReminderSettings(
-                                        title = TextResource.fromStringId(LR.string.settings_notification_advanced),
-                                        description = TextResource.fromStringId(LR.string.settings_notification_advanced_summary),
-                                    ),
-                                )
-                            }
-                        },
-                    ),
-                )
-
-                add(
-                    NotificationPreferenceCategory(
                         title = TextResource.fromStringId(LR.string.settings_notification_recommendations),
                         preferences = buildList {
                             add(
@@ -122,6 +100,28 @@ internal class NotificationsPreferencesRepositoryImpl @Inject constructor(
                             if (settings.recommendationsNotification.value && notificationFeaturesProvider.hasNotificationChannels) {
                                 add(
                                     NotificationPreferenceType.RecommendationSettings(
+                                        title = TextResource.fromStringId(LR.string.settings_notification_advanced),
+                                        description = TextResource.fromStringId(LR.string.settings_notification_advanced_summary),
+                                    ),
+                                )
+                            }
+                        },
+                    ),
+                )
+
+                add(
+                    NotificationPreferenceCategory(
+                        title = TextResource.fromStringId(LR.string.settings_notification_daily_reminders),
+                        preferences = buildList {
+                            add(
+                                NotificationPreferenceType.EnableDailyReminders(
+                                    title = TextResource.fromStringId(LR.string.settings_notification_notify_me),
+                                    isEnabled = settings.dailyRemindersNotification.value,
+                                ),
+                            )
+                            if (settings.dailyRemindersNotification.value && notificationFeaturesProvider.hasNotificationChannels) {
+                                add(
+                                    NotificationPreferenceType.DailyReminderSettings(
                                         title = TextResource.fromStringId(LR.string.settings_notification_advanced),
                                         description = TextResource.fromStringId(LR.string.settings_notification_advanced_summary),
                                     ),

--- a/modules/features/shared/src/main/java/au/com/shiftyjelly/pocketcasts/shared/AppLifecycleObserver.kt
+++ b/modules/features/shared/src/main/java/au/com/shiftyjelly/pocketcasts/shared/AppLifecycleObserver.kt
@@ -132,6 +132,7 @@ class AppLifecycleObserver(
                     settings.autoDownloadOnFollowPodcast.set(true, updateModifiedAt = false)
 
                     // For new users we want to enable all notifications by default
+                    settings.notifyRefreshPodcast.set(true, updateModifiedAt = false)
                     settings.dailyRemindersNotification.set(true, updateModifiedAt = false)
                     settings.recommendationsNotification.set(true, updateModifiedAt = false)
                     settings.newFeaturesNotification.set(true, updateModifiedAt = false)

--- a/modules/features/shared/src/main/java/au/com/shiftyjelly/pocketcasts/shared/AppLifecycleObserver.kt
+++ b/modules/features/shared/src/main/java/au/com/shiftyjelly/pocketcasts/shared/AppLifecycleObserver.kt
@@ -131,8 +131,11 @@ class AppLifecycleObserver(
                     // For new users we want to auto download on follow podcast by default
                     settings.autoDownloadOnFollowPodcast.set(true, updateModifiedAt = false)
 
-                    // For new users we want to enable the daily reminders notification by default
+                    // For new users we want to enable all notifications by default
                     settings.dailyRemindersNotification.set(true, updateModifiedAt = false)
+                    settings.recommendationsNotification.set(true, updateModifiedAt = false)
+                    settings.newFeaturesNotification.set(true, updateModifiedAt = false)
+                    settings.offersNotification.set(true, updateModifiedAt = false)
 
                     notificationScheduler.setupOnboardingNotifications()
                 }

--- a/modules/features/shared/src/test/java/au/com/shiftyjelly/pocketcasts/shared/AppLifecycleObserverTest.kt
+++ b/modules/features/shared/src/test/java/au/com/shiftyjelly/pocketcasts/shared/AppLifecycleObserverTest.kt
@@ -52,6 +52,14 @@ class AppLifecycleObserverTest {
 
     @Mock private lateinit var dailyRemindersNotificationSetting: UserSetting<Boolean>
 
+    @Mock private lateinit var notifyNewEpisodesSetting: UserSetting<Boolean>
+
+    @Mock private lateinit var recommendationsNotificationSetting: UserSetting<Boolean>
+
+    @Mock private lateinit var newFeaturesNotificationSetting: UserSetting<Boolean>
+
+    @Mock private lateinit var offerNotificationSetting: UserSetting<Boolean>
+
     @Mock private lateinit var appLifecycleAnalytics: AppLifecycleAnalytics
 
     @Mock private lateinit var preferencesFeatureProvider: PreferencesFeatureProvider
@@ -75,6 +83,10 @@ class AppLifecycleObserverTest {
         whenever(settings.autoPlayNextEpisodeOnEmpty).thenReturn(autoPlayNextEpisodeSetting)
         whenever(settings.autoDownloadOnFollowPodcast).thenReturn(autoDownloadOnFollowPodcastSetting)
         whenever(settings.dailyRemindersNotification).thenReturn(dailyRemindersNotificationSetting)
+        whenever(settings.notifyRefreshPodcast).thenReturn(notifyNewEpisodesSetting)
+        whenever(settings.recommendationsNotification).thenReturn(recommendationsNotificationSetting)
+        whenever(settings.newFeaturesNotification).thenReturn(newFeaturesNotificationSetting)
+        whenever(settings.offersNotification).thenReturn(offerNotificationSetting)
         whenever(settings.useDarkUpNextTheme).thenReturn(useUpNextDarkThemeSetting)
         whenever(settings.showPodcastsRecentlyPlayedSortOrderTooltip).thenReturn(showPodcastsRecentlyPlayedSortOrderSetting)
         whenever(settings.showFreeAccountEncouragement).thenReturn(showAccountEncouragementSetting)
@@ -111,6 +123,10 @@ class AppLifecycleObserverTest {
         verify(autoPlayNextEpisodeSetting).set(true, updateModifiedAt = false)
         verify(autoDownloadOnFollowPodcastSetting).set(true, updateModifiedAt = false)
         verify(dailyRemindersNotificationSetting).set(true, updateModifiedAt = false)
+        verify(notifyNewEpisodesSetting).set(true, updateModifiedAt = false)
+        verify(recommendationsNotificationSetting).set(true, updateModifiedAt = false)
+        verify(newFeaturesNotificationSetting).set(true, updateModifiedAt = false)
+        verify(offerNotificationSetting).set(true, updateModifiedAt = false)
         verify(useUpNextDarkThemeSetting).set(false, updateModifiedAt = false)
 
         verify(appLifecycleAnalytics, never()).onApplicationUpgrade(any())

--- a/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
+++ b/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
@@ -631,6 +631,7 @@ enum class AnalyticsEvent(val key: String) {
     SETTINGS_NOTIFICATIONS_NEW_FEATURES_AND_TIPS_ADVANCED_SETTINGS_TAPPED("settings_notifications_new_features_advanced_settings_tapped"),
     SETTINGS_NOTIFICATIONS_OFFERS_TOGGLED("settings_notifications_offers_toggle"),
     SETTINGS_NOTIFICATIONS_OFFERS_ADVANCED_SETTINGS_TAPPED("settings_notifications_offers_advanced_settings_tapped"),
+    SETTINGS_NOTIFICATIONS_PERMISSION_OPEN_SYSTEM_SETTINGS("notifications_permissions_open_system_settings"),
 
     /* Settings - Storage & Data Use */
     SETTINGS_STORAGE_SHOWN("settings_storage_shown"),

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/notification/NotificationDelayCalculator.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/notification/NotificationDelayCalculator.kt
@@ -39,13 +39,13 @@ class NotificationDelayCalculator @Inject constructor(
 
     /**
      * Calculates the delay until the re-engagement check worker should be triggered.
-     * The worker is set to run daily at 4 PM.
+     * The worker is set to run in 7 days at 4 PM.
      *
-     * @return Delay in milliseconds until the next 4 PM.
+     * @return Delay in milliseconds until the next trigger time.
      */
     fun calculateDelayForReEngagementCheck(): Long {
         val now = clock.instant().toEpochMilli()
-        val next4PM = calculateBase4PM(now)
+        val next4PM = calculateBase4PM(now, dayOffset = 7)
         return next4PM - now
     }
 

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/notification/NotificationManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/notification/NotificationManager.kt
@@ -4,6 +4,8 @@ interface NotificationManager {
     suspend fun setupOnboardingNotifications()
     suspend fun setupReEngagementNotifications()
     suspend fun setupTrendingAndRecommendationsNotifications()
+    suspend fun setupNewFeaturesNotifications()
+    suspend fun setupOffersNotifications()
     suspend fun updateUserFeatureInteraction(type: NotificationType)
     suspend fun updateUserFeatureInteraction(id: Int)
     suspend fun hasUserInteractedWithFeature(type: NotificationType): Boolean

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/notification/NotificationManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/notification/NotificationManagerImpl.kt
@@ -24,6 +24,14 @@ class NotificationManagerImpl @Inject constructor(
         setupNotificationsForType(TrendingAndRecommendationsNotificationType.values) { it.notificationId }
     }
 
+    override suspend fun setupNewFeaturesNotifications() {
+        setupNotificationsForType(NewFeaturesAndTipsNotificationType.values) { it.notificationId }
+    }
+
+    override suspend fun setupOffersNotifications() {
+        setupNotificationsForType(OffersNotificationType.values) { it.notificationId }
+    }
+
     override suspend fun updateUserFeatureInteraction(type: NotificationType) {
         val now = clock.instant().toEpochMilli()
         userNotificationsDao.updateInteractedAt(type.notificationId, now)

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/notification/NotificationSchedulerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/notification/NotificationSchedulerImpl.kt
@@ -69,7 +69,7 @@ class NotificationSchedulerImpl @Inject constructor(
             DOWNLOADED_EPISODES to downloadedEpisodes,
         )
 
-        val notificationWork = PeriodicWorkRequest.Builder(NotificationWorker::class.java, 1, TimeUnit.DAYS)
+        val notificationWork = PeriodicWorkRequest.Builder(NotificationWorker::class.java, 7, TimeUnit.DAYS)
             .setInputData(workData)
             .setInitialDelay(initialDelay, TimeUnit.MILLISECONDS)
             .addTag(TAG_REENGAGEMENT)
@@ -77,7 +77,7 @@ class NotificationSchedulerImpl @Inject constructor(
 
         WorkManager.getInstance(context).enqueueUniquePeriodicWork(
             TAG_REENGAGEMENT,
-            ExistingPeriodicWorkPolicy.UPDATE,
+            ExistingPeriodicWorkPolicy.CANCEL_AND_REENQUEUE,
             notificationWork,
         )
     }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/notification/NotificationType.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/notification/NotificationType.kt
@@ -173,7 +173,7 @@ sealed class ReEngagementNotificationType(
         get() = ReEngagementNotificationType.notificationId
 
     override fun isSettingsToggleOn(settings: Settings): Boolean {
-        return settings.dailyRemindersNotification.value
+        return settings.newFeaturesNotification.value
     }
 
     data object WeMissYou : ReEngagementNotificationType(

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/notification/NotificationDelayCalculatorTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/notification/NotificationDelayCalculatorTest.kt
@@ -183,23 +183,26 @@ class NotificationDelayCalculatorTest {
 
     @Test fun testReEngagementCheck_Before4PM() {
         val t = getFixedTime(2025, Calendar.APRIL, 10, 15, 0)
-        val calc = calculatorAt(t)
-        val expected = 1 * HOUR_IN_MILLIS
-        assertEquals(expected, calc.calculateDelayForReEngagementCheck())
+        val calculatedDelay = calculatorAt(t).calculateDelayForReEngagementCheck()
+        val calculatedTriggerTime = t + calculatedDelay
+        val expected = getFixedTime(2025, Calendar.APRIL, 17, 16, 0)
+        assertEquals(expected, calculatedTriggerTime)
     }
 
     @Test fun testReEngagementCheck_Exactly4PM() {
         val t = getFixedTime(2025, Calendar.APRIL, 10, 16, 0)
-        val calc = calculatorAt(t)
-        val expected = 24 * HOUR_IN_MILLIS
-        assertEquals(expected, calc.calculateDelayForReEngagementCheck())
+        val calculatedDelay = calculatorAt(t).calculateDelayForReEngagementCheck()
+        val calculatedTriggerTime = t + calculatedDelay
+        val expected = getFixedTime(2025, Calendar.APRIL, 17, 16, 0)
+        assertEquals(expected, calculatedTriggerTime)
     }
 
     @Test fun testReEngagementCheck_After4PM() {
         val t = getFixedTime(2025, Calendar.APRIL, 10, 17, 0)
-        val calc = calculatorAt(t)
-        val expected = 23 * HOUR_IN_MILLIS
-        assertEquals(expected, calc.calculateDelayForReEngagementCheck())
+        val calculatedDelay = calculatorAt(t).calculateDelayForReEngagementCheck()
+        val calculatedTriggerTime = t + calculatedDelay
+        val expected = getFixedTime(2025, Calendar.APRIL, 17, 16, 0)
+        assertEquals(expected, calculatedTriggerTime)
     }
 
     @Test fun testRecommendations_Before4PM() {


### PR DESCRIPTION
## Description
This PR is the last step of the notifications revamp project, putting all the missing pieces into their places.
- Reengagement notifications are scheduled to repeat every 7 days (when applicable)
- Enable all notifiactions by default
- Properly schedule notifications
- Update notifications setting screen order of categories
- Track event when the notification banner cta is tapped

## Testing Instructions
Just check the code please

## Screenshots or Screencast 
![Screenshot_20250529_162149](https://github.com/user-attachments/assets/afbfb87c-e025-4183-9fe7-49709b2af1e4)


## Checklist
- ~[ ] If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- ~[ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- ~[ ] Any jetpack compose components I added or changed are covered by compose previews~
- ~[ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- ~[ ] with different themes~
- ~[ ] with a landscape orientation~
- ~[ ] with the device set to have a large display and font size~
- ~[ ] for accessibility with TalkBack~
