### PR TITLE
Change window class size library

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -83,7 +83,7 @@ compose-material = { module = "androidx.compose.material:material" }
 compose-material-icons-core = { module = "androidx.compose.material:material-icons-core" }
 compose-material-icons-extended = { module = "androidx.compose.material:material-icons-extended" }
 compose-material3 = { module = "androidx.compose.material3:material3" }
-compose-material3-window-size = { module = "androidx.compose.material3:material3-window-size-class-android" }
+compose-material3-adaptive = "androidx.compose.material3.adaptive:adaptive:1.2.0-alpha09" # Using alpha version until breakpoint APIs are available
 compose-runtime = { module = "androidx.compose.runtime:runtime" }
 compose-rxjava2 = { module = "androidx.compose.runtime:runtime-rxjava2" }
 compose-ui = { module = "androidx.compose.ui:ui" }

--- a/modules/features/player/build.gradle.kts
+++ b/modules/features/player/build.gradle.kts
@@ -59,7 +59,6 @@ dependencies {
     implementation(libs.compose.livedata)
     implementation(libs.compose.material)
     implementation(libs.compose.material.icons.core)
-    implementation(libs.compose.material3.window.size)
     implementation(libs.compose.ui)
     implementation(libs.compose.ui.tooling.preview)
     implementation(libs.compose.webview)

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/PlayerHeaderFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/PlayerHeaderFragment.kt
@@ -43,10 +43,7 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.MaterialTheme
-import androidx.compose.material3.windowsizeclass.ExperimentalMaterial3WindowSizeClassApi
-import androidx.compose.material3.windowsizeclass.WindowHeightSizeClass
-import androidx.compose.material3.windowsizeclass.WindowWidthSizeClass
-import androidx.compose.material3.windowsizeclass.calculateWindowSizeClass
+import androidx.compose.material3.adaptive.currentWindowAdaptiveInfo
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
@@ -87,6 +84,8 @@ import au.com.shiftyjelly.pocketcasts.compose.PodcastColors
 import au.com.shiftyjelly.pocketcasts.compose.ad.AdBanner
 import au.com.shiftyjelly.pocketcasts.compose.ad.BlazeAd
 import au.com.shiftyjelly.pocketcasts.compose.ad.rememberAdColors
+import au.com.shiftyjelly.pocketcasts.compose.adaptive.isAtLeastMediumHeight
+import au.com.shiftyjelly.pocketcasts.compose.adaptive.isAtLeastMediumWidth
 import au.com.shiftyjelly.pocketcasts.compose.components.AnimatedNonNullVisibility
 import au.com.shiftyjelly.pocketcasts.compose.components.rememberNestedScrollLockableInteropConnection
 import au.com.shiftyjelly.pocketcasts.compose.extensions.contentWithoutConsumedInsets
@@ -148,7 +147,6 @@ import au.com.shiftyjelly.pocketcasts.images.R as IR
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 import au.com.shiftyjelly.pocketcasts.transcripts.UiState as TranscriptsUiState
 
-@OptIn(ExperimentalMaterial3WindowSizeClassApi::class)
 @AndroidEntryPoint
 class PlayerHeaderFragment :
     BaseFragment(),
@@ -199,10 +197,10 @@ class PlayerHeaderFragment :
         container: ViewGroup?,
         savedInstanceState: Bundle?,
     ) = contentWithoutConsumedInsets {
-        val windowSize = calculateWindowSizeClass(requireActivity())
+        val windowSize = currentWindowAdaptiveInfo().windowSizeClass
         val isPortraitConfiguration = LocalConfiguration.current.inPortrait()
-        val isPortraitPlayer = isPortraitConfiguration || windowSize.heightSizeClass >= WindowHeightSizeClass.Medium
-        val maxWidthFraction = if (isPortraitConfiguration && windowSize.widthSizeClass >= WindowWidthSizeClass.Medium) 0.8f else 1f
+        val isPortraitPlayer = isPortraitConfiguration || windowSize.isAtLeastMediumHeight()
+        val maxWidthFraction = if (isPortraitConfiguration && windowSize.isAtLeastMediumWidth()) 0.8f else 1f
 
         val podcastColors by remember { podcastColorsFlow() }.collectAsState(PodcastColors.ForUserEpisode)
         val headerData by remember { playerHeaderFlow() }.collectAsState(PlayerViewModel.PlayerHeader())

--- a/modules/features/referrals/build.gradle.kts
+++ b/modules/features/referrals/build.gradle.kts
@@ -26,7 +26,6 @@ dependencies {
     implementation(platform(libs.compose.bom))
 
     implementation(libs.compose.material)
-    implementation(libs.compose.material3.window.size)
     implementation(libs.compose.ui)
     implementation(libs.compose.ui.tooling.preview)
     implementation(libs.coroutines.reactive)

--- a/modules/features/referrals/src/main/kotlin/au/com/shiftyjelly/pocketcasts/referrals/ReferralCardAnimatedGradientView.kt
+++ b/modules/features/referrals/src/main/kotlin/au/com/shiftyjelly/pocketcasts/referrals/ReferralCardAnimatedGradientView.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.requiredSize
 import androidx.compose.foundation.layout.size
@@ -76,7 +77,8 @@ private fun ReferralCardAnimatedBackgroundView(
             contentAlignment = Alignment.Center,
             modifier = Modifier
                 .blur(maxWidth / 10)
-                .background(Color.Black),
+                .background(Color.Black)
+                .fillMaxSize(),
         ) {
             val density = LocalDensity.current
             val circleSize = maxHeight * 1.3f

--- a/modules/features/referrals/src/main/kotlin/au/com/shiftyjelly/pocketcasts/referrals/ReferralPageDefaults.kt
+++ b/modules/features/referrals/src/main/kotlin/au/com/shiftyjelly/pocketcasts/referrals/ReferralPageDefaults.kt
@@ -1,15 +1,14 @@
 package au.com.shiftyjelly.pocketcasts.referrals
 
-import androidx.compose.material3.windowsizeclass.WindowHeightSizeClass
-import androidx.compose.material3.windowsizeclass.WindowWidthSizeClass
 import androidx.compose.ui.unit.dp
+import androidx.window.core.layout.WindowSizeClass
+import au.com.shiftyjelly.pocketcasts.compose.adaptive.isAtMostMediumHeight
+import au.com.shiftyjelly.pocketcasts.compose.adaptive.isAtMostMediumWidth
 
 object ReferralPageDefaults {
     fun shouldShowFullScreen(
-        windowWidthSizeClass: WindowWidthSizeClass,
-        windowHeightSizeClass: WindowHeightSizeClass,
-    ) = windowWidthSizeClass == WindowWidthSizeClass.Compact ||
-        windowHeightSizeClass == WindowHeightSizeClass.Compact
+        windowSizeClass: WindowSizeClass,
+    ) = windowSizeClass.isAtMostMediumHeight() || windowSizeClass.isAtMostMediumWidth()
 
     fun pageCornerRadius(showFullScreen: Boolean) = if (showFullScreen) 0.dp else 8.dp
 

--- a/modules/features/referrals/src/main/kotlin/au/com/shiftyjelly/pocketcasts/referrals/ReferralsClaimGuestPassPage.kt
+++ b/modules/features/referrals/src/main/kotlin/au/com/shiftyjelly/pocketcasts/referrals/ReferralsClaimGuestPassPage.kt
@@ -1,6 +1,5 @@
 package au.com.shiftyjelly.pocketcasts.referrals
 
-import android.app.Activity
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
@@ -23,10 +22,7 @@ import androidx.compose.material.Snackbar
 import androidx.compose.material.SnackbarHost
 import androidx.compose.material.SnackbarHostState
 import androidx.compose.material.TextButton
-import androidx.compose.material3.windowsizeclass.ExperimentalMaterial3WindowSizeClassApi
-import androidx.compose.material3.windowsizeclass.WindowHeightSizeClass
-import androidx.compose.material3.windowsizeclass.WindowWidthSizeClass
-import androidx.compose.material3.windowsizeclass.calculateWindowSizeClass
+import androidx.compose.material3.adaptive.currentWindowAdaptiveInfo
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
@@ -45,9 +41,11 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.window.core.layout.WindowSizeClass
 import au.com.shiftyjelly.pocketcasts.compose.AppTheme
 import au.com.shiftyjelly.pocketcasts.compose.CallOnce
 import au.com.shiftyjelly.pocketcasts.compose.Devices
+import au.com.shiftyjelly.pocketcasts.compose.adaptive.isAtLeastMediumHeight
 import au.com.shiftyjelly.pocketcasts.compose.buttons.GradientRowButton
 import au.com.shiftyjelly.pocketcasts.compose.components.TextH10
 import au.com.shiftyjelly.pocketcasts.compose.components.TextH50
@@ -78,7 +76,6 @@ import au.com.shiftyjelly.pocketcasts.utils.extensions.getActivity
 import au.com.shiftyjelly.pocketcasts.images.R as IR
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
-@OptIn(ExperimentalMaterial3WindowSizeClassApi::class)
 @Composable
 fun ReferralsClaimGuestPassPage(
     onDismiss: () -> Unit,
@@ -86,7 +83,6 @@ fun ReferralsClaimGuestPassPage(
 ) {
     AppTheme(Theme.ThemeType.DARK) {
         val context = LocalContext.current
-        val windowSize = calculateWindowSizeClass(context.getActivity() as Activity)
         val state by viewModel.state.collectAsStateWithLifecycle()
         val activity = LocalContext.current.getActivity()
         val snackbarHostState = remember { SnackbarHostState() }
@@ -96,8 +92,6 @@ fun ReferralsClaimGuestPassPage(
         }
 
         ReferralsClaimGuestPassContent(
-            windowWidthSizeClass = windowSize.widthSizeClass,
-            windowHeightSizeClass = windowSize.heightSizeClass,
             state = state,
             onDismiss = onDismiss,
             onActivatePassClick = viewModel::onActivatePassClick,
@@ -159,14 +153,13 @@ fun ReferralsClaimGuestPassPage(
 
 @Composable
 private fun ReferralsClaimGuestPassContent(
-    windowWidthSizeClass: WindowWidthSizeClass,
-    windowHeightSizeClass: WindowHeightSizeClass,
     state: UiState,
     onDismiss: () -> Unit,
     onActivatePassClick: () -> Unit,
     onRetry: () -> Unit,
     snackbarHostState: SnackbarHostState,
 ) {
+    val windowSizeClass = currentWindowAdaptiveInfo().windowSizeClass
     BoxWithConstraints(
         contentAlignment = Alignment.Center,
         modifier = Modifier
@@ -178,7 +171,7 @@ private fun ReferralsClaimGuestPassContent(
             )
             .fillMaxSize(),
     ) {
-        val showFullScreen = shouldShowFullScreen(windowWidthSizeClass, windowHeightSizeClass)
+        val showFullScreen = shouldShowFullScreen(windowSizeClass)
         val pageWidth = if (showFullScreen) maxWidth else (maxWidth.value * PAGE_WIDTH_PERCENT).dp
         val pageModifier = if (showFullScreen) {
             Modifier
@@ -209,7 +202,7 @@ private fun ReferralsClaimGuestPassContent(
                         referralPlan = state.referralPlan,
                         showFullScreen = showFullScreen,
                         pageWidth = pageWidth,
-                        windowHeightSizeClass = windowHeightSizeClass,
+                        windowSizeClass = windowSizeClass,
                         onDismiss = onDismiss,
                         onActivatePassClick = onActivatePassClick,
                     )
@@ -248,7 +241,7 @@ private fun ClaimGuestPassContent(
     referralPlan: ReferralSubscriptionPlan,
     showFullScreen: Boolean,
     pageWidth: Dp,
-    windowHeightSizeClass: WindowHeightSizeClass,
+    windowSizeClass: WindowSizeClass,
     onDismiss: () -> Unit,
     onActivatePassClick: () -> Unit,
 ) {
@@ -296,7 +289,7 @@ private fun ClaimGuestPassContent(
         )
 
         val guestPassCardWidth = pageWidth * 0.8f
-        if (windowHeightSizeClass != WindowHeightSizeClass.Compact) {
+        if (windowSizeClass.isAtLeastMediumHeight()) {
             Spacer(modifier = Modifier.height(24.dp))
 
             val guestPassCardHeight = (guestPassCardWidth.value * ReferralGuestPassCardDefaults.cardAspectRatio).dp
@@ -334,48 +327,31 @@ private fun ClaimGuestPassContent(
 @Preview(device = Devices.PORTRAIT_REGULAR)
 @Composable
 private fun ReferralsClaimGuestPassPortraitPhonePreview() {
-    ReferralsClaimGuestPassContentPreview(
-        windowWidthSizeClass = WindowWidthSizeClass.Compact,
-        windowHeightSizeClass = WindowHeightSizeClass.Medium,
-    )
+    ReferralsClaimGuestPassContentPreview()
 }
 
 @Preview(device = Devices.LANDSCAPE_REGULAR)
 @Composable
 private fun ReferralsClaimGuestPassLandscapePhonePreview() {
-    ReferralsClaimGuestPassContentPreview(
-        windowWidthSizeClass = WindowWidthSizeClass.Compact,
-        windowHeightSizeClass = WindowHeightSizeClass.Compact,
-    )
+    ReferralsClaimGuestPassContentPreview()
 }
 
 @Preview(device = Devices.PORTRAIT_TABLET)
 @Composable
 private fun ReferralsClaimGuestPassPortraitTabletPreview() {
-    ReferralsClaimGuestPassContentPreview(
-        windowWidthSizeClass = WindowWidthSizeClass.Medium,
-        windowHeightSizeClass = WindowHeightSizeClass.Medium,
-    )
+    ReferralsClaimGuestPassContentPreview()
 }
 
 @Preview(device = Devices.LANDSCAPE_TABLET)
 @Composable
 private fun ReferralsClaimGuestPassLandscapeTabletPreview() {
-    ReferralsClaimGuestPassContentPreview(
-        windowWidthSizeClass = WindowWidthSizeClass.Medium,
-        windowHeightSizeClass = WindowHeightSizeClass.Expanded,
-    )
+    ReferralsClaimGuestPassContentPreview()
 }
 
 @Composable
-fun ReferralsClaimGuestPassContentPreview(
-    windowWidthSizeClass: WindowWidthSizeClass,
-    windowHeightSizeClass: WindowHeightSizeClass,
-) {
+fun ReferralsClaimGuestPassContentPreview() {
     AppTheme(Theme.ThemeType.DARK) {
         ReferralsClaimGuestPassContent(
-            windowWidthSizeClass = windowWidthSizeClass,
-            windowHeightSizeClass = windowHeightSizeClass,
             state = UiState.Loaded(
                 referralPlan = SubscriptionPlans.Preview
                     .findOfferPlan(SubscriptionTier.Plus, BillingCycle.Yearly, SubscriptionOffer.Referral)

--- a/modules/features/referrals/src/main/kotlin/au/com/shiftyjelly/pocketcasts/referrals/ReferralsGuestPassFragment.kt
+++ b/modules/features/referrals/src/main/kotlin/au/com/shiftyjelly/pocketcasts/referrals/ReferralsGuestPassFragment.kt
@@ -1,29 +1,25 @@
 package au.com.shiftyjelly.pocketcasts.referrals
 
-import android.app.Activity
 import android.graphics.Color
 import android.os.Bundle
 import android.os.Parcelable
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.compose.foundation.layout.consumeWindowInsets
-import androidx.compose.material3.windowsizeclass.ExperimentalMaterial3WindowSizeClassApi
-import androidx.compose.material3.windowsizeclass.WindowHeightSizeClass
-import androidx.compose.material3.windowsizeclass.WindowWidthSizeClass
-import androidx.compose.material3.windowsizeclass.calculateWindowSizeClass
+import androidx.compose.material3.adaptive.currentWindowAdaptiveInfo
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.graphics.toArgb
-import androidx.compose.ui.platform.LocalContext
 import androidx.core.os.BundleCompat
 import androidx.core.os.bundleOf
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
+import au.com.shiftyjelly.pocketcasts.compose.adaptive.isAtMostMediumHeight
+import au.com.shiftyjelly.pocketcasts.compose.adaptive.isAtMostMediumWidth
 import au.com.shiftyjelly.pocketcasts.compose.extensions.contentWithoutConsumedInsets
 import au.com.shiftyjelly.pocketcasts.ui.helper.FragmentHostListener
 import au.com.shiftyjelly.pocketcasts.ui.helper.NavigationBarColor
 import au.com.shiftyjelly.pocketcasts.ui.helper.StatusBarIconColor
-import au.com.shiftyjelly.pocketcasts.utils.extensions.getActivity
 import au.com.shiftyjelly.pocketcasts.views.fragments.BaseFragment
 import au.com.shiftyjelly.pocketcasts.views.helper.UiUtil.setBackgroundColor
 import dagger.hilt.android.AndroidEntryPoint
@@ -39,14 +35,12 @@ class ReferralsGuestPassFragment : BaseFragment() {
 
     override var statusBarIconColor: StatusBarIconColor = StatusBarIconColor.Light
 
-    @OptIn(ExperimentalMaterial3WindowSizeClassApi::class)
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
         savedInstanceState: Bundle?,
     ) = contentWithoutConsumedInsets {
-        val context = LocalContext.current
-        val windowSize = calculateWindowSizeClass(context.getActivity() as Activity)
+        val windowSize = currentWindowAdaptiveInfo().windowSizeClass
 
         setBackgroundColor(view, ComposeColor.Transparent.toArgb())
 
@@ -73,9 +67,7 @@ class ReferralsGuestPassFragment : BaseFragment() {
         LaunchedEffect(Unit) {
             viewLifecycleOwner.lifecycleScope.launch {
                 viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.RESUMED) {
-                    if (windowSize.widthSizeClass == WindowWidthSizeClass.Compact ||
-                        windowSize.heightSizeClass == WindowHeightSizeClass.Compact
-                    ) {
+                    if (windowSize.isAtMostMediumWidth() || windowSize.isAtMostMediumHeight()) {
                         delay(200) // To prevent race condition in updating activity's status bar color from tab fragments on fresh install
                         updateStatusAndNavColors()
                     }

--- a/modules/features/referrals/src/main/kotlin/au/com/shiftyjelly/pocketcasts/referrals/ReferralsInvalidOfferPage.kt
+++ b/modules/features/referrals/src/main/kotlin/au/com/shiftyjelly/pocketcasts/referrals/ReferralsInvalidOfferPage.kt
@@ -1,6 +1,5 @@
 package au.com.shiftyjelly.pocketcasts.referrals
 
-import android.app.Activity
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
@@ -18,16 +17,12 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.Card
-import androidx.compose.material3.windowsizeclass.ExperimentalMaterial3WindowSizeClassApi
-import androidx.compose.material3.windowsizeclass.WindowHeightSizeClass
-import androidx.compose.material3.windowsizeclass.WindowWidthSizeClass
-import androidx.compose.material3.windowsizeclass.calculateWindowSizeClass
+import androidx.compose.material3.adaptive.currentWindowAdaptiveInfo
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
@@ -44,22 +39,15 @@ import au.com.shiftyjelly.pocketcasts.referrals.ReferralPageDefaults.PAGE_WIDTH_
 import au.com.shiftyjelly.pocketcasts.referrals.ReferralPageDefaults.pageCornerRadius
 import au.com.shiftyjelly.pocketcasts.referrals.ReferralPageDefaults.shouldShowFullScreen
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
-import au.com.shiftyjelly.pocketcasts.utils.extensions.getActivity
 import au.com.shiftyjelly.pocketcasts.images.R as IR
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
-@OptIn(ExperimentalMaterial3WindowSizeClassApi::class)
 @Composable
 fun ReferralsInvalidOfferPage(
     onDismiss: () -> Unit,
 ) {
     AppTheme(Theme.ThemeType.DARK) {
-        val context = LocalContext.current
-        val windowSize = calculateWindowSizeClass(context.getActivity() as Activity)
-
         ReferralsInvalidOfferPageContent(
-            windowWidthSizeClass = windowSize.widthSizeClass,
-            windowHeightSizeClass = windowSize.heightSizeClass,
             onDismiss = onDismiss,
         )
     }
@@ -67,10 +55,10 @@ fun ReferralsInvalidOfferPage(
 
 @Composable
 private fun ReferralsInvalidOfferPageContent(
-    windowWidthSizeClass: WindowWidthSizeClass,
-    windowHeightSizeClass: WindowHeightSizeClass,
     onDismiss: () -> Unit,
 ) {
+    val windowSize = currentWindowAdaptiveInfo().windowSizeClass
+
     BoxWithConstraints(
         contentAlignment = Alignment.Center,
         modifier = Modifier
@@ -82,7 +70,7 @@ private fun ReferralsInvalidOfferPageContent(
             )
             .fillMaxSize(),
     ) {
-        val showFullScreen = shouldShowFullScreen(windowWidthSizeClass, windowHeightSizeClass)
+        val showFullScreen = shouldShowFullScreen(windowSize)
         val pageWidth = if (showFullScreen) maxWidth else (maxWidth.value * PAGE_WIDTH_PERCENT).dp
         val pageModifier = if (showFullScreen) {
             Modifier
@@ -160,48 +148,31 @@ private fun ReferralsInvalidOfferPageContent(
 @Preview(device = Devices.PORTRAIT_REGULAR)
 @Composable
 private fun ReferralsInvalidOfferPagePortraitPhonePreview() {
-    ReferralsInvalidOfferPageContentPreview(
-        windowWidthSizeClass = WindowWidthSizeClass.Compact,
-        windowHeightSizeClass = WindowHeightSizeClass.Medium,
-    )
+    ReferralsInvalidOfferPageContentPreview()
 }
 
 @Preview(device = Devices.LANDSCAPE_REGULAR)
 @Composable
 private fun ReferralsInvalidOfferPageLandscapePhonePreview() {
-    ReferralsInvalidOfferPageContentPreview(
-        windowWidthSizeClass = WindowWidthSizeClass.Compact,
-        windowHeightSizeClass = WindowHeightSizeClass.Compact,
-    )
+    ReferralsInvalidOfferPageContentPreview()
 }
 
 @Preview(device = Devices.PORTRAIT_TABLET)
 @Composable
 private fun ReferralsInvalidOfferPagePortraitTabletPreview() {
-    ReferralsInvalidOfferPageContentPreview(
-        windowWidthSizeClass = WindowWidthSizeClass.Medium,
-        windowHeightSizeClass = WindowHeightSizeClass.Medium,
-    )
+    ReferralsInvalidOfferPageContentPreview()
 }
 
 @Preview(device = Devices.LANDSCAPE_TABLET)
 @Composable
 private fun ReferralsInvalidOfferPageLandscapeTabletPreview() {
-    ReferralsInvalidOfferPageContentPreview(
-        windowWidthSizeClass = WindowWidthSizeClass.Medium,
-        windowHeightSizeClass = WindowHeightSizeClass.Expanded,
-    )
+    ReferralsInvalidOfferPageContentPreview()
 }
 
 @Composable
-fun ReferralsInvalidOfferPageContentPreview(
-    windowWidthSizeClass: WindowWidthSizeClass,
-    windowHeightSizeClass: WindowHeightSizeClass,
-) {
+fun ReferralsInvalidOfferPageContentPreview() {
     AppTheme(Theme.ThemeType.DARK) {
         ReferralsInvalidOfferPageContent(
-            windowWidthSizeClass = windowWidthSizeClass,
-            windowHeightSizeClass = windowHeightSizeClass,
             onDismiss = {},
         )
     }

--- a/modules/features/referrals/src/main/kotlin/au/com/shiftyjelly/pocketcasts/referrals/ReferralsSendGuestPassPage.kt
+++ b/modules/features/referrals/src/main/kotlin/au/com/shiftyjelly/pocketcasts/referrals/ReferralsSendGuestPassPage.kt
@@ -1,6 +1,5 @@
 package au.com.shiftyjelly.pocketcasts.referrals
 
-import android.app.Activity
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
@@ -20,10 +19,7 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.Card
-import androidx.compose.material3.windowsizeclass.ExperimentalMaterial3WindowSizeClassApi
-import androidx.compose.material3.windowsizeclass.WindowHeightSizeClass
-import androidx.compose.material3.windowsizeclass.WindowWidthSizeClass
-import androidx.compose.material3.windowsizeclass.calculateWindowSizeClass
+import androidx.compose.material3.adaptive.currentWindowAdaptiveInfo
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.getValue
@@ -40,9 +36,11 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.window.core.layout.WindowSizeClass
 import au.com.shiftyjelly.pocketcasts.compose.AppTheme
 import au.com.shiftyjelly.pocketcasts.compose.CallOnce
 import au.com.shiftyjelly.pocketcasts.compose.Devices
+import au.com.shiftyjelly.pocketcasts.compose.adaptive.isAtLeastMediumHeight
 import au.com.shiftyjelly.pocketcasts.compose.buttons.CloseButton
 import au.com.shiftyjelly.pocketcasts.compose.buttons.GradientRowButton
 import au.com.shiftyjelly.pocketcasts.compose.components.TextH10
@@ -65,15 +63,12 @@ import au.com.shiftyjelly.pocketcasts.utils.extensions.getActivity
 import au.com.shiftyjelly.pocketcasts.images.R as IR
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
-@OptIn(ExperimentalMaterial3WindowSizeClassApi::class)
 @Composable
 fun ReferralsSendGuestPassPage(
     onDismiss: () -> Unit,
     viewModel: ReferralsSendGuestPassViewModel = hiltViewModel(),
 ) {
     AppTheme(Theme.ThemeType.DARK) {
-        val context = LocalContext.current
-        val windowSize = calculateWindowSizeClass(context.getActivity() as Activity)
         val state by viewModel.state.collectAsStateWithLifecycle()
         val activity = LocalContext.current.getActivity()
 
@@ -82,8 +77,6 @@ fun ReferralsSendGuestPassPage(
         }
 
         ReferralsSendGuestPassContent(
-            windowWidthSizeClass = windowSize.widthSizeClass,
-            windowHeightSizeClass = windowSize.heightSizeClass,
             state = state,
             onRetry = viewModel::onRetry,
             onDismiss = onDismiss,
@@ -103,12 +96,12 @@ fun ReferralsSendGuestPassPage(
 @Composable
 private fun ReferralsSendGuestPassContent(
     state: UiState,
-    windowWidthSizeClass: WindowWidthSizeClass,
-    windowHeightSizeClass: WindowHeightSizeClass,
     onRetry: () -> Unit,
     onDismiss: () -> Unit,
     onShare: (String, String, String) -> Unit,
 ) {
+    val windowSizeClass = currentWindowAdaptiveInfo().windowSizeClass
+
     BoxWithConstraints(
         contentAlignment = Alignment.Center,
         modifier = Modifier
@@ -120,7 +113,7 @@ private fun ReferralsSendGuestPassContent(
             )
             .fillMaxSize(),
     ) {
-        val showFullScreen = shouldShowFullScreen(windowWidthSizeClass, windowHeightSizeClass)
+        val showFullScreen = shouldShowFullScreen(windowSizeClass)
         val pageWidth = if (showFullScreen) maxWidth else (maxWidth.value * PAGE_WIDTH_PERCENT).dp
         val pageModifier = if (showFullScreen) {
             Modifier
@@ -151,7 +144,7 @@ private fun ReferralsSendGuestPassContent(
                     SendGuestPassContent(
                         state = state,
                         showFullScreen = showFullScreen,
-                        windowHeightSizeClass = windowHeightSizeClass,
+                        windowSizeClass = windowSizeClass,
                         pageWidth = pageWidth,
                         onDismiss = onDismiss,
                         onShare = { onShare(state.code, offerName, offerDuration) },
@@ -177,7 +170,7 @@ private fun ReferralsSendGuestPassContent(
 private fun SendGuestPassContent(
     state: UiState.Loaded,
     showFullScreen: Boolean,
-    windowHeightSizeClass: WindowHeightSizeClass,
+    windowSizeClass: WindowSizeClass,
     pageWidth: Dp,
     onDismiss: () -> Unit,
     onShare: () -> Unit,
@@ -213,7 +206,7 @@ private fun SendGuestPassContent(
             textAlign = TextAlign.Center,
         )
 
-        if (windowHeightSizeClass != WindowHeightSizeClass.Compact) {
+        if (windowSizeClass.isAtLeastMediumHeight()) {
             Spacer(modifier = Modifier.height(24.dp))
 
             ReferralsPassCardsStack(
@@ -268,48 +261,31 @@ private fun ReferralsPassCardsStack(
 @Preview(device = Devices.PORTRAIT_REGULAR)
 @Composable
 private fun ReferralsSendGuestPassPortraitPhonePreview() {
-    ReferralsSendGuestPassContentPreview(
-        windowWidthSizeClass = WindowWidthSizeClass.Compact,
-        windowHeightSizeClass = WindowHeightSizeClass.Medium,
-    )
+    ReferralsSendGuestPassContentPreview()
 }
 
 @Preview(device = Devices.LANDSCAPE_REGULAR)
 @Composable
 private fun ReferralsSendGuestPassLandscapePhonePreview() {
-    ReferralsSendGuestPassContentPreview(
-        windowWidthSizeClass = WindowWidthSizeClass.Compact,
-        windowHeightSizeClass = WindowHeightSizeClass.Compact,
-    )
+    ReferralsSendGuestPassContentPreview()
 }
 
 @Preview(device = Devices.PORTRAIT_TABLET)
 @Composable
 private fun ReferralsSendGuestPassPortraitTabletPreview() {
-    ReferralsSendGuestPassContentPreview(
-        windowWidthSizeClass = WindowWidthSizeClass.Medium,
-        windowHeightSizeClass = WindowHeightSizeClass.Medium,
-    )
+    ReferralsSendGuestPassContentPreview()
 }
 
 @Preview(device = Devices.LANDSCAPE_TABLET)
 @Composable
 private fun ReferralsSendGuestPassLandscapeTabletPreview() {
-    ReferralsSendGuestPassContentPreview(
-        windowWidthSizeClass = WindowWidthSizeClass.Medium,
-        windowHeightSizeClass = WindowHeightSizeClass.Expanded,
-    )
+    ReferralsSendGuestPassContentPreview()
 }
 
 @Composable
-fun ReferralsSendGuestPassContentPreview(
-    windowWidthSizeClass: WindowWidthSizeClass,
-    windowHeightSizeClass: WindowHeightSizeClass,
-) {
+fun ReferralsSendGuestPassContentPreview() {
     AppTheme(Theme.ThemeType.DARK) {
         ReferralsSendGuestPassContent(
-            windowWidthSizeClass = windowWidthSizeClass,
-            windowHeightSizeClass = windowHeightSizeClass,
             state = UiState.Loaded(
                 referralPlan = SubscriptionPlans.Preview
                     .findOfferPlan(SubscriptionTier.Plus, BillingCycle.Yearly, SubscriptionOffer.Referral)

--- a/modules/services/compose/build.gradle.kts
+++ b/modules/services/compose/build.gradle.kts
@@ -18,6 +18,7 @@ dependencies {
     ksp(libs.showkase.processor)
 
     api(libs.showkase)
+    api(libs.compose.material3.adaptive)
 
     api(projects.modules.services.model)
     api(projects.modules.services.preferences)

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/adaptive/WindowSizeClass.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/adaptive/WindowSizeClass.kt
@@ -1,0 +1,18 @@
+package au.com.shiftyjelly.pocketcasts.compose.adaptive
+
+import androidx.window.core.layout.WindowSizeClass
+
+fun WindowSizeClass.isAtLeastMediumWidth() = isWidthAtLeastBreakpoint(WindowSizeClass.WIDTH_DP_MEDIUM_LOWER_BOUND)
+fun WindowSizeClass.isAtMostMediumWidth() = isWidthAtMostBreakpoint(WindowSizeClass.WIDTH_DP_MEDIUM_LOWER_BOUND)
+
+fun WindowSizeClass.isAtLeastMediumHeight() = isHeightAtLeastBreakpoint(WindowSizeClass.HEIGHT_DP_MEDIUM_LOWER_BOUND)
+fun WindowSizeClass.isAtMostMediumHeight() = isHeightAtMostBreakpoint(WindowSizeClass.HEIGHT_DP_MEDIUM_LOWER_BOUND)
+
+fun WindowSizeClass.isAtLeastExpandedWidth() = isWidthAtLeastBreakpoint(WindowSizeClass.WIDTH_DP_EXPANDED_LOWER_BOUND)
+fun WindowSizeClass.isAtMostExpandedWidth() = isWidthAtMostBreakpoint(WindowSizeClass.WIDTH_DP_EXPANDED_LOWER_BOUND)
+
+fun WindowSizeClass.isAtLeastExpandedHeight() = isHeightAtLeastBreakpoint(WindowSizeClass.HEIGHT_DP_EXPANDED_LOWER_BOUND)
+fun WindowSizeClass.isAtMostExpandedHeight() = isHeightAtMostBreakpoint(WindowSizeClass.HEIGHT_DP_EXPANDED_LOWER_BOUND)
+
+private fun WindowSizeClass.isWidthAtMostBreakpoint(widthBreakpoint: Int) = minWidthDp <= widthBreakpoint
+private fun WindowSizeClass.isHeightAtMostBreakpoint(heightBreakpoint: Int) = minHeightDp <= heightBreakpoint


### PR DESCRIPTION
## Description

For the Playlists UI, I need to use the window size class to display the onboarding UI properly. Currently, we use `androidx.compose.material3:material3-window-size-class-android`, but this API is marked as experimental and requires an `Activity` to work.

There is an alternative: the `androidx.compose.material3.adaptive:adaptive` library, which is not experimental, integrates with regular Compose types, and does not require an `Activity`. This PR replaces the libraries accordingly.

I also fixed a bug in referrals where the referral card didn’t occupy the whole available space. This happened because the passed-in `Modifier` was used multiple times. While this was addressed in #4201, it introduced the bug mentioned above.

## Testing Instructions

Code review should be enough.

## Screenshots or Screencast 

| Before | After |
| - | - |
| <img width="1080" height="2400" alt="Screenshot_20250717-133756" src="https://github.com/user-attachments/assets/0f68da68-cfb1-4962-88a1-399f16920742" /> | <img width="1080" height="2400" alt="Screenshot_20250717-134122" src="https://github.com/user-attachments/assets/a8c557ec-5a18-4da0-b0d5-25976887e1e8" /> |

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] ~with different themes~
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [ ] ~for accessibility with TalkBack~
