### PR TITLE
[Dependabot] Add `wordpress-lint` to Ignore Configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -30,6 +30,7 @@ updates:
           - "org.jetbrains.kotlinx*"
     ignore:
       # Automattic libraries have a custom versioning scheme which doesn't work with Dependabot.
+      - dependency-name: "org.wordpress:lint"
       - dependency-name: "com.automattic:Automattic-Tracks-Android"
       - dependency-name: "com.automattic:encryptedlogging"
       - dependency-name: "com.automattic.tracks:crashlogging"


### PR DESCRIPTION
Similar:
- [JP/WPAndroid#22082](https://github.com/wordpress-mobile/WordPress-Android/pull/22082)
- [WCAndroid#14419](https://github.com/woocommerce/woocommerce-android/pull/14419)

---

## Description
<!-- Please include a summary of what this PR is changing and why these changes are needed. -->

Having #4236 merged, we now have one more of our libraries that are stored in S3 and have a custom versioning scheme which doesn't work with :dependabot:. Thus this library should be ignored as well, just like the rest.

FYI: At least for now and until we make this whole :dependabot: process work for such S3 libraries of ours as well.

---

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Tap on the Filters tab -->
<!-- 2. Tap on a filter -->
<!-- 3. etc. -->

Not needed, we just make sure that no :dependabot: PRs (like [this](https://github.com/wordpress-mobile/WordPress-Android/pull/22063)) gets opened from here onwards and for this repo. 

---

## Checklist `N/A`

#### I have tested any UI changes... `N/A`