### PR TITLE
Remove old feature flags

### DIFF
--- a/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivityViewModel.kt
+++ b/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivityViewModel.kt
@@ -22,8 +22,6 @@ import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
 import au.com.shiftyjelly.pocketcasts.repositories.user.UserManager
 import au.com.shiftyjelly.pocketcasts.settings.whatsnew.WhatsNewFragment
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
-import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
-import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
 import au.com.shiftyjelly.pocketcasts.views.multiselect.MultiSelectBookmarksHelper
 import dagger.hilt.android.lifecycle.HiltViewModel
 import io.reactivex.BackpressureStrategy
@@ -91,7 +89,7 @@ class MainActivityViewModel
         val lastSeenVersionCode = settings.getWhatsNewVersionCode()
         val migratedVersion = settings.getMigratedVersionCode()
         if (migratedVersion != 0) { // We don't want to show this to new users, there is a race condition between this and the version migration
-            val whatsNewShouldBeShown = WhatsNewFragment.isWhatsNewNewerThan(lastSeenVersionCode) && FeatureFlag.isEnabled(Feature.REIMAGINE_SHARING)
+            val whatsNewShouldBeShown = WhatsNewFragment.isWhatsNewNewerThan(lastSeenVersionCode)
             _state.update { state -> state.copy(shouldShowWhatsNew = whatsNewShouldBeShown) }
         }
     }

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/UpNextAdapter.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/UpNextAdapter.kt
@@ -47,8 +47,6 @@ import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import au.com.shiftyjelly.pocketcasts.ui.theme.ThemeColor
 import au.com.shiftyjelly.pocketcasts.utils.extensions.dpToPx
 import au.com.shiftyjelly.pocketcasts.utils.extensions.getActivity
-import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
-import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
 import au.com.shiftyjelly.pocketcasts.views.helper.SwipeButtonLayoutFactory
 import au.com.shiftyjelly.pocketcasts.views.helper.setEpisodeTimeLeft
 import au.com.shiftyjelly.pocketcasts.views.multiselect.MultiSelectEpisodesHelper
@@ -202,7 +200,7 @@ class UpNextAdapter(
                     root.resources.getQuantityString(LR.plurals.player_up_next_header_title, header.episodeCount, header.episodeCount, time)
                 }
 
-                shuffle.isVisible = isUpNextNotEmpty && FeatureFlag.isEnabled(Feature.UP_NEXT_SHUFFLE)
+                shuffle.isVisible = isUpNextNotEmpty
                 shuffle.updateShuffleButton()
 
                 shuffle.setOnClickListener {
@@ -232,8 +230,6 @@ class UpNextAdapter(
         }
 
         private fun ImageButton.updateShuffleButton() {
-            if (!FeatureFlag.isEnabled(Feature.UP_NEXT_SHUFFLE)) return
-
             this.setImageResource(
                 when {
                     !isSignedInAsPaidUser -> IR.drawable.shuffle_plus_feature_icon

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/bookmark/BookmarksFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/bookmark/BookmarksFragment.kt
@@ -33,13 +33,9 @@ import au.com.shiftyjelly.pocketcasts.settings.SettingsFragment
 import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingFlow
 import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingLauncher
 import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingUpgradeSource
-import au.com.shiftyjelly.pocketcasts.sharing.SharingClient
-import au.com.shiftyjelly.pocketcasts.sharing.SharingRequest
 import au.com.shiftyjelly.pocketcasts.ui.helper.FragmentHostListener
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import au.com.shiftyjelly.pocketcasts.utils.extensions.pxToDp
-import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
-import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
 import au.com.shiftyjelly.pocketcasts.views.R
 import au.com.shiftyjelly.pocketcasts.views.dialog.OptionsDialog
 import au.com.shiftyjelly.pocketcasts.views.fragments.BaseFragment
@@ -77,9 +73,6 @@ class BookmarksFragment : BaseFragment() {
 
     @Inject
     lateinit var settings: Settings
-
-    @Inject
-    lateinit var sharingClient: SharingClient
 
     private val sourceView: SourceView
         get() = SourceView.fromString(arguments?.getString(ARG_SOURCE_VIEW))
@@ -220,16 +213,9 @@ class BookmarksFragment : BaseFragment() {
             val (podcast, episode, bookmark) = bookmarksViewModel.getSharedBookmark() ?: return@launch
             bookmarksViewModel.onShare(podcast.uuid, episode.uuid, sourceView)
             val timestamp = bookmark.timeSecs.seconds
-            if (FeatureFlag.isEnabled(Feature.REIMAGINE_SHARING)) {
-                ShareEpisodeTimestampFragment
-                    .forBookmark(episode, timestamp, podcast.backgroundColor, sourceView)
-                    .show(parentFragmentManager, "share_screen")
-            } else {
-                val request = SharingRequest.bookmark(podcast, episode, timestamp)
-                    .setSourceView(sourceView)
-                    .build()
-                sharingClient.share(request)
-            }
+            ShareEpisodeTimestampFragment
+                .forBookmark(episode, timestamp, podcast.backgroundColor, sourceView)
+                .show(parentFragmentManager, "share_screen")
         }
     }
 

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/ProfileEpisodeListFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/ProfileEpisodeListFragment.kt
@@ -67,8 +67,6 @@ import au.com.shiftyjelly.pocketcasts.settings.viewmodel.ManualCleanupViewModel
 import au.com.shiftyjelly.pocketcasts.ui.extensions.themed
 import au.com.shiftyjelly.pocketcasts.ui.helper.FragmentHostListener
 import au.com.shiftyjelly.pocketcasts.utils.extensions.dpToPx
-import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
-import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
 import au.com.shiftyjelly.pocketcasts.utils.isDeviceRunningOnLowStorage
 import au.com.shiftyjelly.pocketcasts.views.dialog.ConfirmationDialog
 import au.com.shiftyjelly.pocketcasts.views.dialog.OptionsDialog
@@ -276,7 +274,7 @@ class ProfileEpisodeListFragment : BaseFragment(), Toolbar.OnMenuItemClickListen
             )
         }
 
-        if (mode is Mode.Downloaded && FeatureFlag.isEnabled(Feature.MANAGE_DOWNLOADED_EPISODES)) {
+        if (mode is Mode.Downloaded) {
             viewLifecycleOwner.lifecycleScope.launch {
                 viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
                     cleanUpViewModel.state.collect { state ->

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastAdapter.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastAdapter.kt
@@ -63,8 +63,6 @@ import au.com.shiftyjelly.pocketcasts.servers.model.DiscoverPodcast
 import au.com.shiftyjelly.pocketcasts.ui.extensions.themed
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import au.com.shiftyjelly.pocketcasts.ui.theme.ThemeColor
-import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
-import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
 import au.com.shiftyjelly.pocketcasts.views.helper.SwipeButtonLayoutFactory
 import au.com.shiftyjelly.pocketcasts.views.multiselect.MultiSelectBookmarksHelper
 import au.com.shiftyjelly.pocketcasts.views.multiselect.MultiSelectEpisodesHelper
@@ -430,7 +428,7 @@ class PodcastAdapter(
             onHeaderSummaryToggled(headerExpanded, false)
         }
         this.podcast = podcast
-        val isHtmlDescription = FeatureFlag.isEnabled(Feature.PODCAST_HTML_DESCRIPTION) && podcast.podcastHtmlDescription.isNotEmpty()
+        val isHtmlDescription = podcast.podcastHtmlDescription.isNotEmpty()
         val rawDescription = if (isHtmlDescription) { podcast.podcastHtmlDescription } else { podcast.podcastDescription }
         this.podcastDescription = HtmlCompat.fromHtml(
             rawDescription,

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastFragment.kt
@@ -85,8 +85,6 @@ import au.com.shiftyjelly.pocketcasts.ui.helper.StatusBarIconColor
 import au.com.shiftyjelly.pocketcasts.ui.images.CoilManager
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import au.com.shiftyjelly.pocketcasts.utils.extensions.dpToPx
-import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
-import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
 import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
 import au.com.shiftyjelly.pocketcasts.views.dialog.ConfirmationDialog
 import au.com.shiftyjelly.pocketcasts.views.dialog.OptionsDialog
@@ -470,9 +468,7 @@ class PodcastFragment : BaseFragment() {
     private val onEpisodesOptionsClicked: () -> Unit = {
         analyticsTracker.track(AnalyticsEvent.PODCAST_SCREEN_OPTIONS_TAPPED)
         var optionsDialog = OptionsDialog()
-
-        if (FeatureFlag.isEnabled(Feature.PODCAST_FEED_UPDATE)) {
-            optionsDialog = optionsDialog.addTextOption(
+            .addTextOption(
                 titleId = LR.string.podcast_refresh_episodes,
                 imageId = IR.drawable.ic_refresh,
                 click = {
@@ -481,9 +477,6 @@ class PodcastFragment : BaseFragment() {
                     }
                 },
             )
-        }
-
-        optionsDialog
             .addTextOption(
                 titleId = LR.string.podcast_sort_episodes,
                 imageId = IR.drawable.ic_sort,
@@ -699,7 +692,6 @@ class PodcastFragment : BaseFragment() {
     ): View {
         val binding = FragmentPodcastBinding.inflate(inflater, container, false).also { binding = it }
 
-        binding.swipeRefreshLayout.isEnabled = FeatureFlag.isEnabled(Feature.PODCAST_FEED_UPDATE)
         toolbarController.setUpToolbar(
             view = binding.toolbar,
             theme = theme,

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastFragment.kt
@@ -79,8 +79,6 @@ import au.com.shiftyjelly.pocketcasts.settings.SettingsFragment
 import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingFlow
 import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingLauncher
 import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingUpgradeSource
-import au.com.shiftyjelly.pocketcasts.sharing.SharingClient
-import au.com.shiftyjelly.pocketcasts.sharing.SharingRequest
 import au.com.shiftyjelly.pocketcasts.ui.extensions.openUrl
 import au.com.shiftyjelly.pocketcasts.ui.helper.FragmentHostListener
 import au.com.shiftyjelly.pocketcasts.ui.helper.StatusBarIconColor
@@ -186,9 +184,6 @@ class PodcastFragment : BaseFragment() {
 
     @Inject
     lateinit var analyticsTracker: AnalyticsTracker
-
-    @Inject
-    lateinit var sharingClient: SharingClient
 
     @Inject
     lateinit var colorAnalyzer: PodcastImageColorAnalyzer
@@ -939,16 +934,9 @@ class PodcastFragment : BaseFragment() {
             val (podcast, episode, bookmark) = viewModel.getSharedBookmark() ?: return@launch
             viewModel.onBookmarkShare(podcast.uuid, episode.uuid, sourceView)
             val timestamp = bookmark.timeSecs.seconds
-            if (FeatureFlag.isEnabled(Feature.REIMAGINE_SHARING)) {
-                ShareEpisodeTimestampFragment
-                    .forBookmark(episode, timestamp, podcast.backgroundColor, SourceView.PODCAST_SCREEN)
-                    .show(parentFragmentManager, "share_screen")
-            } else {
-                val request = SharingRequest.bookmark(podcast, episode, timestamp)
-                    .setSourceView(SourceView.PODCAST_SCREEN)
-                    .build()
-                sharingClient.share(request)
-            }
+            ShareEpisodeTimestampFragment
+                .forBookmark(episode, timestamp, podcast.backgroundColor, SourceView.PODCAST_SCREEN)
+                .show(parentFragmentManager, "share_screen")
         }
     }
 
@@ -1219,18 +1207,9 @@ class PodcastFragment : BaseFragment() {
             return
         }
 
-        if (FeatureFlag.isEnabled(Feature.REIMAGINE_SHARING)) {
-            SharePodcastFragment
-                .newInstance(podcast, SourceView.PODCAST_SCREEN)
-                .show(parentFragmentManager, "share_screen")
-        } else {
-            lifecycleScope.launch {
-                val request = SharingRequest.podcast(podcast)
-                    .setSourceView(SourceView.PODCAST_SCREEN)
-                    .build()
-                sharingClient.share(request)
-            }
-        }
+        SharePodcastFragment
+            .newInstance(podcast, SourceView.PODCAST_SCREEN)
+            .show(parentFragmentManager, "share_screen")
     }
 
     private fun downloadAll() {

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcasts/PodcastsFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcasts/PodcastsFragment.kt
@@ -76,8 +76,6 @@ import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingUpgradeSourc
 import au.com.shiftyjelly.pocketcasts.ui.extensions.getColor
 import au.com.shiftyjelly.pocketcasts.ui.helper.FragmentHostListener
 import au.com.shiftyjelly.pocketcasts.utils.extensions.hideShadow
-import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
-import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
 import au.com.shiftyjelly.pocketcasts.views.adapter.PodcastTouchCallback
 import au.com.shiftyjelly.pocketcasts.views.extensions.quickScrollToTop
 import au.com.shiftyjelly.pocketcasts.views.fragments.BaseFragment
@@ -181,12 +179,8 @@ class PodcastsFragment :
         toolbar.setOnMenuItemClickListener(this)
 
         toolbar.menu.findItem(R.id.folders_locked).setOnMenuItemClickListener {
-            if (FeatureFlag.isEnabled(Feature.SUGGESTED_FOLDERS)) {
-                if (viewModel.areSuggestedFoldersAvailable.value) {
-                    showSuggestedFoldersCreation(SuggestedFoldersFragment.Source.ToolbarButton)
-                } else {
-                    OnboardingLauncher.openOnboardingFlow(requireActivity(), OnboardingFlow.Upsell(OnboardingUpgradeSource.FOLDERS))
-                }
+            if (viewModel.areSuggestedFoldersAvailable.value) {
+                showSuggestedFoldersCreation(SuggestedFoldersFragment.Source.ToolbarButton)
             } else {
                 OnboardingLauncher.openOnboardingFlow(requireActivity(), OnboardingFlow.Upsell(OnboardingUpgradeSource.FOLDERS))
             }
@@ -303,7 +297,7 @@ class PodcastsFragment :
         viewLifecycleOwner.lifecycleScope.launch {
             viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
                 viewModel.areSuggestedFoldersAvailable.collect { areAvailable ->
-                    if (areAvailable && FeatureFlag.isEnabled(Feature.SUGGESTED_FOLDERS) && viewModel.isEligibleForSuggestedFoldersPopup()) {
+                    if (areAvailable && viewModel.isEligibleForSuggestedFoldersPopup()) {
                         showSuggestedFoldersCreation(SuggestedFoldersFragment.Source.Popup)
                     }
                 }
@@ -382,11 +376,7 @@ class PodcastsFragment :
 
     private fun handleFolderCreation() {
         if (viewModel.areSuggestedFoldersAvailable.value) {
-            if (FeatureFlag.isEnabled(Feature.SUGGESTED_FOLDERS)) {
-                showSuggestedFoldersCreation(SuggestedFoldersFragment.Source.ToolbarButton)
-            } else {
-                showCustomFolderCreation()
-            }
+            showSuggestedFoldersCreation(SuggestedFoldersFragment.Source.ToolbarButton)
         } else {
             showCustomFolderCreation()
         }

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/PodcastsViewModel.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/PodcastsViewModel.kt
@@ -287,7 +287,7 @@ class PodcastsViewModel @AssistedInject constructor(
     private var refreshSuggestedFoldersJob: Job? = null
 
     fun refreshSuggestedFolders() {
-        if (FeatureFlag.isEnabled(Feature.SUGGESTED_FOLDERS) && refreshSuggestedFoldersJob?.isActive != true) {
+        if (refreshSuggestedFoldersJob?.isActive != true) {
             refreshSuggestedFoldersJob = viewModelScope.launch {
                 suggestedFoldersManager.refreshSuggestedFolders()
             }

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/AccountDetailsFragment.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/AccountDetailsFragment.kt
@@ -25,7 +25,6 @@ import au.com.shiftyjelly.pocketcasts.compose.extensions.contentWithoutConsumedI
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.profile.champion.PocketCastsChampionBottomSheetDialog
 import au.com.shiftyjelly.pocketcasts.profile.winback.WinbackFragment
-import au.com.shiftyjelly.pocketcasts.profile.winback.WinbackInitParams
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
 import au.com.shiftyjelly.pocketcasts.repositories.playback.UpNextQueue
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
@@ -43,8 +42,6 @@ import au.com.shiftyjelly.pocketcasts.ui.helper.FragmentHostListener
 import au.com.shiftyjelly.pocketcasts.utils.Gravatar
 import au.com.shiftyjelly.pocketcasts.utils.Util
 import au.com.shiftyjelly.pocketcasts.utils.extensions.pxToDp
-import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
-import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
 import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
 import au.com.shiftyjelly.pocketcasts.views.dialog.ConfirmationDialog
 import au.com.shiftyjelly.pocketcasts.views.fragments.BaseFragment
@@ -145,7 +142,7 @@ class AccountDetailsFragment : BaseFragment() {
             onCancelSubscription = { winbackParams ->
                 analyticsTracker.track(AnalyticsEvent.ACCOUNT_DETAILS_CANCEL_TAPPED)
                 WinbackFragment
-                    .create(if (FeatureFlag.isEnabled(Feature.WINBACK)) winbackParams else WinbackInitParams.Empty)
+                    .create(winbackParams)
                     .show(childFragmentManager, "subscription_winback")
             },
             onChangeNewsletterSubscription = { isChecked ->

--- a/modules/features/reimagine/src/main/kotlin/au/com/shiftyjelly/pocketcasts/reimagine/ShareDialogFragment.kt
+++ b/modules/features/reimagine/src/main/kotlin/au/com/shiftyjelly/pocketcasts/reimagine/ShareDialogFragment.kt
@@ -41,8 +41,6 @@ import au.com.shiftyjelly.pocketcasts.sharing.SharingClient
 import au.com.shiftyjelly.pocketcasts.sharing.SharingRequest
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import au.com.shiftyjelly.pocketcasts.ui.theme.ThemeColor
-import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
-import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
 import au.com.shiftyjelly.pocketcasts.utils.parceler.ColorParceler
 import au.com.shiftyjelly.pocketcasts.utils.parceler.DurationParceler
 import com.google.android.material.bottomsheet.BottomSheetBehavior
@@ -157,18 +155,9 @@ class ShareDialogFragment : BottomSheetDialogFragment() {
                     textId = LR.string.share_podcast,
                     textColor = textColor,
                     onClick = {
-                        if (FeatureFlag.isEnabled(Feature.REIMAGINE_SHARING)) {
-                            SharePodcastFragment
-                                .newInstance(podcast, args.source)
-                                .show(parentFragmentManager, "share_screen")
-                        } else {
-                            lifecycleScope.launch(NonCancellable) {
-                                val request = SharingRequest.podcast(podcast)
-                                    .setSourceView(args.source)
-                                    .build()
-                                sharingClient.share(request)
-                            }
-                        }
+                        SharePodcastFragment
+                            .newInstance(podcast, args.source)
+                            .show(parentFragmentManager, "share_screen")
                     },
                 ),
             )
@@ -179,18 +168,9 @@ class ShareDialogFragment : BottomSheetDialogFragment() {
                     textId = LR.string.podcast_share_episode,
                     textColor = textColor,
                     onClick = {
-                        if (FeatureFlag.isEnabled(Feature.REIMAGINE_SHARING)) {
-                            ShareEpisodeFragment
-                                .newInstance(episode, podcast.backgroundColor, args.source)
-                                .show(parentFragmentManager, "share_screen")
-                        } else {
-                            lifecycleScope.launch(NonCancellable) {
-                                val request = SharingRequest.episode(podcast, episode)
-                                    .setSourceView(args.source)
-                                    .build()
-                                sharingClient.share(request)
-                            }
-                        }
+                        ShareEpisodeFragment
+                            .newInstance(episode, podcast.backgroundColor, args.source)
+                            .show(parentFragmentManager, "share_screen")
                     },
                 ),
             )
@@ -199,34 +179,23 @@ class ShareDialogFragment : BottomSheetDialogFragment() {
                     textId = LR.string.podcast_share_current_position,
                     textColor = textColor,
                     onClick = {
-                        if (FeatureFlag.isEnabled(Feature.REIMAGINE_SHARING)) {
-                            ShareEpisodeTimestampFragment
-                                .forEpisodePosition(episode, podcast.backgroundColor, args.source)
-                                .show(parentFragmentManager, "share_screen")
-                        } else {
-                            lifecycleScope.launch(NonCancellable) {
-                                val request = SharingRequest.episodePosition(podcast, episode, episode.playedUpTo.seconds)
-                                    .setSourceView(args.source)
-                                    .build()
-                                sharingClient.share(request)
-                            }
-                        }
+                        ShareEpisodeTimestampFragment
+                            .forEpisodePosition(episode, podcast.backgroundColor, args.source)
+                            .show(parentFragmentManager, "share_screen")
                     },
                 ),
             )
-            if (FeatureFlag.isEnabled(Feature.REIMAGINE_SHARING)) {
-                add(
-                    shareOption(
-                        textId = LR.string.podcast_share_clip,
-                        textColor = textColor,
-                        onClick = {
-                            ShareClipFragment
-                                .newInstance(episode, podcast.backgroundColor, args.source)
-                                .show(parentFragmentManager, "share_screen")
-                        },
-                    ),
-                )
-            }
+            add(
+                shareOption(
+                    textId = LR.string.podcast_share_clip,
+                    textColor = textColor,
+                    onClick = {
+                        ShareClipFragment
+                            .newInstance(episode, podcast.backgroundColor, args.source)
+                            .show(parentFragmentManager, "share_screen")
+                    },
+                ),
+            )
             if (episode.isDownloaded) {
                 add(
                     shareOption(

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/AdvancedSettingsPage.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/AdvancedSettingsPage.kt
@@ -30,8 +30,6 @@ import au.com.shiftyjelly.pocketcasts.compose.preview.ThemePreviewParameterProvi
 import au.com.shiftyjelly.pocketcasts.compose.theme
 import au.com.shiftyjelly.pocketcasts.settings.viewmodel.AdvancedSettingsViewModel
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
-import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
-import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 /**
@@ -99,9 +97,7 @@ fun AdvancedSettingsView(
                     heading = stringResource(LR.string.settings_advanced_heading_playback),
                     indent = false,
                 ) {
-                    if (FeatureFlag.isEnabled(Feature.CACHE_ENTIRE_PLAYING_EPISODE)) {
-                        CacheEntirePlayingEpisodeRow(state.cacheEntirePlayingEpisodeState)
-                    }
+                    CacheEntirePlayingEpisodeRow(state.cacheEntirePlayingEpisodeState)
                     PrioritizeSeekAccuracydRow(state.prioritizeSeekAccuracyState)
                 }
             }

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/AutoDownloadSettingsFragment.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/AutoDownloadSettingsFragment.kt
@@ -37,8 +37,6 @@ import au.com.shiftyjelly.pocketcasts.settings.viewmodel.ManualCleanupViewModel
 import au.com.shiftyjelly.pocketcasts.settings.viewmodel.toAutoDownloadStatus
 import au.com.shiftyjelly.pocketcasts.ui.helper.FragmentHostListener
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
-import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
-import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
 import au.com.shiftyjelly.pocketcasts.views.extensions.setup
 import au.com.shiftyjelly.pocketcasts.views.fragments.FilterSelectFragment
 import au.com.shiftyjelly.pocketcasts.views.fragments.PodcastSelectFragment
@@ -128,13 +126,8 @@ class AutoDownloadSettingsFragment :
         toolbar?.setup(title = getString(LR.string.settings_title_auto_download), navigationIcon = BackArrow, activity = activity, theme = theme)
         toolbar?.isVisible = showToolbar
 
-        if (FeatureFlag.isEnabled(Feature.AUTO_DOWNLOAD)) {
-            onFollowPodcastPreference?.let { podcastsCategory?.addPreference(it) }
-            podcastsAutoDownloadLimitPreference?.let { podcastsCategory?.addPreference(it) }
-        } else {
-            onFollowPodcastPreference?.let { podcastsCategory?.removePreference(it) }
-            podcastsAutoDownloadLimitPreference?.let { podcastsCategory?.removePreference(it) }
-        }
+        onFollowPodcastPreference?.let { podcastsCategory?.addPreference(it) }
+        podcastsAutoDownloadLimitPreference?.let { podcastsCategory?.addPreference(it) }
 
         if (!showToolbar) {
             val listContainer = view.findViewById<View>(android.R.id.list_container)
@@ -396,9 +389,7 @@ class AutoDownloadSettingsFragment :
         setupOnFollowPodcastToggleStatusCheck()
         autoDownloadOnlyDownloadOnWifi.isChecked = viewModel.getAutoDownloadUnmeteredOnly()
         autoDownloadOnlyWhenCharging.isChecked = viewModel.getAutoDownloadOnlyWhenCharging()
-        if (FeatureFlag.isEnabled(Feature.AUTO_DOWNLOAD)) {
-            newEpisodesPreference?.summary = getString(LR.string.settings_auto_download_new_episodes_description)
-        }
+        newEpisodesPreference?.summary = getString(LR.string.settings_auto_download_new_episodes_description)
     }
 
     @SuppressLint("CheckResult")

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/LowStorageDialogPresenter.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/LowStorageDialogPresenter.kt
@@ -6,8 +6,6 @@ import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTracker
 import au.com.shiftyjelly.pocketcasts.analytics.SourceView
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.utils.Util
-import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
-import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
 import au.com.shiftyjelly.pocketcasts.utils.isDeviceRunningOnLowStorage
 import au.com.shiftyjelly.pocketcasts.views.dialog.ConfirmationDialog
 import au.com.shiftyjelly.pocketcasts.images.R as IR
@@ -22,8 +20,7 @@ class LowStorageDialogPresenter(
 
     suspend fun shouldShow(downloadedFiles: Long): Boolean = isDeviceRunningOnLowStorage() &&
         downloadedFiles != 0L &&
-        settings.shouldShowLowStorageModalAfterSnooze() &&
-        FeatureFlag.isEnabled(Feature.MANAGE_DOWNLOADED_EPISODES)
+        settings.shouldShowLowStorageModalAfterSnooze()
 
     fun getDialog(
         totalDownloadSize: Long,

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/entity/Podcast.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/entity/Podcast.kt
@@ -11,7 +11,6 @@ import androidx.room.Ignore
 import androidx.room.PrimaryKey
 import au.com.shiftyjelly.pocketcasts.localization.helper.RelativeDateFormatter
 import au.com.shiftyjelly.pocketcasts.localization.helper.tryToLocalise
-import au.com.shiftyjelly.pocketcasts.models.entity.Podcast.AutoAddUpNext.values
 import au.com.shiftyjelly.pocketcasts.models.to.AutoArchiveAfterPlaying
 import au.com.shiftyjelly.pocketcasts.models.to.AutoArchiveInactive
 import au.com.shiftyjelly.pocketcasts.models.to.AutoArchiveLimit
@@ -20,8 +19,6 @@ import au.com.shiftyjelly.pocketcasts.models.to.PlaybackEffects
 import au.com.shiftyjelly.pocketcasts.models.to.PodcastGrouping
 import au.com.shiftyjelly.pocketcasts.models.type.EpisodesSortType
 import au.com.shiftyjelly.pocketcasts.models.type.TrimMode
-import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
-import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
 import java.io.Serializable
 import java.net.MalformedURLException
 import java.net.URL
@@ -158,7 +155,7 @@ data class Podcast(
         get() = trimMode != TrimMode.OFF
 
     val canShare: Boolean
-        get() = !FeatureFlag.isEnabled(Feature.SHARE_PODCAST_PRIVATE_NOT_AVAILABLE) || !isPrivate
+        get() = !isPrivate
 
     val isUsingEffects: Boolean
         get() = overrideGlobalEffects && (isSilenceRemoved || isVolumeBoosted || playbackSpeed != 1.0)

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
@@ -208,7 +208,7 @@ class SettingsImpl @Inject constructor(
         sharedPrefs = sharedPreferences,
     )
 
-    override val cacheEntirePlayingEpisode = UserSetting.CacheEntirePlayingEpisodePref(
+    override val cacheEntirePlayingEpisode = UserSetting.BoolPref(
         sharedPrefKey = "cacheEntirePlayingEpisode",
         defaultValue = firebaseRemoteConfig.getBoolean(FirebaseConfig.EXOPLAYER_CACHE_ENTIRE_PLAYING_EPISODE_SETTING_DEFAULT),
         sharedPrefs = sharedPreferences,

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/UserSetting.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/UserSetting.kt
@@ -2,8 +2,6 @@ package au.com.shiftyjelly.pocketcasts.preferences
 
 import android.annotation.SuppressLint
 import android.content.SharedPreferences
-import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
-import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
 import java.time.Clock
 import java.time.Instant
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -305,20 +303,6 @@ abstract class UserSetting<T>(
             intValue.toString()
         },
     )
-
-    // This returns shared pref value only if CACHE_ENTIRE_PLAYING_EPISODE feature flag is enabled, otherwise returns always false
-    class CacheEntirePlayingEpisodePref(
-        sharedPrefKey: String,
-        private val defaultValue: Boolean,
-        sharedPrefs: SharedPreferences,
-    ) : BoolPref(sharedPrefKey, defaultValue, sharedPrefs) {
-
-        override fun get() = if (FeatureFlag.isEnabled(Feature.CACHE_ENTIRE_PLAYING_EPISODE)) {
-            sharedPrefs.getBoolean(sharedPrefKey, defaultValue)
-        } else {
-            false
-        }
-    }
 
     // This manual mock is needed to avoid problems when accessing a lazily initialized UserSetting::flow
     // from a mocked Settings class

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/ExoPlayerDataSourceFactory.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/ExoPlayerDataSourceFactory.kt
@@ -20,8 +20,6 @@ import androidx.media3.extractor.mp3.Mp3Extractor
 import au.com.shiftyjelly.pocketcasts.models.entity.BaseEpisode
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.servers.di.Player
-import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
-import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
 import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
 import com.automattic.android.tracks.crashlogging.CrashLogging
 import dagger.hilt.android.qualifiers.ApplicationContext
@@ -144,7 +142,7 @@ class ExoPlayerDataSourceFactory @Inject constructor(
         }
     }
 
-    private fun BaseEpisode.shouldUseCache() = !isDownloaded && !isDownloading && settings.cacheEntirePlayingEpisode.value && FeatureFlag.isEnabled(Feature.CACHE_ENTIRE_PLAYING_EPISODE)
+    private fun BaseEpisode.shouldUseCache() = !isDownloaded && !isDownloading && settings.cacheEntirePlayingEpisode.value
 
     private fun ClosedRange<Long>.toClippingConfiguration() = ClippingConfiguration.Builder()
         .setStartPositionMs(start)

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/SimplePlayer.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/SimplePlayer.kt
@@ -24,8 +24,6 @@ import au.com.shiftyjelly.pocketcasts.models.to.PlaybackEffects
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.repositories.user.StatsManager
 import au.com.shiftyjelly.pocketcasts.utils.Util
-import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
-import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
 import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
 import java.util.concurrent.TimeUnit
 import kotlinx.coroutines.Dispatchers
@@ -246,9 +244,7 @@ class SimplePlayer(
                 // https://github.com/androidx/media/issues/1032#issuecomment-1921375048
                 // https://github.com/google/ExoPlayer/issues/10577
                 // Internal ref: p1730809737477079-slack-C02A333D8LQ
-                if (FeatureFlag.isEnabled(Feature.RESET_EPISODE_CACHE_ON_416_ERROR) &&
-                    (error.cause as? InvalidResponseCodeException)?.responseCode == 416
-                ) {
+                if ((error.cause as? InvalidResponseCodeException)?.responseCode == 416) {
                     episodeLocation?.let {
                         dataSourceFactory.resetEpisodeCaching(
                             episodeLocation = it,

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/UpNextQueueImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/UpNextQueueImpl.kt
@@ -15,8 +15,6 @@ import au.com.shiftyjelly.pocketcasts.repositories.download.DownloadManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
 import au.com.shiftyjelly.pocketcasts.repositories.sync.SyncManager
 import au.com.shiftyjelly.pocketcasts.repositories.sync.UpNextSyncWorker
-import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
-import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
 import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
 import com.jakewharton.rxrelay2.BehaviorRelay
 import com.jakewharton.rxrelay2.Relay
@@ -243,7 +241,7 @@ class UpNextQueueImpl @Inject constructor(
 
     override suspend fun removeEpisode(episode: BaseEpisode, shouldShuffleUpNext: Boolean) {
         if (contains(episode.uuid)) {
-            if (shouldShuffleUpNext && FeatureFlag.isEnabled(Feature.UP_NEXT_SHUFFLE)) {
+            if (shouldShuffleUpNext) {
                 saveChangesBlocking(UpNextAction.RemoveAndShuffle(episode))
             } else {
                 saveChangesBlocking(UpNextAction.Remove(episode))

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/SubscribeManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/SubscribeManager.kt
@@ -22,8 +22,6 @@ import au.com.shiftyjelly.pocketcasts.servers.cdn.StaticServiceManager
 import au.com.shiftyjelly.pocketcasts.servers.podcast.PodcastCacheServiceManager
 import au.com.shiftyjelly.pocketcasts.servers.sync.PodcastEpisodesResponse
 import au.com.shiftyjelly.pocketcasts.utils.Optional
-import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
-import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
 import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
 import coil.executeBlocking
 import coil.imageLoader
@@ -210,8 +208,7 @@ class SubscribeManager @Inject constructor(
         shouldAutoDownload: Boolean,
     ): Boolean = subscribed &&
         settings.autoDownloadOnFollowPodcast.value &&
-        shouldAutoDownload &&
-        FeatureFlag.isEnabled(Feature.AUTO_DOWNLOAD)
+        shouldAutoDownload
 
     private fun downloadPodcastRxSingle(podcastUuid: String): Single<Podcast> {
         // download the podcast

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/TranscriptsManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/TranscriptsManagerImpl.kt
@@ -13,15 +13,12 @@ import au.com.shiftyjelly.pocketcasts.utils.NetworkWrapper
 import au.com.shiftyjelly.pocketcasts.utils.exception.EmptyDataException
 import au.com.shiftyjelly.pocketcasts.utils.exception.NoNetworkException
 import au.com.shiftyjelly.pocketcasts.utils.exception.ParsingException
-import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
-import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
 import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
 import java.net.UnknownHostException
 import java.util.concurrent.ConcurrentHashMap
 import javax.inject.Inject
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import okhttp3.CacheControl
@@ -68,13 +65,6 @@ class TranscriptsManagerImpl @Inject constructor(
 
     override fun observeTranscriptForEpisode(episodeUuid: String) = transcriptDao
         .observeTranscriptForEpisode(episodeUuid)
-        .map { transcript ->
-            if (FeatureFlag.isEnabled(Feature.GENERATED_TRANSCRIPTS)) {
-                transcript
-            } else {
-                transcript?.takeIf { !it.isGenerated }
-            }
-        }
 
     @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
     fun findBestTranscript(transcripts: List<Transcript>): Transcript? {

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/interceptors/BasicAuthInterceptor.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/interceptors/BasicAuthInterceptor.kt
@@ -1,7 +1,5 @@
 package au.com.shiftyjelly.pocketcasts.servers.interceptors
 
-import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
-import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
 import java.net.HttpURLConnection
 import okhttp3.Credentials
 import okhttp3.Interceptor
@@ -12,7 +10,7 @@ internal class BasicAuthInterceptor : Interceptor {
         val originalRequest = chain.request()
         val response = chain.proceed(originalRequest)
 
-        if (!FeatureFlag.isEnabled(Feature.BASIC_AUTHENTICATION) || response.code != HttpURLConnection.HTTP_UNAUTHORIZED) {
+        if (response.code != HttpURLConnection.HTTP_UNAUTHORIZED) {
             return response
         }
 

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/podcast/PodcastResponse.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/podcast/PodcastResponse.kt
@@ -4,8 +4,6 @@ import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.models.type.EpisodesSortType
 import au.com.shiftyjelly.pocketcasts.utils.extensions.parseIsoDate
-import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
-import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
 import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
 import java.util.Date
@@ -57,9 +55,7 @@ data class PodcastInfo(
         podcast.title = title ?: ""
         podcast.author = author ?: ""
         podcast.podcastCategory = category ?: ""
-        if (FeatureFlag.isEnabled(Feature.PODCAST_HTML_DESCRIPTION)) {
-            podcast.podcastHtmlDescription = descriptionHtml ?: ""
-        }
+        podcast.podcastHtmlDescription = descriptionHtml ?: ""
         podcast.podcastDescription = description ?: ""
         podcast.episodesSortType = if (showType == "serial") EpisodesSortType.EPISODES_SORT_BY_DATE_ASC else EpisodesSortType.EPISODES_SORT_BY_DATE_DESC
         episodes?.mapNotNull { it.toEpisode(uuid) }?.let { episodes ->

--- a/modules/services/servers/src/test/kotlin/au/com/shiftyjelly/pocketcasts/servers/interceptors/BasicAuthInterceptorTest.kt
+++ b/modules/services/servers/src/test/kotlin/au/com/shiftyjelly/pocketcasts/servers/interceptors/BasicAuthInterceptorTest.kt
@@ -1,8 +1,5 @@
 package au.com.shiftyjelly.pocketcasts.servers.interceptors
 
-import au.com.shiftyjelly.pocketcasts.sharedtest.InMemoryFeatureFlagRule
-import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
-import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.mockwebserver.MockResponse
@@ -13,10 +10,6 @@ import org.junit.Rule
 import org.junit.Test
 
 class BasicAuthInterceptorTest {
-
-    @get:Rule
-    val featureFlagRule = InMemoryFeatureFlagRule()
-
     @get:Rule
     val server = MockWebServer()
 
@@ -84,26 +77,6 @@ class BasicAuthInterceptorTest {
     fun `when missing credentials don't add authorization header`() {
         val request = Request.Builder()
             .url(url)
-            .build()
-
-        server.enqueue(
-            MockResponse()
-                .setResponseCode(401)
-                .setHeader("WWW-Authenticate", "Basic realm=\"Please enter username and password\""),
-        )
-        client.newCall(request).execute()
-
-        assertEquals(1, server.requestCount)
-        val serverRequest = server.takeRequest()
-        assertNull(serverRequest.getHeader("Authorization"))
-    }
-
-    @Test
-    fun `when feature flag is off don't add authorization header`() {
-        FeatureFlag.setEnabled(Feature.BASIC_AUTHENTICATION, false)
-
-        val request = Request.Builder()
-            .url(urlWithCredentials)
             .build()
 
         server.enqueue(

--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/Feature.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/Feature.kt
@@ -82,14 +82,6 @@ enum class Feature(
         hasFirebaseRemoteFlag = true,
         hasDevToggle = true,
     ),
-    RESET_EPISODE_CACHE_ON_416_ERROR(
-        key = "reset_episode_cache_on_416_error",
-        title = "Reset episode cache on 416 error",
-        defaultValue = true,
-        tier = FeatureTier.Free,
-        hasFirebaseRemoteFlag = true,
-        hasDevToggle = false,
-    ),
     PODCASTS_SORT_CHANGES(
         key = "podcasts_sort_changes",
         title = "Podcasts Sort Changes",

--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/Feature.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/Feature.kt
@@ -58,14 +58,6 @@ enum class Feature(
         hasFirebaseRemoteFlag = true,
         hasDevToggle = true,
     ),
-    REIMAGINE_SHARING(
-        key = "reimagine_sharing",
-        title = "Use new sharing designs",
-        defaultValue = true,
-        tier = FeatureTier.Free,
-        hasFirebaseRemoteFlag = true,
-        hasDevToggle = true,
-    ),
     EXPLAT_EXPERIMENT(
         key = "explat_experiment",
         title = "ExPlat Experiment",

--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/Feature.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/Feature.kt
@@ -138,14 +138,6 @@ enum class Feature(
         hasFirebaseRemoteFlag = true,
         hasDevToggle = true,
     ),
-    WINBACK(
-        key = "winback",
-        title = "Winback flow",
-        defaultValue = BuildConfig.DEBUG,
-        tier = FeatureTier.Free,
-        hasFirebaseRemoteFlag = true,
-        hasDevToggle = true,
-    ),
     PODCAST_FEED_UPDATE(
         key = "podcast_feed_update",
         title = "Podcast Feed Update",

--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/Feature.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/Feature.kt
@@ -178,14 +178,6 @@ enum class Feature(
         hasFirebaseRemoteFlag = false,
         hasDevToggle = true,
     ),
-    GENERATED_TRANSCRIPTS(
-        key = "generated_transcripts",
-        title = "Generated transcripts",
-        defaultValue = BuildConfig.DEBUG,
-        tier = FeatureTier.Free,
-        hasFirebaseRemoteFlag = true,
-        hasDevToggle = true,
-    ),
     APPSFLYER_ANALYTICS(
         key = "appsflyer_analytics",
         title = "AppsFlyer Analytics",

--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/Feature.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/Feature.kt
@@ -106,14 +106,6 @@ enum class Feature(
         hasFirebaseRemoteFlag = true,
         hasDevToggle = true,
     ),
-    PODCAST_FEED_UPDATE(
-        key = "podcast_feed_update",
-        title = "Podcast Feed Update",
-        defaultValue = BuildConfig.DEBUG,
-        tier = FeatureTier.Free,
-        hasFirebaseRemoteFlag = true,
-        hasDevToggle = true,
-    ),
     PODCASTS_SORT_CHANGES(
         key = "podcasts_sort_changes",
         title = "Podcasts Sort Changes",

--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/Feature.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/Feature.kt
@@ -50,14 +50,6 @@ enum class Feature(
         hasFirebaseRemoteFlag = false,
         hasDevToggle = true,
     ),
-    CACHE_ENTIRE_PLAYING_EPISODE(
-        key = "cache_entire_playing_episode",
-        title = "Cache entire playing episode",
-        defaultValue = true,
-        tier = FeatureTier.Free,
-        hasFirebaseRemoteFlag = true,
-        hasDevToggle = true,
-    ),
     EXPLAT_EXPERIMENT(
         key = "explat_experiment",
         title = "ExPlat Experiment",

--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/Feature.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/Feature.kt
@@ -90,14 +90,6 @@ enum class Feature(
         hasFirebaseRemoteFlag = true,
         hasDevToggle = false,
     ),
-    BASIC_AUTHENTICATION(
-        key = "basic_authentication",
-        title = "Support episode basic authentication",
-        defaultValue = BuildConfig.DEBUG,
-        tier = FeatureTier.Free,
-        hasFirebaseRemoteFlag = true,
-        hasDevToggle = true,
-    ),
     PODCASTS_SORT_CHANGES(
         key = "podcasts_sort_changes",
         title = "Podcasts Sort Changes",

--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/Feature.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/Feature.kt
@@ -106,14 +106,6 @@ enum class Feature(
         hasFirebaseRemoteFlag = true,
         hasDevToggle = true,
     ),
-    SHARE_PODCAST_PRIVATE_NOT_AVAILABLE(
-        key = "share_podcast_private_not_available",
-        title = "Sharing is not available for private podcasts",
-        defaultValue = BuildConfig.DEBUG,
-        tier = FeatureTier.Free,
-        hasFirebaseRemoteFlag = true,
-        hasDevToggle = true,
-    ),
     PODCAST_FEED_UPDATE(
         key = "podcast_feed_update",
         title = "Podcast Feed Update",

--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/Feature.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/Feature.kt
@@ -106,14 +106,6 @@ enum class Feature(
         hasFirebaseRemoteFlag = true,
         hasDevToggle = true,
     ),
-    PODCAST_HTML_DESCRIPTION(
-        key = "podcast_html_description",
-        title = "Use HTML in the podcast description",
-        defaultValue = true,
-        tier = FeatureTier.Free,
-        hasFirebaseRemoteFlag = true,
-        hasDevToggle = true,
-    ),
     SHARE_PODCAST_PRIVATE_NOT_AVAILABLE(
         key = "share_podcast_private_not_available",
         title = "Sharing is not available for private podcasts",

--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/Feature.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/Feature.kt
@@ -74,14 +74,6 @@ enum class Feature(
         hasFirebaseRemoteFlag = true,
         hasDevToggle = true,
     ),
-    MANAGE_DOWNLOADED_EPISODES(
-        key = "manage_downloaded_episodes",
-        title = "Manage Downloaded Episodes",
-        defaultValue = BuildConfig.DEBUG,
-        tier = FeatureTier.Free,
-        hasFirebaseRemoteFlag = true,
-        hasDevToggle = true,
-    ),
     PODCASTS_SORT_CHANGES(
         key = "podcasts_sort_changes",
         title = "Podcasts Sort Changes",

--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/Feature.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/Feature.kt
@@ -82,14 +82,6 @@ enum class Feature(
         hasFirebaseRemoteFlag = true,
         hasDevToggle = true,
     ),
-    UP_NEXT_SHUFFLE(
-        key = "up_next_shuffle",
-        title = "Up Next Shuffle",
-        defaultValue = BuildConfig.DEBUG,
-        tier = FeatureTier.Plus(),
-        hasFirebaseRemoteFlag = true,
-        hasDevToggle = true,
-    ),
     MANAGE_DOWNLOADED_EPISODES(
         key = "manage_downloaded_episodes",
         title = "Manage Downloaded Episodes",

--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/Feature.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/Feature.kt
@@ -154,14 +154,6 @@ enum class Feature(
         hasFirebaseRemoteFlag = true,
         hasDevToggle = true,
     ),
-    SUGGESTED_FOLDERS(
-        key = "suggested_folders",
-        title = "Suggested Folders",
-        defaultValue = BuildConfig.DEBUG,
-        tier = FeatureTier.Free,
-        hasFirebaseRemoteFlag = true,
-        hasDevToggle = true,
-    ),
     PODCASTS_SORT_CHANGES(
         key = "podcasts_sort_changes",
         title = "Podcasts Sort Changes",

--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/Feature.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/Feature.kt
@@ -66,14 +66,6 @@ enum class Feature(
         hasFirebaseRemoteFlag = true,
         hasDevToggle = false,
     ),
-    AUTO_DOWNLOAD(
-        key = "auto_download",
-        title = "Auto download episodes after subscribing to a podcast",
-        defaultValue = BuildConfig.DEBUG,
-        tier = FeatureTier.Free,
-        hasFirebaseRemoteFlag = true,
-        hasDevToggle = true,
-    ),
     PODCASTS_SORT_CHANGES(
         key = "podcasts_sort_changes",
         title = "Podcasts Sort Changes",

--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/providers/FirebaseRemoteFeatureProvider.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/providers/FirebaseRemoteFeatureProvider.kt
@@ -19,10 +19,6 @@ class FirebaseRemoteFeatureProvider @Inject constructor(
                 .getString(FirebaseConfig.SLUMBER_STUDIOS_YEARLY_PROMO_CODE)
                 .isNotEmpty()
 
-        Feature.CACHE_ENTIRE_PLAYING_EPISODE ->
-            firebaseRemoteConfig
-                .getLong(FirebaseConfig.EXOPLAYER_CACHE_ENTIRE_PLAYING_EPISODE_SIZE_IN_MB) > 0
-
         else -> firebaseRemoteConfig.getBoolean(feature.key)
     }
 


### PR DESCRIPTION
## Description

This removes feature flags that have been enabled for quite a while now.

## Testing Instructions

Code review the changes with paying attention whether the boolean logic is consistent.

## Checklist
- [ ] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] ~I have considered whether it makes sense to add tests for my changes~
- [ ] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [ ] ~Any jetpack compose components I added or changed are covered by compose previews~
- [ ] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~