### PR TITLE
Fix icon color on feature item on profile upgrade banner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 *   Bug Fixes
     *   Fix player's playback position being incorrect after app restart
         ([#4208](https://github.com/Automattic/pocket-casts-android/pull/4208))
+    *   Fix icon colors of the upgrade account banner
+        ([#4246](https://github.com/Automattic/pocket-casts-android/pull/4246))
 
 7.93
 -----

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/ProfileUpgradeBanner.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/ProfileUpgradeBanner.kt
@@ -103,6 +103,7 @@ private fun FeatureCard(
         subscriptionPlan.featureItems.forEach { item ->
             UpgradeFeatureItem(
                 item = item,
+                iconColor = MaterialTheme.theme.colors.primaryText01,
                 textColor = MaterialTheme.theme.colors.primaryText01,
             )
         }


### PR DESCRIPTION
## Description
This PR fixes icon color of the feature items on the upgrade banner that appears on your Account page.

| Before | After |
| --- | --- | 
| <img width="1080" height="2400" alt="Screenshot_20250717_213140" src="https://github.com/user-attachments/assets/9e12be0d-804f-4643-a0d3-c0164d74fb51" /> | <img width="1080" height="2400" alt="Screenshot_20250717_213100" src="https://github.com/user-attachments/assets/a8012ccf-fb4a-4a78-8c66-b140f0f2593f" /> |

## Testing Instructions
Just review pls.


## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] ~I have considered whether it makes sense to add tests for my changes~
- [ ] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [ ] ~Any jetpack compose components I added or changed are covered by compose previews~
- [ ] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~
 
