### PR TITLE
Add playlists empty state

### DIFF
--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/PlaylistsFragment.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/PlaylistsFragment.kt
@@ -42,8 +42,8 @@ class PlaylistsFragment :
             PlaylistsPage(
                 uiState = uiState,
                 listState = listState,
-                onCreate = { Timber.i("Create playlist clicked") },
-                onDelete = { playlist -> viewModel.deletePlaylist(playlist.uuid) },
+                onCreatePlaylist = { Timber.i("Create playlist clicked") },
+                onDeletePlaylist = { playlist -> viewModel.deletePlaylist(playlist.uuid) },
                 onShowOptions = { Timber.i("Show playlists options clicked") },
                 onFreeAccountBannerCtaClick = {
                     viewModel.trackFreeAccountCtaClick()

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/PlaylistsPage.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/PlaylistsPage.kt
@@ -12,13 +12,10 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.itemsIndexed
@@ -28,7 +25,6 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.Icon
 import androidx.compose.material.IconButton
 import androidx.compose.material.MaterialTheme
-import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.setValue
@@ -42,6 +38,7 @@ import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.dp
 import au.com.shiftyjelly.pocketcasts.compose.AppThemeWithBackground
 import au.com.shiftyjelly.pocketcasts.compose.Devices
+import au.com.shiftyjelly.pocketcasts.compose.bars.ThemedTopAppBar
 import au.com.shiftyjelly.pocketcasts.compose.components.Banner
 import au.com.shiftyjelly.pocketcasts.compose.components.NoContentBanner
 import au.com.shiftyjelly.pocketcasts.compose.preview.ThemePreviewParameterProvider
@@ -192,29 +189,15 @@ private fun Toolbar(
     onShowOptions: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    Row(
-        verticalAlignment = Alignment.CenterVertically,
-        modifier = modifier
-            .background(MaterialTheme.theme.colors.secondaryUi01)
-            .statusBarsPadding()
-            .fillMaxWidth()
-            .heightIn(min = 56.dp),
-    ) {
-        Text(
-            text = stringResource(LR.string.playlists),
-            style = MaterialTheme.typography.h6,
-            color = MaterialTheme.theme.colors.secondaryText01,
-            modifier = Modifier.padding(start = 16.dp),
-        )
-        Spacer(
-            modifier = Modifier.weight(1f),
-        )
-        AnimatedVisibility(
-            visible = showActionButtons,
-            enter = FadeIn,
-            exit = FadeOut,
-        ) {
-            Row {
+    ThemedTopAppBar(
+        title = stringResource(LR.string.playlists),
+        navigationButton = null,
+        actions = {
+            AnimatedVisibility(
+                visible = showActionButtons,
+                enter = FadeIn,
+                exit = FadeOut,
+            ) {
                 IconButton(
                     onClick = onCreatePlaylist,
                 ) {
@@ -224,6 +207,13 @@ private fun Toolbar(
                         tint = MaterialTheme.theme.colors.secondaryIcon01,
                     )
                 }
+            }
+
+            AnimatedVisibility(
+                visible = showActionButtons,
+                enter = FadeIn,
+                exit = FadeOut,
+            ) {
                 IconButton(
                     onClick = onShowOptions,
                 ) {
@@ -234,8 +224,9 @@ private fun Toolbar(
                     )
                 }
             }
-        }
-    }
+        },
+        modifier = modifier,
+    )
 }
 
 @Composable

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/PlaylistsPage.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/PlaylistsPage.kt
@@ -214,23 +214,25 @@ private fun Toolbar(
             enter = FadeIn,
             exit = FadeOut,
         ) {
-            IconButton(
-                onClick = onCreatePlaylist,
-            ) {
-                Icon(
-                    painter = painterResource(IR.drawable.ic_add_black_24dp),
-                    contentDescription = stringResource(LR.string.new_playlist),
-                    tint = MaterialTheme.theme.colors.secondaryIcon01,
-                )
-            }
-            IconButton(
-                onClick = onShowOptions,
-            ) {
-                Icon(
-                    painter = painterResource(IR.drawable.ic_overflow),
-                    contentDescription = stringResource(LR.string.options),
-                    tint = MaterialTheme.theme.colors.secondaryIcon01,
-                )
+            Row {
+                IconButton(
+                    onClick = onCreatePlaylist,
+                ) {
+                    Icon(
+                        painter = painterResource(IR.drawable.ic_add_black_24dp),
+                        contentDescription = stringResource(LR.string.new_playlist),
+                        tint = MaterialTheme.theme.colors.secondaryIcon01,
+                    )
+                }
+                IconButton(
+                    onClick = onShowOptions,
+                ) {
+                    Icon(
+                        painter = painterResource(IR.drawable.ic_overflow),
+                        contentDescription = stringResource(LR.string.options),
+                        tint = MaterialTheme.theme.colors.secondaryIcon01,
+                    )
+                }
             }
         }
     }

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/bars/ThemedTopAppBar.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/bars/ThemedTopAppBar.kt
@@ -49,10 +49,10 @@ object ThemedTopAppBar {
 
 @Composable
 fun ThemedTopAppBar(
-    onNavigationClick: () -> Unit,
     modifier: Modifier = Modifier,
     title: String? = null,
-    navigationButton: NavigationButton = NavigationButton.Back,
+    navigationButton: NavigationButton? = NavigationButton.Back,
+    onNavigationClick: (() -> Unit)? = null,
     style: ThemedTopAppBar.Style = ThemedTopAppBar.Style.Solid,
     iconColor: Color = when (style) {
         ThemedTopAppBar.Style.Solid -> MaterialTheme.theme.colors.secondaryIcon01
@@ -75,12 +75,16 @@ fun ThemedTopAppBar(
         LocalRippleConfiguration provides RippleConfiguration(color = iconColor),
     ) {
         TopAppBar(
-            navigationIcon = {
-                NavigationIconButton(
-                    onNavigationClick = onNavigationClick,
-                    navigationButton = navigationButton,
-                    iconColor = iconColor,
-                )
+            navigationIcon = if (navigationButton != null) {
+                {
+                    NavigationIconButton(
+                        onNavigationClick = onNavigationClick ?: {},
+                        navigationButton = navigationButton,
+                        iconColor = iconColor,
+                    )
+                }
+            } else {
+                null
             },
             title = {
                 if (title != null) {
@@ -130,6 +134,7 @@ fun NavigationIconButton(
 private fun ThemedTopAppBarPreview(@PreviewParameter(ThemePreviewParameterProvider::class) themeType: Theme.ThemeType) {
     AppTheme(themeType) {
         Column {
+            ThemedTopAppBar(title = "Hello World", navigationButton = null)
             ThemedTopAppBar(title = "Hello World", navigationButton = NavigationButton.Back, onNavigationClick = {})
             ThemedTopAppBar(title = "Hello World", navigationButton = NavigationButton.Close, onNavigationClick = {})
             ThemedTopAppBar(title = "Hello World", navigationButton = NavigationButton.Back, style = ThemedTopAppBar.Style.Immersive, onNavigationClick = {})

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -907,6 +907,9 @@
     <string name="playlists_onboarding_playlist_title">Introducing Playlists</string>
     <string name="playlists_onboarding_playlist_description">Want more control? Manual Playlists let you build custom queues, great for trips, themes, or just your current vibe. Whether Smart or Manual, playlists work the way you do.</string>
     <string name="smart_playlist">Smart Playlist</string>
+    <string name="playlists_empty_state_title">Organize episodes your way</string>
+    <string name="playlists_empty_state_body">Playlists let you organize episodes manually or automatically with Smart Rules.</string>
+    <string name="new_playlist">New Playlist</string>
 
     <!-- Profile -->
 


### PR DESCRIPTION
## Description

This PR adds empty state to playlists page.

Designs: 5sC4z4Mu42LvL4MAAIbQVi-fi-920_43443
Closes: #4212

## Testing Instructions

1. Install the app.
2. Delete all your playlists.
3. You should see the empty state.

## Screenshots or Screencast 

<img width="626" height="614" alt="Screenshot 2025-07-23 at 13 41 46" src="https://github.com/user-attachments/assets/aa28ec20-5e6a-4260-97b6-66be7671901c" />

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack