### PR TITLE
Improve window insets handling on Android pre SDK 30

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@
         ([#4177](https://github.com/Automattic/pocket-casts-android/pull/4177))
     *   Fix upsell notifications showing up even if the user already has an active subscription
         ([#4216](https://github.com/Automattic/pocket-casts-android/pull/4216))
+    *   Fix navigation bar obstructing content on older Android systems
+        ([#4218](https://github.com/Automattic/pocket-casts-android/pull/4218))
 
 7.92
 -----

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@
     *   Fix upsell notifications showing up even if the user already has an active subscription
         ([#4216](https://github.com/Automattic/pocket-casts-android/pull/4216))
     *   Fix navigation bar obstructing content on older Android systems
-        ([#4218](https://github.com/Automattic/pocket-casts-android/pull/4218))
+        ([#4219](https://github.com/Automattic/pocket-casts-android/pull/4219))
 
 7.92
 -----

--- a/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
+++ b/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
@@ -23,10 +23,13 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.platform.ComposeView
 import androidx.core.content.ContextCompat
+import androidx.core.view.ViewCompat
 import androidx.core.view.WindowCompat
+import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.isVisible
 import androidx.core.view.updateLayoutParams
 import androidx.core.view.updatePadding
+import androidx.dynamicanimation.animation.DynamicAnimation.TRANSLATION_Y
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.commitNow
 import androidx.lifecycle.Lifecycle
@@ -175,8 +178,8 @@ import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
 import au.com.shiftyjelly.pocketcasts.utils.observeOnce
 import au.com.shiftyjelly.pocketcasts.view.LockableBottomSheetBehavior
 import au.com.shiftyjelly.pocketcasts.views.activity.WebViewActivity
-import au.com.shiftyjelly.pocketcasts.views.extensions.setSystemWindowInsetToPadding
 import au.com.shiftyjelly.pocketcasts.views.extensions.showAllowingStateLoss
+import au.com.shiftyjelly.pocketcasts.views.extensions.spring
 import au.com.shiftyjelly.pocketcasts.views.fragments.BaseFragment
 import au.com.shiftyjelly.pocketcasts.views.fragments.TopScrollable
 import au.com.shiftyjelly.pocketcasts.views.helper.HasBackstack
@@ -420,22 +423,21 @@ class MainActivity :
         }
 
         binding = ActivityMainBinding.inflate(layoutInflater)
-        val view = binding.root
-        setContentView(view)
+        setContentView(binding.root)
         checkForNotificationPermission()
 
-        binding.root.setSystemWindowInsetToPadding(left = true, right = true)
+        ViewCompat.setOnApplyWindowInsetsListener(binding.root) { view, windowInsets ->
+            val insets = windowInsets.getInsets(WindowInsetsCompat.Type.systemBars() or WindowInsetsCompat.Type.displayCutout())
+            binding.root.updatePadding(left = insets.left, right = insets.right)
+            binding.bottomNavigation.updatePadding(bottom = insets.bottom)
+            windowInsets
+        }
+        binding.bottomNavigation.addOnLayoutChangeListener { view, _, _, _, _, _, _, _, _ ->
+            binding.mainFragment.updatePadding(bottom = view.height)
 
-        binding.bottomNavigation.addOnLayoutChangeListener { _, _, _, _, _, _, _, _, _ ->
-            val miniPlayerHeight = miniPlayerHeight
-            val bottomNavigationHeight = binding.bottomNavigation.height
-            val bottomSheetBehavior = BottomSheetBehavior.from(binding.playerBottomSheet)
-            // Set the player bottom sheet position to show the mini player above the bottom navigation
-            bottomSheetBehavior.peekHeight = miniPlayerHeight + bottomNavigationHeight
-            // Add padding to the main content so the end of the page isn't under the bottom navigation
-            binding.mainFragment.updatePadding(bottom = bottomNavigationHeight)
-            // Position the snackbar above the bottom navigation or the mini player if it's shown
-            updateSnackbarPosition(miniPlayerOpen = false)
+            BottomSheetBehavior.from(binding.playerBottomSheet).apply {
+                peekHeight = miniPlayerHeight + view.height
+            }
         }
 
         lifecycleScope.launch {
@@ -1103,7 +1105,9 @@ class MainActivity :
     }
 
     override fun onPlayerBottomSheetSlide(bottomSheetView: View, slideOffset: Float) {
-        binding.bottomNavigation.translationY = bottomSheetView.height * slideOffset
+        val view = binding.bottomNavigation
+        val targetPosition = 2 * view.height * slideOffset
+        view.spring(TRANSLATION_Y).animateToFinalPosition(targetPosition)
     }
 
     override fun updateSystemColors() {

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -22,19 +22,19 @@
             android:layout_width="match_parent"
             android:layout_height="match_parent"
             android:elevation="8dp"
-            android:visibility="gone"
+            android:visibility="invisible"
             app:behavior_peekHeight="@dimen/miniPlayerPeekHeight"
             app:layout_behavior="com.google.android.material.bottomsheet.ViewPager2AwareBottomSheetBehavior" />
 
-        <com.google.android.material.bottomnavigation.BottomNavigationView
+        <au.com.shiftyjelly.pocketcasts.views.component.BottomNavigationView
             android:id="@+id/bottomNavigation"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_gravity="bottom"
-            android:elevation="8dp"
             android:background="?attr/primary_ui_03"
-            app:itemTextColor="@color/navigation_color"
+            android:elevation="8dp"
             app:itemIconTint="@color/navigation_color"
+            app:itemTextColor="@color/navigation_color"
             app:labelVisibilityMode="labeled"
             app:menu="@menu/navigation" />
 

--- a/modules/features/navigation/src/main/java/au/com/shiftyjelly/pocketcasts/navigation/ActivityDelegate.kt
+++ b/modules/features/navigation/src/main/java/au/com/shiftyjelly/pocketcasts/navigation/ActivityDelegate.kt
@@ -3,7 +3,7 @@ package au.com.shiftyjelly.pocketcasts.navigation
 import androidx.fragment.app.FragmentManager
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleObserver
-import com.google.android.material.bottomnavigation.BottomNavigationView
+import com.google.android.material.navigation.NavigationBarView
 import io.reactivex.disposables.CompositeDisposable
 
 /**
@@ -14,7 +14,7 @@ internal class ActivityDelegate(
     private val modalContainer: Int,
     fragmentManagerFactory: () -> FragmentManager,
     private val lifecycle: Lifecycle,
-    val bottomNavigationView: BottomNavigationView,
+    val bottomNavigationView: NavigationBarView,
     private val bottomNavigator: BottomNavigator,
 ) : LifecycleObserver {
     fun clear() {
@@ -33,8 +33,7 @@ internal class ActivityDelegate(
     @androidx.lifecycle.OnLifecycleEvent(Lifecycle.Event.ON_START)
     fun onActivityStart() {
         bin.clear()
-        val fragmentTransactionHandler =
-            FragmentTransactionHandler(fragmentManager, fragmentContainer, modalContainer)
+        val fragmentTransactionHandler = FragmentTransactionHandler(fragmentManager, fragmentContainer, modalContainer)
         bottomNavigator.fragmentTransactionPublisher
             .subscribe { command ->
                 fragmentTransactionHandler.handle(command)
@@ -70,6 +69,5 @@ internal class ActivityDelegate(
     @androidx.lifecycle.OnLifecycleEvent(Lifecycle.Event.ON_STOP)
     fun onActivityStop() {
         bin.clear()
-        bottomNavigationView.setOnNavigationItemSelectedListener(null)
     }
 }

--- a/modules/features/navigation/src/main/java/au/com/shiftyjelly/pocketcasts/navigation/BottomNavigator.kt
+++ b/modules/features/navigation/src/main/java/au/com/shiftyjelly/pocketcasts/navigation/BottomNavigator.kt
@@ -19,6 +19,8 @@ package au.com.shiftyjelly.pocketcasts.navigation
 import android.view.MenuItem
 import androidx.annotation.IdRes
 import androidx.annotation.VisibleForTesting
+import androidx.core.view.get
+import androidx.core.view.size
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentActivity
 import androidx.lifecycle.ViewModel
@@ -31,6 +33,7 @@ import au.com.shiftyjelly.pocketcasts.navigation.FragmentTransactionCommand.Remo
 import au.com.shiftyjelly.pocketcasts.navigation.FragmentTransactionCommand.ShowAndRemove
 import au.com.shiftyjelly.pocketcasts.navigation.FragmentTransactionCommand.ShowExisting
 import com.google.android.material.bottomnavigation.BottomNavigationView
+import com.google.android.material.navigation.NavigationBarView
 import hu.akarnokd.rxjava2.subjects.UnicastWorkSubject
 import io.reactivex.Observable
 import io.reactivex.subjects.PublishSubject
@@ -377,7 +380,7 @@ open class BottomNavigator internal constructor() : ViewModel() {
             @IdRes defaultTab: Int,
             @IdRes fragmentContainer: Int,
             @IdRes modalContainer: Int,
-            bottomNavigationView: BottomNavigationView,
+            bottomNavigationView: NavigationBarView,
         ): BottomNavigator {
             val navigator = ViewModelProvider(activity).get(BottomNavigator::class.java)
             navigator.onCreate(
@@ -408,7 +411,7 @@ open class BottomNavigator internal constructor() : ViewModel() {
         activity: FragmentActivity,
         fragmentContainer: Int,
         modalContainer: Int,
-        bottomNavigationView: BottomNavigationView,
+        bottomNavigationView: NavigationBarView,
     ) {
         validateInputs(bottomNavigationView, rootFragmentsFactory, defaultTab)
         this.rootFragmentsFactory = rootFragmentsFactory
@@ -436,12 +439,11 @@ open class BottomNavigator internal constructor() : ViewModel() {
     }
 
     private fun validateInputs(
-        bottomNavigationView: BottomNavigationView,
+        bottomNavigationView: NavigationBarView,
         rootFragmentsFactory: Map<Int, () -> FragmentInfo>,
         defaultTab: Int,
     ) {
-        val bottomNavItems =
-            (0 until bottomNavigationView.menu.size()).map { bottomNavigationView.menu.getItem(it) }
+        val bottomNavItems = List(bottomNavigationView.menu.size) { bottomNavigationView.menu[it] }
         var foundDefaultTab = false
         bottomNavItems.forEach {
             if (rootFragmentsFactory[it.itemId] == null) {

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/PlayerBottomSheet.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/PlayerBottomSheet.kt
@@ -10,6 +10,8 @@ import android.view.animation.OvershootInterpolator
 import android.widget.FrameLayout
 import androidx.coordinatorlayout.widget.CoordinatorLayout
 import androidx.core.view.doOnLayout
+import androidx.core.view.isInvisible
+import androidx.core.view.isVisible
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTracker
 import au.com.shiftyjelly.pocketcasts.player.R
@@ -23,10 +25,6 @@ import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackState
 import au.com.shiftyjelly.pocketcasts.repositories.playback.UpNextQueue
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import au.com.shiftyjelly.pocketcasts.utils.extensions.dpToPx
-import au.com.shiftyjelly.pocketcasts.views.extensions.hide
-import au.com.shiftyjelly.pocketcasts.views.extensions.isHidden
-import au.com.shiftyjelly.pocketcasts.views.extensions.isVisible
-import au.com.shiftyjelly.pocketcasts.views.extensions.show
 import com.google.android.material.bottomsheet.BottomSheetBehavior
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
@@ -134,8 +132,8 @@ class PlayerBottomSheet @JvmOverloads constructor(context: Context, attrs: Attri
 
         // only show the mini player when an episode is loaded
         if (upNext is UpNextQueue.State.Loaded) {
-            if ((isHidden() || !hasLoadedFirstTime)) {
-                show()
+            if (isInvisible || !hasLoadedFirstTime) {
+                isVisible = true
                 if (shouldAnimateOnAttach) {
                     translationY = 68.dpToPx(context).toFloat()
                     animate().translationY(0f).setListener(object : AnimatorListenerAdapter() {
@@ -152,12 +150,10 @@ class PlayerBottomSheet @JvmOverloads constructor(context: Context, attrs: Attri
                     }
                 }
             }
-        } else {
-            if (isVisible()) {
-                hide()
-                closePlayer()
-                listener?.onMiniPlayerHidden()
-            }
+        } else if (isVisible) {
+            isInvisible = true
+            closePlayer()
+            listener?.onMiniPlayerHidden()
         }
     }
 

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/PlayerHeaderFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/PlayerHeaderFragment.kt
@@ -763,8 +763,7 @@ class PlayerHeaderFragment : BaseFragment(), PlayerClickListener {
                 modifier = Modifier
                     .weight(1f)
                     .fillMaxHeight()
-                    .verticalScroll(rememberScrollState(), flingBehavior = ShowUpNextFlingBehavior)
-                    .navigationBarsPadding(),
+                    .verticalScroll(rememberScrollState(), flingBehavior = ShowUpNextFlingBehavior),
             ) {
                 AdAndArtworkHorizontal(
                     artworkOrVideoState = artworkOrVideoState,
@@ -803,8 +802,7 @@ class PlayerHeaderFragment : BaseFragment(), PlayerClickListener {
                 modifier = Modifier
                     .weight(1f)
                     .fillMaxHeight()
-                    .verticalScroll(rememberScrollState(), flingBehavior = ShowUpNextFlingBehavior)
-                    .navigationBarsPadding(),
+                    .verticalScroll(rememberScrollState(), flingBehavior = ShowUpNextFlingBehavior),
             ) {
                 Spacer(
                     modifier = Modifier.weight(1f),
@@ -832,8 +830,7 @@ class PlayerHeaderFragment : BaseFragment(), PlayerClickListener {
         Column(
             modifier = modifier
                 .fillMaxSize()
-                .verticalScroll(rememberScrollState(), flingBehavior = ShowUpNextFlingBehavior)
-                .navigationBarsPadding(),
+                .verticalScroll(rememberScrollState(), flingBehavior = ShowUpNextFlingBehavior),
         ) {
             Row {
                 val windowWithPx = LocalWindowInfo.current.containerSize.width

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/bookmark/BookmarksFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/bookmark/BookmarksFragment.kt
@@ -1,5 +1,6 @@
 package au.com.shiftyjelly.pocketcasts.player.view.bookmark
 
+import android.os.Build
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.ViewGroup
@@ -159,10 +160,12 @@ class BookmarksFragment : BaseFragment() {
                         onHeadphoneControlsButtonTapped = {
                             bookmarksViewModel.onHeadphoneControlsButtonTapped()
                         },
-                        bottomInset = if (sourceView == SourceView.PROFILE) {
-                            bottomInset.value.pxToDp(LocalContext.current).dp
-                        } else {
-                            WindowInsets.navigationBars.asPaddingValues().calculateBottomPadding()
+                        bottomInset = when {
+                            sourceView == SourceView.PROFILE -> {
+                                bottomInset.value.pxToDp(LocalContext.current).dp
+                            }
+                            Build.VERSION.SDK_INT > 29 -> WindowInsets.navigationBars.asPaddingValues().calculateBottomPadding()
+                            else -> 56.dp
                         },
                     )
                 }

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/chapters/ChaptersPage.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/chapters/ChaptersPage.kt
@@ -1,7 +1,9 @@
 package au.com.shiftyjelly.pocketcasts.player.view.chapters
 
+import android.os.Build
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
@@ -33,7 +35,11 @@ fun ChaptersPage(
 ) {
     LazyColumn(
         state = lazyListState,
-        contentPadding = WindowInsets.navigationBars.asPaddingValues(),
+        contentPadding = if (Build.VERSION.SDK_INT > 29) {
+            WindowInsets.navigationBars.asPaddingValues()
+        } else {
+            PaddingValues(bottom = 56.dp)
+        },
         modifier = modifier
             .background(LocalChaptersTheme.current.background)
             .fillMaxSize()

--- a/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/component/BottomNavigationView.kt
+++ b/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/component/BottomNavigationView.kt
@@ -1,0 +1,98 @@
+/*
+ * Copyright (C) 2016 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package au.com.shiftyjelly.pocketcasts.views.component
+
+import android.annotation.SuppressLint
+import android.content.Context
+import android.util.AttributeSet
+import com.google.android.material.R
+import com.google.android.material.bottomnavigation.BottomNavigationMenuView
+import com.google.android.material.internal.ThemeEnforcement
+import com.google.android.material.navigation.NavigationBarMenuView
+import com.google.android.material.navigation.NavigationBarView
+import kotlin.math.min
+
+/**
+ * This is a copy of [com.google.android.material.bottomnavigation.BottomNavigationView] but it doesn't apply
+ * window insets on its own. We experience issues on Android pre SDK 30, where insets aren't applied
+ * consistently. Removing automatic application of them from this class gives us more control over it.
+ */
+@SuppressLint("RestrictedApi", "PrivateResource")
+class BottomNavigationView @JvmOverloads constructor(
+    context: Context,
+    attrs: AttributeSet? = null,
+    defStyleAttr: Int = R.attr.bottomNavigationStyle,
+    defStyleRes: Int = R.style.Widget_Design_BottomNavigationView,
+) : NavigationBarView(context, attrs, defStyleAttr, defStyleRes) {
+    var isItemHorizontalTranslationEnabled: Boolean
+        get() = (menuView as BottomNavigationMenuView).isItemHorizontalTranslationEnabled
+        set(value) {
+            val menuView = menuView as BottomNavigationMenuView
+            if (menuView.isItemHorizontalTranslationEnabled != value) {
+                menuView.isItemHorizontalTranslationEnabled = value
+                presenter.updateMenuView(false)
+            }
+        }
+
+    init {
+        val attributes = ThemeEnforcement.obtainTintedStyledAttributes(
+            context,
+            attrs,
+            R.styleable.BottomNavigationView,
+            defStyleAttr,
+            defStyleRes,
+        )
+        isItemHorizontalTranslationEnabled = attributes.getBoolean(
+            R.styleable.BottomNavigationView_itemHorizontalTranslationEnabled, true,
+        )
+        if (attributes.hasValue(R.styleable.BottomNavigationView_android_minHeight)) {
+            minimumHeight = attributes.getDimensionPixelSize(R.styleable.BottomNavigationView_android_minHeight, 0)
+        }
+        attributes.recycle()
+    }
+
+    override fun onMeasure(widthMeasureSpec: Int, heightMeasureSpec: Int) {
+        val minHeightSpec = makeMinHeightSpec(heightMeasureSpec)
+        super.onMeasure(widthMeasureSpec, minHeightSpec)
+    }
+
+    private fun makeMinHeightSpec(measureSpec: Int): Int {
+        var minHeight = suggestedMinimumHeight
+        return if (MeasureSpec.getMode(measureSpec) != MeasureSpec.EXACTLY && minHeight > 0) {
+            minHeight += paddingTop + paddingBottom
+
+            return MeasureSpec.makeMeasureSpec(
+                min(MeasureSpec.getSize(measureSpec), minHeight),
+                MeasureSpec.EXACTLY,
+            )
+        } else {
+            measureSpec
+        }
+    }
+
+    override fun getMaxItemCount(): Int {
+        return MAX_ITEM_COUNT
+    }
+
+    override fun createNavigationBarMenuView(context: Context): NavigationBarMenuView {
+        return BottomNavigationMenuView(context)
+    }
+
+    companion object {
+        private const val MAX_ITEM_COUNT = 5
+    }
+}

--- a/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/extensions/View.kt
+++ b/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/extensions/View.kt
@@ -25,20 +25,11 @@ fun View.hide() {
     this.visibility = View.GONE
 }
 
-fun View.toggleVisibility(): Boolean {
-    this.visibility = if (this.visibility == View.GONE) View.VISIBLE else View.GONE
-    return this.visibility == View.VISIBLE
-}
-
 fun View.findToolbar(): Toolbar {
     return findViewById(R.id.toolbar)
 }
 
 fun View.isVisible() = visibility == View.VISIBLE
-
-fun View.isInvisible() = visibility == View.INVISIBLE
-
-fun View.isHidden() = visibility == View.GONE
 
 fun View.setRippleBackground(borderless: Boolean = false) {
     val resId = if (borderless) android.R.attr.selectableItemBackgroundBorderless else android.R.attr.selectableItemBackground


### PR DESCRIPTION
## Description

This PR improves the handling of window insets on older Android versions. Material's `BottomNavigationView` applies the bottom inset automatically, but it's not reliable with our UI configuration. I replaced it with a custom view that is more or less a copy of Material's component, but without the inset application. Instead, I apply the insets manually in `MainActivity`.

I also changed the hidden player's visibility from `gone` to `invisible`. I'm not entirely sure why, but when it's set to `gone`, the window insets don't update correctly the first time we change visibility, leading to missing insets in the player UI.

Fixes #4209

## Testing Instructions

1. Test player on a device with SDK 29. System navigation bar should not obstruct our navigation tab or player's shelf.
2. Do the same test with a newer SDK.

## Screenshots or Screencast 

| Before | After |
| - | - |
| <img width="1080" height="2400" alt="b1" src="https://github.com/user-attachments/assets/5f621656-df64-4ce8-bf62-ce82b5dd99a3" /> | <img width="1080" height="2400" alt="a1" src="https://github.com/user-attachments/assets/e8d86b54-7612-4d12-9741-908ebe544b9c" /> |
| <img width="1080" height="2400" alt="b2" src="https://github.com/user-attachments/assets/760eb8a0-bd5e-4bfc-ad30-0a64343f32ee" /> | <img width="1080" height="2400" alt="a2" src="https://github.com/user-attachments/assets/fdae3cdf-f95b-4124-a2c6-1c29cf1e89ea" /> |

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [x] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
