### PR TITLE
Add playlists legacy analytics events

### DIFF
--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/PlaylistPreviewRow.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/PlaylistPreviewRow.kt
@@ -46,10 +46,8 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.IntOffset
-import androidx.compose.ui.unit.coerceAtMost
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import androidx.compose.ui.window.PopupProperties
 import au.com.shiftyjelly.pocketcasts.compose.AppThemeWithBackground
 import au.com.shiftyjelly.pocketcasts.compose.components.HorizontalDivider
 import au.com.shiftyjelly.pocketcasts.compose.components.TextH40

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/PlaylistsFragment.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/PlaylistsFragment.kt
@@ -46,17 +46,22 @@ class PlaylistsFragment :
             PlaylistsPage(
                 uiState = uiState,
                 listState = listState,
-                onCreatePlaylist = { Timber.i("Create playlist clicked") },
+                onCreatePlaylist = {
+                    viewModel.trackCreatePlaylistClicked()
+                    Timber.i("Create playlist clicked")
+                },
                 onDeletePlaylist = { playlist -> viewModel.deletePlaylist(playlist.uuid) },
                 onReorderPlaylists = viewModel::updatePlaylistsOrder,
+                onShowPlaylists = { playlists -> viewModel.trackPlaylistsShown(playlists.size) },
                 onFreeAccountBannerCtaClick = {
-                    viewModel.trackFreeAccountCtaClick()
+                    viewModel.trackFreeAccountCtaClicked()
                     OnboardingLauncher.openOnboardingFlow(
                         activity = requireActivity(),
                         onboardingFlow = OnboardingFlow.LoggedOut,
                     )
                 },
                 onFreeAccountBannerDismiss = viewModel::dismissFreeAccountBanner,
+                onShowPremadePlaylistsTooltip = viewModel::trackTooltipShown,
                 onDismissPremadePlaylistsTooltip = viewModel::dismissPremadePlaylistsTooltip,
             )
         }

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/PlaylistsViewModel.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/PlaylistsViewModel.kt
@@ -54,26 +54,57 @@ class PlaylistsViewModel @Inject constructor(
     fun deletePlaylist(uuid: String) {
         viewModelScope.launch {
             playlistManager.deletePlaylist(uuid)
+            trackPlaylistDeleted()
         }
-    }
-
-    fun trackFreeAccountCtaClick() {
-        analyticsTracker.track(AnalyticsEvent.INFORMATIONAL_BANNER_VIEW_CREATE_ACCOUNT_TAP, mapOf("source" to "filters"))
-    }
-
-    fun dismissFreeAccountBanner() {
-        analyticsTracker.track(AnalyticsEvent.INFORMATIONAL_BANNER_VIEW_DISMISSED, mapOf("source" to "filters"))
-        settings.isFreeAccountFiltersBannerDismissed.set(true, updateModifiedAt = true)
     }
 
     fun updatePlaylistsOrder(playlistUuids: List<String>) {
         viewModelScope.launch {
             playlistManager.updatePlaylistsOrder(playlistUuids)
+            trackPlaylistsReodered()
         }
     }
 
+    fun dismissFreeAccountBanner() {
+        trackFreeAccountBannerDismissed()
+        settings.isFreeAccountFiltersBannerDismissed.set(true, updateModifiedAt = true)
+    }
+
     fun dismissPremadePlaylistsTooltip() {
+        trackTooltipDismissed()
         settings.showEmptyFiltersListTooltip.set(false, updateModifiedAt = false)
+    }
+
+    fun trackPlaylistsShown(playlistCount: Int) {
+        analyticsTracker.track(AnalyticsEvent.FILTER_LIST_SHOWN, mapOf("filter_count" to playlistCount))
+    }
+
+    fun trackPlaylistsReodered() {
+        analyticsTracker.track(AnalyticsEvent.FILTER_LIST_REORDERED)
+    }
+
+    fun trackPlaylistDeleted() {
+        analyticsTracker.track(AnalyticsEvent.FILTER_DELETED)
+    }
+
+    fun trackCreatePlaylistClicked() {
+        analyticsTracker.track(AnalyticsEvent.FILTER_CREATE_BUTTON_TAPPED)
+    }
+
+    fun trackTooltipShown() {
+        analyticsTracker.track(AnalyticsEvent.FILTER_TOOLTIP_SHOWN)
+    }
+
+    fun trackTooltipDismissed() {
+        analyticsTracker.track(AnalyticsEvent.FILTER_TOOLTIP_CLOSED)
+    }
+
+    fun trackFreeAccountCtaClicked() {
+        analyticsTracker.track(AnalyticsEvent.INFORMATIONAL_BANNER_VIEW_CREATE_ACCOUNT_TAP, mapOf("source" to "filters"))
+    }
+
+    fun trackFreeAccountBannerDismissed() {
+        analyticsTracker.track(AnalyticsEvent.INFORMATIONAL_BANNER_VIEW_DISMISSED, mapOf("source" to "filters"))
     }
 
     private fun shouldShowPremadePlaylistsTooltip(


### PR DESCRIPTION
## Description

This adds all the filters page analytics events to the playlists page.

Closes: #4211

## Testing Instructions

Verify that these events are tracked on the playlists page:
- `filters_tab_opened`
- `filter_list_shown`
- `filter_list_reordered`
- `filter_deleted`
- `filter_create_button_tapped`
- `filter_tootlip_shown`
- ~`filter_tooltip_closed`~ `filter_tooltip_shown`
- `informational_banner_view_create_account_tap`
- `informational_banner_view_dismissed`

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.