### PR TITLE
Create Smart Playlists

### DIFF
--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/repositories/playlist/PlaylistManagerTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/repositories/playlist/PlaylistManagerTest.kt
@@ -468,105 +468,147 @@ class PlaylistManagerTest {
         val drafts = listOf(
             SmartPlaylistDraft(
                 title = "Title",
+                rules = SmartRules.Default,
             ),
             SmartPlaylistDraft(
                 title = "Title",
-                episodeStatus = EpisodeStatusRule(
-                    unplayed = true,
-                    inProgress = false,
-                    completed = false,
+                rules = SmartRules.Default.copy(
+                    episodeStatus = EpisodeStatusRule(
+                        unplayed = true,
+                        inProgress = false,
+                        completed = false,
+                    ),
                 ),
             ),
             SmartPlaylistDraft(
                 title = "Title",
-                episodeStatus = EpisodeStatusRule(
-                    unplayed = false,
-                    inProgress = true,
-                    completed = false,
+                rules = SmartRules.Default.copy(
+                    episodeStatus = EpisodeStatusRule(
+                        unplayed = false,
+                        inProgress = true,
+                        completed = false,
+                    ),
                 ),
             ),
             SmartPlaylistDraft(
                 title = "Title",
-                episodeStatus = EpisodeStatusRule(
-                    unplayed = false,
-                    inProgress = false,
-                    completed = true,
+                rules = SmartRules.Default.copy(
+                    episodeStatus = EpisodeStatusRule(
+                        unplayed = false,
+                        inProgress = false,
+                        completed = true,
+                    ),
                 ),
             ),
             SmartPlaylistDraft(
                 title = "Title",
-                downloadStatus = DownloadStatusRule.Any,
+                rules = SmartRules.Default.copy(
+                    downloadStatus = DownloadStatusRule.Any,
+                ),
             ),
             SmartPlaylistDraft(
                 title = "Title",
-                downloadStatus = DownloadStatusRule.Downloaded,
+                rules = SmartRules.Default.copy(
+                    downloadStatus = DownloadStatusRule.Downloaded,
+                ),
             ),
             SmartPlaylistDraft(
                 title = "Title",
-                downloadStatus = DownloadStatusRule.NotDownloaded,
+                rules = SmartRules.Default.copy(
+                    downloadStatus = DownloadStatusRule.NotDownloaded,
+                ),
             ),
             SmartPlaylistDraft(
                 title = "Title",
-                mediaType = MediaTypeRule.Any,
+                rules = SmartRules.Default.copy(
+                    mediaType = MediaTypeRule.Any,
+                ),
             ),
             SmartPlaylistDraft(
                 title = "Title",
-                mediaType = MediaTypeRule.Audio,
+                rules = SmartRules.Default.copy(
+                    mediaType = MediaTypeRule.Audio,
+                ),
             ),
             SmartPlaylistDraft(
                 title = "Title",
-                mediaType = MediaTypeRule.Video,
+                rules = SmartRules.Default.copy(
+                    mediaType = MediaTypeRule.Video,
+                ),
             ),
             SmartPlaylistDraft(
                 title = "Title",
-                releaseDate = ReleaseDateRule.AnyTime,
+                rules = SmartRules.Default.copy(
+                    releaseDate = ReleaseDateRule.AnyTime,
+                ),
             ),
             SmartPlaylistDraft(
                 title = "Title",
-                releaseDate = ReleaseDateRule.Last24Hours,
+                rules = SmartRules.Default.copy(
+                    releaseDate = ReleaseDateRule.Last24Hours,
+                ),
             ),
             SmartPlaylistDraft(
                 title = "Title",
-                releaseDate = ReleaseDateRule.Last3Days,
+                rules = SmartRules.Default.copy(
+                    releaseDate = ReleaseDateRule.Last3Days,
+                ),
             ),
             SmartPlaylistDraft(
                 title = "Title",
-                releaseDate = ReleaseDateRule.LastWeek,
+                rules = SmartRules.Default.copy(
+                    releaseDate = ReleaseDateRule.LastWeek,
+                ),
             ),
             SmartPlaylistDraft(
                 title = "Title",
-                releaseDate = ReleaseDateRule.Last2Weeks,
+                rules = SmartRules.Default.copy(
+                    releaseDate = ReleaseDateRule.Last2Weeks,
+                ),
             ),
             SmartPlaylistDraft(
                 title = "Title",
-                releaseDate = ReleaseDateRule.LastMonth,
+                rules = SmartRules.Default.copy(
+                    releaseDate = ReleaseDateRule.LastMonth,
+                ),
             ),
             SmartPlaylistDraft(
                 title = "Title",
-                starred = StarredRule.Any,
+                rules = SmartRules.Default.copy(
+                    starred = StarredRule.Any,
+                ),
             ),
             SmartPlaylistDraft(
                 title = "Title",
-                starred = StarredRule.Starred,
+                rules = SmartRules.Default.copy(
+                    starred = StarredRule.Starred,
+                ),
             ),
             SmartPlaylistDraft(
                 title = "Title",
-                podcasts = PodcastsRule.Any,
+                rules = SmartRules.Default.copy(
+                    podcasts = PodcastsRule.Any,
+                ),
             ),
             SmartPlaylistDraft(
                 title = "Title",
-                podcasts = PodcastsRule.Selected(uuids = listOf("id-1", "id-2")),
+                rules = SmartRules.Default.copy(
+                    podcasts = PodcastsRule.Selected(uuids = listOf("id-1", "id-2")),
+                ),
             ),
             SmartPlaylistDraft(
                 title = "Title",
-                episodeDuration = EpisodeDurationRule.Any,
+                rules = SmartRules.Default.copy(
+                    episodeDuration = EpisodeDurationRule.Any,
+                ),
             ),
             SmartPlaylistDraft(
                 title = "Title",
-                episodeDuration = EpisodeDurationRule.Constrained(longerThan = 50.minutes, shorterThan = 60.minutes),
+                rules = SmartRules.Default.copy(
+                    episodeDuration = EpisodeDurationRule.Constrained(longerThan = 50.minutes, shorterThan = 60.minutes),
+                ),
             ),
         )
-
         drafts.forEach { draft -> manager.upsertSmartPlaylist(draft) }
         val playlists = playlistDao.observeSmartPlaylists().first()
 

--- a/modules/features/filters/build.gradle.kts
+++ b/modules/features/filters/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     alias(libs.plugins.android.library)
     alias(libs.plugins.kotlin.android)
+    alias(libs.plugins.kotlin.parcelize)
     alias(libs.plugins.ksp)
     alias(libs.plugins.hilt)
     alias(libs.plugins.compose.compiler)

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/PlaylistPreviewRow.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/PlaylistPreviewRow.kt
@@ -70,6 +70,7 @@ fun PlaylistPreviewRow(
     playlist: PlaylistPreview,
     showTooltip: Boolean,
     showDivider: Boolean,
+    onClick: () -> Unit,
     onDelete: () -> Unit,
     onClickTooltip: () -> Unit,
     modifier: Modifier = Modifier,
@@ -164,6 +165,10 @@ fun PlaylistPreviewRow(
                         y = 0,
                     )
                 }
+                .clickable(
+                    role = Role.Button,
+                    onClick = onClick,
+                )
                 .anchoredDraggable(
                     state = draggableState,
                     orientation = Orientation.Horizontal,
@@ -265,6 +270,7 @@ private fun PlaylistPreviewRowPreview(
                 ),
                 showTooltip = false,
                 showDivider = true,
+                onClick = {},
                 onDelete = {},
                 onClickTooltip = {},
                 modifier = Modifier.fillMaxWidth(),
@@ -278,6 +284,7 @@ private fun PlaylistPreviewRowPreview(
                 ),
                 showTooltip = false,
                 showDivider = true,
+                onClick = {},
                 onDelete = {},
                 onClickTooltip = {},
                 modifier = Modifier.fillMaxWidth(),
@@ -291,6 +298,7 @@ private fun PlaylistPreviewRowPreview(
                 ),
                 showTooltip = false,
                 showDivider = false,
+                onClick = {},
                 onDelete = {},
                 onClickTooltip = {},
                 modifier = Modifier.fillMaxWidth(),

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/PlaylistsFragment.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/PlaylistsFragment.kt
@@ -17,6 +17,7 @@ import au.com.shiftyjelly.pocketcasts.compose.extensions.contentWithoutConsumedI
 import au.com.shiftyjelly.pocketcasts.playlists.create.CreatePlaylistFragment
 import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingFlow
 import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingLauncher
+import au.com.shiftyjelly.pocketcasts.ui.helper.FragmentHostListener
 import au.com.shiftyjelly.pocketcasts.views.fragments.BaseFragment
 import au.com.shiftyjelly.pocketcasts.views.fragments.TopScrollable
 import dagger.hilt.android.AndroidEntryPoint
@@ -56,6 +57,10 @@ class PlaylistsFragment :
                     }
                 },
                 onDeletePlaylist = { playlist -> viewModel.deletePlaylist(playlist.uuid) },
+                onOpenPlaylist = { playlist ->
+                    val fragment = SmartPlaylistFragment.newInstance(playlist.uuid)
+                    (requireActivity() as FragmentHostListener).addFragment(fragment)
+                },
                 onReorderPlaylists = viewModel::updatePlaylistsOrder,
                 onShowPlaylists = { playlists -> viewModel.trackPlaylistsShown(playlists.size) },
                 onFreeAccountBannerCtaClick = {

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/PlaylistsPage.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/PlaylistsPage.kt
@@ -42,6 +42,8 @@ import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.dp
@@ -68,6 +70,7 @@ internal fun PlaylistsPage(
     uiState: UiState,
     onCreatePlaylist: () -> Unit,
     onDeletePlaylist: (PlaylistPreview) -> Unit,
+    onOpenPlaylist: (PlaylistPreview) -> Unit,
     onReorderPlaylists: (List<String>) -> Unit,
     onShowPlaylists: (List<PlaylistPreview>) -> Unit,
     onFreeAccountBannerCtaClick: () -> Unit,
@@ -106,6 +109,7 @@ internal fun PlaylistsPage(
                 ),
                 onCreatePlaylist = onCreatePlaylist,
                 onDeletePlaylist = onDeletePlaylist,
+                onOpenPlaylist = onOpenPlaylist,
                 onReorderPlaylists = onReorderPlaylists,
                 onShowPlaylists = onShowPlaylists,
                 onDismissPremadePlaylistsTooltip = onDismissPremadePlaylistsTooltip,
@@ -141,6 +145,7 @@ private fun ColumnScope.PlaylistsContent(
     contentPadding: PaddingValues,
     onCreatePlaylist: () -> Unit,
     onDeletePlaylist: (PlaylistPreview) -> Unit,
+    onOpenPlaylist: (PlaylistPreview) -> Unit,
     onReorderPlaylists: (List<String>) -> Unit,
     onShowPlaylists: (List<PlaylistPreview>) -> Unit,
     onDismissPremadePlaylistsTooltip: () -> Unit,
@@ -167,6 +172,7 @@ private fun ColumnScope.PlaylistsContent(
                         listState = listState,
                         contentPadding = contentPadding,
                         onDelete = onDeletePlaylist,
+                        onOpen = onOpenPlaylist,
                         onReorderPlaylists = onReorderPlaylists,
                         onDismissPremadePlaylistsTooltip = onDismissPremadePlaylistsTooltip,
                         modifier = Modifier.fillMaxSize(),
@@ -196,6 +202,7 @@ private fun PlaylistsColumn(
     listState: LazyListState,
     contentPadding: PaddingValues,
     onDelete: (PlaylistPreview) -> Unit,
+    onOpen: (PlaylistPreview) -> Unit,
     onReorderPlaylists: (List<String>) -> Unit,
     onDismissPremadePlaylistsTooltip: () -> Unit,
     modifier: Modifier = Modifier,
@@ -239,6 +246,10 @@ private fun PlaylistsColumn(
                     onDelete = { onDelete(playlist) },
                     onClickTooltip = onDismissPremadePlaylistsTooltip,
                     modifier = Modifier
+                        .clickable(
+                            role = Role.Button,
+                            onClick = { onOpen(playlist) },
+                        )
                         .longPressDraggableHandle(
                             onDragStarted = {
                                 hapticFeedback.performHapticFeedback(HapticFeedbackType.LongPress)
@@ -248,7 +259,8 @@ private fun PlaylistsColumn(
                             },
                         )
                         .animateItem()
-                        .shadow(elevation),
+                        .shadow(elevation)
+                        .semantics(mergeDescendants = true) {},
                 )
             }
         }
@@ -360,6 +372,7 @@ private fun PlaylistsPageEmptyStatePreview() {
             ),
             onCreatePlaylist = {},
             onDeletePlaylist = {},
+            onOpenPlaylist = {},
             onReorderPlaylists = {},
             onShowPlaylists = {},
             onFreeAccountBannerCtaClick = {},
@@ -384,6 +397,7 @@ private fun PlaylistsPageEmptyStateNoBannerPreview() {
             ),
             onCreatePlaylist = {},
             onDeletePlaylist = {},
+            onOpenPlaylist = {},
             onReorderPlaylists = {},
             onShowPlaylists = {},
             onFreeAccountBannerCtaClick = {},
@@ -419,6 +433,7 @@ private fun PlaylistPagePreview(
             ),
             onCreatePlaylist = {},
             onDeletePlaylist = {},
+            onOpenPlaylist = {},
             onReorderPlaylists = {},
             onShowPlaylists = {},
             onFreeAccountBannerCtaClick = {},

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/PlaylistsPage.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/PlaylistsPage.kt
@@ -35,7 +35,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.shadow
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.compositeOver
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.platform.LocalDensity
@@ -43,7 +42,6 @@ import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
-import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.dp
@@ -58,8 +56,6 @@ import au.com.shiftyjelly.pocketcasts.compose.theme
 import au.com.shiftyjelly.pocketcasts.playlists.PlaylistsViewModel.PlaylistsState
 import au.com.shiftyjelly.pocketcasts.playlists.PlaylistsViewModel.UiState
 import au.com.shiftyjelly.pocketcasts.repositories.playlist.PlaylistPreview
-import au.com.shiftyjelly.pocketcasts.ui.helper.ColorUtils
-import au.com.shiftyjelly.pocketcasts.ui.helper.modifyHsv
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme.ThemeType
 import sh.calvin.reorderable.ReorderableItem
 import au.com.shiftyjelly.pocketcasts.images.R as IR
@@ -244,12 +240,9 @@ private fun PlaylistsColumn(
                     showDivider = index != displayItems.lastIndex,
                     backgroundColor = backgroundColor,
                     onDelete = { onDelete(playlist) },
+                    onClick = { onOpen(playlist) },
                     onClickTooltip = onDismissPremadePlaylistsTooltip,
                     modifier = Modifier
-                        .clickable(
-                            role = Role.Button,
-                            onClick = { onOpen(playlist) },
-                        )
                         .longPressDraggableHandle(
                             onDragStarted = {
                                 hapticFeedback.performHapticFeedback(HapticFeedbackType.LongPress)
@@ -259,8 +252,7 @@ private fun PlaylistsColumn(
                             },
                         )
                         .animateItem()
-                        .shadow(elevation)
-                        .semantics(mergeDescendants = true) {},
+                        .shadow(elevation),
                 )
             }
         }

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/SmartPlaylistFragment.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/SmartPlaylistFragment.kt
@@ -1,0 +1,57 @@
+package au.com.shiftyjelly.pocketcasts.playlists
+
+import android.os.Bundle
+import android.os.Parcelable
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.compose.runtime.getValue
+import androidx.core.os.BundleCompat
+import androidx.core.os.bundleOf
+import androidx.fragment.app.viewModels
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import au.com.shiftyjelly.pocketcasts.compose.AppThemeWithBackground
+import au.com.shiftyjelly.pocketcasts.compose.extensions.contentWithoutConsumedInsets
+import au.com.shiftyjelly.pocketcasts.views.fragments.BaseFragment
+import dagger.hilt.android.AndroidEntryPoint
+import dagger.hilt.android.lifecycle.withCreationCallback
+import kotlinx.parcelize.Parcelize
+
+@AndroidEntryPoint
+class SmartPlaylistFragment : BaseFragment() {
+    private val args get() = requireNotNull(arguments?.let { BundleCompat.getParcelable(it, NEW_INSTANCE_ARGS, Args::class.java) })
+
+    private val viewModel by viewModels<SmartPlaylistViewModel>(
+        extrasProducer = {
+            defaultViewModelCreationExtras.withCreationCallback<SmartPlaylistViewModel.Factory> { factory ->
+                factory.create(playlistUuuid = args.playlistUuid)
+            }
+        },
+    )
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?,
+    ) = contentWithoutConsumedInsets {
+        val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+
+        AppThemeWithBackground(theme.activeTheme) {
+            SmartPlaylistPage(
+                uiState = uiState,
+            )
+        }
+    }
+
+    @Parcelize
+    private class Args(
+        val playlistUuid: String,
+    ) : Parcelable
+
+    companion object {
+        private const val NEW_INSTANCE_ARGS = "SmartPlaylistsFragmentArgs"
+
+        fun newInstance(playlistUuid: String) = SmartPlaylistFragment().apply {
+            arguments = bundleOf(NEW_INSTANCE_ARGS to Args(playlistUuid))
+        }
+    }
+}

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/SmartPlaylistPage.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/SmartPlaylistPage.kt
@@ -1,0 +1,22 @@
+package au.com.shiftyjelly.pocketcasts.playlists
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import au.com.shiftyjelly.pocketcasts.compose.components.TextH20
+import au.com.shiftyjelly.pocketcasts.playlists.SmartPlaylistViewModel.UiState
+
+@Composable
+fun SmartPlaylistPage(
+    uiState: UiState,
+    modifier: Modifier = Modifier,
+) {
+    Box(
+        contentAlignment = Alignment.Center,
+        modifier = modifier.fillMaxSize(),
+    ) {
+        TextH20(uiState.playlistTitle)
+    }
+}

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/SmartPlaylistViewModel.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/SmartPlaylistViewModel.kt
@@ -1,0 +1,39 @@
+package au.com.shiftyjelly.pocketcasts.playlists
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import au.com.shiftyjelly.pocketcasts.repositories.playlist.PlaylistManager
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedFactory
+import dagger.assisted.AssistedInject
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.mapNotNull
+import kotlinx.coroutines.flow.stateIn
+
+@HiltViewModel(assistedFactory = SmartPlaylistViewModel.Factory::class)
+class SmartPlaylistViewModel @AssistedInject constructor(
+    @Assisted playlistUuuid: String,
+    private val playlistManager: PlaylistManager,
+) : ViewModel() {
+    val uiState = playlistManager.observePlaylistsPreview()
+        .mapNotNull { playlists -> playlists.firstOrNull { it.uuid == playlistUuuid } }
+        .map { UiState(it.title) }
+        .stateIn(viewModelScope, SharingStarted.Lazily, initialValue = UiState.Empty)
+
+    data class UiState(
+        val playlistTitle: String,
+    ) {
+        companion object {
+            val Empty = UiState(
+                playlistTitle = "",
+            )
+        }
+    }
+
+    @AssistedFactory
+    interface Factory {
+        fun create(playlistUuuid: String): SmartPlaylistViewModel
+    }
+}

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/create/CreatePlaylistFragment.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/create/CreatePlaylistFragment.kt
@@ -1,10 +1,13 @@
 package au.com.shiftyjelly.pocketcasts.playlists.create
 
+import android.content.DialogInterface
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -23,6 +26,7 @@ import au.com.shiftyjelly.pocketcasts.compose.extensions.slideInToEnd
 import au.com.shiftyjelly.pocketcasts.compose.extensions.slideInToStart
 import au.com.shiftyjelly.pocketcasts.compose.extensions.slideOutToEnd
 import au.com.shiftyjelly.pocketcasts.compose.extensions.slideOutToStart
+import au.com.shiftyjelly.pocketcasts.playlists.SmartPlaylistFragment
 import au.com.shiftyjelly.pocketcasts.playlists.rules.AppliedRulesPage
 import au.com.shiftyjelly.pocketcasts.playlists.rules.DownloadStatusRulePage
 import au.com.shiftyjelly.pocketcasts.playlists.rules.EpisodeDurationRulePage
@@ -31,6 +35,7 @@ import au.com.shiftyjelly.pocketcasts.playlists.rules.MediaTypeRulePage
 import au.com.shiftyjelly.pocketcasts.playlists.rules.PodcastsRulePage
 import au.com.shiftyjelly.pocketcasts.playlists.rules.ReleaseDateRulePage
 import au.com.shiftyjelly.pocketcasts.playlists.rules.RuleType
+import au.com.shiftyjelly.pocketcasts.ui.helper.FragmentHostListener
 import au.com.shiftyjelly.pocketcasts.utils.extensions.pxToDp
 import au.com.shiftyjelly.pocketcasts.views.fragments.BaseDialogFragment
 import com.google.android.material.bottomsheet.BottomSheetBehavior
@@ -58,6 +63,8 @@ class CreatePlaylistFragment : BaseDialogFragment() {
     ) = content {
         val uiState by viewModel.uiState.collectAsState()
         var areOtherOptionsExpanded by remember { mutableStateOf(false) }
+
+        OpenCreatedPlaylistEffect()
 
         DialogBox {
             val navController = rememberNavController()
@@ -104,7 +111,7 @@ class CreatePlaylistFragment : BaseDialogFragment() {
                         availableEpisodes = uiState.smartEpisodes,
                         useEpisodeArtwork = uiState.useEpisodeArtwork,
                         areOtherOptionsExpanded = areOtherOptionsExpanded,
-                        onCreatePlaylist = { Timber.i("On create smart playlist") },
+                        onCreatePlaylist = viewModel::createSmartPlaylist,
                         onClickRule = { rule -> navigateOnce(rule.toNavigationRoute()) },
                         toggleOtherOptions = { areOtherOptionsExpanded = !areOtherOptionsExpanded },
                         onClickClose = ::dismiss,
@@ -189,6 +196,16 @@ class CreatePlaylistFragment : BaseDialogFragment() {
                     )
                 }
             }
+        }
+    }
+
+    @Composable
+    private fun OpenCreatedPlaylistEffect() {
+        LaunchedEffect(Unit) {
+            val uuid = viewModel.createdSmartPlaylistUuid.await()
+            dismiss()
+            val fragment = SmartPlaylistFragment.newInstance(uuid)
+            (requireActivity() as FragmentHostListener).addFragment(fragment)
         }
     }
 

--- a/modules/features/filters/src/test/kotlin/au/com/shiftyjelly/pocketcasts/playlists/create/CreatePlaylistViewModelTest.kt
+++ b/modules/features/filters/src/test/kotlin/au/com/shiftyjelly/pocketcasts/playlists/create/CreatePlaylistViewModelTest.kt
@@ -18,9 +18,7 @@ import au.com.shiftyjelly.pocketcasts.sharedtest.MainCoroutineRule
 import kotlin.time.Duration.Companion.minutes
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.flowOf
-import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.runTest
-import kotlinx.coroutines.yield
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
@@ -31,9 +29,8 @@ import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 
 class CreatePlaylistViewModelTest {
-    private val testDispatcher = StandardTestDispatcher()
-
-    @get:Rule val coroutineRule = MainCoroutineRule(testDispatcher)
+    @get:Rule
+    val coroutineRule = MainCoroutineRule()
 
     private val playlistManager = FakePlaylistManager()
 
@@ -60,7 +57,7 @@ class CreatePlaylistViewModelTest {
     }
 
     @Test
-    fun `manage podcasts rule`() = runTest(testDispatcher) {
+    fun `manage podcasts rule`() = runTest {
         viewModel.uiState.test {
             var state = awaitItem()
             assertEquals(UiState.Empty, state)
@@ -99,7 +96,7 @@ class CreatePlaylistViewModelTest {
     }
 
     @Test
-    fun `manage episode status rule`() = runTest(testDispatcher) {
+    fun `manage episode status rule`() = runTest {
         viewModel.uiState.test {
             var state = awaitItem()
             assertEquals(UiState.Empty, state)
@@ -162,7 +159,7 @@ class CreatePlaylistViewModelTest {
     }
 
     @Test
-    fun `manage release date rule`() = runTest(testDispatcher) {
+    fun `manage release date rule`() = runTest {
         viewModel.uiState.test {
             var state = awaitItem()
             assertEquals(UiState.Empty, state)
@@ -184,7 +181,7 @@ class CreatePlaylistViewModelTest {
     }
 
     @Test
-    fun `manage episode duration rule`() = runTest(testDispatcher) {
+    fun `manage episode duration rule`() = runTest {
         viewModel.uiState.test {
             var state = awaitItem()
             assertEquals(UiState.Empty, state)
@@ -245,7 +242,7 @@ class CreatePlaylistViewModelTest {
     }
 
     @Test
-    fun `manage download status rule`() = runTest(testDispatcher) {
+    fun `manage download status rule`() = runTest {
         viewModel.uiState.test {
             var state = awaitItem()
             assertEquals(UiState.Empty, state)
@@ -272,7 +269,7 @@ class CreatePlaylistViewModelTest {
     }
 
     @Test
-    fun `manage media type rule`() = runTest(testDispatcher) {
+    fun `manage media type rule`() = runTest {
         viewModel.uiState.test {
             var state = awaitItem()
             assertEquals(UiState.Empty, state)
@@ -299,7 +296,7 @@ class CreatePlaylistViewModelTest {
     }
 
     @Test
-    fun `manage starred episodes rule`() = runTest(testDispatcher) {
+    fun `manage starred episodes rule`() = runTest {
         viewModel.uiState.test {
             var state = awaitItem()
             assertEquals(UiState.Empty, state)
@@ -321,21 +318,30 @@ class CreatePlaylistViewModelTest {
     }
 
     @Test
-    fun `create smart playlist with applied rules`() = runTest(testDispatcher) {
-        viewModel.useAllPodcasts(false)
-        viewModel.selectPodcast("id-1")
-        viewModel.selectPodcast("id-2")
-        viewModel.useCompletedEpisodes(false)
-        viewModel.useReleaseDate(ReleaseDateRule.Last2Weeks)
-        viewModel.useConstrainedDuration(true)
-        viewModel.useMediaType(MediaTypeRule.Audio)
-        viewModel.useStarredEpisodes(true)
-        RuleType.entries.forEach { ruleType ->
-            viewModel.applyRule(ruleType)
-        }
-
+    fun `create smart playlist with applied rules`() = runTest {
         viewModel.uiState.test {
             skipItems(1)
+
+            viewModel.useAllPodcasts(false)
+            skipItems(1)
+            viewModel.selectPodcast("id-1")
+            skipItems(1)
+            viewModel.selectPodcast("id-2")
+            skipItems(1)
+            viewModel.useCompletedEpisodes(false)
+            skipItems(1)
+            viewModel.useReleaseDate(ReleaseDateRule.Last2Weeks)
+            skipItems(1)
+            viewModel.useConstrainedDuration(true)
+            skipItems(1)
+            viewModel.useMediaType(MediaTypeRule.Audio)
+            skipItems(1)
+            viewModel.useStarredEpisodes(true)
+            skipItems(1)
+            RuleType.entries.forEach { ruleType ->
+                viewModel.applyRule(ruleType)
+                skipItems(1)
+            }
 
             assertFalse(viewModel.createdSmartPlaylistUuid.isCompleted)
 
@@ -352,7 +358,7 @@ class CreatePlaylistViewModelTest {
     }
 
     @Test
-    fun `do not create more than a single smart playlist`() = runTest(testDispatcher) {
+    fun `do not create more than a single smart playlist`() = runTest {
         viewModel.uiState.test {
             skipItems(1)
 

--- a/modules/features/filters/src/test/kotlin/au/com/shiftyjelly/pocketcasts/playlists/create/CreatePlaylistViewModelTest.kt
+++ b/modules/features/filters/src/test/kotlin/au/com/shiftyjelly/pocketcasts/playlists/create/CreatePlaylistViewModelTest.kt
@@ -32,13 +32,13 @@ class CreatePlaylistViewModelTest {
     @get:Rule
     val coroutineRule = MainCoroutineRule()
 
+    private val playlistManager = FakePlaylistManager()
+
     private val viewModel = CreatePlaylistViewModel(
         initialPlaylistTitle = "Playlist name",
+        playlistManager = playlistManager,
         podcastManager = mock {
             on { findSubscribedFlow() } doReturn flowOf(emptyList())
-        },
-        playlistManager = mock {
-            on { observeSmartEpisodes(any()) } doReturn flowOf(emptyList())
         },
         settings = run {
             val settingMock = mock<UserSetting<ArtworkConfiguration>> {

--- a/modules/features/filters/src/test/kotlin/au/com/shiftyjelly/pocketcasts/playlists/create/FakePlaylistManager.kt
+++ b/modules/features/filters/src/test/kotlin/au/com/shiftyjelly/pocketcasts/playlists/create/FakePlaylistManager.kt
@@ -1,0 +1,35 @@
+package au.com.shiftyjelly.pocketcasts.playlists.create
+
+import app.cash.turbine.Turbine
+import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
+import au.com.shiftyjelly.pocketcasts.models.type.SmartRules
+import au.com.shiftyjelly.pocketcasts.repositories.playlist.PlaylistManager
+import au.com.shiftyjelly.pocketcasts.repositories.playlist.PlaylistPreview
+import au.com.shiftyjelly.pocketcasts.repositories.playlist.SmartPlaylistDraft
+import java.util.UUID
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+class FakePlaylistManager : PlaylistManager {
+    val playlistPreviews = MutableStateFlow(emptyList<PlaylistPreview>())
+    override fun observePlaylistsPreview() = playlistPreviews.asStateFlow()
+
+    val smartEpisodes = MutableStateFlow(emptyList<PodcastEpisode>())
+    override fun observeSmartEpisodes(rules: SmartRules) = smartEpisodes.asStateFlow()
+
+    val deletePlaylistTurbine = Turbine<String>(name = "deletePlaylist")
+    override suspend fun deletePlaylist(uuid: String) {
+        deletePlaylistTurbine.add(uuid)
+    }
+
+    val upsertSmartPlaylistTurbine = Turbine<SmartPlaylistDraft>(name = "upsertSmartPlaylist")
+    override suspend fun upsertSmartPlaylist(draft: SmartPlaylistDraft): String {
+        upsertSmartPlaylistTurbine.add(draft)
+        return UUID.randomUUID().toString()
+    }
+
+    val updatePlaylistsOrderTurbine = Turbine<List<String>>(name = "updatePlaylistsOrder")
+    override suspend fun updatePlaylistsOrder(sortedUuids: List<String>) {
+        updatePlaylistsOrderTurbine.add(sortedUuids)
+    }
+}

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playlist/PlaylistManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playlist/PlaylistManager.kt
@@ -11,7 +11,7 @@ interface PlaylistManager {
 
     suspend fun deletePlaylist(uuid: String)
 
-    suspend fun upsertSmartPlaylist(draft: SmartPlaylistDraft)
+    suspend fun upsertSmartPlaylist(draft: SmartPlaylistDraft): String
 
     suspend fun updatePlaylistsOrder(sortedUuids: List<String>)
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playlist/PlaylistManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playlist/PlaylistManagerImpl.kt
@@ -76,8 +76,8 @@ class PlaylistManagerImpl @Inject constructor(
         playlistDao.markPlaylistAsDeleted(uuid)
     }
 
-    override suspend fun upsertSmartPlaylist(draft: SmartPlaylistDraft) {
-        appDatabase.withTransaction {
+    override suspend fun upsertSmartPlaylist(draft: SmartPlaylistDraft): String {
+        return appDatabase.withTransaction {
             val uuids = playlistDao.getAllPlaylistUuids()
             val uuid = if (draft === SmartPlaylistDraft.NewReleases) {
                 Playlist.NEW_RELEASES_UUID
@@ -88,6 +88,7 @@ class PlaylistManagerImpl @Inject constructor(
             }
             val playlist = draft.toSmartPlaylist(uuid, sortPosition = uuids.size + 1)
             playlistDao.upsertSmartPlaylist(playlist)
+            uuid
         }
     }
 

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playlist/SmartPlaylistDraft.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playlist/SmartPlaylistDraft.kt
@@ -11,52 +11,26 @@ import au.com.shiftyjelly.pocketcasts.models.type.SmartRules.StarredRule
 
 data class SmartPlaylistDraft(
     val title: String,
-    val episodeStatus: EpisodeStatusRule? = null,
-    val downloadStatus: DownloadStatusRule? = null,
-    val mediaType: MediaTypeRule? = null,
-    val releaseDate: ReleaseDateRule? = null,
-    val starred: StarredRule? = null,
-    val podcasts: PodcastsRule? = null,
-    val episodeDuration: EpisodeDurationRule? = null,
+    val rules: SmartRules,
 ) {
-    val rules = SmartRules(
-        episodeStatus = episodeStatus ?: SmartRules.Default.episodeStatus,
-        downloadStatus = downloadStatus ?: SmartRules.Default.downloadStatus,
-        mediaType = mediaType ?: SmartRules.Default.mediaType,
-        releaseDate = releaseDate ?: SmartRules.Default.releaseDate,
-        starred = starred ?: SmartRules.Default.starred,
-        podcasts = podcasts ?: SmartRules.Default.podcasts,
-        episodeDuration = episodeDuration ?: SmartRules.Default.episodeDuration,
-    )
-
-    val creationRules = if (
-        episodeStatus != null ||
-        downloadStatus != null ||
-        mediaType != null ||
-        releaseDate != null ||
-        starred != null ||
-        podcasts != null ||
-        episodeDuration != null
-    ) {
-        rules
-    } else {
-        null
-    }
-
     companion object {
         val NewReleases = SmartPlaylistDraft(
             title = "New Releases",
-            releaseDate = ReleaseDateRule.Last2Weeks,
+            rules = SmartRules.Default.copy(
+                releaseDate = ReleaseDateRule.Last2Weeks,
+            ),
         )
 
         val InProgress = SmartPlaylistDraft(
             title = "In Progress",
-            episodeStatus = EpisodeStatusRule(
-                unplayed = false,
-                inProgress = true,
-                completed = false,
+            rules = SmartRules.Default.copy(
+                episodeStatus = EpisodeStatusRule(
+                    unplayed = false,
+                    inProgress = true,
+                    completed = false,
+                ),
+                releaseDate = ReleaseDateRule.LastMonth,
             ),
-            releaseDate = ReleaseDateRule.LastMonth,
         )
     }
 }


### PR DESCRIPTION
## Description

This adds support for Smart Playlist creation. Starred rule is not supported due to design being clarified.

## Testing Instructions

1. Create a Smart Playlist.
2. You should see a screen with its title.
3. Navigate back using system gestures.
4. You should see all playlists.
5. Tap on any playlist.
6. It should open a screen with its title.

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.