### PR TITLE
Add drag & drop support to playlists

### DIFF
--- a/modules/features/filters/build.gradle.kts
+++ b/modules/features/filters/build.gradle.kts
@@ -52,6 +52,7 @@ dependencies {
     implementation(libs.fragment.compose)
     implementation(libs.fragment.ktx)
     implementation(libs.lifecycle.reactivestreams.ktx)
+    implementation(libs.reorderable)
     implementation(libs.rx2.android)
     implementation(libs.rx2.kotlin)
     implementation(libs.timber)

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/PlaylistPreviewRow.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/PlaylistPreviewRow.kt
@@ -163,7 +163,7 @@ fun PlaylistPreviewRow(
                     orientation = Orientation.Horizontal,
                     enabled = draggableState.currentValue != SwipeToDeleteAnchor.Delete,
                 )
-                .background(MaterialTheme.theme.colors.primaryUi02)
+                .background(MaterialTheme.theme.colors.primaryUi01)
                 .semantics(mergeDescendants = true) {},
         ) {
             Row(

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/PlaylistsFragment.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/PlaylistsFragment.kt
@@ -49,7 +49,6 @@ class PlaylistsFragment :
                 onCreatePlaylist = { Timber.i("Create playlist clicked") },
                 onDeletePlaylist = { playlist -> viewModel.deletePlaylist(playlist.uuid) },
                 onReorderPlaylists = viewModel::updatePlaylistsOrder,
-                onShowOptions = { Timber.i("Show playlists options clicked") },
                 onFreeAccountBannerCtaClick = {
                     viewModel.trackFreeAccountCtaClick()
                     OnboardingLauncher.openOnboardingFlow(

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/PlaylistsFragment.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/PlaylistsFragment.kt
@@ -48,7 +48,7 @@ class PlaylistsFragment :
                 listState = listState,
                 onCreatePlaylist = { Timber.i("Create playlist clicked") },
                 onDeletePlaylist = { playlist -> viewModel.deletePlaylist(playlist.uuid) },
-                onReorderPlaylists = viewModel::updatePlaylistPosition,
+                onReorderPlaylists = viewModel::updatePlaylistsOrder,
                 onShowOptions = { Timber.i("Show playlists options clicked") },
                 onFreeAccountBannerCtaClick = {
                     viewModel.trackFreeAccountCtaClick()

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/PlaylistsFragment.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/PlaylistsFragment.kt
@@ -48,6 +48,7 @@ class PlaylistsFragment :
                 listState = listState,
                 onCreatePlaylist = { Timber.i("Create playlist clicked") },
                 onDeletePlaylist = { playlist -> viewModel.deletePlaylist(playlist.uuid) },
+                onReorderPlaylists = viewModel::updatePlaylistPosition,
                 onShowOptions = { Timber.i("Show playlists options clicked") },
                 onFreeAccountBannerCtaClick = {
                     viewModel.trackFreeAccountCtaClick()

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/PlaylistsPage.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/PlaylistsPage.kt
@@ -56,7 +56,6 @@ internal fun PlaylistsPage(
     onCreatePlaylist: () -> Unit,
     onDeletePlaylist: (PlaylistPreview) -> Unit,
     onReorderPlaylists: (List<String>) -> Unit,
-    onShowOptions: () -> Unit,
     onFreeAccountBannerCtaClick: () -> Unit,
     onFreeAccountBannerDismiss: () -> Unit,
     modifier: Modifier = Modifier,
@@ -71,7 +70,6 @@ internal fun PlaylistsPage(
         Toolbar(
             showActionButtons = !uiState.showEmptyState,
             onCreatePlaylist = onCreatePlaylist,
-            onShowOptions = onShowOptions,
         )
 
         FreeAccountBanner(
@@ -210,7 +208,6 @@ private fun ColumnScope.NoPlaylistsContent(
 private fun Toolbar(
     showActionButtons: Boolean,
     onCreatePlaylist: () -> Unit,
-    onShowOptions: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     ThemedTopAppBar(
@@ -228,22 +225,6 @@ private fun Toolbar(
                     Icon(
                         painter = painterResource(IR.drawable.ic_add_black_24dp),
                         contentDescription = stringResource(LR.string.new_playlist),
-                        tint = MaterialTheme.theme.colors.secondaryIcon01,
-                    )
-                }
-            }
-
-            AnimatedVisibility(
-                visible = showActionButtons,
-                enter = FadeIn,
-                exit = FadeOut,
-            ) {
-                IconButton(
-                    onClick = onShowOptions,
-                ) {
-                    Icon(
-                        painter = painterResource(IR.drawable.ic_overflow),
-                        contentDescription = stringResource(LR.string.options),
                         tint = MaterialTheme.theme.colors.secondaryIcon01,
                     )
                 }
@@ -299,7 +280,6 @@ private fun PlaylistsPageEmptyStatePreview() {
             ),
             onCreatePlaylist = {},
             onDeletePlaylist = {},
-            onShowOptions = {},
             onFreeAccountBannerCtaClick = {},
             onFreeAccountBannerDismiss = {},
             onReorderPlaylists = {},
@@ -320,7 +300,6 @@ private fun PlaylistsPageEmptyStateNoBannerPreview() {
             ),
             onCreatePlaylist = {},
             onDeletePlaylist = {},
-            onShowOptions = {},
             onFreeAccountBannerCtaClick = {},
             onFreeAccountBannerDismiss = {},
             onReorderPlaylists = {},
@@ -352,7 +331,6 @@ private fun PlaylistPagePreview(
             ),
             onCreatePlaylist = {},
             onDeletePlaylist = {},
-            onShowOptions = {},
             onFreeAccountBannerCtaClick = {},
             onFreeAccountBannerDismiss = {},
             onReorderPlaylists = {},

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/PlaylistsPage.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/PlaylistsPage.kt
@@ -17,7 +17,6 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.LazyListItemInfo
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
@@ -27,12 +26,6 @@ import androidx.compose.material.Icon
 import androidx.compose.material.IconButton
 import androidx.compose.material.MaterialTheme
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalDensity
@@ -47,18 +40,13 @@ import au.com.shiftyjelly.pocketcasts.compose.bars.ThemedTopAppBar
 import au.com.shiftyjelly.pocketcasts.compose.components.Banner
 import au.com.shiftyjelly.pocketcasts.compose.components.NoContentBanner
 import au.com.shiftyjelly.pocketcasts.compose.preview.ThemePreviewParameterProvider
-import au.com.shiftyjelly.pocketcasts.compose.reorderable.rememberReorderableDataSource
+import au.com.shiftyjelly.pocketcasts.compose.reorderable.rememberReorderableLazyListDataSource
 import au.com.shiftyjelly.pocketcasts.compose.theme
 import au.com.shiftyjelly.pocketcasts.playlists.PlaylistsViewModel.PlaylistsState
 import au.com.shiftyjelly.pocketcasts.playlists.PlaylistsViewModel.UiState
-import au.com.shiftyjelly.pocketcasts.repositories.playlist.Playlist
 import au.com.shiftyjelly.pocketcasts.repositories.playlist.PlaylistPreview
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme.ThemeType
-import kotlinx.coroutines.channels.Channel
-import kotlinx.coroutines.delay
 import sh.calvin.reorderable.ReorderableItem
-import sh.calvin.reorderable.rememberReorderableLazyListState
-import timber.log.Timber
 import au.com.shiftyjelly.pocketcasts.images.R as IR
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
@@ -158,15 +146,10 @@ private fun PlaylistsColumn(
     onReorderPlaylists: (List<String>) -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    val (displayItems, reorderableState) = rememberReorderableDataSource(
+    val (displayItems, reorderableState) = rememberReorderableLazyListDataSource(
+        listState = listState,
         items = playlists,
-        keyOf = PlaylistPreview::uuid,
-        rememberState = { onMove ->
-            rememberReorderableLazyListState(listState) { from, to ->
-                onMove(from, to)
-            }
-        },
-        getIndex = LazyListItemInfo::index,
+        itemKey = PlaylistPreview::uuid,
         onCommit = { orderedList ->
             onReorderPlaylists(orderedList.map(PlaylistPreview::uuid))
         },

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/PlaylistsViewModel.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/PlaylistsViewModel.kt
@@ -4,8 +4,6 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTracker
-import au.com.shiftyjelly.pocketcasts.models.entity.SmartPlaylist
-import au.com.shiftyjelly.pocketcasts.models.entity.SmartPlaylist.Companion.SYNC_STATUS_NOT_SYNCED
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.repositories.playlist.PlaylistManager
 import au.com.shiftyjelly.pocketcasts.repositories.playlist.PlaylistPreview
@@ -14,15 +12,12 @@ import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
 import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.reactive.asFlow
-import timber.log.Timber
 
 @HiltViewModel
 class PlaylistsViewModel @Inject constructor(
@@ -68,9 +63,9 @@ class PlaylistsViewModel @Inject constructor(
         settings.isFreeAccountFiltersBannerDismissed.set(true, updateModifiedAt = true)
     }
 
-    fun updatePlaylistPosition(playlistUuids: List<String>) {
+    fun updatePlaylistsOrder(playlistUuids: List<String>) {
         viewModelScope.launch {
-            playlistManager.updatePlaylistPosition(playlistUuids)
+            playlistManager.updatePlaylistsOrder(playlistUuids)
         }
     }
 

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/PlaylistsViewModel.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/PlaylistsViewModel.kt
@@ -4,6 +4,8 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTracker
+import au.com.shiftyjelly.pocketcasts.models.entity.SmartPlaylist
+import au.com.shiftyjelly.pocketcasts.models.entity.SmartPlaylist.Companion.SYNC_STATUS_NOT_SYNCED
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.repositories.playlist.PlaylistManager
 import au.com.shiftyjelly.pocketcasts.repositories.playlist.PlaylistPreview
@@ -12,12 +14,15 @@ import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
 import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.reactive.asFlow
+import timber.log.Timber
 
 @HiltViewModel
 class PlaylistsViewModel @Inject constructor(
@@ -61,6 +66,12 @@ class PlaylistsViewModel @Inject constructor(
     fun dismissFreeAccountBanner() {
         analyticsTracker.track(AnalyticsEvent.INFORMATIONAL_BANNER_VIEW_DISMISSED, mapOf("source" to "filters"))
         settings.isFreeAccountFiltersBannerDismissed.set(true, updateModifiedAt = true)
+    }
+
+    fun updatePlaylistPosition(playlistUuids: List<String>) {
+        viewModelScope.launch {
+            playlistManager.updatePlaylistPosition(playlistUuids)
+        }
     }
 
     internal data class UiState(

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/reorderable/ReorderableDataSource.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/reorderable/ReorderableDataSource.kt
@@ -1,0 +1,130 @@
+package au.com.shiftyjelly.pocketcasts.compose.reorderable
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.setValue
+import kotlinx.coroutines.CoroutineScope
+import sh.calvin.reorderable.ReorderableLazyCollectionState
+import timber.log.Timber
+
+// Author: Evtim - https://github.com/Calvin-LL/Reorderable/issues/88#issuecomment-3030356851
+/**
+ * Provides a drag-aware data source for use with Calvin-LL's reorderable components.
+ *
+ * Maintains a working order of [items] during drag, and invokes [onCommit] with the final
+ * reordered list after drag completion. While dragging or commit is pending, the reordered
+ * view is returned; otherwise, the original [items] list is returned.
+ *
+ * The reorderable state is always created, but drag handling is bypassed when [enabled] is false.
+ *
+ * @param T Item type.
+ * @param K Stable key type for identifying items.
+ * @param I Identity type used by the reorderable state (e.g., ItemPosition).
+ * @param S Reorderable state type.
+ * @param items Source list.
+ * @param enabled Enables or disables drag handling.
+ * @param keyOf Extracts a stable key from each item.
+ * @param rememberState Factory for the reorderable state with an onMove handler.
+ * @param getIndex Maps reorderable identity to index.
+ * @param onCommit Called after drag ends with the final reordered list.
+ *
+ * @return Pair of the display list and the reorderable state.
+ */
+@Composable
+fun <T : Any, K : Any, I : Any, S : ReorderableLazyCollectionState<I>> rememberReorderableDataSource(
+    items: List<T>,
+    keyOf: (T) -> K,
+    rememberState: @Composable (onMove: CoroutineScope.(I, I) -> Unit) -> S,
+    getIndex: (I) -> Int,
+    onCommit: (List<T>) -> Unit,
+    enabled: Boolean = true,
+): Pair<List<T>, S> {
+    // key -> element lookup for fast remapping
+    var keyToItem by remember { mutableStateOf(mapOf<K, T>()) }
+
+    // key order that mutates during drag
+    var workingOrder by remember { mutableStateOf(listOf<K>()) }
+
+    // Instantiate the reorderState
+    val reorderState = rememberState { from, to ->
+        // Reorder
+        workingOrder = workingOrder.toMutableList().apply {
+            val toIndex = getIndex(to)
+            val fromIndex = getIndex(from)
+            try {
+                add(toIndex, removeAt(fromIndex))
+            } catch (e: Throwable) {
+                Timber.tag("ReorderableDataSource").i("onMove failed: $e")
+            }
+        }
+    }
+
+    if (!enabled) {
+        return items to reorderState
+    }
+
+    // The data source state
+    var sourceState by remember { mutableStateOf(ReorderableDataSourceState.Normal) }
+
+    // Update the source state on drag start/stop
+    val isDragging = reorderState.isAnyItemDragging
+    LaunchedEffect(isDragging, onCommit) {
+        // Update state based on dragging
+        if (isDragging) {
+            // Updater workingOrder to latest snapshot if not dragging
+            if (sourceState == ReorderableDataSourceState.Normal) {
+                workingOrder = items.map(keyOf)
+                keyToItem = items.associateBy(keyOf)
+            }
+            // Update state
+            sourceState = ReorderableDataSourceState.Dragging
+        } else if (sourceState == ReorderableDataSourceState.Dragging) {
+            // Commit
+            onCommit(workingOrder.mapNotNull { keyToItem[it] })
+            sourceState = ReorderableDataSourceState.PendingRefresh
+        }
+    }
+
+    // Monitor items changes in order to switch to Normal. We do this
+    // because after commit on drag stop, we don't want to emit the original items
+    // before the commit had a chance to recompose us with the updated items. We do this
+    // in order to avoid flicker caused by transient resetting to the original unordered items
+    // before the commited changes come through.
+    //
+    // Note that in case the commit did not update the items, we will stay in PendingRefresh
+    // state until down the line either items changes, or another drag is started
+    LaunchedEffect(items) {
+        // Are we waiting a refresh?
+        if (sourceState == ReorderableDataSourceState.PendingRefresh) {
+            // items have changes, switch the state back to normal
+            sourceState = ReorderableDataSourceState.Normal
+        }
+    }
+
+    // Keep the original items in an updated state
+    val originalItems by rememberUpdatedState(items)
+
+    // Derive display items from all of the data
+    val display by remember {
+        derivedStateOf {
+            if (sourceState == ReorderableDataSourceState.Normal) {
+                originalItems
+            } else {
+                workingOrder.mapNotNull { keyToItem[it] }
+            }
+        }
+    }
+
+    return display to reorderState
+}
+
+private enum class ReorderableDataSourceState {
+    Normal,
+    Dragging,
+    PendingRefresh,
+}

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/PlaylistDao.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/PlaylistDao.kt
@@ -32,6 +32,9 @@ abstract class PlaylistDao {
     @Query("SELECT * FROM smart_playlists WHERE manual = 0 AND deleted = 0 AND draft = 0 ORDER BY sortPosition ASC")
     abstract fun observeSmartPlaylists(): Flow<List<SmartPlaylist>>
 
+    @Query("SELECT * FROM smart_playlists WHERE manual = 0 AND deleted = 0 AND draft = 0 ORDER BY sortPosition ASC")
+    abstract suspend fun getSmartPlaylists(): List<SmartPlaylist>
+
     @Query("UPDATE smart_playlists SET deleted = 1, syncStatus = ${SYNC_STATUS_NOT_SYNCED} WHERE uuid = :uuid")
     abstract suspend fun markPlaylistAsDeleted(uuid: String)
 

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playlist/PlaylistManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playlist/PlaylistManager.kt
@@ -8,4 +8,6 @@ interface PlaylistManager {
     suspend fun deletePlaylist(uuid: String)
 
     suspend fun upsertPlaylist(draft: PlaylistDraft)
+
+    suspend fun updatePlaylistPosition(playlistUuids: List<String>)
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playlist/PlaylistManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playlist/PlaylistManager.kt
@@ -9,5 +9,5 @@ interface PlaylistManager {
 
     suspend fun upsertPlaylist(draft: PlaylistDraft)
 
-    suspend fun updatePlaylistPosition(playlistUuids: List<String>)
+    suspend fun updatePlaylistsOrder(sortedUuids: List<String>)
 }


### PR DESCRIPTION
## Description

As the title says this allows to reorder playlists.

There are also some minor UI changes:
- Playlist item uses the same background as the page.
- Removed options button from the toolbar.

Context: p1753384264236179/1753340297.132349-slack-C093RV9N8DR

## Testing Instructions

1. Disable playlists flag.
2. Close the app.
3. Create some filters.
4. Enable playlists flag.
5. Drag and drop playlists to reorder them.
6. Playlists order should sync between different devices.

## Screenshots or Screencast 

https://github.com/user-attachments/assets/99fc023e-868c-4919-89b9-a7929ec1a29a

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack