### PR TITLE
Fix app state after migration

### DIFF
--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/EpisodeDao.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/EpisodeDao.kt
@@ -260,6 +260,10 @@ abstract class EpisodeDao {
     abstract suspend fun findStaleDownloads(notDownloaded: EpisodeStatusEnum = EpisodeStatusEnum.NOT_DOWNLOADED): List<PodcastEpisode>
 
     @Transaction
+    @Query("SELECT * FROM podcast_episodes WHERE (download_task_id IS NOT NULL AND episode_status != :status)")
+    abstract suspend fun findNotFinishedDownloads(status: EpisodeStatusEnum = EpisodeStatusEnum.DOWNLOADED): List<PodcastEpisode>
+
+    @Transaction
     @Query("SELECT * FROM podcast_episodes WHERE episode_status == :downloadEpisodeStatusEnum ORDER BY last_download_attempt_date DESC")
     abstract fun findDownloadedEpisodesRxFlowable(downloadEpisodeStatusEnum: EpisodeStatusEnum = EpisodeStatusEnum.DOWNLOADED): Flowable<List<PodcastEpisode>>
 

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManagerImpl.kt
@@ -694,7 +694,7 @@ class EpisodeManagerImpl @Inject constructor(
     }
 
     override suspend fun findStaleDownloads(): List<PodcastEpisode> {
-        return episodeDao.findStaleDownloads()
+        return episodeDao.findNotFinishedDownloads()
     }
 
     override fun unarchiveBlocking(episode: BaseEpisode) {

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/support/Support.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/support/Support.kt
@@ -247,9 +247,10 @@ class Support @Inject constructor(
             val podcastsOutput = StringBuilder()
             podcastsOutput.append("Podcasts").append(eol).append("--------").append(eol).append(eol)
             val uuidToPodcast = HashMap<String, Podcast>()
-            try {
+            val hasAnyPodcastWithAddUpNext = try {
                 val podcasts = podcastManager.findSubscribedBlocking()
-                for (podcast in podcasts) {
+                val upNextSettings = Array(podcasts.size) { false }
+                podcasts.forEachIndexed { index, podcast ->
                     podcastsOutput.append(podcast.uuid).append(eol)
                     podcastsOutput.append(if (podcast.title.isEmpty()) "-" else podcast.title).append(eol)
                     podcastsOutput.append("Last episode: ").append(podcast.latestEpisodeUuid).append(eol)
@@ -270,9 +271,12 @@ class Support @Inject constructor(
                     podcastsOutput.append(eol)
 
                     uuidToPodcast[podcast.uuid] = podcast
+                    upNextSettings[index] = podcast.autoAddToUpNext != Podcast.AutoAddUpNext.OFF
                 }
+                upNextSettings.any { it }
             } catch (e: Exception) {
                 Timber.e(e)
+                false
             }
             val isAutoDownloadEnabled = podcastManager.hasEpisodesWithAutoDownloadStatus(AUTO_DOWNLOAD_NEW_EPISODES)
 
@@ -288,6 +292,7 @@ class Support @Inject constructor(
             output.append("  New episodes? ").append(yesNoString(settings.autoDownloadNewEpisodes.value == AUTO_DOWNLOAD_NEW_EPISODES)).append(eol)
             output.append("  On follow? ").append(yesNoString(settings.autoDownloadOnFollowPodcast.value)).append(eol)
             output.append("  Limit downloads: ").append(settings.autoDownloadLimit.value).append(eol)
+            output.append("  Any podcast new episode up next? ").append(yesNoString(hasAnyPodcastWithAddUpNext)).append(eol)
             output.append("  Up Next? ").append(yesNoString(settings.autoDownloadUpNext.value)).append(eol)
             output.append("  Only on unmetered WiFi? ").append(yesNoString(settings.autoDownloadUnmeteredOnly.value)).append(eol)
             output.append("  Only when charging? ").append(yesNoString(settings.autoDownloadOnlyWhenCharging.value)).append(eol)

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/support/Support.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/support/Support.kt
@@ -246,14 +246,10 @@ class Support @Inject constructor(
 
             val podcastsOutput = StringBuilder()
             podcastsOutput.append("Podcasts").append(eol).append("--------").append(eol).append(eol)
-            val autoDownloadOn = booleanArrayOf(false)
             val uuidToPodcast = HashMap<String, Podcast>()
             try {
                 val podcasts = podcastManager.findSubscribedBlocking()
                 for (podcast in podcasts) {
-                    if (podcast.isAutoDownloadNewEpisodes) {
-                        autoDownloadOn[0] = true
-                    }
                     podcastsOutput.append(podcast.uuid).append(eol)
                     podcastsOutput.append(if (podcast.title.isEmpty()) "-" else podcast.title).append(eol)
                     podcastsOutput.append("Last episode: ").append(podcast.latestEpisodeUuid).append(eol)
@@ -278,6 +274,7 @@ class Support @Inject constructor(
             } catch (e: Exception) {
                 Timber.e(e)
             }
+            val isAutoDownloadEnabled = podcastManager.hasEpisodesWithAutoDownloadStatus(AUTO_DOWNLOAD_NEW_EPISODES)
 
             output.append(eol)
             output.append("Auto archive settings").append(eol)
@@ -287,7 +284,7 @@ class Support @Inject constructor(
 
             output.append(eol)
             output.append("Auto downloads").append(eol)
-            output.append("  Any podcast? ").append(yesNoString(autoDownloadOn[0])).append(eol)
+            output.append("  Any podcast? ").append(yesNoString(isAutoDownloadEnabled)).append(eol)
             output.append("  New episodes? ").append(yesNoString(settings.autoDownloadNewEpisodes.value == AUTO_DOWNLOAD_NEW_EPISODES)).append(eol)
             output.append("  On follow? ").append(yesNoString(settings.autoDownloadOnFollowPodcast.value)).append(eol)
             output.append("  Limit downloads: ").append(settings.autoDownloadLimit.value).append(eol)


### PR DESCRIPTION
## Description
Okay, this one is a bit complex.
Users have reported that their settings seems broken after they've migrated to a new phone.
The basis of this assumption was a bit hidden on ZenDesk 9739213-zd-a8c - we assumed from the debug.txt file that the auto download setting is not respected by the app:

> Auto downloads
  Any podcast? yes
  New episodes? no
  On follow? no
  Limit downloads: TEN_LATEST_EPISODE
  Up Next? no
  Only on unmetered WiFi? yes
  Only when charging? no
![1000000256](https://github.com/user-attachments/assets/de9ba792-e084-461b-af40-b130f1ac8954)

(notice New episodes? no)

But it turned out that we had a bug in the logging logic... Fixed it in 695ab1d04de1fda8dc8c151cfc6b36e4718f0248
Also added extra log line to get a more fine grained picture on auto add next: 2e11006ddcafa77f8f9f28b4b7289798b4a089a4

However later I discovered that we can indeed find ourselves in a state with 'stuck' downloads.
Backup backs up the complete database, including `user_episodes`. And if we have already scheduled some episodes for download, then their db rows will reflect that in these columns:
- episode_status
- download_task_id
If there were episodes with DOWNLOADING or WAITING_FOR_WIFI state, those ones will remain in this state forever, because the previous task ids no longer exist.
I've updated `DownloadManager.cleanupStaleDownloads()` to reset taskIds and episode statuses and return with the list of the affected episode ids.
I later re-queue them for download so they will go through the original logic via `PodcastManager.checkForEpisodesToDownloadBlocking` and their status will be updated appropriately and a new task id may get assigned to them.
It was quite tricky to get to the bottom of it 😌 


Fixes #3965

## Testing Instructions
Please bear with me while testing this.
Preconfig:
Apply [backup-restore1.patch](https://github.com/user-attachments/files/20783704/backup-restore1.patch) and build `debugProd`

1. Change global Auto download settings and make notes on your settings
2. Change podcast settings - e.g. enable auto download or add new episodes to next queue
3. Follow new podcasts but don't let their auto downloads complete, turn off wifi.
4. Make sure you create a copy of the database --- pull `data/au.com.shiftyjelly.pocketcasts.debug/databases/pocketcasts` file to your local machine
![Screenshot 2025-06-17 at 22 31 40](https://github.com/user-attachments/assets/0709ed45-3729-467b-bac8-413a2e2f2fab)
5. Now download this script [backup_test.txt](https://github.com/user-attachments/files/20783755/backup_test.txt) and then rename it to `.sh` and `chmod +x` on it.
6. Then perform the backup and restore: `./backup_test.sh au.com.shiftyjelly.pocketcasts.debug` 
7. Launch the app and:
- [ ] check if settings have been preserved
- [ ] check if downloads have resumed  -- should not see Downloading or Waiting for Wifi statuses -- unless you're currently not on wifi :D


## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [ ] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [ ] ~Any jetpack compose components I added or changed are covered by compose previews~
- [ ] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~
