### PR TITLE
Allow podcast and folder options dialogs to stay open through config changes (like screen rotation)

### DIFF
--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcasts/FolderOptionsDialog.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcasts/FolderOptionsDialog.kt
@@ -19,15 +19,18 @@ class FolderOptionsDialog(
     val fragment: Fragment,
     val settings: Settings,
 ) {
+    companion object {
+        private const val FRAGMENT_FOLDER_OPTIONS_DIALOG = "folder_options_dialog"
+        private const val FRAGMENT_FOLDER_SORT_DIALOG = "folder_sort_dialog"
+    }
 
-    private var showDialog: OptionsDialog? = null
-    private var sortDialog: OptionsDialog? = null
+    private val showDialog: OptionsDialog
+    private val sortDialog: OptionsDialog
     private val fragmentManager: FragmentManager?
         get() = fragment.activity?.supportFragmentManager
 
-    fun show() {
-        val fragmentManager = fragmentManager ?: return
-        val dialog = OptionsDialog()
+    init {
+        showDialog = (fragmentManager?.findFragmentByTag(FRAGMENT_FOLDER_OPTIONS_DIALOG) as? OptionsDialog ?: OptionsDialog())
             .addTextOption(
                 titleId = LR.string.podcasts_menu_sort_by,
                 imageId = IR.drawable.ic_sort,
@@ -42,7 +45,6 @@ class FolderOptionsDialog(
                 imageId = R.drawable.ic_pencil_edit,
                 click = {
                     onEditFolder()
-                    dismiss()
                 },
             )
             .addTextOption(
@@ -52,17 +54,12 @@ class FolderOptionsDialog(
                     onAddOrRemovePodcast()
                 },
             )
-        dialog.show(fragmentManager, "podcasts_options_dialog")
-        showDialog = dialog
-    }
 
-    private fun openSortOptions() {
-        val fragmentManager = fragmentManager ?: return
         val podcastsSortType = folder.podcastsSortType
-        val title = fragment.getString(LR.string.sort_by)
-        val dialog = OptionsDialog().setTitle(title)
-        for (sortType in PodcastsSortType.values()) {
-            dialog.addCheckedOption(
+        sortDialog = (fragmentManager?.findFragmentByTag(FRAGMENT_FOLDER_SORT_DIALOG) as? OptionsDialog ?: OptionsDialog())
+        sortDialog.setTitle(fragment.getString(LR.string.sort_by))
+        for (sortType in PodcastsSortType.entries) {
+            sortDialog.addCheckedOption(
                 titleId = sortType.labelId,
                 checked = sortType == podcastsSortType,
                 click = {
@@ -70,12 +67,17 @@ class FolderOptionsDialog(
                 },
             )
         }
-        dialog.show(fragmentManager, "podcasts_sort_dialog")
-        sortDialog = dialog
     }
 
-    fun dismiss() {
-        showDialog?.dismiss()
-        sortDialog?.dismiss()
+    fun show() {
+        fragmentManager?.let {
+            showDialog.show(it, FRAGMENT_FOLDER_OPTIONS_DIALOG)
+        }
+    }
+
+    private fun openSortOptions() {
+        fragmentManager?.let {
+            sortDialog.show(it, FRAGMENT_FOLDER_SORT_DIALOG)
+        }
     }
 }


### PR DESCRIPTION


## Description
<!-- Please include a summary of what this PR is changing and why these changes are needed. -->
Allow podcast and folder options dialogs to stay open through config changes (like screen rotation), instead of dismissing them.

Instead of creating the dialog when it is shown and dismissing it on config change, click handlers can be restored by checking to see if a particular dialog fragment is in the fragment manager and if it isn't then instantiate a new one, then establish all the dialog's click handlers.

Fixes # <!-- issue number, if applicable -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Tap on the Filters tab -->
<!-- 2. Tap on a filter -->
<!-- 3. etc. -->
1. On the Podcasts screen, tap the three dot icon in the upper right to open the "podcast options" bottom sheet dialog
2. Rotate the screen to see the dialog remain open and not be dismissed
3. Tap the "Sort by" or "Badges" option to open the "Sort by" or "Badges" bottom sheet dialog
4. Rotate the screen to see the dialog remain open and not be dismissed
5. Select a folder to go to that folder's screen and tap the three dot icon in the upper right to open the "folder options" bottom sheet dialog
6. Rotate the screen to see the dialog remain open and not be dismissed
7. Tap the "Sort by" option to open the "Sort by" bottom sheet dialog
8. Rotate the screen to see the dialog remain open and not be dismissed

## Screenshots or Screencast 
<!-- if applicable -->

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [ ] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
