### PR TITLE
Display price per month for plan change offers

### DIFF
--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/winback/AvailablePlansPage.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/winback/AvailablePlansPage.kt
@@ -359,9 +359,9 @@ private fun SubscriptionRow(
                 val currencyCode = plan.pricingPhase.price.currencyCode
                 TextP40(
                     text = if (currencyCode == "USD") {
-                        stringResource(LR.string.price_per_week_usd, plan.pricePerWeek)
+                        stringResource(LR.string.price_per_month_usd, plan.pricePerMonth)
                     } else {
-                        stringResource(LR.string.price_per_week, plan.pricePerWeek, currencyCode)
+                        stringResource(LR.string.price_per_month, plan.pricePerMonth, currencyCode)
                     },
                     color = MaterialTheme.theme.colors.primaryText02,
                     fontSize = 15.sp,
@@ -440,12 +440,12 @@ private fun ManageSubscriptions(
     }
 }
 
-private val SubscriptionPlan.Base.pricePerWeek: Float
+private val SubscriptionPlan.Base.pricePerMonth: Float
     get() {
         val pricePerWeek = when (billingCycle) {
-            BillingCycle.Monthly -> pricingPhase.price.amount * 12.toBigDecimal()
-            BillingCycle.Yearly -> pricingPhase.price.amount
-        } / 52.toBigDecimal()
+            BillingCycle.Monthly -> pricingPhase.price.amount
+            BillingCycle.Yearly -> pricingPhase.price.amount / 12.toBigDecimal()
+        }
         return pricePerWeek.toFloat()
     }
 

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -202,6 +202,10 @@
     <string name="price_per_week">%1$.2f %2$s/week</string>
     <!-- %1$.2f is price with 2 decimal points precision, \u0024 is a dollar sign -->
     <string name="price_per_week_usd">\u0024%1$.2f/week</string>
+    <!-- %1$.2f is price with 2 decimal points precision, %1$s is the currency -->
+    <string name="price_per_month">%1$.2f %2$s/month</string>
+    <!-- %1$.2f is price with 2 decimal points precision, \u0024 is a dollar sign -->
+    <string name="price_per_month_usd">\u0024%1$.2f/month</string>
     <!-- "Ad" means here advertisement. It should be a short form if possible. -->
     <string name="ad">Ad</string>
     <string name="ad_options">Advertisement options</string>


### PR DESCRIPTION
## Description

This changes price per week to price per month during the plan change.

Internal ref: p1748979309847339-slack-C05RR9P9RAT

## Testing Instructions

Code review should be enough.

## Screenshots or Screencast 

<img width="408" alt="Screenshot 2025-06-04 at 18 21 45" src="https://github.com/user-attachments/assets/691e68c6-f20e-4164-b391-48be9b51fdf4" />

## Checklist
- [ ] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] ~I have considered whether it makes sense to add tests for my changes~
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [ ] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~