### PR TITLE
Open podcast search by tapping the Discover button when the Discover page is displayed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,11 @@
 7.95
 -----
-*   Bug Fixes
-    *   Fix missing file sizes on the episode page
-        ([#4262](https://github.com/Automattic/pocket-casts-android/pull/4262))
 *   Updates
     *   Open podcast search by tapping the Discover button when the Discover page is displayed
         ([#4272](https://github.com/Automattic/pocket-casts-android/pull/4272))
+* Bug Fixes
+    *   Fix missing file sizes on the episode page
+        ([#4262](https://github.com/Automattic/pocket-casts-android/pull/4262))
 
 7.94
 -----

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
     *   Fix missing file sizes on the episode page
         ([#4262](https://github.com/Automattic/pocket-casts-android/pull/4262))
 *   Updates
-    *   Open podcast search when Discover button is double-tapped
+    *   Open podcast search by tapping the Discover button when the Discover page is displayed
         ([#4272](https://github.com/Automattic/pocket-casts-android/pull/4272))
 
 7.94

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
         ([#4262](https://github.com/Automattic/pocket-casts-android/pull/4262))
 *   Updates
     *   Open podcast search when Discover button is double-tapped
+        ([#4272](https://github.com/Automattic/pocket-casts-android/pull/4272))
 
 7.94
 -----

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 *   Bug Fixes
     *   Fix missing file sizes on the episode page
         ([#4262](https://github.com/Automattic/pocket-casts-android/pull/4262))
+*   Updates
+    *   Open podcast search when Discover button is double-tapped
 
 7.94
 -----

--- a/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
+++ b/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
@@ -510,6 +510,18 @@ class MainActivity :
         navigator.resetRootFragmentCommand()
             .subscribe({ fragment ->
                 (fragment as? TopScrollable)?.scrollToTop()
+
+                // Open search UI when Discover button is double-tapped
+                val discoverId = VR.id.navigation_discover
+                val currentFragmentIsDiscover = navigator.currentTab() == discoverId
+                if (currentFragmentIsDiscover) {
+                    val searchFragment = SearchFragment.newInstance(
+                        floating = true,
+                        onlySearchRemote = true,
+                        source = SourceView.DISCOVER,
+                    )
+                    addFragment(searchFragment, onTop = true)
+                }
             })
             .addTo(disposables)
 

--- a/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
+++ b/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
@@ -509,12 +509,13 @@ class MainActivity :
 
         navigator.resetRootFragmentCommand()
             .subscribe({ fragment ->
-                (fragment as? TopScrollable)?.scrollToTop()
+                val didScroll = (fragment as? TopScrollable)?.scrollToTop()
 
-                // Open search UI when Discover button is double-tapped
+                // Open search UI when tapping the Discover navigation button
+                // while at the top of the Discover page already
                 val discoverId = VR.id.navigation_discover
                 val currentFragmentIsDiscover = navigator.currentTab() == discoverId
-                if (currentFragmentIsDiscover) {
+                if (currentFragmentIsDiscover && didScroll == false) {
                     val searchFragment = SearchFragment.newInstance(
                         floating = true,
                         onlySearchRemote = true,

--- a/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/DiscoverFragment.kt
+++ b/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/DiscoverFragment.kt
@@ -304,8 +304,10 @@ class DiscoverFragment :
         }
     }
 
-    override fun scrollToTop() {
+    override fun scrollToTop(): Boolean {
+        val canScroll = binding?.recyclerView?.canScrollVertically(-1) ?: false
         binding?.recyclerView?.quickScrollToTop()
+        return canScroll
     }
 
     companion object {

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/FiltersFragment.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/FiltersFragment.kt
@@ -309,8 +309,10 @@ class FiltersFragment :
         viewModel.onTooltipClosed()
     }
 
-    override fun scrollToTop() {
+    override fun scrollToTop(): Boolean {
+        val canScroll = binding?.recyclerView?.canScrollVertically(-1) ?: false
         binding?.recyclerView?.quickScrollToTop()
+        return canScroll
     }
 }
 

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/PlaylistsFragment.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/PlaylistsFragment.kt
@@ -30,6 +30,8 @@ class PlaylistsFragment :
     private val scrollToTopSignal = MutableSharedFlow<Unit>()
     private val viewModel by viewModels<PlaylistsViewModel>()
 
+    private var getCanScrollBackward: () -> Boolean = { false }
+
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
@@ -37,6 +39,8 @@ class PlaylistsFragment :
     ) = contentWithoutConsumedInsets {
         val listState = rememberLazyListState()
         val uiState by viewModel.uiState.collectAsState()
+
+        getCanScrollBackward = { listState.canScrollBackward }
 
         AppThemeWithBackground(theme.activeTheme) {
             PlaylistsPage(
@@ -78,9 +82,13 @@ class PlaylistsFragment :
         }
     }
 
-    override fun scrollToTop() {
+    override fun scrollToTop(): Boolean {
+        val canScroll = getCanScrollBackward()
+
         lifecycleScope.launch {
             scrollToTopSignal.emit(Unit)
         }
+
+        return canScroll
     }
 }

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/UpNextFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/UpNextFragment.kt
@@ -548,7 +548,9 @@ class UpNextFragment :
         analyticsTracker.track(event, properties)
     }
 
-    override fun scrollToTop() {
+    override fun scrollToTop(): Boolean {
+        val canScroll = binding.recyclerView.canScrollVertically(-1)
         binding.recyclerView.quickScrollToTop()
+        return canScroll
     }
 }

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcasts/PodcastsFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcasts/PodcastsFragment.kt
@@ -639,8 +639,10 @@ class PodcastsFragment :
         (activity as FragmentHostListener).addFragment(fragment)
     }
 
-    override fun scrollToTop() {
+    override fun scrollToTop(): Boolean {
+        val canScroll = binding.recyclerView.canScrollVertically(-1)
         binding.recyclerView.quickScrollToTop()
+        return canScroll
     }
 
     private fun showTooltip() {

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/ProfileFragment.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/ProfileFragment.kt
@@ -45,6 +45,8 @@ class ProfileFragment :
 
     private val scrollToTopSignal = MutableSharedFlow<Unit>()
 
+    private var getCanScrollBackward: () -> Boolean = { false }
+
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
@@ -65,6 +67,8 @@ class ProfileFragment :
         )
 
         val listState = rememberLazyListState()
+
+        getCanScrollBackward = { listState.canScrollBackward }
 
         LaunchedEffect(listState) {
             scrollToTopSignal.collectLatest {
@@ -171,9 +175,13 @@ class ProfileFragment :
         return super.onBackPressed()
     }
 
-    override fun scrollToTop() {
+    override fun scrollToTop(): Boolean {
+        val canScroll = getCanScrollBackward()
+
         lifecycleScope.launch {
             scrollToTopSignal.emit(Unit)
         }
+
+        return canScroll
     }
 }

--- a/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/fragments/TopScrollable.kt
+++ b/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/fragments/TopScrollable.kt
@@ -1,5 +1,7 @@
 package au.com.shiftyjelly.pocketcasts.views.fragments
 
 interface TopScrollable {
-    fun scrollToTop()
+    // Returns `true` if the Fragment did actually scroll
+    // (was not at the top already)
+    fun scrollToTop(): Boolean
 }


### PR DESCRIPTION
## Description
Allows the user to open the podcast search quickly by tapping the Discover navigation button when the Discover page is already displayed. This is a common feature in Android apps like Google Photos, Play Store, and Immich that I miss when using Pocket Casts.

I am curious if the analytics source should be different, though technically it is launched from Discover as it currently says. Please let me know if anything is out of place. Thank you!

## Testing Instructions
1. Navigate to the Discover tab
2. Tap the Discover navigation button
3. The search fragment should open as if the user tapped the top search bar

## Screenshots or Screencast 
[Screen recording of double-tapping the Discover button and the keyboard popping up](https://github.com/user-attachments/assets/6df8c91b-b1b8-4584-8e57-3d69bf4fe48a)


## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack
