### PR TITLE
Add playlist creation page navigation

### DIFF
--- a/modules/features/filters/build.gradle.kts
+++ b/modules/features/filters/build.gradle.kts
@@ -45,6 +45,7 @@ dependencies {
     implementation(libs.coil.compose)
     implementation(libs.compose.material)
     implementation(libs.compose.material3.adaptive)
+    implementation(libs.navigation.compose)
     implementation(libs.compose.ui)
     implementation(libs.compose.ui.tooling.preview)
     implementation(libs.coroutines.core)

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/PlaylistsFragment.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/PlaylistsFragment.kt
@@ -10,6 +10,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.fragment.app.viewModels
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.lifecycleScope
 import au.com.shiftyjelly.pocketcasts.compose.AppThemeWithBackground
 import au.com.shiftyjelly.pocketcasts.compose.extensions.contentWithoutConsumedInsets
@@ -39,7 +40,7 @@ class PlaylistsFragment :
         savedInstanceState: Bundle?,
     ) = contentWithoutConsumedInsets {
         val listState = rememberLazyListState()
-        val uiState by viewModel.uiState.collectAsState()
+        val uiState by viewModel.uiState.collectAsStateWithLifecycle()
 
         getCanScrollBackward = { listState.canScrollBackward }
 

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/create/CreatePlaylistFragment.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/create/CreatePlaylistFragment.kt
@@ -14,12 +14,17 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.platform.rememberNestedScrollInteropConnection
-import androidx.compose.ui.text.TextRange
-import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.unit.dp
 import androidx.fragment.app.viewModels
 import androidx.fragment.compose.content
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+import androidx.navigation.compose.rememberNavController
 import au.com.shiftyjelly.pocketcasts.compose.AppThemeWithBackground
+import au.com.shiftyjelly.pocketcasts.compose.extensions.slideInToEnd
+import au.com.shiftyjelly.pocketcasts.compose.extensions.slideInToStart
+import au.com.shiftyjelly.pocketcasts.compose.extensions.slideOutToEnd
+import au.com.shiftyjelly.pocketcasts.compose.extensions.slideOutToStart
 import au.com.shiftyjelly.pocketcasts.views.fragments.BaseDialogFragment
 import dagger.hilt.android.AndroidEntryPoint
 import dagger.hilt.android.lifecycle.withCreationCallback
@@ -49,18 +54,51 @@ class CreatePlaylistFragment : BaseDialogFragment() {
             AppThemeWithBackground(
                 themeType = theme.activeTheme,
             ) {
-                NewPlaylistPage(
-                    titleState = viewModel.playlistNameState,
-                    onCreateManualPlaylist = { Timber.i("Create Manual Playlist") },
-                    onContinueToSmartPlaylist = { Timber.i("Continue to Smart Playlist") },
-                    onClickClose = ::dismiss,
-                    modifier = Modifier
-                        .fillMaxSize()
-                        .navigationBarsPadding()
-                        .nestedScroll(rememberNestedScrollInteropConnection())
-                        .verticalScroll(rememberScrollState()),
-                )
+                val navController = rememberNavController()
+                NavHost(
+                    navController = navController,
+                    startDestination = NavigationRoutes.NEW_PLAYLIST,
+                    enterTransition = { slideInToStart() },
+                    exitTransition = { slideOutToStart() },
+                    popEnterTransition = { slideInToEnd() },
+                    popExitTransition = { slideOutToEnd() },
+                    modifier = Modifier.fillMaxSize(),
+                ) {
+                    composable(NavigationRoutes.NEW_PLAYLIST) {
+                        NewPlaylistPage(
+                            titleState = viewModel.playlistNameState,
+                            onCreateManualPlaylist = { Timber.i("Create Manual Playlist") },
+                            onContinueToSmartPlaylist = {
+                                navController.navigate(NavigationRoutes.SMART_PLAYLIST_PREVIEW) {
+                                    popUpTo(NavigationRoutes.NEW_PLAYLIST) {
+                                        inclusive = true
+                                    }
+                                }
+                            },
+                            onClickClose = ::dismiss,
+                            modifier = Modifier
+                                .fillMaxSize()
+                                .navigationBarsPadding()
+                                .nestedScroll(rememberNestedScrollInteropConnection())
+                                .verticalScroll(rememberScrollState()),
+                        )
+                    }
+                    composable(NavigationRoutes.SMART_PLAYLIST_PREVIEW) {
+                        SmartPlaylistPreviewPage(
+                            modifier = Modifier
+                                .fillMaxSize()
+                                .navigationBarsPadding()
+                                .nestedScroll(rememberNestedScrollInteropConnection())
+                                .verticalScroll(rememberScrollState()),
+                        )
+                    }
+                }
             }
         }
     }
+}
+
+private object NavigationRoutes {
+    const val NEW_PLAYLIST = "new_playlist"
+    const val SMART_PLAYLIST_PREVIEW = "smart_playlist_preview"
 }

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/create/SmartPlaylistPreviewPage.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/create/SmartPlaylistPreviewPage.kt
@@ -1,0 +1,33 @@
+package au.com.shiftyjelly.pocketcasts.playlists.create
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewParameter
+import au.com.shiftyjelly.pocketcasts.compose.AppThemeWithBackground
+import au.com.shiftyjelly.pocketcasts.compose.Devices
+import au.com.shiftyjelly.pocketcasts.compose.preview.ThemePreviewParameterProvider
+import au.com.shiftyjelly.pocketcasts.ui.theme.Theme.ThemeType
+
+@Composable
+fun SmartPlaylistPreviewPage(
+    modifier: Modifier = Modifier,
+) {
+    Box(
+        modifier = modifier,
+    )
+}
+
+@Preview(device = Devices.PORTRAIT_REGULAR)
+@Composable
+private fun SmartPlaylistPreviewPagePreview(
+    @PreviewParameter(ThemePreviewParameterProvider::class) themeType: ThemeType,
+) {
+    AppThemeWithBackground(themeType) {
+        SmartPlaylistPreviewPage(
+            modifier = Modifier.fillMaxSize(),
+        )
+    }
+}


### PR DESCRIPTION
## Description

As the title says.

## Testing Instructions

1. Start playlist creation
2. Tap Smart Playlist button.
3. You should see a blank screen.
4. Using system back navigation should close the sheet. 

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.