### PR TITLE
Use correct winback event

### DIFF
--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/winback/WinbackViewModel.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/winback/WinbackViewModel.kt
@@ -404,7 +404,7 @@ class WinbackViewModel @Inject constructor(
 
     internal fun trackContinueWithCancellationTapped() {
         tracker.track(
-            event = AnalyticsEvent.WINBACK_CANCEL_CONFIRMATION_CANCEL_BUTTON_TAPPED,
+            event = AnalyticsEvent.WINBACK_WINBACK_OFFER_CANCEL_BUTTON_TAPPED,
         )
     }
 


### PR DESCRIPTION
## Description

This fixes incorrect event triggered when confirming subscription canellation.

Internal ref: p1750774599474669-slack-C080ZKX4UCV

## Testing Instructions

Code review should be enough.

## Checklist
- [ ] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [ ] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [ ] ~Any jetpack compose components I added or changed are covered by compose previews~
- [ ] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~