### PR TITLE
Display ads in the player

### DIFF
--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/PlayerHeaderFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/PlayerHeaderFragment.kt
@@ -28,6 +28,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import androidx.core.net.toUri
 import androidx.core.view.isInvisible
 import androidx.core.view.isVisible
 import androidx.core.view.marginTop
@@ -75,6 +76,7 @@ import au.com.shiftyjelly.pocketcasts.ui.helper.FragmentHostListener
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import au.com.shiftyjelly.pocketcasts.ui.theme.ThemeColor
 import au.com.shiftyjelly.pocketcasts.utils.extensions.dpToPx
+import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
 import au.com.shiftyjelly.pocketcasts.views.dialog.ConfirmationDialog
 import au.com.shiftyjelly.pocketcasts.views.dialog.ConfirmationDialog.ButtonType.Danger
 import au.com.shiftyjelly.pocketcasts.views.extensions.spring
@@ -259,7 +261,12 @@ class PlayerHeaderFragment : BaseFragment(), PlayerClickListener {
                             AdBanner(
                                 ad = ad,
                                 colors = rememberAdColors().bannerAd,
-                                onAdClick = {},
+                                onAdClick = {
+                                    runCatching {
+                                        val intent = Intent(Intent.ACTION_VIEW, ad.ctaUrl.toUri())
+                                        startActivity(intent)
+                                    }.onFailure { LogBuffer.e("Ads", it, "Failed to open an ad: ${ad.id}") }
+                                },
                                 onOptionsClick = {},
                                 modifier = Modifier.padding(bottom = 16.dp, top = 8.dp),
                             )

--- a/modules/features/player/src/test/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/PlayerViewModelTest.kt
+++ b/modules/features/player/src/test/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/PlayerViewModelTest.kt
@@ -13,6 +13,7 @@ import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.models.entity.UserEpisode
 import au.com.shiftyjelly.pocketcasts.models.to.PlaybackEffects
+import au.com.shiftyjelly.pocketcasts.models.type.Subscription
 import au.com.shiftyjelly.pocketcasts.player.viewmodel.PlayerViewModel.NavigationState
 import au.com.shiftyjelly.pocketcasts.player.viewmodel.PlayerViewModel.PlaybackEffectsSettingsTab
 import au.com.shiftyjelly.pocketcasts.player.viewmodel.PlayerViewModel.SnackbarMessage
@@ -269,6 +270,9 @@ class PlayerViewModelTest {
         val useRealTimeForPlaybackRemainingTimeMock = mock<UserSetting<Boolean>>()
         whenever(useRealTimeForPlaybackRemainingTimeMock.flow).thenReturn(MutableStateFlow(false))
         whenever(settings.useRealTimeForPlaybackRemaingTime).thenReturn(useRealTimeForPlaybackRemainingTimeMock)
+        val cachedSubscriptionMock = mock<UserSetting<Subscription?>>()
+        whenever(cachedSubscriptionMock.flow).thenReturn(MutableStateFlow(null))
+        whenever(settings.cachedSubscription).thenReturn(cachedSubscriptionMock)
 
         viewModel = PlayerViewModel(
             playbackManager = playbackManager,

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/PodcastColors.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/PodcastColors.kt
@@ -15,6 +15,11 @@ data class PodcastColors(
     )
 
     companion object {
+        val ForUserEpisode = PodcastColors(
+            background = Color(0xFF3D3D3D),
+            playerTint = Color.White,
+        )
+
         val TheDailyPreview
             get() = PodcastColors(
                 background = Color(0xFF0477C2),


### PR DESCRIPTION
## Description

This includes ads in the player UI.

Designs: aVoIMJy9cdDZzNloBIv9jr-fi-1_1684

## Testing Instructions

1. Open the app as a free user.  
2. Add something to the queue.  
3. Navigate to the Player.  
4. You should see an ad.  
5. Tap the ad.  
6. You should be redirected to the ad's destination link.  
7. Go to **Beta Features** and disable the *Banner Ads* feature flag.  
8. Return to the Player.  
9. You should no longer see ads.  
10. Go to **Beta Features** and enable the *Banner Ads* feature flag again.  
11. Sign in as a free user.  
12. You should still see the ad in the Player.  
13. Sign in as a **paid** user.  
14. You should **not** see the ad in the Player.

## Screenshots or Screencast 

| Podcast episode | Custom file | Animation |
| - | - | - |
| ![ep](https://github.com/user-attachments/assets/6c819f1a-448d-4e02-b2b7-abf3843896cd) | ![Screenshot_20250605-131203](https://github.com/user-attachments/assets/4190d99d-db14-4bf0-96d9-e72120ec400d) | ![demo](https://github.com/user-attachments/assets/05064f06-b11c-4917-ad9e-d3603043a4f0) |

## Checklist
- [ ] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] ~I have considered whether it makes sense to add tests for my changes~
- [ ] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [ ] ~Any jetpack compose components I added or changed are covered by compose previews~
- [ ] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack