### PR TITLE
Observe episodes via smart rules

### DIFF
--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/PlaylistDao.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/PlaylistDao.kt
@@ -75,6 +75,24 @@ abstract class PlaylistDao {
         return observeSmartPlaylistPodcasts(RoomRawQuery(query))
     }
 
+    @RawQuery(observedEntities = [Podcast::class, PodcastEpisode::class])
+    protected abstract fun observeSmartPlaylistEpisodes(query: RoomRawQuery): Flow<List<PodcastEpisode>>
+
+    fun observeSmartPlaylistEpisodes(
+        clock: Clock,
+        smartRules: SmartRules,
+        sortType: PlaylistEpisodeSortType,
+        limit: Int,
+    ): Flow<List<PodcastEpisode>> {
+        val query = createSmartPlaylistEpisodeQuery(
+            selectClause = "DISTINCT episode.*",
+            whereClause = smartRules.toSqlWhereClause(clock),
+            orderByClause = sortType.toOrderByClause(),
+            limit = limit,
+        )
+        return observeSmartPlaylistEpisodes(RoomRawQuery(query))
+    }
+
     private fun createSmartPlaylistEpisodeQuery(
         selectClause: String,
         whereClause: String,

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playlist/PlaylistManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playlist/PlaylistManager.kt
@@ -1,9 +1,13 @@
 package au.com.shiftyjelly.pocketcasts.repositories.playlist
 
+import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
+import au.com.shiftyjelly.pocketcasts.models.type.SmartRules
 import kotlinx.coroutines.flow.Flow
 
 interface PlaylistManager {
     fun observePlaylistsPreview(): Flow<List<PlaylistPreview>>
+
+    fun observeSmartEpisodes(rules: SmartRules): Flow<List<PodcastEpisode>>
 
     suspend fun deletePlaylist(uuid: String)
 

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playlist/PlaylistManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playlist/PlaylistManagerImpl.kt
@@ -2,6 +2,7 @@ package au.com.shiftyjelly.pocketcasts.repositories.playlist
 
 import androidx.room.withTransaction
 import au.com.shiftyjelly.pocketcasts.models.db.AppDatabase
+import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.models.entity.SmartPlaylist
 import au.com.shiftyjelly.pocketcasts.models.entity.SmartPlaylist.Companion.ANYTIME
 import au.com.shiftyjelly.pocketcasts.models.entity.SmartPlaylist.Companion.AUDIO_VIDEO_FILTER_ALL
@@ -14,6 +15,7 @@ import au.com.shiftyjelly.pocketcasts.models.entity.SmartPlaylist.Companion.LAST
 import au.com.shiftyjelly.pocketcasts.models.entity.SmartPlaylist.Companion.LAST_WEEK
 import au.com.shiftyjelly.pocketcasts.models.entity.SmartPlaylist.Companion.SYNC_STATUS_NOT_SYNCED
 import au.com.shiftyjelly.pocketcasts.models.entity.SmartPlaylist.Companion.SYNC_STATUS_SYNCED
+import au.com.shiftyjelly.pocketcasts.models.type.PlaylistEpisodeSortType
 import au.com.shiftyjelly.pocketcasts.models.type.SmartRules
 import au.com.shiftyjelly.pocketcasts.models.type.SmartRules.DownloadStatusRule
 import au.com.shiftyjelly.pocketcasts.models.type.SmartRules.EpisodeDurationRule
@@ -59,6 +61,15 @@ class PlaylistManagerImpl @Inject constructor(
             // before the updated episodes are received. This is rather imperceptible to the user,
             // but adding a short debounce helps avoid these inconsistencies and prevents redundant downstream emissions.
             .debounce(50.milliseconds)
+    }
+
+    override fun observeSmartEpisodes(rules: SmartRules): Flow<List<PodcastEpisode>> {
+        return playlistDao.observeSmartPlaylistEpisodes(
+            clock = clock,
+            smartRules = rules,
+            sortType = PlaylistEpisodeSortType.NewestToOldest,
+            limit = SMART_PLAYLIST_EPISODE_LIMIT,
+        ).distinctUntilChanged()
     }
 
     override suspend fun deletePlaylist(uuid: String) {
@@ -237,5 +248,6 @@ class PlaylistManagerImpl @Inject constructor(
 
     private companion object {
         const val PLAYLIST_ARTWORK_EPISODE_LIMIT = 4
+        const val SMART_PLAYLIST_EPISODE_LIMIT = 500
     }
 }


### PR DESCRIPTION
## Description

This adds a way to observe episodes that are conform to smart rules.

Relates to PCDROID-67

## Testing Instructions

Code review the changes.

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.