### PR TITLE
Add Playlists onboarding support

### DIFF
--- a/modules/features/filters/build.gradle.kts
+++ b/modules/features/filters/build.gradle.kts
@@ -42,6 +42,7 @@ dependencies {
     implementation(libs.androidx.preference.ktx)
     implementation(libs.coroutines.core)
     implementation(libs.coroutines.rx2)
+    implementation(libs.fragment.compose)
     implementation(libs.fragment.ktx)
     implementation(libs.lifecycle.reactivestreams.ktx)
     implementation(libs.rx2.android)

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/PlaylistsFragment.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/PlaylistsFragment.kt
@@ -7,14 +7,19 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.fragment.app.viewModels
 import androidx.lifecycle.lifecycleScope
 import au.com.shiftyjelly.pocketcasts.compose.AppThemeWithBackground
 import au.com.shiftyjelly.pocketcasts.compose.extensions.contentWithoutConsumedInsets
@@ -30,6 +35,7 @@ class PlaylistsFragment :
     BaseFragment(),
     TopScrollable {
     private val scrollToTopSignal = MutableSharedFlow<Unit>()
+    private val viewModel by viewModels<PlaylistsViewModel>()
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -37,6 +43,7 @@ class PlaylistsFragment :
         savedInstanceState: Bundle?,
     ) = contentWithoutConsumedInsets {
         val listState = rememberLazyListState()
+        val uiState by viewModel.uiState.collectAsState()
 
         AppThemeWithBackground(theme.activeTheme) {
             LazyColumn(
@@ -57,9 +64,24 @@ class PlaylistsFragment :
             }
         }
 
+        ScrollToTopEffect(listState)
+        ShowOnboardingEffect(uiState.showOnboarding)
+    }
+
+    @Composable
+    private fun ScrollToTopEffect(listState: LazyListState) {
         LaunchedEffect(listState) {
             scrollToTopSignal.collectLatest {
                 listState.animateScrollToItem(0)
+            }
+        }
+    }
+
+    @Composable
+    private fun ShowOnboardingEffect(show: Boolean) {
+        if (show) {
+            LaunchedEffect(show) {
+                PlaylistsOnboardingFragment().show(childFragmentManager, "playlists_onboarding")
             }
         }
     }

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/PlaylistsOnboardingFragment.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/PlaylistsOnboardingFragment.kt
@@ -1,0 +1,54 @@
+package au.com.shiftyjelly.pocketcasts.playlists
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.unit.dp
+import androidx.fragment.compose.content
+import au.com.shiftyjelly.pocketcasts.compose.AppThemeWithBackground
+import au.com.shiftyjelly.pocketcasts.compose.CallOnce
+import au.com.shiftyjelly.pocketcasts.compose.components.TextH30
+import au.com.shiftyjelly.pocketcasts.preferences.Settings
+import au.com.shiftyjelly.pocketcasts.views.fragments.BaseDialogFragment
+import dagger.hilt.android.AndroidEntryPoint
+import javax.inject.Inject
+
+@AndroidEntryPoint
+class PlaylistsOnboardingFragment : BaseDialogFragment() {
+    @Inject
+    lateinit var settings: Settings
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?,
+    ) = content {
+        CallOnce {
+            settings.showPlaylistsOnboarding.set(false, updateModifiedAt = false)
+        }
+
+        Box(
+            modifier = Modifier
+                .fillMaxHeight(0.93f)
+                .clip(RoundedCornerShape(topStart = 16.dp, topEnd = 16.dp)),
+        ) {
+            AppThemeWithBackground(
+                themeType = theme.activeTheme,
+            ) {
+                Box(
+                    contentAlignment = Alignment.Center,
+                    modifier = Modifier.fillMaxSize(),
+                ) {
+                    TextH30(text = "Onboarding")
+                }
+            }
+        }
+    }
+}

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/PlaylistsViewModel.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/PlaylistsViewModel.kt
@@ -1,0 +1,29 @@
+package au.com.shiftyjelly.pocketcasts.playlists
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import au.com.shiftyjelly.pocketcasts.preferences.Settings
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
+
+@HiltViewModel
+class PlaylistsViewModel @Inject constructor(
+    private val settings: Settings,
+) : ViewModel() {
+    internal val uiState = settings.showPlaylistsOnboarding.flow
+        .map(::UiState)
+        .stateIn(viewModelScope, SharingStarted.Eagerly, UiState.Empty)
+
+    internal data class UiState(
+        val showOnboarding: Boolean,
+    ) {
+        companion object {
+            val Empty = UiState(
+                showOnboarding = false,
+            )
+        }
+    }
+}

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/developer/DeveloperFragment.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/developer/DeveloperFragment.kt
@@ -47,6 +47,7 @@ class DeveloperFragment : BaseFragment() {
                 onShowWhatsNewClick = ::onShowWhatsNewClick,
                 onResetSuggestedFoldersSuggestion = viewModel::resetSuggestedFoldersSuggestion,
                 onShowNotificationsTestingClick = ::onShowNotificationsTestingClick,
+                onResetPlaylistsOnboarding = viewModel::resetPlaylistsOnboarding,
             )
         }
     }

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/developer/DeveloperPage.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/developer/DeveloperPage.kt
@@ -17,6 +17,7 @@ import androidx.compose.material.Card
 import androidx.compose.material.Text
 import androidx.compose.material.TextButton
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.outlined.PlaylistPlay
 import androidx.compose.material.icons.filled.Refresh
 import androidx.compose.material.icons.outlined.BugReport
 import androidx.compose.material.icons.outlined.Delete
@@ -61,6 +62,7 @@ fun DeveloperPage(
     onShowWhatsNewClick: () -> Unit,
     onShowNotificationsTestingClick: () -> Unit,
     onResetSuggestedFoldersSuggestion: () -> Unit,
+    onResetPlaylistsOnboarding: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     var openCrashMessageDialog by remember { mutableStateOf(false) }
@@ -108,6 +110,9 @@ fun DeveloperPage(
         }
         item {
             NotificationsTesting(onClick = onShowNotificationsTestingClick)
+        }
+        item {
+            ResetPlaylistsOnboarding(onClick = onResetPlaylistsOnboarding)
         }
 
         if (openCrashMessageDialog) {
@@ -303,6 +308,19 @@ private fun NotificationsTesting(
 }
 
 @Composable
+private fun ResetPlaylistsOnboarding(
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    SettingRow(
+        primaryText = "Reset Playlists onboarding",
+        secondaryText = "Show Playlists onboarding and tooltips",
+        icon = rememberVectorPainter(Icons.AutoMirrored.Outlined.PlaylistPlay),
+        modifier = modifier.clickable { onClick() },
+    )
+}
+
+@Composable
 private fun ResetSuggestedFoldersSuggestion(
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
@@ -346,6 +364,7 @@ private fun DeveloperPagePreview() {
         onShowWhatsNewClick = {},
         onResetSuggestedFoldersSuggestion = {},
         onShowNotificationsTestingClick = {},
+        onResetPlaylistsOnboarding = {},
     )
 }
 

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/developer/DeveloperViewModel.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/developer/DeveloperViewModel.kt
@@ -168,4 +168,8 @@ class DeveloperViewModel
             settings.suggestedFoldersDismissTimestamp.set(null, updateModifiedAt = false)
         }
     }
+
+    fun resetPlaylistsOnboarding() {
+        settings.showPlaylistsOnboarding.set(true, updateModifiedAt = false)
+    }
 }

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
@@ -589,4 +589,6 @@ interface Settings {
     val isFreeAccountFiltersBannerDismissed: UserSetting<Boolean>
     val isFreeAccountHistoryBannerDismissed: UserSetting<Boolean>
     val showFreeAccountEncouragement: UserSetting<Boolean>
+
+    val showPlaylistsOnboarding: UserSetting<Boolean>
 }

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
@@ -1620,4 +1620,10 @@ class SettingsImpl @Inject constructor(
         defaultValue = true,
         sharedPrefs = sharedPreferences,
     )
+
+    override val showPlaylistsOnboarding = UserSetting.BoolPref(
+        sharedPrefKey = "show_playlists_onboarding",
+        defaultValue = true,
+        sharedPrefs = sharedPreferences,
+    )
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/jobs/VersionMigrationsWorker.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/jobs/VersionMigrationsWorker.kt
@@ -196,6 +196,7 @@ class VersionMigrationsWorker @AssistedInject constructor(
         // don't migrate when first installing
         if (previousVersionCode == 0) {
             settings.setWhatsNewVersionCode(Settings.WHATS_NEW_VERSION_CODE)
+            settings.showPlaylistsOnboarding.set(false, updateModifiedAt = false)
             return
         }
 


### PR DESCRIPTION
## Description

This adds skeleton UI and logic for showing playlists onboarding.

## Testing Instructions

1. Checkout previous version of the app.
```
git checkout 7.92
```
2. Install previous version of the app
3. Open the app.
4. Checkout this branch.
```
git checkout task/playlist-onboarding
```
5. Install the app.
6. Open the app.
7. Go to the Playlists page.
8. You should see the bottom sheet with onboarding.
9. Close the app.
10. Open the app.
11. Go to the Playlists page.
12. You should not see the onboarding.
13. Close the app.
14. Clear the app's data.
15. Open the app.
16. Go to the Playlists page.
17. You should not see the onboarding.

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.