### PR TITLE
Add banner ad track events

### DIFF
--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/PlayerHeaderFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/PlayerHeaderFragment.kt
@@ -202,7 +202,7 @@ class PlayerHeaderFragment : BaseFragment(), PlayerClickListener {
         val podcastColors by remember { podcastColorsFlow() }.collectAsState(PodcastColors.ForUserEpisode)
         val headerData by remember { playerHeaderFlow() }.collectAsState(PlayerViewModel.PlayerHeader())
         val artworkOrVideoState by remember { playerVisualsStateFlow() }.collectAsState(ArtworkOrVideoState.NoContent)
-        val ads by viewModel.activeAds.collectAsState()
+        val activeAd by viewModel.activeAd.collectAsState()
 
         val isTranscriptOpen by shelfSharedViewModel.isTranscriptOpen.collectAsState()
         val transcriptUiState by transcriptViewModel.uiState.collectAsState()
@@ -232,7 +232,7 @@ class PlayerHeaderFragment : BaseFragment(), PlayerClickListener {
                             .padding(start = 16.dp, end = 16.dp, bottom = 16.dp),
                     )
                     PlayerContent(
-                        ad = ads.firstOrNull(),
+                        ad = activeAd,
                         artworkOrVideoState = artworkOrVideoState,
                         headerData = headerData,
                         playerColors = playerColors,

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/PlayerViewModel.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/PlayerViewModel.kt
@@ -74,7 +74,6 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flow
-import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.rx2.asObservable
@@ -777,6 +776,26 @@ class PlayerViewModel @Inject constructor(
                 put(AnalyticsProp.SETTINGS, settings)
             },
             sourceView = SourceView.PLAYER_PLAYBACK_EFFECTS,
+        )
+    }
+
+    fun trackAdImpression(ad: BlazeAd) {
+        analyticsTracker.track(
+            AnalyticsEvent.BANNER_AD_IMPRESSION,
+            mapOf(
+                "promotion" to "player",
+                "id" to ad.id,
+            ),
+        )
+    }
+
+    fun trackAdTapped(ad: BlazeAd) {
+        analyticsTracker.track(
+            AnalyticsEvent.BANNER_AD_TAPPED,
+            mapOf(
+                "promotion" to "player",
+                "id" to ad.id,
+            ),
         )
     }
 

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/PlayerViewModel.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/PlayerViewModel.kt
@@ -313,26 +313,26 @@ class PlayerViewModel @Inject constructor(
     val playerFlow = playbackManager.playerFlow
 
     @OptIn(ExperimentalCoroutinesApi::class)
-    val activeAds = combine(
+    val activeAd = combine(
         settings.cachedSubscription.flow,
         FeatureFlag.isEnabledFlow(Feature.BANNER_ADS),
         ::Pair,
     ).flatMapLatest { (subscription, isEnabled) ->
-        if (isEnabled && subscription == null) {
-            val mockAd = BlazeAd(
-                id = "ad-id",
-                title = "wordpress.com",
-                ctaText = "Democratize publishing and eCommerce one website at a time.",
-                ctaUrl = "https://wordpress.com/",
-                imageUrl = "https://s.w.org/style/images/about/WordPress-logotype-wmark-white.png",
-            )
-            flow {
-                emit(listOf(mockAd))
+        flow<BlazeAd?> {
+            val ad = if (isEnabled && subscription == null) {
+                BlazeAd(
+                    id = "ad-id",
+                    title = "wordpress.com",
+                    ctaText = "Democratize publishing and eCommerce one website at a time.",
+                    ctaUrl = "https://wordpress.com/",
+                    imageUrl = "https://s.w.org/style/images/about/WordPress-logotype-wmark-white.png",
+                )
+            } else {
+                null
             }
-        } else {
-            flowOf(emptyList())
+            emit(ad)
         }
-    }.stateIn(viewModelScope, started = SharingStarted.Eagerly, initialValue = emptyList())
+    }.stateIn(viewModelScope, started = SharingStarted.Eagerly, initialValue = null)
 
     fun setSleepEndOfChapters(chapters: Int = 1, shouldCallUpdateTimer: Boolean = true) {
         val newValue = chapters.coerceIn(1, 240)

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcasts/BannerAdAdapter.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcasts/BannerAdAdapter.kt
@@ -18,6 +18,7 @@ internal class BannerAdAdapter(
     private val themeType: Theme.ThemeType,
     private val onAdClick: (BlazeAd) -> Unit,
     private val onAdOptionsClick: (BlazeAd) -> Unit,
+    private val onAdImpression: (BlazeAd) -> Unit,
 ) : ListAdapter<BlazeAd, RecyclerView.ViewHolder>(BannerAdDiffCallback) {
     override fun getItemViewType(position: Int): Int {
         return AdapterViewTypeIds.BannerAdId
@@ -35,6 +36,13 @@ internal class BannerAdAdapter(
     override fun onBindViewHolder(holder: RecyclerView.ViewHolder, position: Int) {
         (holder as BannerAdViewHolder).bind(currentList[position])
     }
+
+    override fun onViewAttachedToWindow(holder: RecyclerView.ViewHolder) {
+        val ad = requireNotNull((holder as BannerAdViewHolder).ad) {
+            "Banner ad view attached without ad data"
+        }
+        onAdImpression(ad)
+    }
 }
 
 private object BannerAdDiffCallback : DiffUtil.ItemCallback<BlazeAd>() {
@@ -49,11 +57,14 @@ private class BannerAdViewHolder(
     private val onAdClick: (BlazeAd) -> Unit,
     private val onAdOptionsClick: (BlazeAd) -> Unit,
 ) : RecyclerView.ViewHolder(composeView) {
+    var ad: BlazeAd? = null
+
     init {
         composeView.setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnDetachedFromWindowOrReleasedFromPool)
     }
 
     fun bind(ad: BlazeAd) {
+        this.ad = ad
         composeView.setContent {
             AppTheme(themeType) {
                 Box(

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcasts/PodcastsFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcasts/PodcastsFragment.kt
@@ -280,8 +280,8 @@ class PodcastsFragment :
         }
 
         viewLifecycleOwner.lifecycleScope.launch {
-            viewModel.activeAds.collect { activeAds ->
-                bannerAdAdapter?.submitList(activeAds)
+            viewModel.activeAd.collect { activeAd ->
+                bannerAdAdapter?.submitList(listOfNotNull(activeAd))
             }
         }
 
@@ -487,7 +487,7 @@ class PodcastsFragment :
         val folderUuid = folderUuid
 
         binding.emptyView.setContentWithViewCompositionStrategy {
-            val ads by viewModel.activeAds.collectAsState()
+            val activeAd by viewModel.activeAd.collectAsState()
 
             AppTheme(themeType = theme.activeTheme) {
                 Column(
@@ -498,7 +498,7 @@ class PodcastsFragment :
                         .verticalScroll(rememberScrollState())
                         .padding(16.dp),
                 ) {
-                    ads.firstOrNull()?.let { ad ->
+                    activeAd?.let { ad ->
                         AdBanner(
                             ad = ad,
                             colors = rememberAdColors().bannerAd,

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/PodcastsViewModel.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/PodcastsViewModel.kt
@@ -78,30 +78,30 @@ class PodcastsViewModel @AssistedInject constructor(
         )
     }
 
-    val activeAds = if (folderUuid == null) {
+    val activeAd = if (folderUuid == null) {
         combine(
             userManager.getSignInState().asFlow(),
             FeatureFlag.isEnabledFlow(Feature.BANNER_ADS),
             ::Pair,
         ).flatMapLatest { (signInState, isEnabled) ->
-            if (isEnabled && signInState.isNoAccountOrFree) {
-                val mockAd = BlazeAd(
-                    id = "ad-id",
-                    title = "wordpress.com",
-                    ctaText = "Democratize publishing and eCommerce one website at a time.",
-                    ctaUrl = "https://wordpress.com/",
-                    imageUrl = "https://s.w.org/style/images/about/WordPress-logotype-simplified.png",
-                )
-                flow {
-                    emit(listOf(mockAd))
+            flow<BlazeAd?> {
+                val ad = if (isEnabled && signInState.isNoAccountOrFree) {
+                    BlazeAd(
+                        id = "ad-id",
+                        title = "wordpress.com",
+                        ctaText = "Democratize publishing and eCommerce one website at a time.",
+                        ctaUrl = "https://wordpress.com/",
+                        imageUrl = "https://s.w.org/style/images/about/WordPress-logotype-simplified.png",
+                    )
+                } else {
+                    null
                 }
-            } else {
-                flowOf(emptyList())
+                emit(ad)
             }
         }
     } else {
-        flowOf(emptyList())
-    }.stateIn(viewModelScope, started = SharingStarted.Eagerly, initialValue = emptyList())
+        flowOf(null)
+    }.stateIn(viewModelScope, started = SharingStarted.Eagerly, initialValue = null)
 
     init {
         viewModelScope.launch {

--- a/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
+++ b/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
@@ -796,4 +796,8 @@ enum class AnalyticsEvent(val key: String) {
     INFORMATIONAL_MODAL_VIEW_CARD_SHOWED("informational_modal_view_card_showed"),
     INFORMATIONAL_BANNER_VIEW_DISMISSED("informational_banner_view_dismissed"),
     INFORMATIONAL_BANNER_VIEW_CREATE_ACCOUNT_TAP("informational_banner_view_create_account_tap"),
+
+    /* Banner Ads */
+    BANNER_AD_IMPRESSION("banner_ad_impression"),
+    BANNER_AD_TAPPED("banner_ad_tapped"),
 }

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/ad/AdBanner.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/ad/AdBanner.kt
@@ -34,6 +34,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
@@ -57,6 +58,7 @@ import au.com.shiftyjelly.pocketcasts.compose.extensions.fractionedSp
 import au.com.shiftyjelly.pocketcasts.compose.preview.ThemePreviewParameterProvider
 import au.com.shiftyjelly.pocketcasts.compose.theme
 import au.com.shiftyjelly.pocketcasts.repositories.images.PocketCastsImageRequestFactory
+import au.com.shiftyjelly.pocketcasts.repositories.images.PocketCastsImageRequestFactory.PlaceholderType
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme.ThemeType
 import au.com.shiftyjelly.pocketcasts.images.R as IR
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
@@ -95,9 +97,11 @@ fun AdBanner(
             ) {
                 val context = LocalContext.current
                 val theme = MaterialTheme.theme
+                val isPreview = LocalInspectionMode.current
                 CoilImage(
                     imageRequest = remember(context, theme.isDark, ad.imageUrl) {
-                        PocketCastsImageRequestFactory(context).createForFileOrUrl(ad.imageUrl)
+                        val placeholder = if (isPreview) PlaceholderType.Small else PlaceholderType.None
+                        PocketCastsImageRequestFactory(context, placeholderType = placeholder).createForFileOrUrl(ad.imageUrl)
                     },
                     title = stringResource(LR.string.ad_image),
                     showTitle = false,


### PR DESCRIPTION
## Description

This PR adds event racking for banner ads. I also restructured the data layer a bit. Since we're displaying only a single ad I changed data to represent that instead of an list of ads.

## Testing Instructions

Verify these events:

<img width="1031" alt="Screenshot 2025-07-04 at 12 40 40" src="https://github.com/user-attachments/assets/ba6acb8f-d457-4d9a-a3c1-46633567e4fb" />


## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.