### PR TITLE
[Onboarding] Bookmarks

### DIFF
--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingSubscriptionPlan.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingSubscriptionPlan.kt
@@ -234,6 +234,14 @@ data class OnboardingSubscriptionPlan private constructor(
                 LR.string.folders_plus_prompt
             }
 
+            OnboardingUpgradeSource.BOOKMARKS,
+            OnboardingUpgradeSource.BOOKMARKS_SHELF_ACTION,
+            -> if (FeatureFlag.isEnabled(Feature.NEW_ONBOARDING_UPGRADE)) {
+                LR.string.onboarding_bookmarks_title
+            } else {
+                LR.string.onboarding_plus_features_title
+            }
+
             else -> if (FeatureFlag.isEnabled(Feature.NEW_ONBOARDING_UPGRADE)) {
                 LR.string.onboarding_upgrade_generic_title
             } else {

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeScreen.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeScreen.kt
@@ -44,6 +44,7 @@ import au.com.shiftyjelly.pocketcasts.account.onboarding.components.UpgradeFeatu
 import au.com.shiftyjelly.pocketcasts.account.onboarding.components.UpgradePlanRow
 import au.com.shiftyjelly.pocketcasts.account.onboarding.upgrade.OnboardingUpgradeHelper.PrivacyPolicy
 import au.com.shiftyjelly.pocketcasts.account.onboarding.upgrade.OnboardingUpgradeHelper.UpgradeRowButton
+import au.com.shiftyjelly.pocketcasts.account.onboarding.upgrade.contextual.BookmarksAnimation
 import au.com.shiftyjelly.pocketcasts.account.onboarding.upgrade.contextual.FoldersAnimation
 import au.com.shiftyjelly.pocketcasts.account.viewmodel.OnboardingUpgradeFeaturesState
 import au.com.shiftyjelly.pocketcasts.compose.AppThemeWithBackground
@@ -272,6 +273,17 @@ private fun OnboardingUpgradeFeaturesState.NewOnboardingVariant.toContentPages(
                 ),
             )
         }
+        OnboardingUpgradeSource.BOOKMARKS,
+        OnboardingUpgradeSource.BOOKMARKS_SHELF_ACTION,
+        -> {
+            add(UpgradePagerContent.Bookmarks)
+            add(
+                UpgradePagerContent.Features(
+                    features = currentPlan.featureItems,
+                    showCta = false,
+                ),
+            )
+        }
 
         else -> {
             when (this@toContentPages) {
@@ -321,6 +333,9 @@ private sealed interface UpgradePagerContent {
     data object Folders : UpgradePagerContent {
         override val showCta get() = true
     }
+    data object Bookmarks : UpgradePagerContent {
+        override val showCta get() = true
+    }
 }
 
 @Composable
@@ -358,6 +373,7 @@ private fun UpgradeContent(
                 )
 
                 is UpgradePagerContent.Folders -> FoldersUpgradeContent(onCtaClick = scrollToNext)
+                is UpgradePagerContent.Bookmarks -> BookmarksUpgradeContent(onCtaClick = scrollToNext)
             }
         }
     }
@@ -429,6 +445,28 @@ private fun FoldersUpgradeContent(
             modifier = Modifier
                 .fillMaxWidth()
                 .heightIn(min = 320.dp),
+        )
+    }
+}
+
+@Composable
+private fun BookmarksUpgradeContent(
+    onCtaClick: () -> Unit,
+) {
+    Column {
+        TextP40(
+            text = stringResource(LR.string.onboarding_upgrade_schedule_see_features),
+            modifier = Modifier
+                .padding(horizontal = 24.dp)
+                .padding(bottom = 24.dp)
+                .clickable { onCtaClick() },
+            color = MaterialTheme.theme.colors.primaryInteractive01,
+        )
+
+        BookmarksAnimation(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(bottom = 42.dp),
         )
     }
 }

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/contextual/Bookmarks.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/contextual/Bookmarks.kt
@@ -37,6 +37,9 @@ import androidx.compose.ui.graphics.TransformOrigin
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.role
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.IntOffset
@@ -84,7 +87,7 @@ fun BookmarksAnimation(
     }
 
     Box(
-        modifier = modifier,
+        modifier = modifier.semantics { role = Role.Image },
         contentAlignment = Alignment.TopCenter,
     ) {
         bookmarks.forEachIndexed { index, item ->
@@ -215,6 +218,7 @@ private fun Bookmark(
         TextP40(
             text = bookmarkConfig.text,
             color = MaterialTheme.theme.colors.primaryInteractive02,
+            disableAutoScale = true,
         )
         Row(
             modifier = Modifier
@@ -229,6 +233,7 @@ private fun Bookmark(
             TextP40(
                 text = bookmarkConfig.timestamp,
                 color = MaterialTheme.theme.colors.primaryText01,
+                disableAutoScale = true,
             )
             Icon(painter = painterResource(IR.drawable.ic_play), contentDescription = "", tint = MaterialTheme.theme.colors.primaryText01)
         }

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/contextual/Bookmarks.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/contextual/Bookmarks.kt
@@ -2,7 +2,8 @@ package au.com.shiftyjelly.pocketcasts.account.onboarding.upgrade.contextual
 
 import androidx.annotation.DrawableRes
 import androidx.compose.animation.core.FastOutLinearInEasing
-import androidx.compose.animation.core.FastOutSlowInEasing
+import androidx.compose.animation.core.LinearEasing
+import androidx.compose.animation.core.LinearOutSlowInEasing
 import androidx.compose.animation.core.animateFloat
 import androidx.compose.animation.core.animateInt
 import androidx.compose.animation.core.tween
@@ -47,8 +48,8 @@ import au.com.shiftyjelly.pocketcasts.compose.AppTheme
 import au.com.shiftyjelly.pocketcasts.compose.components.TextP40
 import au.com.shiftyjelly.pocketcasts.compose.preview.ThemePreviewParameterProvider
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
-import kotlinx.coroutines.delay
 import kotlin.random.Random
+import kotlinx.coroutines.delay
 import au.com.shiftyjelly.pocketcasts.images.R as IR
 
 private data class AnimationParams(
@@ -71,7 +72,7 @@ fun BookmarksAnimation(
                 AnimationParams(
                     shouldStart = false,
                     centerOffset = IntOffset(Random.nextInt(centerOffsetTolerance), Random.nextInt(centerOffsetTolerance)),
-                    rotationOffset = Random.nextInt(12),
+                    rotationOffset = Random.nextInt(10),
                 ),
             )
         }
@@ -91,9 +92,9 @@ fun BookmarksAnimation(
         bookmarks.forEachIndexed { index, item ->
             val animParams = animationTriggers[index].value
             val startRotation = if (index % 2 == 0) {
-                60 - animParams.rotationOffset
+                30 - animParams.rotationOffset
             } else {
-                -60 + animParams.rotationOffset
+                -30 + animParams.rotationOffset
             }
             val endRotation = if (index % 2 == 0) {
                 0 + animParams.rotationOffset
@@ -158,7 +159,7 @@ private fun Bookmark(
 ) {
     val transition = updateTransition(startAnimation, "bookmarkAnimation")
     val rotationAnim by transition.animateInt(
-        transitionSpec = { tween(durationMillis = 1000, easing = FastOutLinearInEasing) },
+        transitionSpec = { tween(durationMillis = 600, easing = LinearEasing) },
     ) { visible ->
         if (visible) {
             endRotation
@@ -167,7 +168,7 @@ private fun Bookmark(
         }
     }
     val alphaAnim by transition.animateFloat(
-        transitionSpec = { tween(durationMillis = 600, easing = FastOutSlowInEasing) },
+        transitionSpec = { tween(durationMillis = 600, easing = LinearOutSlowInEasing) },
     ) { visible ->
         if (visible) {
             1f
@@ -176,7 +177,7 @@ private fun Bookmark(
         }
     }
     val scaleAnim by transition.animateFloat(
-        transitionSpec = { tween(durationMillis = 1000, easing = FastOutLinearInEasing) },
+        transitionSpec = { tween(durationMillis = 600, easing = FastOutLinearInEasing) },
     ) { visible ->
         if (visible) {
             1f

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/contextual/Bookmarks.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/contextual/Bookmarks.kt
@@ -1,0 +1,228 @@
+package au.com.shiftyjelly.pocketcasts.account.onboarding.upgrade.contextual
+
+import androidx.annotation.DrawableRes
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.animateInt
+import androidx.compose.animation.core.updateTransition
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.layout.wrapContentWidth
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.Icon
+import androidx.compose.material.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.TransformOrigin
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewParameter
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.dp
+import au.com.shiftyjelly.pocketcasts.compose.AppTheme
+import au.com.shiftyjelly.pocketcasts.compose.components.TextP40
+import au.com.shiftyjelly.pocketcasts.compose.preview.ThemePreviewParameterProvider
+import au.com.shiftyjelly.pocketcasts.compose.theme
+import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
+import kotlin.random.Random
+import kotlinx.coroutines.delay
+import au.com.shiftyjelly.pocketcasts.images.R as IR
+
+@Composable
+fun BookmarksAnimation(
+    modifier: Modifier = Modifier,
+    bookmarks: List<BookmarkConfig> = demoBookmarks,
+) {
+    val animationTriggers = remember { mutableListOf(false) }
+
+    LaunchedEffect("animations") {
+        delay(400)
+        animationTriggers.forEachIndexed { index, _ ->
+            animationTriggers[index] = true
+            delay(800)
+        }
+    }
+
+    val centerOffsetTolerance = LocalDensity.current.run {
+        24.dp.toPx().toInt()
+    }
+
+    Box(
+        modifier = modifier,
+        contentAlignment = Alignment.Center,
+    ) {
+        bookmarks.forEachIndexed { index, item ->
+            val centerOffset = IntOffset(Random.nextInt(centerOffsetTolerance), Random.nextInt(centerOffsetTolerance))
+            val rotationTolerance = Random.nextInt(12)
+            val startRotation = if (index % 2 == 0) {
+                45 - rotationTolerance
+            } else {
+                -45 + rotationTolerance
+            }
+            val endRotation = if (index % 2 == 0) {
+                0 + rotationTolerance
+            } else {
+                0 - rotationTolerance
+            }
+            Bookmark(
+                bookmarkConfig = item,
+                modifier = Modifier.fillMaxHeight(),
+                startAnimation = animationTriggers[index],
+                centerOffset = centerOffset,
+                startRotation = startRotation,
+                endRotation = endRotation,
+            )
+        }
+    }
+}
+
+private val demoBookmarks = listOf(
+    BookmarkConfig(
+        backgroundStartColor = Color(0xffE4D820),
+        backgroundEndColor = Color(0xffE8A92C),
+        artworkResId = IR.drawable.artwork_0,
+        text = "Amazing quote!",
+        timestamp = "19:5",
+    ),
+    BookmarkConfig(
+        backgroundStartColor = Color(0xffFF9D00),
+        backgroundEndColor = Color(0xffEC4034),
+        artworkResId = IR.drawable.artwork_3,
+        text = "This bit cracks me up",
+        timestamp = "6:10",
+    ),
+    BookmarkConfig(
+        backgroundStartColor = Color(0xff27D9E9),
+        backgroundEndColor = Color(0xff0202FE),
+        artworkResId = IR.drawable.artwork_4,
+        text = "Love this part!",
+        timestamp = "6:45",
+    ),
+)
+
+data class BookmarkConfig(
+    val backgroundStartColor: Color,
+    val backgroundEndColor: Color,
+    @DrawableRes val artworkResId: Int,
+    val text: String,
+    val timestamp: String,
+)
+
+@Composable
+private fun Bookmark(
+    bookmarkConfig: BookmarkConfig,
+    modifier: Modifier = Modifier,
+    startAnimation: Boolean = true,
+    startRotation: Int = 0,
+    endRotation: Int = 0,
+    centerOffset: IntOffset = IntOffset(0, 0),
+    startScale: Float = 1.5f,
+) {
+    val transition = updateTransition(startAnimation, "bookmarkAnimation")
+    val rotationAnim by transition.animateInt { visible ->
+        if (visible) {
+            endRotation
+        } else {
+            startRotation
+        }
+    }
+    val alphaAnim by transition.animateFloat { visible ->
+        if (visible) {
+            1f
+        } else {
+            0f
+        }
+    }
+    val scaleAnim by transition.animateFloat { visible ->
+        if (visible) {
+            1f
+        } else {
+            startScale
+        }
+    }
+
+    Column(
+        modifier = modifier
+            .graphicsLayer {
+                rotationX = rotationAnim.toFloat()
+                alpha = alphaAnim
+                scaleX = scaleAnim
+                scaleY = scaleAnim
+                transformOrigin = TransformOrigin.Center
+            }
+            .offset {
+                IntOffset(centerOffset.x, centerOffset.y)
+            }
+            .aspectRatio(1f, true)
+            .clip(RoundedCornerShape(13.dp))
+            .background(
+                brush = Brush.linearGradient(colors = listOf(bookmarkConfig.backgroundStartColor, bookmarkConfig.backgroundEndColor)),
+                shape = RoundedCornerShape(13.dp),
+            )
+            .padding(25.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(17.dp)
+    ) {
+        Image(
+            modifier = Modifier
+                .size(77.dp)
+                .clip(RoundedCornerShape(8.dp)),
+            painter = painterResource(bookmarkConfig.artworkResId),
+            contentDescription = "",
+        )
+        TextP40(
+            text = bookmarkConfig.text,
+            color = MaterialTheme.theme.colors.primaryInteractive02,
+        )
+        Row(
+            modifier = Modifier
+                .height(36.dp)
+                .wrapContentWidth()
+                .clip(RoundedCornerShape(18.dp))
+                .background(color = MaterialTheme.theme.colors.primaryInteractive02, shape = RoundedCornerShape(18.dp))
+                .padding(horizontal = 17.dp, vertical = 8.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(10.dp)
+        ) {
+            TextP40(
+                text = bookmarkConfig.timestamp,
+                color = MaterialTheme.theme.colors.primaryText01
+            )
+            Icon(painter = painterResource(IR.drawable.ic_play), contentDescription = "", tint = MaterialTheme.theme.colors.primaryText01)
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun PreviewBookmark(
+    @PreviewParameter(ThemePreviewParameterProvider::class) theme: Theme.ThemeType,
+) = AppTheme(theme) {
+    Column {
+        demoBookmarks.forEach {
+            Bookmark(
+                bookmarkConfig = it,
+                modifier = Modifier.widthIn(max = 230.dp),
+            )
+        }
+    }
+}

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/contextual/Bookmarks.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/contextual/Bookmarks.kt
@@ -22,7 +22,6 @@ import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Icon
-import androidx.compose.material.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -47,10 +46,9 @@ import androidx.compose.ui.unit.dp
 import au.com.shiftyjelly.pocketcasts.compose.AppTheme
 import au.com.shiftyjelly.pocketcasts.compose.components.TextP40
 import au.com.shiftyjelly.pocketcasts.compose.preview.ThemePreviewParameterProvider
-import au.com.shiftyjelly.pocketcasts.compose.theme
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
-import kotlin.random.Random
 import kotlinx.coroutines.delay
+import kotlin.random.Random
 import au.com.shiftyjelly.pocketcasts.images.R as IR
 
 private data class AnimationParams(
@@ -217,7 +215,7 @@ private fun Bookmark(
         )
         TextP40(
             text = bookmarkConfig.text,
-            color = MaterialTheme.theme.colors.primaryInteractive02,
+            color = Color.White,
             disableAutoScale = true,
         )
         Row(
@@ -225,17 +223,21 @@ private fun Bookmark(
                 .height(36.dp)
                 .wrapContentWidth()
                 .clip(RoundedCornerShape(18.dp))
-                .background(color = MaterialTheme.theme.colors.primaryInteractive02, shape = RoundedCornerShape(18.dp))
+                .background(color = Color.White, shape = RoundedCornerShape(18.dp))
                 .padding(horizontal = 17.dp, vertical = 8.dp),
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.spacedBy(10.dp),
         ) {
             TextP40(
                 text = bookmarkConfig.timestamp,
-                color = MaterialTheme.theme.colors.primaryText01,
+                color = Color.Black,
                 disableAutoScale = true,
             )
-            Icon(painter = painterResource(IR.drawable.ic_play), contentDescription = "", tint = MaterialTheme.theme.colors.primaryText01)
+            Icon(
+                painter = painterResource(IR.drawable.ic_play),
+                contentDescription = "",
+                tint = Color.Black,
+            )
         }
     }
 }

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -2513,5 +2513,6 @@
     <string name="onboarding_folders_title_1">Books</string>
     <string name="onboarding_folders_title_2">Favorites</string>
     <string name="onboarding_folders_title_3">Sports</string>
+    <string name="onboarding_bookmarks_title">Bookmarks: no more \"where was that?\"</string>
 
 </resources>


### PR DESCRIPTION
## Description
This is the next contextual upgrade screen, Bookmarks.

Figma: PviUP0aiZctOprDuuYRwpb-fi-4996_2995
Animation: https://video.wordpress.com/v/ibeq2XXi

Fixes https://linear.app/a8c/issue/PCDROID-16/upgrade-screen-bookmarks

## Testing Instructions
1. Log in with an account that doesn't have any subscriptions
2. Navigate to Profile -> Bookmarks -> Get bookmarks
3. Observe animation

## Screenshots or Screencast 

https://github.com/user-attachments/assets/493afd44-35ab-405b-9e12-3f3188b79664



## Checklist
- [ ] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] ~I have considered whether it makes sense to add tests for my changes~
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [ ] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~
 
#### I have tested any UI changes...
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack