### PR TITLE
Fix tooltip sizing

### DIFF
--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/Tooltip.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/Tooltip.kt
@@ -1,6 +1,7 @@
 package au.com.shiftyjelly.pocketcasts.compose.components
 
 import android.icu.text.ListFormatter.Width
+import androidx.annotation.FloatRange
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
@@ -52,7 +53,7 @@ fun TooltipPopup(
     title: String,
     tipPosition: TipPosition,
     body: String? = null,
-    maxWidthFraction: Float = 1f,
+    @FloatRange(from = 0.0, to = 1.0) maxWidthFraction: Float? = null,
     maxWidth: Dp? = null,
     elevation: Dp = 16.dp,
     anchorOffset: DpOffset = DpOffset.Zero,
@@ -80,7 +81,13 @@ fun TooltipPopup(
                 tipPosition = tipPosition,
                 elevation = elevation,
                 modifier = Modifier
-                    .fillMaxWidth(fraction = maxWidthFraction)
+                    .then(
+                        if (maxWidthFraction != null) {
+                            Modifier.fillMaxWidth(maxWidthFraction)
+                        } else {
+                            Modifier
+                        },
+                    )
                     .then(
                         if (maxWidth != null) {
                             Modifier.widthIn(max = maxWidth)
@@ -118,7 +125,6 @@ fun Tooltip(
         modifier = (if (elevation > 0.dp) Modifier.shadow(elevation, tooltipShape) else Modifier)
             .clip(tooltipShape)
             .background(backgroundColor)
-            .fillMaxWidth(0.75f)
             .then(modifier),
     ) {
         Column(


### PR DESCRIPTION
## Description

This fixes a bug I introduced while adding a way to limit tooltip's size.

## Testing Instructions

1. Sign in with a paid account.
2. Go to the Profile tab.
3. Check tooltip size.

## Screenshots or Screencast 

| Before | After |
| - | - |
| <img width="1080" height="2400" alt="b" src="https://github.com/user-attachments/assets/bee43b0f-4a21-4cf0-b537-cb61e24b8a30" /> | <img width="1080" height="2400" alt="a" src="https://github.com/user-attachments/assets/ea03d13e-c95c-4ecd-80d7-114ae5494862" /> |


## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.