### PR TITLE
Display playlist's metadata

### DIFF
--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/PlaylistHeader.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/PlaylistHeader.kt
@@ -16,7 +16,6 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.AppBarDefaults
 import androidx.compose.material.MaterialTheme
-import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
@@ -34,7 +33,6 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.compose.ui.res.pluralStringResource
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.Dp
@@ -44,6 +42,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import au.com.shiftyjelly.pocketcasts.compose.AppTheme
 import au.com.shiftyjelly.pocketcasts.compose.PreviewRegularDevice
+import au.com.shiftyjelly.pocketcasts.compose.components.TextH20
 import au.com.shiftyjelly.pocketcasts.compose.components.TextP60
 import au.com.shiftyjelly.pocketcasts.compose.preview.ThemePreviewParameterProvider
 import au.com.shiftyjelly.pocketcasts.compose.theme
@@ -113,11 +112,8 @@ internal fun PlaylistHeader(
             Spacer(
                 modifier = Modifier.height(20.dp),
             )
-            Text(
+            TextH20(
                 text = data?.title.orEmpty(),
-                color = MaterialTheme.theme.colors.primaryText01,
-                fontSize = 22.sp,
-                fontWeight = FontWeight.Bold,
                 lineHeight = 22.sp,
                 textAlign = TextAlign.Center,
                 modifier = Modifier.padding(horizontal = 64.dp),

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/PlaylistHeader.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/PlaylistHeader.kt
@@ -13,9 +13,12 @@ import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
 import androidx.compose.material.AppBarDefaults
 import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.BlurredEdgeTreatment
@@ -27,20 +30,37 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.CompositingStrategy
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.layout.layout
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalInspectionMode
+import androidx.compose.ui.res.pluralStringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.constrainHeight
 import androidx.compose.ui.unit.constrainWidth
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import au.com.shiftyjelly.pocketcasts.compose.AppTheme
 import au.com.shiftyjelly.pocketcasts.compose.PreviewRegularDevice
+import au.com.shiftyjelly.pocketcasts.compose.components.TextP60
+import au.com.shiftyjelly.pocketcasts.compose.preview.ThemePreviewParameterProvider
 import au.com.shiftyjelly.pocketcasts.compose.theme
+import au.com.shiftyjelly.pocketcasts.localization.helper.toFriendlyString
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme.ThemeType
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.days
+import kotlin.time.Duration.Companion.hours
+import kotlin.time.Duration.Companion.minutes
+import kotlin.time.Duration.Companion.seconds
+import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 internal data class PlaylistHeaderData(
     val title: String,
+    val episodeCount: Int,
+    val playbackDurationLeft: Duration,
     val artworkPodcasts: List<Podcast>,
 )
 
@@ -90,9 +110,40 @@ internal fun PlaylistHeader(
                     )
                 }
             }
-            // Temporary empty space
             Spacer(
-                modifier = Modifier.height(100.dp),
+                modifier = Modifier.height(20.dp),
+            )
+            Text(
+                text = data?.title.orEmpty(),
+                color = MaterialTheme.theme.colors.primaryText01,
+                fontSize = 22.sp,
+                fontWeight = FontWeight.Bold,
+                lineHeight = 22.sp,
+                textAlign = TextAlign.Center,
+                modifier = Modifier.padding(horizontal = 64.dp),
+            )
+            Spacer(
+                modifier = Modifier.height(8.dp),
+            )
+            TextP60(
+                text = buildString {
+                    if (data != null) {
+                        val episodeCount = data.episodeCount
+                        append(pluralStringResource(LR.plurals.episode_count, episodeCount, episodeCount))
+                        append(" • ")
+                        val context = LocalContext.current
+                        val timeLeft = remember(data.playbackDurationLeft, context) {
+                            data.playbackDurationLeft.toFriendlyString(
+                                resources = context.resources,
+                                pluralResourceId = { unit -> unit.shortResourceId },
+                            )
+                        }
+                        append(timeLeft)
+                    }
+                },
+                color = MaterialTheme.theme.colors.primaryText02,
+                textAlign = TextAlign.Center,
+                modifier = Modifier.padding(horizontal = 64.dp),
             )
         }
     }
@@ -230,6 +281,8 @@ private fun PlaylistHeaderNoPodcastPreview() {
             PlaylistHeader(
                 data = PlaylistHeaderData(
                     title = "My Playlist",
+                    episodeCount = 0,
+                    playbackDurationLeft = 0.seconds,
                     artworkPodcasts = emptyList(),
                 ),
                 useBlurredArtwork = false,
@@ -250,6 +303,8 @@ private fun PlaylistHeaderSinglePodcastPreview() {
             PlaylistHeader(
                 data = PlaylistHeaderData(
                     title = "My Playlist",
+                    episodeCount = 100,
+                    playbackDurationLeft = 200.days + 12.hours,
                     artworkPodcasts = listOf(Podcast(uuid = "id-0")),
                 ),
                 useBlurredArtwork = false,
@@ -270,6 +325,32 @@ private fun PlaylistHeaderMultiPodcastPreview() {
             PlaylistHeader(
                 data = PlaylistHeaderData(
                     title = "My Playlist",
+                    episodeCount = 5,
+                    playbackDurationLeft = 1.hours + 15.minutes,
+                    artworkPodcasts = List(4) { index -> Podcast(uuid = "id-$index") },
+                ),
+                useBlurredArtwork = false,
+            )
+        }
+    }
+}
+
+@PreviewRegularDevice
+@Composable
+private fun PlaylistHeaderThemePreview(
+    @PreviewParameter(ThemePreviewParameterProvider::class) themeType: ThemeType,
+) {
+    AppTheme(themeType) {
+        Box(
+            modifier = Modifier
+                .background(MaterialTheme.theme.colors.primaryUi02)
+                .fillMaxSize(),
+        ) {
+            PlaylistHeader(
+                data = PlaylistHeaderData(
+                    title = "My Playlist",
+                    episodeCount = 5,
+                    playbackDurationLeft = 1.hours + 15.minutes,
                     artworkPodcasts = List(4) { index -> Podcast(uuid = "id-$index") },
                 ),
                 useBlurredArtwork = false,

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/SmartPlaylistFragment.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/SmartPlaylistFragment.kt
@@ -87,6 +87,8 @@ class SmartPlaylistFragment :
                     val playlistHeaderData = uiState.smartPlaylist?.let { playlist ->
                         PlaylistHeaderData(
                             title = playlist.title,
+                            episodeCount = playlist.totalEpisodeCount,
+                            playbackDurationLeft = playlist.playbackDurationLeft,
                             artworkPodcasts = playlist.artworkPodcasts,
                         )
                     }

--- a/modules/services/localization/src/main/java/au/com/shiftyjelly/pocketcasts/localization/helper/DurationUtil.kt
+++ b/modules/services/localization/src/main/java/au/com/shiftyjelly/pocketcasts/localization/helper/DurationUtil.kt
@@ -63,22 +63,27 @@ fun Duration.toFriendlyString(
 enum class FriendlyDurationUnit(
     private val durationUnit: DurationUnit,
     @PluralsRes val resourceId: Int,
+    @PluralsRes val shortResourceId: Int,
 ) {
     Second(
         durationUnit = DurationUnit.SECONDS,
         resourceId = LR.plurals.second,
+        shortResourceId = LR.plurals.second_short,
     ),
     Minute(
         durationUnit = DurationUnit.MINUTES,
         resourceId = LR.plurals.minute,
+        shortResourceId = LR.plurals.minute_short,
     ),
     Hour(
         durationUnit = DurationUnit.HOURS,
         resourceId = LR.plurals.hour,
+        shortResourceId = LR.plurals.hour_short,
     ),
     Day(
         durationUnit = DurationUnit.DAYS,
         resourceId = LR.plurals.day,
+        shortResourceId = LR.plurals.day_short,
     ),
     ;
 

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -732,6 +732,26 @@
         <item quantity="one">second</item>
         <item quantity="other">seconds</item>
     </plurals>
+   <!-- A short form representing days. Some like 1 d, 2 d, etc. -->
+    <plurals name="day_short">
+        <item quantity="one">d</item>
+        <item quantity="other">d</item>
+    </plurals>
+    <!-- A short form representing hours. Some like 1 hr, 2 hrs, etc. -->
+    <plurals name="hour_short">
+        <item quantity="one">hr</item>
+        <item quantity="other">hrs</item>
+    </plurals>
+    <!-- A short form representing minutes. Some like 1 min, 2 mins, etc. -->
+    <plurals name="minute_short">
+        <item quantity="one">min</item>
+        <item quantity="other">mins</item>
+    </plurals>
+    <!-- A short form representing seconds. Some like 1 sec, 2 secs, etc. -->
+    <plurals name="second_short">
+        <item quantity="one">sec</item>
+        <item quantity="other">secs</item>
+    </plurals>
     <!-- %1$s is a podcast's title -->
     <string name="notifications_enabled_message">We’ll notify you with new episodes of %1$s.</string>
     <string name="podcast_header_redesign_title">We’ve made some changes!</string>

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/to/SmartPlaylistMetadata.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/to/SmartPlaylistMetadata.kt
@@ -1,0 +1,8 @@
+package au.com.shiftyjelly.pocketcasts.models.to
+
+import androidx.room.ColumnInfo
+
+data class SmartPlaylistMetadata(
+    @ColumnInfo("episode_count") val episodeCount: Int,
+    @ColumnInfo("time_left") val timeLeftSeconds: Double,
+)

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playlist/SmartPlaylist.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playlist/SmartPlaylist.kt
@@ -2,10 +2,13 @@ package au.com.shiftyjelly.pocketcasts.repositories.playlist
 
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
+import kotlin.time.Duration
 
 data class SmartPlaylist(
     val uuid: String,
     val title: String,
+    val totalEpisodeCount: Int,
+    val playbackDurationLeft: Duration,
     val episodes: List<PodcastEpisode>,
     val artworkPodcasts: List<Podcast>,
 )


### PR DESCRIPTION
## Description

This adds an episode count and playback duration left to the playlist page.

Designs: 5sC4z4Mu42LvL4MAAIbQVi-fi-792_22015

Relates to PCDROID-38

## Testing Instructions

1. Open a playlist with some episodes.
2. Verify playlist's metadata

## Screenshots or Screencast 

<img width="540" height="1200" alt="image" src="https://github.com/user-attachments/assets/0c0da261-ddb0-47f2-a612-d7375120027c" />

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack