### PR TITLE
Fix row long texts in rule rows

### DIFF
--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/rules/AppliedRulesPage.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/rules/AppliedRulesPage.kt
@@ -26,7 +26,6 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.Icon
-import androidx.compose.material.IconButton
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
@@ -46,6 +45,8 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.dp
@@ -102,15 +103,6 @@ fun AppliedRulesPage(
             .fillMaxSize()
             .verticalScroll(rememberScrollState()),
     ) {
-        IconButton(
-            onClick = onClickClose,
-        ) {
-            Icon(
-                painter = painterResource(IR.drawable.ic_close),
-                contentDescription = stringResource(LR.string.close),
-                tint = MaterialTheme.theme.colors.primaryIcon03,
-            )
-        }
         ThemedTopAppBar(
             navigationButton = NavigationButton.Close,
             style = ThemedTopAppBar.Style.Immersive,
@@ -433,26 +425,38 @@ private fun RuleRow(
             Spacer(
                 modifier = Modifier.width(16.dp),
             )
-            Text(
-                text = stringResource(ruleType.titleId),
-                color = MaterialTheme.theme.colors.primaryText01,
-                fontSize = 17.sp,
-                lineHeight = 22.sp,
-            )
-            Spacer(
+            Row(
                 modifier = Modifier.weight(1f),
-            )
-            if (description != null) {
+            ) {
                 Text(
-                    text = description,
-                    color = MaterialTheme.theme.colors.primaryText02,
+                    text = stringResource(ruleType.titleId),
+                    color = MaterialTheme.theme.colors.primaryText01,
                     fontSize = 17.sp,
                     lineHeight = 22.sp,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
                 )
                 Spacer(
-                    modifier = Modifier.width(14.dp),
+                    modifier = Modifier.weight(1f),
                 )
+                if (description != null) {
+                    Spacer(
+                        modifier = Modifier.width(8.dp),
+                    )
+                    Text(
+                        text = description,
+                        color = MaterialTheme.theme.colors.primaryText02,
+                        fontSize = 17.sp,
+                        lineHeight = 22.sp,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                        textAlign = TextAlign.End,
+                    )
+                }
             }
+            Spacer(
+                modifier = Modifier.width(16.dp),
+            )
             Image(
                 painter = painterResource(IR.drawable.ic_chevron_trimmed),
                 contentDescription = null,


### PR DESCRIPTION
## Description

This fixes how rule titles and descriptions are displayed in the builder rows.

Fixes PCDROID-68

## Testing Instructions

It's hard to give any testing steps to test it. You can play around with large font and the episode status rule. But code review and screenshots preview should be enough.

## Screenshots or Screencast 

| Before | After |
| - | - |
| <img width="1080" height="2340" alt="image" src="https://github.com/user-attachments/assets/76c36326-5b4c-4945-bd4b-efcf7a7c13fb" /> | <img width="1080" height="2340" alt="image" src="https://github.com/user-attachments/assets/5d326643-fca8-48b2-8fdb-f4fe3f3854c7" /> |

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack
