### PR TITLE
Prevent overwriting calculated episode duration on refresh

### DIFF
--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/PodcastRefresherImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/PodcastRefresherImpl.kt
@@ -55,7 +55,9 @@ class PodcastRefresherImpl @Inject constructor(
                     existingEpisode.downloadUrl = newEpisode.downloadUrl
                     existingEpisode.fileType = newEpisode.fileType
                     existingEpisode.sizeInBytes = newEpisode.sizeInBytes
-                    existingEpisode.duration = newEpisode.duration
+                    if (newEpisode.duration != 0.0) {
+                        existingEpisode.duration = newEpisode.duration
+                    }
                     existingEpisode.publishedDate = newEpisode.publishedDate
                     existingEpisode.season = newEpisode.season
                     existingEpisode.number = newEpisode.number


### PR DESCRIPTION
## Description
It has been reported that the podcast page 'forgets' the episode duration that has been previously calculated by the player.
It only happens on episodes that arrive with `duration=0.0` from the server. In this case our player yields the stream duration (`PlaybackManager.onDurationAvailable`) and we persist that value in the database via `EpisodeManager.updateDurationBlocking`. 
However when we return to the podcast screen, we refresh episodes and that overwrites the previously calculated duration with the server value (0.0).
This PR addresses this scenario. I've added an extra condition to `PodcastRefresherImpl` to keep the local `duration` value unchanged when the server value is zero. 

Fixes #3972 

## Testing Instructions
1. Open Daily Tech News Show podcast
2. Notice that the duration text appears as `-` on each episode row
3. Start playing an episode
4. Notice that the duration gets updated, and after a few seconds of playback the remaning play time gets rendered.
5. Now go to the discover page while episode is still playing
6. Return to podcast tab
- [ ] remaning play time is still available for the podcast being played


## Screenshots or Screencast 
![Screenshot_20250604_152752](https://github.com/user-attachments/assets/8f66fa5b-4767-46b1-8442-353649e9d04c)

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- ~[ ] I have considered whether it makes sense to add tests for my changes~
- ~[ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- ~[ ] Any jetpack compose components I added or changed are covered by compose previews~
- ~[ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~
 
