### PR TITLE
Use correct activeTheme for transcript banner

### DIFF
--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/episode/EpisodeFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/episode/EpisodeFragment.kt
@@ -517,7 +517,7 @@ class EpisodeFragment : BaseFragment() {
         binding?.episodeTranscript?.setContentWithViewCompositionStrategy {
             val transcript = viewModel.transcript.collectAsState().value
 
-            AppTheme(theme.activeTheme) {
+            AppTheme(activeTheme) {
                 Column(
                     modifier = Modifier.fillMaxWidth(),
                 ) {


### PR DESCRIPTION
## Description

Episode details can have forced dark theme. I didn't account for it when styling the transcript banner.

## Testing Instructions

1. Have device theme set to a light one.
2. Add some episodes with transcripts to Up Next.
3. Open Up Next.
4. Tap on an episode in the queue.
5. The transcript banner should use dark theme.

## Screenshots or Screencast 

| Before | After |
| - | - |
| <img width="1080" height="2400" alt="Screenshot_20250716-084855" src="https://github.com/user-attachments/assets/eb30551c-9899-4afa-b2c6-dc65fc84aab9" /> | <img width="1080" height="2400" alt="Screenshot_20250716-084812" src="https://github.com/user-attachments/assets/5c5452de-e32e-4d29-b04d-e3c5324291d3" /> |

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [ ] ~with a landscape orientation~
- [ ] ~with the device set to have a large display and font size~
- [ ] ~for accessibility with TalkBack~
