### PR TITLE
Define player colors

### DIFF
--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/PlayerColors.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/PlayerColors.kt
@@ -1,0 +1,41 @@
+package au.com.shiftyjelly.pocketcasts.compose
+
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.toArgb
+import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
+import au.com.shiftyjelly.pocketcasts.ui.theme.ThemeColor
+
+data class PlayerColors(
+    val theme: Theme.ThemeType,
+    val podcastColors: PodcastColors,
+) {
+    val background01 = Color(ThemeColor.playerBackground01(theme, podcastColors.background.toArgb()))
+
+    val background02 = Color(ThemeColor.playerBackground02(theme, podcastColors.background.toArgb()))
+
+    val highlight01 = Color(ThemeColor.playerHighlight01(theme, podcastColors.tint.toArgb()))
+
+    val highlight02 = Color(ThemeColor.playerHighlight02(theme, podcastColors.tint.toArgb()))
+
+    val highlight03 = Color(ThemeColor.playerHighlight03(theme, podcastColors.tint.toArgb()))
+
+    val highlight04 = Color(ThemeColor.playerHighlight04(theme, podcastColors.tint.toArgb()))
+
+    val highlight05 = Color(ThemeColor.playerHighlight05(theme, podcastColors.tint.toArgb()))
+
+    val highlight06 = Color(ThemeColor.playerHighlight06(theme, podcastColors.tint.toArgb()))
+
+    val highlight07 = Color(ThemeColor.playerHighlight07(theme, podcastColors.tint.toArgb()))
+
+    val contrast01 = Color(ThemeColor.playerContrast01(theme))
+
+    val contrast02 = Color(ThemeColor.playerContrast02(theme))
+
+    val contrast03 = Color(ThemeColor.playerContrast03(theme))
+
+    val contrast04 = Color(ThemeColor.playerContrast04(theme))
+
+    val contrast05 = Color(ThemeColor.playerContrast05(theme))
+
+    val contrast06 = Color(ThemeColor.playerContrast06(theme))
+}

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/PodcastColors.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/PodcastColors.kt
@@ -1,0 +1,53 @@
+package au.com.shiftyjelly.pocketcasts.compose
+
+import androidx.compose.runtime.staticCompositionLocalOf
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.tooling.preview.PreviewParameterProvider
+import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
+
+data class PodcastColors(
+    val background: Color,
+    val tint: Color,
+) {
+    constructor(podcast: Podcast) : this(
+        background = Color(podcast.backgroundColor),
+        tint = Color(podcast.darkThemeTint()),
+    )
+
+    companion object {
+        val TheDailyPreview
+            get() = PodcastColors(
+                background = Color(0xFF0477C2),
+                tint = Color(0xFFCFEB7B),
+            )
+
+        val ThisAmericanLifePreview
+            get() = PodcastColors(
+                background = Color(0xFFEC0404),
+                tint = Color(0xFFF47C84),
+            )
+
+        val ConanPreview
+            get() = PodcastColors(
+                background = Color(0xFF37444F),
+                tint = Color(0xFFF87509),
+            )
+
+        val DarknetDiariesPreview
+            get() = PodcastColors(
+                background = Color(0xFF2E2D2D),
+                tint = Color(0xFFFF3232),
+            )
+    }
+}
+
+val LocalPodcastColors = staticCompositionLocalOf<PodcastColors?> { null }
+
+class PodcastColorsParameterProvider : PreviewParameterProvider<PodcastColors> {
+    override val values = sequenceOf(
+        PodcastColors.TheDailyPreview,
+        PodcastColors.ThisAmericanLifePreview,
+        PodcastColors.ConanPreview,
+        PodcastColors.DarknetDiariesPreview,
+    )
+}

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/Theme.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/Theme.kt
@@ -8,6 +8,7 @@ import androidx.compose.material.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.ReadOnlyComposable
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.unit.sp
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
@@ -97,6 +98,13 @@ data class PocketCastsTheme(
 ) {
     val isDark get() = type.darkTheme
     val isLight get() = !isDark
+
+    @Composable
+    fun rememberPlayerColors(): PlayerColors? {
+        return LocalPodcastColors.current?.let { podcastColors ->
+            remember(podcastColors) { PlayerColors(type, podcastColors) }
+        }
+    }
 }
 
 @SuppressLint("ConflictingOnColor")


### PR DESCRIPTION
## Description

This PR adds a `PlayerColors` type. I need it to contextualize ad colors that can be displayed either in our regular UI or in the player. Since the player uses its own theming, I need access to the appropriate colors—and we don’t currently have anything like that in our theme type. I’ve decided to introduce a new `CompositionLocal`. If `LocalPodcastColors` is present, then `PlayerColors` will be available. This allows to dynamically update the colors and their availability when needed.

## Testing Instructions

Code review and green CI.

## Checklist
- [ ] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] ~I have considered whether it makes sense to add tests for my changes~
- [ ] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [ ] ~Any jetpack compose components I added or changed are covered by compose previews~
- [ ] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~