### PR TITLE
[Onboarding] Connect screen content

### DIFF
--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/components/UpgradeFeatureItem.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/components/UpgradeFeatureItem.kt
@@ -23,7 +23,8 @@ import au.com.shiftyjelly.pocketcasts.ui.R as UR
 fun UpgradeFeatureItem(
     item: UpgradeFeatureItem,
     modifier: Modifier = Modifier,
-    color: Color = Color.Black,
+    iconColor: Color = Color.Black,
+    textColor: Color = Color.Black,
 ) {
     Row(
         modifier = modifier
@@ -35,7 +36,7 @@ fun UpgradeFeatureItem(
         Icon(
             painter = painterResource(item.image),
             contentDescription = null,
-            tint = color,
+            tint = iconColor,
             modifier = Modifier
                 .size(20.dp)
                 .padding(2.dp),
@@ -43,8 +44,8 @@ fun UpgradeFeatureItem(
         Spacer(Modifier.width(16.dp))
         HtmlText(
             html = stringResource(id = item.title),
-            color = color,
-            linkColor = color,
+            color = textColor,
+            linkColor = textColor,
             textStyleResId = UR.style.H50,
         )
     }

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/components/UpgradeFeatureItem.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/components/UpgradeFeatureItem.kt
@@ -43,7 +43,7 @@ fun UpgradeFeatureItem(
         )
         Spacer(Modifier.width(16.dp))
         HtmlText(
-            html = stringResource(id = item.title),
+            html = stringResource(id = item.title()),
             color = textColor,
             linkColor = textColor,
             textStyleResId = UR.style.H50,

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/components/UpgradeTrialTimeline.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/components/UpgradeTrialTimeline.kt
@@ -39,26 +39,28 @@ data class UpgradeTrialItem(
     @DrawableRes val iconResId: Int,
     val title: String,
     val message: String,
-)
-
-@Composable
-fun previewItems() = listOf(
-    UpgradeTrialItem(
-        iconResId = IR.drawable.ic_unlocked,
-        title = stringResource(LR.string.onboarding_upgrade_schedule_today),
-        message = stringResource(LR.string.onboarding_upgrade_schedule_today_message),
-    ),
-    UpgradeTrialItem(
-        iconResId = IR.drawable.ic_envelope,
-        title = stringResource(LR.string.onboarding_upgrade_schedule_day, 24),
-        message = stringResource(LR.string.onboarding_upgrade_schedule_notify),
-    ),
-    UpgradeTrialItem(
-        iconResId =IR.drawable.ic_star,
-        title = stringResource(LR.string.onboarding_upgrade_schedule_day, 31),
-        message = stringResource(LR.string.onboarding_upgrade_schedule_billing, "September 31th"),
-    ),
-)
+) {
+    companion object {
+        @Composable
+        fun getPreviewItems() = listOf(
+            UpgradeTrialItem(
+                iconResId = IR.drawable.ic_unlocked,
+                title = stringResource(LR.string.onboarding_upgrade_schedule_today),
+                message = stringResource(LR.string.onboarding_upgrade_schedule_today_message),
+            ),
+            UpgradeTrialItem(
+                iconResId = IR.drawable.ic_envelope,
+                title = stringResource(LR.string.onboarding_upgrade_schedule_day, 24),
+                message = stringResource(LR.string.onboarding_upgrade_schedule_notify),
+            ),
+            UpgradeTrialItem(
+                iconResId = IR.drawable.ic_star,
+                title = stringResource(LR.string.onboarding_upgrade_schedule_day, 31),
+                message = stringResource(LR.string.onboarding_upgrade_schedule_billing, "September 31th"),
+            ),
+        )
+    }
+}
 
 @Composable
 fun UpgradeTrialTimeline(
@@ -182,11 +184,7 @@ private fun PreviewUpgradeTimeline(
 ) {
     AppThemeWithBackground(theme) {
         UpgradeTrialTimeline(
-            items = listOf(
-                UpgradeTrialItem(iconResId = IR.drawable.ic_star, title = "Star", message = "Message".repeat(10)),
-                UpgradeTrialItem(iconResId = IR.drawable.ic_envelope, title = "Envelope", message = "Message"),
-                UpgradeTrialItem(iconResId = IR.drawable.ic_unlocked, title = "Unlocked", message = "Message".repeat(20)),
-            ),
+            items = UpgradeTrialItem.getPreviewItems(),
         )
     }
 }

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/components/UpgradeTrialTimeline.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/components/UpgradeTrialTimeline.kt
@@ -24,6 +24,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
+import androidx.compose.ui.unit.Constraints
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import au.com.shiftyjelly.pocketcasts.compose.AppThemeWithBackground
@@ -148,7 +149,11 @@ fun UpgradeTrialTimeline(
         // restrict amount of vertical and horizontal space each item may take
         val modifiedConstraints = constraints.copy(
             minHeight = iconSizePx.toInt(),
-            maxHeight = max(iconSizePx.toInt(), constraints.maxHeight / max(1, items.size)),
+            maxHeight = if (constraints.maxHeight == Constraints.Infinity) {
+                Constraints.Infinity
+            } else {
+                max(iconSizePx.toInt(), constraints.maxHeight / max(1, items.size))
+            },
             minWidth = iconSizePx.toInt(),
             maxWidth = max(iconSizePx.toInt(), (constraints.maxWidth - iconPaddingPx - iconSizePx).toInt()),
         )

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/components/UpgradeTrialTimeline.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/components/UpgradeTrialTimeline.kt
@@ -20,6 +20,7 @@ import androidx.compose.ui.layout.Layout
 import androidx.compose.ui.layout.Placeable
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
@@ -32,11 +33,31 @@ import au.com.shiftyjelly.pocketcasts.compose.theme
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme.ThemeType
 import kotlin.math.max
 import au.com.shiftyjelly.pocketcasts.images.R as IR
+import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 data class UpgradeTrialItem(
     @DrawableRes val iconResId: Int,
     val title: String,
     val message: String,
+)
+
+@Composable
+fun previewItems() = listOf(
+    UpgradeTrialItem(
+        iconResId = IR.drawable.ic_unlocked,
+        title = stringResource(LR.string.onboarding_upgrade_schedule_today),
+        message = stringResource(LR.string.onboarding_upgrade_schedule_today_message),
+    ),
+    UpgradeTrialItem(
+        iconResId = IR.drawable.ic_envelope,
+        title = stringResource(LR.string.onboarding_upgrade_schedule_day, 24),
+        message = stringResource(LR.string.onboarding_upgrade_schedule_notify),
+    ),
+    UpgradeTrialItem(
+        iconResId =IR.drawable.ic_star,
+        title = stringResource(LR.string.onboarding_upgrade_schedule_day, 31),
+        message = stringResource(LR.string.onboarding_upgrade_schedule_billing, "September 31th"),
+    ),
 )
 
 @Composable

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeFlow.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeFlow.kt
@@ -4,7 +4,6 @@ import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.material.ModalBottomSheetLayout
 import androidx.compose.material.ModalBottomSheetValue
 import androidx.compose.material.rememberModalBottomSheetState
@@ -110,7 +109,6 @@ fun OnboardingUpgradeFlow(
         }
     }
 
-    @OptIn(ExperimentalMaterialApi::class)
     ModalBottomSheetLayout(
         sheetState = sheetState,
         scrimColor = Color.Black.copy(alpha = 0.5f),

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeFlow.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeFlow.kt
@@ -118,7 +118,7 @@ fun OnboardingUpgradeFlow(
         content = {
             if (flow !is OnboardingFlow.PlusAccountUpgrade) {
                 if (FeatureFlag.isEnabled(Feature.NEW_ONBOARDING_UPGRADE)) {
-                    OnboardingUpgradeScreen(onClosePress = onBackPress, onSubscribePress = {})
+                    OnboardingUpgradeScreen(onClosePress = onBackPress, onSubscribePress = {}, variant = Variants.VARIANT_FEATURES)
                 } else {
                     OnboardingUpgradeFeaturesPage(
                         viewModel = @Suppress("ktlint:compose:vm-forwarding-check") viewModel,

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeScreen.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeScreen.kt
@@ -1,5 +1,7 @@
 package au.com.shiftyjelly.pocketcasts.account.onboarding.upgrade
 
+import UpgradeTrialItem
+import UpgradeTrialTimeline
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
@@ -19,6 +21,7 @@ import androidx.compose.foundation.layout.statusBars
 import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.layout.wrapContentWidth
+import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.pager.VerticalPager
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.foundation.shape.CircleShape
@@ -41,12 +44,13 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.dp
+import au.com.shiftyjelly.pocketcasts.account.onboarding.components.UpgradeFeatureItem
 import au.com.shiftyjelly.pocketcasts.account.onboarding.components.UpgradePlanRow
 import au.com.shiftyjelly.pocketcasts.account.onboarding.upgrade.OnboardingUpgradeHelper.PrivacyPolicy
 import au.com.shiftyjelly.pocketcasts.account.onboarding.upgrade.OnboardingUpgradeHelper.UpgradeRowButton
 import au.com.shiftyjelly.pocketcasts.compose.AppThemeWithBackground
 import au.com.shiftyjelly.pocketcasts.compose.components.TextH10
-import au.com.shiftyjelly.pocketcasts.compose.components.TextH40
+import au.com.shiftyjelly.pocketcasts.compose.components.TextP40
 import au.com.shiftyjelly.pocketcasts.compose.images.SubscriptionBadge
 import au.com.shiftyjelly.pocketcasts.compose.preview.ThemePreviewParameterProvider
 import au.com.shiftyjelly.pocketcasts.compose.theme
@@ -54,10 +58,18 @@ import au.com.shiftyjelly.pocketcasts.images.R
 import au.com.shiftyjelly.pocketcasts.payment.SubscriptionPlan
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme.ThemeType
 import kotlinx.coroutines.launch
+import previewItems
+import au.com.shiftyjelly.pocketcasts.images.R as IR
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
+
+enum class Variants {
+    VARIANT_FEATURES,
+    VARIANT_TRIAL_TIMELINE,
+}
 
 @Composable
 fun OnboardingUpgradeScreen(
+    variant: Variants,
     onClosePress: () -> Unit,
     onSubscribePress: () -> Unit,
     modifier: Modifier = Modifier,
@@ -68,6 +80,7 @@ fun OnboardingUpgradeScreen(
     )
 
     var selectedPlan by remember { mutableStateOf(plans[0]) }
+    val selectedOnboardingPlan = remember(selectedPlan) { OnboardingSubscriptionPlan.create(selectedPlan) }
 
     Column(
         modifier = modifier
@@ -80,12 +93,16 @@ fun OnboardingUpgradeScreen(
             ),
     ) {
         UpgradeHeader(
-            selectedPlan = selectedPlan,
+            selectedPlan = selectedOnboardingPlan,
             onClosePress = onClosePress,
         )
         Spacer(modifier = Modifier.height(24.dp))
         UpgradeContent(
             modifier = Modifier.weight(1f),
+            pages = variant.toContentPages(
+                currentPlan = selectedOnboardingPlan,
+                isEligibleForTrial = true,
+            ),
         )
         Spacer(modifier = Modifier.height(16.dp))
         UpgradeFooter(
@@ -93,6 +110,7 @@ fun OnboardingUpgradeScreen(
                 .fillMaxWidth(),
             plans = plans,
             selectedPlan = selectedPlan,
+            selectedOnboardingPlan = selectedOnboardingPlan,
             onSelectedChange = { selectedPlan = it },
             onClickSubscribe = { onSubscribePress() },
         )
@@ -104,11 +122,10 @@ private fun UpgradeFooter(
     plans: List<SubscriptionPlan.Base>,
     selectedPlan: SubscriptionPlan.Base,
     onSelectedChange: (SubscriptionPlan.Base) -> Unit,
+    selectedOnboardingPlan: OnboardingSubscriptionPlan,
     onClickSubscribe: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    val selectedOnboardingPlan = remember(selectedPlan) { OnboardingSubscriptionPlan.create(selectedPlan) }
-
     Column(
         modifier = modifier,
     ) {
@@ -144,12 +161,10 @@ private fun UpgradeFooter(
 
 @Composable
 private fun UpgradeHeader(
-    selectedPlan: SubscriptionPlan.Base,
+    selectedPlan: OnboardingSubscriptionPlan,
     onClosePress: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    val selectedOnboardingPlan = remember(selectedPlan) { OnboardingSubscriptionPlan.create(selectedPlan) }
-
     Column(modifier = modifier) {
         Row(
             modifier = Modifier.fillMaxWidth(),
@@ -157,8 +172,8 @@ private fun UpgradeHeader(
             verticalAlignment = Alignment.CenterVertically,
         ) {
             SubscriptionBadge(
-                iconRes = selectedOnboardingPlan.badgeIconRes,
-                shortNameRes = selectedOnboardingPlan.shortNameRes,
+                iconRes = selectedPlan.badgeIconRes,
+                shortNameRes = selectedPlan.shortNameRes,
                 backgroundColor = Color.Black,
                 textColor = Color.White,
                 modifier = Modifier
@@ -192,60 +207,120 @@ private fun UpgradeHeader(
 }
 
 @Composable
+private fun Variants.toContentPages(currentPlan: OnboardingSubscriptionPlan, isEligibleForTrial: Boolean) = buildList {
+    when (this@toContentPages) {
+        Variants.VARIANT_FEATURES -> {
+            add(
+                ContentPage.Features(
+                    features = currentPlan.featureItems,
+                    showCta = true,
+                ),
+            )
+            if (isEligibleForTrial) {
+                add(
+                    ContentPage.TrialSchedule(
+                        timelineItems = previewItems(),
+                        showCta = false,
+                    ),
+                )
+            }
+        }
+
+        Variants.VARIANT_TRIAL_TIMELINE -> {
+            add(
+                ContentPage.TrialSchedule(
+                    timelineItems = previewItems(),
+                    showCta = true,
+                ),
+            )
+            add(
+                ContentPage.Features(
+                    features = currentPlan.featureItems,
+                    showCta = false,
+                ),
+            )
+        }
+    }
+}
+
+sealed interface ContentPage {
+    val showCta: Boolean
+
+    data class Features(val features: List<UpgradeFeatureItem>, override val showCta: Boolean) : ContentPage
+    data class TrialSchedule(val timelineItems: List<UpgradeTrialItem>, override val showCta: Boolean) : ContentPage
+}
+
+@Composable
 private fun UpgradeContent(
+    pages: List<ContentPage>,
     modifier: Modifier = Modifier,
 ) {
-    val pagerState = rememberPagerState(initialPage = 0) { 2 }
-    val coroutineScope = rememberCoroutineScope()
-    VerticalPager(
-        modifier = modifier,
-        state = pagerState,
-    ) { page ->
-        if (page == 0) {
-            FeaturesContent(
-                onClick = {
-                    coroutineScope.launch {
-                        pagerState.animateScrollToPage(1)
-                    }
-                },
-            )
-        } else {
-            ScheduleContent(
-                onClick = {
-                    coroutineScope.launch {
-                        pagerState.animateScrollToPage(0)
-                    }
-                },
-            )
+    Column(modifier = modifier) {
+        val pagerState = rememberPagerState(initialPage = 0) { pages.size }
+        val coroutineScope = rememberCoroutineScope()
+        VerticalPager(state = pagerState, modifier = Modifier.fillMaxSize()) { page ->
+            when (val currentPage = pages[page]) {
+                is ContentPage.Features -> FeaturesContent(
+                    features = currentPage,
+                    onCtaClicked = { coroutineScope.launch { pagerState.animateScrollToPage(pages.size - page - 1) } },
+                )
+
+                is ContentPage.TrialSchedule -> ScheduleContent(
+                    trialSchedule = currentPage,
+                    onCtaClicked = { coroutineScope.launch { pagerState.animateScrollToPage(pages.size - page - 1) } },
+                )
+            }
         }
     }
 }
 
 @Composable
 private fun FeaturesContent(
-    onClick: (() -> Unit)? = null,
+    features: ContentPage.Features,
+    onCtaClicked: () -> Unit,
 ) {
-    Box(
-        contentAlignment = Alignment.Center,
-        modifier = Modifier
-            .fillMaxWidth()
-            .heightIn(min = 92.dp),
-    ) {
-        TextH40(text = "Features content", modifier = Modifier.clickable { onClick?.invoke() })
+    LazyColumn {
+        items(features.features.size) {
+            UpgradeFeatureItem(
+                item = features.features[it],
+                iconColor = MaterialTheme.theme.colors.primaryText01,
+                textColor = MaterialTheme.theme.colors.secondaryText02,
+            )
+        }
+        if (features.showCta) {
+            item {
+                Spacer(modifier = Modifier.height(24.dp))
+                TextP40(
+                    text = stringResource(LR.string.onboarding_upgrade_features_trial_schedule),
+                    modifier = Modifier.clickable { onCtaClicked() },
+                    color = MaterialTheme.theme.colors.primaryInteractive01,
+                )
+            }
+        }
     }
 }
 
 @Composable
 private fun ScheduleContent(
-    onClick: (() -> Unit)? = null,
+    trialSchedule: ContentPage.TrialSchedule,
+    onCtaClicked: () -> Unit,
 ) {
-    Box(
-        contentAlignment = Alignment.Center,
-        modifier = Modifier
-            .fillMaxWidth()
-            .heightIn(min = 92.dp),
-    ) {
-        TextH40(text = "Schedule content", modifier = Modifier.clickable { onClick?.invoke() })
+    LazyColumn {
+        item {
+            UpgradeTrialTimeline(
+                items = trialSchedule.timelineItems,
+            )
+        }
+        if (trialSchedule.showCta) {
+            item {
+                Spacer(modifier = Modifier.height(24.dp))
+                TextP40(
+                    text = stringResource(LR.string.onboarding_upgrade_schedule_see_features),
+                    modifier = Modifier.clickable { onCtaClicked() },
+                    color = MaterialTheme.theme.colors.primaryInteractive01,
+                )
+            }
+        }
     }
 }
 
@@ -259,6 +334,7 @@ private fun PreviewOnboardingUpgradeScreen(
             modifier = Modifier.fillMaxSize(),
             onSubscribePress = {},
             onClosePress = {},
+            variant = Variants.VARIANT_FEATURES,
         )
     }
 }

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeScreen.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeScreen.kt
@@ -20,7 +20,6 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.statusBars
 import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.layout.wrapContentHeight
-import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.foundation.pager.VerticalPager
 import androidx.compose.foundation.pager.rememberPagerState
@@ -261,12 +260,12 @@ private fun UpgradeContent(
             when (val currentPage = pages[page]) {
                 is UpgradePagerContent.Features -> FeaturesContent(
                     features = currentPage,
-                    onCtaClick = { coroutineScope.launch { pagerState.animateScrollToPage(pagerState.currentPage + 1) } },
+                    onCtaClick = { coroutineScope.launch { pagerState.animateScrollToPage(pages.size - page) } },
                 )
 
                 is UpgradePagerContent.TrialSchedule -> ScheduleContent(
                     trialSchedule = currentPage,
-                    onCtaClick = { coroutineScope.launch { pagerState.animateScrollToPage(pagerState.currentPage - 1) } },
+                    onCtaClick = { coroutineScope.launch { pagerState.animateScrollToPage(pages.size - page) } },
                 )
             }
         }
@@ -290,7 +289,8 @@ private fun FeaturesContent(
             item {
                 TextP40(
                     text = stringResource(LR.string.onboarding_upgrade_features_trial_schedule),
-                    modifier = Modifier.clickable { onCtaClick() }.padding(top = 24.dp),
+                    modifier = Modifier.padding(top = 24.dp)
+                        .clickable { onCtaClick() },
                     color = MaterialTheme.theme.colors.primaryInteractive01,
                 )
             }
@@ -306,7 +306,6 @@ private fun ScheduleContent(
     FadedLazyColumn {
         item {
             UpgradeTrialTimeline(
-                modifier = Modifier.wrapContentSize(),
                 items = trialSchedule.timelineItems,
             )
         }
@@ -314,7 +313,8 @@ private fun ScheduleContent(
             item {
                 TextP40(
                     text = stringResource(LR.string.onboarding_upgrade_schedule_see_features),
-                    modifier = Modifier.clickable { onCtaClick() }.padding(top = 24.dp),
+                    modifier = Modifier.padding(top = 24.dp)
+                        .clickable { onCtaClick() },
                     color = MaterialTheme.theme.colors.primaryInteractive01,
                 )
             }

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeScreen.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeScreen.kt
@@ -59,7 +59,6 @@ import au.com.shiftyjelly.pocketcasts.images.R
 import au.com.shiftyjelly.pocketcasts.payment.SubscriptionPlan
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme.ThemeType
 import kotlinx.coroutines.launch
-import previewItems
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 enum class Variants {
@@ -219,7 +218,7 @@ private fun Variants.toContentPages(currentPlan: OnboardingSubscriptionPlan, isE
             if (isEligibleForTrial) {
                 add(
                     UpgradePagerContent.TrialSchedule(
-                        timelineItems = previewItems(),
+                        timelineItems = UpgradeTrialItem.getPreviewItems(),
                         showCta = false,
                     ),
                 )
@@ -229,7 +228,7 @@ private fun Variants.toContentPages(currentPlan: OnboardingSubscriptionPlan, isE
         Variants.VARIANT_TRIAL_TIMELINE -> {
             add(
                 UpgradePagerContent.TrialSchedule(
-                    timelineItems = previewItems(),
+                    timelineItems = UpgradeTrialItem.getPreviewItems(),
                     showCta = true,
                 ),
             )
@@ -262,12 +261,12 @@ private fun UpgradeContent(
             when (val currentPage = pages[page]) {
                 is UpgradePagerContent.Features -> FeaturesContent(
                     features = currentPage,
-                    onCtaClicked = { coroutineScope.launch { pagerState.animateScrollToPage(pagerState.currentPage + 1) } },
+                    onCtaClick = { coroutineScope.launch { pagerState.animateScrollToPage(pagerState.currentPage + 1) } },
                 )
 
                 is UpgradePagerContent.TrialSchedule -> ScheduleContent(
                     trialSchedule = currentPage,
-                    onCtaClicked = { coroutineScope.launch { pagerState.animateScrollToPage(pagerState.currentPage - 1) } },
+                    onCtaClick = { coroutineScope.launch { pagerState.animateScrollToPage(pagerState.currentPage - 1) } },
                 )
             }
         }
@@ -277,7 +276,7 @@ private fun UpgradeContent(
 @Composable
 private fun FeaturesContent(
     features: UpgradePagerContent.Features,
-    onCtaClicked: () -> Unit,
+    onCtaClick: () -> Unit,
 ) {
     FadedLazyColumn {
         items(features.features.size) {
@@ -291,7 +290,7 @@ private fun FeaturesContent(
             item {
                 TextP40(
                     text = stringResource(LR.string.onboarding_upgrade_features_trial_schedule),
-                    modifier = Modifier.clickable { onCtaClicked() }.padding(top = 24.dp),
+                    modifier = Modifier.clickable { onCtaClick() }.padding(top = 24.dp),
                     color = MaterialTheme.theme.colors.primaryInteractive01,
                 )
             }
@@ -302,7 +301,7 @@ private fun FeaturesContent(
 @Composable
 private fun ScheduleContent(
     trialSchedule: UpgradePagerContent.TrialSchedule,
-    onCtaClicked: () -> Unit,
+    onCtaClick: () -> Unit,
 ) {
     FadedLazyColumn {
         item {
@@ -315,7 +314,7 @@ private fun ScheduleContent(
             item {
                 TextP40(
                     text = stringResource(LR.string.onboarding_upgrade_schedule_see_features),
-                    modifier = Modifier.clickable { onCtaClicked() }.padding(top = 24.dp),
+                    modifier = Modifier.clickable { onCtaClick() }.padding(top = 24.dp),
                     color = MaterialTheme.theme.colors.primaryInteractive01,
                 )
             }

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/ProfileUpgradeBanner.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/ProfileUpgradeBanner.kt
@@ -103,7 +103,7 @@ private fun FeatureCard(
         subscriptionPlan.featureItems.forEach { item ->
             UpgradeFeatureItem(
                 item = item,
-                color = MaterialTheme.theme.colors.primaryText01,
+                textColor = MaterialTheme.theme.colors.primaryText01,
             )
         }
 

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/UpgradeFeatureItem.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/UpgradeFeatureItem.kt
@@ -11,8 +11,8 @@ interface UpgradeFeatureItem {
     @get:DrawableRes
     val image: Int
 
-    @get:StringRes
-    val title: Int
+    @StringRes
+    fun title(): Int
 
     val isYearlyFeature: Boolean
 
@@ -21,89 +21,95 @@ interface UpgradeFeatureItem {
 
 enum class PlusUpgradeFeatureItem(
     override val image: Int,
-    override val title: Int,
 ) : UpgradeFeatureItem {
     BannerAds(
         image = IR.drawable.ic_remove_ads,
-        title = LR.string.onboarding_plus_feature_no_banner_ads,
     ) {
         override val isYearlyFeature get() = FeatureFlag.isEnabled(Feature.BANNER_ADS)
         override val isMonthlyFeature get() = FeatureFlag.isEnabled(Feature.BANNER_ADS)
+        override fun title() = LR.string.onboarding_plus_feature_no_banner_ads
     },
     Folders(
         image = IR.drawable.ic_plus_feature_folder,
-        title = if (FeatureFlag.isEnabled(Feature.NEW_ONBOARDING_UPGRADE)) {
+    ) {
+        override fun title() = if (FeatureFlag.isEnabled(Feature.NEW_ONBOARDING_UPGRADE)) {
             LR.string.onboarding_upgrade_features_folders
         } else {
             LR.string.onboarding_plus_feature_folders_title
-        },
-    ),
+        }
+    },
     UpNextShuffle(
         image = IR.drawable.ic_plus_feature_shuffle,
-        title = if (FeatureFlag.isEnabled(Feature.NEW_ONBOARDING_UPGRADE)) {
+    ) {
+        override fun title() = if (FeatureFlag.isEnabled(Feature.NEW_ONBOARDING_UPGRADE)) {
             LR.string.onboarding_upgrade_features_shuffle
         } else {
             LR.string.onboarding_plus_feature_up_next_shuffle_title
-        },
-    ),
+        }
+    },
     Bookmarks(
         image = IR.drawable.ic_plus_feature_bookmark,
-        title = if (FeatureFlag.isEnabled(Feature.NEW_ONBOARDING_UPGRADE)) {
+    ) {
+        override fun title() = if (FeatureFlag.isEnabled(Feature.NEW_ONBOARDING_UPGRADE)) {
             LR.string.onboarding_upgrade_features_bookmarks
         } else {
             LR.string.onboarding_plus_feature_bookmarks_title
-        },
-    ),
+        }
+    },
     SkipChapters(
         image = IR.drawable.ic_plus_feature_chapters,
-        title = if (FeatureFlag.isEnabled(Feature.NEW_ONBOARDING_UPGRADE)) {
+    ) {
+        override fun title() = if (FeatureFlag.isEnabled(Feature.NEW_ONBOARDING_UPGRADE)) {
             LR.string.onboarding_upgrade_features_chapters
         } else {
             LR.string.onboarding_plus_feature_chapters_title
-        },
-    ),
+        }
+    },
     CloudStorage(
         image = IR.drawable.ic_plus_feature_cloud_storage,
-        title = if (FeatureFlag.isEnabled(Feature.NEW_ONBOARDING_UPGRADE)) {
+    ) {
+        override fun title() = if (FeatureFlag.isEnabled(Feature.NEW_ONBOARDING_UPGRADE)) {
             LR.string.onboarding_upgrade_features_files
         } else {
             LR.string.onboarding_plus_feature_cloud_storage_title
-        },
-    ),
+        }
+    },
     WatchPlayback(
         image = IR.drawable.ic_plus_feature_wearable,
-        title = if (FeatureFlag.isEnabled(Feature.NEW_ONBOARDING_UPGRADE)) {
+    ) {
+        override fun title() = if (FeatureFlag.isEnabled(Feature.NEW_ONBOARDING_UPGRADE)) {
             LR.string.onboarding_upgrade_features_wear
         } else {
             LR.string.onboarding_plus_feature_watch_playback
-        },
-    ),
+        }
+    },
     ThemesIcons(
         image = IR.drawable.ic_plus_feature_themes,
-        title = if (FeatureFlag.isEnabled(Feature.NEW_ONBOARDING_UPGRADE)) {
+    ) {
+        override fun title() = if (FeatureFlag.isEnabled(Feature.NEW_ONBOARDING_UPGRADE)) {
             LR.string.onboarding_upgrade_features_themes
         } else {
             LR.string.onboarding_plus_feature_extra_themes_icons_title
-        },
-    ),
+        }
+    },
     SlumberStudiosPromo(
         image = IR.drawable.ic_plus_feature_slumber_studios,
-        title = if (FeatureFlag.isEnabled(Feature.NEW_ONBOARDING_UPGRADE)) {
-            LR.string.onboarding_upgrade_features_slumber
-        } else {
-            LR.string.onboarding_plus_feature_slumber_studios_title
-        },
     ) {
         override val isMonthlyFeature get() = false
         override val isYearlyFeature get() = FeatureFlag.isEnabled(Feature.SLUMBER_STUDIOS_YEARLY_PROMO)
+        override fun title() = if (FeatureFlag.isEnabled(Feature.NEW_ONBOARDING_UPGRADE)) {
+            LR.string.onboarding_upgrade_features_slumber
+        } else {
+            LR.string.onboarding_plus_feature_slumber_studios_title
+        }
     },
     LibroFm(
         image = IR.drawable.ic_plus_feature_libro,
-        title = LR.string.onboarding_plus_feature_libro_title,
     ) {
 
         override val isYearlyFeature get() = FeatureFlag.isEnabled(Feature.LIBRO_FM)
         override val isMonthlyFeature get() = FeatureFlag.isEnabled(Feature.LIBRO_FM)
+        override fun title() = LR.string.onboarding_plus_feature_libro_title
     },
     ;
 
@@ -113,32 +119,37 @@ enum class PlusUpgradeFeatureItem(
 
 enum class PatronUpgradeFeatureItem(
     override val image: Int,
-    override val title: Int,
 ) : UpgradeFeatureItem {
     EverythingInPlus(
         image = IR.drawable.ic_check,
-        title = LR.string.onboarding_patron_feature_everything_in_plus_title,
-    ),
+    ) {
+        override fun title() = LR.string.onboarding_patron_feature_everything_in_plus_title
+    },
     EarlyAccess(
         image = IR.drawable.ic_new_features,
-        title = LR.string.onboarding_patron_feature_early_access_title,
-    ),
+    ) {
+        override fun title() = LR.string.onboarding_patron_feature_early_access_title
+    },
     CloudStorage(
         image = IR.drawable.ic_cloud_storage,
-        title = LR.string.onboarding_patron_feature_cloud_storage_title,
-    ),
+    ) {
+        override fun title() = LR.string.onboarding_patron_feature_cloud_storage_title
+    },
     ProfileBadge(
         image = IR.drawable.ic_profile_badge,
-        title = LR.string.onboarding_patron_feature_profile_badge_title,
-    ),
+    ) {
+        override fun title() = LR.string.onboarding_patron_feature_profile_badge_title
+    },
     SpecialIcons(
         image = IR.drawable.ic_icons,
-        title = LR.string.onboarding_patron_feature_special_icons_title,
-    ),
+    ) {
+        override fun title() = LR.string.onboarding_patron_feature_special_icons_title
+    },
     UndyingGratitude(
         image = IR.drawable.ic_heart,
-        title = LR.string.onboarding_patron_feature_gratitude_title,
-    ),
+    ) {
+        override fun title() = LR.string.onboarding_patron_feature_gratitude_title
+    },
     ;
 
     override val isYearlyFeature get() = true

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/UpgradeFeatureItem.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/UpgradeFeatureItem.kt
@@ -32,35 +32,67 @@ enum class PlusUpgradeFeatureItem(
     },
     Folders(
         image = IR.drawable.ic_plus_feature_folder,
-        title = LR.string.onboarding_plus_feature_folders_title,
+        title = if (FeatureFlag.isEnabled(Feature.NEW_ONBOARDING_UPGRADE)) {
+            LR.string.onboarding_upgrade_features_folders
+        } else {
+            LR.string.onboarding_plus_feature_folders_title
+        },
     ),
     UpNextShuffle(
         image = IR.drawable.ic_plus_feature_shuffle,
-        title = LR.string.onboarding_plus_feature_up_next_shuffle_title,
+        title = if (FeatureFlag.isEnabled(Feature.NEW_ONBOARDING_UPGRADE)) {
+            LR.string.onboarding_upgrade_features_shuffle
+        } else {
+            LR.string.onboarding_plus_feature_up_next_shuffle_title
+        },
     ),
     Bookmarks(
         image = IR.drawable.ic_plus_feature_bookmark,
-        title = LR.string.onboarding_plus_feature_bookmarks_title,
+        title = if (FeatureFlag.isEnabled(Feature.NEW_ONBOARDING_UPGRADE)) {
+            LR.string.onboarding_upgrade_features_bookmarks
+        } else {
+            LR.string.onboarding_plus_feature_bookmarks_title
+        },
     ),
     SkipChapters(
         image = IR.drawable.ic_plus_feature_chapters,
-        title = LR.string.onboarding_plus_feature_chapters_title,
+        title = if (FeatureFlag.isEnabled(Feature.NEW_ONBOARDING_UPGRADE)) {
+            LR.string.onboarding_upgrade_features_chapters
+        } else {
+            LR.string.onboarding_plus_feature_chapters_title
+        },
     ),
     CloudStorage(
         image = IR.drawable.ic_plus_feature_cloud_storage,
-        title = LR.string.onboarding_plus_feature_cloud_storage_title,
+        title = if (FeatureFlag.isEnabled(Feature.NEW_ONBOARDING_UPGRADE)) {
+            LR.string.onboarding_upgrade_features_files
+        } else {
+            LR.string.onboarding_plus_feature_cloud_storage_title
+        },
     ),
     WatchPlayback(
         image = IR.drawable.ic_plus_feature_wearable,
-        title = LR.string.onboarding_plus_feature_watch_playback,
+        title = if (FeatureFlag.isEnabled(Feature.NEW_ONBOARDING_UPGRADE)) {
+            LR.string.onboarding_upgrade_features_wear
+        } else {
+            LR.string.onboarding_plus_feature_watch_playback
+        },
     ),
     ThemesIcons(
         image = IR.drawable.ic_plus_feature_themes,
-        title = LR.string.onboarding_plus_feature_extra_themes_icons_title,
+        title = if (FeatureFlag.isEnabled(Feature.NEW_ONBOARDING_UPGRADE)) {
+            LR.string.onboarding_upgrade_features_themes
+        } else {
+            LR.string.onboarding_plus_feature_extra_themes_icons_title
+        },
     ),
     SlumberStudiosPromo(
         image = IR.drawable.ic_plus_feature_slumber_studios,
-        title = LR.string.onboarding_plus_feature_slumber_studios_title,
+        title = if (FeatureFlag.isEnabled(Feature.NEW_ONBOARDING_UPGRADE)) {
+            LR.string.onboarding_upgrade_features_slumber
+        } else {
+            LR.string.onboarding_plus_feature_slumber_studios_title
+        },
     ) {
         override val isMonthlyFeature get() = false
         override val isYearlyFeature get() = FeatureFlag.isEnabled(Feature.SLUMBER_STUDIOS_YEARLY_PROMO)

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -2422,50 +2422,36 @@
     <!-- Notifications -->
     <string name="notification_sync_title">Your shows, on any device!</string>
     <string name="notification_sync_message">Create a free account to sync your shows and listen anywhere.</string>
-
     <string name="notification_import_title">Easily import your podcasts</string>
     <string name="notification_import_message">Switching from another app? Bring all your favorite shows to Pocket Casts.</string>
-
     <string name="notification_up_next_title">Simplify your queue</string>
     <string name="notification_up_next_message">Build a playback queue and say goodbye to jumping around between episodes.</string>
-
     <string name="notification_filters_title">Organize your episodes</string>
     <string name="notification_filters_message">Create smart filters to organize your episodes.</string>
-
     <string name="notification_themes_title">Time for a new look</string>
     <string name="notification_themes_message">Browse our themes and find the one that suits your style.</string>
-
     <string name="notification_staff_picks_title">Explore our Staff Picks</string>
     <string name="notification_staff_picks_message">Perfectly ripe podcasts, picked just for you by real, podcast-loving humans.</string>
-
     <string name="notification_plus_upsell_title">Level up your podcast game</string>
     <string name="notification_plus_upsell_message">Unlock exclusive features like folders, bookmarks, and more with Plus!</string>
-
     <string name="notification_reengage_we_miss_you_title">We miss you!</string>
     <string name="notification_reengage_we_miss_you_message">It\'s been a while since you\'ve listened. Jump back in and enjoy!</string>
-
     <string name="notification_reengage_catch_up_offline_title">Catch up offline</string>
     <plurals name="notification_reengage_catch_up_offline_message">
         <item quantity="one">You have %d new episode downloaded and ready to go!</item>
         <item quantity="other">You have %d new episodes downloaded and ready to go!</item>
     </plurals>
-
     <string name="notification_content_recommendations_trending_title">Trending this week</string>
     <string name="notification_content_recommendations_trending_message">Check out what everyone else is listening this week.</string>
-
     <string name="notification_content_recommendations_title">New recommendations for you</string>
     <string name="notification_content_recommendations_message">Wondering what to listen to next? Check out these shows!</string>
-
     <string name="notifications_settings_turn_on_push_title">Turn on push notifications?</string>
     <string name="notifications_settings_turn_on_push_message">To get notifications from Pocket Casts, you\'ll need to turn them on in your device settings.</string>
     <string name="notifications_settings_turn_on_push_button">Go to device settings</string>
-
     <string name="notification_new_features_smart_folders_title">Your podcasts organized</string>
     <string name="notification_new_features_smart_folders_message">Try Plus and automatically organize your shows with folders</string>
-
     <string name="notification_offers_upgrade_title">Level up your podcast game</string>
     <string name="notification_offers_upgrade_message">Unblock exclusive features like folders, bookmarks, and more with Plus!</string>
-
     <string name="notification_prompt_title">Stay up to date!</string>
     <string name="notification_prompt_message">Notifications are the best way to keep track of new episodes, get recommendations of new shows and tips about Pocket Casts.</string>
     <string name="notification_prompt_cta">Allow Notifications</string>
@@ -2475,5 +2461,22 @@
 
     <!-- Onboarding Upgrade -->
     <string name="onboarding_upgrade_generic_title">Superpowers for your podcasts</string>
+    <string name="onboarding_upgrade_schedule_today">Today</string>
+    <string name="onboarding_upgrade_schedule_today_message">Get access to Folders, Shuffle, Bookmarks, and exclusive content</string>
+    <string name="onboarding_upgrade_schedule_day">Day %1$d</string>
+    <string name="onboarding_upgrade_schedule_notify">We\'ll notify you about your trial ending.</string>
+    <string name="onboarding_upgrade_schedule_billing">You\'ll be charged on %1$s. Cancel anytime before.</string>
+    <string name="onboarding_upgrade_schedule_see_features">See all Plus features</string>
+    <string name="onboarding_upgrade_features_folders">Tidy your collection with Folders</string>
+    <string name="onboarding_upgrade_features_shuffle">Shuffle your queue</string>
+    <string name="onboarding_upgrade_features_bookmarks">Keep timestamps with Bookmarks</string>
+    <string name="onboarding_upgrade_features_chapters">Save time with Preselect Chapters</string>
+    <string name="onboarding_upgrade_features_files">20 GB Cloud Storage for your files</string>
+    <string name="onboarding_upgrade_features_themes">Extra Themes and App Icons</string>
+    <string name="onboarding_upgrade_features_wear">Apps for Wear OS and Apple Watch</string>
+    <string name="onboarding_upgrade_features_slumber"><![CDATA[1 year of content from <a href="https://slumberstudios.com/">Slumber&#160;Studios</a>]]></string>
+    <string name="onboarding_upgrade_features_trial_schedule">How does the free trial work?</string>
+    <string name="onboarding_upgrade_billing_cycle_monthly">Monthly plan</string>
+    <string name="onboarding_upgrade_billing_cycle_yearly">Yearly plan</string>
     <string name="onboarding_upgrade_save_percent">Save %1$d\%%</string>
 </resources>


### PR DESCRIPTION
## Description
Next step of the saga, connecting the dots. Just not on the data level... yet.
This PR adds new capabilities to the previously introduced `OnboardingUpgradeScreen`.
Now it's able to display the desired content, altough it still uses hardcoded data.
Another improvement is that now it can receive a new argument, `Variants` that is an enum type and meant to represent the A/B experiment options.
You can control how 

Designs: PviUP0aiZctOprDuuYRwpb-fi-4999_5992

Fixes https://linear.app/a8c/issue/PCDROID-14/implement-generic-upgrade-screens

## Testing Instructions
1. Make sure `new_onboarding_upgrade` is ON
2. Settings -> Pocket Casts Plus
- [ ] See features
3. Test the app on smaller devices and etc.
4. Apply this patch and rebuild the app: [variant_b.patch](https://github.com/user-attachments/files/21110053/variant_b.patch)
- [ ] See other variant, the trial schedule
5. Repeat step 3



## Screenshots or Screencast 
On small device:

https://github.com/user-attachments/assets/b3644bce-0970-43cf-9eea-db43889cd38f



## Checklist
- [ ] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] ~I have considered whether it makes sense to add tests for my changes~
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [ ] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [ ] ~for accessibility with TalkBack~ -- NOT YET