### PR TITLE
Add play/pause buton to transcript page

### DIFF
--- a/modules/features/transcripts/src/main/kotlin/au/com/shiftyjelly/pocketcasts/transcripts/ui/Toolbar.kt
+++ b/modules/features/transcripts/src/main/kotlin/au/com/shiftyjelly/pocketcasts/transcripts/ui/Toolbar.kt
@@ -69,7 +69,7 @@ import au.com.shiftyjelly.pocketcasts.utils.search.SearchMatches
 import au.com.shiftyjelly.pocketcasts.compose.components.SearchBar as BaseSearchBar
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
-internal data class ToolbarColors(
+data class ToolbarColors(
     val button: Color,
     val buttonBackground: Color,
     val searchBarBackground: Color,
@@ -119,6 +119,7 @@ internal fun Toolbar(
     modifier: Modifier = Modifier,
     colors: ToolbarColors = ToolbarColors.default(MaterialTheme.theme.colors),
     hideSearchBar: Boolean = false,
+    trailingContent: (@Composable (ToolbarColors) -> Unit)? = null,
 ) {
     val focusRequester = remember { FocusRequester() }
     val showSearchTransition = updateTransition(searchState.isSearchOpen)
@@ -150,10 +151,15 @@ internal fun Toolbar(
                         enter = SearchButtonEnterTransition,
                         exit = SearchButtonExitTransition,
                     ) {
-                        ShowSearchButton(
-                            colors = colors,
-                            onClick = onShowSearchBar,
-                        )
+                        Row(
+                            horizontalArrangement = Arrangement.spacedBy(8.dp),
+                        ) {
+                            trailingContent?.invoke(colors)
+                            ShowSearchButton(
+                                colors = colors,
+                                onClick = onShowSearchBar,
+                            )
+                        }
                     }
                     showSearchTransition.AnimatedVisibility(
                         visible = { it },
@@ -424,7 +430,7 @@ private fun ToolbarPreview(
                 modifier = Modifier.fillMaxWidth(),
             )
             Toolbar(
-                initialSearchState = SearchState.Empty.copy(isSearchOpen = true),
+                initialSearchState = SearchState.Empty.copy(isSearchOpen = false),
                 modifier = Modifier.fillMaxWidth(),
             )
             Toolbar(
@@ -459,7 +465,7 @@ private fun ToolbarPlayerPreview(
                     modifier = Modifier.fillMaxWidth(),
                 )
                 Toolbar(
-                    initialSearchState = SearchState.Empty.copy(isSearchOpen = true),
+                    initialSearchState = SearchState.Empty.copy(isSearchOpen = false),
                     colors = transcriptTheme.toolbarColors,
                     modifier = Modifier.fillMaxWidth(),
                 )

--- a/modules/features/transcripts/src/main/kotlin/au/com/shiftyjelly/pocketcasts/transcripts/ui/TranscriptPage.kt
+++ b/modules/features/transcripts/src/main/kotlin/au/com/shiftyjelly/pocketcasts/transcripts/ui/TranscriptPage.kt
@@ -41,6 +41,7 @@ fun TranscriptPage(
     toolbarPadding: PaddingValues = PaddingValues(0.dp),
     transcriptPadding: PaddingValues = PaddingValues(0.dp),
     paywallPadding: PaddingValues = PaddingValues(0.dp),
+    toolbarTrailingContent: (@Composable (ToolbarColors) -> Unit)? = null,
 ) {
     val theme = rememberTranscriptTheme()
     val listState = rememberLazyListState()
@@ -59,6 +60,7 @@ fun TranscriptPage(
             onShowSearchBar = onShowSearchBar,
             onHideSearchBar = onHideSearchBar,
             colors = theme.toolbarColors,
+            trailingContent = toolbarTrailingContent,
             modifier = Modifier
                 .fillMaxWidth()
                 .padding(toolbarPadding),

--- a/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/SourceView.kt
+++ b/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/SourceView.kt
@@ -18,6 +18,7 @@ enum class SourceView(val analyticsValue: String) {
     ENGAGE_SDK_SIGN_IN("engage_sdk_sign_in"),
     EPISODE_DETAILS("episode_details"),
     EPISODE_SWIPE_ACTION("episode_swipe_action"),
+    EPISODE_TRANSCRIPT("episode_transcript"),
     FILES("files"),
     FILES_SETTINGS("files_settings"),
     FILTERS("filters"),

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
@@ -589,6 +589,7 @@ open class PlaybackManager @Inject constructor(
             SourceView.LISTENING_HISTORY,
             SourceView.DOWNLOADS,
             SourceView.EPISODE_DETAILS,
+            SourceView.EPISODE_TRANSCRIPT,
             SourceView.FILES,
             SourceView.FILTERS,
             SourceView.PODCAST_SCREEN,


### PR DESCRIPTION
## Description

This adds ability to play and pause transcripts from the episode details transcript.

Designs: tzuqhOmpPVu5TjKK1XMhf5-fi-939_7392

I'll update changelog if this gets merged to a different milestone than #4143.

## Testing Instructions

1. Open episode details with a transcript.
2. Tap on the transcript excerpt.
3. In the transcript sheet tap on the play/pause button.
4. The playback of the episode should act accordingly.

## Screenshots or Screencast 

https://github.com/user-attachments/assets/4e9f18d0-e462-4bcf-adec-e4785b5a90c9

## Checklist
- [ ] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [ ] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack
