### PR TITLE
Update player's ad colors

### DIFF
--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/ad/AdColors.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/ad/AdColors.kt
@@ -39,17 +39,11 @@ fun rememberAdColors(): AdColors {
     val playerColors = theme.rememberPlayerColors()
     return remember(theme.type, playerColors) {
         if (playerColors != null) {
-            val adBackgroundColor = playerColors.contrast06.compositeOver(playerColors.background01)
-            val titleLabelContrast = ColorUtils.calculateContrast(
-                backgroundColor = adBackgroundColor.copy(alpha = 1f),
-                foregroundColor = playerColors.highlight01.copy(alpha = 1f),
-            )
-
             AdColors(
                 AdColors.Banner(
                     background = playerColors.contrast06,
                     ctaLabel = playerColors.contrast01,
-                    titleLabel = if (titleLabelContrast >= WCGA_AA_TEXT_CONTRAST_REQUIREMENT) playerColors.highlight01 else Color.White,
+                    titleLabel = playerColors.contrast01,
                     adLabelBackground = playerColors.contrast06,
                     adLabel = playerColors.contrast01,
                     icon = playerColors.contrast02,
@@ -90,5 +84,3 @@ fun rememberAdColors(): AdColors {
         }
     }
 }
-
-private const val WCGA_AA_TEXT_CONTRAST_REQUIREMENT = 4.5


### PR DESCRIPTION
## Description

Context: p1753832908491639/1753767585.949519-slack-C08U02AG7C5

## Testing Instructions

1. Open the player as a free user.
2. Notice that the ad CTA and ad title have the same color.

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.