### PR TITLE
Make AutoPlaySource constants lazy

### DIFF
--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/models/db/UpNextQueueTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/models/db/UpNextQueueTest.kt
@@ -42,8 +42,8 @@ class UpNextQueueTest {
         val episodeManager = mock<EpisodeManager> {}
         val settings = mock<Settings> {
             on { autoDownloadUpNext } doReturn UserSetting.Mock(true, mock())
-            on { lastAutoPlaySource } doReturn UserSetting.Mock(AutoPlaySource.None, mock())
-            on { trackingAutoPlaySource } doReturn UserSetting.Mock(AutoPlaySource.None, mock())
+            on { lastAutoPlaySource } doReturn UserSetting.Mock(AutoPlaySource.Predefined.None, mock())
+            on { trackingAutoPlaySource } doReturn UserSetting.Mock(AutoPlaySource.Predefined.None, mock())
         }
         val syncManager = mock<SyncManager> {}
 

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/ProfileEpisodeListFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/ProfileEpisodeListFragment.kt
@@ -243,9 +243,9 @@ class ProfileEpisodeListFragment :
         super.onResume()
         binding?.recyclerView?.adapter = adapter
         when (mode) {
-            Mode.Downloaded -> AutoPlaySource.Downloads
-            Mode.History -> AutoPlaySource.None
-            Mode.Starred -> AutoPlaySource.Starred
+            Mode.Downloaded -> AutoPlaySource.Predefined.Downloads
+            Mode.History -> AutoPlaySource.Predefined.None
+            Mode.Starred -> AutoPlaySource.Predefined.Starred
         }.let { settings.trackingAutoPlaySource.set(it, updateModifiedAt = false) }
     }
 

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/cloud/CloudFilesFragment.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/cloud/CloudFilesFragment.kt
@@ -158,7 +158,7 @@ class CloudFilesFragment :
 
     override fun onResume() {
         super.onResume()
-        settings.trackingAutoPlaySource.set(AutoPlaySource.Files, updateModifiedAt = false)
+        settings.trackingAutoPlaySource.set(AutoPlaySource.Predefined.Files, updateModifiedAt = false)
     }
 
     override fun onPause() {

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
@@ -1385,7 +1385,7 @@ class SettingsImpl @Inject constructor(
 
     override val lastAutoPlaySource = UserSetting.PrefFromString(
         sharedPrefKey = "LastSelectedPodcastOrFilterUuid", // legacy name
-        defaultValue = AutoPlaySource.None,
+        defaultValue = AutoPlaySource.Predefined.None,
         sharedPrefs = sharedPreferences,
         fromString = AutoPlaySource::fromId,
         toString = AutoPlaySource::id,
@@ -1393,7 +1393,7 @@ class SettingsImpl @Inject constructor(
 
     override val trackingAutoPlaySource = UserSetting.PrefFromString(
         sharedPrefKey = "localAutoPlaySource",
-        defaultValue = AutoPlaySource.None,
+        defaultValue = AutoPlaySource.Predefined.None,
         sharedPrefs = sharedPreferences,
         fromString = AutoPlaySource::fromId,
         toString = AutoPlaySource::id,

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/model/AutoPlaySource.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/model/AutoPlaySource.kt
@@ -31,7 +31,7 @@ sealed interface AutoPlaySource {
     }
 
     companion object {
-        private val Constants = listOf(None, Downloads, Files, Starred)
+        private val Constants by lazy(LazyThreadSafetyMode.NONE) { listOf(None, Downloads, Files, Starred) }
 
         fun fromId(id: String) = when {
             runCatching { UUID.fromString(id) }.isSuccess -> PodcastOrFilter(id)

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/model/AutoPlaySource.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/model/AutoPlaySource.kt
@@ -14,29 +14,29 @@ sealed interface AutoPlaySource {
         override val id get() = uuid
     }
 
-    data object Downloads : AutoPlaySource {
-        override val id = "downloads"
-    }
-
-    data object Files : AutoPlaySource {
-        override val id = "files"
-    }
-
-    data object Starred : AutoPlaySource {
-        override val id = "starred"
-    }
-
-    data object None : AutoPlaySource {
-        override val id = ""
+    enum class Predefined(
+        override val id: String,
+    ) : AutoPlaySource {
+        Downloads(
+            id = "downloads",
+        ),
+        Files(
+            id = "files",
+        ),
+        Starred(
+            id = "starred",
+        ),
+        None(
+            id = "",
+        ),
     }
 
     companion object {
-        private val Constants by lazy(LazyThreadSafetyMode.NONE) { listOf(None, Downloads, Files, Starred) }
-
-        fun fromId(id: String) = when {
-            runCatching { UUID.fromString(id) }.isSuccess -> PodcastOrFilter(id)
-            else -> Constants.find { it.id == id } ?: None
-        }
+        fun fromId(id: String) = runCatching { UUID.fromString(id) }
+            .map { PodcastOrFilter(id) }
+            .recover { Predefined.entries.find { it.id == id } }
+            .getOrNull()
+            ?: Predefined.None
 
         fun fromServerId(id: String) = fromId(id)
     }

--- a/modules/services/preferences/src/test/kotlin/au/com/shiftyjelly/pocketcasts/preferences/model/AutoPlaySourceTest.kt
+++ b/modules/services/preferences/src/test/kotlin/au/com/shiftyjelly/pocketcasts/preferences/model/AutoPlaySourceTest.kt
@@ -20,28 +20,28 @@ class AutoPlaySourceTest {
 
         val source = AutoPlaySource.fromId(malformedUuid)
 
-        assertEquals(AutoPlaySource.None, source)
+        assertEquals(AutoPlaySource.Predefined.None, source)
     }
 
     @Test
     fun `create Files from ID`() {
         val source = AutoPlaySource.fromId("files")
 
-        assertEquals(AutoPlaySource.Files, source)
+        assertEquals(AutoPlaySource.Predefined.Files, source)
     }
 
     @Test
     fun `create Downloads from ID`() {
         val source = AutoPlaySource.fromId("downloads")
 
-        assertEquals(AutoPlaySource.Downloads, source)
+        assertEquals(AutoPlaySource.Predefined.Downloads, source)
     }
 
     @Test
     fun `create Starred from ID`() {
         val source = AutoPlaySource.fromId("starred")
 
-        assertEquals(AutoPlaySource.Starred, source)
+        assertEquals(AutoPlaySource.Predefined.Starred, source)
     }
 
     @Test
@@ -59,27 +59,27 @@ class AutoPlaySourceTest {
 
         val source = AutoPlaySource.fromServerId(malformedUuid)
 
-        assertEquals(AutoPlaySource.None, source)
+        assertEquals(AutoPlaySource.Predefined.None, source)
     }
 
     @Test
     fun `create Files from server ID`() {
         val source = AutoPlaySource.fromServerId("files")
 
-        assertEquals(AutoPlaySource.Files, source)
+        assertEquals(AutoPlaySource.Predefined.Files, source)
     }
 
     @Test
     fun `create Downloads from server ID`() {
         val source = AutoPlaySource.fromServerId("downloads")
 
-        assertEquals(AutoPlaySource.Downloads, source)
+        assertEquals(AutoPlaySource.Predefined.Downloads, source)
     }
 
     @Test
     fun `create Starred from server ID`() {
         val source = AutoPlaySource.fromServerId("starred")
 
-        assertEquals(AutoPlaySource.Starred, source)
+        assertEquals(AutoPlaySource.Predefined.Starred, source)
     }
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
@@ -1374,9 +1374,10 @@ open class PlaybackManager @Inject constructor(
         var episodeSource = settings.lastAutoPlaySource.value.toString().lowercase()
 
         val allEpisodes: List<BaseEpisode> = when (val autoSource = settings.lastAutoPlaySource.value) {
-            is AutoPlaySource.Downloads -> episodeManager.findDownloadEpisodesRxFlowable().asFlow().firstOrNull()
-            is AutoPlaySource.Files -> cloudFilesManager.sortedCloudFiles.firstOrNull()
-            is AutoPlaySource.Starred -> episodeManager.findStarredEpisodesRxFlowable().asFlow().firstOrNull()
+            AutoPlaySource.Predefined.Downloads -> episodeManager.findDownloadEpisodesRxFlowable().asFlow().firstOrNull()
+            AutoPlaySource.Predefined.Files -> cloudFilesManager.sortedCloudFiles.firstOrNull()
+            AutoPlaySource.Predefined.Starred -> episodeManager.findStarredEpisodesRxFlowable().asFlow().firstOrNull()
+            AutoPlaySource.Predefined.None -> null
             // First check if it is a podcast uuid, then check if it is from a filter
             is AutoPlaySource.PodcastOrFilter -> {
                 episodeSource = "podcast"
@@ -1388,7 +1389,6 @@ open class PlaybackManager @Inject constructor(
                             playlistManager.findEpisodesBlocking(playlist, episodeManager, this)
                         }
             }
-            is AutoPlaySource.None -> null
         } ?: emptyList()
 
         val allEpisodeUuids = allEpisodes.map { it.uuid }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackService.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackService.kt
@@ -566,7 +566,7 @@ open class PlaybackService :
         val playlist = if (DOWNLOADS_ROOT == parentId) playlistManager.getSystemDownloadsFilter() else playlistManager.findByUuidBlocking(parentId)
         if (playlist != null) {
             val episodeList = if (DOWNLOADS_ROOT == parentId) {
-                autoPlaySource = AutoPlaySource.Downloads
+                autoPlaySource = AutoPlaySource.Predefined.Downloads
                 episodeManager.findDownloadedEpisodesRxFlowable().blockingFirst()
             } else {
                 autoPlaySource = AutoPlaySource.fromId(parentId)
@@ -610,14 +610,14 @@ open class PlaybackService :
     }
 
     protected suspend fun loadFilesChildren(): List<MediaBrowserCompat.MediaItem> {
-        setAutoPlaySource(AutoPlaySource.Files)
+        setAutoPlaySource(AutoPlaySource.Predefined.Files)
         return userEpisodeManager.findUserEpisodes().map {
             AutoConverter.convertEpisodeToMediaItem(this, it, Podcast.userPodcast, useEpisodeArtwork = settings.artworkConfiguration.value.useEpisodeArtwork)
         }
     }
 
     protected suspend fun loadStarredChildren(): List<MediaBrowserCompat.MediaItem> {
-        setAutoPlaySource(AutoPlaySource.Starred)
+        setAutoPlaySource(AutoPlaySource.Predefined.Starred)
         return episodeManager.findStarredEpisodes().take(EPISODE_LIMIT).mapNotNull { episode ->
             podcastManager.findPodcastByUuidBlocking(episode.podcastUuid)?.let { podcast ->
                 AutoConverter.convertEpisodeToMediaItem(context = this, episode = episode, parentPodcast = podcast, useEpisodeArtwork = settings.artworkConfiguration.value.useEpisodeArtwork)

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/UpNextQueueImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/UpNextQueueImpl.kt
@@ -322,8 +322,8 @@ class UpNextQueueImpl @Inject constructor(
         // clear last loaded uuid if anything gets added to the up next queue
         val hasQueuedItems = currentEpisode != null
         if (hasQueuedItems) {
-            settings.trackingAutoPlaySource.set(AutoPlaySource.None, updateModifiedAt = false)
-            settings.lastAutoPlaySource.set(AutoPlaySource.None, updateModifiedAt = true)
+            settings.trackingAutoPlaySource.set(AutoPlaySource.Predefined.None, updateModifiedAt = false)
+            settings.lastAutoPlaySource.set(AutoPlaySource.Predefined.None, updateModifiedAt = true)
         }
     }
 

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/support/Support.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/support/Support.kt
@@ -483,8 +483,8 @@ private fun AutoPlaySource.prettyPrint(
         }
         "Podcast or filter: $uuid"
     }
-    is AutoPlaySource.Downloads -> "Downloads"
-    is AutoPlaySource.Files -> "Files"
-    is AutoPlaySource.Starred -> "Starred"
-    is AutoPlaySource.None -> "None"
+    AutoPlaySource.Predefined.Downloads -> "Downloads"
+    AutoPlaySource.Predefined.Files -> "Files"
+    AutoPlaySource.Predefined.Starred -> "Starred"
+    AutoPlaySource.Predefined.None -> "None"
 }


### PR DESCRIPTION
## Description

Update to Kotlin `2.2.0` changed initialization order of `object`s. Previously `AutoPlaySource.None` was initialized before `companion object`. Now it happens after. This caused an issue because `None` was resolved to `null` causing a crash.

There might be other classes and properties defined like this but I couldn't find any.

## Testing Instructions

1. Open app.
2. Go to filters.
3. App should not crash.

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
