### PR TITLE
Fix race condition between navigation bar translation and player offset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
         ([#4262](https://github.com/Automattic/pocket-casts-android/pull/4262))
     *   Fix the notification message for "Trending this week"
         ([#4273](https://github.com/Automattic/pocket-casts-android/pull/4273))
+    *   Fix navigation bar drawing on top of the player after configuration changes.
+        ([#4294](https://github.com/Automattic/pocket-casts-android/pull/4294))
 
 7.94
 -----

--- a/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
+++ b/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
@@ -26,6 +26,7 @@ import androidx.core.content.ContextCompat
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowCompat
 import androidx.core.view.WindowInsetsCompat
+import androidx.core.view.doOnLayout
 import androidx.core.view.isVisible
 import androidx.core.view.updateLayoutParams
 import androidx.core.view.updatePadding
@@ -1132,8 +1133,10 @@ class MainActivity :
 
     override fun onPlayerBottomSheetSlide(bottomSheetView: View, slideOffset: Float) {
         val view = binding.bottomNavigation
-        val targetPosition = 2 * view.height * slideOffset
-        view.spring(TRANSLATION_Y).animateToFinalPosition(targetPosition)
+        view.doOnLayout {
+            val targetPosition = 2 * view.height * slideOffset
+            view.spring(TRANSLATION_Y).animateToFinalPosition(targetPosition)
+        }
     }
 
     override fun updateSystemColors() {


### PR DESCRIPTION
## Description

There is a race condition when trying to translate navigation bar after a configuration change. Moving animation to post layout fixes the issue.

Fixes PCDROID-64

## Testing Instructions

1. Play something and open the player.
2. Rotate the screen a couple of times.
3. Navigation bar should not draw on top of the player.

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.