### PR TITLE
Add Smart Playlist rules editing

### DIFF
--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/repositories/playlist/PlaylistManagerTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/repositories/playlist/PlaylistManagerTest.kt
@@ -884,6 +884,7 @@ class PlaylistManagerTest {
                 SmartPlaylist(
                     uuid = "playlist-id",
                     title = "Title 1",
+                    smartRules = SmartRules.Default,
                     totalEpisodeCount = 0,
                     playbackDurationLeft = Duration.ZERO,
                     episodes = emptyList(),
@@ -906,6 +907,7 @@ class PlaylistManagerTest {
                 playlistDao.upsertSmartPlaylist(it.copy(allPodcasts = false, podcastUuids = "podcast-id-2"))
             }
             playlist = awaitItem()
+            assertEquals(PodcastsRule.Selected(listOf("podcast-id-2")), playlist?.smartRules?.podcasts)
             assertEquals(listOf(episodes[2]), playlist?.episodes)
             assertEquals(listOf(podcasts[1]), playlist?.artworkPodcasts)
         }

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/SmartPlaylistFragment.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/SmartPlaylistFragment.kt
@@ -23,6 +23,7 @@ import au.com.shiftyjelly.pocketcasts.PlaylistEpisodesAdapterFactory
 import au.com.shiftyjelly.pocketcasts.compose.AppTheme
 import au.com.shiftyjelly.pocketcasts.compose.extensions.setContentWithViewCompositionStrategy
 import au.com.shiftyjelly.pocketcasts.filters.databinding.SmartPlaylistFragmentBinding
+import au.com.shiftyjelly.pocketcasts.playlists.edit.SmartRulesEditFragment
 import au.com.shiftyjelly.pocketcasts.utils.extensions.dpToPx
 import au.com.shiftyjelly.pocketcasts.views.dialog.ConfirmationDialog
 import au.com.shiftyjelly.pocketcasts.views.fragments.BaseFragment
@@ -73,7 +74,7 @@ class SmartPlaylistFragment :
         val leftButton = PlaylistHeaderData.ActionButton(
             iconId = IR.drawable.ic_playlist_smart_rules,
             label = getString(LR.string.smart_rules),
-            onClick = { Timber.tag("Edit smart rules") },
+            onClick = ::openEditor,
         )
         val rightButton = PlaylistHeaderData.ActionButton(
             iconId = IR.drawable.ic_playlist_play,
@@ -194,6 +195,13 @@ class SmartPlaylistFragment :
         } else {
             viewModel.playAll()
         }
+    }
+
+    private fun openEditor() {
+        if (parentFragmentManager.findFragmentByTag("playlist_editor") != null) {
+            return
+        }
+        SmartRulesEditFragment.newInstance(args.playlistUuid).show(parentFragmentManager, "playlist_editor")
     }
 
     override fun onBackPressed(): Boolean {

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/create/CreatePlaylistViewModel.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/create/CreatePlaylistViewModel.kt
@@ -24,14 +24,12 @@ import dagger.assisted.AssistedInject
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Deferred
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 
-@OptIn(ExperimentalCoroutinesApi::class)
 @HiltViewModel(assistedFactory = CreatePlaylistViewModel.Factory::class)
 class CreatePlaylistViewModel @AssistedInject constructor(
     private val playlistManager: PlaylistManager,

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/edit/SmartRulesEditFragment.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/edit/SmartRulesEditFragment.kt
@@ -1,0 +1,257 @@
+package au.com.shiftyjelly.pocketcasts.playlists.edit
+
+import android.os.Bundle
+import android.os.Parcelable
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.nestedscroll.nestedScroll
+import androidx.compose.ui.platform.rememberNestedScrollInteropConnection
+import androidx.core.os.BundleCompat
+import androidx.core.os.bundleOf
+import androidx.fragment.app.viewModels
+import androidx.fragment.compose.content
+import androidx.navigation.NavController
+import androidx.navigation.NavOptionsBuilder
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+import androidx.navigation.compose.rememberNavController
+import au.com.shiftyjelly.pocketcasts.compose.components.AnimatedNonNullVisibility
+import au.com.shiftyjelly.pocketcasts.compose.extensions.slideInToEnd
+import au.com.shiftyjelly.pocketcasts.compose.extensions.slideInToStart
+import au.com.shiftyjelly.pocketcasts.compose.extensions.slideOutToEnd
+import au.com.shiftyjelly.pocketcasts.compose.extensions.slideOutToStart
+import au.com.shiftyjelly.pocketcasts.playlists.rules.AppliedRulesPage
+import au.com.shiftyjelly.pocketcasts.playlists.rules.DownloadStatusRulePage
+import au.com.shiftyjelly.pocketcasts.playlists.rules.EpisodeDurationRulePage
+import au.com.shiftyjelly.pocketcasts.playlists.rules.EpisodeStatusRulePage
+import au.com.shiftyjelly.pocketcasts.playlists.rules.MediaTypeRulePage
+import au.com.shiftyjelly.pocketcasts.playlists.rules.PodcastsRulePage
+import au.com.shiftyjelly.pocketcasts.playlists.rules.ReleaseDateRulePage
+import au.com.shiftyjelly.pocketcasts.playlists.rules.RuleType
+import au.com.shiftyjelly.pocketcasts.playlists.rules.StarredRulePage
+import au.com.shiftyjelly.pocketcasts.views.fragments.BaseDialogFragment
+import dagger.hilt.android.AndroidEntryPoint
+import dagger.hilt.android.lifecycle.withCreationCallback
+import kotlinx.parcelize.Parcelize
+
+@AndroidEntryPoint
+class SmartRulesEditFragment : BaseDialogFragment() {
+    private val args get() = requireNotNull(arguments?.let { BundleCompat.getParcelable(it, NEW_INSTANCE_ARGS, Args::class.java) })
+
+    private val viewModel by viewModels<SmartRulesEditViewModel>(
+        extrasProducer = {
+            defaultViewModelCreationExtras.withCreationCallback<SmartRulesEditViewModel.Factory> { factory ->
+                factory.create(playlistUuid = args.playlistUuid)
+            }
+        },
+    )
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?,
+    ) = content {
+        DialogBox {
+            val navController = rememberNavController()
+            ClearTransientRulesStateEffect(navController)
+
+            AnimatedNonNullVisibility(
+                item = viewModel.uiState.collectAsState().value,
+                enter = fadeIn,
+                exit = fadeOut,
+                modifier = Modifier
+                    .fillMaxSize()
+                    .nestedScroll(rememberNestedScrollInteropConnection()),
+            ) { uiState ->
+                fun goBackToPlaylistPreview() {
+                    navController.popBackStack(NavigationRoutes.SMART_PLAYLIST_PREVIEW, inclusive = false)
+                }
+
+                fun navigateOnce(route: String, builder: NavOptionsBuilder.() -> Unit = {}) {
+                    if (navController.currentDestination?.route != route) {
+                        navController.navigate(route, builder)
+                    }
+                }
+
+                NavHost(
+                    navController = navController,
+                    startDestination = NavigationRoutes.SMART_PLAYLIST_PREVIEW,
+                    enterTransition = { slideInToStart() },
+                    exitTransition = { slideOutToStart() },
+                    popEnterTransition = { slideInToEnd() },
+                    popExitTransition = { slideOutToEnd() },
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .nestedScroll(rememberNestedScrollInteropConnection()),
+                ) {
+                    composable(NavigationRoutes.SMART_PLAYLIST_PREVIEW) {
+                        AppliedRulesPage(
+                            playlistTitle = uiState.playlistTitle,
+                            appliedRules = uiState.appliedRules,
+                            availableEpisodes = uiState.smartEpisodes,
+                            totalEpisodeCount = uiState.totalEpisodeCount,
+                            useEpisodeArtwork = uiState.useEpisodeArtwork,
+                            onClickRule = { rule -> navigateOnce(rule.toNavigationRoute()) },
+                            onClickClose = ::dismiss,
+                        )
+                    }
+                    composable(NavigationRoutes.SMART_RULE_PODCASTS) {
+                        PodcastsRulePage(
+                            useAllPodcasts = uiState.rulesBuilder.useAllPodcasts,
+                            selectedPodcastUuids = uiState.rulesBuilder.selectedPodcasts,
+                            podcasts = uiState.followedPodcasts,
+                            onToggleAllPodcasts = viewModel::useAllPodcasts,
+                            onSelectPodcast = viewModel::selectPodcast,
+                            onDeselectPodcast = viewModel::deselectPodcast,
+                            onSelectAllPodcasts = viewModel::selectAllPodcasts,
+                            onDeselectAllPodcasts = viewModel::deselectAllPodcasts,
+                            onSaveRule = {
+                                viewModel.applyRule(RuleType.Podcasts)
+                                goBackToPlaylistPreview()
+                            },
+                            onClickBack = ::goBackToPlaylistPreview,
+                        )
+                    }
+                    composable(NavigationRoutes.SMART_RULE_EPISODE_STATUS) {
+                        EpisodeStatusRulePage(
+                            rule = uiState.rulesBuilder.episodeStatusRule,
+                            onChangeUnplayedStatus = viewModel::useUnplayedEpisodes,
+                            onChangeInProgressStatus = viewModel::useInProgressEpisodes,
+                            onChangeCompletedStatus = viewModel::useCompletedEpisodes,
+                            onSaveRule = {
+                                viewModel.applyRule(RuleType.EpisodeStatus)
+                                goBackToPlaylistPreview()
+                            },
+                            onClickBack = ::goBackToPlaylistPreview,
+                        )
+                    }
+                    composable(NavigationRoutes.SMART_RULE_RELEASE_DATE) {
+                        ReleaseDateRulePage(
+                            selectedRule = uiState.rulesBuilder.releaseDateRule,
+                            onSelectReleaseDate = viewModel::useReleaseDate,
+                            onSaveRule = {
+                                viewModel.applyRule(RuleType.ReleaseDate)
+                                goBackToPlaylistPreview()
+                            },
+                            onClickBack = ::goBackToPlaylistPreview,
+                        )
+                    }
+                    composable(NavigationRoutes.SMART_RULE_EPISODE_DURATION) {
+                        EpisodeDurationRulePage(
+                            isDurationConstrained = uiState.rulesBuilder.isEpisodeDurationConstrained,
+                            minDuration = uiState.rulesBuilder.minEpisodeDuration,
+                            maxDuration = uiState.rulesBuilder.maxEpisodeDuration,
+                            onChangeConstrainDuration = viewModel::useConstrainedDuration,
+                            onDecrementMinDuration = viewModel::decrementMinDuration,
+                            onIncrementMinDuration = viewModel::incrementMinDuration,
+                            onDecrementMaxDuration = viewModel::decrementMaxDuration,
+                            onIncrementMaxDuration = viewModel::incrementMaxDuration,
+                            onSaveRule = {
+                                viewModel.applyRule(RuleType.EpisodeDuration)
+                                goBackToPlaylistPreview()
+                            },
+                            onClickBack = ::goBackToPlaylistPreview,
+                        )
+                    }
+                    composable(NavigationRoutes.SMART_RULE_DOWNLOAD_STATUS) {
+                        DownloadStatusRulePage(
+                            selectedRule = uiState.rulesBuilder.downloadStatusRule,
+                            onSelectDownloadStatus = viewModel::useDownloadStatus,
+                            onSaveRule = {
+                                viewModel.applyRule(RuleType.DownloadStatus)
+                                goBackToPlaylistPreview()
+                            },
+                            onClickBack = ::goBackToPlaylistPreview,
+                        )
+                    }
+                    composable(NavigationRoutes.SMART_RULE_MEDIA_TYPE) {
+                        MediaTypeRulePage(
+                            selectedRule = uiState.rulesBuilder.mediaTypeRule,
+                            onSelectMediaType = viewModel::useMediaType,
+                            onSaveRule = {
+                                viewModel.applyRule(RuleType.MediaType)
+                                goBackToPlaylistPreview()
+                            },
+                            onClickBack = ::goBackToPlaylistPreview,
+                        )
+                    }
+                    composable(NavigationRoutes.SMART_RULE_STARRED) {
+                        StarredRulePage(
+                            selectedRule = uiState.rulesBuilder.starredRule,
+                            starredEpisodes = uiState.smartStarredEpisodes,
+                            useEpisodeArtwork = uiState.useEpisodeArtwork,
+                            onChangeUseStarredEpisodes = viewModel::useStarredEpisodes,
+                            onSaveRule = {
+                                viewModel.applyRule(RuleType.Starred)
+                                goBackToPlaylistPreview()
+                            },
+                            onClickBack = ::goBackToPlaylistPreview,
+                        )
+                    }
+                }
+            }
+        }
+    }
+
+    @Composable
+    private fun ClearTransientRulesStateEffect(navController: NavController) {
+        var currentRoute by rememberSaveable { mutableStateOf<String?>(null) }
+        LaunchedEffect(navController) {
+            navController.currentBackStackEntryFlow.collect { entry ->
+                val newRoute = entry.destination.route
+                if (currentRoute != newRoute) {
+                    currentRoute = newRoute
+                    viewModel.clearTransientRules()
+                }
+            }
+        }
+    }
+
+    @Parcelize
+    private class Args(
+        val playlistUuid: String,
+    ) : Parcelable
+
+    companion object {
+        private const val NEW_INSTANCE_ARGS = "SmartRulesEditFragmentArgs"
+
+        fun newInstance(playlistUuid: String) = SmartRulesEditFragment().apply {
+            arguments = bundleOf(NEW_INSTANCE_ARGS to Args(playlistUuid))
+        }
+    }
+}
+
+private val fadeIn = fadeIn()
+private val fadeOut = fadeOut()
+
+private object NavigationRoutes {
+    const val SMART_PLAYLIST_PREVIEW = "smart_playlist_preview"
+    const val SMART_RULE_PODCASTS = "smart_rule_podcasts"
+    const val SMART_RULE_EPISODE_STATUS = "smart_rule_episode_status"
+    const val SMART_RULE_RELEASE_DATE = "smart_rule_release_date"
+    const val SMART_RULE_EPISODE_DURATION = "smart_rule_episode_duration"
+    const val SMART_RULE_DOWNLOAD_STATUS = "smart_rule_download_status"
+    const val SMART_RULE_MEDIA_TYPE = "smart_rule_media_type"
+    const val SMART_RULE_STARRED = "smart_rule_starred"
+}
+
+private fun RuleType.toNavigationRoute() = when (this) {
+    RuleType.Podcasts -> NavigationRoutes.SMART_RULE_PODCASTS
+    RuleType.EpisodeStatus -> NavigationRoutes.SMART_RULE_EPISODE_STATUS
+    RuleType.ReleaseDate -> NavigationRoutes.SMART_RULE_RELEASE_DATE
+    RuleType.EpisodeDuration -> NavigationRoutes.SMART_RULE_EPISODE_DURATION
+    RuleType.DownloadStatus -> NavigationRoutes.SMART_RULE_DOWNLOAD_STATUS
+    RuleType.MediaType -> NavigationRoutes.SMART_RULE_MEDIA_TYPE
+    RuleType.Starred -> NavigationRoutes.SMART_RULE_STARRED
+}

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/edit/SmartRulesEditViewModel.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/edit/SmartRulesEditViewModel.kt
@@ -1,0 +1,182 @@
+package au.com.shiftyjelly.pocketcasts.playlists.edit
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
+import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
+import au.com.shiftyjelly.pocketcasts.models.type.SmartRules.DownloadStatusRule
+import au.com.shiftyjelly.pocketcasts.models.type.SmartRules.MediaTypeRule
+import au.com.shiftyjelly.pocketcasts.models.type.SmartRules.ReleaseDateRule
+import au.com.shiftyjelly.pocketcasts.playlists.rules.AppliedRules
+import au.com.shiftyjelly.pocketcasts.playlists.rules.RuleType
+import au.com.shiftyjelly.pocketcasts.playlists.rules.RulesBuilder
+import au.com.shiftyjelly.pocketcasts.preferences.Settings
+import au.com.shiftyjelly.pocketcasts.preferences.model.ArtworkConfiguration.Element
+import au.com.shiftyjelly.pocketcasts.repositories.playlist.PlaylistManager
+import au.com.shiftyjelly.pocketcasts.utils.extensions.combine
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedFactory
+import dagger.assisted.AssistedInject
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.emitAll
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+
+@HiltViewModel(assistedFactory = SmartRulesEditViewModel.Factory::class)
+class SmartRulesEditViewModel @AssistedInject constructor(
+    private val playlistManager: PlaylistManager,
+    rulesEditorFactory: SmartRulesEditor.Factory,
+    settings: Settings,
+    @Assisted private val playlistUuid: String,
+) : ViewModel() {
+    private var rulesEditor: SmartRulesEditor? = null
+
+    val uiState = flow {
+        val playlist = playlistManager.observeSmartPlaylist(playlistUuid).first()
+        if (playlist != null) {
+            val smartRules = playlist.smartRules
+            val editor = rulesEditorFactory.create(
+                scope = viewModelScope,
+                initialBuilder = RulesBuilder.Empty.applyRules(smartRules),
+                initialAppliedRules = AppliedRules(
+                    episodeStatus = smartRules.episodeStatus,
+                    downloadStatus = smartRules.downloadStatus,
+                    mediaType = smartRules.mediaType,
+                    releaseDate = smartRules.releaseDate,
+                    starred = smartRules.starred,
+                    podcasts = smartRules.podcasts,
+                    episodeDuration = smartRules.episodeDuration,
+                ),
+            )
+            rulesEditor = editor
+            // Add a small delay to prevent rendering all data while the bottom sheet is still animating in
+            delay(300)
+            emitAll(
+                combine(
+                    editor.rulesFlow,
+                    editor.builderFlow,
+                    editor.followedPodcasts,
+                    editor.smartEpisodes,
+                    editor.totalEpisodeCount,
+                    editor.smartStarredEpisodes,
+                    settings.artworkConfiguration.flow.map { it.useEpisodeArtwork(Element.Filters) },
+                ) { rules, builder, podcasts, episodes, episodeCount, smartEpisodes, showEpisodeArtwork ->
+                    UiState(
+                        playlistTitle = playlist.title,
+                        appliedRules = rules,
+                        rulesBuilder = builder,
+                        followedPodcasts = podcasts,
+                        smartEpisodes = episodes,
+                        totalEpisodeCount = episodeCount,
+                        smartStarredEpisodes = smartEpisodes,
+                        useEpisodeArtwork = showEpisodeArtwork,
+                    )
+                },
+            )
+        }
+    }.stateIn(viewModelScope, SharingStarted.Eagerly, initialValue = null)
+
+    fun applyRule(type: RuleType) {
+        rulesEditor?.applyRule(type)
+        viewModelScope.launch(NonCancellable) {
+            val smartRules = uiState.value?.appliedRules?.toSmartRules()
+            if (smartRules != null) {
+                playlistManager.updateSmartRules(playlistUuid, smartRules)
+            }
+        }
+    }
+
+    fun useAllPodcasts(shouldUse: Boolean) {
+        rulesEditor?.useAllPodcasts(shouldUse)
+    }
+
+    fun selectPodcast(uuid: String) {
+        rulesEditor?.selectPodcast(uuid)
+    }
+
+    fun deselectPodcast(uuid: String) {
+        rulesEditor?.deselectPodcast(uuid)
+    }
+
+    fun selectAllPodcasts() {
+        rulesEditor?.selectAllPodcasts()
+    }
+
+    fun deselectAllPodcasts() {
+        rulesEditor?.deselectAllPodcasts()
+    }
+
+    fun useUnplayedEpisodes(shouldUse: Boolean) {
+        rulesEditor?.useUnplayedEpisodes(shouldUse)
+    }
+
+    fun useInProgressEpisodes(shouldUse: Boolean) {
+        rulesEditor?.useInProgressEpisodes(shouldUse)
+    }
+
+    fun useCompletedEpisodes(shouldUse: Boolean) {
+        rulesEditor?.useCompletedEpisodes(shouldUse)
+    }
+
+    fun useReleaseDate(rule: ReleaseDateRule) {
+        rulesEditor?.useReleaseDate(rule)
+    }
+
+    fun useConstrainedDuration(shouldUse: Boolean) {
+        rulesEditor?.useConstrainedDuration(shouldUse)
+    }
+
+    fun decrementMinDuration() {
+        rulesEditor?.decrementMinDuration()
+    }
+
+    fun incrementMinDuration() {
+        rulesEditor?.incrementMinDuration()
+    }
+
+    fun decrementMaxDuration() {
+        rulesEditor?.decrementMaxDuration()
+    }
+
+    fun incrementMaxDuration() {
+        rulesEditor?.incrementMaxDuration()
+    }
+
+    fun useDownloadStatus(rule: DownloadStatusRule) {
+        rulesEditor?.useDownloadStatus(rule)
+    }
+
+    fun useMediaType(rule: MediaTypeRule) {
+        rulesEditor?.useMediaType(rule)
+    }
+
+    fun useStarredEpisodes(shouldUse: Boolean) {
+        rulesEditor?.useStarredEpisodes(shouldUse)
+    }
+
+    fun clearTransientRules() {
+        rulesEditor?.clearTransientRules()
+    }
+
+    data class UiState(
+        val playlistTitle: String,
+        val appliedRules: AppliedRules,
+        val rulesBuilder: RulesBuilder,
+        val followedPodcasts: List<Podcast>,
+        val smartEpisodes: List<PodcastEpisode>,
+        val totalEpisodeCount: Int,
+        val smartStarredEpisodes: List<PodcastEpisode>,
+        val useEpisodeArtwork: Boolean,
+    )
+
+    @AssistedFactory
+    interface Factory {
+        fun create(playlistUuid: String): SmartRulesEditViewModel
+    }
+}

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/rules/AppliedRulesPage.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/rules/AppliedRulesPage.kt
@@ -60,12 +60,12 @@ fun AppliedRulesPage(
     availableEpisodes: List<PodcastEpisode>,
     totalEpisodeCount: Int,
     useEpisodeArtwork: Boolean,
-    areOtherOptionsExpanded: Boolean,
-    onCreatePlaylist: () -> Unit,
     onClickRule: (RuleType) -> Unit,
-    toggleOtherOptions: () -> Unit,
     onClickClose: () -> Unit,
     modifier: Modifier = Modifier,
+    areOtherOptionsExpanded: Boolean = false,
+    toggleOtherOptions: (() -> Unit)? = null,
+    onCreatePlaylist: (() -> Unit)? = null,
 ) {
     Column(
         modifier = modifier
@@ -101,7 +101,7 @@ fun AppliedRulesPage(
                             onClickRule = onClickRule,
                         )
                     }
-                    if (inactiveRules.isNotEmpty()) {
+                    if (inactiveRules.isNotEmpty() && toggleOtherOptions != null) {
                         item(
                             key = "inactive-rules",
                             contentType = "inactive-rules",
@@ -111,7 +111,7 @@ fun AppliedRulesPage(
                                 isExpanded = areOtherOptionsExpanded,
                                 onClickRule = onClickRule,
                                 onToggleExpand = toggleOtherOptions,
-                                modifier = Modifier.padding(vertical = 32.dp),
+                                modifier = Modifier.padding(top = 32.dp),
                             )
                         }
                     }
@@ -121,7 +121,9 @@ fun AppliedRulesPage(
                     ) {
                         TextH20(
                             text = stringResource(LR.string.preview_playlist, playlistTitle),
-                            modifier = Modifier.padding(horizontal = 16.dp),
+                            modifier = Modifier
+                                .padding(horizontal = 16.dp)
+                                .padding(top = 32.dp),
                         )
                     }
                     if (availableEpisodes.isNotEmpty()) {
@@ -165,15 +167,17 @@ fun AppliedRulesPage(
                     }
                 }
             }
-            RowButton(
-                text = stringResource(LR.string.create_smart_playlist),
-                enabled = appliedRules.isAnyRuleApplied,
-                onClick = onCreatePlaylist,
-                includePadding = false,
-                modifier = Modifier
-                    .padding(horizontal = 16.dp)
-                    .navigationBarsPadding(),
-            )
+            if (onCreatePlaylist != null) {
+                RowButton(
+                    text = stringResource(LR.string.create_smart_playlist),
+                    enabled = appliedRules.isAnyRuleApplied,
+                    onClick = onCreatePlaylist,
+                    includePadding = false,
+                    modifier = Modifier
+                        .padding(horizontal = 16.dp)
+                        .navigationBarsPadding(),
+                )
+            }
         }
     }
 }

--- a/modules/features/filters/src/test/kotlin/au/com/shiftyjelly/pocketcasts/playlists/create/FakePlaylistManager.kt
+++ b/modules/features/filters/src/test/kotlin/au/com/shiftyjelly/pocketcasts/playlists/create/FakePlaylistManager.kt
@@ -30,6 +30,13 @@ class FakePlaylistManager : PlaylistManager {
     val episodeMetadata = MutableStateFlow(PlaylistEpisodeMetadata.Empty)
     override fun observeEpisodeMetadata(rules: SmartRules) = episodeMetadata.asStateFlow()
 
+    val updateRulesUuidTurbine = Turbine<String>(name = "updateSmartRules:uuid")
+    val updateRulesRulesTurbine = Turbine<SmartRules>(name = "updateSmartRules:rules")
+    override suspend fun updateSmartRules(uuid: String, rules: SmartRules) {
+        updateRulesUuidTurbine.add(uuid)
+        updateRulesRulesTurbine.add(rules)
+    }
+
     val deletePlaylistTurbine = Turbine<String>(name = "deletePlaylist")
     override suspend fun deletePlaylist(uuid: String) {
         deletePlaylistTurbine.add(uuid)

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playlist/PlaylistManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playlist/PlaylistManager.kt
@@ -14,6 +14,8 @@ interface PlaylistManager {
 
     fun observeEpisodeMetadata(rules: SmartRules): Flow<PlaylistEpisodeMetadata>
 
+    suspend fun updateSmartRules(uuid: String, rules: SmartRules)
+
     suspend fun deletePlaylist(uuid: String)
 
     suspend fun upsertSmartPlaylist(draft: SmartPlaylistDraft): String

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playlist/PlaylistManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playlist/PlaylistManagerImpl.kt
@@ -34,6 +34,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flowOf
 import au.com.shiftyjelly.pocketcasts.models.entity.SmartPlaylist as DbPlaylist
@@ -65,24 +66,26 @@ class PlaylistManagerImpl @Inject constructor(
                 if (playlist == null) {
                     flowOf(null)
                 } else {
+                    val smartRules = playlist.smartRules
                     val podcastsFlow = playlistDao.observeSmartPlaylistPodcasts(
                         clock = clock,
-                        smartRules = playlist.smartRules,
+                        smartRules = smartRules,
                         sortType = playlist.sortType,
                         limit = PLAYLIST_ARTWORK_EPISODE_LIMIT,
                     )
-                    val episodesFlow = observeSmartEpisodes(playlist.smartRules)
+                    val episodesFlow = observeSmartEpisodes(smartRules)
                     val metadataFlow = playlistDao.observeEpisodeMetadata(
                         clock = clock,
-                        smartRules = playlist.smartRules,
+                        smartRules = smartRules,
                     )
                     combine(podcastsFlow, episodesFlow, metadataFlow) { podcasts, episodes, metadata ->
                         SmartPlaylist(
                             uuid = playlist.uuid,
                             title = playlist.title,
+                            smartRules = smartRules,
+                            episodes = episodes,
                             totalEpisodeCount = metadata.episodeCount,
                             playbackDurationLeft = metadata.timeLeftSeconds.seconds,
-                            episodes = episodes,
                             artworkPodcasts = podcasts,
                         )
                     }.keepPodcastEpisodesSynced()
@@ -102,6 +105,18 @@ class PlaylistManagerImpl @Inject constructor(
 
     override fun observeEpisodeMetadata(rules: SmartRules): Flow<PlaylistEpisodeMetadata> {
         return playlistDao.observeEpisodeMetadata(clock, rules)
+    }
+
+    override suspend fun updateSmartRules(uuid: String, rules: SmartRules) {
+        appDatabase.withTransaction {
+            val playlist = playlistDao
+                .observeSmartPlaylist(uuid)
+                .first()
+                ?.applySmartRules(rules)
+            if (playlist != null) {
+                playlistDao.upsertSmartPlaylist(playlist)
+            }
+        }
     }
 
     override suspend fun deletePlaylist(uuid: String) {
@@ -225,6 +240,9 @@ class PlaylistManagerImpl @Inject constructor(
         } else {
             SYNC_STATUS_NOT_SYNCED
         },
+    ).applySmartRules(rules)
+
+    private fun DbPlaylist.applySmartRules(rules: SmartRules) = copy(
         unplayed = rules.episodeStatus.unplayed,
         partiallyPlayed = rules.episodeStatus.inProgress,
         finished = rules.episodeStatus.completed,

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playlist/PlaylistManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playlist/PlaylistManagerImpl.kt
@@ -113,6 +113,7 @@ class PlaylistManagerImpl @Inject constructor(
                 .observeSmartPlaylist(uuid)
                 .first()
                 ?.applySmartRules(rules)
+                ?.copy(syncStatus = SYNC_STATUS_NOT_SYNCED)
             if (playlist != null) {
                 playlistDao.upsertSmartPlaylist(playlist)
             }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playlist/SmartPlaylist.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playlist/SmartPlaylist.kt
@@ -2,13 +2,15 @@ package au.com.shiftyjelly.pocketcasts.repositories.playlist
 
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
+import au.com.shiftyjelly.pocketcasts.models.type.SmartRules
 import kotlin.time.Duration
 
 data class SmartPlaylist(
     val uuid: String,
     val title: String,
+    val smartRules: SmartRules,
+    val episodes: List<PodcastEpisode>,
     val totalEpisodeCount: Int,
     val playbackDurationLeft: Duration,
-    val episodes: List<PodcastEpisode>,
     val artworkPodcasts: List<Podcast>,
 )


### PR DESCRIPTION
## Description

This adds the capability to edit rules of existing Smart Playlists. The implementation differs a bit from the designs. When the edit page is open for the first time it show episodes preview immediately instead of waiting until rules are applied. It would too much work to add something that feels like a drawback.

Designs: 5sC4z4Mu42LvL4MAAIbQVi-fi-1719_90945

Closes PCDROID-73

## Testing Instructions

Test editing rules of an existing Smart Playlist.

## Screenshots or Screencast 

https://github.com/user-attachments/assets/8b345f6a-91fe-451a-825d-247a89ece489

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack