### PR TITLE
Fix missing file sizes on episode page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 7.95
 -----
-
+*   Bug Fixes
+    *   Fix missing file sizes on the episode page
+        ([#4262](https://github.com/Automattic/pocket-casts-android/pull/4262))
 
 7.94
 -----

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/PodcastRefresherImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/PodcastRefresherImpl.kt
@@ -54,7 +54,10 @@ class PodcastRefresherImpl @Inject constructor(
                     existingEpisode.title = newEpisode.title
                     existingEpisode.downloadUrl = newEpisode.downloadUrl
                     existingEpisode.fileType = newEpisode.fileType
-                    existingEpisode.sizeInBytes = newEpisode.sizeInBytes
+                    // after downloading an episode use file size instead of the feed XML size
+                    if (newEpisode.sizeInBytes > 0 && !existingEpisode.isDownloaded) {
+                        existingEpisode.sizeInBytes = newEpisode.sizeInBytes
+                    }
                     if (newEpisode.duration != 0.0) {
                         existingEpisode.duration = newEpisode.duration
                     }

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/SmartSmartPlaylistManagerImplTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/SmartSmartPlaylistManagerImplTest.kt
@@ -3,6 +3,7 @@ package au.com.shiftyjelly.pocketcasts.repositories.podcast
 import android.content.Context
 import au.com.shiftyjelly.pocketcasts.models.db.AppDatabase
 import au.com.shiftyjelly.pocketcasts.models.db.dao.SmartPlaylistDao
+import au.com.shiftyjelly.pocketcasts.models.entity.SmartPlaylist
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.repositories.download.DownloadManager
 import au.com.shiftyjelly.pocketcasts.repositories.notification.NotificationManager
@@ -34,7 +35,11 @@ class SmartSmartPlaylistManagerImplTest {
     fun `should mark the user as having interacted with the feature when creating a filter`() = runTest {
         val playlistManager = initViewModel()
 
-        playlistManager.updateBlocking(mock(), mock(), isCreatingFilter = true)
+        playlistManager.updateBlocking(
+            smartPlaylist = SmartPlaylist(),
+            userPlaylistUpdate = UserPlaylistUpdate(listOf(PlaylistProperty.Color), PlaylistUpdateSource.AUTO_DOWNLOAD_SETTINGS),
+            isCreatingFilter = true,
+        )
 
         advanceUntilIdle()
 
@@ -45,7 +50,11 @@ class SmartSmartPlaylistManagerImplTest {
     fun `should not mark the user as having interacted with the feature when a filter is not being created`() = runTest {
         val playlistManager = initViewModel()
 
-        playlistManager.updateBlocking(mock(), mock(), isCreatingFilter = false)
+        playlistManager.updateBlocking(
+            smartPlaylist = SmartPlaylist(),
+            userPlaylistUpdate = UserPlaylistUpdate(listOf(PlaylistProperty.Color), PlaylistUpdateSource.AUTO_DOWNLOAD_SETTINGS),
+            isCreatingFilter = false,
+        )
 
         advanceUntilIdle()
 


### PR DESCRIPTION
## Description

Podcasts like the "The Louis Theroux" podcast list the file size at 0 bytes in the [feed XML](https://feeds.megaphone.fm/GLT1948741183). 

```
<enclosure 
   url="https://traffic.megaphone.fm/GLT1154972783.mp3?updated=1750753094" 
   length="0" 
   type="audio/mpeg"/>
```

There are a few podcasts that do this, and it means we can't list the download file size. However, it will be listed after the file has been downloaded. The issue is that the size is getting wiped when we try to update the podcast information from the server. It might be enough to ignore the new size if it's zero or if the episode has already been downloaded.

## Testing Instructions

1. Subscribe to a podcast that doesn't list the episode file sizes in the XML. Such as [Scott Sigler's Galactic Football League (GFL) Series](https://pca.st/djJO). 
2. Open the podcast page
3. Tap an episode row
4. Tap download
5. ✅ Verify that after the download has finished, the file size is listed
6. Go to Profile tab -> Settings -> Developer 
7. Tap "Delete first episodes"
8. Go back to the podcast page and tap the episode row
9. ✅ Verify that the episode file size is still listed

## Screencast 

https://github.com/user-attachments/assets/fb479606-d76d-4fe3-9ff0-ab10ec6d2d1a

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 