### PR TITLE
Fix notifications prompt showing too often

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@
         ([#4130](https://github.com/Automattic/pocket-casts-android/pull/4130))
     *   Add `@Transaction` to podcast queries that might result in large amount of data
         ([#4151](https://github.com/Automattic/pocket-casts-android/pull/4151))
+    *   Fix issue with notification prompt showing too often
+        ([#4151](https://github.com/Automattic/pocket-casts-android/pull/4151))
 
 7.91
 -----

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@
     *   Add `@Transaction` to podcast queries that might result in large amount of data
         ([#4151](https://github.com/Automattic/pocket-casts-android/pull/4151))
     *   Fix issue with notification prompt showing too often
-        ([#4151](https://github.com/Automattic/pocket-casts-android/pull/4151))
+        ([#4162](https://github.com/Automattic/pocket-casts-android/pull/4162))
 
 7.91
 -----

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/notifications/EnableNotificationsPromptFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/notifications/EnableNotificationsPromptFragment.kt
@@ -54,12 +54,13 @@ internal class EnableNotificationsPromptFragment : BaseDialogFragment() {
             analyticsTracker.track(AnalyticsEvent.NOTIFICATIONS_OPT_IN_ALLOWED)
         } else {
             analyticsTracker.track(AnalyticsEvent.NOTIFICATIONS_OPT_IN_DENIED)
+            handleDismissedByUser()
         }
-
+        isFinalizingActionUsed = true
         dismiss()
     }
 
-    private var wasDismissedViaCloseButton = false
+    private var isFinalizingActionUsed = false
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -84,10 +85,7 @@ internal class EnableNotificationsPromptFragment : BaseDialogFragment() {
                 EnableNotificationsPromptScreen(
                     modifier = Modifier
                         .fillMaxSize()
-                        .padding(
-                            vertical = 16.dp,
-                            horizontal = 16.dp,
-                        )
+                        .padding(16.dp)
                         .windowInsetsPadding(WindowInsets.safeDrawing.only(WindowInsetsSides.Horizontal)),
                     onCtaClicked = {
                         analyticsTracker.track(AnalyticsEvent.NOTIFICATIONS_PERMISSIONS_ALLOW_TAPPED)
@@ -101,7 +99,8 @@ internal class EnableNotificationsPromptFragment : BaseDialogFragment() {
                         }
                     },
                     onDismissClicked = {
-                        wasDismissedViaCloseButton = true
+                        isFinalizingActionUsed = true
+                        handleDismissedByUser()
                         dismiss()
                     },
                 )
@@ -111,9 +110,13 @@ internal class EnableNotificationsPromptFragment : BaseDialogFragment() {
 
     override fun onDismiss(dialog: DialogInterface) {
         super.onDismiss(dialog)
-        if (wasDismissedViaCloseButton) {
-            settings.notificationsPromptAcknowledged.set(value = true, updateModifiedAt = true)
-            analyticsTracker.track(AnalyticsEvent.NOTIFICATIONS_PERMISSIONS_DISMISSED)
+        if (!requireActivity().isChangingConfigurations && !isFinalizingActionUsed) {
+            handleDismissedByUser()
         }
+    }
+
+    private fun handleDismissedByUser() {
+        settings.notificationsPromptAcknowledged.set(value = true, updateModifiedAt = true)
+        analyticsTracker.track(AnalyticsEvent.NOTIFICATIONS_PERMISSIONS_DISMISSED)
     }
 }


### PR DESCRIPTION
## Description

Fixes #4160

## Testing Instructions

1. Start the app and do not give notification permission.
2. Go to the podcasts tab.
3. Drag down the notifications prompt.
4. Go to another tab.
5. Go back to the podcasts tab.
6. Notifications prompt should not appear.
7. Clear app's storage data.
8. Start the app and do not give notification permission.
9. Go to the podcasts tab.
10. Tap the X button.
11. Go to another tab.
12. Go back to the podcasts tab.
13. Notifications prompt should not appear.
14. Clear app's storage data.
15. Start the app and do not give notification permission.
16. Go to the podcasts tab.
17. Tap "Allow Notifications".
18. Do not grant permission.
19. Go to another tab.
20. Go back to the podcasts tab.
21. Notifications prompt should not appear.

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] ~I have considered whether it makes sense to add tests for my changes~
- [ ] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [ ] ~Any jetpack compose components I added or changed are covered by compose previews~
- [ ] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~