### PR TITLE
Control download status rule

### DIFF
--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/create/CreatePlaylistFragment.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/create/CreatePlaylistFragment.kt
@@ -158,6 +158,17 @@ class CreatePlaylistFragment : BaseDialogFragment() {
                         onClickBack = ::goBackToPlaylistPreview,
                     )
                 }
+                composable(NavigationRoutes.SMART_RULE_DOWNLOAD_STATUS) {
+                    DownloadStatusRulePage(
+                        selectedRule = uiState.rulesBuilder.downloadStatusRule,
+                        onSelectDownloadStatus = viewModel::useDownloadStatus,
+                        onSaveRule = {
+                            viewModel.applyRule(RuleType.DownloadStatus)
+                            goBackToPlaylistPreview()
+                        },
+                        onClickBack = ::goBackToPlaylistPreview,
+                    )
+                }
             }
         }
     }
@@ -193,6 +204,7 @@ private object NavigationRoutes {
     const val SMART_RULE_EPISODE_STATUS = "smart_rule_episode_status"
     const val SMART_RULE_RELEASE_DATE = "smart_rule_release_date"
     const val SMART_RULE_EPISODE_DURATION = "smart_rule_episode_duration"
+    const val SMART_RULE_DOWNLOAD_STATUS = "smart_rule_download_status"
 }
 
 private fun RuleType.toNavigationRoute() = when (this) {
@@ -200,7 +212,7 @@ private fun RuleType.toNavigationRoute() = when (this) {
     RuleType.EpisodeStatus -> NavigationRoutes.SMART_RULE_EPISODE_STATUS
     RuleType.ReleaseDate -> NavigationRoutes.SMART_RULE_RELEASE_DATE
     RuleType.EpisodeDuration -> NavigationRoutes.SMART_RULE_EPISODE_DURATION
-    RuleType.DownloadStatus -> NavigationRoutes.SMART_PLAYLIST_PREVIEW
+    RuleType.DownloadStatus -> NavigationRoutes.SMART_RULE_DOWNLOAD_STATUS
     RuleType.MediaType -> NavigationRoutes.SMART_PLAYLIST_PREVIEW
     RuleType.Starred -> NavigationRoutes.SMART_PLAYLIST_PREVIEW
 }

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/create/CreatePlaylistViewModel.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/create/CreatePlaylistViewModel.kt
@@ -100,7 +100,13 @@ class CreatePlaylistViewModel @AssistedInject constructor(
                 }
             }
 
-            RuleType.DownloadStatus -> TODO()
+            RuleType.DownloadStatus -> {
+                val rule = rulesBuilder.value.downloadStatusRule
+                appliedRules.update { rules ->
+                    rules.copy(downloadStatus = rule)
+                }
+            }
+
             RuleType.MediaType -> TODO()
             RuleType.Starred -> TODO()
         }
@@ -175,6 +181,12 @@ class CreatePlaylistViewModel @AssistedInject constructor(
         rulesBuilder.update { builder -> builder.incrementMaxDuration() }
     }
 
+    fun useDownloadStatus(rule: DownloadStatusRule) {
+        rulesBuilder.update { builder ->
+            builder.copy(downloadStatusRule = rule)
+        }
+    }
+
     data class UiState(
         val appliedRules: AppliedRules,
         val rulesBuilder: RulesBuilder,
@@ -245,6 +257,7 @@ class CreatePlaylistViewModel @AssistedInject constructor(
         val isEpisodeDurationConstrained: Boolean,
         val minEpisodeDuration: Duration,
         val maxEpisodeDuration: Duration,
+        val downloadStatusRule: DownloadStatusRule,
     ) {
         val podcastsRule
             get() = if (useAllPodcasts) {
@@ -309,6 +322,7 @@ class CreatePlaylistViewModel @AssistedInject constructor(
                 isEpisodeDurationConstrained = false,
                 minEpisodeDuration = 20.minutes,
                 maxEpisodeDuration = 40.minutes,
+                downloadStatusRule = SmartRules.Default.downloadStatus,
             )
         }
     }

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/create/DownloadStatusRulePage.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/create/DownloadStatusRulePage.kt
@@ -1,0 +1,148 @@
+package au.com.shiftyjelly.pocketcasts.playlists.create
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.Icon
+import androidx.compose.material.IconButton
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.RadioButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewParameter
+import androidx.compose.ui.unit.dp
+import au.com.shiftyjelly.pocketcasts.compose.AppThemeWithBackground
+import au.com.shiftyjelly.pocketcasts.compose.Devices
+import au.com.shiftyjelly.pocketcasts.compose.buttons.RowButton
+import au.com.shiftyjelly.pocketcasts.compose.components.TextH20
+import au.com.shiftyjelly.pocketcasts.compose.components.TextH30
+import au.com.shiftyjelly.pocketcasts.compose.preview.ThemePreviewParameterProvider
+import au.com.shiftyjelly.pocketcasts.compose.theme
+import au.com.shiftyjelly.pocketcasts.images.R
+import au.com.shiftyjelly.pocketcasts.models.type.SmartRules
+import au.com.shiftyjelly.pocketcasts.models.type.SmartRules.DownloadStatusRule
+import au.com.shiftyjelly.pocketcasts.ui.theme.Theme.ThemeType
+import au.com.shiftyjelly.pocketcasts.localization.R as LR
+
+@Composable
+fun DownloadStatusRulePage(
+    selectedRule: DownloadStatusRule,
+    onSelectDownloadStatus: (DownloadStatusRule) -> Unit,
+    onSaveRule: () -> Unit,
+    onClickBack: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .verticalScroll(rememberScrollState()),
+    ) {
+        IconButton(
+            onClick = onClickBack,
+        ) {
+            Icon(
+                painter = painterResource(R.drawable.ic_arrow_back),
+                contentDescription = stringResource(LR.string.back),
+                tint = MaterialTheme.theme.colors.primaryIcon03,
+            )
+        }
+        Column(
+            modifier = Modifier.weight(1f),
+        ) {
+            TextH20(
+                text = stringResource(LR.string.filters_chip_download_status),
+                modifier = Modifier.padding(horizontal = 16.dp),
+            )
+            Spacer(
+                modifier = Modifier.height(12.dp),
+            )
+            DownloadStatusRule.entries.forEach { rule ->
+                DownloadStatusRow(
+                    rule = rule,
+                    isSelected = rule == selectedRule,
+                    onSelect = { onSelectDownloadStatus(rule) },
+                )
+            }
+            Spacer(
+                modifier = Modifier.weight(1f),
+            )
+            RowButton(
+                text = stringResource(LR.string.save_smart_rule),
+                onClick = onSaveRule,
+                includePadding = false,
+                modifier = Modifier
+                    .padding(horizontal = 16.dp)
+                    .navigationBarsPadding(),
+            )
+        }
+    }
+}
+
+@Composable
+private fun DownloadStatusRow(
+    rule: DownloadStatusRule,
+    isSelected: Boolean,
+    onSelect: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = modifier
+            .clickable(
+                enabled = !isSelected,
+                role = Role.RadioButton,
+                onClick = onSelect,
+            )
+            .padding(vertical = 12.dp, horizontal = 16.dp)
+            .semantics(mergeDescendants = true) {},
+    ) {
+        TextH30(
+            text = stringResource(rule.displayLabelId),
+            modifier = Modifier.weight(1f),
+        )
+        RadioButton(
+            selected = isSelected,
+            onClick = null,
+        )
+    }
+}
+
+private val DownloadStatusRule.displayLabelId get() = when (this) {
+    DownloadStatusRule.Any -> LR.string.all
+    DownloadStatusRule.Downloaded -> LR.string.downloaded
+    DownloadStatusRule.NotDownloaded -> LR.string.not_downloaded
+}
+
+@Preview(device = Devices.PORTRAIT_REGULAR)
+@Composable
+private fun DownloadStatusRulePreview(
+    @PreviewParameter(ThemePreviewParameterProvider::class) themeType: ThemeType,
+) {
+    var rule by remember { mutableStateOf(SmartRules.Default.downloadStatus) }
+
+    AppThemeWithBackground(themeType) {
+        DownloadStatusRulePage(
+            selectedRule = rule,
+            onSelectDownloadStatus = { rule = it },
+            onSaveRule = {},
+            onClickBack = {},
+        )
+    }
+}

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/create/SmartPlaylistPreviewPage.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/create/SmartPlaylistPreviewPage.kt
@@ -70,6 +70,7 @@ import au.com.shiftyjelly.pocketcasts.localization.helper.RelativeDateFormatter
 import au.com.shiftyjelly.pocketcasts.localization.helper.TimeHelper
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.models.type.SmartRules
+import au.com.shiftyjelly.pocketcasts.models.type.SmartRules.DownloadStatusRule
 import au.com.shiftyjelly.pocketcasts.models.type.SmartRules.EpisodeDurationRule
 import au.com.shiftyjelly.pocketcasts.models.type.SmartRules.PodcastsRule
 import au.com.shiftyjelly.pocketcasts.models.type.SmartRules.ReleaseDateRule
@@ -605,7 +606,13 @@ private fun AppliedRules.description(ruleType: RuleType) = when (ruleType) {
         }
         null -> null
     }
-    RuleType.DownloadStatus -> TODO()
+
+    RuleType.DownloadStatus -> when (downloadStatus) {
+        DownloadStatusRule.Any -> stringResource(LR.string.all)
+        DownloadStatusRule.Downloaded -> stringResource(LR.string.downloaded)
+        DownloadStatusRule.NotDownloaded -> stringResource(LR.string.not_downloaded)
+        null -> null
+    }
     RuleType.MediaType -> TODO()
     RuleType.Starred -> TODO()
 }

--- a/modules/features/filters/src/test/kotlin/au/com/shiftyjelly/pocketcasts/playlists/create/CreatePlaylistViewModelTest.kt
+++ b/modules/features/filters/src/test/kotlin/au/com/shiftyjelly/pocketcasts/playlists/create/CreatePlaylistViewModelTest.kt
@@ -2,6 +2,8 @@ package au.com.shiftyjelly.pocketcasts.playlists.create
 
 import androidx.compose.ui.text.TextRange
 import app.cash.turbine.test
+import au.com.shiftyjelly.pocketcasts.models.type.SmartRules
+import au.com.shiftyjelly.pocketcasts.models.type.SmartRules.DownloadStatusRule
 import au.com.shiftyjelly.pocketcasts.models.type.SmartRules.EpisodeDurationRule
 import au.com.shiftyjelly.pocketcasts.models.type.SmartRules.EpisodeStatusRule
 import au.com.shiftyjelly.pocketcasts.models.type.SmartRules.PodcastsRule
@@ -234,6 +236,33 @@ class CreatePlaylistViewModelTest {
             viewModel.applyRule(RuleType.EpisodeDuration)
             state = awaitItem()
             assertEquals(EpisodeDurationRule.Any, state.appliedRules.episodeDuration)
+        }
+    }
+
+    @Test
+    fun `manage download status rule`() = runTest {
+        viewModel.uiState.test {
+            var state = awaitItem()
+            assertEquals(UiState.Empty, state)
+
+            viewModel.useDownloadStatus(DownloadStatusRule.Downloaded)
+            state = awaitItem()
+            assertEquals(DownloadStatusRule.Downloaded, state.rulesBuilder.downloadStatusRule)
+            assertNull(state.appliedRules.downloadStatus)
+
+            viewModel.useDownloadStatus(DownloadStatusRule.Any)
+            state = awaitItem()
+            assertEquals(DownloadStatusRule.Any, state.rulesBuilder.downloadStatusRule)
+            assertNull(state.appliedRules.downloadStatus)
+
+            viewModel.useDownloadStatus(DownloadStatusRule.NotDownloaded)
+            state = awaitItem()
+            assertEquals(DownloadStatusRule.NotDownloaded, state.rulesBuilder.downloadStatusRule)
+            assertNull(state.appliedRules.downloadStatus)
+
+            viewModel.applyRule(RuleType.DownloadStatus)
+            state = awaitItem()
+            assertEquals(DownloadStatusRule.NotDownloaded, state.rulesBuilder.downloadStatusRule)
         }
     }
 }


### PR DESCRIPTION
## Description

This adds download status smart rule management.

Designs:
- 5sC4z4Mu42LvL4MAAIbQVi-fi-1573_85899
- 5sC4z4Mu42LvL4MAAIbQVi-fi-1573_85444

Fixes PCDROID-58

## Testing Instructions

1. Start a playlist creation.
2. Continue with Smart Playlist.
3. Tap "Media Type".
4. Verify the screen with the designs.
5. Saving the rule will navigate you back to the playlist preview page.

## Screenshots or Screencast 

| Rule | Applied rule |
| - | - |
| <img width="1080" height="2400" alt="rule" src="https://github.com/user-attachments/assets/de84e565-b67d-441d-bf4c-7399a7381fde" /> | <img width="1080" height="2400" alt="Screenshot_20250801-074124" src="https://github.com/user-attachments/assets/635fbbc4-965c-42cc-a76a-66d227c876ec" /> |

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack