### PR TITLE
Remove bottom padding with empty episode list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 *   Updates
     *   Improve transcripts parsing and loading
         ([#4115](https://github.com/Automattic/pocket-casts-android/pull/4115))
-    *   Remove bottom padding with empty episode list #4121
+    *   Remove bottom padding with empty episode list
         ([#4121](https://github.com/Automattic/pocket-casts-android/pull/4121))
 *   Bug Fixes
     *   Fix keyboard blocking WebView input fields in Help & Feedback page

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 *   Updates
     *   Improve transcripts parsing and loading
         ([#4115](https://github.com/Automattic/pocket-casts-android/pull/4115))
+    *   Remove buttom padding with empty episode list #4121
+        ([#4121](https://github.com/Automattic/pocket-casts-android/pull/4121))
 *   Bug Fixes
     *   Fix keyboard blocking WebView input fields in Help & Feedback page
         ([#4109](https://github.com/Automattic/pocket-casts-android/pull/4109))
@@ -10,6 +12,7 @@
         ([#4091](https://github.com/Automattic/pocket-casts-android/pull/4091))
     *   Respect embedded file artwork in media notifications
         ([#4103](https://github.com/Automattic/pocket-casts-android/pull/4103))
+    
 
 7.91
 -----

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 *   Updates
     *   Improve transcripts parsing and loading
         ([#4115](https://github.com/Automattic/pocket-casts-android/pull/4115))
-    *   Remove buttom padding with empty episode list #4121
+    *   Remove bottom padding with empty episode list #4121
         ([#4121](https://github.com/Automattic/pocket-casts-android/pull/4121))
 *   Bug Fixes
     *   Fix keyboard blocking WebView input fields in Help & Feedback page

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,6 @@
         ([#4091](https://github.com/Automattic/pocket-casts-android/pull/4091))
     *   Respect embedded file artwork in media notifications
         ([#4103](https://github.com/Automattic/pocket-casts-android/pull/4103))
-    
 
 7.91
 -----

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
         ([#4091](https://github.com/Automattic/pocket-casts-android/pull/4091))
     *   Respect embedded file artwork in media notifications
         ([#4103](https://github.com/Automattic/pocket-casts-android/pull/4103))
+    *   Search bar jumps out of view when searching for episodes within a podcast page
+        ([#3899](https://github.com/Automattic/pocket-casts-android/pull/3899))
     
 
 7.91

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,6 @@
         ([#4091](https://github.com/Automattic/pocket-casts-android/pull/4091))
     *   Respect embedded file artwork in media notifications
         ([#4103](https://github.com/Automattic/pocket-casts-android/pull/4103))
-    *   Search bar jumps out of view when searching for episodes within a podcast page
-        ([#3899](https://github.com/Automattic/pocket-casts-android/pull/3899))
     
 
 7.91

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastFragment.kt
@@ -1161,7 +1161,7 @@ class PodcastFragment : BaseFragment() {
         val binding = binding ?: return
         val rowCount = episodes.size
 
-        // No padding if there are no episodes
+        // No padding for empty state to avoid excessive whitespace
         if (rowCount == 0) {
             binding.episodesRecyclerView.updatePadding(bottom = 0)
             return

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastFragment.kt
@@ -1158,22 +1158,26 @@ class PodcastFragment : BaseFragment() {
      * Episode search needs at least a page worth of space under the search box so the user can see the results below.
      */
     private fun addPaddingForEpisodeSearch(episodes: List<PodcastEpisode>) {
-        val rowCount = episodes.size
         val binding = binding ?: return
+        val rowCount = episodes.size
+
+        // No padding if there are no episodes
+        if (rowCount == 0) {
+            binding.episodesRecyclerView.updatePadding(bottom = 0)
+            return
+        }
+
         val pageHeight = binding.episodesRecyclerView.height
         val context = binding.episodesRecyclerView.context
         val episodeHeaderHeightPx = 90.dpToPx(context)
-        val rowHeightPx: Int = 80.dpToPx(context)
-
+        val rowHeightPx = 80.dpToPx(context)
         val actualHeight = episodeHeaderHeightPx + (rowCount * rowHeightPx)
-
         val missingHeightPx = pageHeight - actualHeight
 
-        // only add padding to stop the screen jumping to the wrong location
-        if (binding.episodesRecyclerView.paddingBottom > missingHeightPx) {
-            return
+        // Only add padding if needed to prevent screen jump
+        if (binding.episodesRecyclerView.paddingBottom <= missingHeightPx && missingHeightPx > 0) {
+            binding.episodesRecyclerView.updatePadding(bottom = missingHeightPx)
         }
-        binding.episodesRecyclerView.updatePadding(bottom = if (missingHeightPx < 0) 0 else missingHeightPx)
     }
 
     override fun onDestroyView() {


### PR DESCRIPTION
## Description
<!-- Please include a summary of what this PR is changing and why these changes are needed. -->
Remove the bottm padding on the episodes list when no episodes are visible

Fixes #4030

## Testing Instructions

1. Follow a podcast
2. Open the podcast page
3. Tap the three dots next to "Seach episodes"
4. Tap "Archive all"
5. Scroll down the page

Notice the large padding described in the issue is not present anymore

## Screenshots or Screencast 
<!-- if applicable -->

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
