### PR TITLE
Allow to observe feature flags

### DIFF
--- a/modules/features/shared/src/main/java/au/com/shiftyjelly/pocketcasts/shared/AppLifecycleObserver.kt
+++ b/modules/features/shared/src/main/java/au/com/shiftyjelly/pocketcasts/shared/AppLifecycleObserver.kt
@@ -75,7 +75,6 @@ class AppLifecycleObserver(
     override fun onResume(owner: LifecycleOwner) {
         super.onResume(owner)
         appLifecycleAnalytics.onApplicationEnterForeground()
-        FeatureFlag.refresh()
     }
 
     override fun onPause(owner: LifecycleOwner) {

--- a/modules/services/sharedtest/src/main/java/au/com/shiftyjelly/pocketcasts/sharedtest/InMemoryFeatureFlagRule.kt
+++ b/modules/services/sharedtest/src/main/java/au/com/shiftyjelly/pocketcasts/sharedtest/InMemoryFeatureFlagRule.kt
@@ -1,19 +1,21 @@
 package au.com.shiftyjelly.pocketcasts.sharedtest
 
 import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.ModifiableFeatureProvider
 import au.com.shiftyjelly.pocketcasts.utils.featureflag.ReleaseVersion
 import org.junit.rules.TestWatcher
 import org.junit.runner.Description
 
-class InMemoryFeatureFlagRule : TestWatcher() {
-    private var provider = InMemoryFeatureProvider()
+class InMemoryFeatureFlagRule() : TestWatcher() {
+    private val _provider = InMemoryFeatureProvider()
+    val provider: ModifiableFeatureProvider = InMemoryFeatureProvider()
 
     fun setReleaseVersion(releaseVersion: ReleaseVersion) {
-        provider.currentReleaseVersion = releaseVersion
+        _provider.currentReleaseVersion = releaseVersion
     }
 
     override fun starting(description: Description) {
-        FeatureFlag.initialize(listOf(provider))
+        FeatureFlag.initialize(listOf(_provider))
     }
 
     override fun finished(description: Description) {

--- a/modules/services/sharedtest/src/main/java/au/com/shiftyjelly/pocketcasts/sharedtest/InMemoryFeatureFlagRule.kt
+++ b/modules/services/sharedtest/src/main/java/au/com/shiftyjelly/pocketcasts/sharedtest/InMemoryFeatureFlagRule.kt
@@ -1,21 +1,19 @@
 package au.com.shiftyjelly.pocketcasts.sharedtest
 
 import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
-import au.com.shiftyjelly.pocketcasts.utils.featureflag.ModifiableFeatureProvider
 import au.com.shiftyjelly.pocketcasts.utils.featureflag.ReleaseVersion
 import org.junit.rules.TestWatcher
 import org.junit.runner.Description
 
-class InMemoryFeatureFlagRule() : TestWatcher() {
-    private val _provider = InMemoryFeatureProvider()
-    val provider: ModifiableFeatureProvider = InMemoryFeatureProvider()
+class InMemoryFeatureFlagRule : TestWatcher() {
+    private val provider = InMemoryFeatureProvider()
 
     fun setReleaseVersion(releaseVersion: ReleaseVersion) {
-        _provider.currentReleaseVersion = releaseVersion
+        provider.currentReleaseVersion = releaseVersion
     }
 
     override fun starting(description: Description) {
-        FeatureFlag.initialize(listOf(_provider))
+        FeatureFlag.initialize(listOf(provider))
     }
 
     override fun finished(description: Description) {

--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/di/FirebaseModule.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/di/FirebaseModule.kt
@@ -8,7 +8,6 @@ import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 import javax.inject.Singleton
-import timber.log.Timber
 
 @Module
 @InstallIn(SingletonComponent::class)
@@ -22,13 +21,6 @@ class FirebaseModule {
                 .build()
             setConfigSettingsAsync(config)
             setDefaultsAsync(FirebaseConfig.defaults)
-            fetch().addOnCompleteListener {
-                if (it.isSuccessful) {
-                    activate()
-                } else {
-                    Timber.e("Could not fetch remote config: ${it.exception?.message ?: "Unknown error"}")
-                }
-            }
         }
     }
 }

--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/Feature.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/Feature.kt
@@ -133,7 +133,7 @@ enum class Feature(
 
     // This is set of features used only for testing purposes.
     TEST_FREE_FEATURE(
-        key = "test_free_feautre",
+        key = "test_free_feature",
         title = "Free feature used for testing",
         defaultValue = true,
         tier = FeatureTier.Free,
@@ -141,7 +141,7 @@ enum class Feature(
         hasDevToggle = false,
     ),
     TEST_PLUS_FEATURE(
-        key = "test_plus_feautre",
+        key = "test_plus_feature",
         title = "Plus feature used for testing",
         defaultValue = true,
         tier = FeatureTier.Plus(),
@@ -149,7 +149,7 @@ enum class Feature(
         hasDevToggle = false,
     ),
     TEST_PLUS_RESTRICTED_FEATURE(
-        key = "test_plus_restricted_feautre",
+        key = "test_plus_restricted_feature",
         title = "Plus feature with Patron exclusive access used for testing",
         defaultValue = true,
         tier = FeatureTier.Plus(ReleaseVersion(1, 0)),
@@ -157,7 +157,7 @@ enum class Feature(
         hasDevToggle = false,
     ),
     TEST_PATRON_FEATURE(
-        key = "test_patron_feautre",
+        key = "test_patron_feature",
         title = "Patron feature used for testing",
         defaultValue = true,
         tier = FeatureTier.Patron,

--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/FeatureFlag.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/FeatureFlag.kt
@@ -59,10 +59,6 @@ object FeatureFlag {
         updateFeatureFlowValues()
     }
 
-    fun refresh() {
-        providers.filterIsInstance<RemoteFeatureProvider>().forEach { it.refresh() }
-    }
-
     fun clearProviders() {
         providers.clear()
         updateFeatureFlowValues()

--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/FeatureFlag.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/FeatureFlag.kt
@@ -61,7 +61,6 @@ object FeatureFlag {
 
     fun refresh() {
         providers.filterIsInstance<RemoteFeatureProvider>().forEach { it.refresh() }
-        updateFeatureFlowValues()
     }
 
     fun clearProviders() {

--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/FeatureFlag.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/FeatureFlag.kt
@@ -2,7 +2,10 @@ package au.com.shiftyjelly.pocketcasts.utils.featureflag
 
 import au.com.shiftyjelly.pocketcasts.payment.SubscriptionTier
 import au.com.shiftyjelly.pocketcasts.utils.featureflag.ReleaseVersion.Companion.comparedToEarlyPatronAccess
+import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.CopyOnWriteArrayList
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
 
 /**
  * Manages feature flags in the application with a list of different feature providers.
@@ -14,11 +17,13 @@ import java.util.concurrent.CopyOnWriteArrayList
  */
 object FeatureFlag {
     private val providers = CopyOnWriteArrayList<FeatureProvider>()
+    private val featureFlows = ConcurrentHashMap<Feature, MutableStateFlow<Boolean>>()
 
     fun initialize(
         providers: List<FeatureProvider>,
     ) {
         this.providers.addAll(providers)
+        updateFeatureFlowValues()
     }
 
     fun isEnabled(
@@ -27,6 +32,12 @@ object FeatureFlag {
         return findProviderForFeature<FeatureProvider>(feature)
             ?.isEnabled(feature)
             ?: feature.defaultValue
+    }
+
+    fun isEnabledFlow(
+        feature: Feature,
+    ): StateFlow<Boolean> {
+        return featureFlows.computeIfAbsent(feature) { MutableStateFlow(isEnabled(feature)) }
     }
 
     fun isEnabledForUser(
@@ -45,14 +56,23 @@ object FeatureFlag {
         enabled: Boolean,
     ) {
         findProviderForFeature<ModifiableFeatureProvider>(feature)?.setEnabled(feature, enabled)
+        updateFeatureFlowValues()
     }
 
     fun refresh() {
         providers.filterIsInstance<RemoteFeatureProvider>().forEach { it.refresh() }
+        updateFeatureFlowValues()
     }
 
     fun clearProviders() {
         providers.clear()
+        updateFeatureFlowValues()
+    }
+
+    fun updateFeatureFlowValues() {
+        for ((feature, flow) in featureFlows) {
+            flow.value = isEnabled(feature)
+        }
     }
 
     private fun isFeatureAllowedForCurrentVersion(

--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/FeatureProvider.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/FeatureProvider.kt
@@ -19,9 +19,5 @@ interface ModifiableFeatureProvider : FeatureProvider {
     fun setEnabled(feature: Feature, enabled: Boolean)
 }
 
-interface RemoteFeatureProvider : FeatureProvider {
-    fun refresh()
-}
-
 const val MAX_PRIORITY = 1
 const val MIN_PRIORITY = 2

--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/providers/FirebaseRemoteFeatureProvider.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/providers/FirebaseRemoteFeatureProvider.kt
@@ -2,16 +2,42 @@ package au.com.shiftyjelly.pocketcasts.utils.featureflag.providers
 
 import au.com.shiftyjelly.pocketcasts.utils.config.FirebaseConfig
 import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
 import au.com.shiftyjelly.pocketcasts.utils.featureflag.MAX_PRIORITY
 import au.com.shiftyjelly.pocketcasts.utils.featureflag.RemoteFeatureProvider
 import com.google.firebase.remoteconfig.FirebaseRemoteConfig
+import com.google.firebase.remoteconfig.configUpdates
 import javax.inject.Inject
+import javax.inject.Singleton
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.launch
 import timber.log.Timber
 
-class FirebaseRemoteFeatureProvider @Inject constructor(
+@Singleton
+class FirebaseRemoteFeatureProvider(
     private val firebaseRemoteConfig: FirebaseRemoteConfig,
+    private val scope: CoroutineScope,
 ) : RemoteFeatureProvider {
+    @Inject constructor(firebaseRemoteConfig: FirebaseRemoteConfig) : this(
+        firebaseRemoteConfig,
+        @Suppress("OPT_IN_USAGE")
+        // Using GlobalScope here is perfectly fine. This type is instantiated as a singleton.
+        // We have @ApplicationScope but it lives in a different module which cannot be included here.
+        // GlobalScope and @ApplicationScope are effectively the same as they have the same lifetime.
+        GlobalScope,
+    )
+
     override val priority: Int = MAX_PRIORITY
+
+    init {
+        scope.launch {
+            firebaseRemoteConfig.configUpdates.collect {
+                FeatureFlag.updateFeatureFlowValues()
+            }
+        }
+    }
 
     override fun isEnabled(feature: Feature) = when (feature) {
         Feature.SLUMBER_STUDIOS_YEARLY_PROMO ->

--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/providers/FirebaseRemoteFeatureProvider.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/providers/FirebaseRemoteFeatureProvider.kt
@@ -68,7 +68,7 @@ private suspend fun FirebaseRemoteConfig.fetchSuspending() = suspendCoroutine<Re
                 Result.success(Unit)
             } else {
                 Result.failure(exception)
-            }
+            },
         )
     }
 }
@@ -81,7 +81,7 @@ private suspend fun FirebaseRemoteConfig.activateSuspending() = suspendCoroutine
                 Result.success(Unit)
             } else {
                 Result.failure(exception)
-            }
+            },
         )
     }
 }

--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/providers/FirebaseRemoteFeatureProvider.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/providers/FirebaseRemoteFeatureProvider.kt
@@ -11,7 +11,6 @@ import javax.inject.Inject
 import javax.inject.Singleton
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.GlobalScope
-import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.launch
 import timber.log.Timber
 

--- a/modules/services/utils/src/test/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/FeatureFlagTest.kt
+++ b/modules/services/utils/src/test/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/FeatureFlagTest.kt
@@ -236,19 +236,6 @@ class FeatureFlagTest {
     }
 
     @Test
-    fun `feature flag values are updated with refresh`() = runTest {
-        FeatureFlag.isEnabledFlow(Feature.TEST_FREE_FEATURE).test {
-            assertTrue(awaitItem())
-
-            featureFlagRule.provider.setEnabled(Feature.TEST_FREE_FEATURE, false)
-            expectNoEvents()
-
-            FeatureFlag.refresh()
-            assertFalse(awaitItem())
-        }
-    }
-
-    @Test
     fun `feature flag flow is cached`() {
         val flow1 = FeatureFlag.isEnabledFlow(Feature.TEST_FREE_FEATURE)
         val flow2 = FeatureFlag.isEnabledFlow(Feature.TEST_FREE_FEATURE)


### PR DESCRIPTION
## Description

This PR allows to observe feature flags via `Flow`. I need it to properly support ads feature detection in the player as I'm running into some edge cases which block my progress without doing a lot of work.

## Testing Instructions

1. Apply [this patch](https://github.com/user-attachments/files/20606727/firabase-test.patch).
```
curl -L https://github.com/user-attachments/files/20606727/firabase-test.patch | git apply
```
2. Install `debugProd` variant.
3. Open Logcat and filter by `Testing` tag.
4. Notice `TEST_FREE_FEATURE enabled: true` log.
5. Go to the Firebase Remote config and modify `test_free_feature` key. Publish the changes.
6. Wait 10 seconds.
7. You should see`TEST_FREE_FEATURE enabled: <value>` in the Logcat.
8. Repeat steps 5-7 a couple of times to verify updates.

## Checklist
- [ ] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [ ] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [ ] ~Any jetpack compose components I added or changed are covered by compose previews~
- [ ] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
