### PR TITLE
Update timeline component design

### DIFF
--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/components/UpgradeTrialTimeline.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/components/UpgradeTrialTimeline.kt
@@ -135,7 +135,6 @@ fun UpgradeTrialTimeline(
                     TextP50(
                         text = item.message,
                         color = MaterialTheme.theme.colors.primaryText01.copy(alpha = 0.5f),
-                        maxLines = 2,
                     )
                 }
             }
@@ -172,9 +171,8 @@ fun UpgradeTrialTimeline(
             var offsetY = 0
             val textOffsetX = iconSizePx + iconPaddingPx
             iconPlaceables.zip(textPlaceables) { icon, text ->
-                val iconTopOffset = max(0, (text.height - icon.height) / 2)
-                iconCenterYPositions.add((offsetY + iconTopOffset + icon.height / 2f))
-                icon.placeRelative(0, offsetY + iconTopOffset)
+                iconCenterYPositions.add((offsetY + icon.height / 2f))
+                icon.placeRelative(0, offsetY)
                 text.placeRelative(textOffsetX.toInt(), offsetY + max(0, (icon.height - text.height) / 2))
                 offsetY += max(icon.height, text.height) + spaceBetweenItems.toPx().toInt()
             }


### PR DESCRIPTION
## Description
This PR adds small touches to `UpgradeTrialTimeline` as we have clarified some design questions: p1752052567390479-slack-C0932TFPUDC

## Testing Instructions
1. Make sure `new_onboarding_upgrade` FF is ON
2. Navigate to Settings -> Pocket Casts Plus to see the new onboarding screen
3. Tap the 'How does the free trial work?' cta or just scroll vertically
4. Check screen
- [x] notice icons are now top-aligned
- [x] notice that on large font scaling the texts are not truncated


## Screenshots or Screencast 
| Before | After |
| --- | --- | 
| <img width="291" height="300" alt="Screenshot 2025-07-14 at 14 53 57" src="https://github.com/user-attachments/assets/4fd4bed1-9d8d-4bef-9a7b-c40f16c26a37" /> | <img width="291" height="355" alt="Screenshot 2025-07-14 at 14 53 33" src="https://github.com/user-attachments/assets/b1f71e17-6844-4c7a-b109-9b038c349da0" /> |


## Checklist
- [ ] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] ~I have considered whether it makes sense to add tests for my changes~
- [ ] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [ ] ~Any jetpack compose components I added or changed are covered by compose previews~
- [ ] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~
 