### PR TITLE
[Onboarding] Wire up read data and logic

### DIFF
--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/components/SubscriptionPlanRow.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/components/SubscriptionPlanRow.kt
@@ -287,7 +287,7 @@ private val SubscriptionPlan.pricePerMonth: Float
 
 private val SubscriptionPlan.recurringPrice: Price? get() = when (this) {
     is SubscriptionPlan.Base -> pricingPhase.price
-    is SubscriptionPlan.WithOffer -> pricingPhases.find { it.schedule.recurrenceMode is PricingSchedule.RecurrenceMode.Recurring }?.price
+    is SubscriptionPlan.WithOffer -> pricingPhases.find { it.schedule.recurrenceMode is PricingSchedule.RecurrenceMode.Infinite }?.price
 }
 
 private val SubscriptionPlan.pricePerWeek: Float

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingSubscriptionPlan.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingSubscriptionPlan.kt
@@ -17,6 +17,8 @@ import au.com.shiftyjelly.pocketcasts.payment.SubscriptionOffer
 import au.com.shiftyjelly.pocketcasts.payment.SubscriptionPlan
 import au.com.shiftyjelly.pocketcasts.payment.SubscriptionTier
 import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingUpgradeSource
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
 import java.math.BigDecimal
 import java.time.ZonedDateTime
 import java.time.format.DateTimeFormatter
@@ -189,7 +191,10 @@ data class OnboardingSubscriptionPlan private constructor(
     val featureItems: List<UpgradeFeatureItem>
         get() {
             val items = when (key.tier) {
-                SubscriptionTier.Plus -> PlusUpgradeFeatureItem.entries
+                SubscriptionTier.Plus -> PlusUpgradeFeatureItem.entries.filter {
+                    !FeatureFlag.isEnabled(Feature.NEW_ONBOARDING_UPGRADE) || it != PlusUpgradeFeatureItem.BannerAds
+                }
+
                 SubscriptionTier.Patron -> PatronUpgradeFeatureItem.entries
             }
             return items.filter { item ->

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeFeaturesPage.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeFeaturesPage.kt
@@ -93,6 +93,8 @@ import au.com.shiftyjelly.pocketcasts.payment.SubscriptionTier
 import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingFlow
 import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingUpgradeSource
 import au.com.shiftyjelly.pocketcasts.utils.extensions.pxToDp
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
 import au.com.shiftyjelly.pocketcasts.images.R as IR
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
@@ -132,18 +134,30 @@ internal fun OnboardingUpgradeFeaturesPage(
     when (state) {
         is OnboardingUpgradeFeaturesState.Loading -> Unit // Do Nothing
         is OnboardingUpgradeFeaturesState.Loaded -> {
-            UpgradeLayout(
-                state = state,
-                source = source,
-                scrollState = scrollState,
-                onBackPress = onBackPress,
-                onNotNowPress = onNotNowPress,
-                onChangeBillingCycle = { viewModel.changeBillingCycle(it) },
-                onChangeSubscriptionTier = { viewModel.changeSubscriptionTier(it) },
-                onClickSubscribe = { onClickSubscribe(false) },
-                onClickPrivacyPolicy = { viewModel.onPrivacyPolicyPressed() },
-                onClickTermsAndConditions = { viewModel.onTermsAndConditionsPressed() },
-            )
+            if (FeatureFlag.isEnabled(Feature.NEW_ONBOARDING_UPGRADE)) {
+                OnboardingUpgradeScreen(
+                    variant = Variants.VARIANT_FEATURES,
+                    onClosePress = onBackPress,
+                    state = state,
+                    onChangeSelectedPlan = { viewModel.changeBillingCycle(it.billingCycle) },
+                    onSubscribePress = { onClickSubscribe(false) },
+                    onClickPrivacyPolicy = { viewModel.onPrivacyPolicyPressed() },
+                    onClickTermsAndConditions = { viewModel.onTermsAndConditionsPressed() },
+                )
+            } else {
+                UpgradeLayout(
+                    state = state,
+                    source = source,
+                    scrollState = scrollState,
+                    onBackPress = onBackPress,
+                    onNotNowPress = onNotNowPress,
+                    onChangeBillingCycle = { viewModel.changeBillingCycle(it) },
+                    onChangeSubscriptionTier = { viewModel.changeSubscriptionTier(it) },
+                    onClickSubscribe = { onClickSubscribe(false) },
+                    onClickPrivacyPolicy = { viewModel.onPrivacyPolicyPressed() },
+                    onClickTermsAndConditions = { viewModel.onTermsAndConditionsPressed() },
+                )
+            }
         }
 
         is OnboardingUpgradeFeaturesState.NoSubscriptions -> {

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeFlow.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeFlow.kt
@@ -127,10 +127,10 @@ fun OnboardingUpgradeFlow(
                                         sheetState.show()
                                     }
                                 } else {
-                                    onNeedLogin()
+                                    viewModel.purchaseSelectedPlan(activity, onProceed)
                                 }
                             } else {
-                                LogBuffer.e(LogBuffer.TAG_SUBSCRIPTIONS, NULL_ACTIVITY_ERROR)
+                                onNeedLogin()
                             }
                         } else {
                             LogBuffer.e(LogBuffer.TAG_SUBSCRIPTIONS, NULL_ACTIVITY_ERROR)

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeFlow.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeFlow.kt
@@ -25,8 +25,6 @@ import au.com.shiftyjelly.pocketcasts.payment.SubscriptionTier
 import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingFlow
 import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingUpgradeSource
 import au.com.shiftyjelly.pocketcasts.utils.extensions.getActivity
-import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
-import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
 import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
 import kotlinx.coroutines.launch
 
@@ -115,36 +113,32 @@ fun OnboardingUpgradeFlow(
         sheetShape = RoundedCornerShape(topStart = 28.dp, topEnd = 28.dp),
         content = {
             if (flow !is OnboardingFlow.PlusAccountUpgrade) {
-                if (FeatureFlag.isEnabled(Feature.NEW_ONBOARDING_UPGRADE)) {
-                    OnboardingUpgradeScreen(onClosePress = onBackPress, onSubscribePress = {}, variant = Variants.VARIANT_FEATURES)
-                } else {
-                    OnboardingUpgradeFeaturesPage(
-                        viewModel = @Suppress("ktlint:compose:vm-forwarding-check") viewModel,
-                        state = state,
-                        flow = flow,
-                        source = source,
-                        onBackPress = onBackPress,
-                        onClickSubscribe = { showUpgradeBottomSheet ->
-                            if (activity != null) {
-                                if (isLoggedIn) {
-                                    if (showUpgradeBottomSheet) {
-                                        coroutineScope.launch {
-                                            sheetState.show()
-                                        }
-                                    } else {
-                                        onNeedLogin()
+                OnboardingUpgradeFeaturesPage(
+                    viewModel = @Suppress("ktlint:compose:vm-forwarding-check") viewModel,
+                    state = state,
+                    flow = flow,
+                    source = source,
+                    onBackPress = onBackPress,
+                    onClickSubscribe = { showUpgradeBottomSheet ->
+                        if (activity != null) {
+                            if (isLoggedIn) {
+                                if (showUpgradeBottomSheet) {
+                                    coroutineScope.launch {
+                                        sheetState.show()
                                     }
                                 } else {
-                                    LogBuffer.e(LogBuffer.TAG_SUBSCRIPTIONS, NULL_ACTIVITY_ERROR)
+                                    onNeedLogin()
                                 }
                             } else {
                                 LogBuffer.e(LogBuffer.TAG_SUBSCRIPTIONS, NULL_ACTIVITY_ERROR)
                             }
-                        },
-                        onNotNowPress = onProceed,
-                        onUpdateSystemBars = onUpdateSystemBars,
-                    )
-                }
+                        } else {
+                            LogBuffer.e(LogBuffer.TAG_SUBSCRIPTIONS, NULL_ACTIVITY_ERROR)
+                        }
+                    },
+                    onNotNowPress = onProceed,
+                    onUpdateSystemBars = onUpdateSystemBars,
+                )
             }
         },
         sheetContent = {

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeScreen.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeScreen.kt
@@ -53,6 +53,7 @@ import au.com.shiftyjelly.pocketcasts.compose.preview.ThemePreviewParameterProvi
 import au.com.shiftyjelly.pocketcasts.compose.theme
 import au.com.shiftyjelly.pocketcasts.images.R
 import au.com.shiftyjelly.pocketcasts.payment.BillingCycle
+import au.com.shiftyjelly.pocketcasts.payment.SubscriptionOffer
 import au.com.shiftyjelly.pocketcasts.payment.SubscriptionPlan
 import au.com.shiftyjelly.pocketcasts.payment.SubscriptionPlans
 import au.com.shiftyjelly.pocketcasts.payment.SubscriptionTier
@@ -95,7 +96,7 @@ fun OnboardingUpgradeScreen(
             modifier = Modifier.weight(1f),
             pages = variant.toContentPages(
                 currentPlan = state.selectedPlan,
-                isEligibleForTrial = state.availableBasePlans.any { it.offer != null },
+                isEligibleForTrial = state.availableBasePlans.any { it.offer == SubscriptionOffer.Trial },
             ),
         )
         Spacer(modifier = Modifier.height(24.dp))

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeScreen.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeScreen.kt
@@ -135,12 +135,12 @@ private fun UpgradeFooter(
     Column(
         modifier = modifier,
     ) {
-        plans.forEach { item ->
+        plans.forEachIndexed { index, item ->
             UpgradePlanRow(
                 plan = item,
                 isSelected = selectedOnboardingPlan.key == item.key,
                 onClick = { onSelectedChange(item) },
-                priceComparisonPlan = SubscriptionPlan.PlusMonthlyPreview,
+                priceComparisonPlan = plans.getOrNull(index + 1),
             )
             Spacer(modifier = Modifier.height(10.dp))
         }

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/OnboardingUpgradeFeaturesViewModel.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/OnboardingUpgradeFeaturesViewModel.kt
@@ -211,7 +211,13 @@ sealed class OnboardingUpgradeFeaturesState {
 
         val selectedPlan get() = getPlan(selectedTier, selectedBillingCycle)
 
+        val selectedBasePlan get() = getBasePlan(selectedTier, selectedBillingCycle)
+
         private fun getPlan(tier: SubscriptionTier, billingCycle: BillingCycle) = availablePlans.first { plan ->
+            plan.key.tier == tier && plan.key.billingCycle == billingCycle
+        }
+
+        private fun getBasePlan(tier: SubscriptionTier, billingCycle: BillingCycle) = availableBasePlans.first { plan ->
             plan.key.tier == tier && plan.key.billingCycle == billingCycle
         }
 


### PR DESCRIPTION
## Description
This PR adds the next piece to the puzzle: the new onboarding screen now works with actual data!

Fixes https://linear.app/a8c/issue/PCDROID-28/wire-up-logic-on-upgrade-screens

## Testing Instructions
1. Apply [debug-as-prod (1).patch](https://github.com/user-attachments/files/21287520/debug-as-prod.1.patch)
2. Build `debugProd` variant and install it
3. Do not log in upon opening the app
4. Navigate to Settings -> Pocket Casts Plus
5. Select a plan and tap 'Subscribe' or 'Start free trial' if you're eligible (depends on your google account, if you've ever claimed the free trial with that google account, you won't be eligible)
6. Go through subscription flow presented by the Play billing sdk
- [ ] things worked

## Screencast
https://github.com/user-attachments/assets/9f682269-0065-4426-9452-90facaffa64b


## Checklist
- [ ] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] ~I have considered whether it makes sense to add tests for my changes~
- [ ] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [ ] ~Any jetpack compose components I added or changed are covered by compose previews~
- [ ] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~
 
