### PR TITLE
Update extraction rules for Android 12 and above

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,12 @@
 *   Bug Fixes
     *   Fix keyboard blocking WebView input fields in Help & Feedback page
         ([#4109](https://github.com/Automattic/pocket-casts-android/pull/4109))
-    *   Fix player's theming responsivness
+    *   Fix player's theming responsiveness
         ([#4091](https://github.com/Automattic/pocket-casts-android/pull/4091))
     *   Respect embedded file artwork in media notifications
         ([#4103](https://github.com/Automattic/pocket-casts-android/pull/4103))
+    *   Specify what files to be backed up on Android 12 and up
+        ([#4119](https://github.com/Automattic/pocket-casts-android/pull/4119))
 
 7.91
 -----

--- a/app/src/release/AndroidManifest.xml
+++ b/app/src/release/AndroidManifest.xml
@@ -3,7 +3,8 @@
     xmlns:tools="http://schemas.android.com/tools">
 
     <application
-        tools:replace="android:allowBackup,android:fullBackupContent"
+        tools:replace="android:allowBackup,android:fullBackupContent,android:dataExtractionRules"
         android:allowBackup="true"
-        android:fullBackupContent="@xml/backup_scheme" />
+        android:fullBackupContent="@xml/backup_scheme"
+        android:dataExtractionRules="@xml/extraction_rules"/>
 </manifest>

--- a/modules/services/localization/src/release/res/xml/backup_scheme.xml
+++ b/modules/services/localization/src/release/res/xml/backup_scheme.xml
@@ -2,4 +2,6 @@
 <full-backup-content>
     <include domain="database" path="pocketcasts" />
     <include domain="sharedpref" path="au.com.shiftyjelly.pocketcasts_preferences.xml" />
+    <!-- https://dev.appsflyer.com/hc/docs/install-android-sdk#merge-backup-rules-in-android-11-and-below -->
+    <exclude domain="sharedpref" path="appsflyer-data"/>
 </full-backup-content>

--- a/modules/services/localization/src/release/res/xml/extraction_rules.xml
+++ b/modules/services/localization/src/release/res/xml/extraction_rules.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<data-extraction-rules>
+    <cloud-backup disableIfNoEncrpytionCapabilities="true">
+        <include domain="database" path="pocketcasts" />
+        <include domain="sharedpref" path="au.com.shiftyjelly.pocketcasts_preferences.xml" />
+    </cloud-backup>
+    <device-transfer>
+        <include domain="database" path="pocketcasts" />
+        <include domain="sharedpref" path="au.com.shiftyjelly.pocketcasts_preferences.xml" />
+    </device-transfer>
+</data-extraction-rules>

--- a/modules/services/localization/src/release/res/xml/extraction_rules.xml
+++ b/modules/services/localization/src/release/res/xml/extraction_rules.xml
@@ -3,9 +3,13 @@
     <cloud-backup disableIfNoEncrpytionCapabilities="true">
         <include domain="database" path="pocketcasts" />
         <include domain="sharedpref" path="au.com.shiftyjelly.pocketcasts_preferences.xml" />
+        <!-- https://dev.appsflyer.com/hc/docs/install-android-sdk#merge-backup-rules-in-android-12-and-above -->
+        <exclude domain="sharedpref" path="appsflyer-data"/>
     </cloud-backup>
     <device-transfer>
         <include domain="database" path="pocketcasts" />
         <include domain="sharedpref" path="au.com.shiftyjelly.pocketcasts_preferences.xml" />
+        <!-- https://dev.appsflyer.com/hc/docs/install-android-sdk#merge-backup-rules-in-android-12-and-above -->
+        <exclude domain="sharedpref" path="appsflyer-data"/>
     </device-transfer>
 </data-extraction-rules>


### PR DESCRIPTION
Slack thread: p1749613256594919-slack-C02A333D8LQ
Previous attempt: [pr](#4031) 

## Description
This is yet another attempt to fix the crash that happens around `glance` or `horologist` when they're trying to backup their saved preferences.
It is clear that those two libraries define `androidx.datastore` as dependency, we've explicitly added datastore to our project with its latest version `1.1.7` so those libraries will use this version as well. However, it seems that didn't do the trick.
The [deobfuscated stacktrace](https://a8c.sentry.io/issues/6643782109/events/6f8796de3c4e4098bed36edb71b76e09/?query=) isn't too telling either, the component where the crash comes from is called `h5.PreferenceDataStoreFactory`.
My next best guess was to start looking around how backup works on Android since some threads on Google's issue tracker suggested that this might be backup-related problem.
So I hit up the [official docs](https://developer.android.com/identity/data/autobackup#include-exclude-android-12) and stumbled upon this:
>If your app targets Android 12 (API level 31) or higher, follow the steps in this section to control which files are backed up on devices that are running Android 12 or higher.

What we previously had is backup for Android 11 and below, since in our `release/AndroidManifest.xml` we specified `android:fullBackupContent`.
So I've added `android:dataExtractionRules` and supplied the same list of files to restore and backup - our database and our public preferences => see `xml/extraction_rules.xml`
 
I imagine that some users with Android 12+ had at some point a version of our app installed that used older versions of `glance` and `horologist` and those versions used proto datastore to persist some of their settings. These preferences have been backed up in the user's could since we haven't specified our backup policies for Android 12+ (and by default the complete data preferences directory is backed up, along with other files [read more here](https://developer.android.com/identity/data/autobackup#Files))
So when the user installed the latest version of Pocket Casts, the backup service kicked in and downloaded all the backed up preferences from the cloud and copied them to the `/data` folder of the installation. 
This case should be now solved since the backup service will only restore the specified files (database + OUR prefs). Another win is that we won't upload unnecessary files either on Android 12 for backup.

Please note that this is just a guess since I was never able to repro the original issue no matter how hard I tried. And oh boy, I did try. I added widgets to my home screen, connected to and logged in on the wear app via phone, etc. 

I'd advise to keep an eye on our next release and look for this crash in particular. 


## Testing Instructions
1. Apply [backup-restore.patch](https://github.com/user-attachments/files/20726625/backup-restore.patch) and build prodDebug
2. After launching the app, play around with various settings (e.g. follow podcasts, make changes on podcast settings like auto-download, auto add to up next, etc, make changes on the Settings screen)
3. Download this script [backup_test.txt](https://github.com/user-attachments/files/20726660/backup_test.txt) and `mv backup_test.txt backup_test.sh && chmod +x backup_test.sh && ./backup_test.sh au.com.shiftyjelly.pocketcasts`
4. Wait until the backup and restore goes through
5. Launch the app again and see if all the changes you've made before are preserved

If you want to learn more how you can test backup, check out [these docs](https://developer.android.com/identity/data/testingbackup) 

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [ ] ~Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)~
- [ ] ~I have considered whether it makes sense to add tests for my changes~
- [ ] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [ ] ~Any jetpack compose components I added or changed are covered by compose previews~
- [ ] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~
 