### PR TITLE
Fixes notification message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 *   Bug Fixes
     *   Fix missing file sizes on the episode page
         ([#4262](https://github.com/Automattic/pocket-casts-android/pull/4262))
+    *   Fix the notification message for "Trending this week"
+        ([#4273](https://github.com/Automattic/pocket-casts-android/pull/4273))
 
 7.94
 -----

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -2451,7 +2451,7 @@
         <item quantity="other">You have %d new episodes downloaded and ready to go!</item>
     </plurals>
     <string name="notification_content_recommendations_trending_title">Trending this week</string>
-    <string name="notification_content_recommendations_trending_message">Check out what everyone else is listening this week.</string>
+    <string name="notification_content_recommendations_trending_message">Check out what everyone else is listening to this week.</string>
     <string name="notification_content_recommendations_title">New recommendations for you</string>
     <string name="notification_content_recommendations_message">Wondering what to listen to next? Check out these shows!</string>
     <string name="notifications_settings_turn_on_push_title">Turn on push notifications?</string>


### PR DESCRIPTION
## Description

This change improves the "Trending this week" notification message.

## Testing Instructions

1. Go to Profile -> Settings -> Developer -> Notifications testing
2. Change the "Select notification type" to trending
3. Tap "Fire now"
4. ✅ Verify the notification text looks correct

## Screenshots 

| Before | After |
| --- | --- |
| ![Screenshot_20250724_073850_One UI Home (1)](https://github.com/user-attachments/assets/cc5ed911-08eb-4a6e-abe8-bcecd067e770) | <img width="1080" height="433" alt="Screenshot_20250724_120349" src="https://github.com/user-attachments/assets/82d3e656-5732-4e81-8154-0884fcba5c37" /> | 

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack
