### PR TITLE
Add missing `notification_open` event

### DIFF
--- a/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
+++ b/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
@@ -615,6 +615,7 @@ enum class AnalyticsEvent(val key: String) {
     NOTIFICATIONS_PERMISSIONS_SHOWN("notifications_permissions_shown"),
     NOTIFICATIONS_PERMISSIONS_ALLOW_TAPPED("notifications_permissions_allow_tapped"),
     NOTIFICATIONS_PERMISSIONS_DISMISSED("notifications_permissions_not_now_tapped"),
+    NOTIFICATION_OPENED("notification_opened"),
 
     /* Settings - Notifications */
     SETTINGS_NOTIFICATIONS_SHOWN("settings_notifications_shown"),

--- a/modules/services/repositories/src/main/AndroidManifest.xml
+++ b/modules/services/repositories/src/main/AndroidManifest.xml
@@ -16,6 +16,14 @@
             android:name="androidx.work.impl.foreground.SystemForegroundService"
             android:foregroundServiceType="dataSync"
             tools:node="merge" />
+
+        <receiver
+            android:name=".notification.NotificationOpenReceiver"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="au.com.shiftyjelly.pocketcasts.ACTION_REVAMPED_NOTIFICATION_OPENED" />
+            </intent-filter>
+        </receiver>
     </application>
 
 </manifest>

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/download/DownloadManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/download/DownloadManagerImpl.kt
@@ -32,11 +32,13 @@ import au.com.shiftyjelly.pocketcasts.repositories.download.task.UpdateShowNotes
 import au.com.shiftyjelly.pocketcasts.repositories.file.FileStorage
 import au.com.shiftyjelly.pocketcasts.repositories.file.StorageException
 import au.com.shiftyjelly.pocketcasts.repositories.notification.NotificationHelper
+import au.com.shiftyjelly.pocketcasts.repositories.notification.NotificationOpenReceiver
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.SmartPlaylistManager
 import au.com.shiftyjelly.pocketcasts.repositories.refresh.RefreshPodcastsThread
+import au.com.shiftyjelly.pocketcasts.utils.AppPlatform
 import au.com.shiftyjelly.pocketcasts.utils.Network
 import au.com.shiftyjelly.pocketcasts.utils.Power
 import au.com.shiftyjelly.pocketcasts.utils.Util
@@ -643,7 +645,11 @@ class DownloadManagerImpl @Inject constructor(
 
     private fun openDownloadingPageIntent(): PendingIntent {
         val intent = DownloadsDeepLink.toIntent(context)
-        return PendingIntent.getActivity(context, 0, intent, PendingIntent.FLAG_CANCEL_CURRENT or PendingIntent.FLAG_IMMUTABLE)
+        return if (Util.getAppPlatform(context) == AppPlatform.Phone) {
+            PendingIntent.getBroadcast(context, 0, NotificationOpenReceiver.toDeeplinkIntentRelay(context, intent), PendingIntent.FLAG_CANCEL_CURRENT or PendingIntent.FLAG_IMMUTABLE)
+        } else {
+            PendingIntent.getActivity(context, 0, intent, PendingIntent.FLAG_CANCEL_CURRENT or PendingIntent.FLAG_IMMUTABLE)
+        }
     }
 
     private fun updateSource(source: SourceView) {

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/notification/NotificationOpenReceiver.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/notification/NotificationOpenReceiver.kt
@@ -1,0 +1,105 @@
+package au.com.shiftyjelly.pocketcasts.repositories.notification
+
+import android.content.BroadcastReceiver
+import android.content.ComponentName
+import android.content.Context
+import android.content.Intent
+import androidx.core.content.IntentCompat
+import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
+import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTracker
+import dagger.hilt.android.AndroidEntryPoint
+import javax.inject.Inject
+import timber.log.Timber
+
+@AndroidEntryPoint
+class NotificationOpenReceiver : BroadcastReceiver() {
+    @Inject
+    lateinit var analyticsTracker: AnalyticsTracker
+
+    override fun onReceive(context: Context, intent: Intent) {
+        when (intent.action) {
+            ACTION_REVAMP_NOTIFICATION_OPENED -> handleRevampedNotificationOpen(intent, context)
+            else -> handleRelayedNotificationOpen(intent, context)
+        }
+    }
+
+    private fun handleRelayedNotificationOpen(intent: Intent, context: Context) {
+        val category = intent.getStringExtra(EXTRA_CATEGORY) ?: return
+
+        analyticsTracker.track(
+            event = AnalyticsEvent.NOTIFICATION_OPENED,
+            properties = mapOf(
+                "category" to category,
+            ),
+        )
+
+        val originalIntent = Intent().apply {
+            flags = intent.flags
+            action = intent.action
+            IntentCompat.getParcelableExtra(intent, EXTRA_ORIGINAL_COMPONENT, ComponentName::class.java)?.let {
+                component = it
+            }
+            putExtras(intent)
+            removeExtra(EXTRA_CATEGORY)
+            removeExtra(EXTRA_ORIGINAL_COMPONENT)
+        }
+        tryLaunchIntent(originalIntent, context)
+    }
+
+    private fun handleRevampedNotificationOpen(intent: Intent, context: Context) {
+        val subCategory = intent.getStringExtra(EXTRA_REVAMPED_TYPE) ?: return
+
+        val notificationType = NotificationType.fromSubCategory(subCategory)
+        notificationType?.let {
+            analyticsTracker.track(
+                event = AnalyticsEvent.NOTIFICATION_OPENED,
+                properties = mapOf(
+                    "type" to it.analyticsType,
+                    "category" to CATEGORY_DEEP_LINK,
+                ),
+            )
+            val target = it.toIntent(context)
+            tryLaunchIntent(target, context)
+        }
+    }
+
+    private fun tryLaunchIntent(intent: Intent, context: Context) {
+        try {
+            context.startActivity(intent.apply { flags = Intent.FLAG_ACTIVITY_NEW_TASK })
+        } catch (t: Throwable) {
+            Timber.w("Failed to launch activity for intent $intent")
+        }
+    }
+
+    companion object {
+        private const val ACTION_REVAMP_NOTIFICATION_OPENED = "au.com.shiftyjelly.pocketcasts.ACTION_REVAMPED_NOTIFICATION_OPENED"
+        private const val EXTRA_REVAMPED_TYPE = "au.com.shiftyjelly.pocketcasts.extras.revamped.notification.type"
+        private const val EXTRA_CATEGORY = "au.com.shiftyjelly.pocketcasts.extras.notification.category"
+        private const val EXTRA_ORIGINAL_COMPONENT = "au.com.shiftyjelly.pocketcasts.extras.notification.component"
+        private const val CATEGORY_DEEP_LINK = "DEEP_LINK"
+        private const val CATEGORY_EPISODE = "ep"
+        private const val CATEGORY_PODCAST = "po"
+
+        fun NotificationType.toBroadcast(context: Context) = Intent(context, NotificationOpenReceiver::class.java).apply {
+            action = ACTION_REVAMP_NOTIFICATION_OPENED
+            putExtra(EXTRA_REVAMPED_TYPE, this@toBroadcast.subcategory)
+        }
+
+        fun toEpisodeIntentRelay(context: Context, intent: Intent) = Intent(context, NotificationOpenReceiver::class.java).copyCommonIntentProps(intent, CATEGORY_EPISODE)
+
+        fun toPodcastIntentRelay(context: Context, intent: Intent) = Intent(context, NotificationOpenReceiver::class.java).copyCommonIntentProps(intent, CATEGORY_PODCAST)
+
+        fun toDeeplinkIntentRelay(context: Context, intent: Intent) = Intent(context, NotificationOpenReceiver::class.java).copyCommonIntentProps(intent, CATEGORY_DEEP_LINK)
+
+        private fun Intent.copyCommonIntentProps(source: Intent, category: String): Intent {
+            flags = source.flags
+            action = source.action
+            putExtras(source)
+            source.component?.let {
+                putExtra(EXTRA_ORIGINAL_COMPONENT, it)
+            }
+            putExtra(EXTRA_CATEGORY, category)
+            return this
+        }
+    }
+}

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/notification/NotificationType.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/notification/NotificationType.kt
@@ -22,6 +22,7 @@ import au.com.shiftyjelly.pocketcasts.localization.R as LR
 sealed interface NotificationType {
     val notificationId: Int
     val subcategory: String
+    val analyticsType: String
 
     @get:StringRes
     val titleRes: Int
@@ -59,6 +60,7 @@ sealed interface NotificationType {
 sealed class OnboardingNotificationType(
     override val notificationId: Int,
     override val subcategory: String,
+    override val analyticsType: String,
     @StringRes override val titleRes: Int,
     @StringRes override val messageRes: Int,
     val dayOffset: Int,
@@ -76,6 +78,7 @@ sealed class OnboardingNotificationType(
         titleRes = LR.string.notification_sync_title,
         messageRes = LR.string.notification_sync_message,
         dayOffset = 0,
+        analyticsType = "onboardingSignUp",
     ) {
         override fun toIntent(context: Context) = CreateAccountDeepLink.toIntent(context)
     }
@@ -86,6 +89,7 @@ sealed class OnboardingNotificationType(
         titleRes = LR.string.notification_import_title,
         messageRes = LR.string.notification_import_message,
         dayOffset = 1,
+        analyticsType = "onboardingImport",
     ) {
         override fun toIntent(context: Context) = ImportDeepLink.toIntent(context)
     }
@@ -96,6 +100,7 @@ sealed class OnboardingNotificationType(
         titleRes = LR.string.notification_up_next_title,
         messageRes = LR.string.notification_up_next_message,
         dayOffset = 2,
+        analyticsType = "onboardingUpNext",
     ) {
         override fun toIntent(context: Context) = ShowUpNextTabDeepLink.toIntent(context)
     }
@@ -106,6 +111,7 @@ sealed class OnboardingNotificationType(
         titleRes = LR.string.notification_filters_title,
         messageRes = LR.string.notification_filters_message,
         dayOffset = 3,
+        analyticsType = "onboardingFilters",
     ) {
         override fun toIntent(context: Context) = ShowFiltersDeepLink.toIntent(context)
     }
@@ -116,6 +122,7 @@ sealed class OnboardingNotificationType(
         titleRes = LR.string.notification_themes_title,
         messageRes = LR.string.notification_themes_message,
         dayOffset = 4,
+        analyticsType = "onboardingThemes",
     ) {
         override fun toIntent(context: Context) = ThemesDeepLink.toIntent(context)
     }
@@ -126,6 +133,7 @@ sealed class OnboardingNotificationType(
         titleRes = LR.string.notification_staff_picks_title,
         messageRes = LR.string.notification_staff_picks_message,
         dayOffset = 5,
+        analyticsType = "onboardingStaffPicks",
     ) {
         override fun toIntent(context: Context) = StaffPicksDeepLink.toIntent(context)
     }
@@ -136,6 +144,7 @@ sealed class OnboardingNotificationType(
         titleRes = LR.string.notification_plus_upsell_title,
         messageRes = LR.string.notification_plus_upsell_message,
         dayOffset = 6,
+        analyticsType = "onboardingUpsell",
     ) {
         override fun toIntent(context: Context) = UpsellDeepLink.toIntent(context)
     }
@@ -176,6 +185,9 @@ sealed class ReEngagementNotificationType(
         return settings.newFeaturesNotification.value
     }
 
+    override val analyticsType: String
+        get() = "reengagementWeekly"
+
     data object WeMissYou : ReEngagementNotificationType(
         subcategory = SUBCATEGORY_REENGAGE_WE_MISS_YOU,
         titleRes = LR.string.notification_reengage_we_miss_you_title,
@@ -210,6 +222,7 @@ sealed class ReEngagementNotificationType(
 sealed class TrendingAndRecommendationsNotificationType(
     override val notificationId: Int,
     override val subcategory: String,
+    override val analyticsType: String,
     @StringRes override val titleRes: Int,
     @StringRes override val messageRes: Int? = null,
     @PluralsRes override val messagePluralRes: Int? = null,
@@ -222,6 +235,7 @@ sealed class TrendingAndRecommendationsNotificationType(
         subcategory = SUBCATEGORY_TRENDING,
         titleRes = LR.string.notification_content_recommendations_trending_title,
         messageRes = LR.string.notification_content_recommendations_trending_message,
+        analyticsType = "recommendationsTrending",
     ) {
         override fun toIntent(context: Context) = TrendingDeepLink.toIntent(context)
     }
@@ -231,6 +245,7 @@ sealed class TrendingAndRecommendationsNotificationType(
         subcategory = SUBCATEGORY_RECOMMENDATIONS,
         titleRes = LR.string.notification_content_recommendations_title,
         messageRes = LR.string.notification_content_recommendations_message,
+        analyticsType = "recommendationsYouMightLike",
     ) {
         override fun toIntent(context: Context) = RecommendationsDeepLink.toIntent(context)
     }
@@ -249,6 +264,7 @@ sealed class TrendingAndRecommendationsNotificationType(
 sealed class NewFeaturesAndTipsNotificationType(
     override val notificationId: Int,
     override val subcategory: String,
+    override val analyticsType: String,
     @StringRes override val titleRes: Int,
     @StringRes override val messageRes: Int? = null,
     @PluralsRes override val messagePluralRes: Int? = null,
@@ -261,6 +277,7 @@ sealed class NewFeaturesAndTipsNotificationType(
         subcategory = SUBCATEGORY_SMART_FOLDERS,
         titleRes = LR.string.notification_new_features_smart_folders_title,
         messageRes = LR.string.notification_new_features_smart_folders_message,
+        analyticsType = "newFeatureSuggestedFolders",
     ) {
         override fun toIntent(context: Context) = SmartFoldersDeepLink.toIntent(context)
     }
@@ -277,6 +294,7 @@ sealed class NewFeaturesAndTipsNotificationType(
 sealed class OffersNotificationType(
     override val notificationId: Int,
     override val subcategory: String,
+    override val analyticsType: String,
     @StringRes override val titleRes: Int,
     @StringRes override val messageRes: Int? = null,
     @PluralsRes override val messagePluralRes: Int? = null,
@@ -289,6 +307,7 @@ sealed class OffersNotificationType(
         subcategory = UPGRADE_NOW,
         titleRes = LR.string.notification_offers_upgrade_title,
         messageRes = LR.string.notification_offers_upgrade_message,
+        analyticsType = "upsell",
     ) {
         override fun toIntent(context: Context) = UpsellDeepLink.toIntent(context)
     }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/notification/NotificationWorker.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/notification/NotificationWorker.kt
@@ -13,6 +13,7 @@ import androidx.work.CoroutineWorker
 import androidx.work.WorkerParameters
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.repositories.R
+import au.com.shiftyjelly.pocketcasts.repositories.notification.NotificationOpenReceiver.Companion.toBroadcast
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.SuggestedFoldersManager
 import au.com.shiftyjelly.pocketcasts.repositories.user.UserManager
 import au.com.shiftyjelly.pocketcasts.utils.AppPlatform
@@ -109,15 +110,15 @@ class NotificationWorker @AssistedInject constructor(
             .setContentText(type.formattedMessage(applicationContext, downloadedEpisodes))
             .setColor(ContextCompat.getColor(applicationContext, R.color.notification_color))
             .setAutoCancel(true)
-            .setContentIntent(openPageIntent(type))
+            .setContentIntent(broadcastIntent(type))
     }
 
-    private fun openPageIntent(type: NotificationType): PendingIntent {
-        return PendingIntent.getActivity(
+    private fun broadcastIntent(type: NotificationType): PendingIntent {
+        return PendingIntent.getBroadcast(
             applicationContext,
             0,
-            type.toIntent(applicationContext),
-            PendingIntent.FLAG_CANCEL_CURRENT or PendingIntent.FLAG_IMMUTABLE,
+            type.toBroadcast(applicationContext),
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
         )
     }
 

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
@@ -47,6 +47,7 @@ import au.com.shiftyjelly.pocketcasts.repositories.file.CloudFilesManager
 import au.com.shiftyjelly.pocketcasts.repositories.history.upnext.UpNextHistoryManager
 import au.com.shiftyjelly.pocketcasts.repositories.notification.NotificationHelper
 import au.com.shiftyjelly.pocketcasts.repositories.notification.NotificationManager
+import au.com.shiftyjelly.pocketcasts.repositories.notification.NotificationOpenReceiver
 import au.com.shiftyjelly.pocketcasts.repositories.notification.OnboardingNotificationType
 import au.com.shiftyjelly.pocketcasts.repositories.playback.LocalPlayer.Companion.VOLUME_DUCK
 import au.com.shiftyjelly.pocketcasts.repositories.playback.LocalPlayer.Companion.VOLUME_NORMAL
@@ -1964,7 +1965,11 @@ open class PlaybackManager @Inject constructor(
         val intent = application.packageManager.getLaunchIntentForPackage(application.packageName)?.apply {
             flags = Intent.FLAG_ACTIVITY_SINGLE_TOP
         }
-        val pendingIntent = PendingIntent.getActivity(application, 0, intent, PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE)
+        val pendingIntent = if (Util.getAppPlatform(application) == AppPlatform.Phone && intent != null) {
+            PendingIntent.getBroadcast(application, 0, NotificationOpenReceiver.toPodcastIntentRelay(application, intent), PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE)
+        } else {
+            PendingIntent.getActivity(application, 0, intent, PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE)
+        }
 
         val notificationTag = NotificationBroadcastReceiver.NOTIFICATION_TAG_PLAYBACK_ERROR
 

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/refresh/RefreshPodcastsThread.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/refresh/RefreshPodcastsThread.kt
@@ -32,6 +32,7 @@ import au.com.shiftyjelly.pocketcasts.repositories.download.DownloadManager
 import au.com.shiftyjelly.pocketcasts.repositories.file.FileStorage
 import au.com.shiftyjelly.pocketcasts.repositories.images.PocketCastsImageRequestFactory
 import au.com.shiftyjelly.pocketcasts.repositories.notification.NotificationHelper
+import au.com.shiftyjelly.pocketcasts.repositories.notification.NotificationOpenReceiver
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.FolderManager
@@ -50,7 +51,9 @@ import au.com.shiftyjelly.pocketcasts.servers.ServerResponseException
 import au.com.shiftyjelly.pocketcasts.servers.ServiceManager
 import au.com.shiftyjelly.pocketcasts.servers.podcast.PodcastCacheServiceManagerImpl
 import au.com.shiftyjelly.pocketcasts.servers.sync.exception.RefreshTokenExpiredException
+import au.com.shiftyjelly.pocketcasts.utils.AppPlatform
 import au.com.shiftyjelly.pocketcasts.utils.Network
+import au.com.shiftyjelly.pocketcasts.utils.Util
 import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
 import coil.executeBlocking
 import coil.imageLoader
@@ -473,16 +476,21 @@ class RefreshPodcastsThread(
             val sortKey = String.format("%04d", episodeIndex)
             var intentId = intentId
             val manager = NotificationManagerCompat.from(context)
-
-            val intent = ShowEpisodeDeepLink(
+            val showEpisodeDeepLink = ShowEpisodeDeepLink(
                 episodeUuid = episode.uuid,
                 podcastUuid = podcast.uuid,
                 sourceView = EpisodeViewSource.NOTIFICATION.value,
                 autoPlay = false,
-            ).toIntent(context).apply {
-                action = action + System.currentTimeMillis() + intentId
+            )
+
+            val intent = showEpisodeDeepLink.toIntent(context).apply {
+                action += System.currentTimeMillis() + intentId
             }
-            val pendingIntent = PendingIntent.getActivity(context, intentId, intent, PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE)
+            val pendingIntent = if (Util.getAppPlatform(context) == AppPlatform.Phone) {
+                PendingIntent.getBroadcast(context, intentId, NotificationOpenReceiver.toEpisodeIntentRelay(context, intent), PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE)
+            } else {
+                PendingIntent.getActivity(context, intentId, intent, PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE)
+            }
             intentId += 1
 
             val notificationTag = if (isGroupNotification) {
@@ -608,7 +616,11 @@ class RefreshPodcastsThread(
                 flags = Intent.FLAG_ACTIVITY_SINGLE_TOP
                 action = Settings.INTENT_OPEN_APP_NEW_EPISODES
             }
-            val pendingIntent = PendingIntent.getActivity(context, intentIndex, intent, PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE)
+            val pendingIntent = if (Util.getAppPlatform(context) == AppPlatform.Phone && intent != null) {
+                PendingIntent.getBroadcast(context, intentIndex, NotificationOpenReceiver.toPodcastIntentRelay(context, intent), PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE)
+            } else {
+                PendingIntent.getActivity(context, intentIndex, intent, PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE)
+            }
             intentIndex += 1
 
             val inboxStyle = NotificationCompat.InboxStyle()

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/TokenErrorNotification.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/TokenErrorNotification.kt
@@ -11,6 +11,9 @@ import androidx.core.app.NotificationManagerCompat
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTracker
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
+import au.com.shiftyjelly.pocketcasts.repositories.notification.NotificationOpenReceiver
+import au.com.shiftyjelly.pocketcasts.utils.AppPlatform
+import au.com.shiftyjelly.pocketcasts.utils.Util
 import dagger.hilt.android.qualifiers.ApplicationContext
 import javax.inject.Inject
 import au.com.shiftyjelly.pocketcasts.images.R as IR
@@ -29,7 +32,11 @@ open class TokenErrorNotification @Inject constructor(
         }
 
         if (ActivityCompat.checkSelfPermission(context, Manifest.permission.POST_NOTIFICATIONS) == PackageManager.PERMISSION_GRANTED) {
-            val pendingIntent = PendingIntent.getActivity(context, 0, intent, PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE)
+            val pendingIntent = if (Util.getAppPlatform(context) == AppPlatform.Phone) {
+                PendingIntent.getBroadcast(context, 0, NotificationOpenReceiver.toDeeplinkIntentRelay(context, intent), PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE)
+            } else {
+                PendingIntent.getActivity(context, 0, intent, PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE)
+            }
             val notification = NotificationCompat.Builder(context, Settings.NotificationChannel.NOTIFICATION_CHANNEL_ID_SIGN_IN_ERROR.id)
                 .setVisibility(NotificationCompat.VISIBILITY_PUBLIC)
                 .setContentTitle(context.getString(LR.string.token_refresh_sign_in_error_title))


### PR DESCRIPTION
## Description
This PR cherry brings in the `notification_open` event that has been recently added to `main` (#4261), but this time we're targeting beta.

## Testing Instructions
Since this has been already tested, just make sure that the pipe is green


## Checklist
- [ ] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] ~I have considered whether it makes sense to add tests for my changes~
- [ ] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [ ] ~Any jetpack compose components I added or changed are covered by compose previews~
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 