### PR TITLE
Update episode row specs

### DIFF
--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/rules/EpisodeRow.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/rules/EpisodeRow.kt
@@ -10,11 +10,13 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.unit.dp
@@ -44,8 +46,8 @@ internal fun EpisodeRow(
         modifier = modifier,
     ) {
         Row(
-            verticalAlignment = Alignment.Companion.CenterVertically,
-            modifier = Modifier.Companion
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier
                 .height(IntrinsicSize.Min)
                 .padding(vertical = 12.dp, horizontal = 12.dp),
         ) {
@@ -54,14 +56,16 @@ internal fun EpisodeRow(
                 useEpisodeArtwork = useEpisodeArtwork,
                 placeholderType = PlaceholderType.Small,
                 corners = 4.dp,
-                modifier = Modifier.Companion.size(56.dp),
+                modifier = Modifier
+                    .size(56.dp)
+                    .shadow(2.dp, RoundedCornerShape(4.dp)),
             )
             Spacer(
-                modifier = Modifier.Companion.width(12.dp),
+                modifier = Modifier.width(12.dp),
             )
             Column(
                 verticalArrangement = Arrangement.SpaceBetween,
-                modifier = Modifier.Companion.fillMaxHeight(),
+                modifier = Modifier.fillMaxHeight(),
             ) {
                 TextC70(
                     text = episode.rememberHeaderText(),

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/rules/PodcastsRulePage.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/rules/PodcastsRulePage.kt
@@ -241,8 +241,8 @@ private fun PodcastRow(
     ) {
         PodcastImage(
             uuid = uuid,
-            dropShadow = false,
             cornerSize = 4.dp,
+            elevation = 2.dp,
             modifier = Modifier.size(56.dp),
         )
         Spacer(

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/EpisodeViewHolder.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/EpisodeViewHolder.kt
@@ -291,7 +291,7 @@ class EpisodeViewHolder(
         updateRowText(episode, captionColor, tintColor, date, title, lblStatus)
 
         val artworkVisible = viewMode is ViewMode.Artwork
-        imgArtwork.isVisible = artworkVisible
+        binding.artworkBox.isVisible = artworkVisible
         if (!sameEpisode && artworkVisible) {
             val artworkConfiguration = settings.artworkConfiguration.value
             val useEpisodeArtwork = artworkContext?.let(artworkConfiguration::useEpisodeArtwork) ?: artworkConfiguration.useEpisodeArtwork

--- a/modules/features/podcasts/src/main/res/layout/adapter_episode.xml
+++ b/modules/features/podcasts/src/main/res/layout/adapter_episode.xml
@@ -107,7 +107,7 @@
             android:layout_marginBottom="12dp"
             android:importantForAccessibility="noHideDescendants"
             app:cardCornerRadius="4dp"
-            app:cardElevation="0dp"
+            app:cardElevation="2dp"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintLeft_toRightOf="@id/checkbox"
             app:layout_constraintTop_toTopOf="parent">

--- a/modules/features/podcasts/src/main/res/layout/adapter_user_episode.xml
+++ b/modules/features/podcasts/src/main/res/layout/adapter_user_episode.xml
@@ -107,7 +107,7 @@
             android:importantForAccessibility="noHideDescendants"
             android:src="@drawable/ic_uploadedfile"
             app:cardCornerRadius="4dp"
-            app:cardElevation="0dp"
+            app:cardElevation="2dp"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintLeft_toRightOf="@id/checkbox"
             app:layout_constraintTop_toTopOf="parent">

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/SegmentedTabBar.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/SegmentedTabBar.kt
@@ -93,7 +93,7 @@ private fun RowScope.SegmentedTab(
             backgroundColor = if (isSelected) colors.selectedTabBackgroundColor else colors.unSelectedTabBackgroundColor,
         ),
         onClick = onSelectItem,
-        modifier = Modifier.Companion
+        modifier = Modifier
             .weight(1f)
             .fillMaxSize()
             .defaultMinSize(minWidth = SegmentedTabBarDefaults.tabMinSize)


### PR DESCRIPTION
## Description

This aligns episode row with the specs. I decided to apply it to all instances where the rows are displayed. I think there's no harm in it and will make the experience more uniform. I didn't update the horizontal padding to leave the same amount of space that we currently have.

Designs: 5sC4z4Mu42LvL4MAAIbQVi-fi-1719_91673

## Testing Instructions

Preview episodes in a Smart Playlist.

## Screenshots or Screencast 

| Before | After |
| - | - |
| <img width="1080" height="2400" alt="image" src="https://github.com/user-attachments/assets/824a9bcc-199b-4374-8fc9-a038d1dea7dd" /> | <img width="1080" height="2400" alt="image" src="https://github.com/user-attachments/assets/b9f03131-171d-4303-b3d6-ebef008e8e1b" /> |

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack