### PR TITLE
Add playlists settings

### DIFF
--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/repositories/playlist/PlaylistManagerTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/repositories/playlist/PlaylistManagerTest.kt
@@ -887,6 +887,8 @@ class PlaylistManagerTest {
                     smartRules = SmartRules.Default,
                     episodes = emptyList(),
                     episodeSortType = PlaylistEpisodeSortType.NewestToOldest,
+                    isAutoDownloadEnabled = false,
+                    autoDownloadLimit = 10,
                     totalEpisodeCount = 0,
                     playbackDurationLeft = Duration.ZERO,
                     artworkPodcasts = emptyList(),
@@ -1002,6 +1004,48 @@ class PlaylistManagerTest {
             manager.updateSortType("playlist-id", PlaylistEpisodeSortType.ShortestToLongest)
             playlist = awaitItem()
             assertEquals(PlaylistEpisodeSortType.ShortestToLongest, playlist?.episodeSortType)
+        }
+    }
+
+    @Test
+    fun updateAutoDownload() = runTest(testDispatcher) {
+        playlistDao.upsertSmartPlaylist(DbPlaylist(uuid = "playlist-id", title = "Title 1"))
+
+        manager.observeSmartPlaylist("playlist-id").test {
+            var playlist = awaitItem()
+            assertEquals(false, playlist?.isAutoDownloadEnabled)
+
+            manager.updateAutoDownload("playlist-id", true)
+            playlist = awaitItem()
+            assertEquals(true, playlist?.isAutoDownloadEnabled)
+        }
+    }
+
+    @Test
+    fun updateAutoDownloadLimit() = runTest(testDispatcher) {
+        playlistDao.upsertSmartPlaylist(DbPlaylist(uuid = "playlist-id", title = "Title 1"))
+
+        manager.observeSmartPlaylist("playlist-id").test {
+            var playlist = awaitItem()
+            assertEquals(10, playlist?.autoDownloadLimit)
+
+            manager.updateAutoDownloadLimit("playlist-id", 85)
+            playlist = awaitItem()
+            assertEquals(85, playlist?.autoDownloadLimit)
+        }
+    }
+
+    @Test
+    fun updateName() = runTest(testDispatcher) {
+        playlistDao.upsertSmartPlaylist(DbPlaylist(uuid = "playlist-id", title = "Title 1"))
+
+        manager.observeSmartPlaylist("playlist-id").test {
+            var playlist = awaitItem()
+            assertEquals("Title 1", playlist?.title)
+
+            manager.updateName("playlist-id", "Other title")
+            playlist = awaitItem()
+            assertEquals("Other title", playlist?.title)
         }
     }
 }

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/PlaylistNameField.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/PlaylistNameField.kt
@@ -1,0 +1,75 @@
+package au.com.shiftyjelly.pocketcasts.playlists
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.text.input.TextFieldState
+import androidx.compose.foundation.text.input.clearText
+import androidx.compose.foundation.text.input.rememberTextFieldState
+import androidx.compose.material.Icon
+import androidx.compose.material.IconButton
+import androidx.compose.material.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewParameter
+import androidx.compose.ui.unit.dp
+import au.com.shiftyjelly.pocketcasts.compose.AppThemeWithBackground
+import au.com.shiftyjelly.pocketcasts.compose.components.FormField
+import au.com.shiftyjelly.pocketcasts.compose.preview.ThemePreviewParameterProvider
+import au.com.shiftyjelly.pocketcasts.compose.theme
+import au.com.shiftyjelly.pocketcasts.ui.theme.Theme.ThemeType
+import au.com.shiftyjelly.pocketcasts.images.R as IR
+import au.com.shiftyjelly.pocketcasts.localization.R as LR
+
+@Composable
+internal fun PlaylistNameField(
+    state: TextFieldState,
+    onClickImeAction: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    FormField(
+        state = state,
+        placeholder = stringResource(LR.string.new_playlists_title_placeholder),
+        trailingIcon = {
+            AnimatedVisibility(
+                visible = state.text.isNotBlank(),
+                enter = ClearButtonEnterTransition,
+                exit = ClearButtonExitTransition,
+            ) {
+                IconButton(
+                    onClick = { state.clearText() },
+                ) {
+                    Icon(
+                        painter = painterResource(IR.drawable.ic_close_outlined),
+                        contentDescription = stringResource(LR.string.clear),
+                        tint = MaterialTheme.theme.colors.primaryIcon02,
+                    )
+                }
+            }
+        },
+        onImeAction = onClickImeAction,
+        modifier = modifier,
+    )
+}
+
+private val ClearButtonExitTransition = fadeOut()
+private val ClearButtonEnterTransition = fadeIn()
+
+@Preview
+@Composable
+private fun PlaylistNameFieldPreview(
+    @PreviewParameter(ThemePreviewParameterProvider::class) themeType: ThemeType,
+) {
+    val state = rememberTextFieldState(initialText = "My Playlist")
+    AppThemeWithBackground(themeType) {
+        PlaylistNameField(
+            state = state,
+            onClickImeAction = {},
+            modifier = Modifier.padding(8.dp),
+        )
+    }
+}

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/SmartPlaylistFragment.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/SmartPlaylistFragment.kt
@@ -13,6 +13,7 @@ import androidx.compose.ui.util.lerp
 import androidx.core.os.BundleCompat
 import androidx.core.os.bundleOf
 import androidx.core.view.updatePadding
+import androidx.fragment.app.commit
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.flowWithLifecycle
 import androidx.lifecycle.lifecycleScope
@@ -22,7 +23,9 @@ import androidx.recyclerview.widget.RecyclerView
 import au.com.shiftyjelly.pocketcasts.PlaylistEpisodesAdapterFactory
 import au.com.shiftyjelly.pocketcasts.compose.AppTheme
 import au.com.shiftyjelly.pocketcasts.compose.extensions.setContentWithViewCompositionStrategy
+import au.com.shiftyjelly.pocketcasts.filters.R
 import au.com.shiftyjelly.pocketcasts.filters.databinding.SmartPlaylistFragmentBinding
+import au.com.shiftyjelly.pocketcasts.playlists.edit.SmartPlaylistSettingsFragment
 import au.com.shiftyjelly.pocketcasts.playlists.edit.SmartPlaylistsOptionsFragment
 import au.com.shiftyjelly.pocketcasts.playlists.edit.SmartRulesEditFragment
 import au.com.shiftyjelly.pocketcasts.utils.extensions.dpToPx
@@ -70,6 +73,7 @@ class SmartPlaylistFragment :
         binding.setupContent()
         binding.setupToolbar()
         binding.setupChromeCast()
+        binding.setupSettings()
         return binding.root
     }
 
@@ -200,6 +204,17 @@ class SmartPlaylistFragment :
         }
     }
 
+    private fun SmartPlaylistFragmentBinding.setupSettings() {
+        CastButtonFactory.setUpMediaRouteButton(requireContext(), chromeCastButton)
+        viewLifecycleOwner.lifecycleScope.launch {
+            viewModel.showSettingsSignal
+                .flowWithLifecycle(viewLifecycleOwner.lifecycle)
+                .collect {
+                    openSettings()
+                }
+        }
+    }
+
     private fun playAll() {
         if (parentFragmentManager.findFragmentByTag("confirm_and_play") != null) {
             return
@@ -221,10 +236,10 @@ class SmartPlaylistFragment :
     }
 
     private fun openEditor() {
-        if (parentFragmentManager.findFragmentByTag("playlist_editor") != null) {
+        if (parentFragmentManager.findFragmentByTag("playlist_rules_editor") != null) {
             return
         }
-        SmartRulesEditFragment.newInstance(args.playlistUuid).show(parentFragmentManager, "playlist_editor")
+        SmartRulesEditFragment.newInstance(args.playlistUuid).show(parentFragmentManager, "playlist_rules_editor")
     }
 
     private fun openOptionsSheet() {
@@ -232,6 +247,16 @@ class SmartPlaylistFragment :
             return
         }
         SmartPlaylistsOptionsFragment().show(childFragmentManager, "playlist_options_sheet")
+    }
+
+    private fun openSettings() {
+        if (childFragmentManager.findFragmentByTag("playlist_settings") != null) {
+            return
+        }
+        childFragmentManager.commit {
+            addToBackStack("playlist_settings")
+            add(R.id.playlistFragmentContainer, SmartPlaylistSettingsFragment(), "playlist_settings")
+        }
     }
 
     override fun onBackPressed(): Boolean {

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/SmartPlaylistViewModel.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/SmartPlaylistViewModel.kt
@@ -39,6 +39,9 @@ class SmartPlaylistViewModel @AssistedInject constructor(
     private val _chromeCastSignal = MutableSharedFlow<Unit>()
     val chromeCastSignal = _chromeCastSignal.asSharedFlow()
 
+    private val _showSettingsSignal = MutableSharedFlow<Unit>()
+    val showSettingsSignal = _showSettingsSignal.asSharedFlow()
+
     val uiState = playlistManager.observeSmartPlaylist(playlistUuid)
         .map { UiState(it) }
         .stateIn(viewModelScope, SharingStarted.Lazily, initialValue = UiState.Empty)
@@ -74,6 +77,28 @@ class SmartPlaylistViewModel @AssistedInject constructor(
         }
     }
 
+    fun updateAutoDownload(isEnabled: Boolean) {
+        viewModelScope.launch(NonCancellable) {
+            playlistManager.updateAutoDownload(playlistUuid, isEnabled)
+        }
+    }
+
+    fun updateAutoDownloadLimit(limit: Int) {
+        viewModelScope.launch(NonCancellable) {
+            playlistManager.updateAutoDownloadLimit(playlistUuid, limit)
+        }
+    }
+
+    fun updateName(name: String) {
+        val sanitizedName = name.trim()
+        if (sanitizedName.isEmpty()) {
+            return
+        }
+        viewModelScope.launch(NonCancellable) {
+            playlistManager.updateName(playlistUuid, sanitizedName)
+        }
+    }
+
     fun startMultiSelecting() {
         viewModelScope.launch {
             _startMultiSelectingSignal.emit(Unit)
@@ -83,6 +108,12 @@ class SmartPlaylistViewModel @AssistedInject constructor(
     fun startChromeCast() {
         viewModelScope.launch {
             _chromeCastSignal.emit(Unit)
+        }
+    }
+
+    fun showSettings() {
+        viewModelScope.launch {
+            _showSettingsSignal.emit(Unit)
         }
     }
 

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/create/CreatePlaylistViewModel.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/create/CreatePlaylistViewModel.kt
@@ -143,13 +143,14 @@ class CreatePlaylistViewModel @AssistedInject constructor(
 
     fun createSmartPlaylist() {
         val rules = rulesEditor.rulesFlow.value.toSmartRulesOrDefault()
-        if (isCreationTriggered) {
+        val sanitizedName = playlistNameState.text.toString().trim()
+        if (isCreationTriggered || sanitizedName.isEmpty()) {
             return
         }
         isCreationTriggered = true
 
         val draft = SmartPlaylistDraft(
-            title = playlistNameState.text.toString(),
+            title = sanitizedName,
             rules = rules,
         )
         viewModelScope.launch {

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/create/NewPlaylistPage.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/create/NewPlaylistPage.kt
@@ -1,9 +1,6 @@
 package au.com.shiftyjelly.pocketcasts.playlists.create
 
-import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.core.animateFloatAsState
-import androidx.compose.animation.fadeIn
-import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
@@ -22,11 +19,8 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.input.TextFieldState
-import androidx.compose.foundation.text.input.clearText
 import androidx.compose.foundation.text.input.rememberTextFieldState
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material.Icon
-import androidx.compose.material.IconButton
 import androidx.compose.material.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -51,13 +45,13 @@ import au.com.shiftyjelly.pocketcasts.compose.Devices
 import au.com.shiftyjelly.pocketcasts.compose.bars.NavigationButton
 import au.com.shiftyjelly.pocketcasts.compose.bars.ThemedTopAppBar
 import au.com.shiftyjelly.pocketcasts.compose.buttons.RowButton
-import au.com.shiftyjelly.pocketcasts.compose.components.FormField
 import au.com.shiftyjelly.pocketcasts.compose.components.SparkleImage
 import au.com.shiftyjelly.pocketcasts.compose.components.TextH20
 import au.com.shiftyjelly.pocketcasts.compose.components.TextH40
 import au.com.shiftyjelly.pocketcasts.compose.components.TextP60
 import au.com.shiftyjelly.pocketcasts.compose.preview.ThemePreviewParameterProvider
 import au.com.shiftyjelly.pocketcasts.compose.theme
+import au.com.shiftyjelly.pocketcasts.playlists.PlaylistNameField
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme.ThemeType
 import au.com.shiftyjelly.pocketcasts.images.R as IR
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
@@ -97,27 +91,9 @@ fun NewPlaylistPage(
             Spacer(
                 modifier = Modifier.height(16.dp),
             )
-            FormField(
+            PlaylistNameField(
                 state = titleState,
-                placeholder = stringResource(LR.string.new_playlists_title_placeholder),
-                trailingIcon = {
-                    AnimatedVisibility(
-                        visible = titleState.text.isNotBlank(),
-                        enter = ClearButtonEnterTransition,
-                        exit = ClearButtonExitTransition,
-                    ) {
-                        IconButton(
-                            onClick = { titleState.clearText() },
-                        ) {
-                            Icon(
-                                painter = painterResource(IR.drawable.ic_close_outlined),
-                                contentDescription = stringResource(LR.string.clear),
-                                tint = MaterialTheme.theme.colors.primaryIcon02,
-                            )
-                        }
-                    }
-                },
-                onImeAction = onCreateManualPlaylist,
+                onClickImeAction = onCreateManualPlaylist,
                 modifier = Modifier.focusRequester(focusRequester),
             )
             Spacer(
@@ -191,9 +167,6 @@ private fun SmartPlaylistButton(
         )
     }
 }
-
-private val ClearButtonExitTransition = fadeOut()
-private val ClearButtonEnterTransition = fadeIn()
 
 @Preview(device = Devices.PORTRAIT_REGULAR)
 @Composable

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/edit/SmartPlaylistEpisodeDownloadLimitFragment.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/edit/SmartPlaylistEpisodeDownloadLimitFragment.kt
@@ -1,0 +1,44 @@
+package au.com.shiftyjelly.pocketcasts.playlists.edit
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.nestedscroll.nestedScroll
+import androidx.compose.ui.platform.rememberNestedScrollInteropConnection
+import androidx.fragment.app.viewModels
+import androidx.fragment.compose.content
+import au.com.shiftyjelly.pocketcasts.playlists.SmartPlaylistViewModel
+import au.com.shiftyjelly.pocketcasts.views.fragments.BaseDialogFragment
+import dagger.hilt.android.AndroidEntryPoint
+
+@AndroidEntryPoint
+class SmartPlaylistEpisodeDownloadLimitFragment : BaseDialogFragment() {
+    private val viewModel by viewModels<SmartPlaylistViewModel>({ requireParentFragment() })
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?,
+    ) = content {
+        val uiState by viewModel.uiState.collectAsState()
+        val playlist = uiState.smartPlaylist
+
+        DialogBox(
+            fillMaxHeight = false,
+            modifier = Modifier.nestedScroll(rememberNestedScrollInteropConnection()),
+        ) {
+            if (playlist != null) {
+                SmartPlaylistEpisodeDownloadLimitPage(
+                    episodeLimit = playlist.autoDownloadLimit,
+                    onSelectEpisodeLimit = { limit ->
+                        viewModel.updateAutoDownloadLimit(limit)
+                        dismiss()
+                    },
+                )
+            }
+        }
+    }
+}

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/edit/SmartPlaylistEpisodeDownloadLimitPage.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/edit/SmartPlaylistEpisodeDownloadLimitPage.kt
@@ -1,0 +1,140 @@
+package au.com.shiftyjelly.pocketcasts.playlists.edit
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.Icon
+import androidx.compose.material.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.pluralStringResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewParameter
+import androidx.compose.ui.unit.dp
+import au.com.shiftyjelly.pocketcasts.compose.AppThemeWithBackground
+import au.com.shiftyjelly.pocketcasts.compose.components.TextC50
+import au.com.shiftyjelly.pocketcasts.compose.components.TextH30
+import au.com.shiftyjelly.pocketcasts.compose.preview.ThemePreviewParameterProvider
+import au.com.shiftyjelly.pocketcasts.compose.theme
+import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
+import au.com.shiftyjelly.pocketcasts.images.R as IR
+import au.com.shiftyjelly.pocketcasts.localization.R as LR
+
+@Composable
+internal fun SmartPlaylistEpisodeDownloadLimitPage(
+    episodeLimit: Int,
+    onSelectEpisodeLimit: (Int) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier.verticalScroll(rememberScrollState()),
+    ) {
+        Box(
+            modifier = Modifier
+                .align(Alignment.CenterHorizontally)
+                .padding(top = 8.dp)
+                .background(MaterialTheme.theme.colors.primaryUi05, CircleShape)
+                .size(56.dp, 4.dp),
+        )
+        Spacer(
+            modifier = Modifier.height(16.dp),
+        )
+        TextC50(
+            text = stringResource(LR.string.filters_download_title).uppercase(),
+            color = MaterialTheme.theme.colors.support01,
+            modifier = Modifier.padding(horizontal = 16.dp),
+        )
+        AvailableLimits.forEachIndexed { index, limit ->
+            EpisodeLimitRow(
+                limit = limit,
+                isSelected = limit == episodeLimit,
+                showDivider = index != AvailableLimits.lastIndex,
+                onClick = { onSelectEpisodeLimit(limit) },
+            )
+        }
+    }
+}
+
+@Composable
+private fun EpisodeLimitRow(
+    limit: Int,
+    isSelected: Boolean,
+    showDivider: Boolean,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier
+            .clickable(
+                role = Role.Button,
+                onClick = onClick,
+            )
+            .semantics(mergeDescendants = true) {},
+    ) {
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(vertical = 26.dp, horizontal = 20.dp),
+        ) {
+            TextH30(
+                text = pluralStringResource(LR.plurals.episode_count, limit, limit),
+                modifier = Modifier.weight(1f),
+            )
+            if (isSelected) {
+                Spacer(
+                    modifier = Modifier.size(24.dp),
+                )
+                Icon(
+                    painter = painterResource(IR.drawable.ic_check),
+                    tint = MaterialTheme.theme.colors.primaryIcon01,
+                    contentDescription = null,
+                    modifier = Modifier.size(18.dp),
+                )
+            }
+        }
+        if (showDivider) {
+            Box(
+                modifier = Modifier
+                    .padding(start = 20.dp)
+                    .fillMaxWidth()
+                    .height(1.dp)
+                    .background(MaterialTheme.theme.colors.primaryUi05),
+            )
+        } else {
+            Spacer(
+                modifier = Modifier.height(1.dp),
+            )
+        }
+    }
+}
+
+private val AvailableLimits = listOf(3, 5, 10, 20, 40, 100)
+
+@Preview
+@Composable
+private fun SmartPlaylistEpisodeDownloadLimitPagePreview(
+    @PreviewParameter(ThemePreviewParameterProvider::class) themeType: Theme.ThemeType,
+) {
+    AppThemeWithBackground(themeType) {
+        SmartPlaylistEpisodeDownloadLimitPage(
+            episodeLimit = 20,
+            onSelectEpisodeLimit = {},
+        )
+    }
+}

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/edit/SmartPlaylistSettingsFragment.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/edit/SmartPlaylistSettingsFragment.kt
@@ -1,0 +1,79 @@
+package au.com.shiftyjelly.pocketcasts.playlists.edit
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.text.input.TextFieldState
+import androidx.compose.foundation.text.input.rememberTextFieldState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.snapshotFlow
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalDensity
+import androidx.fragment.app.viewModels
+import au.com.shiftyjelly.pocketcasts.compose.AppThemeWithBackground
+import au.com.shiftyjelly.pocketcasts.compose.extensions.contentWithoutConsumedInsets
+import au.com.shiftyjelly.pocketcasts.playlists.SmartPlaylistViewModel
+import au.com.shiftyjelly.pocketcasts.views.fragments.BaseFragment
+import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.FlowPreview
+import kotlinx.coroutines.flow.debounce
+
+@OptIn(FlowPreview::class)
+@AndroidEntryPoint
+class SmartPlaylistSettingsFragment : BaseFragment() {
+    private val viewModel by viewModels<SmartPlaylistViewModel>({ requireParentFragment() })
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?,
+    ) = contentWithoutConsumedInsets {
+        val uiState by viewModel.uiState.collectAsState()
+        val playlist = uiState.smartPlaylist
+        val bottomPadding by viewModel.bottomInset.collectAsState(0)
+
+        AppThemeWithBackground(theme.activeTheme) {
+            if (playlist != null) {
+                val nameState = rememberTextFieldState(initialText = playlist.title)
+                UpdateNameEffect(nameState)
+
+                SmartPlaylistSettingsPage(
+                    state = nameState,
+                    isAutoDownloadEnabled = playlist.isAutoDownloadEnabled,
+                    autoDownloadEpisodeLimit = playlist.autoDownloadLimit,
+                    onChangeAutoDownloadValue = viewModel::updateAutoDownload,
+                    onClickEpisodeLimit = ::openDownloadLimit,
+                    onClickBack = {
+                        @Suppress("DEPRECATION")
+                        requireActivity().onBackPressed()
+                    },
+                    modifier = Modifier.padding(
+                        bottom = LocalDensity.current.run { bottomPadding.toDp() },
+                    ),
+                )
+            }
+        }
+    }
+
+    @Composable
+    private fun UpdateNameEffect(state: TextFieldState) {
+        LaunchedEffect(state) {
+            snapshotFlow { state.text.toString() }
+                .debounce(300)
+                .collect { newName ->
+                    viewModel.updateName(newName)
+                }
+        }
+    }
+
+    private fun openDownloadLimit() {
+        if (parentFragmentManager.findFragmentByTag("auto_download_limit") != null) {
+            return
+        }
+        SmartPlaylistEpisodeDownloadLimitFragment().show(parentFragmentManager, "auto_download_limit")
+    }
+}

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/edit/SmartPlaylistSettingsPage.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/edit/SmartPlaylistSettingsPage.kt
@@ -1,0 +1,184 @@
+package au.com.shiftyjelly.pocketcasts.playlists.edit
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.imePadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.selection.toggleable
+import androidx.compose.foundation.text.input.TextFieldState
+import androidx.compose.foundation.text.input.rememberTextFieldState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Switch
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.res.pluralStringResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.tooling.preview.PreviewParameter
+import androidx.compose.ui.unit.dp
+import au.com.shiftyjelly.pocketcasts.compose.AppThemeWithBackground
+import au.com.shiftyjelly.pocketcasts.compose.PreviewRegularDevice
+import au.com.shiftyjelly.pocketcasts.compose.bars.ThemedTopAppBar
+import au.com.shiftyjelly.pocketcasts.compose.bars.ThemedTopAppBar.Style
+import au.com.shiftyjelly.pocketcasts.compose.components.HorizontalDivider
+import au.com.shiftyjelly.pocketcasts.compose.components.TextH30
+import au.com.shiftyjelly.pocketcasts.compose.components.TextH40
+import au.com.shiftyjelly.pocketcasts.compose.components.TextP50
+import au.com.shiftyjelly.pocketcasts.compose.preview.ThemePreviewParameterProvider
+import au.com.shiftyjelly.pocketcasts.compose.theme
+import au.com.shiftyjelly.pocketcasts.playlists.PlaylistNameField
+import au.com.shiftyjelly.pocketcasts.ui.theme.Theme.ThemeType
+import au.com.shiftyjelly.pocketcasts.localization.R as LR
+
+@Composable
+fun SmartPlaylistSettingsPage(
+    state: TextFieldState,
+    isAutoDownloadEnabled: Boolean,
+    autoDownloadEpisodeLimit: Int,
+    onChangeAutoDownloadValue: (Boolean) -> Unit,
+    onClickEpisodeLimit: () -> Unit,
+    onClickBack: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val focusManager = LocalFocusManager.current
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .verticalScroll(rememberScrollState())
+            .imePadding(),
+    ) {
+        ThemedTopAppBar(
+            title = stringResource(LR.string.playlist_options),
+            onNavigationClick = onClickBack,
+            style = Style.Immersive,
+        )
+        Spacer(
+            modifier = Modifier.height(16.dp),
+        )
+        PlaylistNameField(
+            state = state,
+            onClickImeAction = {
+                focusManager.clearFocus()
+            },
+            modifier = Modifier.padding(horizontal = 16.dp),
+        )
+        Spacer(
+            modifier = Modifier.height(20.dp),
+        )
+        HorizontalDivider(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp),
+        )
+        AutoDownloadSwitchRow(
+            isAutoDownloadEnabled = isAutoDownloadEnabled,
+            onChangeAutoDownloadValue = onChangeAutoDownloadValue,
+        )
+        AnimatedVisibility(
+            visible = isAutoDownloadEnabled,
+        ) {
+            AutoDownloadEpisodeCountRow(
+                episodeCount = autoDownloadEpisodeLimit,
+                onClick = onClickEpisodeLimit,
+            )
+        }
+    }
+}
+
+@Composable
+private fun AutoDownloadSwitchRow(
+    isAutoDownloadEnabled: Boolean,
+    onChangeAutoDownloadValue: (Boolean) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = modifier
+            .toggleable(
+                role = Role.Switch,
+                value = isAutoDownloadEnabled,
+                onValueChange = onChangeAutoDownloadValue,
+            )
+            .padding(horizontal = 16.dp)
+            .heightIn(min = 48.dp)
+            .semantics(mergeDescendants = true) {},
+    ) {
+        TextH30(
+            text = stringResource(LR.string.auto_download),
+            modifier = Modifier.widthIn(max = 280.dp),
+        )
+        Spacer(
+            modifier = Modifier.weight(1f),
+        )
+        Switch(
+            checked = isAutoDownloadEnabled,
+            onCheckedChange = null,
+        )
+    }
+}
+
+@Composable
+private fun AutoDownloadEpisodeCountRow(
+    episodeCount: Int,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        verticalArrangement = Arrangement.Center,
+        modifier = modifier
+            .fillMaxWidth()
+            .clickable(
+                role = Role.Button,
+                onClick = onClick,
+            )
+            .padding(horizontal = 16.dp)
+            .heightIn(min = 48.dp)
+            .semantics(mergeDescendants = true) {},
+    ) {
+        TextH40(
+            text = stringResource(LR.string.filters_download_first),
+        )
+        TextP50(
+            text = pluralStringResource(LR.plurals.episode_count, episodeCount, episodeCount),
+            color = MaterialTheme.theme.colors.primaryText02,
+        )
+    }
+}
+
+@PreviewRegularDevice
+@Composable
+private fun SmartPlaylistSettingsPagePreview(
+    @PreviewParameter(ThemePreviewParameterProvider::class) themeType: ThemeType,
+) {
+    val state = rememberTextFieldState(initialText = "My Playlist")
+    var isAutoDownloadEnabled by remember { mutableStateOf(true) }
+
+    AppThemeWithBackground(themeType) {
+        SmartPlaylistSettingsPage(
+            state = state,
+            isAutoDownloadEnabled = isAutoDownloadEnabled,
+            autoDownloadEpisodeLimit = 10,
+            onChangeAutoDownloadValue = { isAutoDownloadEnabled = it },
+            onClickEpisodeLimit = {},
+            onClickBack = {},
+        )
+    }
+}

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/edit/SmartPlaylistsOptionsFragment.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/edit/SmartPlaylistsOptionsFragment.kt
@@ -2,7 +2,6 @@ package au.com.shiftyjelly.pocketcasts.playlists.edit
 
 import android.os.Bundle
 import android.view.LayoutInflater
-import android.view.View
 import android.view.ViewGroup
 import androidx.compose.animation.AnimatedContent
 import androidx.compose.foundation.background
@@ -14,11 +13,9 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.MaterialTheme
-import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
@@ -26,24 +23,15 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.platform.rememberNestedScrollInteropConnection
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.viewinterop.AndroidView
 import androidx.fragment.app.viewModels
 import androidx.fragment.compose.content
-import androidx.lifecycle.flowWithLifecycle
-import androidx.lifecycle.lifecycleScope
-import androidx.mediarouter.app.MediaRouteButton
 import au.com.shiftyjelly.pocketcasts.compose.theme
 import au.com.shiftyjelly.pocketcasts.playlists.SmartPlaylistViewModel
 import au.com.shiftyjelly.pocketcasts.playlists.SmartPlaylistViewModel.Companion.DOWNLOAD_ALL_LIMIT
 import au.com.shiftyjelly.pocketcasts.views.dialog.ConfirmationDialog
 import au.com.shiftyjelly.pocketcasts.views.dialog.ConfirmationDialog.ButtonType
 import au.com.shiftyjelly.pocketcasts.views.fragments.BaseDialogFragment
-import com.google.android.gms.cast.framework.CastButtonFactory
 import dagger.hilt.android.AndroidEntryPoint
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.MutableSharedFlow
-import kotlinx.coroutines.launch
-import timber.log.Timber
 import au.com.shiftyjelly.pocketcasts.images.R as IR
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
@@ -105,7 +93,7 @@ class SmartPlaylistsOptionsFragment : BaseDialogFragment() {
                                     dismiss()
                                 },
                                 onClickOpenSettings = {
-                                    Timber.i("Open settings")
+                                    viewModel.showSettings()
                                     dismiss()
                                 },
                             )

--- a/modules/features/filters/src/main/res/layout/smart_playlist_fragment.xml
+++ b/modules/features/filters/src/main/res/layout/smart_playlist_fragment.xml
@@ -32,4 +32,10 @@
         android:minHeight="?android:attr/actionBarSize"
         android:visibility="gone"
         app:navigationIcon="?attr/homeAsUpIndicator" />
+
+    <androidx.fragment.app.FragmentContainerView
+        android:id="@+id/playlistFragmentContainer"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent" />
+
 </FrameLayout>

--- a/modules/features/filters/src/test/kotlin/au/com/shiftyjelly/pocketcasts/playlists/create/FakePlaylistManager.kt
+++ b/modules/features/filters/src/test/kotlin/au/com/shiftyjelly/pocketcasts/playlists/create/FakePlaylistManager.kt
@@ -19,11 +19,7 @@ class FakePlaylistManager : PlaylistManager {
     override fun observePlaylistsPreview() = playlistPreviews.asStateFlow()
 
     val smartPlaylist = MutableStateFlow<SmartPlaylist?>(null)
-    val smartPlaylistUuidTurbine = Turbine<String>(name = "observeSmartPlaylist:uuid")
-    override fun observeSmartPlaylist(uuid: String): Flow<SmartPlaylist?> {
-        smartPlaylistUuidTurbine.add(uuid)
-        return smartPlaylist
-    }
+    override fun observeSmartPlaylist(uuid: String): Flow<SmartPlaylist?> = smartPlaylist
 
     val smartEpisodes = MutableStateFlow(emptyList<PodcastEpisode>())
     override fun observeSmartEpisodes(rules: SmartRules, sortType: PlaylistEpisodeSortType) = smartEpisodes.asStateFlow()
@@ -31,24 +27,17 @@ class FakePlaylistManager : PlaylistManager {
     val episodeMetadata = MutableStateFlow(PlaylistEpisodeMetadata.Empty)
     override fun observeEpisodeMetadata(rules: SmartRules) = episodeMetadata.asStateFlow()
 
-    val updateRulesUuidTurbine = Turbine<String>(name = "updateSmartRules:uuid")
-    val updateRulesRulesTurbine = Turbine<SmartRules>(name = "updateSmartRules:rules")
-    override suspend fun updateSmartRules(uuid: String, rules: SmartRules) {
-        updateRulesUuidTurbine.add(uuid)
-        updateRulesRulesTurbine.add(rules)
-    }
+    override suspend fun updateSmartRules(uuid: String, rules: SmartRules) = Unit
 
-    val updateSortTypeUuidTurbine = Turbine<String>(name = "updateSmartRules:uuid")
-    val updateSortTypeSortTypeTurbine = Turbine<PlaylistEpisodeSortType>(name = "updateSmartSortType:rules")
-    override suspend fun updateSortType(uuid: String, sortType: PlaylistEpisodeSortType) {
-        updateSortTypeUuidTurbine.add(uuid)
-        updateSortTypeSortTypeTurbine.add(sortType)
-    }
+    override suspend fun updateSortType(uuid: String, sortType: PlaylistEpisodeSortType) = Unit
 
-    val deletePlaylistTurbine = Turbine<String>(name = "deletePlaylist")
-    override suspend fun deletePlaylist(uuid: String) {
-        deletePlaylistTurbine.add(uuid)
-    }
+    override suspend fun updateAutoDownload(uuid: String, isEnabled: Boolean) = Unit
+
+    override suspend fun updateAutoDownloadLimit(uuid: String, limit: Int) = Unit
+
+    override suspend fun updateName(uuid: String, name: String) = Unit
+
+    override suspend fun deletePlaylist(uuid: String) = Unit
 
     val upsertSmartPlaylistTurbine = Turbine<SmartPlaylistDraft>(name = "upsertSmartPlaylist")
     override suspend fun upsertSmartPlaylist(draft: SmartPlaylistDraft): String {
@@ -56,8 +45,5 @@ class FakePlaylistManager : PlaylistManager {
         return UUID.randomUUID().toString()
     }
 
-    val updatePlaylistsOrderTurbine = Turbine<List<String>>(name = "updatePlaylistsOrder")
-    override suspend fun updatePlaylistsOrder(sortedUuids: List<String>) {
-        updatePlaylistsOrderTurbine.add(sortedUuids)
-    }
+    override suspend fun updatePlaylistsOrder(sortedUuids: List<String>) = Unit
 }

--- a/modules/services/localization/src/main/res/values-ca/strings.xml
+++ b/modules/services/localization/src/main/res/values-ca/strings.xml
@@ -13,7 +13,6 @@ Language: ca
     <string name="create_playlist">Crear una llista de reproducció</string>
     <string name="new_smart_playlist_banner_body">Afegeix episodis automàticament segons les regles</string>
     <string name="new_smart_playlist_banner_title">Fes-ho en una llista de reproducció intel·ligent</string>
-    <string name="new_playlists_title_placeholder">Títol de la llista de reproducció</string>
     <string name="clear">Esborrar</string>
     <string name="onboarding_folders_title_3">Esports</string>
     <string name="onboarding_folders_title_2">Preferits</string>

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -936,7 +936,7 @@
     <string name="increment_longer_than_duration">Increment \"longer than\" duration</string>
     <string name="increment_shorter_than_duration">Increment \"shorter than\" duration</string>
     <string name="new_playlist">New Playlist</string>
-    <string name="new_playlists_title_placeholder">Playlist’s title</string>
+    <string name="new_playlists_title_placeholder">Playlist’s name</string>
     <string name="new_smart_playlist_banner_body">Automatically add episodes based on rules</string>
     <string name="new_smart_playlist_banner_title">Make into Smart Playlist</string>
     <string name="playlist_download_all">Download All</string>

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/PlaylistDao.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/PlaylistDao.kt
@@ -45,6 +45,15 @@ abstract class PlaylistDao {
     @Query("UPDATE smart_playlists SET sortId = :sortType, syncStatus = $SYNC_STATUS_NOT_SYNCED WHERE uuid = :uuid")
     abstract suspend fun updateSortType(uuid: String, sortType: PlaylistEpisodeSortType)
 
+    @Query("UPDATE smart_playlists SET autoDownload = :isEnabled, syncStatus = $SYNC_STATUS_NOT_SYNCED WHERE uuid = :uuid")
+    abstract suspend fun updateAutoDownload(uuid: String, isEnabled: Boolean)
+
+    @Query("UPDATE smart_playlists SET autoDownloadLimit = :limit, syncStatus = $SYNC_STATUS_NOT_SYNCED WHERE uuid = :uuid")
+    abstract suspend fun updateAutoDownloadLimit(uuid: String, limit: Int)
+
+    @Query("UPDATE smart_playlists SET title = :name, syncStatus = $SYNC_STATUS_NOT_SYNCED WHERE uuid = :uuid")
+    abstract suspend fun updateName(uuid: String, name: String)
+
     @Query("UPDATE smart_playlists SET deleted = 1, syncStatus = $SYNC_STATUS_NOT_SYNCED WHERE uuid = :uuid")
     abstract suspend fun markPlaylistAsDeleted(uuid: String)
 

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playlist/PlaylistManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playlist/PlaylistManager.kt
@@ -19,6 +19,12 @@ interface PlaylistManager {
 
     suspend fun updateSortType(uuid: String, sortType: PlaylistEpisodeSortType)
 
+    suspend fun updateAutoDownload(uuid: String, isEnabled: Boolean)
+
+    suspend fun updateAutoDownloadLimit(uuid: String, limit: Int)
+
+    suspend fun updateName(uuid: String, name: String)
+
     suspend fun deletePlaylist(uuid: String)
 
     suspend fun upsertSmartPlaylist(draft: SmartPlaylistDraft): String

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playlist/PlaylistManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playlist/PlaylistManagerImpl.kt
@@ -85,6 +85,8 @@ class PlaylistManagerImpl @Inject constructor(
                             smartRules = smartRules,
                             episodes = episodes,
                             episodeSortType = playlist.sortType,
+                            isAutoDownloadEnabled = playlist.autoDownload,
+                            autoDownloadLimit = playlist.autodownloadLimit,
                             totalEpisodeCount = metadata.episodeCount,
                             playbackDurationLeft = metadata.timeLeftSeconds.seconds,
                             artworkPodcasts = podcasts,
@@ -123,6 +125,18 @@ class PlaylistManagerImpl @Inject constructor(
 
     override suspend fun updateSortType(uuid: String, sortType: PlaylistEpisodeSortType) {
         playlistDao.updateSortType(uuid, sortType)
+    }
+
+    override suspend fun updateAutoDownload(uuid: String, isEnabled: Boolean) {
+        playlistDao.updateAutoDownload(uuid, isEnabled)
+    }
+
+    override suspend fun updateAutoDownloadLimit(uuid: String, limit: Int) {
+        playlistDao.updateAutoDownloadLimit(uuid, limit)
+    }
+
+    override suspend fun updateName(uuid: String, name: String) {
+        playlistDao.updateName(uuid, name)
     }
 
     override suspend fun deletePlaylist(uuid: String) {

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playlist/SmartPlaylist.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playlist/SmartPlaylist.kt
@@ -12,6 +12,8 @@ data class SmartPlaylist(
     val smartRules: SmartRules,
     val episodes: List<PodcastEpisode>,
     val episodeSortType: PlaylistEpisodeSortType,
+    val isAutoDownloadEnabled: Boolean,
+    val autoDownloadLimit: Int,
     val totalEpisodeCount: Int,
     val playbackDurationLeft: Duration,
     val artworkPodcasts: List<Podcast>,


### PR DESCRIPTION
## Description

This adds ability to change playlist's name and auto-download settings.

Designs: 5sC4z4Mu42LvL4MAAIbQVi-fi-790_19387. Note: The implementation is vastly different from the designs as they use iOS settings screen. This implementation uses what we already have for Filters.

Closes PCDROID-74

## Testing Instructions

1. Open a playlist.
2. Go to "Playlist Options" from the overflow menu.
3. Test changing name and auto download settings.
4. Name should sync between devices.

## Screenshots or Screencast 

| Settings | Episode limit |
| - | - |
| <img width="1080" height="2400" alt="image" src="https://github.com/user-attachments/assets/fb5eba1d-4635-4154-bf9c-5240a820ad5b" /> | <img width="1080" height="2400" alt="image" src="https://github.com/user-attachments/assets/3009e903-86d5-47de-8d1c-63c71573110b" /> |

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack