### PR TITLE
Remove system downloads filter

### DIFF
--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/repositories/playlist/PlaylistManagerTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/repositories/playlist/PlaylistManagerTest.kt
@@ -392,53 +392,8 @@ class PlaylistManagerTest {
     }
 
     @Test
-    fun sortPodcastsInPlaylistPreviewByLastDownloadAttempt() = runTest(testDispatcher) {
-        playlistDao.upsertSmartPlaylist(SmartPlaylist(sortType = PlaylistEpisodeSortType.LastDownloadAttempt))
-        val podcasts = listOf(
-            Podcast(uuid = "podcast-id-1", isSubscribed = true),
-            Podcast(uuid = "podcast-id-2", isSubscribed = true),
-            Podcast(uuid = "podcast-id-3", isSubscribed = true),
-            Podcast(uuid = "podcast-id-4", isSubscribed = true),
-        )
-        podcasts.forEach { podcastDao.insertSuspend(it) }
-        episodeDao.insertAll(
-            listOf(
-                PodcastEpisode(
-                    uuid = "episode-id-1",
-                    podcastUuid = "podcast-id-1",
-                    publishedDate = Date(),
-                    lastDownloadAttemptDate = null,
-                ),
-                PodcastEpisode(
-                    uuid = "episode-id-2",
-                    podcastUuid = "podcast-id-2",
-                    publishedDate = Date(),
-                    lastDownloadAttemptDate = Date(0),
-                ),
-                PodcastEpisode(
-                    uuid = "episode-id-4",
-                    podcastUuid = "podcast-id-3",
-                    publishedDate = Date(1),
-                    lastDownloadAttemptDate = Date(1),
-                ),
-                PodcastEpisode(
-                    uuid = "episode-id-5",
-                    podcastUuid = "podcast-id-4",
-                    publishedDate = Date(),
-                    lastDownloadAttemptDate = Date(2),
-                ),
-            ),
-        )
-
-        val playlist = manager.observePlaylistsPreview().first().single()
-
-        assertEquals(4, playlist.episodeCount)
-        assertEquals(podcasts.reversed(), playlist.podcasts)
-    }
-
-    @Test
     fun selectDistinctPodcastInPlaylistPreview() = runTest(testDispatcher) {
-        playlistDao.upsertSmartPlaylist(SmartPlaylist(sortType = PlaylistEpisodeSortType.LastDownloadAttempt))
+        playlistDao.upsertSmartPlaylist(SmartPlaylist())
         val podcasts = listOf(
             Podcast(uuid = "podcast-id-1", isSubscribed = true),
             Podcast(uuid = "podcast-id-2", isSubscribed = true),

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/entity/SmartPlaylist.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/entity/SmartPlaylist.kt
@@ -47,8 +47,6 @@ data class SmartPlaylist(
     @ColumnInfo(name = "draft") var draft: Boolean = false, // Used when creating a new filter
 ) : Serializable {
     companion object {
-        const val PLAYLIST_ID_SYSTEM_DOWNLOADS: Long = -100L
-
         const val AUDIO_VIDEO_FILTER_ALL = 0
         const val AUDIO_VIDEO_FILTER_AUDIO_ONLY = 1
         const val AUDIO_VIDEO_FILTER_VIDEO_ONLY = 2
@@ -69,9 +67,6 @@ data class SmartPlaylist(
 
     @Ignore
     var episodeCount: Int = 0
-
-    val isSystemDownloadsFilter: Boolean
-        get() = id != null && id == PLAYLIST_ID_SYSTEM_DOWNLOADS
 
     val isAudioOnly: Boolean
         get() = audioVideo == AUDIO_VIDEO_FILTER_AUDIO_ONLY

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/type/PlaylistEpisodeSortType.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/type/PlaylistEpisodeSortType.kt
@@ -15,9 +15,6 @@ enum class PlaylistEpisodeSortType(
     LongestToShortest(
         serverId = 3,
     ),
-    LastDownloadAttempt(
-        serverId = 100,
-    ),
     ;
 
     companion object {

--- a/modules/services/model/src/test/java/au/com/shiftyjelly/pocketcasts/models/type/SmartRulesTest.kt
+++ b/modules/services/model/src/test/java/au/com/shiftyjelly/pocketcasts/models/type/SmartRulesTest.kt
@@ -1,6 +1,5 @@
 package au.com.shiftyjelly.pocketcasts.models.type
 
-import au.com.shiftyjelly.pocketcasts.models.entity.SmartPlaylist
 import au.com.shiftyjelly.pocketcasts.sharedtest.MutableClock
 import kotlin.time.Duration.Companion.days
 import kotlin.time.Duration.Companion.seconds
@@ -18,7 +17,7 @@ class SmartRulesTest {
             completed = false,
         )
 
-        val clause = rule.toSqlWhereClause(clock, playlistId = null)
+        val clause = rule.toSqlWhereClause(clock)
 
         assertEquals("episode.playing_status IN (0)", clause)
     }
@@ -31,7 +30,7 @@ class SmartRulesTest {
             completed = false,
         )
 
-        val clause = rule.toSqlWhereClause(clock, playlistId = null)
+        val clause = rule.toSqlWhereClause(clock)
 
         assertEquals("episode.playing_status IN (1)", clause)
     }
@@ -44,7 +43,7 @@ class SmartRulesTest {
             completed = true,
         )
 
-        val clause = rule.toSqlWhereClause(clock, playlistId = null)
+        val clause = rule.toSqlWhereClause(clock)
 
         assertEquals("episode.playing_status IN (2)", clause)
     }
@@ -57,7 +56,7 @@ class SmartRulesTest {
             completed = true,
         )
 
-        val clause = rule.toSqlWhereClause(clock, playlistId = null)
+        val clause = rule.toSqlWhereClause(clock)
 
         assertEquals("episode.playing_status IN (0,2)", clause)
     }
@@ -70,7 +69,7 @@ class SmartRulesTest {
             completed = true,
         )
 
-        val clause = rule.toSqlWhereClause(clock, playlistId = null)
+        val clause = rule.toSqlWhereClause(clock)
 
         assertEquals("", clause)
     }
@@ -83,7 +82,7 @@ class SmartRulesTest {
             completed = false,
         )
 
-        val clause = rule.toSqlWhereClause(clock, playlistId = null)
+        val clause = rule.toSqlWhereClause(clock)
 
         assertEquals("", clause)
     }
@@ -92,25 +91,16 @@ class SmartRulesTest {
     fun `downloaded episodes`() {
         val rule = SmartRules.DownloadStatusRule.Downloaded
 
-        val clause = rule.toSqlWhereClause(clock, playlistId = null)
+        val clause = rule.toSqlWhereClause(clock)
 
         assertEquals("episode.episode_status IN (4)", clause)
-    }
-
-    @Test
-    fun `downloaded episodes for system downloads playlist`() {
-        val rule = SmartRules.DownloadStatusRule.Downloaded
-
-        val clause = rule.toSqlWhereClause(clock, playlistId = SmartPlaylist.PLAYLIST_ID_SYSTEM_DOWNLOADS)
-
-        assertEquals("episode.episode_status IN (4,2,1,6,5) OR (episode.episode_status = 3 AND episode.last_download_attempt_date > -${7.days.inWholeMilliseconds})", clause)
     }
 
     @Test
     fun `not downloaded episodes`() {
         val rule = SmartRules.DownloadStatusRule.NotDownloaded
 
-        val clause = rule.toSqlWhereClause(clock, playlistId = null)
+        val clause = rule.toSqlWhereClause(clock)
 
         assertEquals("episode.episode_status IN (2,1,6,5,0,3)", clause)
     }
@@ -119,7 +109,7 @@ class SmartRulesTest {
     fun `all episode download statuses`() {
         val rule = SmartRules.DownloadStatusRule.Any
 
-        val clause = rule.toSqlWhereClause(clock, playlistId = null)
+        val clause = rule.toSqlWhereClause(clock)
 
         assertEquals("", clause)
     }
@@ -128,7 +118,7 @@ class SmartRulesTest {
     fun `audio episodes`() {
         val rule = SmartRules.MediaTypeRule.Audio
 
-        val clause = rule.toSqlWhereClause(clock, playlistId = null)
+        val clause = rule.toSqlWhereClause(clock)
 
         assertEquals("episode.file_type LIKE 'audio/%'", clause)
     }
@@ -137,7 +127,7 @@ class SmartRulesTest {
     fun `video episodes`() {
         val rule = SmartRules.MediaTypeRule.Video
 
-        val clause = rule.toSqlWhereClause(clock, playlistId = null)
+        val clause = rule.toSqlWhereClause(clock)
 
         assertEquals("episode.file_type LIKE 'video/%'", clause)
     }
@@ -146,7 +136,7 @@ class SmartRulesTest {
     fun `all media type episodes`() {
         val rule = SmartRules.MediaTypeRule.Any
 
-        val clause = rule.toSqlWhereClause(clock, playlistId = null)
+        val clause = rule.toSqlWhereClause(clock)
 
         assertEquals("", clause)
     }
@@ -155,7 +145,7 @@ class SmartRulesTest {
     fun `episodes released day ago`() {
         val rule = SmartRules.ReleaseDateRule.Last24Hours
 
-        val clause = rule.toSqlWhereClause(clock, playlistId = null)
+        val clause = rule.toSqlWhereClause(clock)
 
         assertEquals("episode.published_date > -${1.days.inWholeMilliseconds}", clause)
     }
@@ -164,7 +154,7 @@ class SmartRulesTest {
     fun `episodes released 3 day ago`() {
         val rule = SmartRules.ReleaseDateRule.Last3Days
 
-        val clause = rule.toSqlWhereClause(clock, playlistId = null)
+        val clause = rule.toSqlWhereClause(clock)
 
         assertEquals("episode.published_date > -${3.days.inWholeMilliseconds}", clause)
     }
@@ -173,7 +163,7 @@ class SmartRulesTest {
     fun `episodes released 7 day ago`() {
         val rule = SmartRules.ReleaseDateRule.LastWeek
 
-        val clause = rule.toSqlWhereClause(clock, playlistId = null)
+        val clause = rule.toSqlWhereClause(clock)
 
         assertEquals("episode.published_date > -${7.days.inWholeMilliseconds}", clause)
     }
@@ -182,7 +172,7 @@ class SmartRulesTest {
     fun `episodes released 14 day ago`() {
         val rule = SmartRules.ReleaseDateRule.Last2Weeks
 
-        val clause = rule.toSqlWhereClause(clock, playlistId = null)
+        val clause = rule.toSqlWhereClause(clock)
 
         assertEquals("episode.published_date > -${14.days.inWholeMilliseconds}", clause)
     }
@@ -191,7 +181,7 @@ class SmartRulesTest {
     fun `episodes released 31 day ago`() {
         val rule = SmartRules.ReleaseDateRule.LastMonth
 
-        val clause = rule.toSqlWhereClause(clock, playlistId = null)
+        val clause = rule.toSqlWhereClause(clock)
 
         assertEquals("episode.published_date > -${31.days.inWholeMilliseconds}", clause)
     }
@@ -200,7 +190,7 @@ class SmartRulesTest {
     fun `episodes released any time ago`() {
         val rule = SmartRules.ReleaseDateRule.AnyTime
 
-        val clause = rule.toSqlWhereClause(clock, playlistId = null)
+        val clause = rule.toSqlWhereClause(clock)
 
         assertEquals("", clause)
     }
@@ -209,7 +199,7 @@ class SmartRulesTest {
     fun `starred episodes`() {
         val rule = SmartRules.StarredRule.Starred
 
-        val clause = rule.toSqlWhereClause(clock, playlistId = null)
+        val clause = rule.toSqlWhereClause(clock)
 
         assertEquals("episode.starred = 1", clause)
     }
@@ -218,7 +208,7 @@ class SmartRulesTest {
     fun `any starred episode status`() {
         val rule = SmartRules.StarredRule.Any
 
-        val clause = rule.toSqlWhereClause(clock, playlistId = null)
+        val clause = rule.toSqlWhereClause(clock)
 
         assertEquals("", clause)
     }
@@ -229,7 +219,7 @@ class SmartRulesTest {
             uuids = listOf("id-1", "id-2"),
         )
 
-        val clause = rule.toSqlWhereClause(clock, playlistId = null)
+        val clause = rule.toSqlWhereClause(clock)
 
         assertEquals("episode.podcast_id IN ('id-1','id-2')", clause)
     }
@@ -238,7 +228,7 @@ class SmartRulesTest {
     fun `all podcasts`() {
         val rule = SmartRules.PodcastsRule.Any
 
-        val clause = rule.toSqlWhereClause(clock, playlistId = null)
+        val clause = rule.toSqlWhereClause(clock)
 
         assertEquals("", clause)
     }
@@ -250,7 +240,7 @@ class SmartRulesTest {
             shorterThan = 200.seconds,
         )
 
-        val clause = rule.toSqlWhereClause(clock, playlistId = null)
+        val clause = rule.toSqlWhereClause(clock)
 
         assertEquals("(episode.duration BETWEEN 128 AND 200)", clause)
     }
@@ -259,7 +249,7 @@ class SmartRulesTest {
     fun `any episode duration`() {
         val rule = SmartRules.EpisodeDurationRule.Any
 
-        val clause = rule.toSqlWhereClause(clock, playlistId = null)
+        val clause = rule.toSqlWhereClause(clock)
 
         assertEquals("", clause)
     }
@@ -268,7 +258,7 @@ class SmartRulesTest {
     fun `default rules`() {
         val rules = SmartRules.Default
 
-        val clause = rules.toSqlWhereClause(clock, playlistId = null)
+        val clause = rules.toSqlWhereClause(clock)
 
         assertEquals("(episode.archived = 0) AND (podcast.subscribed = 1)", clause)
     }
@@ -284,7 +274,7 @@ class SmartRulesTest {
             ),
         )
 
-        val clause = rules.toSqlWhereClause(clock, playlistId = null)
+        val clause = rules.toSqlWhereClause(clock)
 
         assertEquals("(episode.episode_status IN (4)) AND (episode.file_type LIKE 'video/%') AND ((episode.duration BETWEEN 10 AND 50)) AND (episode.archived = 0) AND (podcast.subscribed = 1)", clause)
     }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playlist/PlaylistManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playlist/PlaylistManagerImpl.kt
@@ -45,18 +45,16 @@ class PlaylistManagerImpl @Inject constructor(
     }
 
     private fun List<SmartPlaylist>.toPreviewFlows() = map { playlist ->
-        val podcastsFlow = playlistDao
-            .observeSmartPlaylistPodcasts(
-                smartRules = playlist.smartRules,
-                sortType = playlist.sortType,
-                limit = PLAYLIST_ARTWORK_EPISODE_LIMIT,
-            )
-            .invoke(clock, playlist.id)
-        val episodeCountFlow = playlistDao
-            .observeSmartPlaylistEpisodeCount(
-                smartRules = playlist.smartRules,
-            )
-            .invoke(clock, playlist.id)
+        val podcastsFlow = playlistDao.observeSmartPlaylistPodcasts(
+            clock = clock,
+            smartRules = playlist.smartRules,
+            sortType = playlist.sortType,
+            limit = PLAYLIST_ARTWORK_EPISODE_LIMIT,
+        )
+        val episodeCountFlow = playlistDao.observeSmartPlaylistEpisodeCount(
+            clock = clock,
+            smartRules = playlist.smartRules,
+        )
         combine(podcastsFlow, episodeCountFlow) { podcasts, count ->
             PlaylistPreview(
                 uuid = playlist.uuid,

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PlaylistUpdateAnalytics.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PlaylistUpdateAnalytics.kt
@@ -139,7 +139,6 @@ class PlaylistUpdateAnalytics @Inject constructor(
                         PlaylistEpisodeSortType.OldestToNewest -> "oldest_to_newest"
                         PlaylistEpisodeSortType.ShortestToLongest -> "shortest_to_longest"
                         PlaylistEpisodeSortType.LongestToShortest -> "longest_to_shortest"
-                        PlaylistEpisodeSortType.LastDownloadAttempt -> "last_download_attempt_date"
                     }
                     val properties = mapOf(Key.SORT_ORDER to sortOrderString)
                     analyticsTracker.track(AnalyticsEvent.FILTER_SORT_BY_CHANGED, properties)

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/SmartPlaylistManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/SmartPlaylistManager.kt
@@ -48,8 +48,6 @@ interface SmartPlaylistManager {
 
     fun removePodcastFromPlaylistsBlocking(podcastUuid: String)
 
-    fun getSystemDownloadsFilter(): SmartPlaylist
-
     suspend fun markAllSynced()
 
     fun updateAllBlocking(smartPlaylists: List<SmartPlaylist>)


### PR DESCRIPTION
## Description

This PR removes the code related to the system downloads filter. After gaining a deeper understanding of the filters code, I see no reason for this filter to exist.

https://github.com/Automattic/pocket-casts-android/blob/70a92539eb625bac9d48ab4b84b17825e7d7e89f/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/SmartPlaylistManagerImpl.kt#L543-L560

This filter was created in-memory on demand and was never persisted. Moreover, its rules were never applied anywhere. It was only used as an identifier in the `PlaybackService` to locate downloaded episodes. The logic was unnecessarily convoluted. Removing the filter also allowed us to remove the `LastDownloadAttempt` sorting type.

https://github.com/Automattic/pocket-casts-android/blob/70a92539eb625bac9d48ab4b84b17825e7d7e89f/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackService.kt#L566-L574

## Testing Instructions

1. Download some episodes.
2. [Start Android Auto.](https://developer.android.com/training/cars/testing/dhu)
3. Confirm that downloaded episodes appear in Android Auto. They can be hidden under "More".

## Screenshots or Screencast 

<img width="842" height="549" alt="Screenshot 2025-07-23 at 15 17 43" src="https://github.com/user-attachments/assets/d0cb3111-a63d-4c0b-8345-ef5462bfa185" />

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.