### PR TITLE
[Onboarding] Upgrade screen touchups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 7.95
 -----
+*   New Features
+    *   New Onboarding Generic Upgrade screens
+        ([#4330](https://github.com/Automattic/pocket-casts-android/pull/4330))
 *   Updates
     *   Open podcast search by tapping the Discover button when the Discover page is displayed
         ([#4272](https://github.com/Automattic/pocket-casts-android/pull/4272))

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/OnboardingActivity.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/OnboardingActivity.kt
@@ -1,8 +1,10 @@
 package au.com.shiftyjelly.pocketcasts.account.onboarding
 
+import android.annotation.SuppressLint
 import android.app.Activity
 import android.content.Context
 import android.content.Intent
+import android.content.pm.ActivityInfo
 import android.os.Bundle
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
@@ -46,10 +48,12 @@ class OnboardingActivity : AppCompatActivity() {
             "Onboarding flow is not set"
         }
 
+    @SuppressLint("SourceLockedOrientationActivity")
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         // Make content edge-to-edge
         WindowCompat.setDecorFitsSystemWindows(window, false)
+        requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_SENSOR_PORTRAIT
 
         setContent {
             val onboardingState by upgradeFeaturesViewModel.state.collectAsState()

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/components/SubscriptionPlanRow.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/components/SubscriptionPlanRow.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.focusable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -29,6 +30,7 @@ import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.Dp
@@ -167,7 +169,6 @@ private fun SubscriptionPlanRow(
                     },
                 )
                 .clickable(
-                    enabled = !isSelected,
                     onClick = onClick,
                     role = Role.Button,
                     indication = ripple(color = MaterialTheme.theme.colors.primaryIcon01),
@@ -214,6 +215,7 @@ private fun SubscriptionPlanRow(
         if (plan.tier == SubscriptionTier.Plus && plan.billingCycle == BillingCycle.Yearly && displayLabel.isNotEmpty()) {
             Box(
                 modifier = Modifier
+                    .focusable(false)
                     .align(
                         when (rowConfig.badgePosition) {
                             BadgePosition.RIGHT -> Alignment.TopEnd

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/components/UpgradeTrialTimeline.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/components/UpgradeTrialTimeline.kt
@@ -1,5 +1,6 @@
 import androidx.annotation.DrawableRes
 import androidx.compose.foundation.background
+import androidx.compose.foundation.focusable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -21,6 +22,11 @@ import androidx.compose.ui.layout.Placeable
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.CollectionInfo
+import androidx.compose.ui.semantics.CollectionItemInfo
+import androidx.compose.ui.semantics.collectionInfo
+import androidx.compose.ui.semantics.collectionItemInfo
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
@@ -85,30 +91,38 @@ fun UpgradeTrialTimeline(
     val iconCenterYPositions = mutableListOf<Float>()
 
     Layout(
-        modifier = modifier.drawWithContent {
-            if (items.size > 1) {
-                drawLine(
-                    color = iconColor,
-                    strokeWidth = timelineWidthPx,
-                    start = Offset(x = iconSizePx / 2, y = iconCenterYPositions.firstOrNull() ?: 0f),
-                    end = Offset(x = iconSizePx / 2, y = iconCenterYPositions.lastOrNull() ?: 0f),
+        modifier = modifier
+            .semantics {
+                collectionInfo = CollectionInfo(
+                    rowCount = items.size,
+                    columnCount = 0,
                 )
             }
-            drawContent()
-            if (items.size > 1) {
-                drawRect(
-                    brush = Brush.verticalGradient(
-                        colors = gradientColors,
-                    ),
-                    topLeft = Offset(x = 0f, y = 0f),
-                    size = Size(width = iconSizePx, height = (iconCenterYPositions.lastOrNull() ?: 0f) + iconSizePx),
-                )
-            }
-        },
+            .drawWithContent {
+                if (items.size > 1) {
+                    drawLine(
+                        color = iconColor,
+                        strokeWidth = timelineWidthPx,
+                        start = Offset(x = iconSizePx / 2, y = iconCenterYPositions.firstOrNull() ?: 0f),
+                        end = Offset(x = iconSizePx / 2, y = iconCenterYPositions.lastOrNull() ?: 0f),
+                    )
+                }
+                drawContent()
+                if (items.size > 1) {
+                    drawRect(
+                        brush = Brush.verticalGradient(
+                            colors = gradientColors,
+                        ),
+                        topLeft = Offset(x = 0f, y = 0f),
+                        size = Size(width = iconSizePx, height = (iconCenterYPositions.lastOrNull() ?: 0f) + iconSizePx),
+                    )
+                }
+            },
         content = {
-            items.forEach { item ->
+            items.forEachIndexed { index, item ->
                 Box(
                     modifier = Modifier
+                        .focusable(false)
                         .size(iconSize)
                         .background(
                             color = iconColor,
@@ -124,8 +138,17 @@ fun UpgradeTrialTimeline(
                 }
                 Column(
                     modifier = Modifier
+                        .focusable()
                         .fillMaxWidth()
-                        .wrapContentHeight(),
+                        .wrapContentHeight()
+                        .semantics(mergeDescendants = true) {
+                            collectionItemInfo = CollectionItemInfo(
+                                rowIndex = index,
+                                rowSpan = 0,
+                                columnIndex = 0,
+                                columnSpan = 0,
+                            )
+                        },
                 ) {
                     TextP50(
                         text = item.title,

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeFeaturesPage.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeFeaturesPage.kt
@@ -137,7 +137,13 @@ internal fun OnboardingUpgradeFeaturesPage(
         is OnboardingUpgradeFeaturesState.Loaded -> {
             if (FeatureFlag.isEnabled(Feature.NEW_ONBOARDING_UPGRADE)) {
                 OnboardingUpgradeScreen(
-                    onClosePress = onBackPress,
+                    onClosePress = {
+                        if (source == OnboardingUpgradeSource.RECOMMENDATIONS) {
+                            onNotNowPress()
+                        } else {
+                            onBackPress()
+                        }
+                    },
                     state = state,
                     source = source,
                     onChangeSelectedPlan = { viewModel.changeBillingCycle(it.billingCycle) },

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeScreen.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeScreen.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -165,7 +166,8 @@ private fun UpgradeFooter(
         )
         Spacer(modifier = Modifier.height(12.dp))
         PrivacyPolicy(
-            modifier = Modifier.fillMaxWidth()
+            modifier = Modifier
+                .fillMaxWidth()
                 .padding(bottom = 12.dp),
             color = MaterialTheme.theme.colors.secondaryText02,
             textAlign = TextAlign.Center,
@@ -383,37 +385,67 @@ private fun UpgradeContent(
     val coroutineScope = rememberCoroutineScope()
     val listState = rememberLazyListState()
 
-    FadedLazyColumn(
+    BoxWithConstraints(
         modifier = modifier,
-        state = listState,
     ) {
-        itemsIndexed(pages) { index, page ->
-            val scrollToNext: () -> Unit = {
-                coroutineScope.launch {
-                    listState.animateScrollToItem((index + 1) % pages.size)
+        val itemHeight = this@BoxWithConstraints.maxHeight
+        FadedLazyColumn(
+            modifier = Modifier.fillMaxSize(),
+            state = listState,
+        ) {
+            itemsIndexed(pages) { index, page ->
+                val topPaddingForGenericContent = if (index != 0) 32.dp else 0.dp
+                val baseModifier = Modifier.heightIn(min = itemHeight)
+                val scrollToNext: () -> Unit = {
+                    coroutineScope.launch {
+                        listState.animateScrollToItem((index + 1) % pages.size)
+                    }
                 }
-            }
-            when (page) {
-                is UpgradePagerContent.Features -> FeaturesContent(
-                    modifier = Modifier.padding(
-                        horizontal = 24.dp,
-                    ),
-                    features = page,
-                    onCtaClick = scrollToNext,
-                )
+                when (page) {
+                    is UpgradePagerContent.Features -> FeaturesContent(
+                        modifier = baseModifier
+                            .padding(
+                                horizontal = 24.dp,
+                            )
+                            .padding(
+                                top = topPaddingForGenericContent,
+                            ),
+                        features = page,
+                        onCtaClick = scrollToNext,
+                    )
 
-                is UpgradePagerContent.TrialSchedule -> ScheduleContent(
-                    modifier = Modifier.padding(
-                        horizontal = 24.dp,
-                    ),
-                    trialSchedule = page,
-                    onCtaClick = scrollToNext,
-                )
+                    is UpgradePagerContent.TrialSchedule -> ScheduleContent(
+                        modifier = baseModifier
+                            .padding(
+                                horizontal = 24.dp,
+                            )
+                            .padding(
+                                top = topPaddingForGenericContent,
+                            ),
+                        trialSchedule = page,
+                        onCtaClick = scrollToNext,
+                    )
 
-                is UpgradePagerContent.Folders -> FoldersUpgradeContent(onCtaClick = scrollToNext)
-                is UpgradePagerContent.Bookmarks -> BookmarksUpgradeContent(onCtaClick = scrollToNext)
-                is UpgradePagerContent.Shuffle -> ShuffleUpgradeContent(onCtaClick = scrollToNext)
-                is UpgradePagerContent.PreselectChapters -> PreselectChaptersUpgradeContent(onCtaClick = scrollToNext)
+                    is UpgradePagerContent.Folders -> FoldersUpgradeContent(
+                        modifier = baseModifier,
+                        onCtaClick = scrollToNext,
+                    )
+
+                    is UpgradePagerContent.Bookmarks -> BookmarksUpgradeContent(
+                        modifier = baseModifier,
+                        onCtaClick = scrollToNext,
+                    )
+
+                    is UpgradePagerContent.Shuffle -> ShuffleUpgradeContent(
+                        modifier = baseModifier,
+                        onCtaClick = scrollToNext,
+                    )
+
+                    is UpgradePagerContent.PreselectChapters -> PreselectChaptersUpgradeContent(
+                        modifier = baseModifier,
+                        onCtaClick = scrollToNext,
+                    )
+                }
             }
         }
     }
@@ -470,8 +502,9 @@ private fun ScheduleContent(
 @Composable
 private fun FoldersUpgradeContent(
     onCtaClick: () -> Unit,
+    modifier: Modifier = Modifier,
 ) {
-    Column {
+    Column(modifier = modifier) {
         TextP40(
             text = stringResource(LR.string.onboarding_upgrade_schedule_see_features),
             modifier = Modifier
@@ -492,8 +525,9 @@ private fun FoldersUpgradeContent(
 @Composable
 private fun BookmarksUpgradeContent(
     onCtaClick: () -> Unit,
+    modifier: Modifier = Modifier,
 ) {
-    Column {
+    Column(modifier = modifier) {
         TextP40(
             text = stringResource(LR.string.onboarding_upgrade_schedule_see_features),
             modifier = Modifier
@@ -514,8 +548,9 @@ private fun BookmarksUpgradeContent(
 @Composable
 private fun ShuffleUpgradeContent(
     onCtaClick: () -> Unit,
+    modifier: Modifier = Modifier,
 ) {
-    Column {
+    Column(modifier = modifier) {
         TextP40(
             text = stringResource(LR.string.onboarding_upgrade_schedule_see_features),
             modifier = Modifier
@@ -534,8 +569,9 @@ private fun ShuffleUpgradeContent(
 @Composable
 private fun PreselectChaptersUpgradeContent(
     onCtaClick: () -> Unit,
+    modifier: Modifier = Modifier,
 ) {
-    Column {
+    Column(modifier = modifier) {
         TextP40(
             text = stringResource(LR.string.onboarding_upgrade_schedule_see_features),
             modifier = Modifier
@@ -546,7 +582,8 @@ private fun PreselectChaptersUpgradeContent(
         )
 
         PreselectChaptersAnimation(
-            modifier = Modifier.fillMaxWidth()
+            modifier = Modifier
+                .fillMaxWidth()
                 .padding(horizontal = 32.dp)
                 .padding(bottom = 64.dp),
         )

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeScreen.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeScreen.kt
@@ -29,13 +29,11 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.Icon
 import androidx.compose.material.IconButton
 import androidx.compose.material.MaterialTheme
-import androidx.compose.material3.adaptive.currentWindowAdaptiveInfo
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
@@ -54,7 +52,6 @@ import au.com.shiftyjelly.pocketcasts.account.onboarding.upgrade.contextual.Pres
 import au.com.shiftyjelly.pocketcasts.account.onboarding.upgrade.contextual.ShuffleAnimation
 import au.com.shiftyjelly.pocketcasts.account.viewmodel.OnboardingUpgradeFeaturesState
 import au.com.shiftyjelly.pocketcasts.compose.AppThemeWithBackground
-import au.com.shiftyjelly.pocketcasts.compose.adaptive.isAtMostMediumHeight
 import au.com.shiftyjelly.pocketcasts.compose.components.FadedLazyColumn
 import au.com.shiftyjelly.pocketcasts.compose.components.TextH10
 import au.com.shiftyjelly.pocketcasts.compose.components.TextP40
@@ -89,39 +86,34 @@ fun OnboardingUpgradeScreen(
     onClickTermsAndConditions: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    val configuration = LocalConfiguration.current
-    val windowSizeClass = currentWindowAdaptiveInfo().windowSizeClass
-
-    if (windowSizeClass.isAtMostMediumHeight() && configuration.fontScale >= 1.5) {
-        CompactHeightUpscaledFontUpgradeScreen(
-            state = state,
-            source = source,
-            onClosePress = onClosePress,
-            onSubscribePress = onSubscribePress,
-            onChangeSelectedPlan = onChangeSelectedPlan,
-            onClickPrivacyPolicy = onClickPrivacyPolicy,
-            onClickTermsAndConditions = onClickTermsAndConditions,
-            modifier = modifier
-                .windowInsetsPadding(WindowInsets.statusBars)
-                .windowInsetsPadding(WindowInsets.navigationBars)
-                .background(color = MaterialTheme.colors.background)
-                .fillMaxSize(),
-        )
-    } else {
-        RegularUpgradeScreen(
-            state = state,
-            source = source,
-            onClosePress = onClosePress,
-            onSubscribePress = onSubscribePress,
-            onChangeSelectedPlan = onChangeSelectedPlan,
-            onClickPrivacyPolicy = onClickPrivacyPolicy,
-            onClickTermsAndConditions = onClickTermsAndConditions,
-            modifier = modifier
-                .windowInsetsPadding(WindowInsets.statusBars)
-                .windowInsetsPadding(WindowInsets.navigationBars)
-                .background(color = MaterialTheme.colors.background)
-                .fillMaxSize(),
-        )
+    BoxWithConstraints(
+        modifier = modifier
+            .windowInsetsPadding(WindowInsets.statusBars)
+            .windowInsetsPadding(WindowInsets.navigationBars)
+            .background(color = MaterialTheme.colors.background)
+            .fillMaxSize(),
+    ) {
+        if (this.maxHeight <= 360.dp) {
+            CompactHeightUpscaledFontUpgradeScreen(
+                state = state,
+                source = source,
+                onClosePress = onClosePress,
+                onSubscribePress = onSubscribePress,
+                onChangeSelectedPlan = onChangeSelectedPlan,
+                onClickPrivacyPolicy = onClickPrivacyPolicy,
+                onClickTermsAndConditions = onClickTermsAndConditions,
+            )
+        } else {
+            RegularUpgradeScreen(
+                state = state,
+                source = source,
+                onClosePress = onClosePress,
+                onSubscribePress = onSubscribePress,
+                onChangeSelectedPlan = onChangeSelectedPlan,
+                onClickPrivacyPolicy = onClickPrivacyPolicy,
+                onClickTermsAndConditions = onClickTermsAndConditions,
+            )
+        }
     }
 }
 
@@ -218,7 +210,7 @@ private fun RegularUpgradeScreen(
         )
         Spacer(modifier = Modifier.height(12.dp))
         UpgradeContent(
-            modifier = Modifier.weight(1f),
+            modifier = Modifier.weight(weight = 1f),
             pages = state.onboardingVariant.toContentPages(
                 currentPlan = state.selectedPlan,
                 isEligibleForTrial = state.selectedBasePlan.offer == SubscriptionOffer.Trial,
@@ -389,7 +381,7 @@ private fun OnboardingUpgradeFeaturesState.NewOnboardingVariant.toContentPages(
         OnboardingUpgradeSource.FOLDERS_PODCAST_SCREEN,
         OnboardingUpgradeSource.SUGGESTED_FOLDERS,
         OnboardingUpgradeSource.FOLDERS,
-        -> {
+            -> {
             add(UpgradePagerContent.Folders)
             add(
                 UpgradePagerContent.Features(
@@ -401,7 +393,7 @@ private fun OnboardingUpgradeFeaturesState.NewOnboardingVariant.toContentPages(
 
         OnboardingUpgradeSource.BOOKMARKS,
         OnboardingUpgradeSource.BOOKMARKS_SHELF_ACTION,
-        -> {
+            -> {
             add(UpgradePagerContent.Bookmarks)
             add(
                 UpgradePagerContent.Features(

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeScreen.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeScreen.kt
@@ -34,6 +34,7 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
@@ -93,7 +94,7 @@ fun OnboardingUpgradeScreen(
             .background(color = MaterialTheme.colors.background)
             .fillMaxSize(),
     ) {
-        if (this.maxHeight <= 360.dp) {
+        if (this.maxHeight <= 480.dp || (this.maxHeight <= 640.dp && LocalConfiguration.current.fontScale >= 1.5f)) {
             CompactHeightUpscaledFontUpgradeScreen(
                 state = state,
                 source = source,
@@ -381,7 +382,7 @@ private fun OnboardingUpgradeFeaturesState.NewOnboardingVariant.toContentPages(
         OnboardingUpgradeSource.FOLDERS_PODCAST_SCREEN,
         OnboardingUpgradeSource.SUGGESTED_FOLDERS,
         OnboardingUpgradeSource.FOLDERS,
-            -> {
+        -> {
             add(UpgradePagerContent.Folders)
             add(
                 UpgradePagerContent.Features(
@@ -393,7 +394,7 @@ private fun OnboardingUpgradeFeaturesState.NewOnboardingVariant.toContentPages(
 
         OnboardingUpgradeSource.BOOKMARKS,
         OnboardingUpgradeSource.BOOKMARKS_SHELF_ACTION,
-            -> {
+        -> {
             add(UpgradePagerContent.Bookmarks)
             add(
                 UpgradePagerContent.Features(
@@ -738,7 +739,7 @@ private fun PreviewOnboardingUpgradeScreen(
     }
 }
 
-@Preview(fontScale = 2f, heightDp = 480)
+@Preview(fontScale = 2f, heightDp = 360)
 @Composable
 private fun PreviewOnboardingUpgradeScreenSmall(
     @PreviewParameter(ThemedTierParameterProvider::class) pair: Pair<ThemeType, SubscriptionTier>,

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeScreen.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeScreen.kt
@@ -643,8 +643,7 @@ private fun FoldersUpgradeContent(
 
         FoldersAnimation(
             modifier = Modifier
-                .fillMaxWidth()
-                .heightIn(min = 320.dp),
+                .fillMaxWidth(),
         )
     }
 }
@@ -688,7 +687,8 @@ private fun ShuffleUpgradeContent(
         )
 
         ShuffleAnimation(
-            modifier = Modifier.padding(horizontal = 32.dp),
+            modifier = Modifier
+                .padding(horizontal = 32.dp),
         )
     }
 }

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeScreen.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeScreen.kt
@@ -70,6 +70,7 @@ import java.time.format.DateTimeFormatter
 import java.time.format.FormatStyle
 import java.time.temporal.ChronoUnit
 import kotlinx.coroutines.launch
+import au.com.shiftyjelly.pocketcasts.images.R as IR
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 @Composable
@@ -147,7 +148,9 @@ private fun UpgradeFooter(
                 onClick = { onSelectedChange(item) },
                 priceComparisonPlan = plans.getOrNull(index + 1),
             )
-            Spacer(modifier = Modifier.height(10.dp))
+            if (index < plans.lastIndex) {
+                Spacer(modifier = Modifier.height(10.dp))
+            }
         }
         Spacer(modifier = Modifier.height(16.dp))
         UpgradeRowButton(
@@ -205,7 +208,7 @@ private fun UpgradeHeader(
                 ) {
                     Icon(
                         modifier = Modifier.size(24.dp),
-                        painter = painterResource(R.drawable.ic_close),
+                        painter = painterResource(IR.drawable.ic_close),
                         contentDescription = stringResource(LR.string.close),
                         tint = MaterialTheme.theme.colors.primaryIcon01,
                     )
@@ -277,6 +280,7 @@ private fun OnboardingUpgradeFeaturesState.NewOnboardingVariant.toContentPages(
                 ),
             )
         }
+
         OnboardingUpgradeSource.BOOKMARKS,
         OnboardingUpgradeSource.BOOKMARKS_SHELF_ACTION,
         -> {
@@ -288,6 +292,7 @@ private fun OnboardingUpgradeFeaturesState.NewOnboardingVariant.toContentPages(
                 ),
             )
         }
+
         OnboardingUpgradeSource.UP_NEXT_SHUFFLE -> {
             add(UpgradePagerContent.Shuffle)
             add(
@@ -297,6 +302,7 @@ private fun OnboardingUpgradeFeaturesState.NewOnboardingVariant.toContentPages(
                 ),
             )
         }
+
         OnboardingUpgradeSource.SKIP_CHAPTERS -> {
             add(UpgradePagerContent.PreselectChapters)
             add(
@@ -355,12 +361,15 @@ private sealed interface UpgradePagerContent {
     data object Folders : UpgradePagerContent {
         override val showCta get() = true
     }
+
     data object Bookmarks : UpgradePagerContent {
         override val showCta get() = true
     }
+
     data object Shuffle : UpgradePagerContent {
         override val showCta get() = true
     }
+
     data object PreselectChapters : UpgradePagerContent {
         override val showCta get() = true
     }
@@ -373,6 +382,7 @@ private fun UpgradeContent(
 ) {
     val coroutineScope = rememberCoroutineScope()
     val listState = rememberLazyListState()
+
     FadedLazyColumn(
         modifier = modifier,
         state = listState,

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeScreen.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeScreen.kt
@@ -2,7 +2,6 @@ package au.com.shiftyjelly.pocketcasts.account.onboarding.upgrade
 
 import UpgradeTrialItem
 import UpgradeTrialTimeline
-import android.content.res.Configuration
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
@@ -24,9 +23,7 @@ import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
-import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.Icon
 import androidx.compose.material.IconButton
 import androidx.compose.material.MaterialTheme
@@ -35,7 +32,6 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
@@ -54,7 +50,6 @@ import au.com.shiftyjelly.pocketcasts.account.onboarding.upgrade.contextual.Pres
 import au.com.shiftyjelly.pocketcasts.account.onboarding.upgrade.contextual.ShuffleAnimation
 import au.com.shiftyjelly.pocketcasts.account.viewmodel.OnboardingUpgradeFeaturesState
 import au.com.shiftyjelly.pocketcasts.compose.AppThemeWithBackground
-import au.com.shiftyjelly.pocketcasts.compose.Devices
 import au.com.shiftyjelly.pocketcasts.compose.components.FadedLazyColumn
 import au.com.shiftyjelly.pocketcasts.compose.components.TextH10
 import au.com.shiftyjelly.pocketcasts.compose.components.TextP40
@@ -89,147 +84,46 @@ fun OnboardingUpgradeScreen(
     onClickTermsAndConditions: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    val isPortrait = LocalConfiguration.current.orientation == Configuration.ORIENTATION_PORTRAIT
-
-    if (isPortrait) {
-        Column(
-            modifier = modifier
-                .windowInsetsPadding(WindowInsets.statusBars)
-                .windowInsetsPadding(WindowInsets.navigationBars)
-                .background(color = MaterialTheme.colors.background)
-                .fillMaxSize(),
-        ) {
-            UpgradeHeader(
-                modifier = Modifier.padding(
-                    horizontal = 24.dp,
-                ),
-                selectedPlan = state.selectedPlan,
-                source = source,
-                onClosePress = onClosePress,
-            )
-            Spacer(modifier = Modifier.height(12.dp))
-            UpgradeContent(
-                modifier = Modifier.weight(1f),
-                pages = state.onboardingVariant.toContentPages(
-                    currentPlan = state.selectedPlan,
-                    isEligibleForTrial = state.selectedBasePlan.offer == SubscriptionOffer.Trial,
-                    plan = state.selectedBasePlan,
-                    source = source,
-                ),
-            )
-            Spacer(modifier = Modifier.height(24.dp))
-            UpgradeFooter(
-                modifier = Modifier
-                    .padding(
-                        horizontal = 24.dp,
-                    )
-                    .fillMaxWidth(),
-                plans = state.availableBasePlans,
-                selectedOnboardingPlan = state.selectedPlan,
-                onSelectedChange = {
-                    onChangeSelectedPlan(it)
-                },
-                onClickSubscribe = onSubscribePress,
-                onPrivacyPolicyClick = onClickPrivacyPolicy,
-                onTermsAndConditionsClick = onClickTermsAndConditions,
-            )
-        }
-    } else {
-        Row(
-            modifier = modifier
-                .windowInsetsPadding(WindowInsets.statusBars)
-                .windowInsetsPadding(WindowInsets.navigationBars)
-                .background(color = MaterialTheme.colors.background)
-                .fillMaxSize(),
-        ) {
-            UpgradeContent(
-                modifier = Modifier.fillMaxWidth(.5f)
-                    .padding(vertical = 8.dp),
-                pages = state.onboardingVariant.toContentPages(
-                    currentPlan = state.selectedPlan,
-                    isEligibleForTrial = state.selectedBasePlan.offer == SubscriptionOffer.Trial,
-                    plan = state.selectedBasePlan,
-                    source = source,
-                ),
-            )
-            Column {
-                UpgradeHeader(
-                    modifier = Modifier.padding(
-                        horizontal = 24.dp,
-                    ),
-                    selectedPlan = state.selectedPlan,
-                    source = source,
-                    onClosePress = onClosePress,
-                )
-                Spacer(modifier = Modifier.height(16.dp))
-                ScrollableFooter(
-                    modifier = Modifier
-                        .padding(
-                            horizontal = 24.dp,
-                        )
-                        .fillMaxWidth(),
-                    plans = state.availableBasePlans,
-                    selectedOnboardingPlan = state.selectedPlan,
-                    onSelectedChange = {
-                        onChangeSelectedPlan(it)
-                    },
-                    onClickSubscribe = onSubscribePress,
-                    onPrivacyPolicyClick = onClickPrivacyPolicy,
-                    onTermsAndConditionsClick = onClickTermsAndConditions,
-                )
-            }
-        }
-    }
-}
-
-@Composable
-fun ScrollableFooter(
-    plans: List<SubscriptionPlan>,
-    onSelectedChange: (SubscriptionPlan) -> Unit,
-    selectedOnboardingPlan: OnboardingSubscriptionPlan,
-    onClickSubscribe: () -> Unit,
-    onPrivacyPolicyClick: () -> Unit,
-    onTermsAndConditionsClick: () -> Unit,
-    modifier: Modifier = Modifier,
-) {
     Column(
-        modifier = modifier,
+        modifier = modifier
+            .windowInsetsPadding(WindowInsets.statusBars)
+            .windowInsetsPadding(WindowInsets.navigationBars)
+            .background(color = MaterialTheme.colors.background)
+            .fillMaxSize(),
     ) {
-        Column(
-            modifier = Modifier
-                .weight(1f)
-                .verticalScroll(rememberScrollState()),
-        ) {
-            plans.forEachIndexed { index, item ->
-                UpgradePlanRow(
-                    modifier = Modifier.padding(top = 12.dp),
-                    plan = item,
-                    isSelected = selectedOnboardingPlan.key == item.key,
-                    onClick = { onSelectedChange(item) },
-                    priceComparisonPlan = plans.getOrNull(index + 1),
-                )
-            }
-        }
-        Spacer(modifier = Modifier.height(16.dp))
-        UpgradeRowButton(
-            primaryText = selectedOnboardingPlan.ctaButtonText(isRenewingSubscription = false),
-            backgroundColor = MaterialTheme.theme.colors.primaryInteractive01,
-            textColor = MaterialTheme.theme.colors.primaryInteractive02,
-            fontWeight = FontWeight.W500,
-            onClick = onClickSubscribe,
-            modifier = Modifier
-                .fillMaxWidth()
-                .heightIn(min = 48.dp),
+        UpgradeHeader(
+            modifier = Modifier.padding(
+                horizontal = 24.dp,
+            ),
+            selectedPlan = state.selectedPlan,
+            source = source,
+            onClosePress = onClosePress,
         )
         Spacer(modifier = Modifier.height(12.dp))
-        PrivacyPolicy(
+        UpgradeContent(
+            modifier = Modifier.weight(1f),
+            pages = state.onboardingVariant.toContentPages(
+                currentPlan = state.selectedPlan,
+                isEligibleForTrial = state.selectedBasePlan.offer == SubscriptionOffer.Trial,
+                plan = state.selectedBasePlan,
+                source = source,
+            ),
+        )
+        Spacer(modifier = Modifier.height(24.dp))
+        UpgradeFooter(
             modifier = Modifier
-                .fillMaxWidth()
-                .padding(bottom = 12.dp),
-            color = MaterialTheme.theme.colors.secondaryText02,
-            textAlign = TextAlign.Center,
-            onPrivacyPolicyClick = onPrivacyPolicyClick,
-            onTermsAndConditionsClick = onTermsAndConditionsClick,
+                .padding(
+                    horizontal = 24.dp,
+                )
+                .fillMaxWidth(),
+            plans = state.availableBasePlans,
+            selectedOnboardingPlan = state.selectedPlan,
+            onSelectedChange = {
+                onChangeSelectedPlan(it)
+            },
+            onClickSubscribe = onSubscribePress,
+            onPrivacyPolicyClick = onClickPrivacyPolicy,
+            onTermsAndConditionsClick = onClickTermsAndConditions,
         )
     }
 }
@@ -271,8 +165,7 @@ private fun UpgradeFooter(
         )
         Spacer(modifier = Modifier.height(12.dp))
         PrivacyPolicy(
-            modifier = Modifier
-                .fillMaxWidth()
+            modifier = Modifier.fillMaxWidth()
                 .padding(bottom = 12.dp),
             color = MaterialTheme.theme.colors.secondaryText02,
             textAlign = TextAlign.Center,
@@ -653,8 +546,7 @@ private fun PreselectChaptersUpgradeContent(
         )
 
         PreselectChaptersAnimation(
-            modifier = Modifier
-                .fillMaxWidth()
+            modifier = Modifier.fillMaxWidth()
                 .padding(horizontal = 32.dp)
                 .padding(bottom = 64.dp),
         )
@@ -664,35 +556,6 @@ private fun PreselectChaptersUpgradeContent(
 @Preview
 @Composable
 private fun PreviewOnboardingUpgradeScreen(
-    @PreviewParameter(ThemedTierParameterProvider::class) pair: Pair<ThemeType, SubscriptionTier>,
-) {
-    AppThemeWithBackground(pair.first) {
-        OnboardingUpgradeScreen(
-            state = OnboardingUpgradeFeaturesState.Loaded(
-                selectedTier = pair.second,
-                selectedBillingCycle = BillingCycle.Yearly,
-                subscriptionPlans = SubscriptionPlans.Preview,
-                plansFilter = when (pair.second) {
-                    SubscriptionTier.Plus -> OnboardingUpgradeFeaturesState.LoadedPlansFilter.PLUS_ONLY
-                    SubscriptionTier.Patron -> OnboardingUpgradeFeaturesState.LoadedPlansFilter.PATRON_ONLY
-                },
-                purchaseFailed = false,
-                onboardingVariant = OnboardingUpgradeFeaturesState.NewOnboardingVariant.FEATURES_FIRST,
-            ),
-            modifier = Modifier.fillMaxSize(),
-            onSubscribePress = {},
-            onClosePress = {},
-            onClickPrivacyPolicy = {},
-            onClickTermsAndConditions = {},
-            onChangeSelectedPlan = {},
-            source = OnboardingUpgradeSource.ACCOUNT_DETAILS,
-        )
-    }
-}
-
-@Preview(device = Devices.LANDSCAPE_REGULAR)
-@Composable
-private fun PreviewOnboardingUpgradeScreenLandscape(
     @PreviewParameter(ThemedTierParameterProvider::class) pair: Pair<ThemeType, SubscriptionTier>,
 ) {
     AppThemeWithBackground(pair.first) {

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/contextual/Bookmarks.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/contextual/Bookmarks.kt
@@ -12,6 +12,7 @@ import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.aspectRatio
@@ -85,10 +86,11 @@ fun BookmarksAnimation(
         }
     }
 
-    Box(
+    BoxWithConstraints(
         modifier = modifier.semantics { role = Role.Image },
         contentAlignment = Alignment.TopCenter,
     ) {
+        val itemWidth = this.maxWidth * .4f
         bookmarks.forEachIndexed { index, item ->
             val animParams = animationTriggers[index].value
             val startRotation = if (index % 2 == 0) {
@@ -103,7 +105,7 @@ fun BookmarksAnimation(
             }
             Bookmark(
                 modifier = Modifier
-                    .widthIn(max = 230.dp)
+                    .widthIn(max = itemWidth)
                     .aspectRatio(1f),
                 bookmarkConfig = item,
                 startAnimation = animationTriggers[index].value.shouldStart,

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/contextual/Bookmarks.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/contextual/Bookmarks.kt
@@ -10,6 +10,7 @@ import androidx.compose.animation.core.tween
 import androidx.compose.animation.core.updateTransition
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
+import androidx.compose.foundation.focusable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
@@ -87,7 +88,9 @@ fun BookmarksAnimation(
     }
 
     BoxWithConstraints(
-        modifier = modifier.semantics { role = Role.Image },
+        modifier = modifier
+            .semantics(mergeDescendants = true) { role = Role.Image }
+            .focusable(false),
         contentAlignment = Alignment.TopCenter,
     ) {
         val itemWidth = this.maxWidth * .4f

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/contextual/Folders.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/contextual/Folders.kt
@@ -11,6 +11,7 @@ import androidx.compose.animation.core.tween
 import androidx.compose.animation.core.updateTransition
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
+import androidx.compose.foundation.focusable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -139,7 +140,8 @@ fun FoldersAnimation(
 
     Box(
         modifier = modifier
-            .semantics { role = Role.Image },
+            .semantics(mergeDescendants = true) { role = Role.Image }
+            .focusable(false),
     ) {
         if (showFolders) {
             FolderRow(

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/contextual/PreselectChapters.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/contextual/PreselectChapters.kt
@@ -5,6 +5,7 @@ import androidx.compose.animation.core.animateInt
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.core.updateTransition
 import androidx.compose.foundation.background
+import androidx.compose.foundation.focusable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -75,9 +76,8 @@ fun PreselectChaptersAnimation(modifier: Modifier = Modifier) {
 
     Column(
         modifier = modifier
-            .semantics(true) {
-                role = Role.Image
-            },
+            .semantics(mergeDescendants = true) { role = Role.Image }
+            .focusable(false),
         verticalArrangement = Arrangement.spacedBy(6.dp),
     ) {
         predefinedChapters.forEachIndexed { index, item ->

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/contextual/PreselectChapters.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/contextual/PreselectChapters.kt
@@ -26,6 +26,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
@@ -43,6 +44,7 @@ import au.com.shiftyjelly.pocketcasts.compose.components.TextP60
 import au.com.shiftyjelly.pocketcasts.compose.preview.ThemePreviewParameterProvider
 import au.com.shiftyjelly.pocketcasts.compose.theme
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
+import au.com.shiftyjelly.pocketcasts.utils.Util
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import au.com.shiftyjelly.pocketcasts.images.R as IR
@@ -140,6 +142,11 @@ private fun ChapterRow(
         },
     ) { state -> if (state == AnimatedState.HIDDEN) floatInDistancePx else 0 }
 
+    val isTablet = Util.isTablet(LocalContext.current)
+    val iconSize = if (isTablet) 36.dp else 24.dp
+    val labelSize = if (isTablet) 14.sp else 10.sp
+    val titleSize = if (isTablet) 16.sp else 13.sp
+
     Card(
         modifier = modifier
             .offset { IntOffset(x = 0, y = offsetYAnim) }
@@ -163,14 +170,14 @@ private fun ChapterRow(
                 contentDescription = "",
                 tint = MaterialTheme.theme.colors.primaryUi04,
                 modifier = Modifier
-                    .size(24.dp)
+                    .size(iconSize)
                     .clip(CircleShape)
                     .background(color = MaterialTheme.theme.colors.primaryIcon02, shape = CircleShape)
                     .padding(4.dp),
             )
             Column {
                 TextP60(
-                    fontSize = 10.sp,
+                    fontSize = labelSize,
                     text = stringResource(LR.string.onboarding_preselect_chapters_chapter_title, chapterData.index).uppercase(),
                     color = MaterialTheme.theme.colors.primaryText02,
                     disableAutoScale = true,
@@ -179,6 +186,7 @@ private fun ChapterRow(
                     text = chapterData.title,
                     color = MaterialTheme.theme.colors.primaryText01,
                     disableAutoScale = true,
+                    fontSize = titleSize,
                 )
             }
         }

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/contextual/Shuffle.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/contextual/Shuffle.kt
@@ -33,6 +33,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.layout.Layout
 import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.pluralStringResource
@@ -55,6 +56,7 @@ import au.com.shiftyjelly.pocketcasts.compose.components.TextP60
 import au.com.shiftyjelly.pocketcasts.compose.preview.ThemePreviewParameterProvider
 import au.com.shiftyjelly.pocketcasts.compose.theme
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
+import au.com.shiftyjelly.pocketcasts.utils.Util
 import java.time.Instant
 import java.time.ZoneId
 import java.time.format.DateTimeFormatter
@@ -313,6 +315,10 @@ private fun ShuffleItem(
             }
         }
     }
+    val isTablet = Util.isTablet(LocalContext.current)
+    val iconSize = if (isTablet) 64.dp else 48.dp
+    val secondaryTextSize = if (isTablet) 14.sp else 10.sp
+    val mainTextSize = if (isTablet) 18.sp else 14.sp
 
     Card(
         modifier = modifier
@@ -336,7 +342,7 @@ private fun ShuffleItem(
         ) {
             Image(
                 modifier = Modifier
-                    .size(48.dp)
+                    .size(iconSize)
                     .clip(RoundedCornerShape(3.dp)),
                 painter = painterResource(config.artworkResId),
                 contentDescription = "",
@@ -345,13 +351,14 @@ private fun ShuffleItem(
                 verticalArrangement = Arrangement.spacedBy(1.dp),
             ) {
                 TextH70(
-                    fontSize = 10.sp,
+                    fontSize = secondaryTextSize,
                     text = dateFormatter.format(config.date).toUpperCase(Locale.current),
                     color = MaterialTheme.theme.colors.primaryText02,
                     modifier = Modifier.fillMaxWidth(),
                     disableAutoScale = true,
                 )
                 TextP60(
+                    fontSize = mainTextSize,
                     text = config.title,
                     fontWeight = FontWeight.W500,
                     modifier = Modifier.fillMaxWidth(),
@@ -360,7 +367,7 @@ private fun ShuffleItem(
                     disableAutoScale = true,
                 )
                 TextH70(
-                    fontSize = 10.sp,
+                    fontSize = secondaryTextSize,
                     text = formatDuration(config.durationSeconds),
                     color = MaterialTheme.theme.colors.primaryText02,
                     modifier = Modifier.fillMaxWidth(),

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/contextual/Shuffle.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/contextual/Shuffle.kt
@@ -7,6 +7,7 @@ import androidx.compose.animation.core.tween
 import androidx.compose.animation.core.updateTransition
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
+import androidx.compose.foundation.focusable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -81,7 +82,11 @@ fun ShuffleAnimation(
         }
     }
 
-    Box(modifier = modifier.semantics { role = Role.Image }) {
+    Box(
+        modifier = modifier
+            .semantics(mergeDescendants = true) { role = Role.Image }
+            .focusable(false),
+    ) {
         predefinedShuffle.chunked(3).forEachIndexed { index, dataSet ->
             ShuffleContainer(
                 items = dataSet,

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/contextual/Shuffle.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/contextual/Shuffle.kt
@@ -175,7 +175,7 @@ private fun ShuffleContainer(
     itemsOverlap: Dp = 18.dp,
     isDisplayed: Boolean = true,
 ) {
-    require(items.size % 2 == 0) { "must have odd number of elements!" }
+    require(items.size % 2 == 1) { "must have odd number of elements!" }
 
     val rowAnimations = remember {
         List(items.size) {

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/OnboardingUpgradeFeaturesViewModel.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/OnboardingUpgradeFeaturesViewModel.kt
@@ -96,7 +96,10 @@ class OnboardingUpgradeFeaturesViewModel @AssistedInject constructor(
     }
 
     fun changeBillingCycle(billingCycle: BillingCycle) {
-        analyticsTracker.track(AnalyticsEvent.PLUS_PROMOTION_SUBSCRIPTION_FREQUENCY_CHANGED, mapOf("value" to billingCycle.analyticsValue))
+        val properties = analyticsProps(flow = flow, variant = experimentProvider.getVariation(Experiment.NewOnboardingABTest).toNewOnboardingVariant()).toMutableMap().apply {
+            put("value", billingCycle.analyticsValue)
+        }
+        analyticsTracker.track(AnalyticsEvent.PLUS_PROMOTION_SUBSCRIPTION_FREQUENCY_CHANGED, properties)
         _state.update { state ->
             (_state.value as? OnboardingUpgradeFeaturesState.Loaded)?.copy(selectedBillingCycle = billingCycle)
                 ?: state
@@ -104,7 +107,10 @@ class OnboardingUpgradeFeaturesViewModel @AssistedInject constructor(
     }
 
     fun changeSubscriptionTier(tier: SubscriptionTier) {
-        analyticsTracker.track(AnalyticsEvent.PLUS_PROMOTION_SUBSCRIPTION_TIER_CHANGED, mapOf("value" to tier.analyticsValue))
+        val properties = analyticsProps(flow = flow, variant = experimentProvider.getVariation(Experiment.NewOnboardingABTest).toNewOnboardingVariant()).toMutableMap().apply {
+            put("value", tier.analyticsValue)
+        }
+        analyticsTracker.track(AnalyticsEvent.PLUS_PROMOTION_SUBSCRIPTION_TIER_CHANGED, properties)
         _state.update { state ->
             (_state.value as? OnboardingUpgradeFeaturesState.Loaded)?.copy(selectedTier = tier)
                 ?: state
@@ -149,31 +155,31 @@ class OnboardingUpgradeFeaturesViewModel @AssistedInject constructor(
     }
 
     fun onShown(flow: OnboardingFlow, source: OnboardingUpgradeSource) {
-        analyticsTracker.track(AnalyticsEvent.PLUS_PROMOTION_SHOWN, analyticsProps(flow, source))
+        analyticsTracker.track(AnalyticsEvent.PLUS_PROMOTION_SHOWN, analyticsProps(flow = flow, source = source, variant = experimentProvider.getVariation(Experiment.NewOnboardingABTest).toNewOnboardingVariant()))
     }
 
     fun onDismiss(flow: OnboardingFlow, source: OnboardingUpgradeSource) {
-        analyticsTracker.track(AnalyticsEvent.PLUS_PROMOTION_DISMISSED, analyticsProps(flow, source))
+        analyticsTracker.track(AnalyticsEvent.PLUS_PROMOTION_DISMISSED, analyticsProps(flow = flow, source = source, variant = experimentProvider.getVariation(Experiment.NewOnboardingABTest).toNewOnboardingVariant()))
     }
 
     fun onNotNow(flow: OnboardingFlow, source: OnboardingUpgradeSource) {
-        analyticsTracker.track(AnalyticsEvent.PLUS_PROMOTION_NOT_NOW_BUTTON_TAPPED, analyticsProps(flow, source))
+        analyticsTracker.track(AnalyticsEvent.PLUS_PROMOTION_NOT_NOW_BUTTON_TAPPED, analyticsProps(flow = flow, source = source, variant = experimentProvider.getVariation(Experiment.NewOnboardingABTest).toNewOnboardingVariant()))
     }
 
     fun onPrivacyPolicyPressed() {
-        analyticsTracker.track(AnalyticsEvent.PLUS_PROMOTION_PRIVACY_POLICY_TAPPED)
+        analyticsTracker.track(AnalyticsEvent.PLUS_PROMOTION_PRIVACY_POLICY_TAPPED, analyticsProps(flow = flow, variant = experimentProvider.getVariation(Experiment.NewOnboardingABTest).toNewOnboardingVariant()))
     }
 
     fun onTermsAndConditionsPressed() {
-        analyticsTracker.track(AnalyticsEvent.PLUS_PROMOTION_TERMS_AND_CONDITIONS_TAPPED)
+        analyticsTracker.track(AnalyticsEvent.PLUS_PROMOTION_TERMS_AND_CONDITIONS_TAPPED, analyticsProps(flow = flow, variant = experimentProvider.getVariation(Experiment.NewOnboardingABTest).toNewOnboardingVariant()))
     }
 
     fun onSelectPaymentFrequencyShown(flow: OnboardingFlow, source: OnboardingUpgradeSource) {
-        analyticsTracker.track(AnalyticsEvent.SELECT_PAYMENT_FREQUENCY_SHOWN, analyticsProps(flow, source))
+        analyticsTracker.track(AnalyticsEvent.SELECT_PAYMENT_FREQUENCY_SHOWN, analyticsProps(flow = flow, source = source, variant = experimentProvider.getVariation(Experiment.NewOnboardingABTest).toNewOnboardingVariant()))
     }
 
     fun onSelectPaymentFrequencyDismissed(flow: OnboardingFlow, source: OnboardingUpgradeSource) {
-        analyticsTracker.track(AnalyticsEvent.SELECT_PAYMENT_FREQUENCY_DISMISSED, analyticsProps(flow, source))
+        analyticsTracker.track(AnalyticsEvent.SELECT_PAYMENT_FREQUENCY_DISMISSED, analyticsProps(flow = flow, source = source, variant = experimentProvider.getVariation(Experiment.NewOnboardingABTest).toNewOnboardingVariant()))
     }
 
     @AssistedFactory
@@ -182,10 +188,20 @@ class OnboardingUpgradeFeaturesViewModel @AssistedInject constructor(
     }
 
     companion object {
-        private fun analyticsProps(flow: OnboardingFlow, source: OnboardingUpgradeSource) = mapOf(
-            "flow" to flow.analyticsValue,
-            "source" to source.analyticsValue,
-        )
+        private fun analyticsProps(
+            flow: OnboardingFlow,
+            variant: OnboardingUpgradeFeaturesState.NewOnboardingVariant,
+            source: OnboardingUpgradeSource? = null,
+        ) = buildMap {
+            put("flow", flow.analyticsValue)
+            source?.let {
+                put("source", it.analyticsValue)
+            }
+            if (FeatureFlag.isEnabled(Feature.NEW_ONBOARDING_UPGRADE)) {
+                put("version", "1")
+                put("variant", if (variant == OnboardingUpgradeFeaturesState.NewOnboardingVariant.FEATURES_FIRST) "A" else "B")
+            }
+        }
     }
 }
 

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/shelf/ShelfBottomSheetPage.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/shelf/ShelfBottomSheetPage.kt
@@ -117,7 +117,7 @@ fun ShelfBottomSheetPage(
                     }
 
                     ShelfItem.Bookmark -> shelfSharedViewModel.onAddBookmarkClick(
-                        OnboardingUpgradeSource.OVERFLOW_MENU,
+                        OnboardingUpgradeSource.BOOKMARKS_SHELF_ACTION,
                         ShelfItemSource.OverflowMenu,
                     )
                     ShelfItem.Download -> {

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/AccountDetailsFragment.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/AccountDetailsFragment.kt
@@ -159,6 +159,7 @@ class AccountDetailsFragment : BaseFragment() {
             onSignOut = { signOut() },
             onDeleteAccount = { deleteAccount() },
             onAccountUpgradeClick = {
+                analyticsTracker.track(AnalyticsEvent.PLUS_PROMOTION_UPGRADE_BUTTON_TAPPED, mapOf("version" to "1"))
                 val onboardingFlow = OnboardingFlow.NewOnboardingAccountUpgrade
                 OnboardingLauncher.openOnboardingFlow(requireActivity(), onboardingFlow)
             },

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -2535,7 +2535,7 @@
     <string name="onboarding_folders_title_2">Favorites</string>
     <string name="onboarding_folders_title_3">Sports</string>
     <string name="onboarding_bookmarks_title">Bookmarks: no more \"where was that?\"</string>
-    <string name="onboarding_shuffle_title">Shuffle: The joy of now choosing</string>
+    <string name="onboarding_shuffle_title">Shuffle: The joy of not choosing</string>
     <plurals name="onboarding_shuffle_item_duration_minutes">
         <item quantity="one">%1$d min</item>
         <item quantity="other">%1$d mins</item>

--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/Feature.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/Feature.kt
@@ -143,7 +143,7 @@ enum class Feature(
         title = "New Onboarding Upgrade",
         defaultValue = BuildConfig.DEBUG,
         tier = FeatureTier.Free,
-        hasFirebaseRemoteFlag = false,
+        hasFirebaseRemoteFlag = true,
         hasDevToggle = true,
     ),
     PLAYLISTS_REBRANDING(


### PR DESCRIPTION
## Description
This includes changes related to the generic upgrade screens that we've collected in the linked Linear ticket. Please refer to it to learn the scope.

We're aiming to target 7.95 with the release of the 1st milestone of the New Onboarding project, hence I've set the milestone appropriately

Fixes https://linear.app/a8c/issue/PCDROID-70/make-upgrade-screen-skippable

## Testing Instructions
You should check the upgrade screen on multiple devices and configs (tables/phones + land/port mode).
- [ ] Terms and conditions text is centered horizontally
- [ ] "Terms and conditions" and "Privacy policy" texts are not broken into new lines
- [ ] Upgrade screen always appears in portrait mode (regardless if the phone was in landscape)
- [ ] Tapping the cta ("show all features" or "how does trial work?") will scroll you to the next page in a way that the previous one scrolls completely off-screen 

## Screenshots or Screencast 
| Scrolling demo |  TnC linebreaks | TnC centered | 
| --- | --- | --- | 
| <video src="https://github.com/user-attachments/assets/60e65d3b-4d95-412b-92bf-90cc506a94ea"/> | <img width="1080" height="2400" alt="Screenshot_20250801_160948" src="https://github.com/user-attachments/assets/b22ca0f5-81e8-414e-bba6-cbcc4a92c2e1" /> | <img width="1600" height="2560" alt="Screenshot_20250801_160851" src="https://github.com/user-attachments/assets/65ed7f7e-6898-43b5-9e0e-e8d4fdc22c3c" /> |



## Checklist
- [ ] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] ~I have considered whether it makes sense to add tests for my changes~
- [ ] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [ ] ~Any jetpack compose components I added or changed are covered by compose previews~
- [ ] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~
 