### PR TITLE
[Onboarding] Upgrade Screen skeleton

### DIFF
--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeFlow.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeFlow.kt
@@ -26,6 +26,8 @@ import au.com.shiftyjelly.pocketcasts.payment.SubscriptionTier
 import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingFlow
 import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingUpgradeSource
 import au.com.shiftyjelly.pocketcasts.utils.extensions.getActivity
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
 import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
 import kotlinx.coroutines.launch
 
@@ -115,32 +117,36 @@ fun OnboardingUpgradeFlow(
         sheetShape = RoundedCornerShape(topStart = 28.dp, topEnd = 28.dp),
         content = {
             if (flow !is OnboardingFlow.PlusAccountUpgrade) {
-                OnboardingUpgradeFeaturesPage(
-                    viewModel = @Suppress("ktlint:compose:vm-forwarding-check") viewModel,
-                    state = state,
-                    flow = flow,
-                    source = source,
-                    onBackPress = onBackPress,
-                    onClickSubscribe = { showUpgradeBottomSheet ->
-                        if (activity != null) {
-                            if (isLoggedIn) {
-                                if (showUpgradeBottomSheet) {
-                                    coroutineScope.launch {
-                                        sheetState.show()
+                if (FeatureFlag.isEnabled(Feature.NEW_ONBOARDING_UPGRADE)) {
+                    OnboardingUpgradeScreen(onClosePress = onBackPress, onSubscribePress = {})
+                } else {
+                    OnboardingUpgradeFeaturesPage(
+                        viewModel = @Suppress("ktlint:compose:vm-forwarding-check") viewModel,
+                        state = state,
+                        flow = flow,
+                        source = source,
+                        onBackPress = onBackPress,
+                        onClickSubscribe = { showUpgradeBottomSheet ->
+                            if (activity != null) {
+                                if (isLoggedIn) {
+                                    if (showUpgradeBottomSheet) {
+                                        coroutineScope.launch {
+                                            sheetState.show()
+                                        }
+                                    } else {
+                                        onNeedLogin()
                                     }
                                 } else {
-                                    viewModel.purchaseSelectedPlan(activity, onProceed)
+                                    LogBuffer.e(LogBuffer.TAG_SUBSCRIPTIONS, NULL_ACTIVITY_ERROR)
                                 }
                             } else {
-                                onNeedLogin()
+                                LogBuffer.e(LogBuffer.TAG_SUBSCRIPTIONS, NULL_ACTIVITY_ERROR)
                             }
-                        } else {
-                            LogBuffer.e(LogBuffer.TAG_SUBSCRIPTIONS, NULL_ACTIVITY_ERROR)
-                        }
-                    },
-                    onNotNowPress = onProceed,
-                    onUpdateSystemBars = onUpdateSystemBars,
-                )
+                        },
+                        onNotNowPress = onProceed,
+                        onUpdateSystemBars = onUpdateSystemBars,
+                    )
+                }
             }
         },
         sheetContent = {

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeScreen.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeScreen.kt
@@ -2,15 +2,21 @@ package au.com.shiftyjelly.pocketcasts.account.onboarding.upgrade
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBars
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.foundation.pager.VerticalPager
@@ -44,16 +50,16 @@ import au.com.shiftyjelly.pocketcasts.compose.components.TextH40
 import au.com.shiftyjelly.pocketcasts.compose.images.SubscriptionBadge
 import au.com.shiftyjelly.pocketcasts.compose.preview.ThemePreviewParameterProvider
 import au.com.shiftyjelly.pocketcasts.compose.theme
+import au.com.shiftyjelly.pocketcasts.images.R
 import au.com.shiftyjelly.pocketcasts.payment.SubscriptionPlan
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme.ThemeType
 import kotlinx.coroutines.launch
-import au.com.shiftyjelly.pocketcasts.images.R as IR
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 @Composable
 fun OnboardingUpgradeScreen(
-    onClosePressed: () -> Unit,
-    onSubscribePressed: () -> Unit,
+    onClosePress: () -> Unit,
+    onSubscribePress: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val plans = listOf(
@@ -63,49 +69,33 @@ fun OnboardingUpgradeScreen(
 
     var selectedPlan by remember { mutableStateOf(plans[0]) }
 
-    Box(modifier = modifier.background(color = MaterialTheme.colors.background)) {
-        IconButton(
-            onClick = onClosePressed,
-            modifier = Modifier.align(Alignment.TopEnd),
-        ) {
-            Box(
-                modifier = Modifier
-                    .size(28.dp)
-                    .background(color = MaterialTheme.theme.colors.primaryUi05, shape = CircleShape),
-                contentAlignment = Alignment.Center,
-            ) {
-                Icon(
-                    modifier = Modifier.size(24.dp),
-                    painter = painterResource(IR.drawable.ic_close),
-                    contentDescription = stringResource(au.com.shiftyjelly.pocketcasts.localization.R.string.close),
-                    tint = MaterialTheme.theme.colors.primaryIcon01,
-                )
-            }
-        }
-
-        Column(
+    Column(
+        modifier = modifier
+            .windowInsetsPadding(WindowInsets.statusBars)
+            .windowInsetsPadding(WindowInsets.navigationBars)
+            .background(color = MaterialTheme.colors.background)
+            .fillMaxSize()
+            .padding(
+                horizontal = 24.dp,
+            ),
+    ) {
+        UpgradeHeader(
+            selectedPlan = selectedPlan,
+            onClosePress = onClosePress,
+        )
+        Spacer(modifier = Modifier.height(24.dp))
+        UpgradeContent(
+            modifier = Modifier.weight(1f),
+        )
+        Spacer(modifier = Modifier.height(16.dp))
+        UpgradeFooter(
             modifier = Modifier
-                .fillMaxSize()
-                .padding(
-                    horizontal = 24.dp,
-                    vertical = 16.dp,
-                ),
-        ) {
-            UpgradeHeader(selectedPlan = selectedPlan)
-            Spacer(modifier = Modifier.height(24.dp))
-            UpgradeContent(
-                modifier = Modifier.weight(1f),
-            )
-            Spacer(modifier = Modifier.height(16.dp))
-            UpgradeFooter(
-                modifier = Modifier
-                    .fillMaxWidth(),
-                plans = plans,
-                selectedPlan = selectedPlan,
-                onSelectedChanged = { selectedPlan = it },
-                onClickSubscribe = { onSubscribePressed() },
-            )
-        }
+                .fillMaxWidth(),
+            plans = plans,
+            selectedPlan = selectedPlan,
+            onSelectedChange = { selectedPlan = it },
+            onClickSubscribe = { onSubscribePress() },
+        )
     }
 }
 
@@ -113,7 +103,7 @@ fun OnboardingUpgradeScreen(
 private fun UpgradeFooter(
     plans: List<SubscriptionPlan.Base>,
     selectedPlan: SubscriptionPlan.Base,
-    onSelectedChanged: (SubscriptionPlan.Base) -> Unit,
+    onSelectedChange: (SubscriptionPlan.Base) -> Unit,
     onClickSubscribe: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -126,8 +116,8 @@ private fun UpgradeFooter(
             UpgradePlanRow(
                 plan = item,
                 isSelected = selectedPlan == item,
-                onClick = { onSelectedChanged(item) },
-                otherPlan = SubscriptionPlan.PlusMonthlyPreview,
+                onClick = { onSelectedChange(item) },
+                priceComparisonPlan = SubscriptionPlan.PlusMonthlyPreview,
             )
             Spacer(modifier = Modifier.height(10.dp))
         }
@@ -155,20 +145,44 @@ private fun UpgradeFooter(
 @Composable
 private fun UpgradeHeader(
     selectedPlan: SubscriptionPlan.Base,
+    onClosePress: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val selectedOnboardingPlan = remember(selectedPlan) { OnboardingSubscriptionPlan.create(selectedPlan) }
 
     Column(modifier = modifier) {
-        SubscriptionBadge(
-            iconRes = selectedOnboardingPlan.badgeIconRes,
-            shortNameRes = selectedOnboardingPlan.shortNameRes,
-            backgroundColor = Color.Black,
-            textColor = Color.White,
-            modifier = Modifier
-                .wrapContentWidth()
-                .wrapContentHeight(),
-        )
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            SubscriptionBadge(
+                iconRes = selectedOnboardingPlan.badgeIconRes,
+                shortNameRes = selectedOnboardingPlan.shortNameRes,
+                backgroundColor = Color.Black,
+                textColor = Color.White,
+                modifier = Modifier
+                    .wrapContentWidth()
+                    .wrapContentHeight(),
+            )
+            IconButton(
+                onClick = onClosePress,
+            ) {
+                Box(
+                    modifier = Modifier
+                        .size(28.dp)
+                        .background(color = MaterialTheme.theme.colors.primaryUi05, shape = CircleShape),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    Icon(
+                        modifier = Modifier.size(24.dp),
+                        painter = painterResource(R.drawable.ic_close),
+                        contentDescription = stringResource(LR.string.close),
+                        tint = MaterialTheme.theme.colors.primaryIcon01,
+                    )
+                }
+            }
+        }
         Spacer(modifier = Modifier.height(24.dp))
         TextH10(
             text = stringResource(LR.string.onboarding_upgrade_generic_title),
@@ -181,34 +195,35 @@ private fun UpgradeHeader(
 private fun UpgradeContent(
     modifier: Modifier = Modifier,
 ) {
-    Column(modifier = modifier) {
-        val pagerState = rememberPagerState(initialPage = 0) { 2 }
-        val coroutineScope = rememberCoroutineScope()
-        VerticalPager(state = pagerState, modifier = Modifier.fillMaxSize()) { page ->
-            if (page == 0) {
-                FeaturesContent(
-                    onClicked = {
-                        coroutineScope.launch {
-                            pagerState.animateScrollToPage(1)
-                        }
-                    },
-                )
-            } else {
-                ScheduleContent(
-                    onClicked = {
-                        coroutineScope.launch {
-                            pagerState.animateScrollToPage(0)
-                        }
-                    },
-                )
-            }
+    val pagerState = rememberPagerState(initialPage = 0) { 2 }
+    val coroutineScope = rememberCoroutineScope()
+    VerticalPager(
+        modifier = modifier,
+        state = pagerState,
+    ) { page ->
+        if (page == 0) {
+            FeaturesContent(
+                onClick = {
+                    coroutineScope.launch {
+                        pagerState.animateScrollToPage(1)
+                    }
+                },
+            )
+        } else {
+            ScheduleContent(
+                onClick = {
+                    coroutineScope.launch {
+                        pagerState.animateScrollToPage(0)
+                    }
+                },
+            )
         }
     }
 }
 
 @Composable
 private fun FeaturesContent(
-    onClicked: (() -> Unit)? = null,
+    onClick: (() -> Unit)? = null,
 ) {
     Box(
         contentAlignment = Alignment.Center,
@@ -216,13 +231,13 @@ private fun FeaturesContent(
             .fillMaxWidth()
             .heightIn(min = 92.dp),
     ) {
-        TextH40(text = "Features content", modifier = Modifier.clickable { onClicked?.invoke() })
+        TextH40(text = "Features content", modifier = Modifier.clickable { onClick?.invoke() })
     }
 }
 
 @Composable
 private fun ScheduleContent(
-    onClicked: (() -> Unit)? = null,
+    onClick: (() -> Unit)? = null,
 ) {
     Box(
         contentAlignment = Alignment.Center,
@@ -230,7 +245,7 @@ private fun ScheduleContent(
             .fillMaxWidth()
             .heightIn(min = 92.dp),
     ) {
-        TextH40(text = "Schedule content", modifier = Modifier.clickable { onClicked?.invoke() })
+        TextH40(text = "Schedule content", modifier = Modifier.clickable { onClick?.invoke() })
     }
 }
 
@@ -242,8 +257,8 @@ private fun PreviewOnboardingUpgradeScreen(
     AppThemeWithBackground(theme) {
         OnboardingUpgradeScreen(
             modifier = Modifier.fillMaxSize(),
-            onSubscribePressed = {},
-            onClosePressed = {},
+            onSubscribePress = {},
+            onClosePress = {},
         )
     }
 }

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeScreen.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeScreen.kt
@@ -1,0 +1,249 @@
+package au.com.shiftyjelly.pocketcasts.account.onboarding.upgrade
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.wrapContentHeight
+import androidx.compose.foundation.layout.wrapContentWidth
+import androidx.compose.foundation.pager.VerticalPager
+import androidx.compose.foundation.pager.rememberPagerState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.Icon
+import androidx.compose.material.IconButton
+import androidx.compose.material.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewParameter
+import androidx.compose.ui.unit.dp
+import au.com.shiftyjelly.pocketcasts.account.onboarding.components.UpgradePlanRow
+import au.com.shiftyjelly.pocketcasts.account.onboarding.upgrade.OnboardingUpgradeHelper.PrivacyPolicy
+import au.com.shiftyjelly.pocketcasts.account.onboarding.upgrade.OnboardingUpgradeHelper.UpgradeRowButton
+import au.com.shiftyjelly.pocketcasts.compose.AppThemeWithBackground
+import au.com.shiftyjelly.pocketcasts.compose.components.TextH10
+import au.com.shiftyjelly.pocketcasts.compose.components.TextH40
+import au.com.shiftyjelly.pocketcasts.compose.images.SubscriptionBadge
+import au.com.shiftyjelly.pocketcasts.compose.preview.ThemePreviewParameterProvider
+import au.com.shiftyjelly.pocketcasts.compose.theme
+import au.com.shiftyjelly.pocketcasts.payment.SubscriptionPlan
+import au.com.shiftyjelly.pocketcasts.ui.theme.Theme.ThemeType
+import kotlinx.coroutines.launch
+import au.com.shiftyjelly.pocketcasts.images.R as IR
+import au.com.shiftyjelly.pocketcasts.localization.R as LR
+
+@Composable
+fun OnboardingUpgradeScreen(
+    onClosePressed: () -> Unit,
+    onSubscribePressed: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val plans = listOf(
+        SubscriptionPlan.PlusYearlyPreview,
+        SubscriptionPlan.PlusMonthlyPreview,
+    )
+
+    var selectedPlan by remember { mutableStateOf(plans[0]) }
+
+    Box(modifier = modifier.background(color = MaterialTheme.colors.background)) {
+        IconButton(
+            onClick = onClosePressed,
+            modifier = Modifier.align(Alignment.TopEnd),
+        ) {
+            Box(
+                modifier = Modifier
+                    .size(28.dp)
+                    .background(color = MaterialTheme.theme.colors.primaryUi05, shape = CircleShape),
+                contentAlignment = Alignment.Center,
+            ) {
+                Icon(
+                    modifier = Modifier.size(24.dp),
+                    painter = painterResource(IR.drawable.ic_close),
+                    contentDescription = stringResource(au.com.shiftyjelly.pocketcasts.localization.R.string.close),
+                    tint = MaterialTheme.theme.colors.primaryIcon01,
+                )
+            }
+        }
+
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(
+                    horizontal = 24.dp,
+                    vertical = 16.dp,
+                ),
+        ) {
+            UpgradeHeader(selectedPlan = selectedPlan)
+            Spacer(modifier = Modifier.height(24.dp))
+            UpgradeContent(
+                modifier = Modifier.weight(1f),
+            )
+            Spacer(modifier = Modifier.height(16.dp))
+            UpgradeFooter(
+                modifier = Modifier
+                    .fillMaxWidth(),
+                plans = plans,
+                selectedPlan = selectedPlan,
+                onSelectedChanged = { selectedPlan = it },
+                onClickSubscribe = { onSubscribePressed() },
+            )
+        }
+    }
+}
+
+@Composable
+private fun UpgradeFooter(
+    plans: List<SubscriptionPlan.Base>,
+    selectedPlan: SubscriptionPlan.Base,
+    onSelectedChanged: (SubscriptionPlan.Base) -> Unit,
+    onClickSubscribe: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val selectedOnboardingPlan = remember(selectedPlan) { OnboardingSubscriptionPlan.create(selectedPlan) }
+
+    Column(
+        modifier = modifier,
+    ) {
+        plans.forEach { item ->
+            UpgradePlanRow(
+                plan = item,
+                isSelected = selectedPlan == item,
+                onClick = { onSelectedChanged(item) },
+                otherPlan = SubscriptionPlan.PlusMonthlyPreview,
+            )
+            Spacer(modifier = Modifier.height(10.dp))
+        }
+        Spacer(modifier = Modifier.height(16.dp))
+        UpgradeRowButton(
+            primaryText = selectedOnboardingPlan.ctaButtonText(isRenewingSubscription = false),
+            backgroundColor = MaterialTheme.theme.colors.primaryInteractive01,
+            textColor = MaterialTheme.theme.colors.primaryInteractive02,
+            fontWeight = FontWeight.W500,
+            onClick = onClickSubscribe,
+            modifier = Modifier
+                .fillMaxWidth()
+                .heightIn(min = 48.dp),
+        )
+        Spacer(modifier = Modifier.height(12.dp))
+        PrivacyPolicy(
+            color = MaterialTheme.theme.colors.secondaryText02,
+            textAlign = TextAlign.Center,
+            onPrivacyPolicyClick = {},
+            onTermsAndConditionsClick = {},
+        )
+    }
+}
+
+@Composable
+private fun UpgradeHeader(
+    selectedPlan: SubscriptionPlan.Base,
+    modifier: Modifier = Modifier,
+) {
+    val selectedOnboardingPlan = remember(selectedPlan) { OnboardingSubscriptionPlan.create(selectedPlan) }
+
+    Column(modifier = modifier) {
+        SubscriptionBadge(
+            iconRes = selectedOnboardingPlan.badgeIconRes,
+            shortNameRes = selectedOnboardingPlan.shortNameRes,
+            backgroundColor = Color.Black,
+            textColor = Color.White,
+            modifier = Modifier
+                .wrapContentWidth()
+                .wrapContentHeight(),
+        )
+        Spacer(modifier = Modifier.height(24.dp))
+        TextH10(
+            text = stringResource(LR.string.onboarding_upgrade_generic_title),
+            color = MaterialTheme.theme.colors.primaryText01,
+        )
+    }
+}
+
+@Composable
+private fun UpgradeContent(
+    modifier: Modifier = Modifier,
+) {
+    Column(modifier = modifier) {
+        val pagerState = rememberPagerState(initialPage = 0) { 2 }
+        val coroutineScope = rememberCoroutineScope()
+        VerticalPager(state = pagerState, modifier = Modifier.fillMaxSize()) { page ->
+            if (page == 0) {
+                FeaturesContent(
+                    onClicked = {
+                        coroutineScope.launch {
+                            pagerState.animateScrollToPage(1)
+                        }
+                    },
+                )
+            } else {
+                ScheduleContent(
+                    onClicked = {
+                        coroutineScope.launch {
+                            pagerState.animateScrollToPage(0)
+                        }
+                    },
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun FeaturesContent(
+    onClicked: (() -> Unit)? = null,
+) {
+    Box(
+        contentAlignment = Alignment.Center,
+        modifier = Modifier
+            .fillMaxWidth()
+            .heightIn(min = 92.dp),
+    ) {
+        TextH40(text = "Features content", modifier = Modifier.clickable { onClicked?.invoke() })
+    }
+}
+
+@Composable
+private fun ScheduleContent(
+    onClicked: (() -> Unit)? = null,
+) {
+    Box(
+        contentAlignment = Alignment.Center,
+        modifier = Modifier
+            .fillMaxWidth()
+            .heightIn(min = 92.dp),
+    ) {
+        TextH40(text = "Schedule content", modifier = Modifier.clickable { onClicked?.invoke() })
+    }
+}
+
+@Preview
+@Composable
+private fun PreviewOnboardingUpgradeScreen(
+    @PreviewParameter(ThemePreviewParameterProvider::class) theme: ThemeType,
+) {
+    AppThemeWithBackground(theme) {
+        OnboardingUpgradeScreen(
+            modifier = Modifier.fillMaxSize(),
+            onSubscribePressed = {},
+            onClosePressed = {},
+        )
+    }
+}

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -2473,5 +2473,7 @@
     <string name="notification_snack_cta">Open Settings</string>
     <string name="notification_mockup_image_description">Mockup image</string>
 
+    <!-- Onboarding Upgrade -->
+    <string name="onboarding_upgrade_generic_title">Superpowers for your podcasts</string>
     <string name="onboarding_upgrade_save_percent">Save %1$d\%%</string>
 </resources>

--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/Feature.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/Feature.kt
@@ -138,6 +138,14 @@ enum class Feature(
         hasFirebaseRemoteFlag = true,
         hasDevToggle = true,
     ),
+    NEW_ONBOARDING_UPGRADE(
+        key = "new_onboarding_upgrade",
+        title = "New Onboarding Upgrade",
+        defaultValue = BuildConfig.DEBUG,
+        tier = FeatureTier.Free,
+        hasFirebaseRemoteFlag = false,
+        hasDevToggle = true,
+    ),
 
     // This is set of features used only for testing purposes.
     TEST_FREE_FEATURE(


### PR DESCRIPTION
## Description
This PR adds the FF and conditionally renders the frame of the new screen.
It's worth noting that the screen is not functional at this point, I only included the main elements like the header, scrolling content, and the footer.
All the data you'll see on it is hardcoded.

Designs: PviUP0aiZctOprDuuYRwpb-fi-4999_5992

## Testing Instructions
1. Make sure `new_onboarding_upgrade` FF is ON
2. Tap the Settings -> Pocket Casts Plus to navigate to this new screen

## Screenshots or Screencast 
![Screenshot 2025-07-07 at 22 04 14](https://github.com/user-attachments/assets/95ec9f80-bded-4f71-9ad9-d130418587e7)


## Checklist
- [ ] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] ~I have considered whether it makes sense to add tests for my changes~
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [ ] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [ ] ~for accessibility with TalkBack~  -- NOT YET