### PR TITLE
[Onboarding] Use `FadingLazyColumn` instead of `VerticalPager` for content

### DIFF
--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeScreen.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeScreen.kt
@@ -260,23 +260,20 @@ private fun UpgradeContent(
         state = listState,
     ) {
         itemsIndexed(pages) { index, page ->
+            val scrollToNext: () -> Unit = {
+                coroutineScope.launch {
+                    listState.animateScrollToItem((index + 1) % pages.size)
+                }
+            }
             when (page) {
                 is UpgradePagerContent.Features -> FeaturesContent(
                     features = page,
-                    onCtaClick = {
-                        coroutineScope.launch {
-                            listState.scrollToItem(pages.size - index)
-                        }
-                    },
+                    onCtaClick = scrollToNext,
                 )
 
                 is UpgradePagerContent.TrialSchedule -> ScheduleContent(
                     trialSchedule = page,
-                    onCtaClick = {
-                        coroutineScope.launch {
-                            listState.scrollToItem(pages.size - index)
-                        }
-                    },
+                    onCtaClick = scrollToNext,
                 )
             }
         }
@@ -300,10 +297,7 @@ private fun FeaturesContent(
             TextP40(
                 text = stringResource(LR.string.onboarding_upgrade_features_trial_schedule),
                 modifier = Modifier
-                    .padding(
-                        top = 24.dp,
-                        bottom = 24.dp,
-                    )
+                    .padding(vertical = 24.dp)
                     .clickable { onCtaClick() },
                 color = MaterialTheme.theme.colors.primaryInteractive01,
             )
@@ -324,10 +318,7 @@ private fun ScheduleContent(
             TextP40(
                 text = stringResource(LR.string.onboarding_upgrade_schedule_see_features),
                 modifier = Modifier
-                    .padding(
-                        top = 24.dp,
-                        bottom = 24.dp,
-                    )
+                    .padding(vertical = 24.dp)
                     .clickable { onCtaClick() },
                 color = MaterialTheme.theme.colors.primaryInteractive01,
             )


### PR DESCRIPTION
## Description
This PR gets rid of the `VerticalPager` in favor of a `FadingLazyColumn` to satisfy design expectation about the scrolling behavior.
It's been decided to use a smooth and continuous scroll instead of snappy scroll.

See: p1752505999746529-slack-C0932TFPUDC


## Testing Instructions
1. Install app and make sure `new_onboarding_upgrade` FF is enabled
2. Navigate to Profile -> Pocket Casts Plus to bring up the new upgrade screen
- [ ] you can scroll freely up-down vertically
- [ ] CTAs like 'How does the free trial work?' still scrolls to the expected position
- [ ] fading edges on top and bottom are visible

## Screenshots or Screencast

https://github.com/user-attachments/assets/641f6039-8f28-44cc-9452-7765cf332e5a



## Checklist
- [ ] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] ~I have considered whether it makes sense to add tests for my changes~
- [ ] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [ ] ~Any jetpack compose components I added or changed are covered by compose previews~
- [ ] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~
 