### PR TITLE
Imporve vertical player experience on smaller devices

### DIFF
--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/nowplaying/ArtworkImage.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/nowplaying/ArtworkImage.kt
@@ -10,6 +10,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalInspectionMode
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import au.com.shiftyjelly.pocketcasts.models.entity.BaseEpisode
 import au.com.shiftyjelly.pocketcasts.repositories.images.PocketCastsImageRequestFactory
@@ -20,6 +21,7 @@ import coil.compose.rememberAsyncImagePainter
 internal fun ArtworkImage(
     state: ArtworkImageState,
     modifier: Modifier = Modifier,
+    cornerRadius: Dp = 16.dp,
 ) {
     val context = LocalContext.current
     val isPreview = LocalInspectionMode.current
@@ -47,7 +49,7 @@ internal fun ArtworkImage(
         contentDescription = null,
         modifier = modifier
             .aspectRatio(1f)
-            .clip(RoundedCornerShape(16.dp)),
+            .clip(RoundedCornerShape(cornerRadius)),
     )
 }
 

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/nowplaying/ArtworkOrVideo.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/nowplaying/ArtworkOrVideo.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import au.com.shiftyjelly.pocketcasts.player.view.video.VideoView
 import au.com.shiftyjelly.pocketcasts.repositories.playback.Player
@@ -16,6 +17,7 @@ internal fun ArtworkOrVideo(
     onChapterUrlClick: (HttpUrl) -> Unit,
     configureVideoView: (VideoView) -> Unit,
     modifier: Modifier = Modifier,
+    artworkCornerRadius: Dp = 16.dp,
 ) {
     Box(
         modifier = modifier,
@@ -24,6 +26,7 @@ internal fun ArtworkOrVideo(
             is ArtworkOrVideoState.Artwork -> {
                 ArtworkImage(
                     state = state.artworkImageState,
+                    cornerRadius = artworkCornerRadius,
                 )
             }
 

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/ad/AdBanner.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/ad/AdBanner.kt
@@ -53,6 +53,7 @@ import au.com.shiftyjelly.pocketcasts.compose.LocalPodcastColors
 import au.com.shiftyjelly.pocketcasts.compose.PodcastColors
 import au.com.shiftyjelly.pocketcasts.compose.PodcastColorsParameterProvider
 import au.com.shiftyjelly.pocketcasts.compose.components.CoilImage
+import au.com.shiftyjelly.pocketcasts.compose.extensions.fractionedSp
 import au.com.shiftyjelly.pocketcasts.compose.preview.ThemePreviewParameterProvider
 import au.com.shiftyjelly.pocketcasts.compose.theme
 import au.com.shiftyjelly.pocketcasts.repositories.images.PocketCastsImageRequestFactory
@@ -118,8 +119,8 @@ fun AdBanner(
                     Text(
                         text = ad.ctaText,
                         color = colors.ctaLabel,
-                        fontSize = 14.sp,
-                        lineHeight = 18.sp,
+                        fontSize = 14f.fractionedSp(fraction = 0.4f),
+                        lineHeight = 18f.fractionedSp(fraction = 0.4f),
                         letterSpacing = 0.sp,
                     )
 
@@ -166,8 +167,8 @@ private fun AdTitle(
         Text(
             text = stringResource(LR.string.ad).uppercase(),
             color = colors.adLabel,
-            fontSize = 8.sp,
-            lineHeight = 8.sp,
+            fontSize = 8f.fractionedSp(fraction = 0.4f),
+            lineHeight = 8f.fractionedSp(fraction = 0.4f),
             fontWeight = FontWeight.SemiBold,
             letterSpacing = 0.sp,
             modifier = Modifier
@@ -182,8 +183,8 @@ private fun AdTitle(
         Text(
             text = ad.title,
             color = colors.titleLabel,
-            fontSize = 12.sp,
-            lineHeight = 12.sp,
+            fontSize = 12f.fractionedSp(fraction = 0.4f),
+            lineHeight = 12f.fractionedSp(fraction = 0.4f),
             fontWeight = FontWeight.SemiBold,
             letterSpacing = 0.sp,
         )

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/AnimatedNonNullVisibility.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/AnimatedNonNullVisibility.kt
@@ -8,7 +8,6 @@ import androidx.compose.animation.expandVertically
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.animation.shrinkVertically
-import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -17,11 +16,11 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 
 @Composable
-fun <T : Any> ColumnScope.AnimatedNonNullVisibility(
+fun <T : Any> AnimatedNonNullVisibility(
     item: T?,
     modifier: Modifier = Modifier,
-    enter: EnterTransition = columnEnterTransition,
-    exit: ExitTransition = columnExitTransition,
+    enter: EnterTransition = defaultEnterTransition,
+    exit: ExitTransition = defaultExitTransition,
     label: String = "AnimatedVisibility",
     content: @Composable AnimatedVisibilityScope.(T) -> Unit,
 ) {
@@ -47,5 +46,5 @@ private val fadeOut = fadeOut()
 private val expandVertically = expandVertically()
 private val shrinkVertically = shrinkVertically()
 
-private val columnEnterTransition = fadeIn + expandVertically
-private val columnExitTransition = fadeOut + shrinkVertically
+private val defaultEnterTransition = fadeIn + expandVertically
+private val defaultExitTransition = fadeOut + shrinkVertically

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/extensions/Float.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/extensions/Float.kt
@@ -2,8 +2,19 @@ package au.com.shiftyjelly.pocketcasts.compose.extensions
 
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.TextUnit
+import androidx.compose.ui.unit.lerp
 import androidx.compose.ui.unit.sp
 
 val Float.nonScaledSp
     @Composable
     get() = (this / LocalDensity.current.fontScale).sp
+
+@Composable
+fun Float.fractionedSp(fraction: Float): TextUnit {
+    return if (LocalDensity.current.fontScale <= 1f) {
+        this.sp
+    } else {
+        lerp(this.nonScaledSp, this.sp, fraction)
+    }
+}


### PR DESCRIPTION
## Description

Currently when there is very limited space vertical player doesn't look great. This PR address it by changing artwork's corner radius if artwork is small, hiding artwork when there is no space for or it would look bad, and decreasing font scaling of text on ads.

## Testing Instructions

Test player with various font sizes on a small device.

## Screenshots or Screencast 

| Before | After |
| - | - |
| ![a1](https://github.com/user-attachments/assets/2e69b6dc-3c61-4671-8395-a2f869ec9c01) | ![b1](https://github.com/user-attachments/assets/52778815-7650-434c-afe5-f3d528ad2a26) |
| ![a2](https://github.com/user-attachments/assets/517c18d0-bfd5-4638-ad5b-5f980eb5d158) | ![b2](https://github.com/user-attachments/assets/d0391114-c4a9-4cfe-ba68-f3f92cd465aa) |
| ![a3](https://github.com/user-attachments/assets/75d6a8fa-b1ab-4ec1-8777-aea333950984) | ![b3](https://github.com/user-attachments/assets/fad510ec-fdd1-46ed-ac2d-e8aa712e6fae) |
| ![a4](https://github.com/user-attachments/assets/2e133d63-44c7-45b9-8eaa-fe35a84d5526) | ![b4](https://github.com/user-attachments/assets/dbfe03f5-60b4-4b9a-87c9-ab446c6de6ec) |
![a5](https://github.com/user-attachments/assets/2eb1e3b0-6168-4108-8242-d4b7dc938442) | ![b5](https://github.com/user-attachments/assets/6333bad7-b3db-4407-a94f-ec62cc8bbd50) |
![a6](https://github.com/user-attachments/assets/4feb6c2e-5d14-4f91-8212-07bed24d8a04) | ![b6](https://github.com/user-attachments/assets/813188d4-9fd9-417f-8a05-bc2a3e091f7a) |

## Checklist
- [ ] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] ~I have considered whether it makes sense to add tests for my changes~
- [ ] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [ ] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack
