### PR TITLE
[Onboarding] Accessibility & Talkback

### DIFF
--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/components/SubscriptionPlanRow.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/components/SubscriptionPlanRow.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.focusable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -29,6 +30,7 @@ import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.Dp
@@ -167,7 +169,6 @@ private fun SubscriptionPlanRow(
                     },
                 )
                 .clickable(
-                    enabled = !isSelected,
                     onClick = onClick,
                     role = Role.Button,
                     indication = ripple(color = MaterialTheme.theme.colors.primaryIcon01),
@@ -214,6 +215,7 @@ private fun SubscriptionPlanRow(
         if (plan.tier == SubscriptionTier.Plus && plan.billingCycle == BillingCycle.Yearly && displayLabel.isNotEmpty()) {
             Box(
                 modifier = Modifier
+                    .focusable(false)
                     .align(
                         when (rowConfig.badgePosition) {
                             BadgePosition.RIGHT -> Alignment.TopEnd

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/components/UpgradeTrialTimeline.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/components/UpgradeTrialTimeline.kt
@@ -1,5 +1,6 @@
 import androidx.annotation.DrawableRes
 import androidx.compose.foundation.background
+import androidx.compose.foundation.focusable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -21,6 +22,11 @@ import androidx.compose.ui.layout.Placeable
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.CollectionInfo
+import androidx.compose.ui.semantics.CollectionItemInfo
+import androidx.compose.ui.semantics.collectionInfo
+import androidx.compose.ui.semantics.collectionItemInfo
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
@@ -85,28 +91,35 @@ fun UpgradeTrialTimeline(
     val iconCenterYPositions = mutableListOf<Float>()
 
     Layout(
-        modifier = modifier.drawWithContent {
-            if (items.size > 1) {
-                drawLine(
-                    color = iconColor,
-                    strokeWidth = timelineWidthPx,
-                    start = Offset(x = iconSizePx / 2, y = iconCenterYPositions.firstOrNull() ?: 0f),
-                    end = Offset(x = iconSizePx / 2, y = iconCenterYPositions.lastOrNull() ?: 0f),
+        modifier = modifier
+            .semantics {
+                collectionInfo = CollectionInfo(
+                    rowCount = items.size,
+                    columnCount = 0,
                 )
             }
-            drawContent()
-            if (items.size > 1) {
-                drawRect(
-                    brush = Brush.verticalGradient(
-                        colors = gradientColors,
-                    ),
-                    topLeft = Offset(x = 0f, y = 0f),
-                    size = Size(width = iconSizePx, height = (iconCenterYPositions.lastOrNull() ?: 0f) + iconSizePx),
-                )
-            }
-        },
+            .drawWithContent {
+                if (items.size > 1) {
+                    drawLine(
+                        color = iconColor,
+                        strokeWidth = timelineWidthPx,
+                        start = Offset(x = iconSizePx / 2, y = iconCenterYPositions.firstOrNull() ?: 0f),
+                        end = Offset(x = iconSizePx / 2, y = iconCenterYPositions.lastOrNull() ?: 0f),
+                    )
+                }
+                drawContent()
+                if (items.size > 1) {
+                    drawRect(
+                        brush = Brush.verticalGradient(
+                            colors = gradientColors,
+                        ),
+                        topLeft = Offset(x = 0f, y = 0f),
+                        size = Size(width = iconSizePx, height = (iconCenterYPositions.lastOrNull() ?: 0f) + iconSizePx),
+                    )
+                }
+            },
         content = {
-            items.forEach { item ->
+            items.forEachIndexed { index, item ->
                 Box(
                     modifier = Modifier
                         .size(iconSize)
@@ -124,8 +137,17 @@ fun UpgradeTrialTimeline(
                 }
                 Column(
                     modifier = Modifier
+                        .focusable()
                         .fillMaxWidth()
-                        .wrapContentHeight(),
+                        .wrapContentHeight()
+                        .semantics(mergeDescendants = true) {
+                            collectionItemInfo = CollectionItemInfo(
+                                rowIndex = index,
+                                rowSpan = 0,
+                                columnIndex = 0,
+                                columnSpan = 0,
+                            )
+                        },
                 ) {
                     TextP50(
                         text = item.title,

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/components/UpgradeTrialTimeline.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/components/UpgradeTrialTimeline.kt
@@ -122,6 +122,7 @@ fun UpgradeTrialTimeline(
             items.forEachIndexed { index, item ->
                 Box(
                     modifier = Modifier
+                        .focusable(false)
                         .size(iconSize)
                         .background(
                             color = iconColor,

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeScreen.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeScreen.kt
@@ -30,9 +30,16 @@ import androidx.compose.material.Icon
 import androidx.compose.material.IconButton
 import androidx.compose.material.MaterialTheme
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusDirection
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.FocusRequester.Companion.FocusRequesterFactory.component1
+import androidx.compose.ui.focus.FocusRequester.Companion.FocusRequesterFactory.component2
+import androidx.compose.ui.focus.focusProperties
+import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.res.painterResource
@@ -181,6 +188,8 @@ private fun CompactHeightUpscaledFontUpgradeScreen(
                     onClickSubscribe = onSubscribePress,
                     onPrivacyPolicyClick = onClickPrivacyPolicy,
                     onTermsAndConditionsClick = onClickTermsAndConditions,
+                    selfFocusRequester = FocusRequester.Default,
+                    upFocusRequester = FocusRequester.Default,
                 )
             }
         }
@@ -198,6 +207,8 @@ private fun RegularUpgradeScreen(
     onClickTermsAndConditions: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
+    val (contentFocusRequester, footerFocusRequester) = remember { FocusRequester.createRefs() }
+
     Column(
         modifier = modifier,
     ) {
@@ -218,6 +229,8 @@ private fun RegularUpgradeScreen(
                 plan = state.selectedBasePlan,
                 source = source,
             ),
+            selfFocusRequester = contentFocusRequester,
+            downFocusRequester = footerFocusRequester,
         )
         Spacer(modifier = Modifier.height(24.dp))
         UpgradeFooter(
@@ -234,6 +247,8 @@ private fun RegularUpgradeScreen(
             onClickSubscribe = onSubscribePress,
             onPrivacyPolicyClick = onClickPrivacyPolicy,
             onTermsAndConditionsClick = onClickTermsAndConditions,
+            selfFocusRequester = footerFocusRequester,
+            upFocusRequester = contentFocusRequester,
         )
     }
 }
@@ -246,10 +261,19 @@ private fun UpgradeFooter(
     onClickSubscribe: () -> Unit,
     onPrivacyPolicyClick: () -> Unit,
     onTermsAndConditionsClick: () -> Unit,
+    upFocusRequester: FocusRequester,
+    selfFocusRequester: FocusRequester,
     modifier: Modifier = Modifier,
 ) {
     Column(
-        modifier = modifier,
+        modifier = modifier.focusRequester(selfFocusRequester)
+            .focusProperties {
+                onExit = {
+                    if (requestedFocusDirection == FocusDirection.Up) {
+                        upFocusRequester.requestFocus()
+                    }
+                }
+            },
     ) {
         plans.forEachIndexed { index, item ->
             UpgradePlanRow(
@@ -489,6 +513,8 @@ private sealed interface UpgradePagerContent {
 @Composable
 private fun UpgradeContent(
     pages: List<UpgradePagerContent>,
+    selfFocusRequester: FocusRequester,
+    downFocusRequester: FocusRequester,
     modifier: Modifier = Modifier,
 ) {
     val coroutineScope = rememberCoroutineScope()
@@ -499,7 +525,21 @@ private fun UpgradeContent(
     ) {
         val itemHeight = this@BoxWithConstraints.maxHeight
         FadedLazyColumn(
-            modifier = Modifier.fillMaxSize(),
+            modifier = Modifier
+                .fillMaxSize()
+                .focusRequester(selfFocusRequester)
+                .focusProperties {
+                    onExit = {
+                        selfFocusRequester.saveFocusedChild()
+
+                        if (this.requestedFocusDirection == FocusDirection.Down) {
+                            downFocusRequester.requestFocus()
+                        }
+                    }
+                    onEnter = {
+                        selfFocusRequester.restoreFocusedChild()
+                    }
+                },
             state = listState,
         ) {
             itemsIndexed(pages) { index, page ->

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/contextual/Bookmarks.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/contextual/Bookmarks.kt
@@ -10,6 +10,7 @@ import androidx.compose.animation.core.tween
 import androidx.compose.animation.core.updateTransition
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
+import androidx.compose.foundation.focusable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
@@ -87,7 +88,9 @@ fun BookmarksAnimation(
     }
 
     BoxWithConstraints(
-        modifier = modifier.semantics { role = Role.Image },
+        modifier = modifier
+            .semantics(mergeDescendants = true) { role = Role.Image }
+            .focusable(false),
         contentAlignment = Alignment.TopCenter,
     ) {
         val itemWidth = this.maxWidth * .4f

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/contextual/Folders.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/contextual/Folders.kt
@@ -11,6 +11,7 @@ import androidx.compose.animation.core.tween
 import androidx.compose.animation.core.updateTransition
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
+import androidx.compose.foundation.focusable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -139,7 +140,8 @@ fun FoldersAnimation(
 
     Box(
         modifier = modifier
-            .semantics { role = Role.Image },
+            .semantics(mergeDescendants = true) { role = Role.Image }
+            .focusable(false),
     ) {
         if (showFolders) {
             FolderRow(

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/contextual/PreselectChapters.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/contextual/PreselectChapters.kt
@@ -5,6 +5,7 @@ import androidx.compose.animation.core.animateInt
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.core.updateTransition
 import androidx.compose.foundation.background
+import androidx.compose.foundation.focusable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -75,9 +76,8 @@ fun PreselectChaptersAnimation(modifier: Modifier = Modifier) {
 
     Column(
         modifier = modifier
-            .semantics(true) {
-                role = Role.Image
-            },
+            .semantics(mergeDescendants = true) { role = Role.Image }
+            .focusable(false),
         verticalArrangement = Arrangement.spacedBy(6.dp),
     ) {
         predefinedChapters.forEachIndexed { index, item ->

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/contextual/Shuffle.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/contextual/Shuffle.kt
@@ -7,6 +7,7 @@ import androidx.compose.animation.core.tween
 import androidx.compose.animation.core.updateTransition
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
+import androidx.compose.foundation.focusable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -81,7 +82,11 @@ fun ShuffleAnimation(
         }
     }
 
-    Box(modifier = modifier.semantics { role = Role.Image }) {
+    Box(
+        modifier = modifier
+            .semantics(mergeDescendants = true) { role = Role.Image }
+            .focusable(false),
+    ) {
         predefinedShuffle.chunked(3).forEachIndexed { index, dataSet ->
             ShuffleContainer(
                 items = dataSet,


### PR DESCRIPTION
## Description
This PR adds accessibility improvements and talkback support for the upgrade screens.
You can try and enable TalkBack on your device and use your keyboard to shift focus and traverse the semantic items of the screen. This assumes that you're running the app on an emulator or you're mirroring your device on your computer.
Alternatively, you can just tap on the screen to focus on your selected ui element.

Fixes https://linear.app/a8c/issue/PCDROID-43/accessibility-checks

## Testing Instructions
1. Connect to your device via USB
2. Launch the app and log in with an acocunt that is not subscribed
3. Enable TalkBack service
4. Mirror your phone in AS so you can use your keyboard to traverse the semantics tree
5. Navigate to an onboarding screen (e.g. Profile -> Settings -> Pocket casts plus)
6. Start shifting focus with the arrow keys

## Screenshots or Screencast 

https://github.com/user-attachments/assets/3abd0bcb-babe-4004-9654-ff40bfacf04c
https://github.com/user-attachments/assets/366dcdb6-ba41-433e-9476-97527653f8fa


## Checklist
- [ ] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] ~I have considered whether it makes sense to add tests for my changes~
- [ ] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [ ] ~Any jetpack compose components I added or changed are covered by compose previews~
- [ ] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack
