### PR TITLE
Do not filter colors during parsing

### DIFF
--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/MiniPlayer.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/MiniPlayer.kt
@@ -144,7 +144,7 @@ class MiniPlayer @JvmOverloads constructor(context: Context, attrs: AttributeSet
 
             val podcast = upNextState.podcast
             if (podcast != null) {
-                updateTintColor(podcast.getPlayerTintColor(theme.isDarkTheme), theme)
+                updateTintColor(podcast.getTintColor(theme.isDarkTheme), theme)
             } else {
                 updateTintColor(context.getThemeColor(androidx.appcompat.R.attr.colorAccent), theme)
             }

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/PlayerColors.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/PlayerColors.kt
@@ -13,19 +13,19 @@ data class PlayerColors(
 
     val background02 = Color(ThemeColor.playerBackground02(theme, podcastColors.background.toArgb()))
 
-    val highlight01 = Color(ThemeColor.playerHighlight01(theme, podcastColors.tint.toArgb()))
+    val highlight01 = Color(ThemeColor.playerHighlight01(theme, podcastColors.playerTint.toArgb()))
 
-    val highlight02 = Color(ThemeColor.playerHighlight02(theme, podcastColors.tint.toArgb()))
+    val highlight02 = Color(ThemeColor.playerHighlight02(theme, podcastColors.playerTint.toArgb()))
 
-    val highlight03 = Color(ThemeColor.playerHighlight03(theme, podcastColors.tint.toArgb()))
+    val highlight03 = Color(ThemeColor.playerHighlight03(theme, podcastColors.playerTint.toArgb()))
 
-    val highlight04 = Color(ThemeColor.playerHighlight04(theme, podcastColors.tint.toArgb()))
+    val highlight04 = Color(ThemeColor.playerHighlight04(theme, podcastColors.playerTint.toArgb()))
 
-    val highlight05 = Color(ThemeColor.playerHighlight05(theme, podcastColors.tint.toArgb()))
+    val highlight05 = Color(ThemeColor.playerHighlight05(theme, podcastColors.playerTint.toArgb()))
 
-    val highlight06 = Color(ThemeColor.playerHighlight06(theme, podcastColors.tint.toArgb()))
+    val highlight06 = Color(ThemeColor.playerHighlight06(theme, podcastColors.playerTint.toArgb()))
 
-    val highlight07 = Color(ThemeColor.playerHighlight07(theme, podcastColors.tint.toArgb()))
+    val highlight07 = Color(ThemeColor.playerHighlight07(theme, podcastColors.playerTint.toArgb()))
 
     val contrast01 = Color(ThemeColor.playerContrast01(theme))
 

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/PodcastColors.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/PodcastColors.kt
@@ -7,36 +7,36 @@ import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 
 data class PodcastColors(
     val background: Color,
-    val tint: Color,
+    val playerTint: Color,
 ) {
     constructor(podcast: Podcast) : this(
         background = Color(podcast.backgroundColor),
-        tint = Color(podcast.darkThemeTint()),
+        playerTint = Color(podcast.getPlayerTintColor(isDarkTheme = true)),
     )
 
     companion object {
         val TheDailyPreview
             get() = PodcastColors(
                 background = Color(0xFF0477C2),
-                tint = Color(0xFFCFEB7B),
+                playerTint = Color(0xFFCFEB7B),
             )
 
         val ThisAmericanLifePreview
             get() = PodcastColors(
                 background = Color(0xFFEC0404),
-                tint = Color(0xFFF47C84),
+                playerTint = Color(0xFFF47C84),
             )
 
         val ConanPreview
             get() = PodcastColors(
                 background = Color(0xFF37444F),
-                tint = Color(0xFFF87509),
+                playerTint = Color(0xFFF87509),
             )
 
         val DarknetDiariesPreview
             get() = PodcastColors(
                 background = Color(0xFF2E2D2D),
-                tint = Color(0xFFFF3232),
+                playerTint = Color(0xFFFF3232),
             )
     }
 }

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/cdn/ColorsResponse.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/cdn/ColorsResponse.kt
@@ -1,6 +1,7 @@
 package au.com.shiftyjelly.pocketcasts.servers.cdn
 
 import android.graphics.Color
+import androidx.core.graphics.toColorInt
 import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
 
@@ -12,22 +13,14 @@ data class ColorsResponse(
     fun toArtworkColors(): ArtworkColors {
         return ArtworkColors(
             background = parseColor(colors?.background),
-            tintForLightBg = resetDefaultTint(parseColor(colors?.tintForLightBg), isTintLightColor = true),
-            tintForDarkBg = resetDefaultTint(parseColor(colors?.tintForDarkBg), isTintLightColor = false),
+            tintForLightBg = parseColor(colors?.tintForLightBg),
+            tintForDarkBg = parseColor(colors?.tintForDarkBg),
             timeDownloadedMs = System.currentTimeMillis(),
         )
     }
 
     private fun parseColor(colorString: String?): Int {
-        return if (colorString.isNullOrEmpty()) 0 else Color.parseColor(colorString)
-    }
-
-    private fun resetDefaultTint(color: Int, isTintLightColor: Boolean): Int {
-        return if (isTintLightColor) {
-            if (color == DEFAULT_SERVER_LIGHT_TINT_COLOR) DEFAULT_LIGHT_TINT_COLOR else color
-        } else {
-            if (color == DEFAULT_SERVER_DARK_TINT_COLOR) DEFAULT_DARK_TINT_COLOR else color
-        }
+        return if (colorString.isNullOrEmpty()) Color.BLACK else colorString.toColorInt()
     }
 }
 
@@ -37,9 +30,3 @@ data class Colors(
     @field:Json(name = "tintForDarkBg") val tintForDarkBg: String,
     @field:Json(name = "tintForLightBg") val tintForLightBg: String,
 )
-
-const val DEFAULT_LIGHT_TINT_COLOR = 0xFF1E1F1E.toInt()
-const val DEFAULT_DARK_TINT_COLOR = 0xFFFFFFFF.toInt()
-
-const val DEFAULT_SERVER_LIGHT_TINT_COLOR = 0xFFF44336.toInt()
-const val DEFAULT_SERVER_DARK_TINT_COLOR = 0xFFC62828.toInt()

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/player/NowPlayingViewModel.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/player/NowPlayingViewModel.kt
@@ -79,7 +79,7 @@ class NowPlayingViewModel @Inject constructor(
                         val podcast = playbackState.podcast
                         episode.displaySubtitle(podcast)
                     },
-                    tintColor = playbackState.podcast?.getPlayerTintColor(theme.isDarkTheme),
+                    tintColor = playbackState.podcast?.getTintColor(theme.isDarkTheme),
                     episodeUuid = playbackState.episodeUuid,
                     playing = playbackState.isPlaying,
                     theme = theme,


### PR DESCRIPTION
## Description

Our current color setup is incorrect. We filter out podcast colors before they are being assigned to a podcast object. This is wrong because it prevents `getPlayerTintColor()` function to return expected values. The filtering is done in the `Podcast` type already for appropriate colors and should be done only there:

https://github.com/Automattic/pocket-casts-android/blob/670e52059a84bfa467be1f1df4cf6d82cbd82644/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/entity/Podcast.kt#L243-L249

## Testing Instructions

1. Have a dark theme set.
2. Play something from [the Alive Again podcast](https://pca.st/podcast/6b4093e0-0d26-013e-31d0-0affd846786d).
3. Notice that the Mini Player is still white.

## Checklist
- [ ] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] ~I have considered whether it makes sense to add tests for my changes~
- [ ] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [ ] ~Any jetpack compose components I added or changed are covered by compose previews~
- [ ] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~