### PR TITLE
Improve Up Next analytic

### DIFF
--- a/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/EpisodeAnalytics.kt
+++ b/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/EpisodeAnalytics.kt
@@ -96,6 +96,7 @@ class EpisodeAnalytics @Inject constructor(
 
     private object AnalyticsProp {
         private const val source = "source"
+        private const val podcast_uuid = "podcast_uuid"
         private const val episode_uuid = "episode_uuid"
         private const val count = "count"
         private const val to_top = "to_top"
@@ -107,6 +108,7 @@ class EpisodeAnalytics @Inject constructor(
             mapOf(
                 source to eventSource.analyticsValue,
                 to_top to toTop,
+                podcast_uuid to episode.podcastOrSubstituteUuid,
                 episode_uuid to episode.uuid,
             )
 


### PR DESCRIPTION
## Description

It would be helpful to know if people are adding the paid placements to their Up Next lists. It includes the podcast UUID so we can check.

## Testing Instructions
1. Use the debugProd variant 
2. Go to the Discover tab
3. Tap on a sponsored podcast
4. Swipe on an episode row and add it to the Up Next
5. ✅ Verify the `episode_added_to_up_next` event includes the `podcast_uuid`.

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack
