### PR TITLE
Handle play all action

### DIFF
--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/SmartPlaylistFragment.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/SmartPlaylistFragment.kt
@@ -24,6 +24,7 @@ import au.com.shiftyjelly.pocketcasts.compose.AppTheme
 import au.com.shiftyjelly.pocketcasts.compose.extensions.setContentWithViewCompositionStrategy
 import au.com.shiftyjelly.pocketcasts.filters.databinding.SmartPlaylistFragmentBinding
 import au.com.shiftyjelly.pocketcasts.utils.extensions.dpToPx
+import au.com.shiftyjelly.pocketcasts.views.dialog.ConfirmationDialog
 import au.com.shiftyjelly.pocketcasts.views.fragments.BaseFragment
 import au.com.shiftyjelly.pocketcasts.views.helper.EpisodeItemTouchHelper
 import au.com.shiftyjelly.pocketcasts.views.helper.HasBackstack
@@ -77,7 +78,7 @@ class SmartPlaylistFragment :
         val rightButton = PlaylistHeaderData.ActionButton(
             iconId = IR.drawable.ic_playlist_play,
             label = getString(LR.string.playlist_play_all),
-            onClick = { Timber.tag("Play all episodes") },
+            onClick = ::playAll,
         )
 
         val headerAdapter = PlaylistHeaderAdapter(
@@ -172,6 +173,26 @@ class SmartPlaylistFragment :
                     onClickOptions = { Timber.i("On click options") },
                 )
             }
+        }
+    }
+
+    private fun playAll() {
+        if (parentFragmentManager.findFragmentByTag("confirm_and_play") != null) {
+            return
+        }
+        if (viewModel.shouldShowPlayAllWarning()) {
+            val episodeCount = viewModel.uiState.value.smartPlaylist?.episodes.orEmpty().size
+            val buttonString = getString(LR.string.filters_play_episodes, episodeCount)
+
+            val dialog = ConfirmationDialog()
+                .setTitle(getString(LR.string.filters_play_all))
+                .setSummary(getString(LR.string.filters_play_all_summary))
+                .setIconId(IR.drawable.ic_play_all)
+                .setButtonType(ConfirmationDialog.ButtonType.Danger(buttonString))
+                .setOnConfirm { viewModel.playAll() }
+            dialog.show(parentFragmentManager, "confirm_play_all")
+        } else {
+            viewModel.playAll()
         }
     }
 

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/SmartPlaylistViewModel.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/SmartPlaylistViewModel.kt
@@ -2,22 +2,27 @@ package au.com.shiftyjelly.pocketcasts.playlists
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import au.com.shiftyjelly.pocketcasts.analytics.SourceView
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
+import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
 import au.com.shiftyjelly.pocketcasts.repositories.playlist.PlaylistManager
 import au.com.shiftyjelly.pocketcasts.repositories.playlist.SmartPlaylist
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.flow.mapNotNull
 import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
 
 @HiltViewModel(assistedFactory = SmartPlaylistViewModel.Factory::class)
 class SmartPlaylistViewModel @AssistedInject constructor(
     @Assisted playlistUuid: String,
     private val playlistManager: PlaylistManager,
+    private val playbackManager: PlaybackManager,
     private val settings: Settings,
 ) : ViewModel() {
     val bottomInset = settings.bottomInset
@@ -25,6 +30,24 @@ class SmartPlaylistViewModel @AssistedInject constructor(
     val uiState = playlistManager.observeSmartPlaylist(playlistUuid)
         .map { UiState(it) }
         .stateIn(viewModelScope, SharingStarted.Lazily, initialValue = UiState.Empty)
+
+    fun shouldShowPlayAllWarning(): Boolean {
+        val queueEpisodes = playbackManager.upNextQueue.allEpisodes
+        return queueEpisodes.size >= PLAY_ALL_WARNING_EPISODE_COUNT
+    }
+
+    private var playAllJob: Job? = null
+
+    fun playAll() {
+        if (playAllJob?.isActive == true) {
+            return
+        }
+        playAllJob = viewModelScope.launch(Dispatchers.Default) {
+            val episodes = uiState.value.smartPlaylist?.episodes?.takeIf { it.isNotEmpty() } ?: return@launch
+            playbackManager.upNextQueue.removeAll()
+            playbackManager.playEpisodes(episodes, SourceView.FILTERS)
+        }
+    }
 
     data class UiState(
         val smartPlaylist: SmartPlaylist?,
@@ -39,5 +62,9 @@ class SmartPlaylistViewModel @AssistedInject constructor(
     @AssistedFactory
     interface Factory {
         fun create(playlistUuid: String): SmartPlaylistViewModel
+    }
+
+    companion object {
+        private const val PLAY_ALL_WARNING_EPISODE_COUNT = 4
     }
 }


### PR DESCRIPTION
## Description

This handles playing all episodes from the playlists.

Closes PCDROID-38

## Testing Instructions

1. Add 3 episodes to your queue.
2. Open a playlists with episodes.
3. Tap "Play All".
4. The queue should be updated.
5. Add episodes to the queue until you have at least 4 of them.
6. Go to any playlist.
7. Tap "Play All".
8. You should see a warning.
9. Confirming the action should play all episodes.

## Screenshots or Screencast 

<img width="540" height="1200" alt="image" src="https://github.com/user-attachments/assets/dc3fc572-a116-44b2-a064-9c349331a51a" />

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.