### PR TITLE
Make AdBanner at most 400dp wide

### DIFF
--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcasts/BannerAdAdapter.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcasts/BannerAdAdapter.kt
@@ -1,6 +1,8 @@
 package au.com.shiftyjelly.pocketcasts.podcasts.view.podcasts
 
 import android.view.ViewGroup
+import androidx.compose.foundation.layout.Box
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.recyclerview.widget.DiffUtil
@@ -54,12 +56,16 @@ private class BannerAdViewHolder(
     fun bind(ad: BlazeAd) {
         composeView.setContent {
             AppTheme(themeType) {
-                AdBanner(
-                    ad = ad,
-                    colors = rememberAdColors().bannerAd,
-                    onAdClick = { onAdClick(ad) },
-                    onOptionsClick = { onAdOptionsClick(ad) },
-                )
+                Box(
+                    contentAlignment = Alignment.Center,
+                ) {
+                    AdBanner(
+                        ad = ad,
+                        colors = rememberAdColors().bannerAd,
+                        onAdClick = { onAdClick(ad) },
+                        onOptionsClick = { onAdOptionsClick(ad) },
+                    )
+                }
             }
         }
     }

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/ad/AdBanner.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/ad/AdBanner.kt
@@ -19,6 +19,7 @@ import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.LocalRippleConfiguration
 import androidx.compose.material.MaterialTheme
@@ -44,6 +45,7 @@ import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import au.com.shiftyjelly.pocketcasts.compose.AppTheme
@@ -65,12 +67,13 @@ fun AdBanner(
     onAdClick: () -> Unit,
     onOptionsClick: () -> Unit,
     modifier: Modifier = Modifier,
+    maxWidth: Dp = 400.dp,
 ) {
     CompositionLocalProvider(
         LocalRippleConfiguration provides RippleConfiguration(colors.ripple),
     ) {
         Box(
-            modifier = modifier,
+            modifier = modifier.widthIn(max = maxWidth),
         ) {
             val interactionSource = remember { MutableInteractionSource() }
             val contentDescription = stringResource(LR.string.go_to_ad, ad.ctaText)


### PR DESCRIPTION
## Description

Internal ref: p1749068013674719-slack-C08U02AG7C5

## Testing Instructions

1. Use a tablet.
2. Open the app as a free user.
3. Go to the podcasts tab.
4. Notice that the ad doesn't stretch across the whole screen.

## Screenshots or Screencast 

| Before | After |
| - | - |
| ![Screenshot_20250605_110428](https://github.com/user-attachments/assets/b01cbf41-8546-430a-950c-90c8befcbd94) | ![Screenshot_20250605_110647](https://github.com/user-attachments/assets/ef9f7fac-8642-4742-a7c1-3520127bf803) |

## Checklist
- [ ] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] ~I have considered whether it makes sense to add tests for my changes~
- [ ] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [ ] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~