### PR TITLE
Fixes Discover collection image scaling

### DIFF
--- a/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/compose/PodcastRow.kt
+++ b/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/compose/PodcastRow.kt
@@ -90,7 +90,7 @@ internal fun PodcastRowPlaceholder(
     modifier: Modifier = Modifier,
 ) {
     PodcastRow(
-        podcast = DiscoverPodcastPreview,
+        podcast = DiscoverPodcastPlaceholder,
         onClickSubscribe = {},
         modifier = modifier,
     )
@@ -174,6 +174,17 @@ private fun SubscribeInteractionBox(
 
 private val IconSize = 24.dp
 private val TouchTargetSize = 48.dp
+internal val DiscoverPodcastPlaceholder = DiscoverPodcast(
+    uuid = "",
+    title = "",
+    author = "",
+    description = "",
+    url = "",
+    category = "",
+    language = "",
+    mediaType = "",
+    isSubscribed = false,
+)
 internal val DiscoverPodcastPreview = DiscoverPodcast(
     uuid = "uuid",
     title = "Title",

--- a/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/CollectionListRowAdapter.kt
+++ b/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/CollectionListRowAdapter.kt
@@ -1,7 +1,6 @@
 package au.com.shiftyjelly.pocketcasts.discover.view
 
 import android.view.LayoutInflater
-import android.view.View
 import android.view.ViewGroup
 import androidx.core.view.isVisible
 import androidx.recyclerview.widget.DiffUtil
@@ -103,7 +102,7 @@ class CollectionListRowAdapter(
 
         private val imageRequestFactory = PocketCastsImageRequestFactory(
             binding.root.context,
-            placeholderType = PlaceholderType.Large,
+            placeholderType = PlaceholderType.None,
         ).themed()
 
         init {
@@ -118,18 +117,6 @@ class CollectionListRowAdapter(
             imageRequestFactory.createForFileOrUrl(header.imageUrl).loadInto(binding.imageHeader)
             binding.root.contentDescription =
                 binding.root.context.getString(LR.string.discover_collection_header_content_description, header.title)
-        }
-
-        fun updateVisibility(isVisible: Boolean) {
-            if (isVisible) {
-                binding.root.animate()
-                    .alpha(1f)
-                    .setDuration(300)
-                    .withStartAction { binding.root.visibility = View.VISIBLE }
-                    .start()
-            } else {
-                binding.root.visibility = View.INVISIBLE
-            }
         }
     }
 

--- a/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/DiscoverAdapter.kt
+++ b/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/DiscoverAdapter.kt
@@ -56,7 +56,6 @@ import au.com.shiftyjelly.pocketcasts.discover.util.ScrollingLinearLayoutManager
 import au.com.shiftyjelly.pocketcasts.discover.view.CollectionListRowAdapter.CollectionItem.CollectionHeader
 import au.com.shiftyjelly.pocketcasts.discover.view.CollectionListRowAdapter.CollectionItem.CollectionPodcast
 import au.com.shiftyjelly.pocketcasts.discover.view.CollectionListRowAdapter.Companion.HEADER_OFFSET
-import au.com.shiftyjelly.pocketcasts.discover.view.CollectionListRowAdapter.HeaderViewHolder
 import au.com.shiftyjelly.pocketcasts.discover.view.CollectionListRowAdapter.PodcastsViewHolder.Companion.NUMBER_OF_ROWS_PER_PAGE
 import au.com.shiftyjelly.pocketcasts.discover.view.DiscoverFragment.Companion.EPISODE_UUID_KEY
 import au.com.shiftyjelly.pocketcasts.discover.view.DiscoverFragment.Companion.LIST_ID_KEY
@@ -578,8 +577,6 @@ internal class DiscoverAdapter(
                     if (newState == RecyclerView.SCROLL_STATE_IDLE) {
                         val position = linearLayoutManager.getCurrentPosition()
 
-                        updateHeader(recyclerView, position)
-
                         // Adds extra right padding starting from page 1 to preview the next page, except for the first page
                         if (position == 0) {
                             recyclerView.setPadding(8.dpToPx(itemView.context), 0, 0, 0)
@@ -607,14 +604,6 @@ internal class DiscoverAdapter(
                             recyclerView.setPadding(8.dpToPx(itemView.context), 0, 0, 0)
                         }
                     }
-                }
-
-                private fun updateHeader(
-                    recyclerView: RecyclerView,
-                    position: Int,
-                ) {
-                    val headerViewHolder = recyclerView.findViewHolderForAdapterPosition(0) as? HeaderViewHolder
-                    headerViewHolder?.updateVisibility(position != 1)
                 }
 
                 private fun trackPageChangedEvent(position: Int) {

--- a/modules/features/discover/src/main/res/layout/collection_header.xml
+++ b/modules/features/discover/src/main/res/layout/collection_header.xml
@@ -9,6 +9,14 @@
     android:focusable="true">
 
     <ImageView
+        android:id="@+id/imagePlaceholder"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:src="?attr/defaultArtwork"
+        android:scaleType="centerCrop"
+        tools:ignore="ContentDescription" />
+
+    <ImageView
         android:id="@+id/imageHeader"
         android:layout_width="match_parent"
         android:layout_height="match_parent"

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/nowplaying/EpisodeTitles.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/nowplaying/EpisodeTitles.kt
@@ -19,7 +19,6 @@ import androidx.compose.material.IconButton
 import androidx.compose.material.LocalRippleConfiguration
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.RippleConfiguration
-import androidx.compose.material.RippleDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.getValue


### PR DESCRIPTION
## Description

The scaling of the image for the guest lists and network highlight wasn't working correctly. I figured out it is related to the placeholder image being a different aspect ratio. I have removed the placeholder for this image view as it isn't square. I did try setting the image size, but we usually deal with a square image, and it was starting to get complicated. Please let me know if there's a different way you'd like me to approach this.

This change also fixes the issue with the title and author placeholder text being displayed.

Fixes https://github.com/Automattic/pocket-casts-android/issues/4158

## Testing Instructions

1. Use the debugProd variant
2. Open the Discover tab
3. Scroll down to the Network Highlight
4. ✅ Verify the image looks correct

## Screenshots 

| Before | After |
| --- | --- |
| ![centerCrop](https://github.com/user-attachments/assets/a37af828-d2fe-4afd-b44f-954fe39b221d) | ![Screenshot_20250627_153910](https://github.com/user-attachments/assets/59a8f720-ea33-47e0-b3f5-69eda5fa7519) | 

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack
