### PR TITLE
Control episode status rule

### DIFF
--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/create/CreatePlaylistFragment.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/create/CreatePlaylistFragment.kt
@@ -117,6 +117,19 @@ class CreatePlaylistFragment : BaseDialogFragment() {
                         onClickBack = ::goBackToPlaylistPreview,
                     )
                 }
+                composable(NavigationRoutes.SMART_RULE_EPISODE_STATUS) {
+                    EpisodeStatusRulePage(
+                        rule = uiState.rulesBuilder.episodeStatusRule,
+                        onToggleUnplayedStatus = viewModel::useUnplayedEpisodes,
+                        onToggleInProgressStatus = viewModel::useInProgressEpisodes,
+                        onToggleCompletedStatus = viewModel::useCompletedEpisodes,
+                        onSaveRule = {
+                            viewModel.applyRule(RuleType.EpisodeStatus)
+                            goBackToPlaylistPreview()
+                        },
+                        onClickBack = ::goBackToPlaylistPreview,
+                    )
+                }
             }
         }
     }
@@ -149,11 +162,12 @@ private object NavigationRoutes {
     const val NEW_PLAYLIST = "new_playlist"
     const val SMART_PLAYLIST_PREVIEW = "smart_playlist_preview"
     const val SMART_RULE_PODCASTS = "smart_rule_podcasts"
+    const val SMART_RULE_EPISODE_STATUS = "smart_rule_episode_status"
 }
 
 private fun RuleType.toNavigationRoute() = when (this) {
     RuleType.Podcasts -> NavigationRoutes.SMART_RULE_PODCASTS
-    RuleType.EpisodeStatus -> NavigationRoutes.SMART_PLAYLIST_PREVIEW
+    RuleType.EpisodeStatus -> NavigationRoutes.SMART_RULE_EPISODE_STATUS
     RuleType.ReleaseDate -> NavigationRoutes.SMART_PLAYLIST_PREVIEW
     RuleType.EpisodeDuration -> NavigationRoutes.SMART_PLAYLIST_PREVIEW
     RuleType.DownloadStatus -> NavigationRoutes.SMART_PLAYLIST_PREVIEW

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/create/CreatePlaylistViewModel.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/create/CreatePlaylistViewModel.kt
@@ -68,17 +68,24 @@ class CreatePlaylistViewModel @AssistedInject constructor(
     ).stateIn(viewModelScope, SharingStarted.Eagerly, initialValue = UiState.Empty)
 
     fun applyRule(type: RuleType) {
-        val rule = when (type) {
-            RuleType.Podcasts -> rulesBuilder.value.podcastsRule
-            RuleType.EpisodeStatus -> TODO()
+        when (type) {
+            RuleType.Podcasts -> {
+                val rule = rulesBuilder.value.podcastsRule
+                appliedRules.update { rules ->
+                    rules.copy(podcasts = rule)
+                }
+            }
+            RuleType.EpisodeStatus -> {
+                val rule = rulesBuilder.value.episodeStatusRule
+                appliedRules.update { rules ->
+                    rules.copy(episodeStatus = rule)
+                }
+            }
             RuleType.ReleaseDate -> TODO()
             RuleType.EpisodeDuration -> TODO()
             RuleType.DownloadStatus -> TODO()
             RuleType.MediaType -> TODO()
             RuleType.Starred -> TODO()
-        }
-        appliedRules.update { rules ->
-            rules.copy(podcasts = rule)
         }
     }
 
@@ -99,6 +106,27 @@ class CreatePlaylistViewModel @AssistedInject constructor(
         rulesBuilder.update { builder ->
             val podcasts = builder.selectedPodcasts - uuid
             builder.copy(selectedPodcasts = podcasts)
+        }
+    }
+
+    fun useUnplayedEpisodes(use: Boolean) {
+        rulesBuilder.update { builder ->
+            val rule = builder.episodeStatusRule.copy(unplayed = use)
+            builder.copy(episodeStatusRule = rule)
+        }
+    }
+
+    fun useInProgressEpisodes(use: Boolean) {
+        rulesBuilder.update { builder ->
+            val rule = builder.episodeStatusRule.copy(inProgress = use)
+            builder.copy(episodeStatusRule = rule)
+        }
+    }
+
+    fun useCompletedEpisodes(use: Boolean) {
+        rulesBuilder.update { builder ->
+            val rule = builder.episodeStatusRule.copy(completed = use)
+            builder.copy(episodeStatusRule = rule)
         }
     }
 
@@ -167,6 +195,7 @@ class CreatePlaylistViewModel @AssistedInject constructor(
     data class RulesBuilder(
         val useAllPodcasts: Boolean,
         val selectedPodcasts: Set<String>,
+        val episodeStatusRule: EpisodeStatusRule,
     ) {
         val podcastsRule
             get() = if (useAllPodcasts) {
@@ -179,6 +208,7 @@ class CreatePlaylistViewModel @AssistedInject constructor(
             val Empty = RulesBuilder(
                 useAllPodcasts = true,
                 selectedPodcasts = emptySet(),
+                episodeStatusRule = SmartRules.Default.episodeStatus,
             )
         }
     }

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/create/EpisodeStatusRulePage.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/create/EpisodeStatusRulePage.kt
@@ -1,0 +1,154 @@
+package au.com.shiftyjelly.pocketcasts.playlists.create
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.selection.toggleable
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.Checkbox
+import androidx.compose.material.Icon
+import androidx.compose.material.IconButton
+import androidx.compose.material.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewParameter
+import androidx.compose.ui.unit.dp
+import au.com.shiftyjelly.pocketcasts.compose.AppThemeWithBackground
+import au.com.shiftyjelly.pocketcasts.compose.Devices
+import au.com.shiftyjelly.pocketcasts.compose.buttons.RowButton
+import au.com.shiftyjelly.pocketcasts.compose.components.TextH20
+import au.com.shiftyjelly.pocketcasts.compose.components.TextH30
+import au.com.shiftyjelly.pocketcasts.compose.preview.ThemePreviewParameterProvider
+import au.com.shiftyjelly.pocketcasts.compose.theme
+import au.com.shiftyjelly.pocketcasts.images.R
+import au.com.shiftyjelly.pocketcasts.models.type.SmartRules
+import au.com.shiftyjelly.pocketcasts.ui.theme.Theme.ThemeType
+import au.com.shiftyjelly.pocketcasts.localization.R as LR
+
+@Composable
+fun EpisodeStatusRulePage(
+    rule: SmartRules.EpisodeStatusRule,
+    onToggleUnplayedStatus: (Boolean) -> Unit,
+    onToggleInProgressStatus: (Boolean) -> Unit,
+    onToggleCompletedStatus: (Boolean) -> Unit,
+    onSaveRule: () -> Unit,
+    onClickBack: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .verticalScroll(rememberScrollState()),
+    ) {
+        IconButton(
+            onClick = onClickBack,
+        ) {
+            Icon(
+                painter = painterResource(R.drawable.ic_arrow_back),
+                contentDescription = stringResource(LR.string.back),
+                tint = MaterialTheme.theme.colors.primaryIcon03,
+            )
+        }
+        Column(
+            modifier = Modifier.weight(1f),
+        ) {
+            TextH20(
+                text = stringResource(LR.string.filters_chip_episode_status),
+                modifier = Modifier.padding(horizontal = 16.dp),
+            )
+            Spacer(
+                modifier = Modifier.height(12.dp),
+            )
+            EpisodeStatusRow(
+                text = stringResource(LR.string.unplayed),
+                isSelected = rule.unplayed,
+                onToggle = onToggleUnplayedStatus,
+            )
+            EpisodeStatusRow(
+                text = stringResource(LR.string.in_progress_uppercase),
+                isSelected = rule.inProgress,
+                onToggle = onToggleInProgressStatus,
+            )
+            EpisodeStatusRow(
+                text = stringResource(LR.string.played),
+                isSelected = rule.completed,
+                onToggle = onToggleCompletedStatus,
+            )
+            Spacer(
+                modifier = Modifier.weight(1f),
+            )
+            RowButton(
+                text = stringResource(LR.string.save_smart_rule),
+                enabled = rule.unplayed || rule.inProgress || rule.completed,
+                onClick = onSaveRule,
+                includePadding = false,
+                modifier = Modifier
+                    .padding(horizontal = 16.dp)
+                    .navigationBarsPadding(),
+            )
+        }
+    }
+}
+
+@Composable
+private fun EpisodeStatusRow(
+    text: String,
+    isSelected: Boolean,
+    onToggle: (Boolean) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = modifier
+            .toggleable(
+                value = isSelected,
+                role = Role.Checkbox,
+                onValueChange = onToggle,
+            )
+            .padding(vertical = 12.dp, horizontal = 16.dp)
+            .semantics(mergeDescendants = true) {},
+    ) {
+        TextH30(
+            text = text,
+            modifier = Modifier.weight(1f),
+        )
+        Checkbox(
+            checked = isSelected,
+            onCheckedChange = null,
+        )
+    }
+}
+
+@Preview(device = Devices.PORTRAIT_REGULAR)
+@Composable
+private fun EpisodeStatusRulePreview(
+    @PreviewParameter(ThemePreviewParameterProvider::class) themeType: ThemeType,
+) {
+    var rule by remember { mutableStateOf(SmartRules.Default.episodeStatus) }
+
+    AppThemeWithBackground(themeType) {
+        EpisodeStatusRulePage(
+            rule = rule,
+            onToggleUnplayedStatus = { rule.copy(unplayed = it) },
+            onToggleInProgressStatus = { rule.copy(inProgress = it) },
+            onToggleCompletedStatus = { rule.copy(completed = it) },
+            onSaveRule = {},
+            onClickBack = {},
+        )
+    }
+}

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/create/SmartPlaylistPreviewPage.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/create/SmartPlaylistPreviewPage.kt
@@ -548,7 +548,41 @@ private fun AppliedRules.description(ruleType: RuleType) = when (ruleType) {
         null -> null
     }
 
-    RuleType.EpisodeStatus -> TODO()
+    RuleType.EpisodeStatus -> {
+        if (episodeStatus != null) {
+            when {
+                episodeStatus.unplayed -> when {
+                    episodeStatus.inProgress && episodeStatus.completed -> {
+                        stringResource(LR.string.episode_status_rule_description, stringResource(LR.string.unplayed), 2)
+                    }
+                    episodeStatus.inProgress || episodeStatus.completed -> {
+                        stringResource(LR.string.episode_status_rule_description, stringResource(LR.string.unplayed), 1)
+                    }
+                    else -> {
+                        stringResource(LR.string.unplayed)
+                    }
+                }
+
+                episodeStatus.inProgress -> when {
+                    episodeStatus.completed -> {
+                        stringResource(LR.string.episode_status_rule_description, stringResource(LR.string.in_progress_uppercase), 1)
+                    }
+
+                    else -> {
+                        stringResource(LR.string.in_progress_uppercase)
+                    }
+                }
+
+                episodeStatus.completed -> {
+                    stringResource(LR.string.played)
+                }
+                else -> null
+            }
+        } else {
+            null
+        }
+    }
+
     RuleType.ReleaseDate -> TODO()
     RuleType.EpisodeDuration -> TODO()
     RuleType.DownloadStatus -> TODO()

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/create/SmartPlaylistPreviewPage.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/create/SmartPlaylistPreviewPage.kt
@@ -66,7 +66,6 @@ import au.com.shiftyjelly.pocketcasts.compose.components.TextP50
 import au.com.shiftyjelly.pocketcasts.compose.preview.ThemePreviewParameterProvider
 import au.com.shiftyjelly.pocketcasts.compose.text.toAnnotatedString
 import au.com.shiftyjelly.pocketcasts.compose.theme
-import au.com.shiftyjelly.pocketcasts.images.R
 import au.com.shiftyjelly.pocketcasts.localization.helper.RelativeDateFormatter
 import au.com.shiftyjelly.pocketcasts.localization.helper.TimeHelper
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
@@ -137,8 +136,8 @@ fun SmartPlaylistPreviewPage(
             onClick = onClickClose,
         ) {
             Icon(
-                painter = painterResource(R.drawable.ic_close),
-                contentDescription = stringResource(au.com.shiftyjelly.pocketcasts.localization.R.string.close),
+                painter = painterResource(IR.drawable.ic_close),
+                contentDescription = stringResource(LR.string.close),
                 tint = MaterialTheme.theme.colors.primaryIcon03,
             )
         }

--- a/modules/features/filters/src/test/kotlin/au/com/shiftyjelly/pocketcasts/playlists/create/CreatePlaylistViewModelTest.kt
+++ b/modules/features/filters/src/test/kotlin/au/com/shiftyjelly/pocketcasts/playlists/create/CreatePlaylistViewModelTest.kt
@@ -2,6 +2,8 @@ package au.com.shiftyjelly.pocketcasts.playlists.create
 
 import androidx.compose.ui.text.TextRange
 import app.cash.turbine.test
+import au.com.shiftyjelly.pocketcasts.models.type.SmartRules
+import au.com.shiftyjelly.pocketcasts.models.type.SmartRules.EpisodeStatusRule
 import au.com.shiftyjelly.pocketcasts.models.type.SmartRules.PodcastsRule
 import au.com.shiftyjelly.pocketcasts.playlists.create.CreatePlaylistViewModel.UiState
 import au.com.shiftyjelly.pocketcasts.preferences.UserSetting
@@ -84,6 +86,69 @@ class CreatePlaylistViewModelTest {
             viewModel.applyRule(RuleType.Podcasts)
             state = awaitItem()
             assertEquals(PodcastsRule.Selected(listOf("id-1", "id-2")), state.appliedRules.podcasts)
+        }
+    }
+
+    @Test
+    fun `manage episode status rule`() = runTest {
+        viewModel.uiState.test {
+            var state = awaitItem()
+            assertEquals(UiState.Empty, state)
+
+            viewModel.useUnplayedEpisodes(false)
+            state = awaitItem()
+            assertFalse(state.rulesBuilder.episodeStatusRule.unplayed)
+            assertNull(state.appliedRules.episodeStatus)
+
+            viewModel.useInProgressEpisodes(false)
+            state = awaitItem()
+            assertFalse(state.rulesBuilder.episodeStatusRule.inProgress)
+            assertNull(state.appliedRules.episodeStatus)
+
+            viewModel.useCompletedEpisodes(false)
+            state = awaitItem()
+            assertFalse(state.rulesBuilder.episodeStatusRule.completed)
+            assertNull(state.appliedRules.episodeStatus)
+
+            viewModel.applyRule(RuleType.EpisodeStatus)
+            state = awaitItem()
+            assertEquals(
+                EpisodeStatusRule(unplayed = false, inProgress = false, completed = false),
+                state.appliedRules.episodeStatus,
+            )
+
+            viewModel.useUnplayedEpisodes(true)
+            state = awaitItem()
+            assertTrue(state.rulesBuilder.episodeStatusRule.unplayed)
+
+            viewModel.applyRule(RuleType.EpisodeStatus)
+            state = awaitItem()
+            assertEquals(
+                EpisodeStatusRule(unplayed = true, inProgress = false, completed = false),
+                state.appliedRules.episodeStatus,
+            )
+
+            viewModel.useInProgressEpisodes(true)
+            state = awaitItem()
+            assertTrue(state.rulesBuilder.episodeStatusRule.inProgress)
+
+            viewModel.applyRule(RuleType.EpisodeStatus)
+            state = awaitItem()
+            assertEquals(
+                EpisodeStatusRule(unplayed = true, inProgress = true, completed = false),
+                state.appliedRules.episodeStatus,
+            )
+
+            viewModel.useCompletedEpisodes(true)
+            state = awaitItem()
+            assertTrue(state.rulesBuilder.episodeStatusRule.completed)
+
+            viewModel.applyRule(RuleType.EpisodeStatus)
+            state = awaitItem()
+            assertEquals(
+                EpisodeStatusRule(unplayed = true, inProgress = true, completed = true),
+                state.appliedRules.episodeStatus,
+            )
         }
     }
 }

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -50,6 +50,7 @@
     <string name="go_to_podcast">Go to podcast</string>
     <string name="go_to_files">Go to files</string>
     <string name="in_progress">In progress</string>
+    <string name="in_progress_uppercase">In Progress</string>
     <string name="log_in">Log in</string>
     <string name="log_in_subtitle">Start listening to your favorite podcasts</string>
     <string name="log_out">Log out</string>
@@ -931,6 +932,8 @@
     <string name="preview_playlist">Preview %1$s</string>
     <string name="smart_playlist_create_no_content_title">No matching episodes</string>
     <string name="smart_playlist_create_no_content_body">None of the episodes in your podcasts match these rules.\n\nTry adjusting the rules, or save this playlist for future episodes that might fit.</string>
+    <!-- %1$s is status like 'In Progress' and %2$d is count of other episode statuses -->
+    <string name="episode_status_rule_description">%1$s + %2$d</string>
 
     <!-- Profile -->
 


### PR DESCRIPTION
## Description

This adds episode status smart rule management.

Designs:
- 5sC4z4Mu42LvL4MAAIbQVi-fi-1573_85650
- 5sC4z4Mu42LvL4MAAIbQVi-fi-1573_85444

Fixes PCDROID-56

## Testing Instructions

1. Start a playlist creation.
2. Continue with Smart Playlist.
3. Tap "Episode status".
4. Verify the screen with the designs.
5. Saving the rule will navigate you back to the playlist preview page.

## Screenshots or Screencast 

| Rule | Applied rule |
| - | - |
| <img width="1080" height="2400" alt="a" src="https://github.com/user-attachments/assets/0dcd89c5-534f-40b9-a790-8213908fb274" /> | <img width="1080" height="2400" alt="Screenshot_20250731-072526" src="https://github.com/user-attachments/assets/47e0f346-9e34-4c0a-854f-eb0e42ed6db2" /> |


## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack