### PR TITLE
Add Smart Playlist creation logic

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -664,6 +664,9 @@
             android:authorities="${applicationId}.androidx-startup"
             android:exported="false"
             tools:node="merge">
+            <meta-data
+                android:name="au.com.shiftyjelly.pocketcasts.repositories.playlist.DefaultPlaylistsStartupInitializater"
+                android:value="androidx.startup" />
             <!-- If you are using androidx.startup to initialize other components -->
             <meta-data
                 android:name="androidx.work.WorkManagerInitializer"

--- a/app/src/test/java/au/com/shiftyjelly/pocketcasts/filters/FiltersFragmentViewModelTest.kt
+++ b/app/src/test/java/au/com/shiftyjelly/pocketcasts/filters/FiltersFragmentViewModelTest.kt
@@ -4,10 +4,9 @@ import au.com.shiftyjelly.pocketcasts.models.entity.SmartPlaylist
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.preferences.UserSetting
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
+import au.com.shiftyjelly.pocketcasts.repositories.playlist.Playlist
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.SmartPlaylistManager
-import au.com.shiftyjelly.pocketcasts.repositories.podcast.SmartPlaylistManagerImpl.Companion.IN_PROGRESS_UUID
-import au.com.shiftyjelly.pocketcasts.repositories.podcast.SmartPlaylistManagerImpl.Companion.NEW_RELEASE_UUID
 import au.com.shiftyjelly.pocketcasts.repositories.user.UserManager
 import au.com.shiftyjelly.pocketcasts.sharedtest.MainCoroutineRule
 import io.reactivex.Flowable
@@ -28,8 +27,8 @@ class FiltersFragmentViewModelTest {
     val coroutineRule = MainCoroutineRule()
 
     private val defaultFilters = listOf(
-        SmartPlaylist(id = 1, uuid = NEW_RELEASE_UUID),
-        SmartPlaylist(id = 2, uuid = IN_PROGRESS_UUID),
+        SmartPlaylist(id = 1, uuid = Playlist.NEW_RELEASES_UUID),
+        SmartPlaylist(id = 2, uuid = Playlist.IN_PROGRESS_UUID),
     )
 
     @Before

--- a/automotive/src/main/AndroidManifest.xml
+++ b/automotive/src/main/AndroidManifest.xml
@@ -65,6 +65,9 @@
             android:authorities="${applicationId}.androidx-startup"
             android:exported="false"
             tools:node="merge">
+            <meta-data
+                android:name="au.com.shiftyjelly.pocketcasts.repositories.playlist.DefaultPlaylistsStartupInitializater"
+                android:value="androidx.startup" />
             <!-- If you are using androidx.startup to initialize other components -->
             <meta-data
                 android:name="androidx.work.WorkManagerInitializer"

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/FiltersFragmentViewModel.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/FiltersFragmentViewModel.kt
@@ -9,10 +9,9 @@ import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTracker
 import au.com.shiftyjelly.pocketcasts.models.entity.SmartPlaylist
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
+import au.com.shiftyjelly.pocketcasts.repositories.playlist.Playlist
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.SmartPlaylistManager
-import au.com.shiftyjelly.pocketcasts.repositories.podcast.SmartPlaylistManagerImpl.Companion.IN_PROGRESS_UUID
-import au.com.shiftyjelly.pocketcasts.repositories.podcast.SmartPlaylistManagerImpl.Companion.NEW_RELEASE_UUID
 import au.com.shiftyjelly.pocketcasts.repositories.user.UserManager
 import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
 import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
@@ -122,7 +121,7 @@ class FiltersFragmentViewModel @Inject constructor(
         if (!settings.showEmptyFiltersListTooltip.value) return
         if (filters.size > 2) return
 
-        val requiredUuids = setOf(NEW_RELEASE_UUID, IN_PROGRESS_UUID)
+        val requiredUuids = setOf(Playlist.NEW_RELEASES_UUID, Playlist.IN_PROGRESS_UUID)
         val filterUuids = filters.map { it.uuid }.toSet()
 
         if (filterUuids != requiredUuids) return

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/PlaylistDao.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/PlaylistDao.kt
@@ -26,6 +26,9 @@ abstract class PlaylistDao {
     @Upsert
     abstract suspend fun upsertSmartPlaylists(playlists: List<SmartPlaylist>)
 
+    @Query("SELECT uuid FROM smart_playlists")
+    abstract suspend fun getAllPlaylistUuids(): List<String>
+
     @Query("SELECT * FROM smart_playlists WHERE manual = 0 AND deleted = 0 AND draft = 0 ORDER BY sortPosition ASC")
     abstract fun observeSmartPlaylists(): Flow<List<SmartPlaylist>>
 

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/entity/SmartPlaylist.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/entity/SmartPlaylist.kt
@@ -20,31 +20,33 @@ data class SmartPlaylist(
     @PrimaryKey @ColumnInfo(name = "_id") var id: Long? = null,
     @ColumnInfo(name = "uuid") var uuid: String = "",
     @ColumnInfo(name = "title") var title: String = "",
+    @ColumnInfo(name = "iconId") var iconId: Int = 0,
     @ColumnInfo(name = "sortPosition") var sortPosition: Int? = null,
+    @ColumnInfo(name = "sortId") var sortType: PlaylistEpisodeSortType = PlaylistEpisodeSortType.NewestToOldest,
     @ColumnInfo(name = "manual") var manual: Boolean = false,
-    @ColumnInfo(name = "unplayed") var unplayed: Boolean = true,
-    @ColumnInfo(name = "partiallyPlayed") var partiallyPlayed: Boolean = true,
-    @ColumnInfo(name = "finished") var finished: Boolean = true,
-    @ColumnInfo(name = "audioVideo") var audioVideo: Int = AUDIO_VIDEO_FILTER_ALL,
-    @ColumnInfo(name = "allPodcasts") var allPodcasts: Boolean = true,
-    @ColumnInfo(name = "podcastUuids") var podcastUuids: String? = null,
-    @ColumnInfo(name = "downloaded") var downloaded: Boolean = true,
-    @ColumnInfo(name = "downloading") var downloading: Boolean = true,
-    @ColumnInfo(name = "notDownloaded") var notDownloaded: Boolean = true,
+    @ColumnInfo(name = "draft") var draft: Boolean = false, // Used when creating a new filter
+    @ColumnInfo(name = "deleted") var deleted: Boolean = false,
+    @ColumnInfo(name = "syncStatus") var syncStatus: Int = SYNC_STATUS_SYNCED,
+    // Auto download configuration
     @ColumnInfo(name = "autoDownload") var autoDownload: Boolean = false,
     @ColumnInfo(name = "autoDownloadWifiOnly") var autoDownloadUnmeteredOnly: Boolean = false,
     @ColumnInfo(name = "autoDownloadPowerOnly") var autoDownloadPowerOnly: Boolean = false,
-    @ColumnInfo(name = "sortId") var sortType: PlaylistEpisodeSortType = PlaylistEpisodeSortType.NewestToOldest,
-    @ColumnInfo(name = "iconId") var iconId: Int = 0,
+    @ColumnInfo(name = "autoDownloadLimit") var autodownloadLimit: Int = 10,
+    // Filter rules
+    @ColumnInfo(name = "unplayed") var unplayed: Boolean = true,
+    @ColumnInfo(name = "partiallyPlayed") var partiallyPlayed: Boolean = true,
+    @ColumnInfo(name = "finished") var finished: Boolean = true,
+    @ColumnInfo(name = "downloaded") var downloaded: Boolean = true,
+    @ColumnInfo(name = "notDownloaded") var notDownloaded: Boolean = true,
+    @ColumnInfo(name = "downloading") var downloading: Boolean = true, // Legacy field
+    @ColumnInfo(name = "audioVideo") var audioVideo: Int = AUDIO_VIDEO_FILTER_ALL,
     @ColumnInfo(name = "filterHours") var filterHours: Int = 0,
     @ColumnInfo(name = "starred") var starred: Boolean = false,
-    @ColumnInfo(name = "deleted") var deleted: Boolean = false,
-    @ColumnInfo(name = "syncStatus") var syncStatus: Int = SYNC_STATUS_SYNCED,
-    @ColumnInfo(name = "autoDownloadLimit") var autodownloadLimit: Int = 10,
+    @ColumnInfo(name = "allPodcasts") var allPodcasts: Boolean = true,
+    @ColumnInfo(name = "podcastUuids") var podcastUuids: String? = null,
     @ColumnInfo(name = "filterDuration") var filterDuration: Boolean = false,
     @ColumnInfo(name = "longerThan") var longerThan: Int = 20,
     @ColumnInfo(name = "shorterThan") var shorterThan: Int = 40,
-    @ColumnInfo(name = "draft") var draft: Boolean = false, // Used when creating a new filter
 ) : Serializable {
     companion object {
         const val AUDIO_VIDEO_FILTER_ALL = 0

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/di/InitializerEntryPoint.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/di/InitializerEntryPoint.kt
@@ -1,0 +1,16 @@
+package au.com.shiftyjelly.pocketcasts.repositories.di
+
+import android.content.Context
+import au.com.shiftyjelly.pocketcasts.repositories.playlist.DefaultPlaylistsStartupInitializater
+import dagger.hilt.EntryPoint
+import dagger.hilt.InstallIn
+import dagger.hilt.android.EntryPointAccessors
+import dagger.hilt.components.SingletonComponent
+
+@EntryPoint
+@InstallIn(SingletonComponent::class)
+interface InitializerEntryPoint {
+    fun inject(initializer: DefaultPlaylistsStartupInitializater)
+}
+
+internal fun Context.initialzierEntryPoint() = EntryPointAccessors.fromApplication<InitializerEntryPoint>(this)

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playlist/DefaultPlaylistsInitializater.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playlist/DefaultPlaylistsInitializater.kt
@@ -1,0 +1,35 @@
+package au.com.shiftyjelly.pocketcasts.repositories.playlist
+
+import android.content.Context
+import androidx.work.CoroutineWorker
+import androidx.work.Data
+import androidx.work.ExistingWorkPolicy
+import androidx.work.OneTimeWorkRequestBuilder
+import androidx.work.WorkManager
+import androidx.work.WorkerParameters
+import au.com.shiftyjelly.pocketcasts.preferences.Settings
+import dagger.assisted.Assisted
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+
+@Singleton
+class DefaultPlaylistsInitializater @Inject constructor(
+    private val settings: Settings,
+    private val playlistManager: PlaylistManager,
+) {
+    private val mutex = Mutex()
+
+    suspend fun initialize(force: Boolean = false) = mutex.withLock {
+        if (force || !settings.getBooleanForKey(CREATED_DEFAULT_PLAYLISTS_KEY, false)) {
+            playlistManager.createPlaylist(PlaylistDraft.NewReleases)
+            playlistManager.createPlaylist(PlaylistDraft.InProgress)
+            settings.setBooleanForKey(CREATED_DEFAULT_PLAYLISTS_KEY, true)
+        }
+    }
+
+    companion object {
+        private const val CREATED_DEFAULT_PLAYLISTS_KEY = "createdDefaultPlaylists"
+    }
+}

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playlist/DefaultPlaylistsStartupInitializater.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playlist/DefaultPlaylistsStartupInitializater.kt
@@ -1,0 +1,26 @@
+package au.com.shiftyjelly.pocketcasts.repositories.playlist
+
+import android.content.Context
+import androidx.startup.Initializer
+import au.com.shiftyjelly.pocketcasts.repositories.di.ApplicationScope
+import au.com.shiftyjelly.pocketcasts.repositories.di.initialzierEntryPoint
+import javax.inject.Inject
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.launch
+
+class DefaultPlaylistsStartupInitializater : Initializer<Unit> {
+    @Inject lateinit var initializater: DefaultPlaylistsInitializater
+
+    @Inject @ApplicationScope
+    lateinit var applicationScope: CoroutineScope
+
+    override fun create(context: Context) {
+        context.initialzierEntryPoint().inject(this)
+        applicationScope.launch(NonCancellable) {
+            initializater.initialize()
+        }
+    }
+
+    override fun dependencies() = emptyList<Class<out Initializer<*>>>()
+}

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playlist/Playlist.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playlist/Playlist.kt
@@ -1,0 +1,8 @@
+package au.com.shiftyjelly.pocketcasts.repositories.playlist
+
+sealed interface Playlist {
+    companion object {
+        const val NEW_RELEASES_UUID = "2797DCF8-1C93-4999-B52A-D1849736FA2C"
+        const val IN_PROGRESS_UUID = "D89A925C-5CE1-41A4-A879-2751838CE5CE"
+    }
+}

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playlist/PlaylistDraft.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playlist/PlaylistDraft.kt
@@ -1,0 +1,31 @@
+package au.com.shiftyjelly.pocketcasts.repositories.playlist
+
+import au.com.shiftyjelly.pocketcasts.models.type.SmartRules
+import au.com.shiftyjelly.pocketcasts.models.type.SmartRules.EpisodeStatusRule
+import au.com.shiftyjelly.pocketcasts.models.type.SmartRules.ReleaseDateRule
+
+data class PlaylistDraft(
+    val title: String,
+    val rules: SmartRules,
+) {
+    companion object {
+        val NewReleases = PlaylistDraft(
+            title = "New Releases",
+            rules = SmartRules.Default.copy(
+                releaseDate = ReleaseDateRule.Last2Weeks,
+            ),
+        )
+
+        val InProgress = PlaylistDraft(
+            title = "In Progress",
+            rules = SmartRules.Default.copy(
+                episodeStatus = EpisodeStatusRule(
+                    unplayed = false,
+                    inProgress = true,
+                    completed = false,
+                ),
+                releaseDate = ReleaseDateRule.LastMonth,
+            ),
+        )
+    }
+}

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playlist/PlaylistManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playlist/PlaylistManager.kt
@@ -6,4 +6,6 @@ interface PlaylistManager {
     fun observePlaylistsPreview(): Flow<List<PlaylistPreview>>
 
     suspend fun deletePlaylist(uuid: String)
+
+    suspend fun createPlaylist(draft: PlaylistDraft)
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playlist/PlaylistManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playlist/PlaylistManagerImpl.kt
@@ -1,9 +1,28 @@
 package au.com.shiftyjelly.pocketcasts.repositories.playlist
 
-import au.com.shiftyjelly.pocketcasts.models.db.dao.PlaylistDao
+import androidx.room.withTransaction
+import au.com.shiftyjelly.pocketcasts.models.db.AppDatabase
 import au.com.shiftyjelly.pocketcasts.models.entity.SmartPlaylist
+import au.com.shiftyjelly.pocketcasts.models.entity.SmartPlaylist.Companion.ANYTIME
+import au.com.shiftyjelly.pocketcasts.models.entity.SmartPlaylist.Companion.AUDIO_VIDEO_FILTER_ALL
+import au.com.shiftyjelly.pocketcasts.models.entity.SmartPlaylist.Companion.AUDIO_VIDEO_FILTER_AUDIO_ONLY
+import au.com.shiftyjelly.pocketcasts.models.entity.SmartPlaylist.Companion.AUDIO_VIDEO_FILTER_VIDEO_ONLY
+import au.com.shiftyjelly.pocketcasts.models.entity.SmartPlaylist.Companion.LAST_24_HOURS
+import au.com.shiftyjelly.pocketcasts.models.entity.SmartPlaylist.Companion.LAST_2_WEEKS
+import au.com.shiftyjelly.pocketcasts.models.entity.SmartPlaylist.Companion.LAST_3_DAYS
+import au.com.shiftyjelly.pocketcasts.models.entity.SmartPlaylist.Companion.LAST_MONTH
+import au.com.shiftyjelly.pocketcasts.models.entity.SmartPlaylist.Companion.LAST_WEEK
+import au.com.shiftyjelly.pocketcasts.models.entity.SmartPlaylist.Companion.SYNC_STATUS_NOT_SYNCED
+import au.com.shiftyjelly.pocketcasts.models.entity.SmartPlaylist.Companion.SYNC_STATUS_SYNCED
 import au.com.shiftyjelly.pocketcasts.models.type.SmartRules
+import au.com.shiftyjelly.pocketcasts.models.type.SmartRules.DownloadStatusRule
+import au.com.shiftyjelly.pocketcasts.models.type.SmartRules.EpisodeDurationRule
+import au.com.shiftyjelly.pocketcasts.models.type.SmartRules.MediaTypeRule
+import au.com.shiftyjelly.pocketcasts.models.type.SmartRules.PodcastsRule
+import au.com.shiftyjelly.pocketcasts.models.type.SmartRules.ReleaseDateRule
+import au.com.shiftyjelly.pocketcasts.models.type.SmartRules.StarredRule
 import java.time.Clock
+import java.util.UUID
 import javax.inject.Inject
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.minutes
@@ -19,9 +38,11 @@ import kotlinx.coroutines.flow.flowOf
 
 @OptIn(ExperimentalCoroutinesApi::class, FlowPreview::class)
 class PlaylistManagerImpl @Inject constructor(
-    private val playlistDao: PlaylistDao,
+    private val appDatabase: AppDatabase,
     private val clock: Clock,
 ) : PlaylistManager {
+    private val playlistDao = appDatabase.playlistDao()
+
     override fun observePlaylistsPreview(): Flow<List<PlaylistPreview>> {
         return playlistDao
             .observeSmartPlaylists()
@@ -42,6 +63,21 @@ class PlaylistManagerImpl @Inject constructor(
 
     override suspend fun deletePlaylist(uuid: String) {
         playlistDao.markPlaylistAsDeleted(uuid)
+    }
+
+    override suspend fun createPlaylist(draft: PlaylistDraft) {
+        appDatabase.withTransaction {
+            val uuids = playlistDao.getAllPlaylistUuids()
+            val uuid = if (draft === PlaylistDraft.NewReleases) {
+                Playlist.NEW_RELEASES_UUID
+            } else if (draft === PlaylistDraft.InProgress) {
+                Playlist.IN_PROGRESS_UUID
+            } else {
+                generateUniqueUuid(uuids)
+            }
+            val playlist = draft.toSmartPlaylist(uuid, sortPosition = uuids.size + 1)
+            playlistDao.upsertSmartPlaylist(playlist)
+        }
     }
 
     private fun List<SmartPlaylist>.toPreviewFlows() = map { playlist ->
@@ -73,43 +109,121 @@ class PlaylistManagerImpl @Inject constructor(
                 completed = finished,
             ),
             downloadStatus = when {
-                downloaded && notDownloaded -> SmartRules.DownloadStatusRule.Any
-                downloaded -> SmartRules.DownloadStatusRule.Downloaded
-                notDownloaded -> SmartRules.DownloadStatusRule.NotDownloaded
-                else -> SmartRules.DownloadStatusRule.Any
+                downloaded && notDownloaded -> DownloadStatusRule.Any
+                downloaded -> DownloadStatusRule.Downloaded
+                notDownloaded -> DownloadStatusRule.NotDownloaded
+                else -> DownloadStatusRule.Any
             },
             mediaType = when (audioVideo) {
-                SmartPlaylist.AUDIO_VIDEO_FILTER_AUDIO_ONLY -> SmartRules.MediaTypeRule.Audio
-                SmartPlaylist.AUDIO_VIDEO_FILTER_VIDEO_ONLY -> SmartRules.MediaTypeRule.Video
-                else -> SmartRules.MediaTypeRule.Any
+                AUDIO_VIDEO_FILTER_AUDIO_ONLY -> MediaTypeRule.Audio
+                AUDIO_VIDEO_FILTER_VIDEO_ONLY -> MediaTypeRule.Video
+                else -> MediaTypeRule.Any
             },
             releaseDate = when (filterHours) {
-                SmartPlaylist.LAST_24_HOURS -> SmartRules.ReleaseDateRule.Last24Hours
-                SmartPlaylist.LAST_3_DAYS -> SmartRules.ReleaseDateRule.Last3Days
-                SmartPlaylist.LAST_WEEK -> SmartRules.ReleaseDateRule.LastWeek
-                SmartPlaylist.LAST_2_WEEKS -> SmartRules.ReleaseDateRule.Last2Weeks
-                SmartPlaylist.LAST_MONTH -> SmartRules.ReleaseDateRule.LastMonth
-                else -> SmartRules.ReleaseDateRule.AnyTime
+                LAST_24_HOURS -> ReleaseDateRule.Last24Hours
+                LAST_3_DAYS -> ReleaseDateRule.Last3Days
+                LAST_WEEK -> ReleaseDateRule.LastWeek
+                LAST_2_WEEKS -> ReleaseDateRule.Last2Weeks
+                LAST_MONTH -> ReleaseDateRule.LastMonth
+                else -> ReleaseDateRule.AnyTime
             },
             starred = if (starred) {
-                SmartRules.StarredRule.Starred
+                StarredRule.Starred
             } else {
-                SmartRules.StarredRule.Any
+                StarredRule.Any
             },
             podcastsRule = if (podcastUuidList.isEmpty()) {
-                SmartRules.PodcastsRule.Any
+                PodcastsRule.Any
             } else {
-                SmartRules.PodcastsRule.Selected(podcastUuidList)
+                PodcastsRule.Selected(podcastUuidList)
             },
             episodeDuration = if (filterDuration) {
-                SmartRules.EpisodeDurationRule.Constrained(
+                EpisodeDurationRule.Constrained(
                     longerThan = longerThan.minutes,
                     shorterThan = shorterThan.minutes + 59.seconds,
                 )
             } else {
-                SmartRules.EpisodeDurationRule.Any
+                EpisodeDurationRule.Any
             },
         )
+
+    private fun PlaylistDraft.toSmartPlaylist(
+        uuid: String,
+        sortPosition: Int,
+    ) = SmartPlaylist(
+        uuid = uuid,
+        title = title,
+        // We use referential equality so only predefined playlists use preset icons
+        iconId = if (this === PlaylistDraft.NewReleases) {
+            10 // Red clock
+        } else if (this === PlaylistDraft.InProgress) {
+            43 // Purple play
+        } else {
+            0
+        },
+        sortPosition = sortPosition,
+        manual = false,
+        draft = false,
+        deleted = false,
+        // We use referential equality so only predefined playlists are synced by default
+        syncStatus = if (this === PlaylistDraft.NewReleases || this === PlaylistDraft.InProgress) {
+            SYNC_STATUS_SYNCED
+        } else {
+            SYNC_STATUS_NOT_SYNCED
+        },
+        unplayed = rules.episodeStatus.unplayed,
+        partiallyPlayed = rules.episodeStatus.inProgress,
+        finished = rules.episodeStatus.completed,
+        downloaded = rules.downloadStatus in listOf(DownloadStatusRule.Downloaded, DownloadStatusRule.Any),
+        notDownloaded = rules.downloadStatus in listOf(DownloadStatusRule.NotDownloaded, DownloadStatusRule.Any),
+        downloading = rules.downloadStatus in listOf(DownloadStatusRule.NotDownloaded, DownloadStatusRule.Any),
+        audioVideo = when (rules.mediaType) {
+            MediaTypeRule.Any -> AUDIO_VIDEO_FILTER_ALL
+            MediaTypeRule.Audio -> AUDIO_VIDEO_FILTER_AUDIO_ONLY
+            MediaTypeRule.Video -> AUDIO_VIDEO_FILTER_VIDEO_ONLY
+        },
+        filterHours = when (rules.releaseDate) {
+            ReleaseDateRule.AnyTime -> ANYTIME
+            ReleaseDateRule.Last24Hours -> LAST_24_HOURS
+            ReleaseDateRule.Last3Days -> LAST_3_DAYS
+            ReleaseDateRule.LastWeek -> LAST_WEEK
+            ReleaseDateRule.Last2Weeks -> LAST_2_WEEKS
+            ReleaseDateRule.LastMonth -> LAST_MONTH
+        },
+        starred = when (rules.starred) {
+            StarredRule.Any -> false
+            StarredRule.Starred -> true
+        },
+        allPodcasts = when (rules.podcastsRule) {
+            is PodcastsRule.Any -> true
+            is PodcastsRule.Selected -> false
+        },
+        podcastUuids = when (val rule = rules.podcastsRule) {
+            is PodcastsRule.Any -> null
+            is PodcastsRule.Selected -> rule.uuids.joinToString(separator = ",")
+        },
+        filterDuration = when (rules.episodeDuration) {
+            is EpisodeDurationRule.Any -> false
+            is EpisodeDurationRule.Constrained -> true
+        },
+        longerThan = when (val rule = rules.episodeDuration) {
+            is EpisodeDurationRule.Any -> 20
+            is EpisodeDurationRule.Constrained -> rule.longerThan.inWholeMinutes.toInt()
+        },
+        shorterThan = when (val rule = rules.episodeDuration) {
+            is EpisodeDurationRule.Any -> 40
+            is EpisodeDurationRule.Constrained -> rule.shorterThan.inWholeMinutes.toInt()
+        },
+    )
+
+    private tailrec fun generateUniqueUuid(uuids: List<String>): String {
+        val uuid = UUID.randomUUID().toString()
+        return if (uuids.none { it.equals(uuid, ignoreCase = true) }) {
+            uuid
+        } else {
+            generateUniqueUuid(uuids)
+        }
+    }
 
     private companion object {
         const val PLAYLIST_ARTWORK_EPISODE_LIMIT = 4

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/user/UserManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/user/UserManager.kt
@@ -17,6 +17,7 @@ import au.com.shiftyjelly.pocketcasts.repositories.notification.NotificationSche
 import au.com.shiftyjelly.pocketcasts.repositories.notification.TrendingAndRecommendationsNotificationType
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
 import au.com.shiftyjelly.pocketcasts.repositories.playback.UpNextQueue
+import au.com.shiftyjelly.pocketcasts.repositories.playlist.DefaultPlaylistsInitializater
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.FolderManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/SmartPlaylistEpisodeSortTypeManagerImplTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/SmartPlaylistEpisodeSortTypeManagerImplTest.kt
@@ -74,6 +74,7 @@ class SmartPlaylistEpisodeSortTypeManagerImplTest {
             notificationManager = notificationManager,
             context = context,
             appDatabase = appDatabase,
+            playlistsInitializater = mock(),
         )
     }
 }

--- a/wear/src/main/AndroidManifest.xml
+++ b/wear/src/main/AndroidManifest.xml
@@ -98,6 +98,9 @@
             android:authorities="${applicationId}.androidx-startup"
             android:exported="false"
             tools:node="merge">
+            <meta-data
+                android:name="au.com.shiftyjelly.pocketcasts.repositories.playlist.DefaultPlaylistsStartupInitializater"
+                android:value="androidx.startup" />
             <!-- If you are using androidx.startup to initialize other components -->
             <meta-data
                 android:name="androidx.work.WorkManagerInitializer"


### PR DESCRIPTION
## Description

This PR adds logic for Smart Playlist creation.

- `PlaylistManager` now maps from the `PlaylistDraft` type to the `SmartPlaylist` database model, including logic for default playlists.
- Default playlist creation logic has been moved out of `SmartPlaylistManager` to allow for practical testing of the new implementation.

## Testing Instructions

1. Install fresh app.
2. You should see "New Releases" and "In Progress" playlists.

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.