### PR TITLE
[Buildkite] Test Android Staging on `ami-0c4656f5c0214d48d`

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -2,7 +2,7 @@
 ---
 
 agents:
-  queue: "android"
+  queue: "android-staging"
 
 steps:
   - label: Gradle Wrapper Validation


### PR DESCRIPTION
Related: [buildkite-ci#699](https://github.com/Automattic/buildkite-ci/pull/699)

AMI Name: `android-build-image-6.36.0v1.12-rc-1`

---

## Description
<!-- Please include a summary of what this PR is changing and why these changes are needed. -->

This PR changes the Buildkite agent from `android` to `android-staging`. This change is not meant to be merged, but rather used to verify that the new AMI `ami-0c4656f5c0214d48d` works as expected.

---

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Tap on the Filters tab -->
<!-- 2. Tap on a filter -->
<!-- 3. etc. -->

Check CI and verify everything is working as expected with the `android-staging` agent.

---

## Checklist `N/A`

#### I have tested any UI changes... `N/A`