### PR TITLE
Extract rules editing logic

### DIFF
--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/edit/SmartRulesEditor.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/edit/SmartRulesEditor.kt
@@ -1,0 +1,230 @@
+package au.com.shiftyjelly.pocketcasts.playlists.edit
+
+import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
+import au.com.shiftyjelly.pocketcasts.models.type.SmartRules
+import au.com.shiftyjelly.pocketcasts.models.type.SmartRules.StarredRule
+import au.com.shiftyjelly.pocketcasts.playlists.rules.AppliedRules
+import au.com.shiftyjelly.pocketcasts.playlists.rules.RuleType
+import au.com.shiftyjelly.pocketcasts.playlists.rules.RulesBuilder
+import au.com.shiftyjelly.pocketcasts.repositories.playlist.PlaylistManager
+import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedFactory
+import dagger.assisted.AssistedInject
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.flow.update
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class SmartRulesEditor @AssistedInject constructor(
+    private val playlistManager: PlaylistManager,
+    private val podcastManager: PodcastManager,
+    @Assisted scope: CoroutineScope,
+    @Assisted initialBuilder: RulesBuilder,
+    @Assisted initialAppliedRules: AppliedRules,
+) {
+    private val _builderFlow = MutableStateFlow(initialBuilder)
+    val builderFlow = _builderFlow.asStateFlow()
+
+    private val _rulesFlow = MutableStateFlow(initialAppliedRules)
+    val rulesFlow = _rulesFlow.asStateFlow()
+
+    val smartEpisodes = rulesFlow.flatMapLatest { appliedRules ->
+        val smartRules = appliedRules.toSmartRules()
+        if (smartRules != null) {
+            playlistManager.observeSmartEpisodes(smartRules)
+        } else {
+            flowOf(emptyList())
+        }
+    }.stateIn(scope, SharingStarted.Lazily, initialValue = emptyList())
+
+    val totalEpisodeCount = rulesFlow.flatMapLatest { appliedRules ->
+        val smartRules = appliedRules.toSmartRules() ?: SmartRules.Default
+        val starredRules = smartRules.copy(starred = StarredRule.Starred)
+        playlistManager.observeEpisodeMetadata(starredRules).map { it.episodeCount }
+    }.stateIn(scope, SharingStarted.Lazily, initialValue = 0)
+
+    val smartStarredEpisodes = rulesFlow.flatMapLatest { appliedRules ->
+        val smartRules = appliedRules.toSmartRules() ?: SmartRules.Default
+        val starredRules = smartRules.copy(starred = StarredRule.Starred)
+        playlistManager.observeSmartEpisodes(starredRules)
+    }.stateIn(scope, SharingStarted.Lazily, initialValue = emptyList())
+
+    val followedPodcasts = podcastManager
+        .findSubscribedFlow()
+        .stateIn(scope, SharingStarted.Lazily, initialValue = emptyList())
+
+    fun useAllPodcasts(shouldUse: Boolean) {
+        _builderFlow.update { builder ->
+            builder.copy(useAllPodcasts = shouldUse)
+        }
+    }
+
+    fun selectPodcast(uuid: String) {
+        _builderFlow.update { builder ->
+            val podcasts = builder.selectedPodcasts + uuid
+            builder.copy(selectedPodcasts = podcasts)
+        }
+    }
+
+    fun deselectPodcast(uuid: String) {
+        _builderFlow.update { builder ->
+            val podcasts = builder.selectedPodcasts - uuid
+            builder.copy(selectedPodcasts = podcasts)
+        }
+    }
+
+    fun selectAllPodcasts() {
+        _builderFlow.update { builder ->
+            val uuids = followedPodcasts.value.mapTo(mutableSetOf(), Podcast::uuid)
+            builder.copy(selectedPodcasts = uuids)
+        }
+    }
+
+    fun deselectAllPodcasts() {
+        _builderFlow.update { builder ->
+            builder.copy(selectedPodcasts = emptySet())
+        }
+    }
+
+    fun useUnplayedEpisodes(shouldUse: Boolean) {
+        _builderFlow.update { builder ->
+            val rule = builder.episodeStatusRule.copy(unplayed = shouldUse)
+            builder.copy(episodeStatusRule = rule)
+        }
+    }
+
+    fun useInProgressEpisodes(shouldUse: Boolean) {
+        _builderFlow.update { builder ->
+            val rule = builder.episodeStatusRule.copy(inProgress = shouldUse)
+            builder.copy(episodeStatusRule = rule)
+        }
+    }
+
+    fun useCompletedEpisodes(shouldUse: Boolean) {
+        _builderFlow.update { builder ->
+            val rule = builder.episodeStatusRule.copy(completed = shouldUse)
+            builder.copy(episodeStatusRule = rule)
+        }
+    }
+
+    fun useReleaseDate(rule: SmartRules.ReleaseDateRule) {
+        _builderFlow.update { builder ->
+            builder.copy(releaseDateRule = rule)
+        }
+    }
+
+    fun useConstrainedDuration(shouldUse: Boolean) {
+        _builderFlow.update { builder ->
+            builder.copy(isEpisodeDurationConstrained = shouldUse)
+        }
+    }
+
+    fun decrementMinDuration() {
+        _builderFlow.update { builder -> builder.decrementMinDuration() }
+    }
+
+    fun incrementMinDuration() {
+        _builderFlow.update { builder -> builder.incrementMinDuration() }
+    }
+
+    fun decrementMaxDuration() {
+        _builderFlow.update { builder -> builder.decrementMaxDuration() }
+    }
+
+    fun incrementMaxDuration() {
+        _builderFlow.update { builder -> builder.incrementMaxDuration() }
+    }
+
+    fun useDownloadStatus(rule: SmartRules.DownloadStatusRule) {
+        _builderFlow.update { builder ->
+            builder.copy(downloadStatusRule = rule)
+        }
+    }
+
+    fun useMediaType(rule: SmartRules.MediaTypeRule) {
+        _builderFlow.update { builder ->
+            builder.copy(mediaTypeRule = rule)
+        }
+    }
+
+    fun useStarredEpisodes(shouldUse: Boolean) {
+        _builderFlow.update { builder ->
+            builder.copy(useStarredEpisode = shouldUse)
+        }
+    }
+
+    fun applyRule(type: RuleType) {
+        when (type) {
+            RuleType.Podcasts -> {
+                val rule = _builderFlow.value.podcastsRule
+                _rulesFlow.update { rules ->
+                    rules.copy(podcasts = rule)
+                }
+            }
+
+            RuleType.EpisodeStatus -> {
+                val rule = _builderFlow.value.episodeStatusRule
+                _rulesFlow.update { rules ->
+                    rules.copy(episodeStatus = rule)
+                }
+            }
+
+            RuleType.ReleaseDate -> {
+                val rule = _builderFlow.value.releaseDateRule
+                _rulesFlow.update { rules ->
+                    rules.copy(releaseDate = rule)
+                }
+            }
+
+            RuleType.EpisodeDuration -> {
+                val rule = _builderFlow.value.episodeDurationRule
+                _rulesFlow.update { rules ->
+                    rules.copy(episodeDuration = rule)
+                }
+            }
+
+            RuleType.DownloadStatus -> {
+                val rule = _builderFlow.value.downloadStatusRule
+                _rulesFlow.update { rules ->
+                    rules.copy(downloadStatus = rule)
+                }
+            }
+
+            RuleType.MediaType -> {
+                val rule = _builderFlow.value.mediaTypeRule
+                _rulesFlow.update { rules ->
+                    rules.copy(mediaType = rule)
+                }
+            }
+
+            RuleType.Starred -> {
+                val rule = _builderFlow.value.starredRule
+                _rulesFlow.update { rules ->
+                    rules.copy(starred = rule)
+                }
+            }
+        }
+    }
+
+    fun clearTransientRules() {
+        val appliedRules = _rulesFlow.value
+        _builderFlow.update { builder -> builder.applyRules(appliedRules.toSmartRulesOrDefault()) }
+    }
+
+    @AssistedFactory
+    interface Factory {
+        fun create(
+            scope: CoroutineScope,
+            initialBuilder: RulesBuilder,
+            initialAppliedRules: AppliedRules,
+        ): SmartRulesEditor
+    }
+}


### PR DESCRIPTION
## Description

This PR extracts rules editing logic from a view model to the `SmartRulesEditor` class. It is needed to share the code between playlist creation and playlist editing. The view model is heavily covered with tests so it is a very safe refactor.

Relates to PCDROID-73

## Testing Instructions

Smoke test playlist creation.

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.