### PR TITLE
Don't schedule or display revamped notifications on wear or automotive

### DIFF
--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/notification/NotificationSchedulerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/notification/NotificationSchedulerImpl.kt
@@ -12,6 +12,8 @@ import au.com.shiftyjelly.pocketcasts.repositories.notification.NotificationWork
 import au.com.shiftyjelly.pocketcasts.repositories.notification.ReEngagementNotificationType.Companion.SUBCATEGORY_REENGAGE_CATCH_UP_OFFLINE
 import au.com.shiftyjelly.pocketcasts.repositories.notification.ReEngagementNotificationType.Companion.SUBCATEGORY_REENGAGE_WE_MISS_YOU
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
+import au.com.shiftyjelly.pocketcasts.utils.AppPlatform
+import au.com.shiftyjelly.pocketcasts.utils.Util
 import dagger.hilt.android.qualifiers.ApplicationContext
 import jakarta.inject.Inject
 import java.util.concurrent.TimeUnit
@@ -32,6 +34,8 @@ class NotificationSchedulerImpl @Inject constructor(
     }
 
     override fun setupOnboardingNotifications(delayProvider: ((OnboardingNotificationType) -> Duration)?) {
+        if (!isRunningOnPhone) return
+
         listOf(
             OnboardingNotificationType.Sync,
             OnboardingNotificationType.Import,
@@ -58,6 +62,8 @@ class NotificationSchedulerImpl @Inject constructor(
     }
 
     override suspend fun setupReEngagementNotification(delayProvider: ((ReEngagementNotificationType) -> Duration)?) {
+        if (!isRunningOnPhone) return
+
         val initialDelay = delayProvider?.invoke(ReEngagementNotificationType.WeMissYou)?.inWholeMilliseconds ?: delayCalculator.calculateDelayForReEngagementCheck()
 
         val downloadedEpisodes = episodeManager.downloadedEpisodesThatHaveNotBeenPlayedCount()
@@ -83,6 +89,8 @@ class NotificationSchedulerImpl @Inject constructor(
     }
 
     override suspend fun setupTrendingAndRecommendationsNotifications(delayProvider: ((TrendingAndRecommendationsNotificationType) -> Duration)?) {
+        if (!isRunningOnPhone) return
+
         TrendingAndRecommendationsNotificationType.values.forEachIndexed { index, notification ->
             val initialDelay = delayProvider?.invoke(notification)?.inWholeMilliseconds ?: delayCalculator.calculateDelayForRecommendations(index)
             val workData = workDataOf(
@@ -105,6 +113,8 @@ class NotificationSchedulerImpl @Inject constructor(
     }
 
     override suspend fun setupNewFeaturesAndTipsNotifications(delayProvider: ((NewFeaturesAndTipsNotificationType) -> Duration)?) {
+        if (!isRunningOnPhone) return
+
         // this should be later updated to fire the desired feature for the given release
         val workData = workDataOf(
             SUBCATEGORY to NewFeaturesAndTipsNotificationType.SmartFolders.subcategory,
@@ -123,6 +133,8 @@ class NotificationSchedulerImpl @Inject constructor(
     }
 
     override suspend fun setupOffersNotifications(delayProvider: ((OffersNotificationType) -> Duration)?) {
+        if (!isRunningOnPhone) return
+
         val workData = workDataOf(
             SUBCATEGORY to OffersNotificationType.UpgradeNow.subcategory,
         )
@@ -170,4 +182,6 @@ class NotificationSchedulerImpl @Inject constructor(
             }
         }
     }
+
+    private val isRunningOnPhone = Util.getAppPlatform(context) == AppPlatform.Phone
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/notification/NotificationWorker.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/notification/NotificationWorker.kt
@@ -15,6 +15,8 @@ import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.repositories.R
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.SuggestedFoldersManager
 import au.com.shiftyjelly.pocketcasts.repositories.user.UserManager
+import au.com.shiftyjelly.pocketcasts.utils.AppPlatform
+import au.com.shiftyjelly.pocketcasts.utils.Util
 import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
 import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
 import dagger.assisted.Assisted
@@ -35,6 +37,8 @@ class NotificationWorker @AssistedInject constructor(
     private val userManager: UserManager,
 ) : CoroutineWorker(context, params) {
     override suspend fun doWork(): Result {
+        if (Util.getAppPlatform(applicationContext) != AppPlatform.Phone) return Result.failure()
+
         val subcategory = inputData.getString(SUBCATEGORY) ?: return Result.failure()
 
         val type = NotificationType.fromSubCategory(subcategory) ?: return Result.failure()


### PR DESCRIPTION
## Description
I mistakenly scheduled/cancelled trending and recommendations notifications when the user's sign in state changes, unconditionally. However we should only show these kind of notifications on phone platform.
I've made changes and added checks when scheduling and showing notifications from the revamp project to ensure that they're only considered when the app is running on a phone.

Fixes https://linear.app/a8c/issue/PCDROID-12/notifications-revamp-consider-only-phone-platform

## Testing Instructions
Core review would be enough, i think 👌 


## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] ~I have considered whether it makes sense to add tests for my changes~
- [ ] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [ ] ~Any jetpack compose components I added or changed are covered by compose previews~
- [ ] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~
 