### PR TITLE
Add function for dialog shape

### DIFF
--- a/modules/features/ads/src/main/kotlin/au/com/shiftyjelly/pocketcasts/ads/AdReportFragment.kt
+++ b/modules/features/ads/src/main/kotlin/au/com/shiftyjelly/pocketcasts/ads/AdReportFragment.kt
@@ -51,7 +51,10 @@ class AdReportFragment : BaseDialogFragment() {
         container: ViewGroup?,
         savedInstanceState: Bundle?,
     ) = contentWithoutConsumedInsets {
-        AppTheme(theme.activeTheme) {
+        DialogBox(
+            fillMaxHeight = false,
+            useThemeBackground = false,
+        ) {
             CompositionLocalProvider(LocalPodcastColors provides args.podcastColors) {
                 val sheetColors = rememberAdColors().reportSheet
                 AdReportContent(

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/PlaylistsOnboardingFragment.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/PlaylistsOnboardingFragment.kt
@@ -6,11 +6,9 @@ import android.view.ViewGroup
 import androidx.annotation.DrawableRes
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -20,14 +18,12 @@ import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material3.adaptive.currentWindowAdaptiveInfo
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
@@ -65,19 +61,11 @@ class PlaylistsOnboardingFragment : BaseDialogFragment() {
         container: ViewGroup?,
         savedInstanceState: Bundle?,
     ) = content {
-        Box(
-            modifier = Modifier
-                .fillMaxHeight(0.93f)
-                .nestedScroll(rememberViewInteropNestedScrollConnection())
-                .clip(RoundedCornerShape(topStart = 16.dp, topEnd = 16.dp)),
-        ) {
-            AppThemeWithBackground(
-                themeType = theme.activeTheme,
-            ) {
-                OnboardingContent(
-                    onGotItClick = ::dismiss,
-                )
-            }
+        DialogBox {
+            OnboardingContent(
+                onGotItClick = ::dismiss,
+                modifier = Modifier.nestedScroll(rememberViewInteropNestedScrollConnection()),
+            )
         }
 
         CallOnce {

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/create/CreatePlaylistFragment.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/create/CreatePlaylistFragment.kt
@@ -3,24 +3,18 @@ package au.com.shiftyjelly.pocketcasts.playlists.create
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.ViewGroup
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.platform.rememberNestedScrollInteropConnection
-import androidx.compose.ui.unit.dp
 import androidx.fragment.app.viewModels
 import androidx.fragment.compose.content
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
-import au.com.shiftyjelly.pocketcasts.compose.AppThemeWithBackground
 import au.com.shiftyjelly.pocketcasts.compose.extensions.slideInToEnd
 import au.com.shiftyjelly.pocketcasts.compose.extensions.slideInToStart
 import au.com.shiftyjelly.pocketcasts.compose.extensions.slideOutToEnd
@@ -46,52 +40,44 @@ class CreatePlaylistFragment : BaseDialogFragment() {
         container: ViewGroup?,
         savedInstanceState: Bundle?,
     ) = content {
-        Box(
-            modifier = Modifier
-                .fillMaxHeight(0.93f)
-                .clip(RoundedCornerShape(topStart = 16.dp, topEnd = 16.dp)),
-        ) {
-            AppThemeWithBackground(
-                themeType = theme.activeTheme,
+        DialogBox {
+            val navController = rememberNavController()
+            NavHost(
+                navController = navController,
+                startDestination = NavigationRoutes.NEW_PLAYLIST,
+                enterTransition = { slideInToStart() },
+                exitTransition = { slideOutToStart() },
+                popEnterTransition = { slideInToEnd() },
+                popExitTransition = { slideOutToEnd() },
+                modifier = Modifier.fillMaxSize(),
             ) {
-                val navController = rememberNavController()
-                NavHost(
-                    navController = navController,
-                    startDestination = NavigationRoutes.NEW_PLAYLIST,
-                    enterTransition = { slideInToStart() },
-                    exitTransition = { slideOutToStart() },
-                    popEnterTransition = { slideInToEnd() },
-                    popExitTransition = { slideOutToEnd() },
-                    modifier = Modifier.fillMaxSize(),
-                ) {
-                    composable(NavigationRoutes.NEW_PLAYLIST) {
-                        NewPlaylistPage(
-                            titleState = viewModel.playlistNameState,
-                            onCreateManualPlaylist = { Timber.i("Create Manual Playlist") },
-                            onContinueToSmartPlaylist = {
-                                navController.navigate(NavigationRoutes.SMART_PLAYLIST_PREVIEW) {
-                                    popUpTo(NavigationRoutes.NEW_PLAYLIST) {
-                                        inclusive = true
-                                    }
+                composable(NavigationRoutes.NEW_PLAYLIST) {
+                    NewPlaylistPage(
+                        titleState = viewModel.playlistNameState,
+                        onCreateManualPlaylist = { Timber.i("Create Manual Playlist") },
+                        onContinueToSmartPlaylist = {
+                            navController.navigate(NavigationRoutes.SMART_PLAYLIST_PREVIEW) {
+                                popUpTo(NavigationRoutes.NEW_PLAYLIST) {
+                                    inclusive = true
                                 }
-                            },
-                            onClickClose = ::dismiss,
-                            modifier = Modifier
-                                .fillMaxSize()
-                                .navigationBarsPadding()
-                                .nestedScroll(rememberNestedScrollInteropConnection())
-                                .verticalScroll(rememberScrollState()),
-                        )
-                    }
-                    composable(NavigationRoutes.SMART_PLAYLIST_PREVIEW) {
-                        SmartPlaylistPreviewPage(
-                            modifier = Modifier
-                                .fillMaxSize()
-                                .navigationBarsPadding()
-                                .nestedScroll(rememberNestedScrollInteropConnection())
-                                .verticalScroll(rememberScrollState()),
-                        )
-                    }
+                            }
+                        },
+                        onClickClose = ::dismiss,
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .navigationBarsPadding()
+                            .nestedScroll(rememberNestedScrollInteropConnection())
+                            .verticalScroll(rememberScrollState()),
+                    )
+                }
+                composable(NavigationRoutes.SMART_PLAYLIST_PREVIEW) {
+                    SmartPlaylistPreviewPage(
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .navigationBarsPadding()
+                            .nestedScroll(rememberNestedScrollInteropConnection())
+                            .verticalScroll(rememberScrollState()),
+                    )
                 }
             }
         }

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/folders/SuggestedFoldersFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/folders/SuggestedFoldersFragment.kt
@@ -106,55 +106,53 @@ class SuggestedFoldersFragment : BaseDialogFragment() {
 
         val state by viewModel.state.collectAsState()
 
-        DialogBox {
-            Box(
-                modifier = Modifier
-                    .nestedScroll(rememberNestedScrollInteropConnection())
-                    .fillMaxSize(),
-            ) {
-                val navController = rememberNavController()
+        DialogBox(
+            modifier = Modifier
+                .nestedScroll(rememberNestedScrollInteropConnection())
+                .fillMaxSize(),
+        ) {
+            val navController = rememberNavController()
 
-                NavHost(
-                    navController = navController,
-                    startDestination = SuggestedFoldersNavRoutes.SUGGESTED_FOLDERS,
-                    enterTransition = { slideInToStart() },
-                    exitTransition = { slideOutToStart() },
-                    popEnterTransition = { slideInToEnd() },
-                    popExitTransition = { slideOutToEnd() },
-                    modifier = Modifier.fillMaxSize(),
-                ) {
-                    composable(SuggestedFoldersNavRoutes.SUGGESTED_FOLDERS) {
-                        SuggestedFoldersPage(
-                            folders = state.suggestedFolders,
-                            action = state.action,
-                            onActionClick = { state.action?.let { handleSuggestedAction(it, state.signInState.isSignedInAsPlusOrPatron) } },
-                            onCreateCustomFolderClick = { handleCustomFolderCreation(state.signInState.isSignedInAsPlusOrPatron) },
-                            onFolderClick = { folder ->
-                                viewModel.trackPreviewFolderTapped(folder)
-                                navController.navigate(SuggestedFoldersNavRoutes.folderDetailsDestination(folder.name))
-                            },
-                            onCloseClick = ::dismiss,
-                        )
+            NavHost(
+                navController = navController,
+                startDestination = SuggestedFoldersNavRoutes.SUGGESTED_FOLDERS,
+                enterTransition = { slideInToStart() },
+                exitTransition = { slideOutToStart() },
+                popEnterTransition = { slideInToEnd() },
+                popExitTransition = { slideOutToEnd() },
+                modifier = Modifier.fillMaxSize(),
+            ) {
+                composable(SuggestedFoldersNavRoutes.SUGGESTED_FOLDERS) {
+                    SuggestedFoldersPage(
+                        folders = state.suggestedFolders,
+                        action = state.action,
+                        onActionClick = { state.action?.let { handleSuggestedAction(it, state.signInState.isSignedInAsPlusOrPatron) } },
+                        onCreateCustomFolderClick = { handleCustomFolderCreation(state.signInState.isSignedInAsPlusOrPatron) },
+                        onFolderClick = { folder ->
+                            viewModel.trackPreviewFolderTapped(folder)
+                            navController.navigate(SuggestedFoldersNavRoutes.folderDetailsDestination(folder.name))
+                        },
+                        onCloseClick = ::dismiss,
+                    )
+                }
+                composable(
+                    SuggestedFoldersNavRoutes.folderDetailsRoute(),
+                    listOf(
+                        navArgument(SuggestedFoldersNavRoutes.SUGGESTED_FOLDER_NAME_ARGUMENT) {
+                            type = NavType.StringType
+                        },
+                    ),
+                ) { backStackEntry ->
+                    val arguments = requireNotNull(backStackEntry.arguments) { "Missing back stack entry arguments" }
+                    val folderName = requireNotNull(arguments.getString(SuggestedFoldersNavRoutes.SUGGESTED_FOLDER_NAME_ARGUMENT)) {
+                        "Missing folder name period argument"
                     }
-                    composable(
-                        SuggestedFoldersNavRoutes.folderDetailsRoute(),
-                        listOf(
-                            navArgument(SuggestedFoldersNavRoutes.SUGGESTED_FOLDER_NAME_ARGUMENT) {
-                                type = NavType.StringType
-                            },
-                        ),
-                    ) { backStackEntry ->
-                        val arguments = requireNotNull(backStackEntry.arguments) { "Missing back stack entry arguments" }
-                        val folderName = requireNotNull(arguments.getString(SuggestedFoldersNavRoutes.SUGGESTED_FOLDER_NAME_ARGUMENT)) {
-                            "Missing folder name period argument"
-                        }
-                        SuggestedFolderPodcastsPage(
-                            folder = remember(folderName, state.suggestedFolders) {
-                                state.suggestedFolders.find { it.name == folderName }
-                            },
-                            onGoBackClick = navController::popBackStack,
-                        )
-                    }
+                    SuggestedFolderPodcastsPage(
+                        folder = remember(folderName, state.suggestedFolders) {
+                            state.suggestedFolders.find { it.name == folderName }
+                        },
+                        onGoBackClick = navController::popBackStack,
+                    )
                 }
             }
         }

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/notifications/EnableNotificationsPromptFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/notifications/EnableNotificationsPromptFragment.kt
@@ -7,23 +7,13 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.activity.result.contract.ActivityResultContracts
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.WindowInsets
-import androidx.compose.foundation.layout.WindowInsetsSides
-import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.safeDrawing
-import androidx.compose.foundation.layout.windowInsetsPadding
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.unit.dp
 import androidx.fragment.compose.content
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTracker
-import au.com.shiftyjelly.pocketcasts.compose.AppThemeWithBackground
 import au.com.shiftyjelly.pocketcasts.compose.CallOnce
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.repositories.notification.NotificationHelper
@@ -71,40 +61,28 @@ internal class EnableNotificationsPromptFragment : BaseDialogFragment() {
             analyticsTracker.track(AnalyticsEvent.NOTIFICATIONS_PERMISSIONS_SHOWN)
         }
 
-        Box(
-            modifier = Modifier
-                .fillMaxHeight(0.93f)
-                .clip(
-                    RoundedCornerShape(
-                        topStart = 16.dp,
-                        topEnd = 16.dp,
-                    ),
-                ),
-        ) {
-            AppThemeWithBackground(theme.activeTheme) {
-                EnableNotificationsPromptScreen(
-                    modifier = Modifier
-                        .fillMaxSize()
-                        .padding(16.dp)
-                        .windowInsetsPadding(WindowInsets.safeDrawing.only(WindowInsetsSides.Horizontal)),
-                    onCtaClick = {
-                        analyticsTracker.track(AnalyticsEvent.NOTIFICATIONS_PERMISSIONS_ALLOW_TAPPED)
-                        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-                            if (shouldShowRequestPermissionRationale(Manifest.permission.POST_NOTIFICATIONS)) {
-                                permissionRequester.launch(Manifest.permission.POST_NOTIFICATIONS)
-                                analyticsTracker.track(AnalyticsEvent.NOTIFICATIONS_OPT_IN_SHOWN)
-                            } else {
-                                notificationHelper.openNotificationSettings(requireActivity())
-                            }
+        DialogBox {
+            EnableNotificationsPromptScreen(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(16.dp),
+                onCtaClick = {
+                    analyticsTracker.track(AnalyticsEvent.NOTIFICATIONS_PERMISSIONS_ALLOW_TAPPED)
+                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                        if (shouldShowRequestPermissionRationale(Manifest.permission.POST_NOTIFICATIONS)) {
+                            permissionRequester.launch(Manifest.permission.POST_NOTIFICATIONS)
+                            analyticsTracker.track(AnalyticsEvent.NOTIFICATIONS_OPT_IN_SHOWN)
+                        } else {
+                            notificationHelper.openNotificationSettings(requireActivity())
                         }
-                    },
-                    onDismissClick = {
-                        isFinalizingActionUsed = true
-                        handleDismissedByUser()
-                        dismiss()
-                    },
-                )
-            }
+                    }
+                },
+                onDismissClick = {
+                    isFinalizingActionUsed = true
+                    handleDismissedByUser()
+                    dismiss()
+                },
+            )
         }
     }
 

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/ad/AdReportContent.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/ad/AdReportContent.kt
@@ -36,10 +36,7 @@ fun AdReportContent(
 
     Column(
         horizontalAlignment = Alignment.CenterHorizontally,
-        modifier = modifier.background(
-            color = colors.surface,
-            shape = RoundedCornerShape(topStart = 8.dp, topEnd = 8.dp),
-        ),
+        modifier = modifier.background(color = colors.surface),
     ) {
         Spacer(
             modifier = Modifier.height(8.dp),

--- a/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/fragments/BaseDialogFragment.kt
+++ b/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/fragments/BaseDialogFragment.kt
@@ -17,6 +17,8 @@ import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.movableContentOf
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.unit.dp
@@ -167,8 +169,10 @@ open class BaseDialogFragment :
         bottomSheetView()?.backgroundTintList = ColorStateList.valueOf(color)
     }
 
+    @Suppress("ktlint:compose:modifier-not-used-at-root")
     @Composable
     protected fun DialogBox(
+        modifier: Modifier = Modifier,
         useThemeBackground: Boolean = true,
         fillMaxHeight: Boolean = true,
         content: @Composable BoxScope.() -> Unit,
@@ -178,26 +182,33 @@ open class BaseDialogFragment :
                 .then(if (fillMaxHeight) Modifier.fillMaxHeight(0.93f) else Modifier)
                 .clip(RoundedCornerShape(topStart = 16.dp, topEnd = 16.dp)),
         ) {
-            if (useThemeBackground) {
-                AppThemeWithBackground(theme.activeTheme) {
-                    DialogContent(content)
-                }
-            } else {
-                AppTheme(theme.activeTheme) {
-                    DialogContent(content)
-                }
+            Background(useThemeBackground) {
+                DialogContent(modifier, content)
             }
         }
     }
 
     @Composable
     private fun DialogContent(
+        modifier: Modifier = Modifier,
         content: @Composable BoxScope.() -> Unit,
     ) {
         val insets = WindowInsets.safeDrawing.only(WindowInsetsSides.Horizontal)
         Box(
-            modifier = Modifier.windowInsetsPadding(insets),
+            modifier = modifier.windowInsetsPadding(insets),
             content = content,
         )
+    }
+
+    @Composable
+    private fun Background(
+        useThemeBackground: Boolean,
+        content: @Composable () -> Unit,
+    ) {
+        if (useThemeBackground) {
+            AppThemeWithBackground(theme.activeTheme, content)
+        } else {
+            AppTheme(theme.activeTheme, content)
+        }
     }
 }

--- a/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/fragments/BaseDialogFragment.kt
+++ b/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/fragments/BaseDialogFragment.kt
@@ -7,10 +7,25 @@ import android.os.Bundle
 import android.view.View
 import android.widget.FrameLayout
 import androidx.annotation.ColorInt
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxScope
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.WindowInsetsSides
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.only
+import androidx.compose.foundation.layout.safeDrawing
+import androidx.compose.foundation.layout.windowInsetsPadding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.unit.dp
 import androidx.core.graphics.ColorUtils
 import androidx.core.view.WindowInsetsControllerCompat
 import androidx.core.view.doOnLayout
 import androidx.navigation.NavHostController
+import au.com.shiftyjelly.pocketcasts.compose.AppTheme
+import au.com.shiftyjelly.pocketcasts.compose.AppThemeWithBackground
 import au.com.shiftyjelly.pocketcasts.ui.helper.FragmentHostListener
 import au.com.shiftyjelly.pocketcasts.ui.helper.NavigationBarColor
 import au.com.shiftyjelly.pocketcasts.ui.helper.StatusBarIconColor
@@ -150,5 +165,39 @@ open class BaseDialogFragment :
         @ColorInt color: Int,
     ) {
         bottomSheetView()?.backgroundTintList = ColorStateList.valueOf(color)
+    }
+
+    @Composable
+    protected fun DialogBox(
+        useThemeBackground: Boolean = true,
+        fillMaxHeight: Boolean = true,
+        content: @Composable BoxScope.() -> Unit,
+    ) {
+        Box(
+            modifier = Modifier
+                .then(if (fillMaxHeight) Modifier.fillMaxHeight(0.93f) else Modifier)
+                .clip(RoundedCornerShape(topStart = 16.dp, topEnd = 16.dp)),
+        ) {
+            if (useThemeBackground) {
+                AppThemeWithBackground(theme.activeTheme) {
+                    DialogContent(content)
+                }
+            } else {
+                AppTheme(theme.activeTheme) {
+                    DialogContent(content)
+                }
+            }
+        }
+    }
+
+    @Composable
+    private fun DialogContent(
+        content: @Composable BoxScope.() -> Unit,
+    ) {
+        val insets = WindowInsets.safeDrawing.only(WindowInsetsSides.Horizontal)
+        Box(
+            modifier = Modifier.windowInsetsPadding(insets),
+            content = content,
+        )
     }
 }


### PR DESCRIPTION
## Description

Our `BaseDialogFragment` doesn't have a good way of setting correct dialog shape. This is a workaround. It allows classes inheriting from `BaseDialogFragment` to apply correct shape that accounts for insets, etc. 

## Testing Instructions

Open transcripts from episodes details in the landscape mode. The content should not draw behind camera cutout. You can also test other fragments that were modified in this PR.

## Screenshots or Screencast 

| Before | After |
| - | - |
| <img width="1200" height="540" alt="Screenshot_20250729-195121" src="https://github.com/user-attachments/assets/7a84f910-36ed-41f8-9faa-1cf107768b60" /> | <img width="1200" height="540" alt="Screenshot_20250729-195309" src="https://github.com/user-attachments/assets/454c083d-adaa-4de5-83da-3e2c00936e0f" /> |

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack
