### PR TITLE
[Onboarding] Analytics

### DIFF
--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/OnboardingUpgradeFeaturesViewModel.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/OnboardingUpgradeFeaturesViewModel.kt
@@ -96,7 +96,10 @@ class OnboardingUpgradeFeaturesViewModel @AssistedInject constructor(
     }
 
     fun changeBillingCycle(billingCycle: BillingCycle) {
-        analyticsTracker.track(AnalyticsEvent.PLUS_PROMOTION_SUBSCRIPTION_FREQUENCY_CHANGED, mapOf("value" to billingCycle.analyticsValue))
+        val properties = analyticsProps(flow = flow, variant = experimentProvider.getVariation(Experiment.NewOnboardingABTest).toNewOnboardingVariant()).toMutableMap().apply {
+            put("value", billingCycle.analyticsValue)
+        }
+        analyticsTracker.track(AnalyticsEvent.PLUS_PROMOTION_SUBSCRIPTION_FREQUENCY_CHANGED, properties)
         _state.update { state ->
             (_state.value as? OnboardingUpgradeFeaturesState.Loaded)?.copy(selectedBillingCycle = billingCycle)
                 ?: state
@@ -104,7 +107,10 @@ class OnboardingUpgradeFeaturesViewModel @AssistedInject constructor(
     }
 
     fun changeSubscriptionTier(tier: SubscriptionTier) {
-        analyticsTracker.track(AnalyticsEvent.PLUS_PROMOTION_SUBSCRIPTION_TIER_CHANGED, mapOf("value" to tier.analyticsValue))
+        val properties = analyticsProps(flow = flow, variant = experimentProvider.getVariation(Experiment.NewOnboardingABTest).toNewOnboardingVariant()).toMutableMap().apply {
+            put("value", tier.analyticsValue)
+        }
+        analyticsTracker.track(AnalyticsEvent.PLUS_PROMOTION_SUBSCRIPTION_TIER_CHANGED, properties)
         _state.update { state ->
             (_state.value as? OnboardingUpgradeFeaturesState.Loaded)?.copy(selectedTier = tier)
                 ?: state
@@ -149,31 +155,31 @@ class OnboardingUpgradeFeaturesViewModel @AssistedInject constructor(
     }
 
     fun onShown(flow: OnboardingFlow, source: OnboardingUpgradeSource) {
-        analyticsTracker.track(AnalyticsEvent.PLUS_PROMOTION_SHOWN, analyticsProps(flow, source))
+        analyticsTracker.track(AnalyticsEvent.PLUS_PROMOTION_SHOWN, analyticsProps(flow = flow, source = source, variant = experimentProvider.getVariation(Experiment.NewOnboardingABTest).toNewOnboardingVariant()))
     }
 
     fun onDismiss(flow: OnboardingFlow, source: OnboardingUpgradeSource) {
-        analyticsTracker.track(AnalyticsEvent.PLUS_PROMOTION_DISMISSED, analyticsProps(flow, source))
+        analyticsTracker.track(AnalyticsEvent.PLUS_PROMOTION_DISMISSED, analyticsProps(flow = flow, source = source, variant = experimentProvider.getVariation(Experiment.NewOnboardingABTest).toNewOnboardingVariant()))
     }
 
     fun onNotNow(flow: OnboardingFlow, source: OnboardingUpgradeSource) {
-        analyticsTracker.track(AnalyticsEvent.PLUS_PROMOTION_NOT_NOW_BUTTON_TAPPED, analyticsProps(flow, source))
+        analyticsTracker.track(AnalyticsEvent.PLUS_PROMOTION_NOT_NOW_BUTTON_TAPPED, analyticsProps(flow = flow, source = source, variant = experimentProvider.getVariation(Experiment.NewOnboardingABTest).toNewOnboardingVariant()))
     }
 
     fun onPrivacyPolicyPressed() {
-        analyticsTracker.track(AnalyticsEvent.PLUS_PROMOTION_PRIVACY_POLICY_TAPPED)
+        analyticsTracker.track(AnalyticsEvent.PLUS_PROMOTION_PRIVACY_POLICY_TAPPED, analyticsProps(flow = flow, variant = experimentProvider.getVariation(Experiment.NewOnboardingABTest).toNewOnboardingVariant()))
     }
 
     fun onTermsAndConditionsPressed() {
-        analyticsTracker.track(AnalyticsEvent.PLUS_PROMOTION_TERMS_AND_CONDITIONS_TAPPED)
+        analyticsTracker.track(AnalyticsEvent.PLUS_PROMOTION_TERMS_AND_CONDITIONS_TAPPED, analyticsProps(flow = flow, variant = experimentProvider.getVariation(Experiment.NewOnboardingABTest).toNewOnboardingVariant()))
     }
 
     fun onSelectPaymentFrequencyShown(flow: OnboardingFlow, source: OnboardingUpgradeSource) {
-        analyticsTracker.track(AnalyticsEvent.SELECT_PAYMENT_FREQUENCY_SHOWN, analyticsProps(flow, source))
+        analyticsTracker.track(AnalyticsEvent.SELECT_PAYMENT_FREQUENCY_SHOWN, analyticsProps(flow = flow, source = source, variant = experimentProvider.getVariation(Experiment.NewOnboardingABTest).toNewOnboardingVariant()))
     }
 
     fun onSelectPaymentFrequencyDismissed(flow: OnboardingFlow, source: OnboardingUpgradeSource) {
-        analyticsTracker.track(AnalyticsEvent.SELECT_PAYMENT_FREQUENCY_DISMISSED, analyticsProps(flow, source))
+        analyticsTracker.track(AnalyticsEvent.SELECT_PAYMENT_FREQUENCY_DISMISSED, analyticsProps(flow = flow, source = source, variant = experimentProvider.getVariation(Experiment.NewOnboardingABTest).toNewOnboardingVariant()))
     }
 
     @AssistedFactory
@@ -182,10 +188,20 @@ class OnboardingUpgradeFeaturesViewModel @AssistedInject constructor(
     }
 
     companion object {
-        private fun analyticsProps(flow: OnboardingFlow, source: OnboardingUpgradeSource) = mapOf(
-            "flow" to flow.analyticsValue,
-            "source" to source.analyticsValue,
-        )
+        private fun analyticsProps(
+            flow: OnboardingFlow,
+            variant: OnboardingUpgradeFeaturesState.NewOnboardingVariant,
+            source: OnboardingUpgradeSource? = null,
+        ) = buildMap {
+            put("flow", flow.analyticsValue)
+            source?.let {
+                put("source", it.analyticsValue)
+            }
+            if (FeatureFlag.isEnabled(Feature.NEW_ONBOARDING_UPGRADE)) {
+                put("version", "1")
+                put("variant", if (variant == OnboardingUpgradeFeaturesState.NewOnboardingVariant.FEATURES_FIRST) "A" else "B")
+            }
+        }
     }
 }
 

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/AccountDetailsFragment.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/AccountDetailsFragment.kt
@@ -159,6 +159,7 @@ class AccountDetailsFragment : BaseFragment() {
             onSignOut = { signOut() },
             onDeleteAccount = { deleteAccount() },
             onAccountUpgradeClick = {
+                analyticsTracker.track(AnalyticsEvent.PLUS_PROMOTION_UPGRADE_BUTTON_TAPPED, mapOf("version" to "1"))
                 val onboardingFlow = OnboardingFlow.NewOnboardingAccountUpgrade
                 OnboardingLauncher.openOnboardingFlow(requireActivity(), onboardingFlow)
             },


### PR DESCRIPTION
## Description
This PR implements the analytics for the first iteration of the New onboarding project: events that are related to the new upgrade screens.

The requirements (copied from the [linear project](https://linear.app/a8c/project/new-onboarding-new-upgrade-screens-5e53ce5c4955/overview)):
```
We are keeping the previous analytics events for the upgrade screen and will add a version parameter that will have the value 1 for this new version of the screen.

plus_promotion_show

plus_promotion_dismissed

plus_promotion_upgrade_button_tapped

plus_promotion_not_now_button_tapped

plus_promotion_subscription_frequency_changed

plus_promotion_privacy_policy_tapped

plus_promotion_terms_and_conditions_tapped

We will also add a parameter called variant to track what type of screen was show that will hold the values A or B

```

Fixes https://linear.app/a8c/issue/PCDROID-44/analytics

## Testing Instructions
Monitor LogCat with the "Tracked" filter while executing these steps:

1. Log in with an account that doesn't have any subscriptions
2. Navigate to profile -> Account
3. Tap the CTA on the upgrade banner
4. Change sub frequency
5. Tap TNC and PP links
6. Tap the Subscribe CTA at the bottom of the page

You should see the new event properties in LogCat.
I'm attaching mine below:

```
2025-08-05 15:22:52.671 13085-13134 Tracks                  au....shiftyjelly.pocketcasts.debug  I  🔵 Tracked: plus_promotion_upgrade_button_tapped, Properties: {"version":"1","has_dynamic_font_size":false,"user_is_logged_in":true,"plus_has_subscription":false,"plus_has_lifetime":false,"plus_subscription_tier":"none","plus_subscription_platform":"none","plus_subscription_frequency":"none","theme_selected":"default_light","theme_dark_preference":"default_dark","theme_light_preference":"default_l
2025-08-05 15:22:53.440 13085-13187 Tracks                  au....shiftyjelly.pocketcasts.debug  I  🔵 Tracked: plus_promotion_shown, Properties: {"flow":"new_onboarding_account_upgrade","source":"unknown","version":"1","variant":"A","has_dynamic_font_size":false,"user_is_logged_in":true,"plus_has_subscription":false,"plus_has_lifetime":false,"plus_subscription_tier":"none","plus_subscription_platform":"none","plus_subscription_frequency":"none","theme_selected":"default_light","theme_dark_prefe
2025-08-05 15:22:57.839 13085-13191 Tracks                  au....shiftyjelly.pocketcasts.debug  I  🔵 Tracked: plus_promotion_subscription_frequency_changed, Properties: {"flow":"new_onboarding_account_upgrade","version":"1","variant":"A","value":"monthly","has_dynamic_font_size":false,"user_is_logged_in":true,"plus_has_subscription":false,"plus_has_lifetime":false,"plus_subscription_tier":"none","plus_subscription_platform":"none","plus_subscription_frequency":"none","theme_selected":"default_
2025-08-05 15:23:00.600 13085-13187 Tracks                  au....shiftyjelly.pocketcasts.debug  I  🔵 Tracked: plus_promotion_privacy_policy_tapped, Properties: {"flow":"new_onboarding_account_upgrade","version":"1","variant":"A","has_dynamic_font_size":false,"user_is_logged_in":true,"plus_has_subscription":false,"plus_has_lifetime":false,"plus_subscription_tier":"none","plus_subscription_platform":"none","plus_subscription_frequency":"none","theme_selected":"default_light","theme_dark_preferen
2025-08-05 15:23:01.605 13085-13187 Tracks                  au....shiftyjelly.pocketcasts.debug  I  🔵 Tracked: application_closed, Properties: {"time_in_app":29,"has_dynamic_font_size":false,"user_is_logged_in":true,"plus_has_subscription":false,"plus_has_lifetime":false,"plus_subscription_tier":"none","plus_subscription_platform":"none","plus_subscription_frequency":"none","theme_selected":"default_light","theme_dark_preference":"default_dark","theme_light_preference":"default_light","theme_us
2025-08-05 15:23:02.082 13085-13210 Tracks                  au....shiftyjelly.pocketcasts.debug  I  🔵 Tracked: application_opened, Properties: {"has_dynamic_font_size":false,"user_is_logged_in":true,"plus_has_subscription":false,"plus_has_lifetime":false,"plus_subscription_tier":"none","plus_subscription_platform":"none","plus_subscription_frequency":"none","theme_selected":"default_light","theme_dark_preference":"default_dark","theme_light_preference":"default_light","theme_use_system_settings
2025-08-05 15:23:03.856 13085-13187 Tracks                  au....shiftyjelly.pocketcasts.debug  I  🔵 Tracked: plus_promotion_terms_and_conditions_tapped, Properties: {"flow":"new_onboarding_account_upgrade","version":"1","variant":"A","has_dynamic_font_size":false,"user_is_logged_in":true,"plus_has_subscription":false,"plus_has_lifetime":false,"plus_subscription_tier":"none","plus_subscription_platform":"none","plus_subscription_frequency":"none","theme_selected":"default_light","theme_dark_pr
2025-08-05 15:23:04.787 13085-13187 Tracks                  au....shiftyjelly.pocketcasts.debug  I  🔵 Tracked: application_closed, Properties: {"time_in_app":2,"has_dynamic_font_size":false,"user_is_logged_in":true,"plus_has_subscription":false,"plus_has_lifetime":false,"plus_subscription_tier":"none","plus_subscription_platform":"none","plus_subscription_frequency":"none","theme_selected":"default_light","theme_dark_preference":"default_dark","theme_light_preference":"default_light","theme_use
2025-08-05 15:23:05.510 13085-13191 Tracks                  au....shiftyjelly.pocketcasts.debug  I  🔵 Tracked: application_opened, Properties: {"has_dynamic_font_size":false,"user_is_logged_in":true,"plus_has_subscription":false,"plus_has_lifetime":false,"plus_subscription_tier":"none","plus_subscription_platform":"none","plus_subscription_frequency":"none","theme_selected":"default_light","theme_dark_preference":"default_dark","theme_light_preference":"default_light","theme_use_system_settings
2025-08-05 15:23:10.000 13085-13210 Tracks                  au....shiftyjelly.pocketcasts.debug  I  🔵 Tracked: select_payment_frequency_next_button_tapped, Properties: {"flow":"new_onboarding_account_upgrade","source":"unknown","product":"com.pocketcasts.plus.monthly","has_dynamic_font_size":false,"user_is_logged_in":true,"plus_has_subscription":false,"plus_has_lifetime":false,"plus_subscription_tier":"none","plus_subscription_platform":"none","plus_subscription_frequency":"none","theme_selecte
```


## Screenshots or Screencast 
(to demonstrate the steps above)
https://github.com/user-attachments/assets/df30f6cd-5ab7-411f-85b8-77c9ba54a0e2



## Checklist
- [ ] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] ~I have considered whether it makes sense to add tests for my changes~
- [ ] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [ ] ~Any jetpack compose components I added or changed are covered by compose previews~
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 