### PR TITLE
Add SmartRules type

### DIFF
--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/type/SmartRules.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/type/SmartRules.kt
@@ -1,0 +1,246 @@
+package au.com.shiftyjelly.pocketcasts.models.type
+
+import au.com.shiftyjelly.pocketcasts.models.entity.SmartPlaylist
+import java.time.Clock
+import java.time.temporal.ChronoUnit
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.days
+
+data class SmartRules(
+    val episodeStatus: EpisodeStatusRule,
+    val downloadStatus: DownloadStatusRule,
+    val mediaType: MediaTypeRule,
+    val releaseDate: ReleaseDateRule,
+    val starred: StarredRule,
+    val podcastsRule: PodcastsRule,
+    val episodeDuration: EpisodeDurationRule,
+) {
+    fun toSqlWhereClause(clock: Clock, playlistId: Long?) = buildString {
+        episodeStatus.run { append(clock, playlistId) }
+        downloadStatus.run { append(clock, playlistId) }
+        mediaType.run { append(clock, playlistId) }
+        releaseDate.run { append(clock, playlistId) }
+        starred.run { append(clock, playlistId) }
+        podcastsRule.run { append(clock, playlistId) }
+        episodeDuration.run { append(clock, playlistId) }
+        NonArchivedRule.run { append(clock, playlistId) }
+    }
+
+    data class EpisodeStatusRule(
+        val unplayed: Boolean,
+        val inProgres: Boolean,
+        val completed: Boolean,
+    ) : SmartRule {
+        override fun toSqlWhereClause(clock: Clock, playlistId: Long?) = buildString {
+            if (!areAllConstraintsTicked && isAnyConstraintTicked) {
+                val statuses = buildList {
+                    if (unplayed) {
+                        add(EpisodePlayingStatus.NOT_PLAYED)
+                    }
+                    if (inProgres) {
+                        add(EpisodePlayingStatus.IN_PROGRESS)
+                    }
+                    if (completed) {
+                        add(EpisodePlayingStatus.COMPLETED)
+                    }
+                }
+                append("playing_status IN (")
+                statuses.forEachIndexed { index, status ->
+                    if (index != 0) {
+                        append(',')
+                    }
+                    append(status.ordinal)
+                }
+                append(')')
+            }
+        }
+
+        private val areAllConstraintsTicked get() = unplayed && inProgres && completed
+
+        private val isAnyConstraintTicked get() = unplayed || inProgres || completed
+    }
+
+    enum class DownloadStatusRule : SmartRule {
+        Any,
+        Downloaded,
+        NotDownloaded,
+        ;
+
+        override fun toSqlWhereClause(clock: Clock, playlistId: Long?) = buildString {
+            if (this@DownloadStatusRule != Any) {
+                val isSystemDownloadsPlaylist = playlistId == SmartPlaylist.PLAYLIST_ID_SYSTEM_DOWNLOADS
+                val includeDownloaded = this@DownloadStatusRule == Downloaded
+                val includeDownloading = isSystemDownloadsPlaylist || this@DownloadStatusRule == NotDownloaded
+                val includeNotDownloaded = this@DownloadStatusRule == NotDownloaded
+
+                val statuses = buildList {
+                    if (includeDownloaded) {
+                        add(EpisodeStatusEnum.DOWNLOADED)
+                    }
+                    if (includeDownloading) {
+                        add(EpisodeStatusEnum.DOWNLOADING)
+                        add(EpisodeStatusEnum.QUEUED)
+                        add(EpisodeStatusEnum.WAITING_FOR_POWER)
+                        add(EpisodeStatusEnum.WAITING_FOR_WIFI)
+                    }
+                    if (includeNotDownloaded) {
+                        add(EpisodeStatusEnum.NOT_DOWNLOADED)
+                        add(EpisodeStatusEnum.DOWNLOAD_FAILED)
+                    }
+                }
+                append("episode_status IN (")
+                statuses.forEachIndexed { index, status ->
+                    if (index != 0) {
+                        append(',')
+                    }
+                    append(status.ordinal)
+                }
+                append(')')
+
+                if (isSystemDownloadsPlaylist) {
+                    if (isNotEmpty()) {
+                        append(" OR ")
+                    }
+                    append("(episode_status = ")
+                    append(EpisodeStatusEnum.DOWNLOAD_FAILED.ordinal)
+                    append(" AND last_download_attempt_date > ")
+                    append(clock.instant().minus(7, ChronoUnit.DAYS).toEpochMilli())
+                    append(')')
+                }
+            }
+        }
+    }
+
+    enum class MediaTypeRule : SmartRule {
+        Any,
+        Audio,
+        Video,
+        ;
+
+        override fun toSqlWhereClause(clock: Clock, playlistId: Long?) = buildString {
+            when (this@MediaTypeRule) {
+                Any -> Unit
+                Audio -> append("file_type LIKE 'audio/%'")
+                Video -> append("file_type LIKE 'video/%'")
+            }
+        }
+    }
+
+    enum class ReleaseDateRule(
+        private val duration: Duration,
+    ) : SmartRule {
+        AnyTime(
+            duration = Duration.INFINITE,
+        ),
+        Last24Hours(
+            duration = 1.days,
+        ),
+        Last3Days(
+            duration = 3.days,
+        ),
+        LastWeek(
+            duration = 7.days,
+        ),
+        Last2Weeks(
+            duration = 14.days,
+        ),
+        LastMonth(
+            duration = 31.days,
+        ),
+        ;
+
+        override fun toSqlWhereClause(clock: Clock, playlistId: Long?) = buildString {
+            if (duration != Duration.INFINITE) {
+                append("published_date > ")
+                append(clock.instant().minusMillis(duration.inWholeMilliseconds).toEpochMilli())
+            }
+        }
+    }
+
+    enum class StarredRule : SmartRule {
+        Any,
+        Starred,
+        ;
+
+        override fun toSqlWhereClause(clock: Clock, playlistId: Long?) = buildString {
+            when (this@StarredRule) {
+                Any -> Unit
+                Starred -> append("starred = 1")
+            }
+        }
+    }
+
+    sealed interface PodcastsRule : SmartRule {
+        data object Any : PodcastsRule {
+            override fun toSqlWhereClause(clock: Clock, playlistId: Long?) = ""
+        }
+
+        data class Selected(
+            val uuids: List<String>,
+        ) : PodcastsRule {
+            override fun toSqlWhereClause(clock: Clock, playlistId: Long?) = buildString {
+                append("podcast_id IN (")
+                uuids.forEachIndexed { index, uuid ->
+                    if (index != 0) {
+                        append(',')
+                    }
+                    append('\'')
+                    append(uuid)
+                    append('\'')
+                }
+                append(')')
+            }
+        }
+    }
+
+    sealed interface EpisodeDurationRule : SmartRule {
+        data object Any : EpisodeDurationRule {
+            override fun toSqlWhereClause(clock: Clock, playlistId: Long?) = ""
+        }
+
+        data class Constrained(
+            val longerThan: Duration,
+            val shorterThan: Duration,
+        ) : EpisodeDurationRule {
+            override fun toSqlWhereClause(clock: Clock, playlistId: Long?) = buildString {
+                append("(duration BETWEEN ")
+                append(longerThan.inWholeSeconds)
+                append(" AND ")
+                append(shorterThan.inWholeSeconds)
+                append(')')
+            }
+        }
+    }
+
+    data object NonArchivedRule : SmartRule {
+        override fun toSqlWhereClause(clock: Clock, playlistId: Long?) = "archived = 0"
+    }
+
+    sealed interface SmartRule {
+        fun StringBuilder.append(clock: Clock, playlistId: Long?) {
+            val sqlString = toSqlWhereClause(clock, playlistId)
+            if (sqlString.isNotEmpty()) {
+                if (isNotEmpty()) {
+                    append(" AND ")
+                }
+                append('(')
+                append(sqlString)
+                append(')')
+            }
+        }
+
+        fun toSqlWhereClause(clock: Clock, playlistId: Long?): String
+    }
+
+    companion object {
+        val Default = SmartRules(
+            EpisodeStatusRule(unplayed = true, inProgres = true, completed = true),
+            DownloadStatusRule.Any,
+            MediaTypeRule.Any,
+            ReleaseDateRule.AnyTime,
+            StarredRule.Any,
+            PodcastsRule.Any,
+            EpisodeDurationRule.Any,
+        )
+    }
+}

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/type/SmartRules.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/type/SmartRules.kt
@@ -46,12 +46,7 @@ data class SmartRules(
                     }
                 }
                 append("episode.playing_status IN (")
-                statuses.forEachIndexed { index, status ->
-                    if (index != 0) {
-                        append(',')
-                    }
-                    append(status.ordinal)
-                }
+                append(statuses.joinToString(separator = ",") { status -> "${status.ordinal}" })
                 append(')')
             }
         }
@@ -90,12 +85,7 @@ data class SmartRules(
                     }
                 }
                 append("episode.episode_status IN (")
-                statuses.forEachIndexed { index, status ->
-                    if (index != 0) {
-                        append(',')
-                    }
-                    append(status.ordinal)
-                }
+                append(statuses.joinToString(separator = ",") { status -> "${status.ordinal}" })
                 append(')')
 
                 if (isSystemDownloadsPlaylist) {
@@ -181,14 +171,7 @@ data class SmartRules(
         ) : PodcastsRule {
             override fun toSqlWhereClause(clock: Clock, playlistId: Long?) = buildString {
                 append("episode.podcast_id IN (")
-                uuids.forEachIndexed { index, uuid ->
-                    if (index != 0) {
-                        append(',')
-                    }
-                    append('\'')
-                    append(uuid)
-                    append('\'')
-                }
+                append(uuids.joinToString(separator = ",") { uuid -> "'$uuid'" })
                 append(')')
             }
         }

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/type/SmartRules.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/type/SmartRules.kt
@@ -29,7 +29,7 @@ data class SmartRules(
 
     data class EpisodeStatusRule(
         val unplayed: Boolean,
-        val inProgres: Boolean,
+        val inProgress: Boolean,
         val completed: Boolean,
     ) : SmartRule {
         override fun toSqlWhereClause(clock: Clock, playlistId: Long?) = buildString {
@@ -38,7 +38,7 @@ data class SmartRules(
                     if (unplayed) {
                         add(EpisodePlayingStatus.NOT_PLAYED)
                     }
-                    if (inProgres) {
+                    if (inProgress) {
                         add(EpisodePlayingStatus.IN_PROGRESS)
                     }
                     if (completed) {
@@ -56,9 +56,9 @@ data class SmartRules(
             }
         }
 
-        private val areAllConstraintsTicked get() = unplayed && inProgres && completed
+        private val areAllConstraintsTicked get() = unplayed && inProgress && completed
 
-        private val isAnyConstraintTicked get() = unplayed || inProgres || completed
+        private val isAnyConstraintTicked get() = unplayed || inProgress || completed
     }
 
     enum class DownloadStatusRule : SmartRule {
@@ -239,7 +239,7 @@ data class SmartRules(
 
     companion object {
         val Default = SmartRules(
-            EpisodeStatusRule(unplayed = true, inProgres = true, completed = true),
+            EpisodeStatusRule(unplayed = true, inProgress = true, completed = true),
             DownloadStatusRule.Any,
             MediaTypeRule.Any,
             ReleaseDateRule.AnyTime,

--- a/modules/services/model/src/test/java/au/com/shiftyjelly/pocketcasts/models/type/SmartRulesTest.kt
+++ b/modules/services/model/src/test/java/au/com/shiftyjelly/pocketcasts/models/type/SmartRulesTest.kt
@@ -14,7 +14,7 @@ class SmartRulesTest {
     fun `unplayed episodes`() {
         val rule = SmartRules.EpisodeStatusRule(
             unplayed = true,
-            inProgres = false,
+            inProgress = false,
             completed = false,
         )
 
@@ -27,7 +27,7 @@ class SmartRulesTest {
     fun `in progress episodes`() {
         val rule = SmartRules.EpisodeStatusRule(
             unplayed = false,
-            inProgres = true,
+            inProgress = true,
             completed = false,
         )
 
@@ -40,7 +40,7 @@ class SmartRulesTest {
     fun `completed episodes`() {
         val rule = SmartRules.EpisodeStatusRule(
             unplayed = false,
-            inProgres = false,
+            inProgress = false,
             completed = true,
         )
 
@@ -53,7 +53,7 @@ class SmartRulesTest {
     fun `mixed episode played statuses`() {
         val rule = SmartRules.EpisodeStatusRule(
             unplayed = true,
-            inProgres = false,
+            inProgress = false,
             completed = true,
         )
 
@@ -66,7 +66,7 @@ class SmartRulesTest {
     fun `all episode played statuses`() {
         val rule = SmartRules.EpisodeStatusRule(
             unplayed = true,
-            inProgres = true,
+            inProgress = true,
             completed = true,
         )
 
@@ -79,7 +79,7 @@ class SmartRulesTest {
     fun `no episode played statuses`() {
         val rule = SmartRules.EpisodeStatusRule(
             unplayed = false,
-            inProgres = false,
+            inProgress = false,
             completed = false,
         )
 

--- a/modules/services/model/src/test/java/au/com/shiftyjelly/pocketcasts/models/type/SmartRulesTest.kt
+++ b/modules/services/model/src/test/java/au/com/shiftyjelly/pocketcasts/models/type/SmartRulesTest.kt
@@ -1,0 +1,291 @@
+package au.com.shiftyjelly.pocketcasts.models.type
+
+import au.com.shiftyjelly.pocketcasts.models.entity.SmartPlaylist
+import au.com.shiftyjelly.pocketcasts.sharedtest.MutableClock
+import kotlin.time.Duration.Companion.days
+import kotlin.time.Duration.Companion.seconds
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class SmartRulesTest {
+    private val clock = MutableClock()
+
+    @Test
+    fun `unplayed episodes`() {
+        val rule = SmartRules.EpisodeStatusRule(
+            unplayed = true,
+            inProgres = false,
+            completed = false,
+        )
+
+        val clause = rule.toSqlWhereClause(clock, playlistId = null)
+
+        assertEquals("playing_status IN (0)", clause)
+    }
+
+    @Test
+    fun `in progress episodes`() {
+        val rule = SmartRules.EpisodeStatusRule(
+            unplayed = false,
+            inProgres = true,
+            completed = false,
+        )
+
+        val clause = rule.toSqlWhereClause(clock, playlistId = null)
+
+        assertEquals("playing_status IN (1)", clause)
+    }
+
+    @Test
+    fun `completed episodes`() {
+        val rule = SmartRules.EpisodeStatusRule(
+            unplayed = false,
+            inProgres = false,
+            completed = true,
+        )
+
+        val clause = rule.toSqlWhereClause(clock, playlistId = null)
+
+        assertEquals("playing_status IN (2)", clause)
+    }
+
+    @Test
+    fun `mixed episode played statuses`() {
+        val rule = SmartRules.EpisodeStatusRule(
+            unplayed = true,
+            inProgres = false,
+            completed = true,
+        )
+
+        val clause = rule.toSqlWhereClause(clock, playlistId = null)
+
+        assertEquals("playing_status IN (0,2)", clause)
+    }
+
+    @Test
+    fun `all episode played statuses`() {
+        val rule = SmartRules.EpisodeStatusRule(
+            unplayed = true,
+            inProgres = true,
+            completed = true,
+        )
+
+        val clause = rule.toSqlWhereClause(clock, playlistId = null)
+
+        assertEquals("", clause)
+    }
+
+    @Test
+    fun `no episode played statuses`() {
+        val rule = SmartRules.EpisodeStatusRule(
+            unplayed = false,
+            inProgres = false,
+            completed = false,
+        )
+
+        val clause = rule.toSqlWhereClause(clock, playlistId = null)
+
+        assertEquals("", clause)
+    }
+
+    @Test
+    fun `downloaded episodes`() {
+        val rule = SmartRules.DownloadStatusRule.Downloaded
+
+        val clause = rule.toSqlWhereClause(clock, playlistId = null)
+
+        assertEquals("episode_status IN (4)", clause)
+    }
+
+    @Test
+    fun `downloaded episodes for system downloads playlist`() {
+        val rule = SmartRules.DownloadStatusRule.Downloaded
+
+        val clause = rule.toSqlWhereClause(clock, playlistId = SmartPlaylist.PLAYLIST_ID_SYSTEM_DOWNLOADS)
+
+        assertEquals("episode_status IN (4,2,1,6,5) OR (episode_status = 3 AND last_download_attempt_date > -${7.days.inWholeMilliseconds})", clause)
+    }
+
+    @Test
+    fun `not downloaded episodes`() {
+        val rule = SmartRules.DownloadStatusRule.NotDownloaded
+
+        val clause = rule.toSqlWhereClause(clock, playlistId = null)
+
+        assertEquals("episode_status IN (2,1,6,5,0,3)", clause)
+    }
+
+    @Test
+    fun `all episode download statuses`() {
+        val rule = SmartRules.DownloadStatusRule.Any
+
+        val clause = rule.toSqlWhereClause(clock, playlistId = null)
+
+        assertEquals("", clause)
+    }
+
+    @Test
+    fun `audio episodes`() {
+        val rule = SmartRules.MediaTypeRule.Audio
+
+        val clause = rule.toSqlWhereClause(clock, playlistId = null)
+
+        assertEquals("file_type LIKE 'audio/%'", clause)
+    }
+
+    @Test
+    fun `video episodes`() {
+        val rule = SmartRules.MediaTypeRule.Video
+
+        val clause = rule.toSqlWhereClause(clock, playlistId = null)
+
+        assertEquals("file_type LIKE 'video/%'", clause)
+    }
+
+    @Test
+    fun `all media type episodes`() {
+        val rule = SmartRules.MediaTypeRule.Any
+
+        val clause = rule.toSqlWhereClause(clock, playlistId = null)
+
+        assertEquals("", clause)
+    }
+
+    @Test
+    fun `episodes released day ago`() {
+        val rule = SmartRules.ReleaseDateRule.Last24Hours
+
+        val clause = rule.toSqlWhereClause(clock, playlistId = null)
+
+        assertEquals("published_date > -${1.days.inWholeMilliseconds}", clause)
+    }
+
+    @Test
+    fun `episodes released 3 day ago`() {
+        val rule = SmartRules.ReleaseDateRule.Last3Days
+
+        val clause = rule.toSqlWhereClause(clock, playlistId = null)
+
+        assertEquals("published_date > -${3.days.inWholeMilliseconds}", clause)
+    }
+
+    @Test
+    fun `episodes released 7 day ago`() {
+        val rule = SmartRules.ReleaseDateRule.LastWeek
+
+        val clause = rule.toSqlWhereClause(clock, playlistId = null)
+
+        assertEquals("published_date > -${7.days.inWholeMilliseconds}", clause)
+    }
+
+    @Test
+    fun `episodes released 14 day ago`() {
+        val rule = SmartRules.ReleaseDateRule.Last2Weeks
+
+        val clause = rule.toSqlWhereClause(clock, playlistId = null)
+
+        assertEquals("published_date > -${14.days.inWholeMilliseconds}", clause)
+    }
+
+    @Test
+    fun `episodes released 31 day ago`() {
+        val rule = SmartRules.ReleaseDateRule.LastMonth
+
+        val clause = rule.toSqlWhereClause(clock, playlistId = null)
+
+        assertEquals("published_date > -${31.days.inWholeMilliseconds}", clause)
+    }
+
+    @Test
+    fun `episodes released any time ago`() {
+        val rule = SmartRules.ReleaseDateRule.AnyTime
+
+        val clause = rule.toSqlWhereClause(clock, playlistId = null)
+
+        assertEquals("", clause)
+    }
+
+    @Test
+    fun `starred episodes`() {
+        val rule = SmartRules.StarredRule.Starred
+
+        val clause = rule.toSqlWhereClause(clock, playlistId = null)
+
+        assertEquals("starred = 1", clause)
+    }
+
+    @Test
+    fun `any starred episode status`() {
+        val rule = SmartRules.StarredRule.Any
+
+        val clause = rule.toSqlWhereClause(clock, playlistId = null)
+
+        assertEquals("", clause)
+    }
+
+    @Test
+    fun `selected podcasts`() {
+        val rule = SmartRules.PodcastsRule.Selected(
+            uuids = listOf("id-1", "id-2"),
+        )
+
+        val clause = rule.toSqlWhereClause(clock, playlistId = null)
+
+        assertEquals("podcast_id IN ('id-1','id-2')", clause)
+    }
+
+    @Test
+    fun `all podcasts`() {
+        val rule = SmartRules.PodcastsRule.Any
+
+        val clause = rule.toSqlWhereClause(clock, playlistId = null)
+
+        assertEquals("", clause)
+    }
+
+    @Test
+    fun `constrained episode duration`() {
+        val rule = SmartRules.EpisodeDurationRule.Constrained(
+            longerThan = 128.seconds,
+            shorterThan = 200.seconds,
+        )
+
+        val clause = rule.toSqlWhereClause(clock, playlistId = null)
+
+        assertEquals("(duration BETWEEN 128 AND 200)", clause)
+    }
+
+    @Test
+    fun `any episode duration`() {
+        val rule = SmartRules.EpisodeDurationRule.Any
+
+        val clause = rule.toSqlWhereClause(clock, playlistId = null)
+
+        assertEquals("", clause)
+    }
+
+    @Test
+    fun `default rules`() {
+        val rules = SmartRules.Default
+
+        val clause = rules.toSqlWhereClause(clock, playlistId = null)
+
+        assertEquals("(archived = 0)", clause)
+    }
+
+    @Test
+    fun `multiple rules`() {
+        val rules = SmartRules.Default.copy(
+            downloadStatus = SmartRules.DownloadStatusRule.Downloaded,
+            mediaType = SmartRules.MediaTypeRule.Video,
+            episodeDuration = SmartRules.EpisodeDurationRule.Constrained(
+                longerThan = 10.seconds,
+                shorterThan = 50.seconds,
+            ),
+        )
+
+        val clause = rules.toSqlWhereClause(clock, playlistId = null)
+
+        assertEquals("(episode_status IN (4)) AND (file_type LIKE 'video/%') AND ((duration BETWEEN 10 AND 50)) AND (archived = 0)", clause)
+    }
+}

--- a/modules/services/model/src/test/java/au/com/shiftyjelly/pocketcasts/models/type/SmartRulesTest.kt
+++ b/modules/services/model/src/test/java/au/com/shiftyjelly/pocketcasts/models/type/SmartRulesTest.kt
@@ -20,7 +20,7 @@ class SmartRulesTest {
 
         val clause = rule.toSqlWhereClause(clock, playlistId = null)
 
-        assertEquals("playing_status IN (0)", clause)
+        assertEquals("episode.playing_status IN (0)", clause)
     }
 
     @Test
@@ -33,7 +33,7 @@ class SmartRulesTest {
 
         val clause = rule.toSqlWhereClause(clock, playlistId = null)
 
-        assertEquals("playing_status IN (1)", clause)
+        assertEquals("episode.playing_status IN (1)", clause)
     }
 
     @Test
@@ -46,7 +46,7 @@ class SmartRulesTest {
 
         val clause = rule.toSqlWhereClause(clock, playlistId = null)
 
-        assertEquals("playing_status IN (2)", clause)
+        assertEquals("episode.playing_status IN (2)", clause)
     }
 
     @Test
@@ -59,7 +59,7 @@ class SmartRulesTest {
 
         val clause = rule.toSqlWhereClause(clock, playlistId = null)
 
-        assertEquals("playing_status IN (0,2)", clause)
+        assertEquals("episode.playing_status IN (0,2)", clause)
     }
 
     @Test
@@ -94,7 +94,7 @@ class SmartRulesTest {
 
         val clause = rule.toSqlWhereClause(clock, playlistId = null)
 
-        assertEquals("episode_status IN (4)", clause)
+        assertEquals("episode.episode_status IN (4)", clause)
     }
 
     @Test
@@ -103,7 +103,7 @@ class SmartRulesTest {
 
         val clause = rule.toSqlWhereClause(clock, playlistId = SmartPlaylist.PLAYLIST_ID_SYSTEM_DOWNLOADS)
 
-        assertEquals("episode_status IN (4,2,1,6,5) OR (episode_status = 3 AND last_download_attempt_date > -${7.days.inWholeMilliseconds})", clause)
+        assertEquals("episode.episode_status IN (4,2,1,6,5) OR (episode.episode_status = 3 AND episode.last_download_attempt_date > -${7.days.inWholeMilliseconds})", clause)
     }
 
     @Test
@@ -112,7 +112,7 @@ class SmartRulesTest {
 
         val clause = rule.toSqlWhereClause(clock, playlistId = null)
 
-        assertEquals("episode_status IN (2,1,6,5,0,3)", clause)
+        assertEquals("episode.episode_status IN (2,1,6,5,0,3)", clause)
     }
 
     @Test
@@ -130,7 +130,7 @@ class SmartRulesTest {
 
         val clause = rule.toSqlWhereClause(clock, playlistId = null)
 
-        assertEquals("file_type LIKE 'audio/%'", clause)
+        assertEquals("episode.file_type LIKE 'audio/%'", clause)
     }
 
     @Test
@@ -139,7 +139,7 @@ class SmartRulesTest {
 
         val clause = rule.toSqlWhereClause(clock, playlistId = null)
 
-        assertEquals("file_type LIKE 'video/%'", clause)
+        assertEquals("episode.file_type LIKE 'video/%'", clause)
     }
 
     @Test
@@ -157,7 +157,7 @@ class SmartRulesTest {
 
         val clause = rule.toSqlWhereClause(clock, playlistId = null)
 
-        assertEquals("published_date > -${1.days.inWholeMilliseconds}", clause)
+        assertEquals("episode.published_date > -${1.days.inWholeMilliseconds}", clause)
     }
 
     @Test
@@ -166,7 +166,7 @@ class SmartRulesTest {
 
         val clause = rule.toSqlWhereClause(clock, playlistId = null)
 
-        assertEquals("published_date > -${3.days.inWholeMilliseconds}", clause)
+        assertEquals("episode.published_date > -${3.days.inWholeMilliseconds}", clause)
     }
 
     @Test
@@ -175,7 +175,7 @@ class SmartRulesTest {
 
         val clause = rule.toSqlWhereClause(clock, playlistId = null)
 
-        assertEquals("published_date > -${7.days.inWholeMilliseconds}", clause)
+        assertEquals("episode.published_date > -${7.days.inWholeMilliseconds}", clause)
     }
 
     @Test
@@ -184,7 +184,7 @@ class SmartRulesTest {
 
         val clause = rule.toSqlWhereClause(clock, playlistId = null)
 
-        assertEquals("published_date > -${14.days.inWholeMilliseconds}", clause)
+        assertEquals("episode.published_date > -${14.days.inWholeMilliseconds}", clause)
     }
 
     @Test
@@ -193,7 +193,7 @@ class SmartRulesTest {
 
         val clause = rule.toSqlWhereClause(clock, playlistId = null)
 
-        assertEquals("published_date > -${31.days.inWholeMilliseconds}", clause)
+        assertEquals("episode.published_date > -${31.days.inWholeMilliseconds}", clause)
     }
 
     @Test
@@ -211,7 +211,7 @@ class SmartRulesTest {
 
         val clause = rule.toSqlWhereClause(clock, playlistId = null)
 
-        assertEquals("starred = 1", clause)
+        assertEquals("episode.starred = 1", clause)
     }
 
     @Test
@@ -231,7 +231,7 @@ class SmartRulesTest {
 
         val clause = rule.toSqlWhereClause(clock, playlistId = null)
 
-        assertEquals("podcast_id IN ('id-1','id-2')", clause)
+        assertEquals("episode.podcast_id IN ('id-1','id-2')", clause)
     }
 
     @Test
@@ -252,7 +252,7 @@ class SmartRulesTest {
 
         val clause = rule.toSqlWhereClause(clock, playlistId = null)
 
-        assertEquals("(duration BETWEEN 128 AND 200)", clause)
+        assertEquals("(episode.duration BETWEEN 128 AND 200)", clause)
     }
 
     @Test
@@ -270,7 +270,7 @@ class SmartRulesTest {
 
         val clause = rules.toSqlWhereClause(clock, playlistId = null)
 
-        assertEquals("(archived = 0)", clause)
+        assertEquals("(episode.archived = 0) AND (podcast.subscribed = 1)", clause)
     }
 
     @Test
@@ -286,6 +286,6 @@ class SmartRulesTest {
 
         val clause = rules.toSqlWhereClause(clock, playlistId = null)
 
-        assertEquals("(episode_status IN (4)) AND (file_type LIKE 'video/%') AND ((duration BETWEEN 10 AND 50)) AND (archived = 0)", clause)
+        assertEquals("(episode.episode_status IN (4)) AND (episode.file_type LIKE 'video/%') AND ((episode.duration BETWEEN 10 AND 50)) AND (episode.archived = 0) AND (podcast.subscribed = 1)", clause)
     }
 }


### PR DESCRIPTION
## Description

This PR introduces the `SmartRules` type. Currently, the logic for mapping rules to SQL `WHERE` clauses resides in `SmartPlaylistManagerImpl`:

https://github.com/Automattic/pocket-casts-android/blob/1af3fb7b371d4c920e467707b465406bc94877b0/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/SmartPlaylistManagerImpl.kt#L383-L529

However, this code is untested, making it difficult to detect regressions. This may become an issue as I continue working on filters.

## Testing Instructions

This PR does not yet integrate the new code with the existing one For now, review the `SmartRules` API.

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.