### PR TITLE
Corrects Java version for the remote build cache

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -137,7 +137,7 @@ private fun assertSecretsApplied() {
 private fun assertJava21Amazon() {
     val version = System.getProperty("java.version")
     val vendor = System.getProperty("java.vendor")
-    val expectedJdkVersion = "21.0.7"
+    val expectedJdkVersion = "21.0.6"
 
     if (!(version.contains(expectedJdkVersion) && vendor.contains("amazon", ignoreCase = true))) {
         logger.error("Java version: $version, vendor: $vendor")


### PR DESCRIPTION
## Description

When I upgraded to Java 21, the version I set for the remote build cache was wrong. 

> FYI: I saw you (correctly) changed the [expectedJdkVersion](https://github.com/Automattic/pocket-casts-android/blob/main/settings.gradle.kts?rgh-link-date=2025-07-14T12%3A04%3A26Z#L140) to now point to 21 instead, so that you could have better remote build cache hits. Please check this (paqN3M-1wZ-p2#comment-1436) comment and if possible change that to 21.0.6 Amazon Corretto, because this is the version that CI uses atm, and you matching that will be perfect for you.
>
> PS: See [build](https://buildkite.com/automattic/pocket-casts-android/builds/12504/steps/canvas?sid=0197fd3b-6cf7-4171-a428-c80e4142e01d#0197fd3b-6d71-4ef5-95bd-038e5a0dc74a/265-1870) -> [scan](https://scans.gradle.com/s/4pod37pcxnhrg) -> [infrastructure](https://scans.gradle.com/s/4pod37pcxnhrg#infrastructure) -> Amazon Corretto OpenJDK Runtime Environment 21.0.6+7-LTS

https://github.com/Automattic/pocket-casts-android/pull/4220#issuecomment-3069233056

## Testing Instructions

1. Turn on the build cache in `developer.properties`.
```
use_remote_build_cache_locally=true
```
2. Use the `debugProd` variant
3. Search for "Remote cache" in the build logs to check it worked correctly

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 