### PR TITLE
Fix clips link causing infinite deep linking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@
     *   Bring back landscape UI
         ([#4156](https://github.com/Automattic/pocket-casts-android/pull/4156))
 *   Bug Fixes
+    *   Fix clip links causing app being unresponsive.
+        ([#4217](https://github.com/Automattic/pocket-casts-android/pull/4217))
     *   Collapse player when opening a notification
         ([#4150](https://github.com/Automattic/pocket-casts-android/pull/4150))
     *   Fix episodes not being removed from the downloads list

--- a/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/activity/WebViewActivity.kt
+++ b/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/activity/WebViewActivity.kt
@@ -100,6 +100,7 @@ class WebViewActivity : AppCompatActivity(), CoroutineScope {
         }
 
         binding.webview.settings.javaScriptEnabled = true
+        binding.webview.settings.domStorageEnabled = true
 
         if (savedInstanceState == null) {
             extraUrl?.let { url ->

--- a/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/activity/WebViewActivity.kt
+++ b/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/activity/WebViewActivity.kt
@@ -1,11 +1,9 @@
 package au.com.shiftyjelly.pocketcasts.views.activity
 
 import android.annotation.SuppressLint
-import android.content.ActivityNotFoundException
 import android.content.Context
 import android.content.Intent
 import android.graphics.Bitmap
-import android.net.Uri
 import android.os.Bundle
 import android.view.MenuItem
 import android.webkit.WebResourceRequest
@@ -14,6 +12,7 @@ import android.webkit.WebViewClient
 import androidx.activity.OnBackPressedCallback
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.view.isVisible
+import au.com.shiftyjelly.pocketcasts.preferences.BuildConfig
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.views.databinding.ActivityWebViewBinding
 import au.com.shiftyjelly.pocketcasts.views.extensions.includeStatusBarPadding
@@ -90,24 +89,12 @@ class WebViewActivity : AppCompatActivity(), CoroutineScope {
                 binding.loading.isVisible = false
             }
 
-            // Any link you tap on we will open in the external browser
             override fun shouldOverrideUrlLoading(view: WebView, request: WebResourceRequest): Boolean {
-                val url = request.url.toString()
-                if (extraUrl == url) {
-                    return false
-                }
-                val parsedUri = Uri.parse(url)
-                return if (parsedUri != null) {
-                    val intent = Intent(Intent.ACTION_VIEW)
-                    intent.data = Uri.parse(url)
-                    try {
-                        startActivity(intent)
-                        true
-                    } catch (e: ActivityNotFoundException) {
-                        false
-                    }
-                } else {
-                    false
+                val uri = request.url
+                return when {
+                    uri.host == BuildConfig.WEB_BASE_HOST -> false
+                    uri.toString() == extraUrl -> false
+                    else -> runCatching { startActivity(Intent(Intent.ACTION_VIEW, uri)) }.isSuccess
                 }
             }
         }


### PR DESCRIPTION
## Description

Our `WebView` configuration caused infinite deep linking to a clip resource because of launching a new Activity every time we received an URL. `pca.st` redirected to `pocketcasts.com` allowing to skip check for the same URL.

## Testing Instructions

1. Open a clip link like `https://pca.st/episode/9adc6b43-7b23-4a0e-b2bc-7ed7922bdc6e?t=15,51.6` in the `debugProd` or the `release` app.
2. You should see the Web player with a clip.

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.