### PR TITLE
Fix episodes not being removed from the downloads list

### DIFF
--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManagerImpl.kt
@@ -554,6 +554,7 @@ class EpisodeManagerImpl @Inject constructor(
         cleanUpDownloadFiles(episode)
 
         if (updateDatabase) {
+            updateDownloadTaskId(episode, null)
             updateEpisodeStatus(episode, EpisodeStatusEnum.NOT_DOWNLOADED)
             if (disableAutoDownload) {
                 updateAutoDownloadStatus(episode, PodcastEpisode.AUTO_DOWNLOAD_STATUS_IGNORE)


### PR DESCRIPTION
## Description

This change fixes an issue where, when an episode download is removed, the episode still appears in the Profile tab, Downloads page. The issue is that the query still shows episodes if the `download_task_id` column is set, and the code doesn't remove this after cancelling the download and deleting the file. 

```
SELECT * FROM podcast_episodes 
WHERE 
  (download_task_id IS NOT NULL OR 
   episode_status == 'DOWNLOADED' OR 
     (episode_status == 'DOWNLOAD_FAILED' AND 
      last_download_attempt_date > '1059149463321600000000' AND 
      archived == 0)
   ) 
ORDER BY last_download_attempt_date DESC
```

Fixes https://github.com/Automattic/pocket-casts-android/issues/4159#issuecomment-3013862206

## Testing Instructions
1. Download an episode
2. ✅ Verify the download is on the Profile tab -> Downloads page
3. Tap the episode row
4. Tap Mark Played
5. ✅ Verify the episode is removed from the Downloads tab

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [ ] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
