### PR TITLE
Add transcript entries sanitization

### DIFF
--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/transcript/TranscripSanitization.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/transcript/TranscripSanitization.kt
@@ -5,6 +5,7 @@ import au.com.shiftyjelly.pocketcasts.models.to.TranscriptEntry
 internal fun List<TranscriptEntry>.sanitize() = map(TranscriptEntry::compactWhiteSpace)
     .joinSplitSentences()
     .joinConsecutiveSpeakers()
+    .removeRepeatedSpeakers()
     .map(TranscriptEntry::trim)
     .filter(TranscriptEntry::isNotEmpty)
 
@@ -109,6 +110,24 @@ private fun List<TranscriptEntry>.joinConsecutiveSpeakers(): List<TranscriptEntr
         entries += TranscriptEntry.Speaker(names)
     }
     return entries
+}
+
+private fun List<TranscriptEntry>.removeRepeatedSpeakers(): List<TranscriptEntry> {
+    var lastSpeaker: String? = null
+    return mapNotNull { entry ->
+        when (entry) {
+            is TranscriptEntry.Speaker -> {
+                if (lastSpeaker != entry.name) {
+                    lastSpeaker = entry.name
+                    entry
+                } else {
+                    null
+                }
+            }
+
+            is TranscriptEntry.Text -> entry
+        }
+    }
 }
 
 private fun TranscriptEntry.trim() = when (this) {

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/transcript/TranscripSanitization.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/transcript/TranscripSanitization.kt
@@ -24,7 +24,7 @@ private fun TranscriptEntry.compactWhiteSpace() = when (this) {
 }
 
 private val AnyWhiteSpace = """\s+""".toRegex()
-private val TwoOrMoreEmptySpaces = """[ \t]+""".toRegex()
+private val TwoOrMoreEmptySpaces = """[ \t]{2,}""".toRegex()
 private val ThreeOrMoreNewLines = """\n{3,}""".toRegex()
 
 private fun List<TranscriptEntry>.joinSplitSentences(): List<TranscriptEntry> {

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/transcript/TranscripSanitization.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/transcript/TranscripSanitization.kt
@@ -1,0 +1,160 @@
+package au.com.shiftyjelly.pocketcasts.repositories.transcript
+
+import au.com.shiftyjelly.pocketcasts.models.to.TranscriptEntry
+
+internal fun List<TranscriptEntry>.sanitize() = map(TranscriptEntry::compactWhiteSpace)
+    .joinSplitSentences()
+    .joinConsecutiveSpeakers()
+    .map(TranscriptEntry::trim)
+    .filter(TranscriptEntry::isNotEmpty)
+
+private fun TranscriptEntry.compactWhiteSpace() = when (this) {
+    is TranscriptEntry.Speaker -> {
+        val newName = name.replace(AnyWhiteSpace, " ")
+        copy(name = newName)
+    }
+
+    is TranscriptEntry.Text -> {
+        val newValue = value
+            .replace(TwoOrMoreEmptySpaces, " ")
+            .replace(ThreeOrMoreNewLines, "\n\n")
+        copy(value = newValue)
+    }
+}
+
+private val AnyWhiteSpace = """\s+""".toRegex()
+private val TwoOrMoreEmptySpaces = """[ \t]+""".toRegex()
+private val ThreeOrMoreNewLines = """\n{3,}""".toRegex()
+
+private fun List<TranscriptEntry>.joinSplitSentences(): List<TranscriptEntry> {
+    val phraseAccumulator = StringBuilder()
+    val entries = mutableListOf<TranscriptEntry>()
+
+    fun appendToAccumulator(text: String) {
+        phraseAccumulator.append(' ').append(text.trimStart())
+    }
+
+    fun buildFullSentence(text: String): TranscriptEntry {
+        appendToAccumulator(text)
+        val sentences = phraseAccumulator.toString()
+        phraseAccumulator.clear()
+        return TranscriptEntry.Text(sentences)
+    }
+
+    fun buildMidSentence(text: String): TranscriptEntry? {
+        val midSentence = text.findMidSentence()
+
+        return if (midSentence != null) {
+            val (index, punctuation) = midSentence
+
+            val midSentenceText = text.substring(0, index + punctuation.length)
+            val sentence = buildFullSentence(midSentenceText)
+
+            val leftOverText = text.drop(midSentenceText.length)
+            appendToAccumulator(leftOverText)
+
+            sentence
+        } else {
+            appendToAccumulator(text)
+            null
+        }
+    }
+
+    mapNotNullTo(entries) { entry ->
+        when (entry) {
+            is TranscriptEntry.Speaker -> entry
+            is TranscriptEntry.Text -> {
+                val text = entry.value
+                if (text.endsAsSentence()) {
+                    buildFullSentence(text)
+                } else {
+                    buildMidSentence(text)
+                }
+            }
+        }
+    }
+    if (phraseAccumulator.isNotEmpty()) {
+        entries += TranscriptEntry.Text(phraseAccumulator.toString())
+    }
+    return entries
+}
+
+private fun List<TranscriptEntry>.joinConsecutiveSpeakers(): List<TranscriptEntry> {
+    val namesAccumulator = mutableSetOf<String>()
+    val entries = mutableListOf<TranscriptEntry>()
+    flatMapTo(entries) { entry ->
+        when (entry) {
+            is TranscriptEntry.Speaker -> {
+                val names = entry.name.takeIf(String::isNotEmpty)?.split(", ")
+                if (names != null) {
+                    namesAccumulator += names
+                }
+                emptyList<TranscriptEntry>()
+            }
+
+            is TranscriptEntry.Text -> {
+                buildList {
+                    if (namesAccumulator.isNotEmpty()) {
+                        val names = namesAccumulator.sorted().joinToString(separator = ", ")
+                        namesAccumulator.clear()
+                        add(TranscriptEntry.Speaker(names))
+                    }
+                    add(entry)
+                }
+            }
+        }
+    }
+    if (namesAccumulator.isNotEmpty()) {
+        val names = namesAccumulator.sorted().joinToString(separator = ", ")
+        entries += TranscriptEntry.Speaker(names)
+    }
+    return entries
+}
+
+private fun TranscriptEntry.trim() = when (this) {
+    is TranscriptEntry.Speaker -> copy(name = name.trim())
+    is TranscriptEntry.Text -> copy(value = value.trim())
+}
+
+private fun TranscriptEntry.isNotEmpty() = when (this) {
+    is TranscriptEntry.Speaker -> name.isNotEmpty()
+    is TranscriptEntry.Text -> value.isNotEmpty()
+}
+
+fun String.endsAsSentence(): Boolean {
+    return EndOfSentencePunctuation.any { punctuation -> endsWith(punctuation) }
+}
+
+private val EndOfSentencePunctuation = listOf(
+    // Sentences
+    ".", "!", "?", "…",
+    // Interrupted sentences
+    "-",
+    // Brackets
+    ")", "]", ">", "}",
+    // Quotation marks
+    "\"", "”", "'", "’",
+)
+
+private fun String.findMidSentence(): Pair<Int, String>? {
+    // We first search for punctuation followed by quotation marks (e.g., '."') before looking for standalone punctuation.
+    //
+    // This prevents cases where findLastAnyOf() would match only the punctuation character,
+    // causing quotation marks to be incorrectly moved to the next line.
+    //
+    // For example, in: `This is "sentence." And another one`,
+    // matching '.' would split the text before the closing quote, producing: `"And another one`.
+    return findLastAnyOf(MidSentenceQuotationPunctuation) ?: findLastAnyOf(MidSentencePunctuation)
+}
+
+private val MidSentencePunctuation = listOf(
+    ".",
+    "!",
+    "?",
+    "…",
+)
+
+private val MidSentenceQuotationPunctuation = MidSentencePunctuation.flatMap { punctuation ->
+    val quotationMarks = listOf("\"", "”", "'", "’")
+    quotationMarks.map { quotationMark -> "$punctuation$quotationMark" }
+}

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/transcript/TranscriptSanitizationTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/transcript/TranscriptSanitizationTest.kt
@@ -1,0 +1,338 @@
+package au.com.shiftyjelly.pocketcasts.repositories.transcript
+
+import au.com.shiftyjelly.pocketcasts.models.to.TranscriptEntry
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.experimental.runners.Enclosed
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
+
+@RunWith(Enclosed::class)
+class TranscriptSanitizationTest {
+    class GeneralBehavior {
+        @Test
+        fun `do not modify clean transcript`() {
+            val input = buildTranscript {
+                speaker("Speaker 1")
+                text("Text? And more text text.")
+                text("Text!")
+                speaker("Sepaker 2")
+                text("Text…")
+            }
+
+            val output = input.sanitize()
+
+            assertEquals(input, output)
+        }
+
+        @Test
+        fun `trim white space`() {
+            val input = buildTranscript {
+                speaker("\n\t Speaker \t\n")
+                text("\n\t Text. \t\n")
+            }
+
+            val output = input.sanitize()
+
+            assertEquals(
+                buildTranscript {
+                    speaker("Speaker")
+                    text("Text.")
+                },
+                output,
+            )
+        }
+
+        @Test
+        fun `compact inner white space`() {
+            val input = buildTranscript {
+                speaker("Speaker  with\n\n\twhite \n space")
+                text("Text  with     multiple\t empty\t\tspaces.")
+                text("Text\n\n\nwith\n\n\n\n\nmultiple new lines.")
+            }
+
+            val output = input.sanitize()
+
+            assertEquals(
+                buildTranscript {
+                    speaker("Speaker with white space")
+                    text("Text with multiple empty spaces.")
+                    text("Text\n\nwith\n\nmultiple new lines.")
+                },
+                output,
+            )
+        }
+
+        @Test
+        fun `remove empty entries`() {
+            val input = buildTranscript {
+                text("Text 1.")
+                text("")
+                speaker("Speaker")
+                speaker("")
+                text("Text 2.")
+                text("")
+                text("")
+                speaker("")
+            }
+
+            val output = input.sanitize()
+
+            assertEquals(
+                buildTranscript {
+                    text("Text 1.")
+                    speaker("Speaker")
+                    text("Text 2.")
+                },
+                output,
+            )
+        }
+
+        @Test
+        fun `join consecutive speakers`() {
+            val input = buildTranscript {
+                speaker("Speaker 1")
+                speaker("Speaker 2")
+                speaker("Speaker 3")
+            }
+
+            val output = input.sanitize()
+
+            assertEquals(
+                buildTranscript {
+                    speaker("Speaker 1, Speaker 2, Speaker 3")
+                },
+                output,
+            )
+        }
+
+        @Test
+        fun `filter out duplicate speakers`() {
+            val input = buildTranscript {
+                speaker("Speaker 1, Speaker 2")
+                speaker("Speaker 3, Speaker 3")
+                speaker("Speaker 1, Speaker 2, Speaker 4")
+                speaker("Speaker 3")
+            }
+
+            val output = input.sanitize()
+
+            assertEquals(
+                buildTranscript {
+                    speaker("Speaker 1, Speaker 2, Speaker 3, Speaker 4")
+                },
+                output,
+            )
+        }
+
+        @Test
+        fun `sort speakers`() {
+            val input = buildTranscript {
+                speaker("C, B")
+                speaker("D")
+                speaker("A")
+            }
+
+            val output = input.sanitize()
+
+            assertEquals(
+                buildTranscript {
+                    speaker("A, B, C, D")
+                },
+                output,
+            )
+        }
+
+        @Test
+        fun `join split texts`() {
+            val input = buildTranscript {
+                text("Text 1")
+                text("Text 2")
+                text("Text 3")
+            }
+
+            val output = input.sanitize()
+
+            assertEquals(
+                buildTranscript {
+                    text("Text 1 Text 2 Text 3")
+                },
+                output,
+            )
+        }
+
+        @Test
+        fun `move unfinished sentence to next text`() {
+            val input = buildTranscript {
+                text("Period. Unfinished")
+                text("sentence. And now")
+                text("next, unfinished")
+                text("sentence.")
+            }
+
+            val output = input.sanitize()
+
+            assertEquals(
+                buildTranscript {
+                    text("Period.")
+                    text("Unfinished sentence.")
+                    text("And now next, unfinished sentence.")
+                },
+                output,
+            )
+        }
+    }
+
+    @RunWith(Parameterized::class)
+    class FullSentenceDetection(
+        private val pattern: String,
+        patternDescription: String,
+    ) {
+        @Test
+        fun `detect sentence break`() {
+            val input = buildTranscript {
+                text("Some text")
+                text("end$pattern")
+                text("more text")
+            }
+
+            val output = input.sanitize()
+
+            assertEquals(
+                buildTranscript {
+                    text("Some text end$pattern")
+                    text("more text")
+                },
+                output,
+            )
+        }
+
+        companion object {
+            @JvmStatic
+            @Parameterized.Parameters(name = "{1}")
+            fun params() = listOf(
+                arrayOf(".", "dot"),
+                arrayOf("!", "exclamation mark"),
+                arrayOf("?", "question mark"),
+                arrayOf("…", "ellipsis"),
+                arrayOf("-", "hyphen"),
+                arrayOf(")", "parenthesis"),
+                arrayOf("]", "square bracket"),
+                arrayOf(">", "diamond bracket"),
+                arrayOf("}", "curly bracket"),
+                arrayOf("\"", "double quote"),
+                arrayOf("”", "double styled quote"),
+                arrayOf("'", "single quote"),
+                arrayOf("’", "single styled quote"),
+            )
+        }
+    }
+
+    @RunWith(Parameterized::class)
+    class MidSentenceDetectedPattern(
+        private val pattern: String,
+        patternDescription: String,
+    ) {
+        @Test
+        fun `detect mid-sentence break`() {
+            val input = buildTranscript {
+                text("Some text$pattern and now")
+                text("more text")
+            }
+
+            val output = input.sanitize()
+
+            assertEquals(
+                buildTranscript {
+                    text("Some text$pattern")
+                    text("and now more text")
+                },
+                output,
+            )
+        }
+
+        companion object {
+            @JvmStatic
+            @Parameterized.Parameters(name = "{1}")
+            fun params() = listOf(
+                arrayOf(".", "dot"),
+                arrayOf("!", "exclamation mark"),
+                arrayOf("?", "question mark"),
+                arrayOf("…", "ellipsis"),
+                arrayOf(".\"", "dot double quote"),
+                arrayOf("!\"", "exclamation mark double quote"),
+                arrayOf("?\"", "question mark double quote"),
+                arrayOf("…\"", "ellipsis double quote"),
+                arrayOf(".”", "dot with double styled quote"),
+                arrayOf("!”", "exclamation mark with double styled quote"),
+                arrayOf("?”", "question mark with double styled quote"),
+                arrayOf("…”", "ellipsis with double styled quote"),
+                arrayOf(".'", "dot with single quote"),
+                arrayOf("!'", "exclamation mark with single quote"),
+                arrayOf("?'", "question mark with single quote"),
+                arrayOf("…'", "ellipsis with single quote"),
+                arrayOf(".’", "dot with single styled quote"),
+                arrayOf("!’", "exclamation mark with single styled quote"),
+                arrayOf("?’", "question mark with single styled quote"),
+                arrayOf("…’", "ellipsis with single styled quote"),
+            )
+        }
+    }
+
+    @RunWith(Parameterized::class)
+    class MidSentenceIgnoredPatterns(
+        private val pattern: String,
+        patternDescription: String,
+    ) {
+        @Test
+        fun `detect mid-sentence break`() {
+            val input = buildTranscript {
+                text("Some text$pattern and now")
+                text("more text")
+            }
+
+            val output = input.sanitize()
+
+            assertEquals(
+                buildTranscript {
+                    text("Some text$pattern and now more text")
+                },
+                output,
+            )
+        }
+
+        companion object {
+            @JvmStatic
+            @Parameterized.Parameters(name = "{1}")
+            fun params() = listOf(
+                arrayOf("-", "hyphen"),
+                arrayOf(")", "parenthesis"),
+                arrayOf("]", "square bracket"),
+                arrayOf(">", "diamond bracket"),
+                arrayOf("}", "curly bracket"),
+                arrayOf("\"", "double quote"),
+                arrayOf("”", "double styled quote"),
+                arrayOf("'", "single quote"),
+                arrayOf("’", "single styled quote"),
+            )
+        }
+    }
+}
+
+private fun buildTranscript(block: TranscriptBuilder.() -> Unit): List<TranscriptEntry> {
+    return TranscriptBuilder().apply(block).build()
+}
+
+private class TranscriptBuilder() {
+    private val entries = mutableListOf<TranscriptEntry>()
+
+    fun text(value: String) {
+        entries += TranscriptEntry.Text(value)
+    }
+
+    fun speaker(value: String) {
+        entries += TranscriptEntry.Speaker(value)
+    }
+
+    fun build() = entries
+}

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/transcript/TranscriptSanitizationTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/transcript/TranscriptSanitizationTest.kt
@@ -144,6 +144,40 @@ class TranscriptSanitizationTest {
         }
 
         @Test
+        fun `remove repeated speakers`() {
+            val input = buildTranscript {
+                speaker("Speaker 1")
+                text("Text 1.")
+                speaker("Speaker 1")
+                text("Text 2.")
+                speaker("Speaker 1")
+                text("Text 3.")
+                text("Text 4.")
+                speaker("Speaker 2")
+                text("Text 5.")
+                speaker("Speaker 1")
+                text("Text 6.")
+            }
+
+            val output = input.sanitize()
+
+            assertEquals(
+                buildTranscript {
+                    speaker("Speaker 1")
+                    text("Text 1.")
+                    text("Text 2.")
+                    text("Text 3.")
+                    text("Text 4.")
+                    speaker("Speaker 2")
+                    text("Text 5.")
+                    speaker("Speaker 1")
+                    text("Text 6.")
+                },
+                output,
+            )
+        }
+
+        @Test
         fun `join split texts`() {
             val input = buildTranscript {
                 text("Text 1")


### PR DESCRIPTION
## Description

This PR adds transcript sanitization logic. Currently, it addresses the following issues:
- Excessive white space in the text.
- Sentences split across multiple entries. Transcripts can appear like the example below. We need to detect and concatenate such strings to improve readability. Some logic for this already exists, but it is as exhaustive and isn't applied across all types of transcripts.
```
Some start of a sentence

that is continued here. But now we have a new one

That goes here. So what should we do? We need to join them.
```
- Grouping utterances by the same speaker. This works in combination with sentence detection.
- Filtering out empty entries.

> [!note]
> Sentence detection heuristics aren't perfect, as they don't account for characters like the [Japanese Full Stop](https://www.compart.com/en/unicode/U+3002). And possibly multitude of edge cases. However, this is still an improvement over the current implementation, which handles only `.`, `!`, and `?`.


## Testing Instructions

I already tested it locally with some transcripts but for now code review should be enough. Once I integrate it with our code we can verify it further before merging the integration.

## Checklist
- [ ] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [ ] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [ ] ~Any jetpack compose components I added or changed are covered by compose previews~
- [ ] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~