### PR TITLE
Improve ad title's accessibility

### DIFF
--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/ad/AdColors.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/ad/AdColors.kt
@@ -4,7 +4,9 @@ import androidx.compose.material.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.compositeOver
 import au.com.shiftyjelly.pocketcasts.compose.theme
+import au.com.shiftyjelly.pocketcasts.ui.helper.ColorUtils
 
 data class AdColors(
     val bannerAd: Banner,
@@ -37,11 +39,17 @@ fun rememberAdColors(): AdColors {
     val playerColors = theme.rememberPlayerColors()
     return remember(theme.type, playerColors) {
         if (playerColors != null) {
+            val adBackgroundColor = playerColors.contrast06.compositeOver(playerColors.background01)
+            val titleLabelContrast = ColorUtils.calculateContrast(
+                backgroundColor = adBackgroundColor.copy(alpha = 1f),
+                foregroundColor = playerColors.highlight01.copy(alpha = 1f),
+            )
+
             AdColors(
                 AdColors.Banner(
                     background = playerColors.contrast06,
                     ctaLabel = playerColors.contrast01,
-                    titleLabel = playerColors.highlight01,
+                    titleLabel = if (titleLabelContrast >= WcagAaTextContrastRequirement) playerColors.highlight01 else Color.White,
                     adLabelBackground = playerColors.contrast06,
                     adLabel = playerColors.contrast01,
                     icon = playerColors.contrast02,
@@ -82,3 +90,5 @@ fun rememberAdColors(): AdColors {
         }
     }
 }
+
+private const val WcagAaTextContrastRequirement = 4.5

--- a/modules/services/ui/src/main/java/au/com/shiftyjelly/pocketcasts/ui/helper/ColorUtils.kt
+++ b/modules/services/ui/src/main/java/au/com/shiftyjelly/pocketcasts/ui/helper/ColorUtils.kt
@@ -4,6 +4,7 @@ import android.graphics.Color
 import androidx.annotation.ColorInt
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.graphics.Color as ComposeColor
+import androidx.core.graphics.ColorUtils as AndroidColorUtils
 
 object ColorUtils {
     @ColorInt fun calculateCombinedColor(@ColorInt originalColor: Int, @ColorInt overlayColor: Int): Int {
@@ -48,6 +49,10 @@ object ColorUtils {
         }
         hsv[2] = (factor * targetValue).coerceIn(0f, 1f)
         return ComposeColor(Color.HSVToColor(hsv))
+    }
+
+    fun calculateContrast(backgroundColor: ComposeColor, foregroundColor: ComposeColor): Double {
+        return AndroidColorUtils.calculateContrast(foregroundColor.toArgb(), backgroundColor.toArgb())
     }
 }
 


### PR DESCRIPTION
## Description

Improve ad title contrast.

## Testing Instructions

Check contrast of player ad titles for different podcasts.

## Screenshots or Screencast 

| Before | After |
| - | - |
| ![b](https://github.com/user-attachments/assets/889f5e9d-f72e-4d93-a63a-09b4fd95143c) | ![a](https://github.com/user-attachments/assets/4d91ba3b-81fb-4856-adc8-6c733fcd3fc1) |

## Checklist
- [ ] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] ~I have considered whether it makes sense to add tests for my changes~
- [ ] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [ ] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [ ] ~with a landscape orientation~
- [ ] ~with the device set to have a large display and font size~
- [ ] ~for accessibility with TalkBack~