### PR TITLE
[Onboarding] Add new generic upgrade variants

### DIFF
--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/components/UpgradeFeatureItem.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/components/UpgradeFeatureItem.kt
@@ -23,7 +23,8 @@ import au.com.shiftyjelly.pocketcasts.ui.R as UR
 fun UpgradeFeatureItem(
     item: UpgradeFeatureItem,
     modifier: Modifier = Modifier,
-    color: Color = Color.Black,
+    iconColor: Color = Color.Black,
+    textColor: Color = Color.Black,
 ) {
     Row(
         modifier = modifier
@@ -35,7 +36,7 @@ fun UpgradeFeatureItem(
         Icon(
             painter = painterResource(item.image),
             contentDescription = null,
-            tint = color,
+            tint = iconColor,
             modifier = modifier
                 .size(20.dp)
                 .padding(2.dp),
@@ -43,8 +44,8 @@ fun UpgradeFeatureItem(
         Spacer(Modifier.width(16.dp))
         HtmlText(
             html = stringResource(id = item.title),
-            color = color,
-            linkColor = color,
+            color = textColor,
+            linkColor = textColor,
             textStyleResId = UR.style.H50,
         )
     }

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/components/UpgradePlanSelector.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/components/UpgradePlanSelector.kt
@@ -1,0 +1,211 @@
+package au.com.shiftyjelly.pocketcasts.account.onboarding.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.Icon
+import androidx.compose.material.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.layout.SubcomposeLayout
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewParameter
+import androidx.compose.ui.unit.dp
+import au.com.shiftyjelly.pocketcasts.compose.AppThemeWithBackground
+import au.com.shiftyjelly.pocketcasts.compose.components.TextH40
+import au.com.shiftyjelly.pocketcasts.compose.components.TextH50
+import au.com.shiftyjelly.pocketcasts.compose.preview.ThemePreviewParameterProvider
+import au.com.shiftyjelly.pocketcasts.compose.theme
+import au.com.shiftyjelly.pocketcasts.images.R
+import au.com.shiftyjelly.pocketcasts.ui.theme.Theme.ThemeType
+
+@Composable
+fun UpgradePlanSelector(
+    plan: String,
+    priceAndPeriod: String,
+    isSelected: Boolean,
+    onSelected: () -> Unit,
+    modifier: Modifier = Modifier,
+    savings: String? = null,
+    pricePerWeek: String? = null,
+) {
+    SubcomposeLayout(modifier = modifier) { constraints ->
+        val savingsBadge = savings?.let {
+            val badgeMeasurable = subcompose("savings") {
+                SavingsLabel(
+                    savings = savings,
+                )
+            }
+            badgeMeasurable.first().measure(constraints)
+        }
+        val badgeHeight = savingsBadge?.height ?: 0
+
+        val row = subcompose("selector_row") {
+            PlanRow(
+                modifier = Modifier.fillMaxWidth(),
+                plan = plan,
+                priceAndPeriod = priceAndPeriod,
+                isSelected = isSelected,
+                onSelected = onSelected,
+                pricePerWeek = pricePerWeek,
+            )
+        }
+        val placeable = row.first().measure(constraints)
+        val rowWidth = placeable.width
+        val rowHeight = placeable.height
+
+        val totalHeight = rowHeight + badgeHeight / 2
+        layout(rowWidth, totalHeight) {
+            placeable.placeRelative(x = 0, y = badgeHeight / 2)
+            savingsBadge?.let {
+                it.placeRelative(x = (rowWidth - it.width) / 2, y = 0)
+            }
+        }
+    }
+}
+
+@Composable
+private fun PlanRow(
+    plan: String,
+    priceAndPeriod: String,
+    isSelected: Boolean,
+    onSelected: () -> Unit,
+    modifier: Modifier = Modifier,
+    pricePerWeek: String? = null,
+) {
+    Row(
+        modifier = modifier
+            .clip(RoundedCornerShape(12.dp))
+            .then(
+                if (isSelected) {
+                    Modifier.border(
+                        width = 2.dp,
+                        color = MaterialTheme.theme.colors.primaryInteractive01,
+                        shape = RoundedCornerShape(12.dp),
+                    )
+                } else {
+                    Modifier
+                },
+            )
+            .background(
+                color = MaterialTheme.theme.colors.primaryUi03,
+            )
+            .clickable { onSelected() }
+            .padding(16.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(16.dp),
+    ) {
+        Box(
+            modifier = Modifier
+                .size(24.dp)
+                .clip(CircleShape)
+                .then(
+                    if (isSelected) {
+                        Modifier.background(color = MaterialTheme.theme.colors.primaryInteractive01)
+                    } else {
+                        Modifier.border(
+                            width = 2.dp,
+                            color = MaterialTheme.theme.colors.primaryIcon02,
+                            shape = CircleShape,
+                        )
+                    },
+                ),
+            contentAlignment = Alignment.Center,
+        ) {
+            if (isSelected) {
+                Icon(
+                    painter = painterResource(R.drawable.ic_check),
+                    contentDescription = "",
+                    tint = MaterialTheme.theme.colors.primaryInteractive02,
+                )
+            }
+        }
+
+        Column(modifier = Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(7.dp)) {
+            TextH40(
+                text = plan,
+                color = MaterialTheme.theme.colors.primaryText01,
+                fontWeight = FontWeight.W700,
+            )
+            TextH40(
+                text = priceAndPeriod,
+                color = MaterialTheme.theme.colors.secondaryText02,
+            )
+        }
+        pricePerWeek?.let {
+            TextH40(
+                text = pricePerWeek,
+                color = MaterialTheme.theme.colors.secondaryText02,
+            )
+        }
+    }
+}
+
+@Composable
+private fun SavingsLabel(
+    savings: String,
+    modifier: Modifier = Modifier,
+) {
+    TextH50(
+        modifier = modifier
+            .background(
+                color = MaterialTheme.theme.colors.primaryInteractive01,
+                shape = RoundedCornerShape(12.dp),
+            )
+            .padding(horizontal = 12.dp, vertical = 2.dp),
+        text = savings,
+        color = MaterialTheme.theme.colors.primaryInteractive02,
+    )
+}
+
+@Preview
+@Composable
+private fun PreviewUpgradePlanSelectors(
+    @PreviewParameter(ThemePreviewParameterProvider::class) theme: ThemeType,
+) {
+    AppThemeWithBackground(theme) {
+        Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+            UpgradePlanSelector(
+                plan = "Annual plan",
+                priceAndPeriod = "$33.99/year",
+                isSelected = false,
+                onSelected = {},
+                pricePerWeek = "1.11/week",
+            )
+            UpgradePlanSelector(
+                plan = "Annual plan",
+                priceAndPeriod = "$33.99/year",
+                isSelected = true,
+                onSelected = {},
+                pricePerWeek = "1.11/week",
+            )
+            UpgradePlanSelector(
+                plan = "Annual plan",
+                priceAndPeriod = "$33.99/year",
+                isSelected = false,
+                onSelected = {},
+                savings = "Save 12%",
+            )
+            UpgradePlanSelector(
+                plan = "Annual plan",
+                priceAndPeriod = "$33.99/year",
+                isSelected = true,
+                onSelected = {},
+                savings = "Save 12%",
+            )
+        }
+    }
+}

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/components/UpgradeTrialScheduleItem.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/components/UpgradeTrialScheduleItem.kt
@@ -1,0 +1,127 @@
+package au.com.shiftyjelly.pocketcasts.account.onboarding.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.Icon
+import androidx.compose.material.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawWithContent
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.painter.Painter
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewParameter
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import au.com.shiftyjelly.pocketcasts.compose.AppThemeWithBackground
+import au.com.shiftyjelly.pocketcasts.compose.components.TextP50
+import au.com.shiftyjelly.pocketcasts.compose.preview.ThemePreviewParameterProvider
+import au.com.shiftyjelly.pocketcasts.compose.theme
+import au.com.shiftyjelly.pocketcasts.ui.theme.Theme.ThemeType
+import au.com.shiftyjelly.pocketcasts.images.R as IR
+
+@Composable
+fun UpgradeTrialScheduleItem(
+    title: String,
+    message: String,
+    icon: Painter,
+    modifier: Modifier = Modifier,
+    connection: ScheduleItemConnection? = null,
+    iconSize: Dp = 43.dp,
+    connectingRodWith: Dp = 8.dp,
+) {
+    val iconBackground = MaterialTheme.theme.colors.primaryInteractive01
+    val density = LocalDensity.current
+    val connectingRodWidthPx = density.run { connectingRodWith.toPx() }
+    val iconSizePx = density.run { iconSize.toPx() }
+    Row(
+        modifier = modifier
+            .drawWithContent {
+                when (connection) {
+                    ScheduleItemConnection.TOP -> drawRect(
+                        color = iconBackground,
+                        topLeft = Offset(x = iconSizePx / 2f - (connectingRodWidthPx / 2f), y = -1f),
+                        size = Size(width = connectingRodWidthPx, height = size.height / 2f),
+                    )
+
+                    ScheduleItemConnection.BOTTOM -> drawRect(
+                        color = iconBackground,
+                        topLeft = Offset(x = iconSizePx / 2f - (connectingRodWidthPx / 2f), y = size.height / 2f),
+                        size = Size(width = connectingRodWidthPx, height = (size.height / 2f) + 1f),
+                    )
+
+                    ScheduleItemConnection.TOP_AND_BOTTOM -> drawRect(
+                        color = iconBackground,
+                        topLeft = Offset(x = iconSizePx / 2f - (connectingRodWidthPx / 2f), y = 0f),
+                        size = Size(width = connectingRodWidthPx, height = size.height),
+                    )
+
+                    else -> Unit
+                }
+                drawContent()
+            },
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(14.dp),
+    ) {
+        Box(
+            modifier = Modifier
+                .size(iconSize)
+                .background(
+                    color = iconBackground,
+                    shape = CircleShape,
+                ),
+            contentAlignment = Alignment.Center,
+        ) {
+            Icon(
+                painter = icon,
+                tint = MaterialTheme.colors.background,
+                contentDescription = "",
+            )
+        }
+        Column(modifier = Modifier.fillMaxWidth()) {
+            TextP50(
+                text = title,
+                color = MaterialTheme.theme.colors.primaryText01,
+                fontWeight = FontWeight.W700,
+            )
+            TextP50(
+                text = message,
+                color = MaterialTheme.theme.colors.secondaryText02,
+            )
+        }
+    }
+}
+
+enum class ScheduleItemConnection {
+    TOP,
+    BOTTOM,
+    TOP_AND_BOTTOM,
+}
+
+@Preview
+@Composable
+private fun PreviewUpgradeTrialSchedules(
+    @PreviewParameter(ThemePreviewParameterProvider::class) theme: ThemeType,
+) {
+    AppThemeWithBackground(theme) {
+        Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+            UpgradeTrialScheduleItem(
+                title = "Title1",
+                message = "Message 1",
+                icon = painterResource(IR.drawable.ic_unlocked),
+                connection = ScheduleItemConnection.TOP,
+            )
+        }
+    }
+}

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeFlow.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeFlow.kt
@@ -118,7 +118,7 @@ fun OnboardingUpgradeFlow(
         content = {
             if (flow !is OnboardingFlow.PlusAccountUpgrade) {
                 if (FeatureFlag.isEnabled(Feature.NEW_ONBOARDING_UPGRADE)) {
-                    OnboardingUpgradeVariantsScreen(onClosePressed = onBackPressed, onPlanChanged = {}, onSubscribePressed = {})
+                    OnboardingUpgradeVariantsScreen(onClosePressed = onBackPressed, onSubscribePressed = {})
                 } else {
                     OnboardingUpgradeFeaturesPage(
                         viewModel = viewModel,

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeVariants.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeVariants.kt
@@ -100,7 +100,7 @@ internal fun OnboardingUpgradeFeaturesScreen(
                 modifier = Modifier.weight(1f),
                 subscriptionPlan = OnboardingSubscriptionPlan.create(
                     SubscriptionPlan.WithOffer(
-                        name = "plus", tier = SubscriptionTier.Plus, billingCycle = BillingCycle.Monthly, offer = SubscriptionOffer.Trial, pricingPhases = listOf(
+                        name = "plus", tier = SubscriptionTier.Plus, billingCycle = BillingCycle.Yearly, offer = SubscriptionOffer.Trial, pricingPhases = listOf(
                             PricingPhase(
                                 price = Price(
                                     amount = BigDecimal.valueOf(0), currencyCode = "USD", formattedPrice = "$29.9"
@@ -183,7 +183,11 @@ private fun FeaturesContent(
 ) {
     Column {
         featureList.forEach {
-            UpgradeFeatureItem(it)
+            UpgradeFeatureItem(
+                item = it,
+                textColor = MaterialTheme.theme.colors.secondaryText02,
+                iconColor = MaterialTheme.theme.colors.primaryText01,
+            )
         }
         Spacer(modifier = Modifier.height(24.dp))
         onShowScheduleClicked?.let {

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeVariants.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeVariants.kt
@@ -5,7 +5,6 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxHeight
@@ -27,11 +26,9 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.draw.drawWithContent
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Size
-import androidx.compose.ui.graphics.BlendMode
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.painter.Painter
@@ -39,7 +36,6 @@ import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.dp
@@ -63,6 +59,7 @@ import au.com.shiftyjelly.pocketcasts.ui.theme.Theme.ThemeType
 import java.math.BigDecimal
 import kotlinx.coroutines.launch
 import au.com.shiftyjelly.pocketcasts.images.R as IR
+import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 @Composable
 internal fun OnboardingUpgradeFeaturesScreen(
@@ -76,20 +73,27 @@ internal fun OnboardingUpgradeFeaturesScreen(
             onClick = onClosePressed,
             modifier = Modifier.align(Alignment.TopEnd),
         ) {
-            Icon(
-                modifier = Modifier.background(color = MaterialTheme.theme.colors.primaryUi05, shape = CircleShape),
-                painter = painterResource(IR.drawable.ic_close),
-                contentDescription = stringResource(au.com.shiftyjelly.pocketcasts.localization.R.string.close),
-                tint = MaterialTheme.theme.colors.primaryIcon01,
-            )
+            Box(
+                modifier = Modifier
+                    .size(28.dp)
+                    .background(color = MaterialTheme.theme.colors.primaryUi05, shape = CircleShape),
+                contentAlignment = Alignment.Center,
+            ) {
+                Icon(
+                    modifier = Modifier.size(24.dp),
+                    painter = painterResource(IR.drawable.ic_close),
+                    contentDescription = stringResource(au.com.shiftyjelly.pocketcasts.localization.R.string.close),
+                    tint = MaterialTheme.theme.colors.primaryIcon01,
+                )
+            }
         }
 
         Column(
             modifier = Modifier
                 .fillMaxSize()
                 .padding(
-                    horizontal = 12.dp,
-                    vertical = 12.dp,
+                    horizontal = 24.dp,
+                    vertical = 16.dp,
                 ),
         ) {
             UpgradeContent(
@@ -140,13 +144,16 @@ private fun UpgradeContent(
                 .wrapContentHeight(),
         )
         Spacer(modifier = Modifier.height(24.dp))
-        TextH10(text = "Superpowers for your podcasts", color = MaterialTheme.theme.colors.primaryText01)
+        TextH10(
+            text = stringResource(LR.string.onboarding_upgrade_generic_title),
+            color = MaterialTheme.theme.colors.primaryText01,
+        )
         Spacer(modifier = Modifier.height(24.dp))
 
         val pagerState = rememberPagerState(initialPage = 0) { 2 }
         val coroutineScope = rememberCoroutineScope()
         VerticalPager(state = pagerState, modifier = Modifier.fillMaxSize()) { page ->
-            if (page == 1) {
+            if (page == 0) {
                 FeaturesContent(
                     featureList = subscriptionPlan.featureItems,
                     onShowScheduleClicked = {
@@ -181,7 +188,7 @@ private fun FeaturesContent(
         Spacer(modifier = Modifier.height(24.dp))
         onShowScheduleClicked?.let {
             TextP40(
-                text = "How does the free trial work?",
+                text = stringResource(LR.string.onboarding_upgrade_features_trial_schedule),
                 modifier = Modifier.clickable { it() },
                 color = MaterialTheme.theme.colors.primaryInteractive01
             )
@@ -194,54 +201,55 @@ private fun ScheduleContent(
     pricingPhase: PricingPhase,
     onShowFeaturesClicked: (() -> Unit)? = null,
 ) {
-    val gradientColors = listOf(
-        Color.Transparent,
-        Color.White.copy(alpha = .8f),
-    )
-    val density = LocalDensity.current
-    val iconSizePx = density.run { 43.dp.toPx() }
-    Column(
-        modifier = Modifier.drawWithContent {
-            drawContent()
-            drawRect(
-                brush = Brush.verticalGradient(
-                    colors = gradientColors,
-                ),
-                topLeft = Offset(x = 0f, y = 0f),
-                size = Size(width = iconSizePx, size.height),
+    Column {
+        val gradientColors = listOf(
+            Color.Transparent,
+            MaterialTheme.colors.background.copy(alpha = 0.8f)
+        )
+        val density = LocalDensity.current
+        val iconSizePx = density.run { 43.dp.toPx() }
+        Column(
+            modifier = Modifier.drawWithContent {
+                drawContent()
+                drawRect(
+                    brush = Brush.verticalGradient(
+                        colors = gradientColors,
+                    ),
+                    topLeft = Offset(x = 0f, y = 0f),
+                    size = Size(width = iconSizePx, size.height),
+                )
+            },
+        ) {
+            ScheduleItem(
+                modifier = Modifier.heightIn(min = 64.dp),
+                title = stringResource(LR.string.onboarding_upgrade_schedule_today),
+                message = stringResource(LR.string.onboarding_upgrade_schedule_today_message),
+                icon = painterResource(IR.drawable.ic_unlocked),
+                connection = ScheduleItemConnection.BOTTOM,
             )
-        },
-    ) {
-        ScheduleItem(
-            modifier = Modifier.heightIn(min = 64.dp),
-            title = "Today",
-            message = "Get access to Folders, Shuffle, Bookmarks, and exclusive contnet",
-            icon = painterResource(IR.drawable.ic_locked_large), // TODO unlock
-            connection = ScheduleItemConnection.BOTTOM,
-        )
-        ScheduleItem(
-            modifier = Modifier.heightIn(min = 64.dp),
-            title = "Day ${pricingPhase.schedule.periodCount - 7}",
-            message = "We'll notify you about your trial ending.",
-            icon = painterResource(IR.drawable.ic_notifications),
-            connection = ScheduleItemConnection.TOP_AND_BOTTOM,
-        )
-        ScheduleItem(
-            modifier = Modifier.heightIn(min = 64.dp),
-            title = "Day ${pricingPhase.schedule.periodCount}",
-            message = "You'll be charged on September 31th.\nCancel anytime before.",
-            icon = painterResource(IR.drawable.ic_star),
-            connection = ScheduleItemConnection.TOP,
-        )
-    }
-    Spacer(modifier = Modifier.height(24.dp))
-    onShowFeaturesClicked?.let {
-        TextP40(
-            textAlign = TextAlign.Start,
-            text = "See all Plus features",
-            modifier = Modifier.clickable { it() },
-            color = MaterialTheme.theme.colors.primaryInteractive01
-        )
+            ScheduleItem(
+                modifier = Modifier.heightIn(min = 64.dp),
+                title = stringResource(LR.string.onboarding_upgrade_schedule_day, pricingPhase.schedule.periodCount - 7),
+                message = stringResource(LR.string.onboarding_upgrade_schedule_notify),
+                icon = painterResource(IR.drawable.ic_envelope),
+                connection = ScheduleItemConnection.TOP_AND_BOTTOM,
+            )
+            ScheduleItem(
+                modifier = Modifier.heightIn(min = 64.dp),
+                title = stringResource(LR.string.onboarding_upgrade_schedule_day, pricingPhase.schedule.periodCount),
+                message = stringResource(LR.string.onboarding_upgrade_schedule_billing, "September 31th"),
+                icon = painterResource(IR.drawable.ic_star),
+                connection = ScheduleItemConnection.TOP,
+            )
+        }
+        Spacer(modifier = Modifier.height(24.dp))
+        onShowFeaturesClicked?.let {
+            TextP40(
+                text = stringResource(LR.string.onboarding_upgrade_schedule_see_features),
+                modifier = Modifier.clickable { it() },
+                color = MaterialTheme.theme.colors.primaryInteractive01
+            )
+        }
     }
 }
 

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeVariants.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeVariants.kt
@@ -1,0 +1,312 @@
+package au.com.shiftyjelly.pocketcasts.account.onboarding.upgrade
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.wrapContentHeight
+import androidx.compose.foundation.layout.wrapContentWidth
+import androidx.compose.foundation.pager.VerticalPager
+import androidx.compose.foundation.pager.rememberPagerState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.Icon
+import androidx.compose.material.IconButton
+import androidx.compose.material.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.draw.drawWithContent
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.BlendMode
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.painter.Painter
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewParameter
+import androidx.compose.ui.unit.dp
+import au.com.shiftyjelly.pocketcasts.account.onboarding.components.UpgradeFeatureItem
+import au.com.shiftyjelly.pocketcasts.compose.AppThemeWithBackground
+import au.com.shiftyjelly.pocketcasts.compose.components.TextH10
+import au.com.shiftyjelly.pocketcasts.compose.components.TextP40
+import au.com.shiftyjelly.pocketcasts.compose.components.TextP50
+import au.com.shiftyjelly.pocketcasts.compose.images.SubscriptionBadge
+import au.com.shiftyjelly.pocketcasts.compose.preview.ThemePreviewParameterProvider
+import au.com.shiftyjelly.pocketcasts.compose.theme
+import au.com.shiftyjelly.pocketcasts.payment.BillingCycle
+import au.com.shiftyjelly.pocketcasts.payment.Price
+import au.com.shiftyjelly.pocketcasts.payment.PricingPhase
+import au.com.shiftyjelly.pocketcasts.payment.PricingSchedule
+import au.com.shiftyjelly.pocketcasts.payment.SubscriptionOffer
+import au.com.shiftyjelly.pocketcasts.payment.SubscriptionPlan
+import au.com.shiftyjelly.pocketcasts.payment.SubscriptionTier
+import au.com.shiftyjelly.pocketcasts.payment.getOrNull
+import au.com.shiftyjelly.pocketcasts.ui.theme.Theme.ThemeType
+import java.math.BigDecimal
+import kotlinx.coroutines.launch
+import au.com.shiftyjelly.pocketcasts.images.R as IR
+
+@Composable
+internal fun OnboardingUpgradeFeaturesScreen(
+    onClosePressed: () -> Unit,
+    onPlanChanged: (SubscriptionPlan) -> Unit,
+    onSubscribePressed: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Box(modifier = modifier.background(color = MaterialTheme.colors.background)) {
+        IconButton(
+            onClick = onClosePressed,
+            modifier = Modifier.align(Alignment.TopEnd),
+        ) {
+            Icon(
+                modifier = Modifier.background(color = MaterialTheme.theme.colors.primaryUi05, shape = CircleShape),
+                painter = painterResource(IR.drawable.ic_close),
+                contentDescription = stringResource(au.com.shiftyjelly.pocketcasts.localization.R.string.close),
+                tint = MaterialTheme.theme.colors.primaryIcon01,
+            )
+        }
+
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(
+                    horizontal = 12.dp,
+                    vertical = 12.dp,
+                ),
+        ) {
+            UpgradeContent(
+                modifier = Modifier.weight(1f),
+                subscriptionPlan = OnboardingSubscriptionPlan.create(
+                    SubscriptionPlan.WithOffer(
+                        name = "plus", tier = SubscriptionTier.Plus, billingCycle = BillingCycle.Monthly, offer = SubscriptionOffer.Trial, pricingPhases = listOf(
+                            PricingPhase(
+                                price = Price(
+                                    amount = BigDecimal.valueOf(0), currencyCode = "USD", formattedPrice = "$29.9"
+                                ),
+                                schedule = PricingSchedule(recurrenceMode = PricingSchedule.RecurrenceMode.Recurring(1), period = PricingSchedule.Period.Monthly, periodCount = 1)
+                            ),
+                            PricingPhase(
+                                price = Price(
+                                    amount = BigDecimal.valueOf(39.9), currencyCode = "USD", formattedPrice = "$29.9"
+                                ),
+                                schedule = PricingSchedule(recurrenceMode = PricingSchedule.RecurrenceMode.Infinite, period = PricingSchedule.Period.Monthly, periodCount = 11)
+                            ),
+                        )
+                    )
+                ).getOrNull()!!
+            )
+            Box(
+                modifier = Modifier
+                    .fillMaxHeight(.3f)
+                    .fillMaxWidth()
+                    .background(color = Color.Blue)
+            )
+        }
+
+    }
+}
+
+@Composable
+private fun UpgradeContent(
+    subscriptionPlan: OnboardingSubscriptionPlan,
+    modifier: Modifier = Modifier
+) {
+    Column(modifier = modifier) {
+        SubscriptionBadge(
+            iconRes = subscriptionPlan.badgeIconRes,
+            shortNameRes = subscriptionPlan.shortNameRes,
+            backgroundColor = Color.Black,
+            textColor = Color.White,
+            modifier = Modifier
+                .wrapContentWidth()
+                .wrapContentHeight(),
+        )
+        Spacer(modifier = Modifier.height(24.dp))
+        TextH10(text = "Superpowers for your podcasts", color = MaterialTheme.theme.colors.primaryText01)
+        Spacer(modifier = Modifier.height(24.dp))
+
+        val pagerState = rememberPagerState(initialPage = 0) { 2 }
+        val coroutineScope = rememberCoroutineScope()
+        VerticalPager(state = pagerState, modifier = Modifier.fillMaxSize()) { page ->
+            if (page == 1) {
+                FeaturesContent(
+                    featureList = subscriptionPlan.featureItems,
+                    onShowScheduleClicked = {
+                        coroutineScope.launch {
+                            pagerState.animateScrollToPage(0)
+                        }
+                    },
+                )
+            } else {
+                ScheduleContent(
+                    pricingPhase = subscriptionPlan.pricingPhase,
+                    onShowFeaturesClicked = {
+                        coroutineScope.launch {
+                            pagerState.animateScrollToPage(1)
+                        }
+                    },
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun FeaturesContent(
+    featureList: List<UpgradeFeatureItem>,
+    onShowScheduleClicked: (() -> Unit)? = null,
+) {
+    Column {
+        featureList.forEach {
+            UpgradeFeatureItem(it)
+        }
+        Spacer(modifier = Modifier.height(24.dp))
+        onShowScheduleClicked?.let {
+            TextP40(
+                text = "How does the free trial work?",
+                modifier = Modifier.clickable { it() },
+                color = MaterialTheme.theme.colors.primaryInteractive01
+            )
+        }
+    }
+}
+
+@Composable
+private fun ScheduleContent(
+    pricingPhase: PricingPhase,
+    onShowFeaturesClicked: (() -> Unit)? = null,
+) {
+    val gradientColors = listOf(
+        Color.Transparent,
+        Color.White.copy(alpha = .8f),
+    )
+    val density = LocalDensity.current
+    val iconSizePx = density.run { 43.dp.toPx() }
+    Column(
+        modifier = Modifier.drawWithContent {
+            drawContent()
+            drawRect(
+                brush = Brush.verticalGradient(
+                    colors = gradientColors,
+                ),
+                topLeft = Offset(x = 0f, y = 0f),
+                size = Size(width = iconSizePx, size.height),
+            )
+        },
+    ) {
+        ScheduleItem(
+            modifier = Modifier.heightIn(min = 64.dp),
+            title = "Today",
+            message = "Get access to Folders, Shuffle, Bookmarks, and exclusive contnet",
+            icon = painterResource(IR.drawable.ic_locked_large), // TODO unlock
+            connection = ScheduleItemConnection.BOTTOM,
+        )
+        ScheduleItem(
+            modifier = Modifier.heightIn(min = 64.dp),
+            title = "Day ${pricingPhase.schedule.periodCount - 7}",
+            message = "We'll notify you about your trial ending.",
+            icon = painterResource(IR.drawable.ic_notifications),
+            connection = ScheduleItemConnection.TOP_AND_BOTTOM,
+        )
+        ScheduleItem(
+            modifier = Modifier.heightIn(min = 64.dp),
+            title = "Day ${pricingPhase.schedule.periodCount}",
+            message = "You'll be charged on September 31th.\nCancel anytime before.",
+            icon = painterResource(IR.drawable.ic_star),
+            connection = ScheduleItemConnection.TOP,
+        )
+    }
+    Spacer(modifier = Modifier.height(24.dp))
+    onShowFeaturesClicked?.let {
+        TextP40(
+            textAlign = TextAlign.Start,
+            text = "See all Plus features",
+            modifier = Modifier.clickable { it() },
+            color = MaterialTheme.theme.colors.primaryInteractive01
+        )
+    }
+}
+
+@Composable
+private fun ScheduleItem(
+    title: String,
+    message: String,
+    icon: Painter,
+    connection: ScheduleItemConnection,
+    modifier: Modifier = Modifier
+) {
+    val iconBackground = MaterialTheme.theme.colors.primaryInteractive01
+    val density = LocalDensity.current
+    val connectingRodWidthPx = density.run { 8.dp.toPx() }
+    val iconSize = 43.dp
+    val iconSizePx = density.run { iconSize.toPx() }
+    Row(
+        modifier = modifier
+            .drawWithContent {
+                when (connection) {
+                    ScheduleItemConnection.TOP -> drawRect(color = iconBackground, topLeft = Offset(x = iconSizePx / 2f - (connectingRodWidthPx / 2f), y = -1f), size = Size(width = connectingRodWidthPx, height = size.height / 2f))
+                    ScheduleItemConnection.BOTTOM -> drawRect(color = iconBackground, topLeft = Offset(x = iconSizePx / 2f - (connectingRodWidthPx / 2f), y = size.height / 2f), size = Size(width = connectingRodWidthPx, height = (size.height / 2f) + 1f))
+                    ScheduleItemConnection.TOP_AND_BOTTOM -> drawRect(color = iconBackground, topLeft = Offset(x = iconSizePx / 2f - (connectingRodWidthPx / 2f), y = 0f), size = Size(width = connectingRodWidthPx, height = size.height))
+                }
+                drawContent()
+            },
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(14.dp),
+    ) {
+        Box(
+            modifier = Modifier
+                .size(iconSize)
+                .background(color = iconBackground, shape = CircleShape),
+            contentAlignment = Alignment.Center,
+        ) {
+            Icon(
+                painter = icon,
+                tint = MaterialTheme.colors.background,
+                contentDescription = "",
+            )
+        }
+        Column(modifier = Modifier.fillMaxWidth()) {
+            TextP50(text = title, color = MaterialTheme.theme.colors.primaryText01, fontWeight = FontWeight.W700)
+            TextP50(text = message, color = MaterialTheme.theme.colors.secondaryText02)
+        }
+    }
+}
+
+private enum class ScheduleItemConnection {
+    TOP,
+    BOTTOM,
+    TOP_AND_BOTTOM
+}
+
+@Preview
+@Composable
+private fun PreviewOnboardingUpgradeFeaturesScreen(
+    @PreviewParameter(ThemePreviewParameterProvider::class) theme: ThemeType,
+) {
+    AppThemeWithBackground(theme) {
+        OnboardingUpgradeFeaturesScreen(
+            modifier = Modifier.fillMaxSize(),
+            onSubscribePressed = {},
+            onPlanChanged = {},
+            onClosePressed = {},
+        )
+    }
+}

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeVariantsScreen.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeVariantsScreen.kt
@@ -1,12 +1,9 @@
 package au.com.shiftyjelly.pocketcasts.account.onboarding.upgrade
 
 import androidx.compose.foundation.background
-import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -20,7 +17,6 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.pager.VerticalPager
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Icon
 import androidx.compose.material.IconButton
 import androidx.compose.material.MaterialTheme
@@ -32,14 +28,11 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.drawWithContent
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.painter.Painter
-import androidx.compose.ui.layout.SubcomposeLayout
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
@@ -48,15 +41,15 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.dp
+import au.com.shiftyjelly.pocketcasts.account.onboarding.components.ScheduleItemConnection
 import au.com.shiftyjelly.pocketcasts.account.onboarding.components.UpgradeFeatureItem
+import au.com.shiftyjelly.pocketcasts.account.onboarding.components.UpgradePlanSelector
+import au.com.shiftyjelly.pocketcasts.account.onboarding.components.UpgradeTrialScheduleItem
 import au.com.shiftyjelly.pocketcasts.account.onboarding.upgrade.OnboardingUpgradeHelper.PrivacyPolicy
 import au.com.shiftyjelly.pocketcasts.account.onboarding.upgrade.OnboardingUpgradeHelper.UpgradeRowButton
 import au.com.shiftyjelly.pocketcasts.compose.AppThemeWithBackground
 import au.com.shiftyjelly.pocketcasts.compose.components.TextH10
-import au.com.shiftyjelly.pocketcasts.compose.components.TextH40
-import au.com.shiftyjelly.pocketcasts.compose.components.TextH50
 import au.com.shiftyjelly.pocketcasts.compose.components.TextP40
-import au.com.shiftyjelly.pocketcasts.compose.components.TextP50
 import au.com.shiftyjelly.pocketcasts.compose.images.SubscriptionBadge
 import au.com.shiftyjelly.pocketcasts.compose.preview.ThemePreviewParameterProvider
 import au.com.shiftyjelly.pocketcasts.compose.theme
@@ -77,7 +70,6 @@ import au.com.shiftyjelly.pocketcasts.localization.R as LR
 @Composable
 fun OnboardingUpgradeVariantsScreen(
     onClosePressed: () -> Unit,
-    onPlanChanged: (SubscriptionPlan) -> Unit,
     onSubscribePressed: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -109,7 +101,7 @@ fun OnboardingUpgradeVariantsScreen(
                     vertical = 16.dp,
                 ),
         ) {
-            val create = OnboardingSubscriptionPlan.create(
+            val mockPlan = OnboardingSubscriptionPlan.create(
                 SubscriptionPlan.WithOffer(
                     name = "plus",
                     tier = SubscriptionTier.Plus,
@@ -118,42 +110,46 @@ fun OnboardingUpgradeVariantsScreen(
                     pricingPhases = listOf(
                         PricingPhase(
                             price = Price(
-                                amount = BigDecimal.valueOf(0), currencyCode = "USD", formattedPrice = "$29.9"
+                                amount = BigDecimal.valueOf(0),
+                                currencyCode = "USD",
+                                formattedPrice = "$29.9",
                             ),
                             schedule = PricingSchedule(
                                 recurrenceMode = PricingSchedule.RecurrenceMode.Recurring(1),
                                 period = PricingSchedule.Period.Monthly,
-                                periodCount = 1
-                            )
+                                periodCount = 1,
+                            ),
                         ),
                         PricingPhase(
                             price = Price(
-                                amount = BigDecimal.valueOf(39.9), currencyCode = "USD", formattedPrice = "$29.9"
+                                amount = BigDecimal.valueOf(39.9),
+                                currencyCode = "USD",
+                                formattedPrice = "$29.9",
                             ),
                             schedule = PricingSchedule(
                                 recurrenceMode = PricingSchedule.RecurrenceMode.Infinite,
                                 period = PricingSchedule.Period.Monthly,
-                                periodCount = 11
-                            )
+                                periodCount = 11,
+                            ),
                         ),
-                    )
-                )
-            )
-            UpgradeHeader(subscriptionPlan = create.getOrNull()!!)
+                    ),
+                ),
+            ).getOrNull()
+            checkNotNull(mockPlan)
+            UpgradeHeader(subscriptionPlan = mockPlan)
             Spacer(modifier = Modifier.height(24.dp))
             UpgradeContent(
                 modifier = Modifier.weight(1f),
-                subscriptionPlan = create.getOrNull()!!
+                subscriptionPlan = mockPlan,
             )
             Spacer(modifier = Modifier.height(16.dp))
             UpgradeFooter(
                 modifier = Modifier
                     .fillMaxWidth(),
-                selectedPlan = create.getOrNull()!!,
+                selectedPlan = mockPlan,
                 onClickSubscribe = onSubscribePressed,
             )
         }
-
     }
 }
 
@@ -161,14 +157,14 @@ fun OnboardingUpgradeVariantsScreen(
 private fun UpgradeFooter(
     selectedPlan: OnboardingSubscriptionPlan,
     onClickSubscribe: () -> Unit,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
 ) {
     var isYearlySelected by remember { mutableStateOf(true) }
 
     Column(
-        modifier = modifier
+        modifier = modifier,
     ) {
-        TierSelector(
+        UpgradePlanSelector(
             plan = stringResource(LR.string.onboarding_upgrade_billing_cycle_yearly),
             priceAndPeriod = "$39.99/year",
             pricePerWeek = "$0.77/week",
@@ -177,7 +173,7 @@ private fun UpgradeFooter(
             savings = stringResource(LR.string.onboarding_upgrade_save_percent, 16),
         )
         Spacer(modifier = Modifier.height(10.dp))
-        TierSelector(
+        UpgradePlanSelector(
             plan = stringResource(LR.string.onboarding_upgrade_billing_cycle_monthly),
             priceAndPeriod = "$3.99/month",
             isSelected = !isYearlySelected,
@@ -199,7 +195,7 @@ private fun UpgradeFooter(
             color = MaterialTheme.theme.colors.secondaryText02,
             textAlign = TextAlign.Center,
             onPrivacyPolicyClick = {},
-            onTermsAndConditionsClick = {}
+            onTermsAndConditionsClick = {},
         )
     }
 }
@@ -230,7 +226,7 @@ private fun UpgradeHeader(
 @Composable
 private fun UpgradeContent(
     subscriptionPlan: OnboardingSubscriptionPlan,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
 ) {
     Column(modifier = modifier) {
         val pagerState = rememberPagerState(initialPage = 0) { 2 }
@@ -280,7 +276,7 @@ private fun FeaturesContent(
                 TextP40(
                     text = stringResource(LR.string.onboarding_upgrade_features_trial_schedule),
                     modifier = Modifier.clickable { it() },
-                    color = MaterialTheme.theme.colors.primaryInteractive01
+                    color = MaterialTheme.theme.colors.primaryInteractive01,
                 )
             }
         }
@@ -295,7 +291,7 @@ private fun ScheduleContent(
     Column {
         val gradientColors = listOf(
             Color.Transparent,
-            MaterialTheme.colors.background.copy(alpha = 0.8f)
+            MaterialTheme.colors.background.copy(alpha = 0.8f),
         )
         val density = LocalDensity.current
         val iconSizePx = density.run { 43.dp.toPx() }
@@ -311,21 +307,21 @@ private fun ScheduleContent(
                 )
             },
         ) {
-            ScheduleItem(
+            UpgradeTrialScheduleItem(
                 modifier = Modifier.heightIn(min = 64.dp),
                 title = stringResource(LR.string.onboarding_upgrade_schedule_today),
                 message = stringResource(LR.string.onboarding_upgrade_schedule_today_message),
                 icon = painterResource(IR.drawable.ic_unlocked),
                 connection = ScheduleItemConnection.BOTTOM,
             )
-            ScheduleItem(
+            UpgradeTrialScheduleItem(
                 modifier = Modifier.heightIn(min = 64.dp),
                 title = stringResource(LR.string.onboarding_upgrade_schedule_day, pricingPhase.schedule.periodCount - 7),
                 message = stringResource(LR.string.onboarding_upgrade_schedule_notify),
                 icon = painterResource(IR.drawable.ic_envelope),
                 connection = ScheduleItemConnection.TOP_AND_BOTTOM,
             )
-            ScheduleItem(
+            UpgradeTrialScheduleItem(
                 modifier = Modifier.heightIn(min = 64.dp),
                 title = stringResource(LR.string.onboarding_upgrade_schedule_day, pricingPhase.schedule.periodCount),
                 message = stringResource(LR.string.onboarding_upgrade_schedule_billing, "September 31th"),
@@ -338,198 +334,10 @@ private fun ScheduleContent(
             TextP40(
                 text = stringResource(LR.string.onboarding_upgrade_schedule_see_features),
                 modifier = Modifier.clickable { it() },
-                color = MaterialTheme.theme.colors.primaryInteractive01
-            )
-        }
-    }
-}
-
-@Composable
-private fun ScheduleItem(
-    title: String,
-    message: String,
-    icon: Painter,
-    connection: ScheduleItemConnection,
-    modifier: Modifier = Modifier
-) {
-    val iconBackground = MaterialTheme.theme.colors.primaryInteractive01
-    val density = LocalDensity.current
-    val connectingRodWidthPx = density.run { 8.dp.toPx() }
-    val iconSize = 43.dp
-    val iconSizePx = density.run { iconSize.toPx() }
-    Row(
-        modifier = modifier
-            .drawWithContent {
-                when (connection) {
-                    ScheduleItemConnection.TOP -> drawRect(color = iconBackground, topLeft = Offset(x = iconSizePx / 2f - (connectingRodWidthPx / 2f), y = -1f), size = Size(width = connectingRodWidthPx, height = size.height / 2f))
-                    ScheduleItemConnection.BOTTOM -> drawRect(color = iconBackground, topLeft = Offset(x = iconSizePx / 2f - (connectingRodWidthPx / 2f), y = size.height / 2f), size = Size(width = connectingRodWidthPx, height = (size.height / 2f) + 1f))
-                    ScheduleItemConnection.TOP_AND_BOTTOM -> drawRect(color = iconBackground, topLeft = Offset(x = iconSizePx / 2f - (connectingRodWidthPx / 2f), y = 0f), size = Size(width = connectingRodWidthPx, height = size.height))
-                }
-                drawContent()
-            },
-        verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.spacedBy(14.dp),
-    ) {
-        Box(
-            modifier = Modifier
-                .size(iconSize)
-                .background(color = iconBackground, shape = CircleShape),
-            contentAlignment = Alignment.Center,
-        ) {
-            Icon(
-                painter = icon,
-                tint = MaterialTheme.colors.background,
-                contentDescription = "",
-            )
-        }
-        Column(modifier = Modifier.fillMaxWidth()) {
-            TextP50(text = title, color = MaterialTheme.theme.colors.primaryText01, fontWeight = FontWeight.W700)
-            TextP50(text = message, color = MaterialTheme.theme.colors.secondaryText02)
-        }
-    }
-}
-
-private enum class ScheduleItemConnection {
-    TOP,
-    BOTTOM,
-    TOP_AND_BOTTOM
-}
-
-@Composable
-private fun TierSelector(
-    plan: String,
-    priceAndPeriod: String,
-    isSelected: Boolean,
-    onSelected: () -> Unit,
-    modifier: Modifier = Modifier,
-    savings: String? = null,
-    pricePerWeek: String? = null,
-) {
-    SubcomposeLayout(modifier = modifier) { constraints ->
-        val savingsBadge = savings?.let {
-            val badgeMeasurable = subcompose("savings") {
-                SavingsLabel(
-                    savings = savings,
-                )
-            }
-            badgeMeasurable.first().measure(constraints)
-        }
-        val badgeHeight = savingsBadge?.height ?: 0
-
-        val row = subcompose("selector_row") {
-            PlanRow(
-                modifier = Modifier.fillMaxWidth(),
-                plan = plan,
-                priceAndPeriod = priceAndPeriod,
-                isSelected = isSelected,
-                onSelected = onSelected,
-                pricePerWeek = pricePerWeek,
-            )
-        }
-        val placeable = row.first().measure(constraints)
-        val rowWidth = placeable.width
-        val rowHeight = placeable.height
-
-        val totalHeight = rowHeight + badgeHeight / 2
-        layout(rowWidth, totalHeight) {
-            placeable.placeRelative(x = 0, y = badgeHeight / 2)
-            savingsBadge?.let {
-                it.placeRelative(x = (rowWidth - it.width) / 2, y = 0)
-            }
-        }
-    }
-}
-
-@Composable
-private fun PlanRow(
-    plan: String,
-    priceAndPeriod: String,
-    isSelected: Boolean,
-    onSelected: () -> Unit,
-    modifier: Modifier = Modifier,
-    pricePerWeek: String? = null,
-) {
-    Row(
-        modifier = modifier
-            .clip(RoundedCornerShape(12.dp))
-            .then(
-                if (isSelected) {
-                    Modifier.border(
-                        width = 2.dp,
-                        color = MaterialTheme.theme.colors.primaryInteractive01,
-                        shape = RoundedCornerShape(12.dp),
-                    )
-                } else {
-                    Modifier
-                }
-            )
-            .background(
-                color = MaterialTheme.theme.colors.primaryUi03,
-            )
-            .clickable { onSelected() }
-            .padding(16.dp),
-        verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.spacedBy(16.dp),
-    ) {
-        Box(
-            modifier = Modifier
-                .size(24.dp)
-                .clip(CircleShape)
-                .then(
-                    if (isSelected) {
-                        Modifier.background(color = MaterialTheme.theme.colors.primaryInteractive01)
-                    } else Modifier.border(
-                        width = 2.dp,
-                        color = MaterialTheme.theme.colors.primaryIcon02,
-                        shape = CircleShape,
-                    )
-                ),
-            contentAlignment = Alignment.Center
-        ) {
-            if (isSelected) {
-                Icon(
-                    painter = painterResource(IR.drawable.ic_check),
-                    contentDescription = "",
-                    tint = MaterialTheme.theme.colors.primaryInteractive02,
-                )
-            }
-        }
-
-        Column(modifier = Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(7.dp)) {
-            TextH40(
-                text = plan,
-                color = MaterialTheme.theme.colors.primaryText01,
-                fontWeight = FontWeight.W700
-            )
-            TextH40(
-                text = priceAndPeriod,
-                color = MaterialTheme.theme.colors.secondaryText02
-            )
-        }
-        pricePerWeek?.let {
-            TextH40(
-                text = pricePerWeek,
-                color = MaterialTheme.theme.colors.secondaryText02,
-            )
-        }
-    }
-}
-
-@Composable
-private fun SavingsLabel(
-    savings: String,
-    modifier: Modifier = Modifier,
-) {
-    TextH50(
-        modifier = modifier
-            .background(
                 color = MaterialTheme.theme.colors.primaryInteractive01,
-                shape = RoundedCornerShape(12.dp)
             )
-            .padding(horizontal = 12.dp, vertical = 2.dp),
-        text = savings,
-        color = MaterialTheme.theme.colors.primaryInteractive02,
-    )
+        }
+    }
 }
 
 @Preview
@@ -541,7 +349,6 @@ private fun PreviewOnboardingUpgradeFeaturesScreen(
         OnboardingUpgradeVariantsScreen(
             modifier = Modifier.fillMaxSize(),
             onSubscribePressed = {},
-            onPlanChanged = {},
             onClosePressed = {},
         )
     }

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeVariantsScreen.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeVariantsScreen.kt
@@ -16,6 +16,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.layout.wrapContentWidth
+import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.pager.VerticalPager
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.foundation.shape.CircleShape
@@ -74,7 +75,7 @@ import au.com.shiftyjelly.pocketcasts.images.R as IR
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 @Composable
-internal fun OnboardingUpgradeFeaturesScreen(
+fun OnboardingUpgradeVariantsScreen(
     onClosePressed: () -> Unit,
     onPlanChanged: (SubscriptionPlan) -> Unit,
     onSubscribePressed: () -> Unit,
@@ -110,18 +111,30 @@ internal fun OnboardingUpgradeFeaturesScreen(
         ) {
             val create = OnboardingSubscriptionPlan.create(
                 SubscriptionPlan.WithOffer(
-                    name = "plus", tier = SubscriptionTier.Plus, billingCycle = BillingCycle.Yearly, offer = SubscriptionOffer.Trial, pricingPhases = listOf(
+                    name = "plus",
+                    tier = SubscriptionTier.Plus,
+                    billingCycle = BillingCycle.Yearly,
+                    offer = SubscriptionOffer.Trial,
+                    pricingPhases = listOf(
                         PricingPhase(
                             price = Price(
                                 amount = BigDecimal.valueOf(0), currencyCode = "USD", formattedPrice = "$29.9"
                             ),
-                            schedule = PricingSchedule(recurrenceMode = PricingSchedule.RecurrenceMode.Recurring(1), period = PricingSchedule.Period.Monthly, periodCount = 1)
+                            schedule = PricingSchedule(
+                                recurrenceMode = PricingSchedule.RecurrenceMode.Recurring(1),
+                                period = PricingSchedule.Period.Monthly,
+                                periodCount = 1
+                            )
                         ),
                         PricingPhase(
                             price = Price(
                                 amount = BigDecimal.valueOf(39.9), currencyCode = "USD", formattedPrice = "$29.9"
                             ),
-                            schedule = PricingSchedule(recurrenceMode = PricingSchedule.RecurrenceMode.Infinite, period = PricingSchedule.Period.Monthly, periodCount = 11)
+                            schedule = PricingSchedule(
+                                recurrenceMode = PricingSchedule.RecurrenceMode.Infinite,
+                                period = PricingSchedule.Period.Monthly,
+                                periodCount = 11
+                            )
                         ),
                     )
                 )
@@ -251,21 +264,25 @@ private fun FeaturesContent(
     featureList: List<UpgradeFeatureItem>,
     onShowScheduleClicked: (() -> Unit)? = null,
 ) {
-    Column {
+    LazyColumn {
         featureList.forEach {
-            UpgradeFeatureItem(
-                item = it,
-                textColor = MaterialTheme.theme.colors.secondaryText02,
-                iconColor = MaterialTheme.theme.colors.primaryText01,
-            )
+            item {
+                UpgradeFeatureItem(
+                    item = it,
+                    textColor = MaterialTheme.theme.colors.secondaryText02,
+                    iconColor = MaterialTheme.theme.colors.primaryText01,
+                )
+            }
         }
-        Spacer(modifier = Modifier.height(24.dp))
-        onShowScheduleClicked?.let {
-            TextP40(
-                text = stringResource(LR.string.onboarding_upgrade_features_trial_schedule),
-                modifier = Modifier.clickable { it() },
-                color = MaterialTheme.theme.colors.primaryInteractive01
-            )
+        item {
+            onShowScheduleClicked?.let {
+                Spacer(modifier = Modifier.height(24.dp))
+                TextP40(
+                    text = stringResource(LR.string.onboarding_upgrade_features_trial_schedule),
+                    modifier = Modifier.clickable { it() },
+                    color = MaterialTheme.theme.colors.primaryInteractive01
+                )
+            }
         }
     }
 }
@@ -316,8 +333,8 @@ private fun ScheduleContent(
                 connection = ScheduleItemConnection.TOP,
             )
         }
-        Spacer(modifier = Modifier.height(24.dp))
         onShowFeaturesClicked?.let {
+            Spacer(modifier = Modifier.height(24.dp))
             TextP40(
                 text = stringResource(LR.string.onboarding_upgrade_schedule_see_features),
                 modifier = Modifier.clickable { it() },
@@ -521,7 +538,7 @@ private fun PreviewOnboardingUpgradeFeaturesScreen(
     @PreviewParameter(ThemePreviewParameterProvider::class) theme: ThemeType,
 ) {
     AppThemeWithBackground(theme) {
-        OnboardingUpgradeFeaturesScreen(
+        OnboardingUpgradeVariantsScreen(
             modifier = Modifier.fillMaxSize(),
             onSubscribePressed = {},
             onPlanChanged = {},

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/ProfileUpgradeBanner.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/ProfileUpgradeBanner.kt
@@ -103,7 +103,7 @@ private fun FeatureCard(
         subscriptionPlan.featureItems.forEach { item ->
             UpgradeFeatureItem(
                 item = item,
-                color = MaterialTheme.theme.colors.primaryText01,
+                textColor = MaterialTheme.theme.colors.primaryText01,
             )
         }
 

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/UpgradeFeatureItem.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/UpgradeFeatureItem.kt
@@ -32,35 +32,67 @@ enum class PlusUpgradeFeatureItem(
     },
     Folders(
         image = IR.drawable.ic_plus_feature_folder,
-        title = LR.string.onboarding_plus_feature_folders_title,
+        title = if (FeatureFlag.isEnabled(Feature.NEW_ONBOARDING_UPGRADE)) {
+            LR.string.onboarding_upgrade_features_folders
+        } else {
+            LR.string.onboarding_plus_feature_folders_title
+        },
     ),
     UpNextShuffle(
         image = IR.drawable.ic_plus_feature_shuffle,
-        title = LR.string.onboarding_plus_feature_up_next_shuffle_title,
+        title = if (FeatureFlag.isEnabled(Feature.NEW_ONBOARDING_UPGRADE)) {
+            LR.string.onboarding_upgrade_features_shuffle
+        } else {
+            LR.string.onboarding_plus_feature_up_next_shuffle_title
+        },
     ),
     Bookmarks(
         image = IR.drawable.ic_plus_feature_bookmark,
-        title = LR.string.onboarding_plus_feature_bookmarks_title,
+        title = if (FeatureFlag.isEnabled(Feature.NEW_ONBOARDING_UPGRADE)) {
+            LR.string.onboarding_upgrade_features_bookmarks
+        } else {
+            LR.string.onboarding_plus_feature_bookmarks_title
+        },
     ),
     SkipChapters(
         image = IR.drawable.ic_plus_feature_chapters,
-        title = LR.string.onboarding_plus_feature_chapters_title,
+        title = if (FeatureFlag.isEnabled(Feature.NEW_ONBOARDING_UPGRADE)) {
+            LR.string.onboarding_upgrade_features_chapters
+        } else {
+            LR.string.onboarding_plus_feature_chapters_title
+        },
     ),
     CloudStorage(
         image = IR.drawable.ic_plus_feature_cloud_storage,
-        title = LR.string.onboarding_plus_feature_cloud_storage_title,
+        title = if (FeatureFlag.isEnabled(Feature.NEW_ONBOARDING_UPGRADE)) {
+            LR.string.onboarding_upgrade_features_files
+        } else {
+            LR.string.onboarding_plus_feature_cloud_storage_title
+        },
     ),
     WatchPlayback(
         image = IR.drawable.ic_plus_feature_wearable,
-        title = LR.string.onboarding_plus_feature_watch_playback,
+        title = if (FeatureFlag.isEnabled(Feature.NEW_ONBOARDING_UPGRADE)) {
+            LR.string.onboarding_upgrade_features_wear
+        } else {
+            LR.string.onboarding_plus_feature_watch_playback
+        },
     ),
     ThemesIcons(
         image = IR.drawable.ic_plus_feature_themes,
-        title = LR.string.onboarding_plus_feature_extra_themes_icons_title,
+        title = if (FeatureFlag.isEnabled(Feature.NEW_ONBOARDING_UPGRADE)) {
+            LR.string.onboarding_upgrade_features_themes
+        } else {
+            LR.string.onboarding_plus_feature_extra_themes_icons_title
+        },
     ),
     SlumberStudiosPromo(
         image = IR.drawable.ic_plus_feature_slumber_studios,
-        title = LR.string.onboarding_plus_feature_slumber_studios_title,
+        title = if (FeatureFlag.isEnabled(Feature.NEW_ONBOARDING_UPGRADE)) {
+            LR.string.onboarding_upgrade_features_slumber
+        } else {
+            LR.string.onboarding_plus_feature_slumber_studios_title
+        },
     ) {
         override val isMonthlyFeature get() = false
         override val isYearlyFeature get() = FeatureFlag.isEnabled(Feature.SLUMBER_STUDIOS_YEARLY_PROMO)

--- a/modules/services/images/src/main/res/drawable/ic_envelope.xml
+++ b/modules/services/images/src/main/res/drawable/ic_envelope.xml
@@ -1,0 +1,15 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillAlpha="0.5"
+        android:fillColor="#ffffff"
+        android:pathData="M3.769,5.818C4.146,5.414 4.779,5.392 5.182,5.769L11.318,11.495C11.702,11.854 12.298,11.854 12.682,11.495L18.818,5.769C19.221,5.392 19.854,5.414 20.231,5.818C20.608,6.221 20.586,6.854 20.182,7.231L14.047,12.957C12.894,14.033 11.106,14.033 9.953,12.957L3.818,7.231C3.414,6.854 3.392,6.221 3.769,5.818Z"
+        android:strokeAlpha="0.5" />
+    <path
+        android:fillColor="#ffffff"
+        android:fillType="evenOdd"
+        android:pathData="M5,5C3.895,5 3,5.895 3,7V17C3,18.105 3.895,19 5,19H19C20.105,19 21,18.105 21,17V7C21,5.895 20.105,5 19,5H5ZM19,7H5L5,17H19V7Z" />
+</vector>

--- a/modules/services/images/src/main/res/drawable/ic_unlocked.xml
+++ b/modules/services/images/src/main/res/drawable/ic_unlocked.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#ffffff"
+        android:pathData="M12,3C9.817,3 8,4.828 8,7.143V8H18C19.105,8 20,8.895 20,10V20L19.989,20.204C19.887,21.213 19.036,22 18,22H6L5.796,21.989C4.854,21.894 4.106,21.146 4.011,20.204L4,20V10C4,8.964 4.787,8.113 5.796,8.011L6,8V7.143C6,3.777 8.66,1 12,1V3ZM6,20H18V10H6V20ZM12,12C13.105,12 14,12.895 14,14C14,14.74 13.597,15.384 13,15.729V17C13,17.552 12.552,18 12,18C11.448,18 11,17.552 11,17V15.729C10.403,15.384 10,14.74 10,14C10,12.895 10.895,12 12,12Z" />
+</vector>

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -2473,8 +2473,7 @@
     <string name="onboarding_upgrade_features_files">20 GB Cloud Storage for your files</string>
     <string name="onboarding_upgrade_features_themes">Extra Themes and App Icons</string>
     <string name="onboarding_upgrade_features_wear">Apps for Wear OS and Apple Watch</string>
-    <string name="onboarding_upgrade_features_slumber">1 year of content from Slumber Studios</string>
-    <string name="onboarding_upgrade_features_libro">Free audiobook from Libro.fm</string>
+    <string name="onboarding_upgrade_features_slumber"><![CDATA[1 year of content from <a href="https://slumberstudios.com/">Slumber&#160;Studios</a>]]></string>
     <string name="onboarding_upgrade_features_trial_schedule">How does the free trial work?</string>
 
 </resources>

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -2477,5 +2477,5 @@
     <string name="onboarding_upgrade_features_trial_schedule">How does the free trial work?</string>
     <string name="onboarding_upgrade_billing_cycle_monthly">Monthly plan</string>
     <string name="onboarding_upgrade_billing_cycle_yearly">Yearly plan</string>
-    <string name="onboarding_upgrade_save_percent">Save %1$d%</string>
+    <string name="onboarding_upgrade_save_percent">Save %1$d\%%</string>
 </resources>

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -2475,5 +2475,7 @@
     <string name="onboarding_upgrade_features_wear">Apps for Wear OS and Apple Watch</string>
     <string name="onboarding_upgrade_features_slumber"><![CDATA[1 year of content from <a href="https://slumberstudios.com/">Slumber&#160;Studios</a>]]></string>
     <string name="onboarding_upgrade_features_trial_schedule">How does the free trial work?</string>
-
+    <string name="onboarding_upgrade_billing_cycle_monthly">Monthly plan</string>
+    <string name="onboarding_upgrade_billing_cycle_yearly">Yearly plan</string>
+    <string name="onboarding_upgrade_save_percent">Save %1$d%</string>
 </resources>

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -2421,55 +2421,60 @@
     <!-- Notifications -->
     <string name="notification_sync_title">Your shows, on any device!</string>
     <string name="notification_sync_message">Create a free account to sync your shows and listen anywhere.</string>
-
     <string name="notification_import_title">Easily import your podcasts</string>
     <string name="notification_import_message">Switching from another app? Bring all your favorite shows to Pocket Casts.</string>
-
     <string name="notification_up_next_title">Simplify your queue</string>
     <string name="notification_up_next_message">Build a playback queue and say goodbye to jumping around between episodes.</string>
-
     <string name="notification_filters_title">Organize your episodes</string>
     <string name="notification_filters_message">Create smart filters to organize your episodes.</string>
-
     <string name="notification_themes_title">Time for a new look</string>
     <string name="notification_themes_message">Browse our themes and find the one that suits your style.</string>
-
     <string name="notification_staff_picks_title">Explore our Staff Picks</string>
     <string name="notification_staff_picks_message">Perfectly ripe podcasts, picked just for you by real, podcast-loving humans.</string>
-
     <string name="notification_plus_upsell_title">Level up your podcast game</string>
     <string name="notification_plus_upsell_message">Unlock exclusive features like folders, bookmarks, and more with Plus!</string>
-
     <string name="notification_reengage_we_miss_you_title">We miss you!</string>
     <string name="notification_reengage_we_miss_you_message">It\'s been a while since you\'ve listened. Jump back in and enjoy!</string>
-
     <string name="notification_reengage_catch_up_offline_title">Catch up offline</string>
     <plurals name="notification_reengage_catch_up_offline_message">
         <item quantity="one">You have %d new episode downloaded and ready to go!</item>
         <item quantity="other">You have %d new episodes downloaded and ready to go!</item>
     </plurals>
-
     <string name="notification_content_recommendations_trending_title">Trending this week</string>
     <string name="notification_content_recommendations_trending_message">Check out what everyone else is listening this week.</string>
-
     <string name="notification_content_recommendations_title">New recommendations for you</string>
     <string name="notification_content_recommendations_message">Wondering what to listen to next? Check out these shows!</string>
-
     <string name="notifications_settings_turn_on_push_title">Turn on push notifications?</string>
     <string name="notifications_settings_turn_on_push_message">To get notifications from Pocket Casts, you\'ll need to turn them on in your device settings.</string>
     <string name="notifications_settings_turn_on_push_button">Go to device settings</string>
-
     <string name="notification_new_features_smart_folders_title">Your podcasts organized</string>
     <string name="notification_new_features_smart_folders_message">Try Plus and automatically organize your shows with folders</string>
-
     <string name="notification_offers_upgrade_title">Level up your podcast game</string>
     <string name="notification_offers_upgrade_message">Unblock exclusive features like folders, bookmarks, and more with Plus!</string>
-
     <string name="notification_prompt_title">Stay up to date!</string>
     <string name="notification_prompt_message">Notifications are the best way to keep track of new episodes, get recommendations of new shows and tips about Pocket Casts.</string>
     <string name="notification_prompt_cta">Allow Notifications</string>
     <string name="notification_snack_message">Please allow notifications in your device settings</string>
     <string name="notification_snack_cta">Open Settings</string>
     <string name="notification_mockup_image_description">Mockup image</string>
+
+    <!-- Onboarding Upgrade -->
+    <string name="onboarding_upgrade_generic_title">Superpowers for your podcasts</string>
+    <string name="onboarding_upgrade_schedule_today">Today</string>
+    <string name="onboarding_upgrade_schedule_today_message">Get access to Folders, Shuffle, Bookmarks, and exclusive content</string>
+    <string name="onboarding_upgrade_schedule_day">Day %1$d</string>
+    <string name="onboarding_upgrade_schedule_notify">We\'ll notify you about your trial ending.</string>
+    <string name="onboarding_upgrade_schedule_billing">You\'ll be charged on %1$s. Cancel anytime before.</string>
+    <string name="onboarding_upgrade_schedule_see_features">See all Plus features</string>
+    <string name="onboarding_upgrade_features_folders">Tidy your collection with Folders</string>
+    <string name="onboarding_upgrade_features_shuffle">Shuffle your queue</string>
+    <string name="onboarding_upgrade_features_bookmarks">Keep timestamps with Bookmarks</string>
+    <string name="onboarding_upgrade_features_chapters">Save time with Preselect Chapters</string>
+    <string name="onboarding_upgrade_features_files">20 GB Cloud Storage for your files</string>
+    <string name="onboarding_upgrade_features_themes">Extra Themes and App Icons</string>
+    <string name="onboarding_upgrade_features_wear">Apps for Wear OS and Apple Watch</string>
+    <string name="onboarding_upgrade_features_slumber">1 year of content from Slumber Studios</string>
+    <string name="onboarding_upgrade_features_libro">Free audiobook from Libro.fm</string>
+    <string name="onboarding_upgrade_features_trial_schedule">How does the free trial work?</string>
 
 </resources>

--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/Feature.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/Feature.kt
@@ -138,6 +138,14 @@ enum class Feature(
         hasFirebaseRemoteFlag = true,
         hasDevToggle = true,
     ),
+    NEW_ONBOARDING_UPGRADE(
+        key = "new_onboarding_upgrade",
+        title = "New Onboarding Upgrade",
+        defaultValue = BuildConfig.DEBUG,
+        tier = FeatureTier.Free,
+        hasFirebaseRemoteFlag = false,
+        hasDevToggle = true
+    ),
 
     // This is set of features used only for testing purposes.
     TEST_FREE_FEATURE(

--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/Feature.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/Feature.kt
@@ -144,7 +144,7 @@ enum class Feature(
         defaultValue = BuildConfig.DEBUG,
         tier = FeatureTier.Free,
         hasFirebaseRemoteFlag = false,
-        hasDevToggle = true
+        hasDevToggle = true,
     ),
 
     // This is set of features used only for testing purposes.


### PR DESCRIPTION
## Description
This PR is the first step of the new onboarding saga.
It introdudes the the a mocked screen that can display both variants.
As long as the FF `new_onboarding_upgrade` is enabled, you'll be able to see the screen in action when you tap the Settings->Pocket Casts Plus item.

Please note that TalkBack and accessbility were not considered in the scope of this PR, I'm planning to polish those areas in upcoming PRs.

It's important to call out that the screen is mocked, there is no real data interaction yet.

Fixes https://linear.app/a8c/issue/PCDROID-14/implement-generic-upgrade-screens

## Testing Instructions
1. Install app
2. Tap Settings -> Pocket Casts Plus

## Screenshots or Screencast 
| Variant A | Variant B | 
| --- | --- | 
| ![Screenshot 2025-07-04 at 20 48 33](https://github.com/user-attachments/assets/0ea1e3d0-61be-4a04-8c66-87dcead76866) | ![Screenshot 2025-07-04 at 20 48 59](https://github.com/user-attachments/assets/f030537a-6825-450c-878e-9204004331d9) |

https://github.com/user-attachments/assets/8f942ccd-504f-4262-bf54-9b782ffc013a



## Checklist
- [ ] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~ -- will be added when the entire feature is merged to `main`
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] ~I have considered whether it makes sense to add tests for my changes~
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [ ] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~
 
#### I have tested any UI changes...
- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [ ] ~with a landscape orientation~
- [ ] ~with the device set to have a large display and font size~
- [ ] ~for accessibility with TalkBack~
