### PR TITLE
Set playback position after updating duration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 7.94
 -----
-
+*   Bug Fixes
+    *   Fix player's playback position being incorrect after app restart
+        ([#4208](https://github.com/Automattic/pocket-casts-android/pull/4208))
 
 7.93
 -----

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/nowplaying/PlayerSeekBar.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/nowplaying/PlayerSeekBar.kt
@@ -43,14 +43,14 @@ internal fun PlayerSeekBar(
         },
         update = { seekBar ->
             seekBar.apply {
-                setCurrentTime(playbackPosition)
+                setTintColor(playerColors.highlight01.toArgb(), theme)
                 setDuration(playbackDuration)
                 setAdjustDuration(adjustPlaybackDuration)
                 setPlaybackSpeed(playbackSpeed)
                 setChapters(chapters)
                 this.isBuffering = isBuffering
                 bufferedUpToInSecs = bufferedUpTo.inWholeSeconds.toInt()
-                setTintColor(playerColors.highlight01.toArgb(), theme)
+                setCurrentTime(playbackPosition)
             }
         },
         modifier = modifier.fillMaxWidth(),


### PR DESCRIPTION
## Description

Playback position was set before the duration causing it to show incorrect position without playback.

Fixes #4207 

## Testing Instructions

1. Play an episode.
2. Seek to the middle of that episode.
3. Pause it.
4. Close the app.
5. Open the app.
6. Open the player.
7. Seek bar should be in a correct position.

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
