### PR TITLE
Extract rules UI component

### DIFF
--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/rules/AppliedRulesPage.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/rules/AppliedRulesPage.kt
@@ -2,8 +2,6 @@ package au.com.shiftyjelly.pocketcasts.playlists.rules
 
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.core.animateFloatAsState
-import androidx.compose.foundation.Image
-import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -16,57 +14,40 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.Icon
 import androidx.compose.material.MaterialTheme
-import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.ReadOnlyComposable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.rotate
-import androidx.compose.ui.graphics.ColorFilter
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.semantics
-import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import au.com.shiftyjelly.pocketcasts.compose.AppThemeWithBackground
 import au.com.shiftyjelly.pocketcasts.compose.Devices
 import au.com.shiftyjelly.pocketcasts.compose.bars.NavigationButton
 import au.com.shiftyjelly.pocketcasts.compose.bars.ThemedTopAppBar
 import au.com.shiftyjelly.pocketcasts.compose.buttons.RowButton
 import au.com.shiftyjelly.pocketcasts.compose.components.FadedLazyColumn
-import au.com.shiftyjelly.pocketcasts.compose.components.HorizontalDivider
 import au.com.shiftyjelly.pocketcasts.compose.components.NoContentBanner
 import au.com.shiftyjelly.pocketcasts.compose.components.TextH20
 import au.com.shiftyjelly.pocketcasts.compose.components.TextP50
 import au.com.shiftyjelly.pocketcasts.compose.preview.ThemePreviewParameterProvider
 import au.com.shiftyjelly.pocketcasts.compose.theme
-import au.com.shiftyjelly.pocketcasts.localization.helper.TimeHelper
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
-import au.com.shiftyjelly.pocketcasts.models.type.SmartRules
-import au.com.shiftyjelly.pocketcasts.models.type.SmartRules.DownloadStatusRule
-import au.com.shiftyjelly.pocketcasts.models.type.SmartRules.EpisodeDurationRule
-import au.com.shiftyjelly.pocketcasts.models.type.SmartRules.MediaTypeRule
 import au.com.shiftyjelly.pocketcasts.models.type.SmartRules.PodcastsRule
-import au.com.shiftyjelly.pocketcasts.models.type.SmartRules.ReleaseDateRule
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme.ThemeType
 import java.util.Date
 import au.com.shiftyjelly.pocketcasts.images.R as IR
@@ -115,7 +96,7 @@ fun AppliedRulesPage(
                     ) {
                         ActiveRulesContent(
                             rules = activeRules,
-                            totalEpisodeCount = totalEpisodeCount,
+                            episodeCount = totalEpisodeCount,
                             appliedRules = appliedRules,
                             onClickRule = onClickRule,
                         )
@@ -201,7 +182,7 @@ fun AppliedRulesPage(
 private fun ActiveRulesContent(
     rules: List<RuleType>,
     appliedRules: AppliedRules,
-    totalEpisodeCount: Int,
+    episodeCount: Int,
     onClickRule: (RuleType) -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -214,9 +195,10 @@ private fun ActiveRulesContent(
         Spacer(
             modifier = Modifier.height(16.dp),
         )
-        Rules(
-            ruleTypes = rules,
-            description = { rule -> appliedRules.description(rule, totalEpisodeCount) },
+        AppliedRulesColumn(
+            rules = rules,
+            appliedRules = appliedRules,
+            episodeCount = episodeCount,
             onClickRule = onClickRule,
         )
     }
@@ -269,9 +251,8 @@ private fun InactiveRulesContent(
                 Spacer(
                     modifier = Modifier.height(16.dp),
                 )
-                Rules(
-                    ruleTypes = rules,
-                    description = { null },
+                RulesColumn(
+                    rules = rules,
                     onClickRule = onClickRule,
                 )
             }
@@ -301,119 +282,13 @@ private fun NoRulesContent(
         Spacer(
             modifier = Modifier.height(24.dp),
         )
-        Rules(
-            ruleTypes = RuleType.entries,
-            description = { null },
+        RulesColumn(
+            rules = RuleType.entries,
             onClickRule = onClickRule,
         )
         Spacer(
             modifier = Modifier.height(24.dp),
         )
-    }
-}
-
-@Composable
-private fun Rules(
-    ruleTypes: List<RuleType>,
-    description: @Composable (RuleType) -> String?,
-    onClickRule: (RuleType) -> Unit,
-    modifier: Modifier = Modifier,
-) {
-    Column(
-        modifier = modifier
-            .clip(RoundedCornerShape(10.dp))
-            .background(MaterialTheme.theme.colors.primaryUi02Active),
-    ) {
-        ruleTypes.forEachIndexed { index, type ->
-            RuleRow(
-                ruleType = type,
-                description = description(type),
-                onClick = { onClickRule(type) },
-                showDivider = index != ruleTypes.lastIndex,
-            )
-        }
-    }
-}
-
-@Composable
-private fun RuleRow(
-    ruleType: RuleType,
-    description: String?,
-    showDivider: Boolean,
-    onClick: () -> Unit,
-    modifier: Modifier = Modifier,
-) {
-    Column(
-        modifier = modifier
-            .clickable(
-                role = Role.Button,
-                onClick = { onClick() },
-            )
-            .semantics(mergeDescendants = true) {},
-    ) {
-        Row(
-            verticalAlignment = Alignment.CenterVertically,
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(horizontal = 16.dp, vertical = 10.dp),
-        ) {
-            Icon(
-                painter = painterResource(ruleType.iconId),
-                contentDescription = null,
-                tint = MaterialTheme.theme.colors.primaryIcon03,
-                modifier = Modifier.size(24.dp),
-            )
-            Spacer(
-                modifier = Modifier.width(16.dp),
-            )
-            Row(
-                modifier = Modifier.weight(1f),
-            ) {
-                Text(
-                    text = stringResource(ruleType.titleId),
-                    color = MaterialTheme.theme.colors.primaryText01,
-                    fontSize = 17.sp,
-                    lineHeight = 22.sp,
-                    maxLines = 1,
-                    overflow = TextOverflow.Ellipsis,
-                )
-                Spacer(
-                    modifier = Modifier.weight(1f),
-                )
-                if (description != null) {
-                    Spacer(
-                        modifier = Modifier.width(8.dp),
-                    )
-                    Text(
-                        text = description,
-                        color = MaterialTheme.theme.colors.primaryText02,
-                        fontSize = 17.sp,
-                        lineHeight = 22.sp,
-                        maxLines = 1,
-                        overflow = TextOverflow.Ellipsis,
-                        textAlign = TextAlign.End,
-                    )
-                }
-            }
-            Spacer(
-                modifier = Modifier.width(16.dp),
-            )
-            Image(
-                painter = painterResource(IR.drawable.ic_chevron_trimmed),
-                contentDescription = null,
-                colorFilter = ColorFilter.tint(MaterialTheme.theme.colors.primaryIcon02),
-            )
-        }
-        if (showDivider) {
-            HorizontalDivider(
-                thickness = 0.5.dp,
-                startIndent = 56.dp,
-            )
-        } else {
-            Spacer(
-                modifier = Modifier.height(0.5.dp),
-            )
-        }
     }
 }
 
@@ -438,92 +313,6 @@ private fun rememberActiveRules(rules: AppliedRules): List<RuleType> {
 private fun rememberInactiveRules(activeRules: List<RuleType>): List<RuleType> {
     return remember(activeRules) {
         RuleType.entries - activeRules
-    }
-}
-
-@Composable
-@ReadOnlyComposable
-private fun AppliedRules.description(ruleType: RuleType, episodeCount: Int) = when (ruleType) {
-    RuleType.Podcasts -> when (podcasts) {
-        is PodcastsRule.Any -> stringResource(LR.string.all)
-        is PodcastsRule.Selected -> podcasts.uuids.size.toString()
-        null -> null
-    }
-
-    RuleType.EpisodeStatus -> {
-        if (episodeStatus != null) {
-            when {
-                episodeStatus.unplayed -> when {
-                    episodeStatus.inProgress && episodeStatus.completed -> {
-                        stringResource(LR.string.episode_status_rule_description, stringResource(LR.string.unplayed), 2)
-                    }
-                    episodeStatus.inProgress || episodeStatus.completed -> {
-                        stringResource(LR.string.episode_status_rule_description, stringResource(LR.string.unplayed), 1)
-                    }
-                    else -> {
-                        stringResource(LR.string.unplayed)
-                    }
-                }
-
-                episodeStatus.inProgress -> when {
-                    episodeStatus.completed -> {
-                        stringResource(LR.string.episode_status_rule_description, stringResource(LR.string.in_progress_uppercase), 1)
-                    }
-
-                    else -> {
-                        stringResource(LR.string.in_progress_uppercase)
-                    }
-                }
-
-                episodeStatus.completed -> {
-                    stringResource(LR.string.played)
-                }
-                else -> null
-            }
-        } else {
-            null
-        }
-    }
-
-    RuleType.ReleaseDate -> when (releaseDate) {
-        ReleaseDateRule.AnyTime -> stringResource(LR.string.filters_time_anytime)
-        ReleaseDateRule.Last24Hours -> stringResource(LR.string.filters_time_24_hours)
-        ReleaseDateRule.Last3Days -> stringResource(LR.string.filters_time_3_days)
-        ReleaseDateRule.LastWeek -> stringResource(LR.string.filters_time_week)
-        ReleaseDateRule.Last2Weeks -> stringResource(LR.string.filters_time_2_weeks)
-        ReleaseDateRule.LastMonth -> stringResource(LR.string.filters_time_month)
-        null -> null
-    }
-
-    RuleType.EpisodeDuration -> when (episodeDuration) {
-        is EpisodeDurationRule.Any -> stringResource(LR.string.off)
-        is EpisodeDurationRule.Constrained -> {
-            val context = LocalContext.current
-            val min = TimeHelper.getTimeDurationShortString(episodeDuration.longerThan.inWholeMilliseconds, context)
-            val max = TimeHelper.getTimeDurationShortString(episodeDuration.shorterThan.inWholeMilliseconds, context)
-            "$min - $max"
-        }
-        null -> null
-    }
-
-    RuleType.DownloadStatus -> when (downloadStatus) {
-        DownloadStatusRule.Any -> stringResource(LR.string.all)
-        DownloadStatusRule.Downloaded -> stringResource(LR.string.downloaded)
-        DownloadStatusRule.NotDownloaded -> stringResource(LR.string.not_downloaded)
-        null -> null
-    }
-
-    RuleType.MediaType -> when (mediaType) {
-        MediaTypeRule.Any -> stringResource(LR.string.all)
-        MediaTypeRule.Audio -> stringResource(LR.string.audio)
-        MediaTypeRule.Video -> stringResource(LR.string.video)
-        null -> null
-    }
-
-    RuleType.Starred -> when (starred) {
-        SmartRules.StarredRule.Any -> stringResource(LR.string.off)
-        SmartRules.StarredRule.Starred -> episodeCount.toString()
-        null -> null
     }
 }
 
@@ -552,7 +341,7 @@ private fun AppliedRulesPageNoRulesPreview(
 
 @Preview(device = Devices.PORTRAIT_REGULAR)
 @Composable
-private fun AppliedRulesPageEpisodessPreview(
+private fun AppliedRulesPageEpisodesPreview(
     @PreviewParameter(ThemePreviewParameterProvider::class) themeType: ThemeType,
 ) {
     var expanded by remember { mutableStateOf(false) }

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/rules/RulesColumn.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/rules/RulesColumn.kt
@@ -59,8 +59,8 @@ fun AppliedRulesColumn(
 ) {
     RulesColumn(
         rules = rules,
-        description = {rule -> appliedRules.description(rule, episodeCount) },
-        onClickRule =  onClickRule,
+        description = { rule -> appliedRules.description(rule, episodeCount) },
+        onClickRule = onClickRule,
         modifier = modifier,
     )
 }
@@ -273,7 +273,7 @@ private fun AppliedRulesColumnPreview(
                 podcasts = SmartRules.Default.podcasts,
                 episodeDuration = EpisodeDurationRule.Constrained(
                     longerThan = 15.minutes,
-                    shorterThan = 1.hours + 10.minutes
+                    shorterThan = 1.hours + 10.minutes,
                 ),
             ),
             episodeCount = 17,

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/rules/RulesColumn.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/rules/RulesColumn.kt
@@ -1,0 +1,283 @@
+package au.com.shiftyjelly.pocketcasts.playlists.rules
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.Icon
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.ReadOnlyComposable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewParameter
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import au.com.shiftyjelly.pocketcasts.compose.AppTheme
+import au.com.shiftyjelly.pocketcasts.compose.components.HorizontalDivider
+import au.com.shiftyjelly.pocketcasts.compose.preview.ThemePreviewParameterProvider
+import au.com.shiftyjelly.pocketcasts.compose.theme
+import au.com.shiftyjelly.pocketcasts.localization.helper.TimeHelper
+import au.com.shiftyjelly.pocketcasts.models.type.SmartRules
+import au.com.shiftyjelly.pocketcasts.models.type.SmartRules.DownloadStatusRule
+import au.com.shiftyjelly.pocketcasts.models.type.SmartRules.EpisodeDurationRule
+import au.com.shiftyjelly.pocketcasts.models.type.SmartRules.MediaTypeRule
+import au.com.shiftyjelly.pocketcasts.models.type.SmartRules.PodcastsRule
+import au.com.shiftyjelly.pocketcasts.models.type.SmartRules.ReleaseDateRule
+import au.com.shiftyjelly.pocketcasts.ui.theme.Theme.ThemeType
+import kotlin.time.Duration.Companion.hours
+import kotlin.time.Duration.Companion.minutes
+import au.com.shiftyjelly.pocketcasts.images.R as IR
+import au.com.shiftyjelly.pocketcasts.localization.R as LR
+
+@Composable
+fun AppliedRulesColumn(
+    rules: List<RuleType>,
+    appliedRules: AppliedRules,
+    episodeCount: Int,
+    onClickRule: (RuleType) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    RulesColumn(
+        rules = rules,
+        description = {rule -> appliedRules.description(rule, episodeCount) },
+        onClickRule =  onClickRule,
+        modifier = modifier,
+    )
+}
+
+@Composable
+fun RulesColumn(
+    rules: List<RuleType>,
+    onClickRule: (RuleType) -> Unit,
+    modifier: Modifier = Modifier,
+    description: @Composable (RuleType) -> String? = { null },
+) {
+    Column(
+        modifier = modifier
+            .clip(RoundedCornerShape(10.dp))
+            .background(MaterialTheme.theme.colors.primaryUi02Active),
+    ) {
+        rules.forEachIndexed { index, type ->
+            RuleRow(
+                ruleType = type,
+                description = description(type),
+                onClick = { onClickRule(type) },
+                showDivider = index != rules.lastIndex,
+            )
+        }
+    }
+}
+
+@Composable
+private fun RuleRow(
+    ruleType: RuleType,
+    description: String?,
+    showDivider: Boolean,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier
+            .clickable(
+                role = Role.Button,
+                onClick = { onClick() },
+            )
+            .semantics(mergeDescendants = true) {},
+    ) {
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp, vertical = 10.dp),
+        ) {
+            Icon(
+                painter = painterResource(ruleType.iconId),
+                contentDescription = null,
+                tint = MaterialTheme.theme.colors.primaryIcon03,
+                modifier = Modifier.size(24.dp),
+            )
+            Spacer(
+                modifier = Modifier.width(16.dp),
+            )
+            Row(
+                modifier = Modifier.weight(1f),
+            ) {
+                Text(
+                    text = stringResource(ruleType.titleId),
+                    color = MaterialTheme.theme.colors.primaryText01,
+                    fontSize = 17.sp,
+                    lineHeight = 22.sp,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+                Spacer(
+                    modifier = Modifier.weight(1f),
+                )
+                if (description != null) {
+                    Spacer(
+                        modifier = Modifier.width(8.dp),
+                    )
+                    Text(
+                        text = description,
+                        color = MaterialTheme.theme.colors.primaryText02,
+                        fontSize = 17.sp,
+                        lineHeight = 22.sp,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                        textAlign = TextAlign.End,
+                    )
+                }
+            }
+            Spacer(
+                modifier = Modifier.width(16.dp),
+            )
+            Image(
+                painter = painterResource(IR.drawable.ic_chevron_trimmed),
+                contentDescription = null,
+                colorFilter = ColorFilter.tint(MaterialTheme.theme.colors.primaryIcon02),
+            )
+        }
+        if (showDivider) {
+            HorizontalDivider(
+                thickness = 0.5.dp,
+                startIndent = 56.dp,
+            )
+        } else {
+            Spacer(
+                modifier = Modifier.height(0.5.dp),
+            )
+        }
+    }
+}
+
+@Composable
+@ReadOnlyComposable
+private fun AppliedRules.description(ruleType: RuleType, episodeCount: Int) = when (ruleType) {
+    RuleType.Podcasts -> when (podcasts) {
+        is PodcastsRule.Any -> stringResource(LR.string.all)
+        is PodcastsRule.Selected -> podcasts.uuids.size.toString()
+        null -> null
+    }
+
+    RuleType.EpisodeStatus -> {
+        if (episodeStatus != null) {
+            when {
+                episodeStatus.unplayed -> when {
+                    episodeStatus.inProgress && episodeStatus.completed -> {
+                        stringResource(LR.string.episode_status_rule_description, stringResource(LR.string.unplayed), 2)
+                    }
+                    episodeStatus.inProgress || episodeStatus.completed -> {
+                        stringResource(LR.string.episode_status_rule_description, stringResource(LR.string.unplayed), 1)
+                    }
+                    else -> {
+                        stringResource(LR.string.unplayed)
+                    }
+                }
+
+                episodeStatus.inProgress -> when {
+                    episodeStatus.completed -> {
+                        stringResource(LR.string.episode_status_rule_description, stringResource(LR.string.in_progress_uppercase), 1)
+                    }
+
+                    else -> {
+                        stringResource(LR.string.in_progress_uppercase)
+                    }
+                }
+
+                episodeStatus.completed -> {
+                    stringResource(LR.string.played)
+                }
+                else -> null
+            }
+        } else {
+            null
+        }
+    }
+
+    RuleType.ReleaseDate -> when (releaseDate) {
+        ReleaseDateRule.AnyTime -> stringResource(LR.string.filters_time_anytime)
+        ReleaseDateRule.Last24Hours -> stringResource(LR.string.filters_time_24_hours)
+        ReleaseDateRule.Last3Days -> stringResource(LR.string.filters_time_3_days)
+        ReleaseDateRule.LastWeek -> stringResource(LR.string.filters_time_week)
+        ReleaseDateRule.Last2Weeks -> stringResource(LR.string.filters_time_2_weeks)
+        ReleaseDateRule.LastMonth -> stringResource(LR.string.filters_time_month)
+        null -> null
+    }
+
+    RuleType.EpisodeDuration -> when (episodeDuration) {
+        is EpisodeDurationRule.Any -> stringResource(LR.string.off)
+        is EpisodeDurationRule.Constrained -> {
+            val context = LocalContext.current
+            val min = TimeHelper.getTimeDurationShortString(episodeDuration.longerThan.inWholeMilliseconds, context)
+            val max = TimeHelper.getTimeDurationShortString(episodeDuration.shorterThan.inWholeMilliseconds, context)
+            "$min - $max"
+        }
+        null -> null
+    }
+
+    RuleType.DownloadStatus -> when (downloadStatus) {
+        DownloadStatusRule.Any -> stringResource(LR.string.all)
+        DownloadStatusRule.Downloaded -> stringResource(LR.string.downloaded)
+        DownloadStatusRule.NotDownloaded -> stringResource(LR.string.not_downloaded)
+        null -> null
+    }
+
+    RuleType.MediaType -> when (mediaType) {
+        MediaTypeRule.Any -> stringResource(LR.string.all)
+        MediaTypeRule.Audio -> stringResource(LR.string.audio)
+        MediaTypeRule.Video -> stringResource(LR.string.video)
+        null -> null
+    }
+
+    RuleType.Starred -> when (starred) {
+        SmartRules.StarredRule.Any -> stringResource(LR.string.off)
+        SmartRules.StarredRule.Starred -> episodeCount.toString()
+        null -> null
+    }
+}
+
+@Preview
+@Composable
+private fun AppliedRulesColumnPreview(
+    @PreviewParameter(ThemePreviewParameterProvider::class) themeType: ThemeType,
+) {
+    AppTheme(themeType) {
+        AppliedRulesColumn(
+            rules = RuleType.entries,
+            appliedRules = AppliedRules(
+                episodeStatus = SmartRules.Default.episodeStatus,
+                downloadStatus = DownloadStatusRule.Downloaded,
+                mediaType = SmartRules.Default.mediaType,
+                releaseDate = SmartRules.Default.releaseDate,
+                starred = SmartRules.StarredRule.Starred,
+                podcasts = SmartRules.Default.podcasts,
+                episodeDuration = EpisodeDurationRule.Constrained(
+                    longerThan = 15.minutes,
+                    shorterThan = 1.hours + 10.minutes
+                ),
+            ),
+            episodeCount = 17,
+            onClickRule = {},
+        )
+    }
+}


### PR DESCRIPTION
## Description

This extracts common component for the rules UI that will be used for Smart Playlist editing.

Relates to: PCDROID-73

## Testing Instructions

Smoke test rules UI during Playlist creation.

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack
