### PR TITLE
Add transcripts module

### DIFF
--- a/modules/features/transcripts/build.gradle.kts
+++ b/modules/features/transcripts/build.gradle.kts
@@ -1,0 +1,30 @@
+plugins {
+    alias(libs.plugins.android.library)
+    alias(libs.plugins.kotlin.android)
+    alias(libs.plugins.compose.compiler)
+}
+
+android {
+    namespace = "au.com.shiftyjelly.pocketcasts.transcripts"
+    buildFeatures {
+        buildConfig = true
+        viewBinding = false
+        compose = true
+    }
+}
+
+dependencies {
+    api(libs.compose.runtime)
+
+    api(projects.modules.services.compose)
+
+    implementation(platform(libs.compose.bom))
+
+    implementation(libs.compose.material)
+    implementation(libs.compose.foundation)
+    implementation(libs.compose.ui)
+    implementation(libs.compose.ui.graphics)
+    implementation(libs.compose.ui.tooling.preview)
+
+    implementation(projects.modules.services.ui)
+}

--- a/modules/features/transcripts/src/main/kotlin/au/shiftyjelly/pocketcasts/transcripts/TranscriptEntry.kt
+++ b/modules/features/transcripts/src/main/kotlin/au/shiftyjelly/pocketcasts/transcripts/TranscriptEntry.kt
@@ -1,0 +1,25 @@
+package au.shiftyjelly.pocketcasts.transcripts
+
+internal data class TranscriptEntry(
+    val text: String,
+    val style: Style,
+) {
+    enum class Style {
+        Simple, Speaker,
+    }
+
+    companion object {
+        val PreviewList = listOf(
+            TranscriptEntry("Lorem ipsum odor amet, consectetuer adipiscing elit.", Style.Simple),
+            TranscriptEntry("Speaker 1", Style.Speaker),
+            TranscriptEntry("Sodales sem fusce elementum commodo risus purus auctor neque.", Style.Simple),
+            TranscriptEntry("Tempus leo eu aenean sed diam urna tempor. Pulvinar vivamus fringilla lacus nec metus bibendum egestas. Iaculis massa nisl malesuada lacinia integer nunc posuere.", Style.Simple),
+            TranscriptEntry("Speaker 2", Style.Speaker),
+            TranscriptEntry("Duis elementum condimentum interdum. Vivamus sollicitudin blandit luctus. In vulputate ipsum dolor, vitae lacinia augue sollicitudin vel. Phasellus eget augue odio. Cras pharetra libero et lorem laoreet varius. Mauris libero massa, dictum eu dapibus at, condimentum nec eros. Morbi varius lobortis odio a fermentum.", Style.Simple),
+            TranscriptEntry("Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi.", Style.Simple),
+            TranscriptEntry("Integer non vestibulum enim, nec accumsan lacus. Suspendisse consequat nec ex ac volutpat. Ut iaculis nec odio in elementum. Proin tincidunt est lectus, et posuere magna mollis at. Integer vitae ornare quam. Vivamus lobortis tortor et nunc feugiat molestie. Maecenas vel nulla consequat, porttitor elit ut, tristique diam. Aenean id lectus nec augue finibus consequat at id lorem.", Style.Simple),
+            TranscriptEntry("Pulvinar vivamus fringilla lacus nec metus bibendum egestas. Iaculis massa nisl malesuada lacinia integer nunc posuere. Ut hendrerit semper vel class aptent taciti sociosqu. Ad litora torquent per conubia nostra inceptos himenaeos.", Style.Simple),
+            TranscriptEntry("Quisque faucibus ex sapien vitae pellentesque sem placerat. In id cursus mi pretium tellus duis convallis.", Style.Simple),
+        )
+    }
+}

--- a/modules/features/transcripts/src/main/kotlin/au/shiftyjelly/pocketcasts/transcripts/TranscriptEntry.kt
+++ b/modules/features/transcripts/src/main/kotlin/au/shiftyjelly/pocketcasts/transcripts/TranscriptEntry.kt
@@ -1,25 +1,26 @@
 package au.shiftyjelly.pocketcasts.transcripts
 
-internal data class TranscriptEntry(
-    val text: String,
-    val style: Style,
-) {
-    enum class Style {
-        Simple, Speaker,
-    }
+sealed interface TranscriptEntry {
+    data class Text(
+        val value: String,
+    ) : TranscriptEntry
+
+    data class Speaker(
+        val name: String,
+    ) : TranscriptEntry
 
     companion object {
         val PreviewList = listOf(
-            TranscriptEntry("Lorem ipsum odor amet, consectetuer adipiscing elit.", Style.Simple),
-            TranscriptEntry("Speaker 1", Style.Speaker),
-            TranscriptEntry("Sodales sem fusce elementum commodo risus purus auctor neque.", Style.Simple),
-            TranscriptEntry("Tempus leo eu aenean sed diam urna tempor. Pulvinar vivamus fringilla lacus nec metus bibendum egestas. Iaculis massa nisl malesuada lacinia integer nunc posuere.", Style.Simple),
-            TranscriptEntry("Speaker 2", Style.Speaker),
-            TranscriptEntry("Duis elementum condimentum interdum. Vivamus sollicitudin blandit luctus. In vulputate ipsum dolor, vitae lacinia augue sollicitudin vel. Phasellus eget augue odio. Cras pharetra libero et lorem laoreet varius. Mauris libero massa, dictum eu dapibus at, condimentum nec eros. Morbi varius lobortis odio a fermentum.", Style.Simple),
-            TranscriptEntry("Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi.", Style.Simple),
-            TranscriptEntry("Integer non vestibulum enim, nec accumsan lacus. Suspendisse consequat nec ex ac volutpat. Ut iaculis nec odio in elementum. Proin tincidunt est lectus, et posuere magna mollis at. Integer vitae ornare quam. Vivamus lobortis tortor et nunc feugiat molestie. Maecenas vel nulla consequat, porttitor elit ut, tristique diam. Aenean id lectus nec augue finibus consequat at id lorem.", Style.Simple),
-            TranscriptEntry("Pulvinar vivamus fringilla lacus nec metus bibendum egestas. Iaculis massa nisl malesuada lacinia integer nunc posuere. Ut hendrerit semper vel class aptent taciti sociosqu. Ad litora torquent per conubia nostra inceptos himenaeos.", Style.Simple),
-            TranscriptEntry("Quisque faucibus ex sapien vitae pellentesque sem placerat. In id cursus mi pretium tellus duis convallis.", Style.Simple),
+            TranscriptEntry.Text("Lorem ipsum odor amet, consectetuer adipiscing elit."),
+            TranscriptEntry.Speaker("Speaker 1"),
+            TranscriptEntry.Text("Sodales sem fusce elementum commodo risus purus auctor neque."),
+            TranscriptEntry.Text("Tempus leo eu aenean sed diam urna tempor. Pulvinar vivamus fringilla lacus nec metus bibendum egestas. Iaculis massa nisl malesuada lacinia integer nunc posuere."),
+            TranscriptEntry.Speaker("Speaker 2"),
+            TranscriptEntry.Text("Duis elementum condimentum interdum. Vivamus sollicitudin blandit luctus. In vulputate ipsum dolor, vitae lacinia augue sollicitudin vel. Phasellus eget augue odio. Cras pharetra libero et lorem laoreet varius. Mauris libero massa, dictum eu dapibus at, condimentum nec eros. Morbi varius lobortis odio a fermentum."),
+            TranscriptEntry.Text("Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi."),
+            TranscriptEntry.Text("Integer non vestibulum enim, nec accumsan lacus. Suspendisse consequat nec ex ac volutpat. Ut iaculis nec odio in elementum. Proin tincidunt est lectus, et posuere magna mollis at. Integer vitae ornare quam. Vivamus lobortis tortor et nunc feugiat molestie. Maecenas vel nulla consequat, porttitor elit ut, tristique diam. Aenean id lectus nec augue finibus consequat at id lorem."),
+            TranscriptEntry.Text("Pulvinar vivamus fringilla lacus nec metus bibendum egestas. Iaculis massa nisl malesuada lacinia integer nunc posuere. Ut hendrerit semper vel class aptent taciti sociosqu. Ad litora torquent per conubia nostra inceptos himenaeos."),
+            TranscriptEntry.Text("Quisque faucibus ex sapien vitae pellentesque sem placerat. In id cursus mi pretium tellus duis convallis."),
         )
     }
 }

--- a/modules/features/transcripts/src/main/kotlin/au/shiftyjelly/pocketcasts/transcripts/ui/TransciptLines.kt
+++ b/modules/features/transcripts/src/main/kotlin/au/shiftyjelly/pocketcasts/transcripts/ui/TransciptLines.kt
@@ -1,0 +1,130 @@
+package au.shiftyjelly.pocketcasts.transcripts.ui
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyListState
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.Font
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewParameter
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import au.com.shiftyjelly.pocketcasts.compose.AppTheme
+import au.com.shiftyjelly.pocketcasts.compose.AppThemeWithBackground
+import au.com.shiftyjelly.pocketcasts.compose.LocalPodcastColors
+import au.com.shiftyjelly.pocketcasts.compose.PodcastColors
+import au.com.shiftyjelly.pocketcasts.compose.PodcastColorsParameterProvider
+import au.com.shiftyjelly.pocketcasts.compose.components.FadedLazyColumn
+import au.com.shiftyjelly.pocketcasts.compose.extensions.verticalScrollBar
+import au.com.shiftyjelly.pocketcasts.compose.preview.ThemePreviewParameterProvider
+import au.com.shiftyjelly.pocketcasts.compose.theme
+import au.com.shiftyjelly.pocketcasts.ui.R
+import au.com.shiftyjelly.pocketcasts.ui.theme.Theme.ThemeType
+import au.shiftyjelly.pocketcasts.transcripts.TranscriptEntry
+
+@Composable
+internal fun TranscriptLines(
+    entries: List<TranscriptEntry>,
+    modifier: Modifier = Modifier,
+    state: LazyListState = rememberLazyListState(),
+    colors: TranscriptColors = TranscriptColors.default(MaterialTheme.theme.colors),
+) {
+    FadedLazyColumn(
+        contentPadding = PaddingValues(vertical = 16.dp),
+        modifier = modifier.verticalScrollBar(
+            scrollState = state,
+            thumbColor = colors.secondaryElement,
+        ),
+    ) {
+        items(entries) { entry ->
+            TranscriptLine(
+                entry = entry,
+                colors = colors,
+                modifier = Modifier.padding(entry.style.toPadding()),
+            )
+        }
+    }
+}
+
+@Composable
+private fun TranscriptLine(
+    entry: TranscriptEntry,
+    colors: TranscriptColors,
+    modifier: Modifier = Modifier,
+) {
+    Text(
+        text = entry.text,
+        style = entry.style.toTextStyle(),
+        color = colors.text,
+        modifier = modifier,
+    )
+}
+
+private fun TranscriptEntry.Style.toTextStyle() = when (this) {
+    TranscriptEntry.Style.Simple -> SimpleTextStyle
+    TranscriptEntry.Style.Speaker -> SpeakerTextStyle
+}
+
+private fun TranscriptEntry.Style.toPadding() = when (this) {
+    TranscriptEntry.Style.Simple -> SimplePadding
+    TranscriptEntry.Style.Speaker -> SpeakerPadding
+}
+
+internal val RobotoSerifFontFamily = FontFamily(Font(R.font.roboto_serif))
+
+private val SimpleTextStyle = TextStyle(
+    fontSize = 16.sp,
+    fontWeight = FontWeight.Medium,
+    fontFamily = RobotoSerifFontFamily,
+)
+private val SpeakerTextStyle = SimpleTextStyle.copy(
+    fontSize = 12.sp,
+)
+
+private val SimplePadding = PaddingValues(start = 32.dp, end = 32.dp, bottom = 16.dp)
+private val SpeakerPadding = PaddingValues(start = 32.dp, end = 32.dp, bottom = 8.dp, top = 16.dp)
+
+@Preview
+@Composable
+private fun TranscriptLinesPreview(
+    @PreviewParameter(ThemePreviewParameterProvider::class) theme: ThemeType,
+) {
+    AppThemeWithBackground(theme) {
+        Column {
+            TranscriptLines(
+                entries = TranscriptEntry.PreviewList,
+            )
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun TranscriptLinesPlayerPreview(
+    @PreviewParameter(PodcastColorsParameterProvider::class) podcastColors: PodcastColors,
+) {
+    AppTheme(ThemeType.ROSE) {
+        CompositionLocalProvider(LocalPodcastColors provides podcastColors) {
+            val transciptColors = rememberTranscriptColors()
+            Column(
+                modifier = Modifier.background(transciptColors.background),
+            ) {
+                TranscriptLines(
+                    entries = TranscriptEntry.PreviewList,
+                    colors = transciptColors,
+                )
+            }
+        }
+    }
+}

--- a/modules/features/transcripts/src/main/kotlin/au/shiftyjelly/pocketcasts/transcripts/ui/TransciptLines.kt
+++ b/modules/features/transcripts/src/main/kotlin/au/shiftyjelly/pocketcasts/transcripts/ui/TransciptLines.kt
@@ -51,7 +51,7 @@ internal fun TranscriptLines(
             TranscriptLine(
                 entry = entry,
                 colors = colors,
-                modifier = Modifier.padding(entry.style.toPadding()),
+                modifier = Modifier.padding(entry.padding()),
             )
         }
     }
@@ -64,21 +64,26 @@ private fun TranscriptLine(
     modifier: Modifier = Modifier,
 ) {
     Text(
-        text = entry.text,
-        style = entry.style.toTextStyle(),
+        text = entry.text(),
+        style = entry.textStyle(),
         color = colors.text,
         modifier = modifier,
     )
 }
 
-private fun TranscriptEntry.Style.toTextStyle() = when (this) {
-    TranscriptEntry.Style.Simple -> SimpleTextStyle
-    TranscriptEntry.Style.Speaker -> SpeakerTextStyle
+private fun TranscriptEntry.text() = when (this) {
+    is TranscriptEntry.Text -> value
+    is TranscriptEntry.Speaker -> name
 }
 
-private fun TranscriptEntry.Style.toPadding() = when (this) {
-    TranscriptEntry.Style.Simple -> SimplePadding
-    TranscriptEntry.Style.Speaker -> SpeakerPadding
+private fun TranscriptEntry.textStyle() = when (this) {
+    is TranscriptEntry.Text -> SimpleTextStyle
+    is TranscriptEntry.Speaker -> SpeakerTextStyle
+}
+
+private fun TranscriptEntry.padding() = when (this) {
+    is TranscriptEntry.Text -> SimplePadding
+    is TranscriptEntry.Speaker -> SpeakerPadding
 }
 
 internal val RobotoSerifFontFamily = FontFamily(Font(R.font.roboto_serif))

--- a/modules/features/transcripts/src/main/kotlin/au/shiftyjelly/pocketcasts/transcripts/ui/TranscriptColors.kt
+++ b/modules/features/transcripts/src/main/kotlin/au/shiftyjelly/pocketcasts/transcripts/ui/TranscriptColors.kt
@@ -1,0 +1,43 @@
+package au.shiftyjelly.pocketcasts.transcripts.ui
+
+import androidx.compose.material.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.graphics.Color
+import au.com.shiftyjelly.pocketcasts.compose.PlayerColors
+import au.com.shiftyjelly.pocketcasts.compose.ThemeColors
+import au.com.shiftyjelly.pocketcasts.compose.theme
+
+data class TranscriptColors(
+    val background: Color,
+    val text: Color,
+    val secondaryElement: Color,
+) {
+    companion object {
+        fun default(colors: ThemeColors) = TranscriptColors(
+            background = colors.primaryUi01,
+            text = colors.primaryText01,
+            secondaryElement = colors.primaryUi05,
+        )
+
+        fun player(colors: PlayerColors) = TranscriptColors(
+            background = colors.background01,
+            text = colors.contrast02,
+            secondaryElement = colors.contrast05,
+        )
+    }
+}
+
+@Composable
+fun rememberTranscriptColors(): TranscriptColors {
+    val theme = MaterialTheme.theme
+    val playerColors = theme.rememberPlayerColors()
+
+    return remember(theme.type, playerColors) {
+        if (playerColors != null) {
+            TranscriptColors.player(playerColors)
+        } else {
+            TranscriptColors.default(theme.colors)
+        }
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -66,6 +66,7 @@ include(":modules:features:shared")
 include(":modules:features:reimagine")
 include(":modules:features:referrals")
 include(":modules:features:taskerplugin")
+include(":modules:features:transcripts")
 include(":modules:features:widgets")
 
 // services


### PR DESCRIPTION
## Description

In order to support transcripts in the episode view we need to decouple them from the player. Currently all the code lives in the player's module and uses things like `ShelfSharedViewModel`. This is a first PR that simply adds component to display transcript lines.

## Testing Instructions

Code review should be enough.

## Screenshots or Screencast 

### Regular theme

![Screenshot 2025-06-10 at 07 50 35](https://github.com/user-attachments/assets/a8f25c29-758e-4640-9b09-430d9a64d52b)

### Player theme

![Screenshot 2025-06-10 at 07 50 47](https://github.com/user-attachments/assets/6d6a064b-3fab-4d94-8741-ffe5302ee6b4)

## Checklist
- [ ] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] ~I have considered whether it makes sense to add tests for my changes~
- [ ] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [ ] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~