### PR TITLE
Add starred rule control

### DIFF
--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/create/CreatePlaylistFragment.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/create/CreatePlaylistFragment.kt
@@ -34,6 +34,7 @@ import au.com.shiftyjelly.pocketcasts.playlists.rules.MediaTypeRulePage
 import au.com.shiftyjelly.pocketcasts.playlists.rules.PodcastsRulePage
 import au.com.shiftyjelly.pocketcasts.playlists.rules.ReleaseDateRulePage
 import au.com.shiftyjelly.pocketcasts.playlists.rules.RuleType
+import au.com.shiftyjelly.pocketcasts.playlists.rules.StarredRulePage
 import au.com.shiftyjelly.pocketcasts.ui.helper.FragmentHostListener
 import au.com.shiftyjelly.pocketcasts.utils.extensions.pxToDp
 import au.com.shiftyjelly.pocketcasts.views.fragments.BaseDialogFragment
@@ -196,6 +197,19 @@ class CreatePlaylistFragment : BaseDialogFragment() {
                         onClickBack = ::goBackToPlaylistPreview,
                     )
                 }
+                composable(NavigationRoutes.SMART_RULE_STARRED) {
+                    StarredRulePage(
+                        selectedRule = uiState.rulesBuilder.starredRule,
+                        starredEpisodes = uiState.smartStarredEpisodes,
+                        useEpisodeArtwork = uiState.useEpisodeArtwork,
+                        onChangeUseStarredEpisodes = viewModel::useStarredEpisodes,
+                        onSaveRule = {
+                            viewModel.applyRule(RuleType.MediaType)
+                            goBackToPlaylistPreview()
+                        },
+                        onClickBack = ::goBackToPlaylistPreview,
+                    )
+                }
             }
         }
     }
@@ -243,6 +257,7 @@ private object NavigationRoutes {
     const val SMART_RULE_EPISODE_DURATION = "smart_rule_episode_duration"
     const val SMART_RULE_DOWNLOAD_STATUS = "smart_rule_download_status"
     const val SMART_RULE_MEDIA_TYPE = "smart_rule_media_type"
+    const val SMART_RULE_STARRED = "smart_rule_starred"
 }
 
 private fun RuleType.toNavigationRoute() = when (this) {
@@ -252,5 +267,5 @@ private fun RuleType.toNavigationRoute() = when (this) {
     RuleType.EpisodeDuration -> NavigationRoutes.SMART_RULE_EPISODE_DURATION
     RuleType.DownloadStatus -> NavigationRoutes.SMART_RULE_DOWNLOAD_STATUS
     RuleType.MediaType -> NavigationRoutes.SMART_RULE_MEDIA_TYPE
-    RuleType.Starred -> NavigationRoutes.SMART_PLAYLIST_PREVIEW
+    RuleType.Starred -> NavigationRoutes.SMART_RULE_STARRED
 }

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/create/CreatePlaylistFragment.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/create/CreatePlaylistFragment.kt
@@ -109,6 +109,7 @@ class CreatePlaylistFragment : BaseDialogFragment() {
                         playlistTitle = viewModel.playlistNameState.text.toString(),
                         appliedRules = uiState.appliedRules,
                         availableEpisodes = uiState.smartEpisodes,
+                        totalEpisodeCount = uiState.totalEpisodeCount,
                         useEpisodeArtwork = uiState.useEpisodeArtwork,
                         areOtherOptionsExpanded = areOtherOptionsExpanded,
                         onCreatePlaylist = viewModel::createSmartPlaylist,
@@ -204,7 +205,7 @@ class CreatePlaylistFragment : BaseDialogFragment() {
                         useEpisodeArtwork = uiState.useEpisodeArtwork,
                         onChangeUseStarredEpisodes = viewModel::useStarredEpisodes,
                         onSaveRule = {
-                            viewModel.applyRule(RuleType.MediaType)
+                            viewModel.applyRule(RuleType.Starred)
                             goBackToPlaylistPreview()
                         },
                         onClickBack = ::goBackToPlaylistPreview,

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/create/CreatePlaylistViewModel.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/create/CreatePlaylistViewModel.kt
@@ -67,6 +67,15 @@ class CreatePlaylistViewModel @AssistedInject constructor(
         }
     }
 
+    private val totalEpisodeCount = appliedRules.flatMapLatest { appliedRules ->
+        val smartRules = appliedRules.toSmartRules()
+        if (smartRules != null) {
+            playlistManager.observeEpisodeMetadata(smartRules).map { it.episodeCount }
+        } else {
+            flowOf(0)
+        }
+    }
+
     private val smartStarredEpisodes = appliedRules.flatMapLatest { appliedRules ->
         val smartRules = appliedRules.toSmartRules() ?: SmartRules.Default
         val starredRules = smartRules.copy(starred = StarredRule.Starred)
@@ -78,6 +87,7 @@ class CreatePlaylistViewModel @AssistedInject constructor(
         rulesBuilder,
         podcastManager.findSubscribedFlow(),
         smartEpisodes,
+        totalEpisodeCount,
         smartStarredEpisodes,
         settings.artworkConfiguration.flow.map { it.useEpisodeArtwork(Element.Filters) },
         ::UiState,
@@ -260,6 +270,7 @@ class CreatePlaylistViewModel @AssistedInject constructor(
         val rulesBuilder: RulesBuilder,
         val followedPodcasts: List<Podcast>,
         val smartEpisodes: List<PodcastEpisode>,
+        val totalEpisodeCount: Int,
         val smartStarredEpisodes: List<PodcastEpisode>,
         val useEpisodeArtwork: Boolean,
     ) {
@@ -268,6 +279,7 @@ class CreatePlaylistViewModel @AssistedInject constructor(
                 appliedRules = AppliedRules.Empty,
                 rulesBuilder = RulesBuilder.Empty,
                 followedPodcasts = emptyList(),
+                totalEpisodeCount = 0,
                 smartEpisodes = emptyList(),
                 smartStarredEpisodes = emptyList(),
                 useEpisodeArtwork = false,

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/rules/AppliedRulesPage.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/rules/AppliedRulesPage.kt
@@ -61,6 +61,7 @@ import au.com.shiftyjelly.pocketcasts.compose.preview.ThemePreviewParameterProvi
 import au.com.shiftyjelly.pocketcasts.compose.theme
 import au.com.shiftyjelly.pocketcasts.localization.helper.TimeHelper
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
+import au.com.shiftyjelly.pocketcasts.models.type.SmartRules
 import au.com.shiftyjelly.pocketcasts.models.type.SmartRules.DownloadStatusRule
 import au.com.shiftyjelly.pocketcasts.models.type.SmartRules.EpisodeDurationRule
 import au.com.shiftyjelly.pocketcasts.models.type.SmartRules.MediaTypeRule
@@ -76,6 +77,7 @@ fun AppliedRulesPage(
     playlistTitle: String,
     appliedRules: AppliedRules,
     availableEpisodes: List<PodcastEpisode>,
+    totalEpisodeCount: Int,
     useEpisodeArtwork: Boolean,
     areOtherOptionsExpanded: Boolean,
     onCreatePlaylist: () -> Unit,
@@ -113,6 +115,7 @@ fun AppliedRulesPage(
                     ) {
                         ActiveRulesContent(
                             rules = activeRules,
+                            totalEpisodeCount = totalEpisodeCount,
                             appliedRules = appliedRules,
                             onClickRule = onClickRule,
                         )
@@ -198,6 +201,7 @@ fun AppliedRulesPage(
 private fun ActiveRulesContent(
     rules: List<RuleType>,
     appliedRules: AppliedRules,
+    totalEpisodeCount: Int,
     onClickRule: (RuleType) -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -212,7 +216,7 @@ private fun ActiveRulesContent(
         )
         Rules(
             ruleTypes = rules,
-            description = { rule -> appliedRules.description(rule) },
+            description = { rule -> appliedRules.description(rule, totalEpisodeCount) },
             onClickRule = onClickRule,
         )
     }
@@ -439,7 +443,7 @@ private fun rememberInactiveRules(activeRules: List<RuleType>): List<RuleType> {
 
 @Composable
 @ReadOnlyComposable
-private fun AppliedRules.description(ruleType: RuleType) = when (ruleType) {
+private fun AppliedRules.description(ruleType: RuleType, episodeCount: Int) = when (ruleType) {
     RuleType.Podcasts -> when (podcasts) {
         is PodcastsRule.Any -> stringResource(LR.string.all)
         is PodcastsRule.Selected -> podcasts.uuids.size.toString()
@@ -492,7 +496,7 @@ private fun AppliedRules.description(ruleType: RuleType) = when (ruleType) {
     }
 
     RuleType.EpisodeDuration -> when (episodeDuration) {
-        is EpisodeDurationRule.Any -> stringResource(LR.string.any_duration)
+        is EpisodeDurationRule.Any -> stringResource(LR.string.off)
         is EpisodeDurationRule.Constrained -> {
             val context = LocalContext.current
             val min = TimeHelper.getTimeDurationShortString(episodeDuration.longerThan.inWholeMilliseconds, context)
@@ -516,7 +520,11 @@ private fun AppliedRules.description(ruleType: RuleType) = when (ruleType) {
         null -> null
     }
 
-    RuleType.Starred -> TODO()
+    RuleType.Starred -> when (starred) {
+        SmartRules.StarredRule.Any -> stringResource(LR.string.off)
+        SmartRules.StarredRule.Starred -> episodeCount.toString()
+        null -> null
+    }
 }
 
 @Preview(device = Devices.PORTRAIT_REGULAR)
@@ -530,6 +538,7 @@ private fun AppliedRulesPageNoRulesPreview(
             playlistTitle = "Comedy",
             appliedRules = AppliedRules.Empty,
             availableEpisodes = emptyList(),
+            totalEpisodeCount = 0,
             useEpisodeArtwork = false,
             areOtherOptionsExpanded = expanded,
             onCreatePlaylist = {},
@@ -561,6 +570,7 @@ private fun AppliedRulesPageEpisodessPreview(
                     publishedDate = Date(0),
                 )
             },
+            totalEpisodeCount = 10,
             useEpisodeArtwork = false,
             areOtherOptionsExpanded = expanded,
             onCreatePlaylist = {},
@@ -585,6 +595,7 @@ private fun AppliedRulesPageNoEpisodesPreview(
                 podcasts = PodcastsRule.Any,
             ),
             availableEpisodes = emptyList(),
+            totalEpisodeCount = 0,
             useEpisodeArtwork = false,
             areOtherOptionsExpanded = expanded,
             onCreatePlaylist = {},

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/rules/AppliedRulesPage.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/rules/AppliedRulesPage.kt
@@ -5,15 +5,12 @@ import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
-import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -44,7 +41,6 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.semantics
-import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
@@ -56,19 +52,13 @@ import au.com.shiftyjelly.pocketcasts.compose.Devices
 import au.com.shiftyjelly.pocketcasts.compose.bars.NavigationButton
 import au.com.shiftyjelly.pocketcasts.compose.bars.ThemedTopAppBar
 import au.com.shiftyjelly.pocketcasts.compose.buttons.RowButton
-import au.com.shiftyjelly.pocketcasts.compose.components.EpisodeImage
 import au.com.shiftyjelly.pocketcasts.compose.components.FadedLazyColumn
 import au.com.shiftyjelly.pocketcasts.compose.components.HorizontalDivider
 import au.com.shiftyjelly.pocketcasts.compose.components.NoContentBanner
-import au.com.shiftyjelly.pocketcasts.compose.components.TextC70
 import au.com.shiftyjelly.pocketcasts.compose.components.TextH20
-import au.com.shiftyjelly.pocketcasts.compose.components.TextH40
-import au.com.shiftyjelly.pocketcasts.compose.components.TextH60
 import au.com.shiftyjelly.pocketcasts.compose.components.TextP50
 import au.com.shiftyjelly.pocketcasts.compose.preview.ThemePreviewParameterProvider
-import au.com.shiftyjelly.pocketcasts.compose.text.toAnnotatedString
 import au.com.shiftyjelly.pocketcasts.compose.theme
-import au.com.shiftyjelly.pocketcasts.localization.helper.RelativeDateFormatter
 import au.com.shiftyjelly.pocketcasts.localization.helper.TimeHelper
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.models.type.SmartRules.DownloadStatusRule
@@ -76,14 +66,10 @@ import au.com.shiftyjelly.pocketcasts.models.type.SmartRules.EpisodeDurationRule
 import au.com.shiftyjelly.pocketcasts.models.type.SmartRules.MediaTypeRule
 import au.com.shiftyjelly.pocketcasts.models.type.SmartRules.PodcastsRule
 import au.com.shiftyjelly.pocketcasts.models.type.SmartRules.ReleaseDateRule
-import au.com.shiftyjelly.pocketcasts.repositories.extensions.getSummaryText
-import au.com.shiftyjelly.pocketcasts.repositories.images.PocketCastsImageRequestFactory.PlaceholderType
-import au.com.shiftyjelly.pocketcasts.ui.extensions.getThemeColor
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme.ThemeType
 import java.util.Date
 import au.com.shiftyjelly.pocketcasts.images.R as IR
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
-import au.com.shiftyjelly.pocketcasts.ui.R as UR
 
 @Composable
 fun AppliedRulesPage(
@@ -290,55 +276,6 @@ private fun InactiveRulesContent(
 }
 
 @Composable
-private fun EpisodeRow(
-    episode: PodcastEpisode,
-    useEpisodeArtwork: Boolean,
-    modifier: Modifier = Modifier,
-) {
-    Column(
-        modifier = modifier,
-    ) {
-        Row(
-            verticalAlignment = Alignment.CenterVertically,
-            modifier = Modifier
-                .height(IntrinsicSize.Min)
-                .padding(vertical = 12.dp, horizontal = 12.dp),
-        ) {
-            EpisodeImage(
-                episode = episode,
-                useEpisodeArtwork = useEpisodeArtwork,
-                placeholderType = PlaceholderType.Small,
-                corners = 4.dp,
-                modifier = Modifier.size(56.dp),
-            )
-            Spacer(
-                modifier = Modifier.width(12.dp),
-            )
-            Column(
-                verticalArrangement = Arrangement.SpaceBetween,
-                modifier = Modifier.fillMaxHeight(),
-            ) {
-                TextC70(
-                    text = episode.rememberHeaderText(),
-                )
-                TextH40(
-                    text = episode.title,
-                    lineHeight = 15.sp,
-                    maxLines = 2,
-                )
-                TextH60(
-                    text = episode.rememberTimeLeftText(),
-                    color = MaterialTheme.theme.colors.primaryText02,
-                )
-            }
-        }
-        HorizontalDivider(
-            startIndent = 12.dp,
-        )
-    }
-}
-
-@Composable
 private fun NoRulesContent(
     title: String,
     onClickRule: (RuleType) -> Unit,
@@ -497,25 +434,6 @@ private fun rememberActiveRules(rules: AppliedRules): List<RuleType> {
 private fun rememberInactiveRules(activeRules: List<RuleType>): List<RuleType> {
     return remember(activeRules) {
         RuleType.entries - activeRules
-    }
-}
-
-@Composable
-private fun PodcastEpisode.rememberHeaderText(): AnnotatedString {
-    val context = LocalContext.current
-    val formatter = remember(context) { RelativeDateFormatter(context) }
-    return remember(playingStatus, isArchived) {
-        val tintColor = context.getThemeColor(UR.attr.primary_icon_01)
-        val spannable = getSummaryText(formatter, tintColor, showDuration = false, context)
-        spannable.toAnnotatedString()
-    }
-}
-
-@Composable
-private fun PodcastEpisode.rememberTimeLeftText(): String {
-    val context = LocalContext.current
-    return remember(playedUpToMs, durationMs, isInProgress, context) {
-        TimeHelper.getTimeLeft(playedUpToMs, durationMs.toLong(), isInProgress, context).text
     }
 }
 

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/rules/EpisodeRow.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/rules/EpisodeRow.kt
@@ -1,0 +1,103 @@
+package au.com.shiftyjelly.pocketcasts.playlists.rules
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.IntrinsicSize
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.material.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import au.com.shiftyjelly.pocketcasts.compose.components.EpisodeImage
+import au.com.shiftyjelly.pocketcasts.compose.components.HorizontalDivider
+import au.com.shiftyjelly.pocketcasts.compose.components.TextC70
+import au.com.shiftyjelly.pocketcasts.compose.components.TextH40
+import au.com.shiftyjelly.pocketcasts.compose.components.TextH60
+import au.com.shiftyjelly.pocketcasts.compose.text.toAnnotatedString
+import au.com.shiftyjelly.pocketcasts.compose.theme
+import au.com.shiftyjelly.pocketcasts.localization.helper.RelativeDateFormatter
+import au.com.shiftyjelly.pocketcasts.localization.helper.TimeHelper
+import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
+import au.com.shiftyjelly.pocketcasts.repositories.extensions.getSummaryText
+import au.com.shiftyjelly.pocketcasts.repositories.images.PocketCastsImageRequestFactory.PlaceholderType
+import au.com.shiftyjelly.pocketcasts.ui.extensions.getThemeColor
+import au.com.shiftyjelly.pocketcasts.ui.R as UR
+
+@Composable
+internal fun EpisodeRow(
+    episode: PodcastEpisode,
+    useEpisodeArtwork: Boolean,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier,
+    ) {
+        Row(
+            verticalAlignment = Alignment.Companion.CenterVertically,
+            modifier = Modifier.Companion
+                .height(IntrinsicSize.Min)
+                .padding(vertical = 12.dp, horizontal = 12.dp),
+        ) {
+            EpisodeImage(
+                episode = episode,
+                useEpisodeArtwork = useEpisodeArtwork,
+                placeholderType = PlaceholderType.Small,
+                corners = 4.dp,
+                modifier = Modifier.Companion.size(56.dp),
+            )
+            Spacer(
+                modifier = Modifier.Companion.width(12.dp),
+            )
+            Column(
+                verticalArrangement = Arrangement.SpaceBetween,
+                modifier = Modifier.Companion.fillMaxHeight(),
+            ) {
+                TextC70(
+                    text = episode.rememberHeaderText(),
+                )
+                TextH40(
+                    text = episode.title,
+                    lineHeight = 15.sp,
+                    maxLines = 2,
+                )
+                TextH60(
+                    text = episode.rememberTimeLeftText(),
+                    color = MaterialTheme.theme.colors.primaryText02,
+                )
+            }
+        }
+        HorizontalDivider(
+            startIndent = 12.dp,
+        )
+    }
+}
+
+@Composable
+private fun PodcastEpisode.rememberHeaderText(): AnnotatedString {
+    val context = LocalContext.current
+    val formatter = remember(context) { RelativeDateFormatter(context) }
+    return remember(playingStatus, isArchived) {
+        val tintColor = context.getThemeColor(UR.attr.primary_icon_01)
+        val spannable = getSummaryText(formatter, tintColor, showDuration = false, context)
+        spannable.toAnnotatedString()
+    }
+}
+
+@Composable
+private fun PodcastEpisode.rememberTimeLeftText(): String {
+    val context = LocalContext.current
+    return remember(playedUpToMs, durationMs, isInProgress, context) {
+        TimeHelper.getTimeLeft(playedUpToMs, durationMs.toLong(), isInProgress, context).text
+    }
+}

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/rules/StarredRulePage.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/rules/StarredRulePage.kt
@@ -120,7 +120,11 @@ private fun StarredSwitchRow(
                 modifier = Modifier.height(4.dp),
             )
             TextP50(
-                text = stringResource(LR.string.smart_rule_starred_description),
+                text = if (useStarredEpisodes) {
+                    stringResource(LR.string.smart_rule_starred_description)
+                } else {
+                    stringResource(LR.string.smart_rule_starred_description_disabled)
+                },
                 color = MaterialTheme.theme.colors.primaryText02,
                 modifier = Modifier.widthIn(max = 280.dp),
             )

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/rules/StarredRulePage.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/rules/StarredRulePage.kt
@@ -25,6 +25,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
@@ -104,7 +105,8 @@ private fun StarredSwitchRow(
                 value = useStarredEpisodes,
                 onValueChange = onChangeUseStarredEpisodes,
             )
-            .padding(horizontal = 16.dp),
+            .padding(horizontal = 16.dp)
+            .semantics(mergeDescendants = true) {},
     ) {
         Column(
             modifier = Modifier

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/rules/StarredRulePage.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/rules/StarredRulePage.kt
@@ -1,0 +1,190 @@
+package au.com.shiftyjelly.pocketcasts.playlists.rules
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.animateContentSize
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.selection.toggleable
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Switch
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.tooling.preview.PreviewParameter
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import au.com.shiftyjelly.pocketcasts.compose.AppThemeWithBackground
+import au.com.shiftyjelly.pocketcasts.compose.PreviewRegularDevice
+import au.com.shiftyjelly.pocketcasts.compose.components.FadedLazyColumn
+import au.com.shiftyjelly.pocketcasts.compose.components.TextH30
+import au.com.shiftyjelly.pocketcasts.compose.components.TextP50
+import au.com.shiftyjelly.pocketcasts.compose.preview.ThemePreviewParameterProvider
+import au.com.shiftyjelly.pocketcasts.compose.theme
+import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
+import au.com.shiftyjelly.pocketcasts.models.type.SmartRules.StarredRule
+import au.com.shiftyjelly.pocketcasts.ui.theme.Theme.ThemeType
+import java.util.Date
+import au.com.shiftyjelly.pocketcasts.localization.R as LR
+
+@Composable
+fun StarredRulePage(
+    selectedRule: StarredRule,
+    starredEpisodes: List<PodcastEpisode>,
+    useEpisodeArtwork: Boolean,
+    onChangeUseStarredEpisodes: (Boolean) -> Unit,
+    onSaveRule: () -> Unit,
+    onClickBack: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val useStarredEpisodes = when (selectedRule) {
+        StarredRule.Starred -> true
+        StarredRule.Any -> false
+    }
+
+    RulePage(
+        title = stringResource(LR.string.filters_title_starred),
+        onSaveRule = onSaveRule,
+        onClickBack = onClickBack,
+        modifier = modifier,
+    ) { bottomPadding ->
+        Column(
+            modifier = Modifier.padding(
+                top = 24.dp,
+                bottom = if (useStarredEpisodes) 0.dp else bottomPadding,
+            ),
+        ) {
+            StarredSwitchRow(
+                useStarredEpisodes = useStarredEpisodes,
+                onChangeUseStarredEpisodes = onChangeUseStarredEpisodes,
+            )
+            Spacer(
+                modifier = Modifier.height(12.dp),
+            )
+            AnimatedVisibility(
+                visible = useStarredEpisodes,
+                enter = fadeIn,
+                exit = fadeOut,
+                modifier = Modifier.weight(1f),
+            ) {
+                EpisodesColumn(
+                    episodes = starredEpisodes,
+                    useEpisodeArtwork = useEpisodeArtwork,
+                    bottomPadding = bottomPadding,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun StarredSwitchRow(
+    useStarredEpisodes: Boolean,
+    onChangeUseStarredEpisodes: (Boolean) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Row(
+        modifier = modifier
+            .toggleable(
+                role = Role.Switch,
+                value = useStarredEpisodes,
+                onValueChange = onChangeUseStarredEpisodes,
+            )
+            .padding(horizontal = 16.dp),
+    ) {
+        Column(
+            modifier = Modifier
+                .animateContentSize()
+                .weight(1f)
+                .heightIn(min = 32.dp),
+        ) {
+            TextH30(
+                text = stringResource(LR.string.smart_rule_starred_label),
+                modifier = Modifier.widthIn(max = 280.dp),
+            )
+            Spacer(
+                modifier = Modifier.height(4.dp),
+            )
+            TextP50(
+                text = stringResource(LR.string.smart_rule_starred_description),
+                color = MaterialTheme.theme.colors.primaryText02,
+                modifier = Modifier.widthIn(max = 280.dp),
+            )
+        }
+        Spacer(
+            modifier = Modifier.width(16.dp),
+        )
+        Switch(
+            checked = useStarredEpisodes,
+            onCheckedChange = null,
+        )
+    }
+}
+
+@Composable
+private fun EpisodesColumn(
+    episodes: List<PodcastEpisode>,
+    useEpisodeArtwork: Boolean,
+    bottomPadding: Dp,
+    modifier: Modifier = Modifier,
+) {
+    FadedLazyColumn(
+        contentPadding = PaddingValues(bottom = bottomPadding),
+        modifier = modifier,
+    ) {
+        items(episodes) { episode ->
+            EpisodeRow(
+                episode = episode,
+                useEpisodeArtwork = useEpisodeArtwork,
+            )
+        }
+    }
+}
+
+private val fadeIn = fadeIn()
+private val fadeOut = fadeOut()
+
+@Composable
+@PreviewRegularDevice
+private fun StarredRulePreview(
+    @PreviewParameter(ThemePreviewParameterProvider::class) themeType: ThemeType,
+) {
+    var rule by remember { mutableStateOf(StarredRule.Starred) }
+    val episodes = remember {
+        List(10) { index ->
+            PodcastEpisode(
+                uuid = "uuid-$index",
+                title = "Episode $index",
+                duration = 6000.0,
+                publishedDate = Date(0),
+            )
+        }
+    }
+
+    AppThemeWithBackground(themeType) {
+        StarredRulePage(
+            selectedRule = rule,
+            starredEpisodes = episodes,
+            useEpisodeArtwork = false,
+            onChangeUseStarredEpisodes = { useStarred ->
+                rule = if (useStarred) StarredRule.Starred else StarredRule.Any
+            },
+            onSaveRule = {},
+            onClickBack = {},
+        )
+    }
+}

--- a/modules/features/filters/src/test/kotlin/au/com/shiftyjelly/pocketcasts/playlists/create/FakePlaylistManager.kt
+++ b/modules/features/filters/src/test/kotlin/au/com/shiftyjelly/pocketcasts/playlists/create/FakePlaylistManager.kt
@@ -2,6 +2,7 @@ package au.com.shiftyjelly.pocketcasts.playlists.create
 
 import app.cash.turbine.Turbine
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
+import au.com.shiftyjelly.pocketcasts.models.to.PlaylistEpisodeMetadata
 import au.com.shiftyjelly.pocketcasts.models.type.SmartRules
 import au.com.shiftyjelly.pocketcasts.repositories.playlist.PlaylistManager
 import au.com.shiftyjelly.pocketcasts.repositories.playlist.PlaylistPreview
@@ -25,6 +26,9 @@ class FakePlaylistManager : PlaylistManager {
 
     val smartEpisodes = MutableStateFlow(emptyList<PodcastEpisode>())
     override fun observeSmartEpisodes(rules: SmartRules) = smartEpisodes.asStateFlow()
+
+    val episodeMetadata = MutableStateFlow(PlaylistEpisodeMetadata.Empty)
+    override fun observeEpisodeMetadata(rules: SmartRules) = episodeMetadata.asStateFlow()
 
     val deletePlaylistTurbine = Turbine<String>(name = "deletePlaylist")
     override suspend fun deletePlaylist(uuid: String) {

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -952,7 +952,8 @@
     <string name="smart_rule_podcasts_select_all">Select All</string>
     <string name="smart_rule_podcasts_deselect_all">Deselect All</string>
     <string name="smart_rule_starred_label">Starred Episodes</string>
-    <string name="smart_rule_starred_description">Include starred episodes that match your rules.</string>
+    <string name="smart_rule_starred_description">Only include starred episodes that match your other rules.</string>
+    <string name="smart_rule_starred_description_disabled">Starred episodes can still appear if they match your other rules.</string>
     <string name="save_smart_rule">Save Smart Rule</string>
     <string name="enabled_rules">Enabled Rules</string>
     <!-- %1$s is playlist's title -->

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -238,7 +238,6 @@
         <item quantity="other">%d episodes</item>
     </plurals>
     <string name="empty_play_state">Pick an episode to begin</string>
-    <string name="any_duration">Any duration</string>
 
     <string name="seconds_label">Seconds</string>
     <string name="seconds_singular">1 second</string>

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -926,48 +926,48 @@
 
     <!-- Playlists -->
 
-    <string name="playlists">Playlists</string>
-    <string name="playlists_onboarding_smart_playlist_title">Filters are now Smart Playlists</string>
-    <string name="playlists_onboarding_smart_playlist_description">They still work exactly the same, using rules to auto-add your episodes. All your existing Filters are right here, nothing’s changed but the name.</string>
-    <string name="playlists_onboarding_playlist_title">Introducing Playlists</string>
-    <string name="playlists_onboarding_playlist_description">Want more control? Manual Playlists let you build custom queues, great for trips, themes, or just your current vibe. Whether Smart or Manual, playlists work the way you do.</string>
-    <string name="smart_playlist">Smart Playlist</string>
-    <string name="smart_rules">Smart Rules</string>
-    <string name="playlists_empty_state_title">Organize episodes your way</string>
-    <string name="playlists_empty_state_body">Playlists let you organize episodes manually or automatically with Smart Rules.</string>
-    <string name="new_playlist">New Playlist</string>
-    <string name="premade_playlists_tooltip_title">Smart Playlists, ready to go</string>
-    <string name="premade_playlists_tooltip_body">We made these to help you get started.\nThey auto-update based on your listening.</string>
-    <string name="new_playlists_title_placeholder">Playlist’s title</string>
-    <string name="new_smart_playlist_banner_title">Make into Smart Playlist</string>
-    <string name="new_smart_playlist_banner_body">Automatically add episodes based on rules</string>
     <string name="create_playlist">Create Playlist</string>
     <string name="create_smart_playlist">Create Smart Playlist</string>
-    <string name="smart_rules_description">Set up Smart Rules to automatically add episodes to your Smart Playlist.</string>
-    <string name="smart_rule_podcasts_title">Choose Podcasts</string>
-    <string name="smart_rule_podcasts_all_label">All Followed Podcasts</string>
-    <string name="smart_rule_podcasts_all_description">New podcasts you follow will be automatically added.</string>
-    <string name="smart_rule_podcasts_all_description_disabled">New podcasts you follow will not be automatically added.</string>
-    <string name="smart_rule_podcasts_select_all">Select All</string>
-    <string name="smart_rule_podcasts_deselect_all">Deselect All</string>
-    <string name="smart_rule_starred_label">Starred Episodes</string>
-    <string name="smart_rule_starred_description">Only include starred episodes that match your other rules.</string>
-    <string name="smart_rule_starred_description_disabled">Starred episodes can still appear if they match your other rules.</string>
-    <string name="save_smart_rule">Save Smart Rule</string>
+    <string name="decrement_longer_than_duration">Decrement \"longer than\" duration</string>
+    <string name="decrement_shorter_than_duration">Decrement \"shorter than\" duration</string>
     <string name="enabled_rules">Enabled Rules</string>
-    <!-- %1$s is playlist's title -->
-    <string name="preview_playlist">Preview %1$s</string>
-    <string name="smart_playlist_create_no_content_title">No matching episodes</string>
-    <string name="smart_playlist_create_no_content_body">None of the episodes in your podcasts match these rules.\n\nTry adjusting the rules, or save this playlist for future episodes that might fit.</string>
     <!-- %1$s is status like 'In Progress' and %2$d is count of other episode statuses -->
     <string name="episode_status_rule_description">%1$s + %2$d</string>
-    <string name="decrement_longer_than_duration">Decrement \"longer than\" duration</string>
     <string name="increment_longer_than_duration">Increment \"longer than\" duration</string>
-    <string name="decrement_shorter_than_duration">Decrement \"shorter than\" duration</string>
     <string name="increment_shorter_than_duration">Increment \"shorter than\" duration</string>
+    <string name="new_playlist">New Playlist</string>
+    <string name="new_playlists_title_placeholder">Playlist’s title</string>
+    <string name="new_smart_playlist_banner_body">Automatically add episodes based on rules</string>
+    <string name="new_smart_playlist_banner_title">Make into Smart Playlist</string>
     <string name="playlist_play_all">Play All</string>
-    <string name="smart_playlist_no_content_title">No episodes</string>
+    <string name="playlists">Playlists</string>
+    <string name="playlists_empty_state_body">Playlists let you organize episodes manually or automatically with Smart Rules.</string>
+    <string name="playlists_empty_state_title">Organize episodes your way</string>
+    <string name="playlists_onboarding_playlist_description">Want more control? Manual Playlists let you build custom queues, great for trips, themes, or just your current vibe. Whether Smart or Manual, playlists work the way you do.</string>
+    <string name="playlists_onboarding_playlist_title">Introducing Playlists</string>
+    <string name="playlists_onboarding_smart_playlist_description">They still work exactly the same, using rules to auto-add your episodes. All your existing Filters are right here, nothing’s changed but the name.</string>
+    <string name="playlists_onboarding_smart_playlist_title">Filters are now Smart Playlists</string>
+    <string name="premade_playlists_tooltip_body">We made these to help you get started.\nThey auto-update based on your listening.</string>
+    <string name="premade_playlists_tooltip_title">Smart Playlists, ready to go</string>
+    <!-- %1$s is playlist's title -->
+    <string name="preview_playlist">Preview %1$s</string>
+    <string name="save_smart_rule">Save Smart Rule</string>
+    <string name="smart_playlist">Smart Playlist</string>
+    <string name="smart_playlist_create_no_content_body">None of the episodes in your podcasts match these rules.\n\nTry adjusting the rules, or save this playlist for future episodes that might fit.</string>
+    <string name="smart_playlist_create_no_content_title">No matching episodes</string>
     <string name="smart_playlist_no_content_body">Either it’s time to celebrate completing this list, or edit your rules to get some more.</string>
+    <string name="smart_playlist_no_content_title">No episodes</string>
+    <string name="smart_rule_podcasts_all_description">New podcasts you follow will be automatically added.</string>
+    <string name="smart_rule_podcasts_all_description_disabled">New podcasts you follow will not be automatically added.</string>
+    <string name="smart_rule_podcasts_all_label">All Followed Podcasts</string>
+    <string name="smart_rule_podcasts_deselect_all">Deselect All</string>
+    <string name="smart_rule_podcasts_select_all">Select All</string>
+    <string name="smart_rule_podcasts_title">Choose Podcasts</string>
+    <string name="smart_rule_starred_description">Only include starred episodes that match your other rules.</string>
+    <string name="smart_rule_starred_description_disabled">Starred episodes can still appear if they match your other rules.</string>
+    <string name="smart_rule_starred_label">Starred Episodes</string>
+    <string name="smart_rules">Smart Rules</string>
+    <string name="smart_rules_description">Set up Smart Rules to automatically add episodes to your Smart Playlist.</string>
 
     <!-- Profile -->
 

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -951,6 +951,8 @@
     <string name="smart_rule_podcasts_all_description_disabled">New podcasts you follow will not be automatically added.</string>
     <string name="smart_rule_podcasts_select_all">Select All</string>
     <string name="smart_rule_podcasts_deselect_all">Deselect All</string>
+    <string name="smart_rule_starred_label">Starred Episodes</string>
+    <string name="smart_rule_starred_description">Include starred episodes that match your rules.</string>
     <string name="save_smart_rule">Save Smart Rule</string>
     <string name="enabled_rules">Enabled Rules</string>
     <!-- %1$s is playlist's title -->

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/PlaylistDao.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/PlaylistDao.kt
@@ -9,7 +9,7 @@ import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.models.entity.SmartPlaylist
 import au.com.shiftyjelly.pocketcasts.models.entity.SmartPlaylist.Companion.SYNC_STATUS_NOT_SYNCED
-import au.com.shiftyjelly.pocketcasts.models.to.SmartPlaylistMetadata
+import au.com.shiftyjelly.pocketcasts.models.to.PlaylistEpisodeMetadata
 import au.com.shiftyjelly.pocketcasts.models.type.PlaylistEpisodeSortType
 import au.com.shiftyjelly.pocketcasts.models.type.PlaylistEpisodeSortType.LongestToShortest
 import au.com.shiftyjelly.pocketcasts.models.type.PlaylistEpisodeSortType.NewestToOldest
@@ -46,19 +46,19 @@ abstract class PlaylistDao {
     abstract suspend fun markPlaylistAsDeleted(uuid: String)
 
     @RawQuery(observedEntities = [Podcast::class, PodcastEpisode::class])
-    protected abstract fun observeSmartPlaylistEpisodeMetadata(query: RoomRawQuery): Flow<SmartPlaylistMetadata>
+    protected abstract fun observeEpisodeMetadata(query: RoomRawQuery): Flow<PlaylistEpisodeMetadata>
 
-    fun observeSmartPlaylistEpisodeMetadata(
+    fun observeEpisodeMetadata(
         clock: Clock,
         smartRules: SmartRules,
-    ): Flow<SmartPlaylistMetadata> {
+    ): Flow<PlaylistEpisodeMetadata> {
         val query = createSmartPlaylistEpisodeQuery(
             selectClause = "COUNT(*) AS episode_count, SUM(MAX(episode.duration - episode.played_up_to, 0)) AS time_left",
             whereClause = smartRules.toSqlWhereClause(clock),
             orderByClause = null,
             limit = null,
         )
-        return observeSmartPlaylistEpisodeMetadata(RoomRawQuery(query))
+        return observeEpisodeMetadata(RoomRawQuery(query))
     }
 
     @RawQuery(observedEntities = [Podcast::class, PodcastEpisode::class])

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/to/PlaylistEpisodeMetadata.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/to/PlaylistEpisodeMetadata.kt
@@ -2,7 +2,14 @@ package au.com.shiftyjelly.pocketcasts.models.to
 
 import androidx.room.ColumnInfo
 
-data class SmartPlaylistMetadata(
+data class PlaylistEpisodeMetadata(
     @ColumnInfo("episode_count") val episodeCount: Int,
     @ColumnInfo("time_left") val timeLeftSeconds: Double,
-)
+) {
+    companion object {
+        val Empty = PlaylistEpisodeMetadata(
+            episodeCount = 0,
+            timeLeftSeconds = 0.0,
+        )
+    }
+}

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playlist/PlaylistManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playlist/PlaylistManager.kt
@@ -1,6 +1,7 @@
 package au.com.shiftyjelly.pocketcasts.repositories.playlist
 
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
+import au.com.shiftyjelly.pocketcasts.models.to.PlaylistEpisodeMetadata
 import au.com.shiftyjelly.pocketcasts.models.type.SmartRules
 import kotlinx.coroutines.flow.Flow
 
@@ -10,6 +11,8 @@ interface PlaylistManager {
     fun observeSmartPlaylist(uuid: String): Flow<SmartPlaylist?>
 
     fun observeSmartEpisodes(rules: SmartRules): Flow<List<PodcastEpisode>>
+
+    fun observeEpisodeMetadata(rules: SmartRules): Flow<PlaylistEpisodeMetadata>
 
     suspend fun deletePlaylist(uuid: String)
 

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playlist/PlaylistManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playlist/PlaylistManagerImpl.kt
@@ -14,6 +14,7 @@ import au.com.shiftyjelly.pocketcasts.models.entity.SmartPlaylist.Companion.LAST
 import au.com.shiftyjelly.pocketcasts.models.entity.SmartPlaylist.Companion.LAST_WEEK
 import au.com.shiftyjelly.pocketcasts.models.entity.SmartPlaylist.Companion.SYNC_STATUS_NOT_SYNCED
 import au.com.shiftyjelly.pocketcasts.models.entity.SmartPlaylist.Companion.SYNC_STATUS_SYNCED
+import au.com.shiftyjelly.pocketcasts.models.to.PlaylistEpisodeMetadata
 import au.com.shiftyjelly.pocketcasts.models.type.PlaylistEpisodeSortType
 import au.com.shiftyjelly.pocketcasts.models.type.SmartRules
 import au.com.shiftyjelly.pocketcasts.models.type.SmartRules.DownloadStatusRule
@@ -71,7 +72,7 @@ class PlaylistManagerImpl @Inject constructor(
                         limit = PLAYLIST_ARTWORK_EPISODE_LIMIT,
                     )
                     val episodesFlow = observeSmartEpisodes(playlist.smartRules)
-                    val metadataFlow = playlistDao.observeSmartPlaylistEpisodeMetadata(
+                    val metadataFlow = playlistDao.observeEpisodeMetadata(
                         clock = clock,
                         smartRules = playlist.smartRules,
                     )
@@ -97,6 +98,10 @@ class PlaylistManagerImpl @Inject constructor(
             sortType = PlaylistEpisodeSortType.NewestToOldest,
             limit = SMART_PLAYLIST_EPISODE_LIMIT,
         ).distinctUntilChanged()
+    }
+
+    override fun observeEpisodeMetadata(rules: SmartRules): Flow<PlaylistEpisodeMetadata> {
+        return playlistDao.observeEpisodeMetadata(clock, rules)
     }
 
     override suspend fun deletePlaylist(uuid: String) {
@@ -136,7 +141,7 @@ class PlaylistManagerImpl @Inject constructor(
             sortType = playlist.sortType,
             limit = PLAYLIST_ARTWORK_EPISODE_LIMIT,
         )
-        val episodeCountFlow = playlistDao.observeSmartPlaylistEpisodeMetadata(
+        val episodeCountFlow = playlistDao.observeEpisodeMetadata(
             clock = clock,
             smartRules = playlist.smartRules,
         )


### PR DESCRIPTION
## Description

This adds starred rule UI.

Designs: 5sC4z4Mu42LvL4MAAIbQVi-fi-1573_85959

Closes PCDROID-60

## Testing Instructions

1. Have some starred episodes.
2. Start Smart Playlist creation.
3. Play around the starred rule.

## Screenshots or Screencast 

| Enabled | Disabled | Applied Enabled | Applied Disabled |
| - | - | - | - |
| <img width="324" height="720" alt="image" src="https://github.com/user-attachments/assets/c9656d70-5171-449e-8e58-e6c753d13d6a" /> | <img width="324" height="720" alt="image" src="https://github.com/user-attachments/assets/6a71c4fa-43db-445d-a314-8aef8f94a889" /> | <img width="324" height="720" alt="image" src="https://github.com/user-attachments/assets/d95517e1-7d86-4fa8-ac43-07fca437500b" /> | <img width="324" height="720" alt="image" src="https://github.com/user-attachments/assets/54e41064-8c49-4275-9454-61a2e669923b" /> |

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack