### PR TITLE
Add resistance to dismissing playlist sheet

### DIFF
--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/create/CreatePlaylistFragment.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/create/CreatePlaylistFragment.kt
@@ -2,11 +2,9 @@ package au.com.shiftyjelly.pocketcasts.playlists.create
 
 import android.os.Bundle
 import android.view.LayoutInflater
+import android.view.View
 import android.view.ViewGroup
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.navigationBarsPadding
-import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
@@ -21,9 +19,13 @@ import au.com.shiftyjelly.pocketcasts.compose.extensions.slideInToEnd
 import au.com.shiftyjelly.pocketcasts.compose.extensions.slideInToStart
 import au.com.shiftyjelly.pocketcasts.compose.extensions.slideOutToEnd
 import au.com.shiftyjelly.pocketcasts.compose.extensions.slideOutToStart
+import au.com.shiftyjelly.pocketcasts.utils.extensions.pxToDp
 import au.com.shiftyjelly.pocketcasts.views.fragments.BaseDialogFragment
+import com.google.android.material.bottomsheet.BottomSheetBehavior
+import com.google.android.material.bottomsheet.ViewPager2AwareBottomSheetBehavior
 import dagger.hilt.android.AndroidEntryPoint
 import dagger.hilt.android.lifecycle.withCreationCallback
+import kotlin.math.roundToInt
 import timber.log.Timber
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
@@ -81,6 +83,29 @@ class CreatePlaylistFragment : BaseDialogFragment() {
                 }
             }
         }
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        bottomSheetView()
+            ?.let { BottomSheetBehavior.from(it) as? ViewPager2AwareBottomSheetBehavior }
+            ?.let { behavior ->
+                behavior.setPreFlingInterceptor(
+                    object : ViewPager2AwareBottomSheetBehavior.PreFlingInterceptor {
+                        override fun shouldInterceptFlingGesture(velocityX: Float, velocityY: Float): Boolean {
+                            val offsetPx = (view.height * (1f - behavior.calculateSlideOffset())).roundToInt()
+                            val offsetDp = offsetPx.pxToDp(requireContext())
+                            return offsetDp < 150
+                        }
+
+                        override fun onFlingIntercepted(velocityX: Float, velocityY: Float) {
+                            view.post {
+                                behavior.state = BottomSheetBehavior.STATE_EXPANDED
+                            }
+                        }
+                    },
+                )
+            }
     }
 }
 

--- a/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/fragments/BaseDialogFragment.kt
+++ b/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/fragments/BaseDialogFragment.kt
@@ -115,7 +115,7 @@ open class BaseDialogFragment :
         bottomSheetView()?.let { bottomSheet ->
             val behavior = BottomSheetBehavior.from(bottomSheet)
             behavior.state = BottomSheetBehavior.STATE_EXPANDED
-            behavior.peekHeight = BottomSheetBehavior.PEEK_HEIGHT_AUTO
+            behavior.peekHeight = 0
             behavior.skipCollapsed = true
         }
     }

--- a/modules/services/views/src/main/java/com/google/android/material/bottomsheet/ViewPager2AwareBottomSheetBehavior.kt
+++ b/modules/services/views/src/main/java/com/google/android/material/bottomsheet/ViewPager2AwareBottomSheetBehavior.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.util.AttributeSet
 import android.view.View
 import android.view.ViewGroup
+import androidx.coordinatorlayout.widget.CoordinatorLayout
 import androidx.core.view.ViewCompat
 import androidx.core.view.forEach
 import androidx.core.view.get
@@ -20,6 +21,22 @@ open class ViewPager2AwareBottomSheetBehavior<V : View> @JvmOverloads constructo
     context: Context,
     attrs: AttributeSet? = null,
 ) : BottomSheetBehavior<V>(context, attrs) {
+    private var preFlingInterceptor: PreFlingInterceptor? = null
+
+    fun setPreFlingInterceptor(interceptor: PreFlingInterceptor) {
+        preFlingInterceptor = interceptor
+    }
+
+    override fun onNestedPreFling(coordinatorLayout: CoordinatorLayout, child: V, target: View, velocityX: Float, velocityY: Float): Boolean {
+        val shouldDisableFling = preFlingInterceptor?.shouldInterceptFlingGesture(velocityX, velocityY) ?: false
+        return if (shouldDisableFling) {
+            preFlingInterceptor?.onFlingIntercepted(velocityX, velocityY)
+            true
+        } else {
+            super.onNestedPreFling(coordinatorLayout, child, target, velocityX, velocityY)
+        }
+    }
+
     override fun findScrollingChild(view: View): View? {
         if (!view.isVisible) {
             return null
@@ -44,5 +61,11 @@ open class ViewPager2AwareBottomSheetBehavior<V : View> @JvmOverloads constructo
             }
         }
         return null
+    }
+
+    interface PreFlingInterceptor {
+        fun shouldInterceptFlingGesture(velocityX: Float, velocityY: Float): Boolean
+
+        fun onFlingIntercepted(velocityX: Float, velocityY: Float)
     }
 }


### PR DESCRIPTION
## Description

Playlists are created using a bottom sheet. Unfortunately, the swipe-to-dismiss gesture is very sensitive. Sometimes it even triggers when swiping up.

Because of our integration with Jetpack Compose, we do not have an easy way to reduce the gesture's sensitivity. Increasing friction does notwork, and relying on fling velocity is not reliable because Compose interferes with those values due to nested scroll interop issues.

However, the sheet's offset and the view's height are consistent and easy to work with. While this is not an ideal solution, I implemented a workaround where the sheet re-expands itself if the offset threshold does not reach 150 dp after flinging.

This solution is not perfect, but I prefer it over disabling the swipe gesture completely.

## Testing Instructions

1. Start playlist creation.
2. Notice that swiping it down to dismiss it gives some resistance.

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.