### PR TITLE
Add playlist header artwork elevation

### DIFF
--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/PlaylistArtwork.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/PlaylistArtwork.kt
@@ -6,7 +6,6 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.MaterialTheme
 import androidx.compose.runtime.Composable

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/PlaylistArtwork.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/PlaylistArtwork.kt
@@ -13,6 +13,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
@@ -38,11 +39,13 @@ fun PlaylistArtwork(
     artworkSize: Dp,
     modifier: Modifier = Modifier,
     cornerSize: Dp = artworkSize / 14,
+    elevation: Dp = 2.dp,
 ) {
     when (podcasts.size) {
         0 -> NoImage(
             artworkSize = artworkSize,
             cornerSize = cornerSize,
+            elevation = elevation,
             modifier = modifier,
         )
 
@@ -50,6 +53,7 @@ fun PlaylistArtwork(
             podcast = podcasts[0],
             artworkSize = artworkSize,
             cornerSize = cornerSize,
+            elevation = elevation,
             modifier = modifier,
         )
 
@@ -60,6 +64,7 @@ fun PlaylistArtwork(
             podcast4 = podcasts[3],
             artworkSize = artworkSize,
             cornerSize = cornerSize,
+            elevation = elevation,
             modifier = modifier,
         )
     }
@@ -69,12 +74,20 @@ fun PlaylistArtwork(
 private fun NoImage(
     artworkSize: Dp,
     cornerSize: Dp,
+    elevation: Dp,
     modifier: Modifier = Modifier,
 ) {
     Box(
         contentAlignment = Alignment.Center,
         modifier = modifier
             .size(artworkSize)
+            .then(
+                if (elevation > 0.dp) {
+                    Modifier.shadow(elevation, RoundedCornerShape(cornerSize))
+                } else {
+                    Modifier
+                },
+            )
             .clip(RoundedCornerShape(cornerSize))
             .background(MaterialTheme.theme.colors.primaryUi05),
     ) {
@@ -94,6 +107,7 @@ private fun SingleImage(
     podcast: Podcast,
     artworkSize: Dp,
     cornerSize: Dp,
+    elevation: Dp,
     modifier: Modifier = Modifier,
 ) {
     val context = LocalContext.current
@@ -107,6 +121,13 @@ private fun SingleImage(
         contentDescription = null,
         modifier = modifier
             .size(artworkSize)
+            .then(
+                if (elevation > 0.dp) {
+                    Modifier.shadow(elevation, RoundedCornerShape(cornerSize))
+                } else {
+                    Modifier
+                },
+            )
             .clip(RoundedCornerShape(cornerSize)),
     )
 }
@@ -119,6 +140,7 @@ private fun QuadImage(
     podcast4: Podcast,
     artworkSize: Dp,
     cornerSize: Dp,
+    elevation: Dp,
     modifier: Modifier = Modifier,
 ) {
     val context = LocalContext.current
@@ -136,7 +158,15 @@ private fun QuadImage(
         requestFactory.create(podcast4)
     }
     Row(
-        modifier = modifier.size(artworkSize),
+        modifier = modifier
+            .size(artworkSize)
+            .then(
+                if (elevation > 0.dp) {
+                    Modifier.shadow(elevation, RoundedCornerShape(cornerSize))
+                } else {
+                    Modifier
+                },
+            ),
     ) {
         Column {
             Image(

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/PlaylistHeader.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/PlaylistHeader.kt
@@ -235,6 +235,7 @@ private fun PlaylistForegroundArtwork(
                 PlaylistArtwork(
                     podcasts = podcasts,
                     artworkSize = artworkSize,
+                    elevation = 0.dp,
                 )
             } else {
                 Spacer(
@@ -308,6 +309,7 @@ private fun ArtworkOrPreview(
             podcasts = podcasts,
             artworkSize = artworkSize,
             cornerSize = 0.dp,
+            elevation = 0.dp,
             modifier = modifier,
         )
     } else {
@@ -564,7 +566,7 @@ private enum class ActionButtonStyle {
 
 private val artworkCrossfadeFastSpec = spring<Float>(stiffness = Spring.StiffnessLow)
 private val artworkCrossfadeSpec = spring<Float>(stiffness = Spring.StiffnessVeryLow)
-private val artworkShadowSpec = tween<Dp>(durationMillis = 500, delayMillis = 1000)
+private val artworkShadowSpec = tween<Dp>(durationMillis = 500, delayMillis = 500)
 
 private val actionButtonShape = RoundedCornerShape(8.dp)
 private val actionButtonMaxWidth = 200.dp


### PR DESCRIPTION
## Description

As the title says.

## Testing Instructions

Open a playlist and notice the shadow behind foreground artwork.

## Screenshots or Screencast 

| Before | After |
| - | - |
| <img width="1080" height="2400" alt="image" src="https://github.com/user-attachments/assets/66559706-c196-454b-8ca9-a523b50f6654" /> | <img width="1080" height="2400" alt="image" src="https://github.com/user-attachments/assets/96545c8b-23ac-4427-9600-6cc54e4f2c76" /> |

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack