### PR TITLE
Specify category when uploading `sarif` files

### DIFF
--- a/.buildkite/commands/lint.sh
+++ b/.buildkite/commands/lint.sh
@@ -26,8 +26,8 @@ else
   lint_exit_code=0
 fi
 
-upload_sarif_to_github 'app/build/reports/lint-results-release.sarif'
-upload_sarif_to_github 'automotive/build/reports/lint-results-release.sarif'
-upload_sarif_to_github 'wear/build/reports/lint-results-release.sarif'
+upload_sarif_to_github 'app/build/reports/lint-results-release.sarif' 'app'
+upload_sarif_to_github 'automotive/build/reports/lint-results-release.sarif' 'automotive'
+upload_sarif_to_github 'wear/build/reports/lint-results-release.sarif' 'wear'
 
 exit $lint_exit_code

--- a/.buildkite/shared-pipeline-vars
+++ b/.buildkite/shared-pipeline-vars
@@ -3,4 +3,4 @@
 # This file is `source`'d before calling `buildkite-agent pipeline upload`, and can be used
 # to set up some variables that will be interpolated in the `.yml` pipeline before uploading it.
 
-export CI_TOOLKIT="automattic/a8c-ci-toolkit#5.3.1"
+export CI_TOOLKIT="automattic/a8c-ci-toolkit#7a2a31cb5938e63e08981a125e3ec2b0fc74a941"

--- a/.buildkite/shared-pipeline-vars
+++ b/.buildkite/shared-pipeline-vars
@@ -3,4 +3,4 @@
 # This file is `source`'d before calling `buildkite-agent pipeline upload`, and can be used
 # to set up some variables that will be interpolated in the `.yml` pipeline before uploading it.
 
-export CI_TOOLKIT="automattic/a8c-ci-toolkit#7a2a31cb5938e63e08981a125e3ec2b0fc74a941"
+export CI_TOOLKIT="automattic/a8c-ci-toolkit#5.4.0"


### PR DESCRIPTION
So the results are not overwritten.

Relates to: AINFRA-943

## Description
<!-- Please include a summary of what this PR is changing and why these changes are needed. -->

This PR is a follow up to #4236 . After this PR, Lint results from `wear` module started overwriting these from `app` and `automotive`. This PR fixes the problem by providing `category` when uploading the `sarif` file. 

Implementation details: https://github.com/Automattic/a8c-ci-toolkit-buildkite-plugin/pull/183.

Lint is failing but not because of this PR: it'll be fixed in #4260

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Tap on the Filters tab -->
<!-- 2. Tap on a filter -->
<!-- 3. etc. -->

Compare [main results](https://github.com/Automattic/pocket-casts-android/security/code-scanning) and these from [this PR](https://github.com/Automattic/pocket-casts-android/security/code-scanning?query=is%3Aopen+pr%3A4265).


## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [ ] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack
