### PR TITLE
Control podcasts smart rule

### DIFF
--- a/modules/features/filters/build.gradle.kts
+++ b/modules/features/filters/build.gradle.kts
@@ -66,6 +66,8 @@ dependencies {
 
     testImplementation(libs.coroutines.test)
     testImplementation(libs.junit)
+    testImplementation(libs.mockito.core)
+    testImplementation(libs.mockito.kotlin)
     testImplementation(libs.turbine)
 
     testImplementation(projects.modules.services.sharedtest)

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/create/CreatePlaylistFragment.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/create/CreatePlaylistFragment.kt
@@ -76,8 +76,13 @@ class CreatePlaylistFragment : BaseDialogFragment() {
                     SmartPlaylistPreviewPage(
                         draft = uiState.smartPlaylistDraft,
                         onCreateSmartPlaylist = { Timber.i("On create smart playlist") },
-                        onClickRule = { Timber.i("On edit rule: $it") },
+                        onClickRule = { rule -> navController.navigate(rule.toNavigationRoute()) },
                         onClickClose = ::dismiss,
+                        modifier = Modifier.nestedScroll(rememberNestedScrollInteropConnection()),
+                    )
+                }
+                composable(NavigationRoutes.SMART_RULE_PODCASTS) {
+                    PodcastsRulePage(
                         modifier = Modifier.nestedScroll(rememberNestedScrollInteropConnection()),
                     )
                 }
@@ -112,4 +117,15 @@ class CreatePlaylistFragment : BaseDialogFragment() {
 private object NavigationRoutes {
     const val NEW_PLAYLIST = "new_playlist"
     const val SMART_PLAYLIST_PREVIEW = "smart_playlist_preview"
+    const val SMART_RULE_PODCASTS = "smart_rule_podcasts"
+}
+
+private fun RuleType.toNavigationRoute() = when (this) {
+    RuleType.Podcasts -> NavigationRoutes.SMART_RULE_PODCASTS
+    RuleType.EpisodeStatus -> NavigationRoutes.SMART_PLAYLIST_PREVIEW
+    RuleType.ReleaseDate -> NavigationRoutes.SMART_PLAYLIST_PREVIEW
+    RuleType.EpisodeDuration -> NavigationRoutes.SMART_PLAYLIST_PREVIEW
+    RuleType.DownloadStatus -> NavigationRoutes.SMART_PLAYLIST_PREVIEW
+    RuleType.MediaType -> NavigationRoutes.SMART_PLAYLIST_PREVIEW
+    RuleType.Starred -> NavigationRoutes.SMART_PLAYLIST_PREVIEW
 }

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/create/CreatePlaylistViewModel.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/create/CreatePlaylistViewModel.kt
@@ -3,41 +3,147 @@ package au.com.shiftyjelly.pocketcasts.playlists.create
 import androidx.compose.foundation.text.input.TextFieldState
 import androidx.compose.ui.text.TextRange
 import androidx.lifecycle.ViewModel
-import au.com.shiftyjelly.pocketcasts.repositories.playlist.SmartPlaylistDraft
+import androidx.lifecycle.viewModelScope
+import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
+import au.com.shiftyjelly.pocketcasts.models.type.SmartRules.DownloadStatusRule
+import au.com.shiftyjelly.pocketcasts.models.type.SmartRules.EpisodeDurationRule
+import au.com.shiftyjelly.pocketcasts.models.type.SmartRules.EpisodeStatusRule
+import au.com.shiftyjelly.pocketcasts.models.type.SmartRules.MediaTypeRule
+import au.com.shiftyjelly.pocketcasts.models.type.SmartRules.PodcastsRule
+import au.com.shiftyjelly.pocketcasts.models.type.SmartRules.ReleaseDateRule
+import au.com.shiftyjelly.pocketcasts.models.type.SmartRules.StarredRule
+import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 
 @HiltViewModel(assistedFactory = CreatePlaylistViewModel.Factory::class)
 class CreatePlaylistViewModel @AssistedInject constructor(
-    @Assisted initialPlaylistName: String,
+    private val podcastManager: PodcastManager,
+    @Assisted initialPlaylistTitle: String,
 ) : ViewModel() {
     val playlistNameState = TextFieldState(
-        initialText = initialPlaylistName,
-        initialSelection = TextRange(0, initialPlaylistName.length),
+        initialText = initialPlaylistTitle,
+        initialSelection = TextRange(0, initialPlaylistTitle.length),
     )
 
-    private val _uiState = MutableStateFlow(
+    private val appliedRules = MutableStateFlow(AppliedRules.Empty)
+    private val rulesBuilder = MutableStateFlow(RulesBuilder.Empty)
+
+    val uiState = combine(
+        appliedRules,
+        rulesBuilder,
+        podcastManager.findSubscribedFlow(),
+    ) { appliedRules, rulesBuilder, followedPodcasts ->
         UiState(
-            smartPlaylistDraft = SmartPlaylistDraft(title = initialPlaylistName),
-        ),
-    )
-    val uiState = _uiState.asStateFlow()
+            appliedRules,
+            rulesBuilder,
+            followedPodcasts,
+        )
+    }.stateIn(viewModelScope, SharingStarted.Eagerly, initialValue = UiState.Empty)
 
-    fun updateDraftTitle() {
-        _uiState.update { state ->
-            val draft = state.smartPlaylistDraft.copy(title = playlistNameState.text.toString())
-            state.copy(smartPlaylistDraft = draft)
+    fun applyRule(type: RuleType) {
+        val rule = when (type) {
+            RuleType.Podcasts -> rulesBuilder.value.podcastsRule
+            RuleType.EpisodeStatus -> TODO()
+            RuleType.ReleaseDate -> TODO()
+            RuleType.EpisodeDuration -> TODO()
+            RuleType.DownloadStatus -> TODO()
+            RuleType.MediaType -> TODO()
+            RuleType.Starred -> TODO()
+        }
+        appliedRules.update { rules ->
+            rules.copy(podcasts = rule)
+        }
+    }
+
+    fun useAllPodcasts(use: Boolean) {
+        rulesBuilder.update { builder ->
+            builder.copy(useAllPodcasts = use)
+        }
+    }
+
+    fun selectPodcast(uuid: String) {
+        rulesBuilder.update { builder ->
+            val podcasts = builder.selectedPodcasts + uuid
+            builder.copy(selectedPodcasts = podcasts)
+        }
+    }
+
+    fun deselectPodcast(uuid: String) {
+        rulesBuilder.update { builder ->
+            val podcasts = builder.selectedPodcasts - uuid
+            builder.copy(selectedPodcasts = podcasts)
         }
     }
 
     data class UiState(
-        val smartPlaylistDraft: SmartPlaylistDraft,
-    )
+        val appliedRules: AppliedRules,
+        val rulesBuilder: RulesBuilder,
+        val followedPodcasts: List<Podcast>,
+    ) {
+        companion object {
+            val Empty = UiState(
+                appliedRules = AppliedRules.Empty,
+                rulesBuilder = RulesBuilder.Empty,
+                followedPodcasts = emptyList(),
+            )
+        }
+    }
+
+    data class AppliedRules(
+        val episodeStatus: EpisodeStatusRule?,
+        val downloadStatus: DownloadStatusRule?,
+        val mediaType: MediaTypeRule?,
+        val releaseDate: ReleaseDateRule?,
+        val starred: StarredRule?,
+        val podcasts: PodcastsRule?,
+        val episodeDuration: EpisodeDurationRule?,
+    ) {
+        val isAnyRuleApplied = episodeStatus != null ||
+            downloadStatus != null ||
+            mediaType != null ||
+            releaseDate != null ||
+            starred != null ||
+            podcasts != null ||
+            episodeDuration != null
+
+        companion object {
+            val Empty = AppliedRules(
+                episodeStatus = null,
+                downloadStatus = null,
+                mediaType = null,
+                releaseDate = null,
+                starred = null,
+                podcasts = null,
+                episodeDuration = null,
+            )
+        }
+    }
+
+    data class RulesBuilder(
+        val useAllPodcasts: Boolean,
+        val selectedPodcasts: Set<String>,
+    ) {
+        val podcastsRule get() = if (useAllPodcasts) {
+            PodcastsRule.Any
+        } else {
+            PodcastsRule.Selected(selectedPodcasts.toList())
+        }
+
+        companion object {
+            val Empty = RulesBuilder(
+                useAllPodcasts = true,
+                selectedPodcasts = emptySet(),
+            )
+        }
+    }
 
     @AssistedFactory
     interface Factory {

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/create/PodcastsRulePage.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/create/PodcastsRulePage.kt
@@ -1,0 +1,21 @@
+package au.com.shiftyjelly.pocketcasts.playlists.create
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+
+@Composable
+fun PodcastsRulePage(
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .verticalScroll(rememberScrollState()),
+    ) {
+
+    }
+}

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/create/PodcastsRulePage.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/create/PodcastsRulePage.kt
@@ -1,14 +1,71 @@
 package au.com.shiftyjelly.pocketcasts.playlists.create
 
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.animateContentSize
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.selection.toggleable
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.Checkbox
+import androidx.compose.material.Icon
+import androidx.compose.material.IconButton
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Switch
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewParameter
+import androidx.compose.ui.unit.dp
+import au.com.shiftyjelly.pocketcasts.compose.AppThemeWithBackground
+import au.com.shiftyjelly.pocketcasts.compose.Devices
+import au.com.shiftyjelly.pocketcasts.compose.buttons.RowButton
+import au.com.shiftyjelly.pocketcasts.compose.components.FadedLazyColumn
+import au.com.shiftyjelly.pocketcasts.compose.components.PodcastImage
+import au.com.shiftyjelly.pocketcasts.compose.components.TextH20
+import au.com.shiftyjelly.pocketcasts.compose.components.TextH30
+import au.com.shiftyjelly.pocketcasts.compose.components.TextH40
+import au.com.shiftyjelly.pocketcasts.compose.components.TextH60
+import au.com.shiftyjelly.pocketcasts.compose.components.TextP50
+import au.com.shiftyjelly.pocketcasts.compose.preview.ThemePreviewParameterProvider
+import au.com.shiftyjelly.pocketcasts.compose.theme
+import au.com.shiftyjelly.pocketcasts.images.R
+import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
+import au.com.shiftyjelly.pocketcasts.ui.theme.Theme.ThemeType
+import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 @Composable
 fun PodcastsRulePage(
+    useAllPodcasts: Boolean,
+    selectedPodcastUuids: Set<String>,
+    podcasts: List<Podcast>,
+    onToggleAllPodcasts: (Boolean) -> Unit,
+    onSelectPodcast: (String) -> Unit,
+    onDeselectPodcast: (String) -> Unit,
+    onSaveRule: () -> Unit,
+    onClickBack: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Column(
@@ -16,6 +73,219 @@ fun PodcastsRulePage(
             .fillMaxSize()
             .verticalScroll(rememberScrollState()),
     ) {
+        IconButton(
+            onClick = onClickBack,
+        ) {
+            Icon(
+                painter = painterResource(R.drawable.ic_arrow_back),
+                contentDescription = stringResource(LR.string.back),
+                tint = MaterialTheme.theme.colors.primaryIcon03,
+            )
+        }
+        Column(
+            modifier = Modifier.weight(1f),
+        ) {
+            TextH20(
+                text = stringResource(LR.string.smart_rule_podcasts_title),
+                modifier = Modifier.padding(horizontal = 16.dp),
+            )
+            Spacer(
+                modifier = Modifier.height(24.dp),
+            )
+            AllPodcastsToggle(
+                useAllPodcasts = useAllPodcasts,
+                onToggleAllPodcasts = onToggleAllPodcasts,
+            )
+            Spacer(
+                modifier = Modifier.height(12.dp),
+            )
+            PodcastsColumn(
+                useAllPodcasts = useAllPodcasts,
+                selectedPodcastUuids = selectedPodcastUuids,
+                podcasts = podcasts,
+                onSelectPodcast = onSelectPodcast,
+                onDeselectPodcast = onDeselectPodcast,
+                modifier = Modifier.weight(1f),
+            )
+            RowButton(
+                text = stringResource(LR.string.save_smart_rule),
+                enabled = if (useAllPodcasts) {
+                    true
+                } else {
+                    selectedPodcastUuids.isNotEmpty()
+                },
+                onClick = onSaveRule,
+                includePadding = false,
+                modifier = Modifier
+                    .padding(horizontal = 16.dp)
+                    .navigationBarsPadding(),
+            )
+        }
+    }
+}
 
+@Composable
+private fun AllPodcastsToggle(
+    useAllPodcasts: Boolean,
+    onToggleAllPodcasts: (Boolean) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Row(
+        modifier = modifier
+            .toggleable(
+                role = Role.Switch,
+                value = useAllPodcasts,
+                onValueChange = onToggleAllPodcasts,
+            )
+            .padding(horizontal = 16.dp),
+    ) {
+        Column(
+            modifier = Modifier
+                .animateContentSize()
+                .weight(1f)
+                .heightIn(min = 32.dp),
+        ) {
+            TextH30(
+                text = stringResource(LR.string.smart_rule_podcasts_all_label),
+                modifier = Modifier.widthIn(max = 280.dp),
+            )
+            AnimatedVisibility(
+                visible = useAllPodcasts,
+            ) {
+                Column {
+                    Spacer(
+                        modifier = Modifier.height(4.dp),
+                    )
+                    TextP50(
+                        text = stringResource(LR.string.smart_rule_podcasts_all_description),
+                        modifier = Modifier.widthIn(max = 280.dp),
+                    )
+                }
+            }
+        }
+        Spacer(
+            modifier = Modifier.width(16.dp),
+        )
+        Switch(
+            checked = useAllPodcasts,
+            onCheckedChange = null,
+        )
+    }
+}
+
+@Composable
+private fun PodcastsColumn(
+    useAllPodcasts: Boolean,
+    selectedPodcastUuids: Set<String>,
+    podcasts: List<Podcast>,
+    onSelectPodcast: (String) -> Unit,
+    onDeselectPodcast: (String) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val alpha by animateFloatAsState(if (useAllPodcasts) 0.4f else 1f)
+    FadedLazyColumn(
+        contentPadding = PaddingValues(bottom = 24.dp),
+        modifier = modifier.alpha(alpha),
+    ) {
+        items(podcasts) { podcast ->
+            PodcastRow(
+                title = podcast.title,
+                author = podcast.author,
+                uuid = podcast.uuid,
+                isSelected = if (useAllPodcasts) {
+                    true
+                } else {
+                    podcast.uuid in selectedPodcastUuids
+                },
+                enabled = !useAllPodcasts,
+                onToggle = { isSelected ->
+                    if (isSelected) {
+                        onSelectPodcast(podcast.uuid)
+                    } else {
+                        onDeselectPodcast(podcast.uuid)
+                    }
+                },
+            )
+        }
+    }
+}
+
+@Composable
+private fun PodcastRow(
+    title: String,
+    author: String,
+    uuid: String,
+    isSelected: Boolean,
+    enabled: Boolean,
+    onToggle: (Boolean) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = modifier
+            .toggleable(
+                role = Role.Button,
+                value = isSelected,
+                enabled = enabled,
+                onValueChange = onToggle,
+            )
+            .padding(horizontal = 16.dp, vertical = 12.dp),
+    ) {
+        PodcastImage(
+            uuid = uuid,
+            dropShadow = false,
+            cornerSize = 4.dp,
+            modifier = Modifier.size(56.dp),
+        )
+        Spacer(
+            modifier = Modifier.width(12.dp),
+        )
+        Column(
+            modifier = Modifier.weight(1f),
+        ) {
+            TextH40(
+                text = title,
+                maxLines = 2,
+            )
+            Spacer(
+                modifier = Modifier.height(2.dp),
+            )
+            TextH60(
+                text = author,
+                color = MaterialTheme.theme.colors.primaryText02,
+                maxLines = 1,
+            )
+        }
+        Spacer(
+            modifier = Modifier.width(12.dp),
+        )
+        Checkbox(
+            checked = isSelected,
+            onCheckedChange = null,
+        )
+    }
+}
+
+@Preview(device = Devices.PORTRAIT_REGULAR)
+@Composable
+private fun PodcastsRulePreview(
+    @PreviewParameter(ThemePreviewParameterProvider::class) themeType: ThemeType,
+) {
+    var useAllPodcasts by remember { mutableStateOf(true) }
+    var podcastUuids by remember { mutableStateOf(emptySet<String>()) }
+
+    AppThemeWithBackground(themeType) {
+        PodcastsRulePage(
+            useAllPodcasts = useAllPodcasts,
+            selectedPodcastUuids = podcastUuids,
+            podcasts = List(10) { index ->
+                Podcast(uuid = "id-$index", title = "Title $index", author = "Author $index")
+            },
+            onToggleAllPodcasts = { useAllPodcasts = it },
+            onSelectPodcast = { podcastUuids += it },
+            onDeselectPodcast = { podcastUuids -= it },
+            onSaveRule = {},
+            onClickBack = {},
+        )
     }
 }

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/create/SmartPlaylistPreviewPage.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/create/SmartPlaylistPreviewPage.kt
@@ -46,6 +46,7 @@ import au.com.shiftyjelly.pocketcasts.compose.components.TextP50
 import au.com.shiftyjelly.pocketcasts.compose.preview.ThemePreviewParameterProvider
 import au.com.shiftyjelly.pocketcasts.compose.theme
 import au.com.shiftyjelly.pocketcasts.images.R
+import au.com.shiftyjelly.pocketcasts.playlists.create.CreatePlaylistViewModel.AppliedRules
 import au.com.shiftyjelly.pocketcasts.repositories.playlist.SmartPlaylistDraft
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme.ThemeType
 import au.com.shiftyjelly.pocketcasts.images.R as IR
@@ -87,7 +88,8 @@ enum class RuleType(
 
 @Composable
 fun SmartPlaylistPreviewPage(
-    draft: SmartPlaylistDraft,
+    playlistTitle: String,
+    appliedRules: AppliedRules,
     onCreateSmartPlaylist: () -> Unit,
     onClickRule: (RuleType) -> Unit,
     onClickClose: () -> Unit,
@@ -112,14 +114,14 @@ fun SmartPlaylistPreviewPage(
                 .weight(1f)
                 .padding(horizontal = 16.dp),
         ) {
-            val activeRules = rememberActiveRules(draft)
+            val activeRules = rememberAppliedRules(appliedRules)
             FadedLazyColumn(
                 modifier = Modifier.weight(1f),
             ) {
                 if (activeRules.isEmpty()) {
                     item {
                         NoRulesContent(
-                            title = draft.title,
+                            title = playlistTitle,
                             onClickRule = onClickRule,
                         )
                     }
@@ -127,7 +129,7 @@ fun SmartPlaylistPreviewPage(
             }
             RowButton(
                 text = stringResource(LR.string.create_smart_playlist),
-                enabled = draft.creationRules != null,
+                enabled = appliedRules.isAnyRuleApplied,
                 onClick = onCreateSmartPlaylist,
                 includePadding = false,
                 modifier = Modifier.navigationBarsPadding(),
@@ -263,17 +265,17 @@ private fun RuleRow(
 }
 
 @Composable
-private fun rememberActiveRules(draft: SmartPlaylistDraft): List<RuleType> {
-    return remember(draft) {
+private fun rememberAppliedRules(rules: AppliedRules): List<RuleType> {
+    return remember(rules) {
         RuleType.entries.filter { type ->
             when (type) {
-                RuleType.EpisodeStatus -> draft.episodeStatus != null
-                RuleType.DownloadStatus -> draft.downloadStatus != null
-                RuleType.MediaType -> draft.mediaType != null
-                RuleType.ReleaseDate -> draft.releaseDate != null
-                RuleType.Starred -> draft.starred != null
-                RuleType.Podcasts -> draft.podcasts != null
-                RuleType.EpisodeDuration -> draft.episodeDuration != null
+                RuleType.EpisodeStatus -> rules.episodeStatus != null
+                RuleType.DownloadStatus -> rules.downloadStatus != null
+                RuleType.MediaType -> rules.mediaType != null
+                RuleType.ReleaseDate -> rules.releaseDate != null
+                RuleType.Starred -> rules.starred != null
+                RuleType.Podcasts -> rules.podcasts != null
+                RuleType.EpisodeDuration -> rules.episodeDuration != null
             }
         }
     }
@@ -286,7 +288,8 @@ private fun SmartPlaylistPreviewPagePreview(
 ) {
     AppThemeWithBackground(themeType) {
         SmartPlaylistPreviewPage(
-            draft = SmartPlaylistDraft("Comedy"),
+            playlistTitle = "Comedy",
+            appliedRules = AppliedRules.Empty,
             onCreateSmartPlaylist = {},
             onClickRule = {},
             onClickClose = {},

--- a/modules/features/filters/src/test/kotlin/au/com/shiftyjelly/pocketcasts/playlists/create/CreatePlaylistViewModelTest.kt
+++ b/modules/features/filters/src/test/kotlin/au/com/shiftyjelly/pocketcasts/playlists/create/CreatePlaylistViewModelTest.kt
@@ -11,7 +11,7 @@ class CreatePlaylistViewModelTest {
     val coroutineRule = MainCoroutineRule()
 
     private val viewModel = CreatePlaylistViewModel(
-        initialPlaylistName = "Playlist name",
+        initialPlaylistTitle = "Playlist name",
     )
 
     @Test

--- a/modules/features/filters/src/test/kotlin/au/com/shiftyjelly/pocketcasts/playlists/create/CreatePlaylistViewModelTest.kt
+++ b/modules/features/filters/src/test/kotlin/au/com/shiftyjelly/pocketcasts/playlists/create/CreatePlaylistViewModelTest.kt
@@ -1,10 +1,21 @@
 package au.com.shiftyjelly.pocketcasts.playlists.create
 
 import androidx.compose.ui.text.TextRange
+import app.cash.turbine.test
+import au.com.shiftyjelly.pocketcasts.models.type.SmartRules
+import au.com.shiftyjelly.pocketcasts.models.type.SmartRules.PodcastsRule
+import au.com.shiftyjelly.pocketcasts.playlists.create.CreatePlaylistViewModel.UiState
 import au.com.shiftyjelly.pocketcasts.sharedtest.MainCoroutineRule
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
 
 class CreatePlaylistViewModelTest {
     @get:Rule
@@ -12,11 +23,53 @@ class CreatePlaylistViewModelTest {
 
     private val viewModel = CreatePlaylistViewModel(
         initialPlaylistTitle = "Playlist name",
+        podcastManager = mock {
+            on { findSubscribedFlow() } doReturn flowOf(emptyList())
+        },
     )
 
     @Test
     fun `initial playlist name is highlighted`() {
         assertEquals("Playlist name", viewModel.playlistNameState.text)
         assertEquals(TextRange(0, 13), viewModel.playlistNameState.selection)
+    }
+
+    @Test
+    fun `manage podcasts rule`() = runTest {
+        viewModel.uiState.test {
+            var state = awaitItem()
+            assertEquals(UiState.Empty, state)
+
+            viewModel.useAllPodcasts(false)
+            state = awaitItem()
+            assertFalse(state.rulesBuilder.useAllPodcasts)
+            assertNull(state.appliedRules.podcasts)
+
+            viewModel.useAllPodcasts(true)
+            state = awaitItem()
+            assertTrue(state.rulesBuilder.useAllPodcasts)
+            assertNull(state.appliedRules.podcasts)
+
+            viewModel.applyRule(RuleType.Podcasts)
+            state = awaitItem()
+            assertEquals(PodcastsRule.Any, state.appliedRules.podcasts)
+
+            viewModel.useAllPodcasts(false)
+            skipItems(1)
+
+            viewModel.selectPodcast("id-1")
+            state = awaitItem()
+            assertEquals(setOf("id-1"), state.rulesBuilder.selectedPodcasts)
+            assertEquals(PodcastsRule.Any, state.appliedRules.podcasts)
+
+            viewModel.selectPodcast("id-2")
+            state = awaitItem()
+            assertEquals(setOf("id-1", "id-2"), state.rulesBuilder.selectedPodcasts)
+            assertEquals(PodcastsRule.Any, state.appliedRules.podcasts)
+
+            viewModel.applyRule(RuleType.Podcasts)
+            state = awaitItem()
+            assertEquals(PodcastsRule.Selected(listOf("id-1", "id-2")), state.appliedRules.podcasts)
+        }
     }
 }

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -920,6 +920,10 @@
     <string name="create_playlist">Create Playlist</string>
     <string name="create_smart_playlist">Create Smart Playlist</string>
     <string name="smart_rules_description">Set up Smart Rules to automatically add episodes to your Smart Playlist.</string>
+    <string name="smart_rule_podcasts_title">Choose Podcasts</string>
+    <string name="smart_rule_podcasts_all_label">All Followed Podcasts</string>
+    <string name="smart_rule_podcasts_all_description">New podcasts you follow will be automatically added.</string>
+    <string name="save_smart_rule">Save Smart Rule</string>
 
     <!-- Profile -->
 


### PR DESCRIPTION
## Description

This adds podcasts smart rule management.

Designs: 5sC4z4Mu42LvL4MAAIbQVi-fi-766_37538

Fixes PCDROID-54

## Testing Instructions

1. Start a playlist creation.
2. Continue with Smart Playlist.
3. Tap "Podcasts".
4. Verify the screen with the designs.
5. Saving the rule will navigate you back to the playlist preview page. It will be empty because active preview is not implemented yet. However the create button should be enabled.

## Screenshots or Screencast 

| All | None | Some |
| - | - | - |
| <img width="1080" height="2400" alt="all" src="https://github.com/user-attachments/assets/b816a6aa-08a0-4980-904f-bce58845ef65" /> | <img width="1080" height="2400" alt="none" src="https://github.com/user-attachments/assets/d171a03b-4afb-4fbc-92f2-9800fa40a3dc" /> | <img width="1080" height="2400" alt="some" src="https://github.com/user-attachments/assets/8d27e817-163a-481f-a24e-502ba6c9baba" /> |

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack