### PR TITLE
Add new transcripts loading logic

### DIFF
--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/TranscriptDao.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/TranscriptDao.kt
@@ -14,4 +14,7 @@ abstract class TranscriptDao {
 
     @Query("SELECT * FROM episode_transcript WHERE episode_uuid IS :episodeUuid")
     abstract fun observeTranscriptForEpisode(episodeUuid: String): Flow<Transcript?>
+
+    @Query("SELECT * FROM episode_transcript WHERE episode_uuid IS :episodeUuid")
+    abstract fun observeTranscripts(episodeUuid: String): Flow<List<Transcript>>
 }

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/to/Transcript.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/to/Transcript.kt
@@ -1,0 +1,27 @@
+package au.com.shiftyjelly.pocketcasts.models.to
+
+sealed interface Transcript {
+    val type: TranscriptType
+    val url: String
+    val isGenerated: Boolean
+    val episodeUuid: String
+    val podcastUuid: String?
+
+    data class Text(
+        val entries: List<TranscriptEntry>,
+        override val type: TranscriptType,
+        override val url: String,
+        override val isGenerated: Boolean,
+        override val episodeUuid: String,
+        override val podcastUuid: String?,
+    ) : Transcript
+
+    data class Web(
+        override val url: String,
+        override val isGenerated: Boolean,
+        override val episodeUuid: String,
+        override val podcastUuid: String?,
+    ) : Transcript {
+        override val type get() = TranscriptType.Html
+    }
+}

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/to/TranscriptType.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/to/TranscriptType.kt
@@ -1,0 +1,31 @@
+package au.com.shiftyjelly.pocketcasts.models.to
+
+enum class TranscriptType(
+    val analyticsValue: String,
+    private val associatedMimeTypes: Set<String>,
+) {
+    Vtt(
+        analyticsValue = "vtt",
+        associatedMimeTypes = setOf("text/vtt"),
+    ),
+    Srt(
+        analyticsValue = "srt",
+        associatedMimeTypes = setOf("application/srt", "application/x-subrip"),
+    ),
+    Json(
+        analyticsValue = "json",
+        associatedMimeTypes = setOf("application/json"),
+    ),
+    Html(
+        analyticsValue = "html",
+        associatedMimeTypes = setOf("text/html"),
+    ),
+    ;
+
+    companion object {
+        fun fromMimeType(value: String): TranscriptType? {
+            val lowercaseValue = value.lowercase()
+            return entries.firstOrNull { lowercaseValue in it.associatedMimeTypes }
+        }
+    }
+}

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/TranscriptsManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/TranscriptsManagerImpl.kt
@@ -8,7 +8,7 @@ import au.com.shiftyjelly.pocketcasts.models.entity.Transcript
 import au.com.shiftyjelly.pocketcasts.repositories.di.ApplicationScope
 import au.com.shiftyjelly.pocketcasts.repositories.shownotes.findTranscripts
 import au.com.shiftyjelly.pocketcasts.servers.ShowNotesServiceManager
-import au.com.shiftyjelly.pocketcasts.servers.podcast.TranscriptCacheService
+import au.com.shiftyjelly.pocketcasts.servers.podcast.TranscriptService
 import au.com.shiftyjelly.pocketcasts.utils.NetworkWrapper
 import au.com.shiftyjelly.pocketcasts.utils.exception.EmptyDataException
 import au.com.shiftyjelly.pocketcasts.utils.exception.NoNetworkException
@@ -28,7 +28,7 @@ import timber.log.Timber
 @OptIn(UnstableApi::class)
 class TranscriptsManagerImpl @Inject constructor(
     private val transcriptDao: TranscriptDao,
-    private val service: TranscriptCacheService,
+    private val service: TranscriptService,
     private val networkWrapper: NetworkWrapper,
     private val showNotesServiceManager: ShowNotesServiceManager,
     @ApplicationScope private val scope: CoroutineScope,

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/transcript/TranscriptManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/transcript/TranscriptManager.kt
@@ -1,0 +1,16 @@
+package au.com.shiftyjelly.pocketcasts.repositories.transcript
+
+import au.com.shiftyjelly.pocketcasts.models.to.Transcript
+import kotlinx.coroutines.flow.Flow
+
+interface TranscriptManager {
+    fun observeIsTranscriptAvailable(episodeUuid: String): Flow<Boolean>
+
+    suspend fun loadTranscript(
+        episodeUuid: String,
+    ): Transcript?
+
+    fun resetInvalidTranscripts(
+        episodeUuid: String,
+    )
+}

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/transcript/TranscriptManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/transcript/TranscriptManagerImpl.kt
@@ -1,0 +1,148 @@
+package au.com.shiftyjelly.pocketcasts.repositories.transcript
+
+import androidx.collection.LruCache
+import au.com.shiftyjelly.pocketcasts.models.db.dao.TranscriptDao
+import au.com.shiftyjelly.pocketcasts.models.to.Transcript
+import au.com.shiftyjelly.pocketcasts.models.to.TranscriptType
+import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
+import au.com.shiftyjelly.pocketcasts.servers.podcast.TranscriptService
+import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
+import java.util.concurrent.ConcurrentHashMap
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlin.time.Duration.Companion.minutes
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.asFlow
+import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.firstOrNull
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.mapNotNull
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeoutOrNull
+import okhttp3.CacheControl
+import au.com.shiftyjelly.pocketcasts.models.entity.Transcript as DbTranscript
+
+@Singleton
+class TranscriptManagerImpl @Inject constructor(
+    private val transcriptDao: TranscriptDao,
+    private val transcriptService: TranscriptService,
+    private val episodeManager: EpisodeManager,
+    private val parsers: Map<TranscriptType, @JvmSuppressWildcards TranscriptParser>,
+) : TranscriptManager {
+    private val transcriptUrlBlacklist = ConcurrentHashMap<String, String>()
+    private val lruCache = LruCache<String, Transcript>(maxSize = 20)
+
+    override fun observeIsTranscriptAvailable(episodeUuid: String): Flow<Boolean> {
+        return transcriptDao.observeTranscripts(episodeUuid).map { it.isNotEmpty() }
+    }
+
+    override suspend fun loadTranscript(
+        episodeUuid: String,
+    ): Transcript? {
+        val cachedTranscript = lruCache[episodeUuid]
+        if (cachedTranscript != null) {
+            return cachedTranscript
+        }
+
+        val transcript = loadLocalTranscripts(episodeUuid)
+            .asFlow()
+            .mapNotNull(::associateWithParser)
+            .mapNotNull(::readTranscript)
+            .firstOrNull()
+
+        if (transcript != null) {
+            lruCache.put(episodeUuid, transcript)
+        }
+
+        return transcript
+    }
+
+    private suspend fun loadLocalTranscripts(episodeUuid: String): List<DbTranscript> {
+        // When we request to load transcripts the URLs might still not be processed from the show notes.
+        // Setting an arbitriarly large timeout allows us to wait for show notes to be processed.
+        // In the worst case scenario transcripts won't be available for the first time if show notes haven't
+        // been processed in time.
+        val availableTranscripts = withTimeoutOrNull(1.minutes) {
+            transcriptDao.observeTranscripts(episodeUuid)
+                .filter { it.isNotEmpty() }
+                .firstOrNull()
+        }
+        return availableTranscripts
+            ?.filter { it.url !in transcriptUrlBlacklist[episodeUuid].orEmpty() }
+            ?.sortedWith(TranscriptsComparator)
+            .orEmpty()
+    }
+
+    private fun associateWithParser(transcript: DbTranscript): Pair<TranscriptParser, DbTranscript>? {
+        val parser = TranscriptType.fromMimeType(transcript.type)?.let(parsers::get)
+        if (parser == null) {
+            transcriptUrlBlacklist.put(transcript.episodeUuid, transcript.url)
+        }
+        return parser?.let { it to transcript }
+    }
+
+    private suspend fun readTranscript(parserWithTranscript: Pair<TranscriptParser, DbTranscript>): Transcript? {
+        val (parser, transcript) = parserWithTranscript
+        val podcastUuid = episodeManager.findByUuid(transcript.episodeUuid)?.podcastUuid
+
+        return runCatching { transcriptService.getTranscriptOrThrow(transcript.url, CacheControl.FORCE_NETWORK) }
+            .recoverCatching { transcriptService.getTranscriptOrThrow(transcript.url, CacheControl.FORCE_CACHE) }
+            .mapCatching { body ->
+                val transcriptEntries = withContext(Dispatchers.Default) {
+                    val entries = body.use { parser.parse(it.source()) }.getOrThrow()
+                    entries.sanitize()
+                }
+                Transcript.Text(
+                    entries = transcriptEntries,
+                    type = parser.type,
+                    url = transcript.url,
+                    isGenerated = transcript.isGenerated,
+                    episodeUuid = transcript.episodeUuid,
+                    podcastUuid = podcastUuid,
+                )
+            }
+            .recoverCatching { error ->
+                if (error is HtmlParser.ScriptDetectedException) {
+                    Transcript.Web(
+                        url = transcript.url,
+                        isGenerated = transcript.isGenerated,
+                        episodeUuid = transcript.episodeUuid,
+                        podcastUuid = podcastUuid,
+                    )
+                } else {
+                    throw error
+                }
+            }
+            .onFailure { error ->
+                if (error is CancellationException) {
+                    throw error
+                } else {
+                    LogBuffer.e("Transcripts", error, "Failed to load transcript ${transcript.url} for episode ${transcript.episodeUuid}")
+                    transcriptUrlBlacklist.put(transcript.episodeUuid, transcript.url)
+                }
+            }
+            .getOrNull()
+    }
+
+    override fun resetInvalidTranscripts(
+        episodeUuid: String,
+    ) {
+        transcriptUrlBlacklist.remove(episodeUuid)
+    }
+}
+
+private val TranscriptsComparator = compareBy<DbTranscript>(
+    { it.isGenerated },
+    { TranscriptType.fromMimeType(it.type).priority },
+)
+
+private val TranscriptType?.priority
+    get() = when (this) {
+        TranscriptType.Vtt -> 0
+        TranscriptType.Json -> 1
+        TranscriptType.Srt -> 2
+        TranscriptType.Html -> 3
+        null -> Int.MAX_VALUE
+    }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/transcript/TranscriptParser.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/transcript/TranscriptParser.kt
@@ -15,12 +15,15 @@ import androidx.media3.extractor.text.webvtt.WebvttParser
 import au.com.shiftyjelly.pocketcasts.models.converter.TranscriptCue
 import au.com.shiftyjelly.pocketcasts.models.converter.TranscriptSegments
 import au.com.shiftyjelly.pocketcasts.models.to.TranscriptEntry
+import au.com.shiftyjelly.pocketcasts.models.to.TranscriptType
 import com.squareup.moshi.Moshi
 import okio.BufferedSource
 import okio.use
 import androidx.media3.extractor.text.SubtitleParser as Media3SubtitleParser
 
-internal interface TranscriptParser {
+interface TranscriptParser {
+    val type: TranscriptType
+
     fun parse(source: BufferedSource): Result<List<TranscriptEntry>>
 }
 
@@ -46,6 +49,8 @@ internal abstract class SubtitleParser(
 }
 
 internal class WebVttParser : SubtitleParser(WebvttParser()) {
+    override val type get() = TranscriptType.Vtt
+
     override fun toEntries(cue: Cue): List<TranscriptEntry> {
         val cueText = cue.text
         if (cueText.isNullOrEmpty()) {
@@ -67,6 +72,8 @@ internal class WebVttParser : SubtitleParser(WebvttParser()) {
 }
 
 internal class SrtParser : SubtitleParser(SubripParser()) {
+    override val type get() = TranscriptType.Srt
+
     override fun toEntries(cue: Cue): List<TranscriptEntry> {
         val cueText = cue.text?.toString()
         if (cueText.isNullOrEmpty()) {
@@ -90,6 +97,8 @@ internal class SrtParser : SubtitleParser(SubripParser()) {
 }
 
 internal class HtmlParser : TranscriptParser {
+    override val type get() = TranscriptType.Html
+
     override fun parse(source: BufferedSource) = runCatching {
         val text = source.use { it.readUtf8() }
         // Having a script tag most likely means that we should redirect to a web page
@@ -123,6 +132,8 @@ internal class HtmlParser : TranscriptParser {
 internal class JsonParser(
     moshi: Moshi,
 ) : TranscriptParser {
+    override val type get() = TranscriptType.Json
+
     private val adapter = moshi.adapter(TranscriptSegments::class.java)
 
     override fun parse(source: BufferedSource) = runCatching {

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/TranscriptsManagerImplTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/TranscriptsManagerImplTest.kt
@@ -8,7 +8,7 @@ import au.com.shiftyjelly.pocketcasts.servers.podcast.ShowNotesEpisode
 import au.com.shiftyjelly.pocketcasts.servers.podcast.ShowNotesPodcast
 import au.com.shiftyjelly.pocketcasts.servers.podcast.ShowNotesResponse
 import au.com.shiftyjelly.pocketcasts.servers.podcast.ShowNotesTranscript
-import au.com.shiftyjelly.pocketcasts.servers.podcast.TranscriptCacheService
+import au.com.shiftyjelly.pocketcasts.servers.podcast.TranscriptService
 import au.com.shiftyjelly.pocketcasts.sharedtest.MainCoroutineRule
 import au.com.shiftyjelly.pocketcasts.utils.NetworkWrapper
 import au.com.shiftyjelly.pocketcasts.utils.exception.EmptyDataException
@@ -43,7 +43,7 @@ class TranscriptsManagerImplTest {
     val coroutineRule = MainCoroutineRule()
 
     private val transcriptDao: TranscriptDao = mock()
-    private val transcriptCacheService: TranscriptCacheService = mock()
+    private val transcriptCacheService: TranscriptService = mock()
     private val networkWrapper: NetworkWrapper = mock()
     private val transcriptCuesInfoBuilder: TranscriptCuesInfoBuilder = mock()
     private val showNotesServiceManager: ShowNotesServiceManager = mock()

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/transcript/TranscriptManagerTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/transcript/TranscriptManagerTest.kt
@@ -1,0 +1,397 @@
+package au.com.shiftyjelly.pocketcasts.repositories.transcript
+
+import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
+import au.com.shiftyjelly.pocketcasts.models.to.Transcript
+import au.com.shiftyjelly.pocketcasts.models.to.TranscriptEntry
+import au.com.shiftyjelly.pocketcasts.models.to.TranscriptType
+import au.com.shiftyjelly.pocketcasts.repositories.transcript.HtmlParser.ScriptDetectedException
+import au.com.shiftyjelly.pocketcasts.servers.podcast.TranscriptService
+import java.util.Date
+import kotlin.time.Duration.Companion.minutes
+import kotlin.time.Duration.Companion.seconds
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.async
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.runTest
+import okhttp3.CacheControl
+import okhttp3.ResponseBody
+import okhttp3.ResponseBody.Companion.toResponseBody
+import okio.BufferedSource
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import retrofit2.Response
+import au.com.shiftyjelly.pocketcasts.models.entity.Transcript as DbTranscript
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class TranscriptManagerTest {
+    private val localTranscriptsFlow = MutableStateFlow(emptyList<DbTranscript>())
+    private val service = TestTranscriptService()
+    private val parsers = TranscriptType.entries.associateWith { TestParser(it) }
+
+    private val vttDbTranscript = createDbTranscript("text/vtt")
+    private val srtDbTranscript = createDbTranscript("application/srt")
+    private val subripDbTranscript = createDbTranscript("application/x-subrip")
+    private val jsonDbTranscript = createDbTranscript("application/json")
+    private val htmlDbTranscript = createDbTranscript("text/html")
+
+    private val transcriptManager = TranscriptManagerImpl(
+        transcriptDao = mock {
+            on { observeTranscripts(any()) } doReturn localTranscriptsFlow
+        },
+        transcriptService = service,
+        episodeManager = mock {
+            onBlocking { findByUuid(any()) } doReturn PodcastEpisode(
+                uuid = "episode-id",
+                podcastUuid = "podcast-id",
+                publishedDate = Date(),
+            )
+        },
+        parsers = parsers,
+    )
+
+    @Test
+    fun `load vtt transcript`() = runTest {
+        localTranscriptsFlow.value = listOf(vttDbTranscript)
+
+        val transcript = transcriptManager.loadTranscript("episode-id")
+
+        assertEquals(
+            Transcript.Text(
+                entries = TranscriptEntry.PreviewList,
+                type = TranscriptType.Vtt,
+                url = "transcript-url",
+                isGenerated = false,
+                episodeUuid = "episode-id",
+                podcastUuid = "podcast-id",
+            ),
+            transcript,
+        )
+    }
+
+    @Test
+    fun `load srt transcript`() = runTest {
+        localTranscriptsFlow.value = listOf(srtDbTranscript)
+
+        val transcript = transcriptManager.loadTranscript("episode-id")
+
+        assertEquals(
+            Transcript.Text(
+                entries = TranscriptEntry.PreviewList,
+                type = TranscriptType.Srt,
+                url = "transcript-url",
+                isGenerated = false,
+                episodeUuid = "episode-id",
+                podcastUuid = "podcast-id",
+            ),
+            transcript,
+        )
+    }
+
+    @Test
+    fun `load subrip transcript`() = runTest {
+        localTranscriptsFlow.value = listOf(subripDbTranscript)
+
+        val transcript = transcriptManager.loadTranscript("episode-id")
+
+        assertEquals(
+            Transcript.Text(
+                entries = TranscriptEntry.PreviewList,
+                type = TranscriptType.Srt,
+                url = "transcript-url",
+                isGenerated = false,
+                episodeUuid = "episode-id",
+                podcastUuid = "podcast-id",
+            ),
+            transcript,
+        )
+    }
+
+    @Test
+    fun `load json transcript`() = runTest {
+        localTranscriptsFlow.value = listOf(jsonDbTranscript)
+
+        val transcript = transcriptManager.loadTranscript("episode-id")
+
+        assertEquals(
+            Transcript.Text(
+                entries = TranscriptEntry.PreviewList,
+                type = TranscriptType.Json,
+                url = "transcript-url",
+                isGenerated = false,
+                episodeUuid = "episode-id",
+                podcastUuid = "podcast-id",
+            ),
+            transcript,
+        )
+    }
+
+    @Test
+    fun `load html transcript`() = runTest {
+        localTranscriptsFlow.value = listOf(htmlDbTranscript)
+
+        val transcript = transcriptManager.loadTranscript("episode-id")
+
+        assertEquals(
+            Transcript.Text(
+                entries = TranscriptEntry.PreviewList,
+                type = TranscriptType.Html,
+                url = "transcript-url",
+                isGenerated = false,
+                episodeUuid = "episode-id",
+                podcastUuid = "podcast-id",
+            ),
+            transcript,
+        )
+    }
+
+    @Test
+    fun `load html web-based transcript`() = runTest {
+        localTranscriptsFlow.value = listOf(htmlDbTranscript)
+        parsers.getValue(TranscriptType.Html).parsingException = ScriptDetectedException()
+
+        val transcript = transcriptManager.loadTranscript("episode-id")
+
+        assertEquals(
+            Transcript.Web(
+                url = "transcript-url",
+                isGenerated = false,
+                episodeUuid = "episode-id",
+                podcastUuid = "podcast-id",
+            ),
+            transcript,
+        )
+    }
+
+    @Test
+    fun `prioritize vtt over json transcript`() = runTest {
+        localTranscriptsFlow.value = listOf(jsonDbTranscript, vttDbTranscript)
+
+        val transcript = transcriptManager.loadTranscript("episode-id")!!
+
+        assertEquals(TranscriptType.Vtt, transcript.type)
+    }
+
+    @Test
+    fun `prioritize json over srt transcript`() = runTest {
+        localTranscriptsFlow.value = listOf(srtDbTranscript, jsonDbTranscript)
+
+        val transcript = transcriptManager.loadTranscript("episode-id")!!
+
+        assertEquals(TranscriptType.Json, transcript.type)
+    }
+
+    @Test
+    fun `prioritize srt over html transcript`() = runTest {
+        localTranscriptsFlow.value = listOf(htmlDbTranscript, srtDbTranscript)
+
+        val transcript = transcriptManager.loadTranscript("episode-id")!!
+
+        assertEquals(TranscriptType.Srt, transcript.type)
+    }
+
+    @Test
+    fun `prioritize non-generated over generated transcript`() = runTest {
+        localTranscriptsFlow.value = listOf(vttDbTranscript.copy(isGenerated = true), htmlDbTranscript.copy(isGenerated = false))
+
+        val transcript = transcriptManager.loadTranscript("episode-id")!!
+
+        assertFalse(transcript.isGenerated)
+    }
+
+    @Test
+    fun `do not load unknown transcript format`() = runTest {
+        localTranscriptsFlow.value = listOf(createDbTranscript(type = "unknown"))
+
+        val transcript = transcriptManager.loadTranscript("episode-id")
+
+        assertNull(transcript)
+    }
+
+    @Test
+    fun `do not load transcript if local ones are not loaded in time`() = runTest {
+        val transcript = async { transcriptManager.loadTranscript("episode-id") }
+
+        advanceTimeBy(1.minutes)
+
+        assertNull(transcript.await())
+    }
+
+    @Test
+    fun `load transcript if local ones are loaded in time`() = runTest {
+        val transcript = async { transcriptManager.loadTranscript("episode-id") }
+
+        advanceTimeBy(59.seconds)
+        localTranscriptsFlow.value = listOf(vttDbTranscript)
+
+        assertNotNull(transcript.await())
+    }
+
+    /**
+     * This is a quick verification check. Sanitization is verified in [TranscriptSanitizationTest]
+     */
+    @Test
+    fun `sanitize loaded transcript entries`() = runTest {
+        localTranscriptsFlow.value = listOf(vttDbTranscript)
+        parsers.getValue(TranscriptType.Vtt).entries = listOf(
+            TranscriptEntry.Text("\t\n  Empty space padding.\n\t  "),
+            TranscriptEntry.Text("Three\n\n\nor\n\n\n\nmore empty lines."),
+        )
+
+        val transcript = transcriptManager.loadTranscript("episode-id")
+
+        assertEquals(
+            listOf(
+                TranscriptEntry.Text("Empty space padding."),
+                TranscriptEntry.Text("Three\n\nor\n\nmore empty lines."),
+            ),
+            (transcript as Transcript.Text).entries,
+        )
+    }
+
+    @Test
+    fun `fail to load transcript if parsing fails`() = runTest {
+        localTranscriptsFlow.value = listOf(vttDbTranscript)
+        parsers.getValue(TranscriptType.Vtt).parsingException = RuntimeException()
+
+        val transcript = transcriptManager.loadTranscript("episode-id")
+
+        assertNull(transcript)
+    }
+
+    @Test
+    fun `fail to load transcript if service fails`() = runTest {
+        localTranscriptsFlow.value = listOf(vttDbTranscript)
+        service.shouldThrow = true
+
+        val transcript = transcriptManager.loadTranscript("episode-id")
+
+        assertNull(transcript)
+    }
+
+    @Test
+    fun `load next available transcript if parsing fails`() = runTest {
+        localTranscriptsFlow.value = listOf(vttDbTranscript, jsonDbTranscript, srtDbTranscript, htmlDbTranscript)
+        parsers.getValue(TranscriptType.Vtt).parsingException = RuntimeException()
+        parsers.getValue(TranscriptType.Json).parsingException = RuntimeException()
+        parsers.getValue(TranscriptType.Srt).parsingException = RuntimeException()
+
+        val transcript = transcriptManager.loadTranscript("episode-id")!!
+
+        assertEquals(TranscriptType.Html, transcript.type)
+    }
+
+    @Test
+    fun `cache recently parsed transcript`() = runTest {
+        localTranscriptsFlow.value = listOf(vttDbTranscript)
+        val transcript1 = transcriptManager.loadTranscript("episode-id")
+
+        localTranscriptsFlow.value = emptyList()
+        parsers.getValue(TranscriptType.Vtt).parsingException = RuntimeException()
+        val transcript2 = transcriptManager.loadTranscript("episode-id")
+
+        assertNotNull(transcript2)
+        assertEquals(transcript1, transcript2)
+    }
+
+    @Test
+    fun `do not use cached transcript for a different episode`() = runTest {
+        localTranscriptsFlow.value = listOf(vttDbTranscript)
+        transcriptManager.loadTranscript("episode-id")
+
+        parsers.getValue(TranscriptType.Vtt).parsingException = RuntimeException()
+        val transcript2 = transcriptManager.loadTranscript("episode-id-2")
+
+        assertNull(transcript2)
+    }
+
+    @Test
+    fun `blacklist transcripts that fail to parse`() = runTest {
+        val parser = parsers.getValue(TranscriptType.Vtt)
+        localTranscriptsFlow.value = listOf(vttDbTranscript)
+
+        parser.parsingException = RuntimeException()
+        transcriptManager.loadTranscript("episode-id")
+
+        parser.parsingException = null
+        val transcript = transcriptManager.loadTranscript("episode-id")
+
+        assertNull(transcript)
+    }
+
+    @Test
+    fun `blacklist transcripts that fail to be fetched`() = runTest {
+        localTranscriptsFlow.value = listOf(vttDbTranscript)
+
+        service.shouldThrow = true
+        transcriptManager.loadTranscript("episode-id")
+
+        service.shouldThrow = false
+        val transcript = transcriptManager.loadTranscript("episode-id")
+
+        assertNull(transcript)
+    }
+
+    @Test
+    fun `clear transcript blacklist`() = runTest {
+        val parser = parsers.getValue(TranscriptType.Vtt)
+        localTranscriptsFlow.value = listOf(vttDbTranscript)
+
+        parser.parsingException = RuntimeException()
+        transcriptManager.loadTranscript("episode-id")
+
+        parser.parsingException = null
+        transcriptManager.resetInvalidTranscripts("episode-id")
+        val transcript = transcriptManager.loadTranscript("episode-id")
+
+        assertNotNull(transcript)
+    }
+}
+
+private class TestParser(
+    override val type: TranscriptType,
+) : TranscriptParser {
+    var entries = TranscriptEntry.PreviewList
+    var parsingException: Exception? = null
+
+    override fun parse(source: BufferedSource): Result<List<TranscriptEntry>> {
+        val exception = parsingException
+        return if (exception != null) {
+            Result.failure(exception)
+        } else {
+            Result.success(entries)
+        }
+    }
+}
+
+private class TestTranscriptService : TranscriptService {
+    var shouldThrow = false
+
+    override suspend fun getTranscript(url: String, cacheControl: CacheControl): Response<ResponseBody> {
+        return Response.error(404, "Not found".toResponseBody())
+    }
+
+    override suspend fun getTranscriptOrThrow(url: String, cacheControl: CacheControl): ResponseBody {
+        return if (shouldThrow) {
+            error("Test exception")
+        } else {
+            "Ok".toResponseBody()
+        }
+    }
+}
+
+private fun createDbTranscript(
+    type: String,
+) = DbTranscript(
+    episodeUuid = "episode-id",
+    url = "transcript-url",
+    type = type,
+    isGenerated = false,
+    language = "en",
+)

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/di/ServersModule.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/di/ServersModule.kt
@@ -17,7 +17,7 @@ import au.com.shiftyjelly.pocketcasts.servers.model.DisplayStyleMoshiAdapter
 import au.com.shiftyjelly.pocketcasts.servers.model.ExpandedStyleMoshiAdapter
 import au.com.shiftyjelly.pocketcasts.servers.model.ListTypeMoshiAdapter
 import au.com.shiftyjelly.pocketcasts.servers.podcast.PodcastCacheService
-import au.com.shiftyjelly.pocketcasts.servers.podcast.TranscriptCacheService
+import au.com.shiftyjelly.pocketcasts.servers.podcast.TranscriptService
 import au.com.shiftyjelly.pocketcasts.servers.server.ListWebService
 import au.com.shiftyjelly.pocketcasts.servers.sync.LoginIdentity
 import au.com.shiftyjelly.pocketcasts.servers.sync.update.SyncUpdateResponse
@@ -299,7 +299,7 @@ class ServersModule {
 
     @Provides
     @Singleton
-    fun provideTranscriptCacheServer(@TranscriptRetrofit retrofit: Retrofit): TranscriptCacheService = retrofit.create()
+    fun provideTranscriptCacheServer(@TranscriptRetrofit retrofit: Retrofit): TranscriptService = retrofit.create()
 }
 
 @Qualifier

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/podcast/TranscriptService.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/podcast/TranscriptService.kt
@@ -7,10 +7,16 @@ import retrofit2.http.GET
 import retrofit2.http.Header
 import retrofit2.http.Url
 
-interface TranscriptCacheService {
+interface TranscriptService {
     @GET
     suspend fun getTranscript(
         @Url url: String,
         @Header("Cache-Control") cacheControl: CacheControl,
     ): Response<ResponseBody>
+
+    @GET
+    suspend fun getTranscriptOrThrow(
+        @Url url: String,
+        @Header("Cache-Control") cacheControl: CacheControl,
+    ): ResponseBody
 }


### PR DESCRIPTION
## Description

Currently, the transcripts API requires ping-pong calls, which are handled in `TranscriptsViewModel`. This responsibility should reside in lower layers such as repositories or managers. This PR introduces improved transcript management logic. I haven’t integrated it yet to keep the code review surface minimal, but I will do so in the next PR.

The new `TranscriptManager` offers several advantages over the current implementation:

- Encapsulates all loading logic, including selecting the most appropriate transcripts.
- Caches the 20 most recent processed transcripts using an `LruCache`.
- Applies transcripts sanitization.
- Contains well-tested logic.

## Testing Instructions

Code review should be enough.

## Checklist
- [ ] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [ ] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [ ] ~Any jetpack compose components I added or changed are covered by compose previews~
- [ ] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~