### PR TITLE
Fix upsell notification display criteria

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@
         ([#4167](https://github.com/Automattic/pocket-casts-android/pull/4167))
     *   Fix revamped notifications showing up on wear and automotive
         ([#4177](https://github.com/Automattic/pocket-casts-android/pull/4177))
+    *   Fix upsell notifications showing up even if the user already has an active subscription
+        ([#4216](https://github.com/Automattic/pocket-casts-android/pull/4216))
 
 7.92
 -----

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/notification/NotificationWorker.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/notification/NotificationWorker.kt
@@ -73,7 +73,9 @@ class NotificationWorker @AssistedInject constructor(
                 val folders = suggestedFoldersManager.observeSuggestedFolders().firstOrNull()
                 !folders.isNullOrEmpty()
             }
-            is OffersNotificationType.UpgradeNow -> {
+            is OnboardingNotificationType.PlusUpsell,
+            is OffersNotificationType.UpgradeNow,
+            -> {
                 val subscription = settings.cachedSubscription.value
                 subscription == null || subscription.expiryDate.isBefore(Instant.now())
             }


### PR DESCRIPTION
## Description
There's a bug in our notification display logic, so `OnboardingNotificationType.PlusUpsell` notifications are still being displayed even if the user has already subscribed.
This PR addresses that issue.

Fixes https://linear.app/a8c/issue/PCDROID-29/upsell-notification-still-showing-when-the-user-is-subscribed

## Testing Instructions
1. Apply this patch and build the app
[notifications.patch](https://github.com/user-attachments/files/21143063/notifications.patch)
2. Grant notifications permission when prompted
3. Sign in with an account that doesn't have an active subscription
4. Navigate to Settings->Notifications
5. Disable then enable 'Pocket Casts Offers' toggle
6. Wait for 5 seconds
- [ ] upgrade notification is displayed
7. Dismiss the notification
8. Now disable and enable 'Daily reminders' toggle
- [ ] upsell notification is displayed (along with many others)
9. Now gift yourself a sub on the admin page and refresh the app to sync your subscription
10. Repeat steps 5-8, but now you should not see the upgrade/upsell notifications

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] ~I have considered whether it makes sense to add tests for my changes~
- [ ] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [ ] ~Any jetpack compose components I added or changed are covered by compose previews~
- [ ] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~
