### PR TITLE
Control episode duration rule

### DIFF
--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/create/CreatePlaylistFragment.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/create/CreatePlaylistFragment.kt
@@ -141,6 +141,23 @@ class CreatePlaylistFragment : BaseDialogFragment() {
                         onClickBack = ::goBackToPlaylistPreview,
                     )
                 }
+                composable(NavigationRoutes.SMART_RULE_EPISODE_DURATION) {
+                    EpisodeDurationRulePage(
+                        isDurationConstrained = uiState.rulesBuilder.isEpisodeDurationConstrained,
+                        minDuration = uiState.rulesBuilder.minEpisodeDuration,
+                        maxDuration = uiState.rulesBuilder.maxEpisodeDuration,
+                        onToggleConstrainDuration = viewModel::constrainDuration,
+                        onDecrementMinDuration = viewModel::decrementMinDuration,
+                        onIncrementMinDuration = viewModel::incrementMinDuration,
+                        onDecrementMaxDuration = viewModel::decrementMaxDuration,
+                        onIncrementMaxDuration = viewModel::incrementMaxDuration,
+                        onSaveRule = {
+                            viewModel.applyRule(RuleType.EpisodeDuration)
+                            goBackToPlaylistPreview()
+                        },
+                        onClickBack = ::goBackToPlaylistPreview,
+                    )
+                }
             }
         }
     }
@@ -175,13 +192,14 @@ private object NavigationRoutes {
     const val SMART_RULE_PODCASTS = "smart_rule_podcasts"
     const val SMART_RULE_EPISODE_STATUS = "smart_rule_episode_status"
     const val SMART_RULE_RELEASE_DATE = "smart_rule_release_date"
+    const val SMART_RULE_EPISODE_DURATION = "smart_rule_episode_duration"
 }
 
 private fun RuleType.toNavigationRoute() = when (this) {
     RuleType.Podcasts -> NavigationRoutes.SMART_RULE_PODCASTS
     RuleType.EpisodeStatus -> NavigationRoutes.SMART_RULE_EPISODE_STATUS
     RuleType.ReleaseDate -> NavigationRoutes.SMART_RULE_RELEASE_DATE
-    RuleType.EpisodeDuration -> NavigationRoutes.SMART_PLAYLIST_PREVIEW
+    RuleType.EpisodeDuration -> NavigationRoutes.SMART_RULE_EPISODE_DURATION
     RuleType.DownloadStatus -> NavigationRoutes.SMART_PLAYLIST_PREVIEW
     RuleType.MediaType -> NavigationRoutes.SMART_PLAYLIST_PREVIEW
     RuleType.Starred -> NavigationRoutes.SMART_PLAYLIST_PREVIEW

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/create/CreatePlaylistViewModel.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/create/CreatePlaylistViewModel.kt
@@ -160,31 +160,19 @@ class CreatePlaylistViewModel @AssistedInject constructor(
     }
 
     fun decrementMinDuration() {
-        rulesBuilder.update { builder ->
-            val duration = builder.minEpisodeDuration - 5.minutes
-            builder.withMinDuration(duration)
-        }
+        rulesBuilder.update { builder -> builder.decrementMinDuration() }
     }
 
     fun incrementMinDuration() {
-        rulesBuilder.update { builder ->
-            val duration = builder.minEpisodeDuration + 5.minutes
-            builder.withMinDuration(duration)
-        }
+        rulesBuilder.update { builder -> builder.incrementMinDuration() }
     }
 
     fun decrementMaxDuration() {
-        rulesBuilder.update { builder ->
-            val duration = builder.maxEpisodeDuration - 5.minutes
-            builder.withMaxDuration(duration)
-        }
+        rulesBuilder.update { builder -> builder.decrementMaxDuration() }
     }
 
     fun incrementMaxDuration() {
-        rulesBuilder.update { builder ->
-            val duration = builder.maxEpisodeDuration + 5.minutes
-            builder.withMaxDuration(duration)
-        }
+        rulesBuilder.update { builder -> builder.incrementMaxDuration() }
     }
 
     data class UiState(
@@ -265,16 +253,44 @@ class CreatePlaylistViewModel @AssistedInject constructor(
                 PodcastsRule.Selected(selectedPodcasts.toList())
             }
 
-        fun withMinDuration(duration: Duration) = if (duration < ZERO || duration >= maxEpisodeDuration) {
-            this
-        } else {
-            copy(minEpisodeDuration = duration)
+        fun decrementMinDuration(): RulesBuilder {
+            val minDuration = minEpisodeDuration
+            val newDuration = minDuration - if (minDuration > 5.minutes) 5.minutes else 1.minutes
+            return if (newDuration >= ZERO && newDuration < maxEpisodeDuration) {
+                copy(minEpisodeDuration = newDuration)
+            } else {
+                this
+            }
         }
 
-        fun withMaxDuration(duration: Duration) = if (duration <= minEpisodeDuration) {
-            this
-        } else {
-            copy(maxEpisodeDuration = duration)
+        fun incrementMinDuration(): RulesBuilder {
+            val minDuration = minEpisodeDuration
+            val newDuration = minDuration + if (minDuration >= 5.minutes) 5.minutes else 1.minutes
+            return if (newDuration >= ZERO && newDuration < maxEpisodeDuration) {
+                copy(minEpisodeDuration = newDuration)
+            } else {
+                this
+            }
+        }
+
+        fun decrementMaxDuration(): RulesBuilder {
+            val maxDuration = maxEpisodeDuration
+            val newDuration = maxDuration - if (maxDuration > 5.minutes) 5.minutes else 1.minutes
+            return if (newDuration > ZERO && newDuration > minEpisodeDuration) {
+                copy(maxEpisodeDuration = newDuration)
+            } else {
+                this
+            }
+        }
+
+        fun incrementMaxDuration(): RulesBuilder {
+            val maxDuration = maxEpisodeDuration
+            val newDuration = maxDuration + if (maxDuration >= 5.minutes) 5.minutes else 1.minutes
+            return if (newDuration > ZERO && newDuration > minEpisodeDuration) {
+                copy(maxEpisodeDuration = newDuration)
+            } else {
+                this
+            }
         }
 
         val episodeDurationRule

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/create/CreatePlaylistViewModel.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/create/CreatePlaylistViewModel.kt
@@ -271,7 +271,7 @@ class CreatePlaylistViewModel @AssistedInject constructor(
             copy(minEpisodeDuration = duration)
         }
 
-        fun withMaxDuration(duration: Duration) = if (duration < minEpisodeDuration) {
+        fun withMaxDuration(duration: Duration) = if (duration <= minEpisodeDuration) {
             this
         } else {
             copy(maxEpisodeDuration = duration)

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/create/CreatePlaylistViewModel.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/create/CreatePlaylistViewModel.kt
@@ -153,9 +153,9 @@ class CreatePlaylistViewModel @AssistedInject constructor(
         }
     }
 
-    fun constrainDuration(constrain: Boolean) {
+    fun constrainDuration(isConstrained: Boolean) {
         rulesBuilder.update { builder ->
-            builder.copy(isEpisodeDurationConstrained = constrain)
+            builder.copy(isEpisodeDurationConstrained = isConstrained)
         }
     }
 

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/create/EpisodeDurationRulePage.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/create/EpisodeDurationRulePage.kt
@@ -1,5 +1,6 @@
 package au.com.shiftyjelly.pocketcasts.playlists.create
 
+import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -8,12 +9,15 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.selection.toggleable
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.Icon
 import androidx.compose.material.IconButton
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.RadioButton
+import androidx.compose.material.Switch
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -21,6 +25,8 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
@@ -30,17 +36,21 @@ import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.dp
 import au.com.shiftyjelly.pocketcasts.compose.AppThemeWithBackground
 import au.com.shiftyjelly.pocketcasts.compose.Devices
+import au.com.shiftyjelly.pocketcasts.compose.buttons.IconButtonSmall
 import au.com.shiftyjelly.pocketcasts.compose.buttons.RowButton
 import au.com.shiftyjelly.pocketcasts.compose.components.TextH20
 import au.com.shiftyjelly.pocketcasts.compose.components.TextH30
+import au.com.shiftyjelly.pocketcasts.compose.components.TextH40
 import au.com.shiftyjelly.pocketcasts.compose.preview.ThemePreviewParameterProvider
 import au.com.shiftyjelly.pocketcasts.compose.theme
 import au.com.shiftyjelly.pocketcasts.images.R
+import au.com.shiftyjelly.pocketcasts.localization.helper.TimeHelper
 import au.com.shiftyjelly.pocketcasts.models.type.SmartRules
 import au.com.shiftyjelly.pocketcasts.models.type.SmartRules.ReleaseDateRule
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme.ThemeType
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.minutes
+import au.com.shiftyjelly.pocketcasts.images.R as IR
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 @Composable
@@ -79,7 +89,50 @@ fun EpisodeDurationRulePage(
                 modifier = Modifier.padding(horizontal = 16.dp),
             )
             Spacer(
-                modifier = Modifier.height(12.dp),
+                modifier = Modifier.height(24.dp),
+            )
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                modifier = Modifier
+                    .toggleable(
+                        value = isDurationConstrained,
+                        role = Role.Switch,
+                        onValueChange = onToggleConstrainDuration,
+                    )
+                    .padding(horizontal = 16.dp, vertical = 12.dp),
+            ) {
+                TextH30(
+                    text = stringResource(LR.string.filters_filter_by_duration),
+                    modifier = Modifier.weight(1f),
+                )
+                Switch(
+                    checked = isDurationConstrained,
+                    onCheckedChange = null,
+                )
+            }
+            DurtionRow(
+                label = stringResource(LR.string.filters_duration_longer_than),
+                duration = minDuration,
+                isEnabled = isDurationConstrained,
+                decrementDescription = stringResource(LR.string.decrement_longer_than_duration),
+                incrementDescription = stringResource(LR.string.increment_longer_than_duration),
+                onDecrement = onDecrementMinDuration,
+                onIncrement = onIncrementMinDuration,
+            )
+            DurtionRow(
+                label = stringResource(LR.string.filters_duration_shorter_than),
+                duration = maxDuration,
+                isEnabled = isDurationConstrained,
+                decrementDescription = stringResource(LR.string.decrement_shorter_than_duration),
+                incrementDescription = stringResource(LR.string.increment_shorter_than_duration),
+                onDecrement = onDecrementMaxDuration,
+                onIncrement = onIncrementMaxDuration,
+            )
+            Spacer(
+                modifier = Modifier.height(24.dp),
+            )
+            Spacer(
+                modifier = Modifier.weight(1f),
             )
             RowButton(
                 text = stringResource(LR.string.save_smart_rule),
@@ -98,12 +151,67 @@ fun EpisodeDurationRulePage(
     }
 }
 
+@Composable
+private fun DurtionRow(
+    label: String,
+    duration: Duration,
+    isEnabled: Boolean,
+    decrementDescription: String,
+    incrementDescription: String,
+    onDecrement: () -> Unit,
+    onIncrement: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val context = LocalContext.current
+    val alpha by animateFloatAsState(if (isEnabled) 1f else 0.5f)
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = modifier
+            .alpha(alpha)
+            .padding(start = 16.dp, end = 6.dp),
+    ) {
+        TextH40(
+            text = label,
+        )
+        Spacer(
+            modifier = Modifier.weight(1f),
+        )
+        TextH40(
+            text = TimeHelper.getTimeDurationShortString(
+                context = context,
+                timeMs = duration.inWholeMilliseconds,
+            ),
+        )
+        Spacer(
+            modifier = Modifier.width(4.dp),
+        )
+        IconButton(
+            onClick = onDecrement,
+        ) {
+            Icon(
+                painter = painterResource(IR.drawable.ic_minus),
+                contentDescription = decrementDescription,
+                tint = MaterialTheme.theme.colors.primaryIcon01,
+            )
+        }
+        IconButton(
+            onClick = onIncrement,
+        ) {
+            Icon(
+                painter = painterResource(IR.drawable.ic_effects_plus),
+                contentDescription = incrementDescription,
+                tint = MaterialTheme.theme.colors.primaryIcon01,
+            )
+        }
+    }
+}
+
 @Preview(device = Devices.PORTRAIT_REGULAR)
 @Composable
 private fun EpisodeDurationRulePreview(
     @PreviewParameter(ThemePreviewParameterProvider::class) themeType: ThemeType,
 ) {
-    var isConstrained by remember { mutableStateOf(false) }
+    var isConstrained by remember { mutableStateOf(true) }
     var minDuration by remember { mutableStateOf(20.minutes) }
     var maxDuration by remember { mutableStateOf(40.minutes) }
 

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/create/EpisodeDurationRulePage.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/create/EpisodeDurationRulePage.kt
@@ -1,0 +1,124 @@
+package au.com.shiftyjelly.pocketcasts.playlists.create
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.Icon
+import androidx.compose.material.IconButton
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.RadioButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewParameter
+import androidx.compose.ui.unit.dp
+import au.com.shiftyjelly.pocketcasts.compose.AppThemeWithBackground
+import au.com.shiftyjelly.pocketcasts.compose.Devices
+import au.com.shiftyjelly.pocketcasts.compose.buttons.RowButton
+import au.com.shiftyjelly.pocketcasts.compose.components.TextH20
+import au.com.shiftyjelly.pocketcasts.compose.components.TextH30
+import au.com.shiftyjelly.pocketcasts.compose.preview.ThemePreviewParameterProvider
+import au.com.shiftyjelly.pocketcasts.compose.theme
+import au.com.shiftyjelly.pocketcasts.images.R
+import au.com.shiftyjelly.pocketcasts.models.type.SmartRules
+import au.com.shiftyjelly.pocketcasts.models.type.SmartRules.ReleaseDateRule
+import au.com.shiftyjelly.pocketcasts.ui.theme.Theme.ThemeType
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.minutes
+import au.com.shiftyjelly.pocketcasts.localization.R as LR
+
+@Composable
+fun EpisodeDurationRulePage(
+    isDurationConstrained: Boolean,
+    minDuration: Duration,
+    maxDuration: Duration,
+    onToggleConstrainDuration: (Boolean) -> Unit,
+    onDecrementMinDuration: () -> Unit,
+    onIncrementMinDuration: () -> Unit,
+    onDecrementMaxDuration: () -> Unit,
+    onIncrementMaxDuration: () -> Unit,
+    onSaveRule: () -> Unit,
+    onClickBack: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .verticalScroll(rememberScrollState()),
+    ) {
+        IconButton(
+            onClick = onClickBack,
+        ) {
+            Icon(
+                painter = painterResource(R.drawable.ic_arrow_back),
+                contentDescription = stringResource(LR.string.back),
+                tint = MaterialTheme.theme.colors.primaryIcon03,
+            )
+        }
+        Column(
+            modifier = Modifier.weight(1f),
+        ) {
+            TextH20(
+                text = stringResource(LR.string.filters_episode_duration),
+                modifier = Modifier.padding(horizontal = 16.dp),
+            )
+            Spacer(
+                modifier = Modifier.height(12.dp),
+            )
+            RowButton(
+                text = stringResource(LR.string.save_smart_rule),
+                enabled = if (isDurationConstrained) {
+                    maxDuration >= minDuration
+                } else {
+                    true
+                },
+                onClick = onSaveRule,
+                includePadding = false,
+                modifier = Modifier
+                    .padding(horizontal = 16.dp)
+                    .navigationBarsPadding(),
+            )
+        }
+    }
+}
+
+@Preview(device = Devices.PORTRAIT_REGULAR)
+@Composable
+private fun EpisodeDurationRulePreview(
+    @PreviewParameter(ThemePreviewParameterProvider::class) themeType: ThemeType,
+) {
+    var isConstrained by remember { mutableStateOf(false) }
+    var minDuration by remember { mutableStateOf(20.minutes) }
+    var maxDuration by remember { mutableStateOf(40.minutes) }
+
+    AppThemeWithBackground(themeType) {
+        EpisodeDurationRulePage(
+            isDurationConstrained = isConstrained,
+            minDuration = minDuration,
+            maxDuration = maxDuration,
+            onToggleConstrainDuration = { isConstrained = it },
+            onDecrementMinDuration = { minDuration -= 5.minutes },
+            onIncrementMinDuration = { minDuration += 5.minutes },
+            onDecrementMaxDuration = { maxDuration -= 5.minutes },
+            onIncrementMaxDuration = { maxDuration += 5.minutes },
+            onSaveRule = {},
+            onClickBack = {},
+        )
+    }
+}

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/create/SmartPlaylistPreviewPage.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/create/SmartPlaylistPreviewPage.kt
@@ -70,6 +70,8 @@ import au.com.shiftyjelly.pocketcasts.images.R
 import au.com.shiftyjelly.pocketcasts.localization.helper.RelativeDateFormatter
 import au.com.shiftyjelly.pocketcasts.localization.helper.TimeHelper
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
+import au.com.shiftyjelly.pocketcasts.models.type.SmartRules
+import au.com.shiftyjelly.pocketcasts.models.type.SmartRules.EpisodeDurationRule
 import au.com.shiftyjelly.pocketcasts.models.type.SmartRules.PodcastsRule
 import au.com.shiftyjelly.pocketcasts.models.type.SmartRules.ReleaseDateRule
 import au.com.shiftyjelly.pocketcasts.playlists.create.CreatePlaylistViewModel.AppliedRules
@@ -594,7 +596,16 @@ private fun AppliedRules.description(ruleType: RuleType) = when (ruleType) {
         null -> null
     }
 
-    RuleType.EpisodeDuration -> TODO()
+    RuleType.EpisodeDuration -> when (episodeDuration) {
+        is EpisodeDurationRule.Any -> stringResource(LR.string.any_duration)
+        is EpisodeDurationRule.Constrained -> {
+            val context = LocalContext.current
+            val min = TimeHelper.getTimeDurationShortString(episodeDuration.longerThan.inWholeMilliseconds, context)
+            val max = TimeHelper.getTimeDurationShortString(episodeDuration.shorterThan.inWholeMilliseconds, context)
+            "$min - $max"
+        }
+        null -> null
+    }
     RuleType.DownloadStatus -> TODO()
     RuleType.MediaType -> TODO()
     RuleType.Starred -> TODO()

--- a/modules/features/filters/src/test/kotlin/au/com/shiftyjelly/pocketcasts/playlists/create/CreatePlaylistViewModelTest.kt
+++ b/modules/features/filters/src/test/kotlin/au/com/shiftyjelly/pocketcasts/playlists/create/CreatePlaylistViewModelTest.kt
@@ -236,35 +236,4 @@ class CreatePlaylistViewModelTest {
             assertEquals(EpisodeDurationRule.Any, state.appliedRules.episodeDuration)
         }
     }
-
-    @Test
-    fun `min and max episode durations cannot overlap`() = runTest {
-        viewModel.constrainDuration(true)
-        repeat(4) {
-            viewModel.decrementMinDuration()
-        }
-        repeat(6) {
-            viewModel.decrementMaxDuration()
-        }
-
-        viewModel.uiState.test {
-            var state = awaitItem()
-            assertEquals(0.minutes, state.rulesBuilder.minEpisodeDuration)
-            assertEquals(10.minutes, state.rulesBuilder.maxEpisodeDuration)
-
-            viewModel.decrementMinDuration()
-            expectNoEvents()
-
-            viewModel.incrementMinDuration()
-            state = awaitItem()
-            assertEquals(5.minutes, state.rulesBuilder.minEpisodeDuration)
-            assertEquals(10.minutes, state.rulesBuilder.maxEpisodeDuration)
-
-            viewModel.incrementMinDuration()
-            expectNoEvents()
-
-            viewModel.decrementMaxDuration()
-            expectNoEvents()
-        }
-    }
 }

--- a/modules/features/filters/src/test/kotlin/au/com/shiftyjelly/pocketcasts/playlists/create/RulesBuilderTest.kt
+++ b/modules/features/filters/src/test/kotlin/au/com/shiftyjelly/pocketcasts/playlists/create/RulesBuilderTest.kt
@@ -1,0 +1,109 @@
+package au.com.shiftyjelly.pocketcasts.playlists.create
+
+import androidx.navigation.NavDeepLinkRequest
+import au.com.shiftyjelly.pocketcasts.playlists.create.CreatePlaylistViewModel.RulesBuilder
+import kotlin.time.Duration.Companion.minutes
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class RulesBuilderTest {
+    @Test
+    fun `change min episode duration`() {
+        var builder = RulesBuilder.Empty.copy(
+            minEpisodeDuration = 15.minutes,
+            maxEpisodeDuration = 20.minutes,
+        )
+
+        builder = builder.incrementMinDuration()
+        assertEquals(15.minutes, builder.minEpisodeDuration)
+
+        builder = builder.decrementMinDuration()
+        assertEquals(10.minutes, builder.minEpisodeDuration)
+
+        builder = builder.incrementMinDuration()
+        assertEquals(15.minutes, builder.minEpisodeDuration)
+
+        builder = builder.decrementMinDuration()
+        assertEquals(10.minutes, builder.minEpisodeDuration)
+
+        builder = builder.decrementMinDuration()
+        assertEquals(5.minutes, builder.minEpisodeDuration)
+
+        builder = builder.incrementMinDuration()
+        assertEquals(10.minutes, builder.minEpisodeDuration)
+
+        builder = builder.decrementMinDuration()
+        assertEquals(5.minutes, builder.minEpisodeDuration)
+
+        builder = builder.decrementMinDuration()
+        assertEquals(4.minutes, builder.minEpisodeDuration)
+
+        builder = builder.incrementMinDuration()
+        assertEquals(5.minutes, builder.minEpisodeDuration)
+
+        builder = builder.decrementMinDuration()
+        assertEquals(4.minutes, builder.minEpisodeDuration)
+
+        builder = builder.decrementMinDuration()
+        assertEquals(3.minutes, builder.minEpisodeDuration)
+
+        builder = builder.decrementMinDuration()
+        assertEquals(2.minutes, builder.minEpisodeDuration)
+
+        builder = builder.decrementMinDuration()
+        assertEquals(1.minutes, builder.minEpisodeDuration)
+
+        builder = builder.decrementMinDuration()
+        assertEquals(0.minutes, builder.minEpisodeDuration)
+
+        builder = builder.decrementMinDuration()
+        assertEquals(0.minutes, builder.minEpisodeDuration)
+    }
+
+    @Test
+    fun `change max episode duration`() {
+        var builder = RulesBuilder.Empty.copy(
+            minEpisodeDuration = 0.minutes,
+            maxEpisodeDuration = 1.minutes,
+        )
+
+        builder = builder.decrementMaxDuration()
+        assertEquals(1.minutes, builder.maxEpisodeDuration)
+
+        builder = builder.incrementMaxDuration()
+        assertEquals(2.minutes, builder.maxEpisodeDuration)
+
+        builder = builder.decrementMaxDuration()
+        assertEquals(1.minutes, builder.maxEpisodeDuration)
+
+        builder = builder.incrementMaxDuration()
+        assertEquals(2.minutes, builder.maxEpisodeDuration)
+
+        builder = builder.incrementMaxDuration()
+        assertEquals(3.minutes, builder.maxEpisodeDuration)
+
+        builder = builder.incrementMaxDuration()
+        assertEquals(4.minutes, builder.maxEpisodeDuration)
+
+        builder = builder.incrementMaxDuration()
+        assertEquals(5.minutes, builder.maxEpisodeDuration)
+
+        builder = builder.decrementMaxDuration()
+        assertEquals(4.minutes, builder.maxEpisodeDuration)
+
+        builder = builder.incrementMaxDuration()
+        assertEquals(5.minutes, builder.maxEpisodeDuration)
+
+        builder = builder.incrementMaxDuration()
+        assertEquals(10.minutes, builder.maxEpisodeDuration)
+
+        builder = builder.decrementMaxDuration()
+        assertEquals(5.minutes, builder.maxEpisodeDuration)
+
+        builder = builder.incrementMaxDuration()
+        assertEquals(10.minutes, builder.maxEpisodeDuration)
+
+        builder = builder.incrementMaxDuration()
+        assertEquals(15.minutes, builder.maxEpisodeDuration)
+    }
+}

--- a/modules/services/localization/src/main/java/au/com/shiftyjelly/pocketcasts/localization/helper/TimeHelper.kt
+++ b/modules/services/localization/src/main/java/au/com/shiftyjelly/pocketcasts/localization/helper/TimeHelper.kt
@@ -32,7 +32,7 @@ object TimeHelper {
             output = context.getString(R.string.time_short_hours_minutes, hours, mins) // "${hours}h ${mins}m"
         } else if (mins > 0) {
             output = context.getString(R.string.time_short_minutes, mins) // "${mins}m"
-        } else if (secs > 0 && mins == 0L) {
+        } else if (secs >= 0 && mins == 0L) {
             output = context.getString(R.string.time_short_seconds, secs) // "${secs}s"
         }
         return output.ifEmpty { emptyString }

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -934,10 +934,10 @@
     <string name="smart_playlist_create_no_content_body">None of the episodes in your podcasts match these rules.\n\nTry adjusting the rules, or save this playlist for future episodes that might fit.</string>
     <!-- %1$s is status like 'In Progress' and %2$d is count of other episode statuses -->
     <string name="episode_status_rule_description">%1$s + %2$d</string>
-    <string name="decrement_longer_than_duration">Decrement "longer than" duration</string>
-    <string name="increment_longer_than_duration">Increment "longer than" duration</string>
-    <string name="decrement_shorter_than_duration">Decrement "shorter than" duration</string>
-    <string name="increment_shorter_than_duration">Increment "shorter than" duration</string>
+    <string name="decrement_longer_than_duration">Decrement \"longer than\" duration</string>
+    <string name="increment_longer_than_duration">Increment \"longer than\" duration</string>
+    <string name="decrement_shorter_than_duration">Decrement \"shorter than\" duration</string>
+    <string name="increment_shorter_than_duration">Increment \"shorter than\" duration</string>
 
     <!-- Profile -->
 

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -237,6 +237,7 @@
         <item quantity="other">%d episodes</item>
     </plurals>
     <string name="empty_play_state">Pick an episode to begin</string>
+    <string name="any_duration">Any duration</string>
 
     <string name="seconds_label">Seconds</string>
     <string name="seconds_singular">1 second</string>
@@ -933,6 +934,10 @@
     <string name="smart_playlist_create_no_content_body">None of the episodes in your podcasts match these rules.\n\nTry adjusting the rules, or save this playlist for future episodes that might fit.</string>
     <!-- %1$s is status like 'In Progress' and %2$d is count of other episode statuses -->
     <string name="episode_status_rule_description">%1$s + %2$d</string>
+    <string name="decrement_longer_than_duration">Decrement "longer than" duration</string>
+    <string name="increment_longer_than_duration">Increment "longer than" duration</string>
+    <string name="decrement_shorter_than_duration">Decrement "shorter than" duration</string>
+    <string name="increment_shorter_than_duration">Increment "shorter than" duration</string>
 
     <!-- Profile -->
 


### PR DESCRIPTION
## Description

This adds episode duration smart rule management. The control buttons are a bit bigger in the designs because designs do not account for the accessibility and min tap target.

Designs:
- 5sC4z4Mu42LvL4MAAIbQVi-fi-1573_85778
- 5sC4z4Mu42LvL4MAAIbQVi-fi-1573_85444

Fixes PCDROID-57

## Testing Instructions

1. Start a playlist creation.
2. Continue with Smart Playlist.
3. Tap "Duration".
4. Verify the screen with the designs.
5. Saving the rule will navigate you back to the playlist preview page.

## Screenshots or Screencast 

| Rule | Applied rule 1 | Applied rule 2 |
| - | - | - |
| <img width="1080" height="2400" alt="Screenshot_20250731-123936" src="https://github.com/user-attachments/assets/b25f68e4-f874-431e-a1b6-922f45435016" /> | <img width="1080" height="2400" alt="Screenshot_20250731-123717" src="https://github.com/user-attachments/assets/75a27096-9d34-4c13-8686-34ca7b5e9099" /> | <img width="1080" height="2400" alt="Screenshot_20250731-123723" src="https://github.com/user-attachments/assets/7927cf26-0c6c-42e9-9e7d-8033a22c6e82" /> |

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack