### PR TITLE
Add transcripts highlighting to the new UI

### DIFF
--- a/modules/features/transcripts/src/main/kotlin/au/com/shiftyjelly/pocketcasts/transcripts/SearchState.kt
+++ b/modules/features/transcripts/src/main/kotlin/au/com/shiftyjelly/pocketcasts/transcripts/SearchState.kt
@@ -1,0 +1,7 @@
+package au.com.shiftyjelly.pocketcasts.transcripts
+
+data class SearchState(
+    val searchTerm: String?,
+    val selectedSearchCoordinates: Pair<Int, Int>?,
+    val searchResultIndices: Map<Int, List<Int>>,
+)

--- a/modules/features/transcripts/src/main/kotlin/au/com/shiftyjelly/pocketcasts/transcripts/ui/TransciptLines.kt
+++ b/modules/features/transcripts/src/main/kotlin/au/com/shiftyjelly/pocketcasts/transcripts/ui/TransciptLines.kt
@@ -44,7 +44,7 @@ internal fun TranscriptLines(
     searchState: SearchState,
     modifier: Modifier = Modifier,
     state: LazyListState = rememberLazyListState(),
-    colors: TranscriptColors = TranscriptColors.default(MaterialTheme.theme.colors),
+    colors: TranscriptTheme = TranscriptTheme.default(MaterialTheme.theme.colors),
 ) {
     FadedLazyColumn(
         contentPadding = PaddingValues(vertical = 16.dp),
@@ -70,7 +70,7 @@ private fun TranscriptLine(
     entryIndex: Int,
     entry: TranscriptEntry,
     searchState: SearchState,
-    colors: TranscriptColors,
+    colors: TranscriptTheme,
     modifier: Modifier = Modifier,
 ) {
     val entryText = entry.text()

--- a/modules/features/transcripts/src/main/kotlin/au/com/shiftyjelly/pocketcasts/transcripts/ui/TransciptLines.kt
+++ b/modules/features/transcripts/src/main/kotlin/au/com/shiftyjelly/pocketcasts/transcripts/ui/TransciptLines.kt
@@ -1,4 +1,4 @@
-package au.shiftyjelly.pocketcasts.transcripts.ui
+package au.com.shiftyjelly.pocketcasts.transcripts.ui
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Column

--- a/modules/features/transcripts/src/main/kotlin/au/com/shiftyjelly/pocketcasts/transcripts/ui/TransciptLines.kt
+++ b/modules/features/transcripts/src/main/kotlin/au/com/shiftyjelly/pocketcasts/transcripts/ui/TransciptLines.kt
@@ -13,12 +13,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.buildAnnotatedString
-import androidx.compose.ui.text.font.Font
-import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
@@ -35,7 +31,6 @@ import au.com.shiftyjelly.pocketcasts.compose.preview.ThemePreviewParameterProvi
 import au.com.shiftyjelly.pocketcasts.compose.theme
 import au.com.shiftyjelly.pocketcasts.models.to.TranscriptEntry
 import au.com.shiftyjelly.pocketcasts.transcripts.SearchState
-import au.com.shiftyjelly.pocketcasts.ui.R
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme.ThemeType
 
 @Composable
@@ -89,9 +84,9 @@ private fun TranscriptLine(
             searchHighlights.forEach { (startIndex, endIndex) ->
                 val highlightCoordinates = entryIndex to startIndex
                 val style = if (highlightCoordinates == searchState.selectedSearchCoordinates) {
-                    SpanStyle(Color.Red)
+                    colors.searchHighlightSpanStyle
                 } else {
-                    SpanStyle(Color.Blue)
+                    colors.searchDefaultSpanStyle
                 }
                 addStyle(style, startIndex, endIndex)
             }
@@ -131,12 +126,10 @@ private fun isValidHighlightRange(start: Int, end: Int, maxLength: Int): Boolean
     return true
 }
 
-internal val RobotoSerifFontFamily = FontFamily(Font(R.font.roboto_serif))
-
 private val SimpleTextStyle = TextStyle(
     fontSize = 16.sp,
     fontWeight = FontWeight.Medium,
-    fontFamily = RobotoSerifFontFamily,
+    fontFamily = TranscriptTheme.RobotoSerifFontFamily,
 )
 private val SpeakerTextStyle = SimpleTextStyle.copy(
     fontSize = 12.sp,

--- a/modules/features/transcripts/src/main/kotlin/au/com/shiftyjelly/pocketcasts/transcripts/ui/TranscriptColors.kt
+++ b/modules/features/transcripts/src/main/kotlin/au/com/shiftyjelly/pocketcasts/transcripts/ui/TranscriptColors.kt
@@ -1,4 +1,4 @@
-package au.shiftyjelly.pocketcasts.transcripts.ui
+package au.com.shiftyjelly.pocketcasts.transcripts.ui
 
 import androidx.compose.material.MaterialTheme
 import androidx.compose.runtime.Composable

--- a/modules/features/transcripts/src/main/kotlin/au/com/shiftyjelly/pocketcasts/transcripts/ui/TranscriptTheme.kt
+++ b/modules/features/transcripts/src/main/kotlin/au/com/shiftyjelly/pocketcasts/transcripts/ui/TranscriptTheme.kt
@@ -4,26 +4,48 @@ import androidx.compose.material.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.font.Font
+import androidx.compose.ui.text.font.FontFamily
 import au.com.shiftyjelly.pocketcasts.compose.PlayerColors
 import au.com.shiftyjelly.pocketcasts.compose.ThemeColors
 import au.com.shiftyjelly.pocketcasts.compose.theme
+import au.com.shiftyjelly.pocketcasts.ui.R
 
 data class TranscriptTheme(
     val background: Color,
     val text: Color,
     val secondaryElement: Color,
+    val searchDefaultSpanStyle: SpanStyle,
+    val searchHighlightSpanStyle: SpanStyle,
 ) {
     companion object {
+        internal val RobotoSerifFontFamily = FontFamily(Font(R.font.roboto_serif))
+
         fun default(colors: ThemeColors) = TranscriptTheme(
             background = colors.primaryUi01,
             text = colors.primaryText01,
             secondaryElement = colors.primaryUi05,
+            searchDefaultSpanStyle = SpanStyle(
+                background = colors.primaryUi05.copy(alpha = 0.6f),
+            ),
+            searchHighlightSpanStyle = SpanStyle(
+                background = colors.primaryUi05,
+            ),
         )
 
         fun player(colors: PlayerColors) = TranscriptTheme(
             background = colors.background01,
             text = colors.contrast02,
             secondaryElement = colors.contrast05,
+            searchDefaultSpanStyle = SpanStyle(
+                background = Color.White.copy(alpha = 0.2f),
+                color = Color.White,
+            ),
+            searchHighlightSpanStyle = SpanStyle(
+                background = Color.White,
+                color = Color.Black,
+            ),
         )
     }
 }

--- a/modules/features/transcripts/src/main/kotlin/au/com/shiftyjelly/pocketcasts/transcripts/ui/TranscriptTheme.kt
+++ b/modules/features/transcripts/src/main/kotlin/au/com/shiftyjelly/pocketcasts/transcripts/ui/TranscriptTheme.kt
@@ -8,19 +8,19 @@ import au.com.shiftyjelly.pocketcasts.compose.PlayerColors
 import au.com.shiftyjelly.pocketcasts.compose.ThemeColors
 import au.com.shiftyjelly.pocketcasts.compose.theme
 
-data class TranscriptColors(
+data class TranscriptTheme(
     val background: Color,
     val text: Color,
     val secondaryElement: Color,
 ) {
     companion object {
-        fun default(colors: ThemeColors) = TranscriptColors(
+        fun default(colors: ThemeColors) = TranscriptTheme(
             background = colors.primaryUi01,
             text = colors.primaryText01,
             secondaryElement = colors.primaryUi05,
         )
 
-        fun player(colors: PlayerColors) = TranscriptColors(
+        fun player(colors: PlayerColors) = TranscriptTheme(
             background = colors.background01,
             text = colors.contrast02,
             secondaryElement = colors.contrast05,
@@ -29,15 +29,15 @@ data class TranscriptColors(
 }
 
 @Composable
-fun rememberTranscriptColors(): TranscriptColors {
+fun rememberTranscriptColors(): TranscriptTheme {
     val theme = MaterialTheme.theme
     val playerColors = theme.rememberPlayerColors()
 
     return remember(theme.type, playerColors) {
         if (playerColors != null) {
-            TranscriptColors.player(playerColors)
+            TranscriptTheme.player(playerColors)
         } else {
-            TranscriptColors.default(theme.colors)
+            TranscriptTheme.default(theme.colors)
         }
     }
 }

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/to/TranscriptEntry.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/to/TranscriptEntry.kt
@@ -11,10 +11,10 @@ sealed interface TranscriptEntry {
 
     companion object {
         val PreviewList = listOf(
-            Text("Lorem ipsum odor amet, consectetuer adipiscing elit."),
-            Speaker("Speaker 1"),
+            Text("Lorem ipsum odor amet, lorem consectetuer adipiscing elit."),
+            Speaker("Speaker Lorem 1"),
             Text("Sodales sem fusce elementum commodo risus purus auctor neque."),
-            Text("Tempus leo eu aenean sed diam urna tempor. Pulvinar vivamus fringilla lacus nec metus bibendum egestas. Iaculis massa nisl malesuada lacinia integer nunc posuere."),
+            Text("Tempus leo eu aenean lorem sed diam urna tempor. Pulvinar vivamus fringilla lacus nec metus bibendum egestas. Iaculis massa nisl malesuada lacinia integer nunc posuere."),
             Speaker("Speaker 2"),
             Text("Duis elementum condimentum interdum. Vivamus sollicitudin blandit luctus. In vulputate ipsum dolor, vitae lacinia augue sollicitudin vel. Phasellus eget augue odio. Cras pharetra libero et lorem laoreet varius. Mauris libero massa, dictum eu dapibus at, condimentum nec eros. Morbi varius lobortis odio a fermentum."),
             Text("Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi."),


### PR DESCRIPTION
## Description

This adds highlighting to the decoupled UI. It might seem a bit esoteric if you're not familiar with the KMP algorithm that we use for search. It uses the same principles that we currently have but instead of having a single list of search result indices it is kept as a map of entry to indices list.

## Testing Instructions

Code review the changes and preview the UI.

## Screenshots or Screencast 

### Player context

<img width="1032" alt="Screenshot 2025-06-13 at 09 42 48" src="https://github.com/user-attachments/assets/331bd634-a284-41f5-997d-a9c92a7dc5ed" />

### Episode context

<img width="1287" alt="Screenshot 2025-06-13 at 09 42 38" src="https://github.com/user-attachments/assets/d9fa109e-5323-4aa5-a844-c99c24093c14" />

## Checklist
- [ ] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] ~I have considered whether it makes sense to add tests for my changes~
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [ ] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~