### PR TITLE
[Onboarding] Notification Prompt Changes

### DIFF
--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/notifications/EnableNotificationsPromptFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/notifications/EnableNotificationsPromptFragment.kt
@@ -17,6 +17,8 @@ import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTracker
 import au.com.shiftyjelly.pocketcasts.compose.CallOnce
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.repositories.notification.NotificationHelper
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
 import au.com.shiftyjelly.pocketcasts.views.fragments.BaseDialogFragment
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
@@ -62,27 +64,56 @@ internal class EnableNotificationsPromptFragment : BaseDialogFragment() {
         }
 
         DialogBox {
-            EnableNotificationsPromptScreen(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .padding(16.dp),
-                onCtaClick = {
-                    analyticsTracker.track(AnalyticsEvent.NOTIFICATIONS_PERMISSIONS_ALLOW_TAPPED)
-                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-                        if (shouldShowRequestPermissionRationale(Manifest.permission.POST_NOTIFICATIONS)) {
-                            permissionRequester.launch(Manifest.permission.POST_NOTIFICATIONS)
-                            analyticsTracker.track(AnalyticsEvent.NOTIFICATIONS_OPT_IN_SHOWN)
-                        } else {
-                            notificationHelper.openNotificationSettings(requireActivity())
+            if (FeatureFlag.isEnabled(Feature.NEW_ONBOARDING_ACCOUNT_CREATION)) {
+                EnableNotificationsPromptScreenNewOnboarding(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .padding(22.dp),
+                    onCtaClick = {
+                        // TODO check FF and only execute this if checkbox is ticked!
+                        analyticsTracker.track(AnalyticsEvent.NOTIFICATIONS_PERMISSIONS_ALLOW_TAPPED)
+                        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                            if (shouldShowRequestPermissionRationale(Manifest.permission.POST_NOTIFICATIONS)) {
+                                permissionRequester.launch(Manifest.permission.POST_NOTIFICATIONS)
+                                analyticsTracker.track(AnalyticsEvent.NOTIFICATIONS_OPT_IN_SHOWN)
+                            } else {
+                                notificationHelper.openNotificationSettings(requireActivity())
+                            }
                         }
-                    }
-                },
-                onDismissClick = {
-                    isFinalizingActionUsed = true
-                    handleDismissedByUser()
-                    dismiss()
-                },
-            )
+                    },
+                    onDismissClick = {
+                        isFinalizingActionUsed = true
+                        handleDismissedByUser()
+                        dismiss()
+                    },
+                    isNewsletterSelected = false,
+                    isNotificationSelected = false,
+                    onNotificationChanged = {},
+                    onNewsletterChanged = {}
+                )
+            } else {
+                EnableNotificationsPromptScreen(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .padding(16.dp),
+                    onCtaClick = {
+                        analyticsTracker.track(AnalyticsEvent.NOTIFICATIONS_PERMISSIONS_ALLOW_TAPPED)
+                        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                            if (shouldShowRequestPermissionRationale(Manifest.permission.POST_NOTIFICATIONS)) {
+                                permissionRequester.launch(Manifest.permission.POST_NOTIFICATIONS)
+                                analyticsTracker.track(AnalyticsEvent.NOTIFICATIONS_OPT_IN_SHOWN)
+                            } else {
+                                notificationHelper.openNotificationSettings(requireActivity())
+                            }
+                        }
+                    },
+                    onDismissClick = {
+                        isFinalizingActionUsed = true
+                        handleDismissedByUser()
+                        dismiss()
+                    },
+                )
+            }
         }
     }
 

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/notifications/EnableNotificationsPromptScreen.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/notifications/EnableNotificationsPromptScreen.kt
@@ -62,8 +62,8 @@ internal fun EnableNotificationsPromptScreen(
         isAccountCreationFlagEnabled = false,
         isNotificationSelected = false,
         isNewsletterSelected = false,
-        onNotificationChanged = {},
-        onNewsletterChanged = {}
+        onNotificationChange = {},
+        onNewsletterChange = {},
     )
 }
 
@@ -72,9 +72,9 @@ internal fun EnableNotificationsPromptScreenNewOnboarding(
     onCtaClick: () -> Unit,
     onDismissClick: () -> Unit,
     isNewsletterSelected: Boolean,
-    onNewsletterChanged: (Boolean) -> Unit,
+    onNewsletterChange: (Boolean) -> Unit,
     isNotificationSelected: Boolean,
-    onNotificationChanged: (Boolean) -> Unit,
+    onNotificationChange: (Boolean) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     EnableNotificationsPromptScreenV2(
@@ -84,11 +84,10 @@ internal fun EnableNotificationsPromptScreenNewOnboarding(
         isAccountCreationFlagEnabled = true,
         isNotificationSelected = isNotificationSelected,
         isNewsletterSelected = isNewsletterSelected,
-        onNotificationChanged = onNotificationChanged,
-        onNewsletterChanged = onNewsletterChanged
+        onNotificationChange = onNotificationChange,
+        onNewsletterChange = onNewsletterChange,
     )
 }
-
 
 @Composable
 private fun EnableNotificationsPromptScreenV2(
@@ -96,9 +95,9 @@ private fun EnableNotificationsPromptScreenV2(
     onDismissClick: () -> Unit,
     isAccountCreationFlagEnabled: Boolean,
     isNewsletterSelected: Boolean,
-    onNewsletterChanged: (Boolean) -> Unit,
+    onNewsletterChange: (Boolean) -> Unit,
     isNotificationSelected: Boolean,
-    onNotificationChanged: (Boolean) -> Unit,
+    onNotificationChange: (Boolean) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val configuration = LocalConfiguration.current
@@ -152,17 +151,17 @@ private fun EnableNotificationsPromptScreenV2(
                             modifier = Modifier
                                 .fillMaxWidth(),
                             isSelected = isNewsletterSelected,
-                            onSelectedChanged = onNewsletterChanged,
+                            onSelectedChange = onNewsletterChange,
                             title = stringResource(LR.string.onboarding_notification_popup_newsletter),
-                            subTitle = stringResource(LR.string.onboarding_notification_popup_newsletter_message)
+                            subTitle = stringResource(LR.string.onboarding_notification_popup_newsletter_message),
                         )
                         Spacer(modifier = Modifier.height(18.dp))
                         CheckboxRow(
                             modifier = Modifier.fillMaxWidth(),
                             isSelected = isNotificationSelected,
-                            onSelectedChanged = onNotificationChanged,
+                            onSelectedChange = onNotificationChange,
                             title = stringResource(LR.string.onboarding_notification_popup_notifications),
-                            subTitle = stringResource(LR.string.onboarding_notification_popup_notifications_message)
+                            subTitle = stringResource(LR.string.onboarding_notification_popup_notifications_message),
                         )
                         Spacer(modifier = Modifier.height(24.dp))
                         RowButton(
@@ -215,17 +214,17 @@ private fun EnableNotificationsPromptScreenV2(
                     modifier = Modifier
                         .fillMaxWidth(),
                     isSelected = isNewsletterSelected,
-                    onSelectedChanged = onNewsletterChanged,
+                    onSelectedChange = onNewsletterChange,
                     title = stringResource(LR.string.onboarding_notification_popup_newsletter),
-                    subTitle = stringResource(LR.string.onboarding_notification_popup_newsletter_message)
+                    subTitle = stringResource(LR.string.onboarding_notification_popup_newsletter_message),
                 )
                 Spacer(modifier = Modifier.height(18.dp))
                 CheckboxRow(
                     modifier = Modifier.fillMaxWidth(),
                     isSelected = isNotificationSelected,
-                    onSelectedChanged = onNotificationChanged,
+                    onSelectedChange = onNotificationChange,
                     title = stringResource(LR.string.onboarding_notification_popup_notifications),
-                    subTitle = stringResource(LR.string.onboarding_notification_popup_notifications_message)
+                    subTitle = stringResource(LR.string.onboarding_notification_popup_notifications_message),
                 )
                 Spacer(modifier = Modifier.height(24.dp))
                 RowButton(
@@ -259,10 +258,10 @@ private fun EnableNotificationsPromptScreenV2(
 @Composable
 private fun CheckboxRow(
     isSelected: Boolean,
-    onSelectedChanged: (Boolean) -> Unit,
+    onSelectedChange: (Boolean) -> Unit,
     title: String,
     subTitle: String,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
 ) {
     Row(
         verticalAlignment = Alignment.CenterVertically,
@@ -271,13 +270,13 @@ private fun CheckboxRow(
             .toggleable(
                 value = isSelected,
                 role = Role.Checkbox,
-                onValueChange = onSelectedChanged,
+                onValueChange = onSelectedChange,
             ),
     ) {
         CircularCheckBox(
             modifier = Modifier.size(24.dp),
             isChecked = isSelected,
-            onCheckedChange = onSelectedChanged,
+            onCheckedChange = onSelectedChange,
         )
         Column(
             modifier = Modifier.weight(1f),
@@ -290,7 +289,7 @@ private fun CheckboxRow(
             TextP60(
                 text = subTitle,
                 modifier = Modifier.fillMaxWidth(),
-                color = MaterialTheme.theme.colors.primaryText01.copy(alpha = .4f)
+                color = MaterialTheme.theme.colors.primaryText01.copy(alpha = .4f),
             )
         }
     }
@@ -313,7 +312,7 @@ private fun CircularCheckBox(
                     Modifier.background(color = MaterialTheme.theme.colors.primaryIcon01)
                 } else {
                     Modifier.border(width = 2.dp, color = MaterialTheme.theme.colors.primaryInteractive01, shape = CircleShape)
-                }
+                },
             ),
         contentAlignment = Alignment.Center,
     ) {
@@ -321,7 +320,7 @@ private fun CircularCheckBox(
             Icon(
                 painter = painterResource(IR.drawable.ic_checkmark_small),
                 tint = MaterialTheme.theme.colors.primaryUi01,
-                contentDescription = ""
+                contentDescription = "",
             )
         }
     }
@@ -348,7 +347,7 @@ private fun EnableNotificationsPromptScreenV2Preview(
         onCtaClick = {},
         isNewsletterSelected = true,
         isNotificationSelected = false,
-        onNotificationChanged = {},
-        onNewsletterChanged = {}
+        onNotificationChange = {},
+        onNewsletterChange = {},
     )
 }

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/notifications/EnableNotificationsPromptScreen.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/notifications/EnableNotificationsPromptScreen.kt
@@ -2,23 +2,35 @@ package au.com.shiftyjelly.pocketcasts.podcasts.view.notifications
 
 import android.content.res.Configuration
 import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.selection.toggleable
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.ButtonDefaults
 import androidx.compose.material.Icon
 import androidx.compose.material.IconButton
 import androidx.compose.material.MaterialTheme
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
@@ -28,7 +40,9 @@ import androidx.compose.ui.unit.sp
 import au.com.shiftyjelly.pocketcasts.compose.AppThemeWithBackground
 import au.com.shiftyjelly.pocketcasts.compose.buttons.RowButton
 import au.com.shiftyjelly.pocketcasts.compose.components.TextH10
+import au.com.shiftyjelly.pocketcasts.compose.components.TextH40
 import au.com.shiftyjelly.pocketcasts.compose.components.TextP40
+import au.com.shiftyjelly.pocketcasts.compose.components.TextP60
 import au.com.shiftyjelly.pocketcasts.compose.preview.ThemePreviewParameterProvider
 import au.com.shiftyjelly.pocketcasts.compose.theme
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
@@ -39,6 +53,52 @@ import au.com.shiftyjelly.pocketcasts.localization.R as LR
 internal fun EnableNotificationsPromptScreen(
     onCtaClick: () -> Unit,
     onDismissClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    EnableNotificationsPromptScreenV2(
+        onCtaClick = onCtaClick,
+        onDismissClick = onDismissClick,
+        modifier = modifier,
+        isAccountCreationFlagEnabled = false,
+        isNotificationSelected = false,
+        isNewsletterSelected = false,
+        onNotificationChanged = {},
+        onNewsletterChanged = {}
+    )
+}
+
+@Composable
+internal fun EnableNotificationsPromptScreenNewOnboarding(
+    onCtaClick: () -> Unit,
+    onDismissClick: () -> Unit,
+    isNewsletterSelected: Boolean,
+    onNewsletterChanged: (Boolean) -> Unit,
+    isNotificationSelected: Boolean,
+    onNotificationChanged: (Boolean) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    EnableNotificationsPromptScreenV2(
+        onCtaClick = onCtaClick,
+        onDismissClick = onDismissClick,
+        modifier = modifier,
+        isAccountCreationFlagEnabled = true,
+        isNotificationSelected = isNotificationSelected,
+        isNewsletterSelected = isNewsletterSelected,
+        onNotificationChanged = onNotificationChanged,
+        onNewsletterChanged = onNewsletterChanged
+    )
+}
+
+
+@Composable
+private fun EnableNotificationsPromptScreenV2(
+    onCtaClick: () -> Unit,
+    onDismissClick: () -> Unit,
+    isAccountCreationFlagEnabled: Boolean,
+    isNewsletterSelected: Boolean,
+    onNewsletterChanged: (Boolean) -> Unit,
+    isNotificationSelected: Boolean,
+    onNotificationChanged: (Boolean) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val configuration = LocalConfiguration.current
@@ -82,21 +142,53 @@ internal fun EnableNotificationsPromptScreen(
                     TextP40(
                         modifier = Modifier.padding(horizontal = 32.dp),
                         text = stringResource(LR.string.notification_prompt_message),
-                        color = MaterialTheme.theme.colors.secondaryText02,
+                        color = MaterialTheme.theme.colors.primaryText01.copy(alpha = .5f),
                         textAlign = TextAlign.Center,
                     )
                     Spacer(modifier = Modifier.weight(1f))
-                    RowButton(
-                        text = stringResource(LR.string.notification_prompt_cta),
-                        textColor = MaterialTheme.theme.colors.primaryInteractive02,
-                        fontSize = 18.sp,
-                        fontWeight = FontWeight.W500,
-                        colors = ButtonDefaults.buttonColors(
-                            backgroundColor = MaterialTheme.theme.colors.primaryInteractive01,
-                        ),
-                        includePadding = false,
-                        onClick = onCtaClick,
-                    )
+
+                    if (isAccountCreationFlagEnabled) {
+                        CheckboxRow(
+                            modifier = Modifier
+                                .fillMaxWidth(),
+                            isSelected = isNewsletterSelected,
+                            onSelectedChanged = onNewsletterChanged,
+                            title = stringResource(LR.string.onboarding_notification_popup_newsletter),
+                            subTitle = stringResource(LR.string.onboarding_notification_popup_newsletter_message)
+                        )
+                        Spacer(modifier = Modifier.height(18.dp))
+                        CheckboxRow(
+                            modifier = Modifier.fillMaxWidth(),
+                            isSelected = isNotificationSelected,
+                            onSelectedChanged = onNotificationChanged,
+                            title = stringResource(LR.string.onboarding_notification_popup_notifications),
+                            subTitle = stringResource(LR.string.onboarding_notification_popup_notifications_message)
+                        )
+                        Spacer(modifier = Modifier.height(24.dp))
+                        RowButton(
+                            text = stringResource(LR.string.onboarding_notifications_popup_save),
+                            textColor = MaterialTheme.theme.colors.primaryInteractive02,
+                            fontSize = 18.sp,
+                            fontWeight = FontWeight.W500,
+                            colors = ButtonDefaults.buttonColors(
+                                backgroundColor = MaterialTheme.theme.colors.primaryInteractive01,
+                            ),
+                            includePadding = false,
+                            onClick = onCtaClick,
+                        )
+                    } else {
+                        RowButton(
+                            text = stringResource(LR.string.notification_prompt_cta),
+                            textColor = MaterialTheme.theme.colors.primaryInteractive02,
+                            fontSize = 18.sp,
+                            fontWeight = FontWeight.W500,
+                            colors = ButtonDefaults.buttonColors(
+                                backgroundColor = MaterialTheme.theme.colors.primaryInteractive01,
+                            ),
+                            includePadding = false,
+                            onClick = onCtaClick,
+                        )
+                    }
                 }
             }
         } else {
@@ -114,20 +206,122 @@ internal fun EnableNotificationsPromptScreen(
             TextP40(
                 modifier = Modifier.padding(horizontal = 32.dp),
                 text = stringResource(LR.string.notification_prompt_message),
-                color = MaterialTheme.theme.colors.secondaryText02,
+                color = MaterialTheme.theme.colors.primaryText01.copy(alpha = .5f),
                 textAlign = TextAlign.Center,
             )
             Spacer(modifier = Modifier.weight(1f))
-            RowButton(
-                text = stringResource(LR.string.notification_prompt_cta),
-                textColor = MaterialTheme.theme.colors.primaryInteractive02,
-                fontSize = 18.sp,
-                fontWeight = FontWeight.W500,
-                colors = ButtonDefaults.buttonColors(
-                    backgroundColor = MaterialTheme.theme.colors.primaryInteractive01,
-                ),
-                includePadding = false,
-                onClick = onCtaClick,
+            if (isAccountCreationFlagEnabled) {
+                CheckboxRow(
+                    modifier = Modifier
+                        .fillMaxWidth(),
+                    isSelected = isNewsletterSelected,
+                    onSelectedChanged = onNewsletterChanged,
+                    title = stringResource(LR.string.onboarding_notification_popup_newsletter),
+                    subTitle = stringResource(LR.string.onboarding_notification_popup_newsletter_message)
+                )
+                Spacer(modifier = Modifier.height(18.dp))
+                CheckboxRow(
+                    modifier = Modifier.fillMaxWidth(),
+                    isSelected = isNotificationSelected,
+                    onSelectedChanged = onNotificationChanged,
+                    title = stringResource(LR.string.onboarding_notification_popup_notifications),
+                    subTitle = stringResource(LR.string.onboarding_notification_popup_notifications_message)
+                )
+                Spacer(modifier = Modifier.height(24.dp))
+                RowButton(
+                    text = stringResource(LR.string.onboarding_notifications_popup_save),
+                    textColor = MaterialTheme.theme.colors.primaryInteractive02,
+                    fontSize = 18.sp,
+                    fontWeight = FontWeight.W500,
+                    colors = ButtonDefaults.buttonColors(
+                        backgroundColor = MaterialTheme.theme.colors.primaryInteractive01,
+                    ),
+                    includePadding = false,
+                    onClick = onCtaClick,
+                )
+            } else {
+                RowButton(
+                    text = stringResource(LR.string.notification_prompt_cta),
+                    textColor = MaterialTheme.theme.colors.primaryInteractive02,
+                    fontSize = 18.sp,
+                    fontWeight = FontWeight.W500,
+                    colors = ButtonDefaults.buttonColors(
+                        backgroundColor = MaterialTheme.theme.colors.primaryInteractive01,
+                    ),
+                    includePadding = false,
+                    onClick = onCtaClick,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun CheckboxRow(
+    isSelected: Boolean,
+    onSelectedChanged: (Boolean) -> Unit,
+    title: String,
+    subTitle: String,
+    modifier: Modifier = Modifier
+) {
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(16.dp),
+        modifier = modifier
+            .toggleable(
+                value = isSelected,
+                role = Role.Checkbox,
+                onValueChange = onSelectedChanged,
+            ),
+    ) {
+        CircularCheckBox(
+            modifier = Modifier.size(24.dp),
+            isChecked = isSelected,
+            onCheckedChange = onSelectedChanged,
+        )
+        Column(
+            modifier = Modifier.weight(1f),
+            verticalArrangement = Arrangement.spacedBy(4.dp),
+        ) {
+            TextH40(
+                text = title,
+                modifier = Modifier.fillMaxWidth(),
+            )
+            TextP60(
+                text = subTitle,
+                modifier = Modifier.fillMaxWidth(),
+                color = MaterialTheme.theme.colors.primaryText01.copy(alpha = .4f)
+            )
+        }
+    }
+}
+
+@Composable
+private fun CircularCheckBox(
+    isChecked: Boolean,
+    onCheckedChange: (Boolean) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Box(
+        modifier = modifier
+            .clip(CircleShape)
+            .clickable(interactionSource = remember { MutableInteractionSource() }, indication = null) {
+                onCheckedChange(!isChecked)
+            }
+            .then(
+                if (isChecked) {
+                    Modifier.background(color = MaterialTheme.theme.colors.primaryIcon01)
+                } else {
+                    Modifier.border(width = 2.dp, color = MaterialTheme.theme.colors.primaryInteractive01, shape = CircleShape)
+                }
+            ),
+        contentAlignment = Alignment.Center,
+    ) {
+        if (isChecked) {
+            Icon(
+                painter = painterResource(IR.drawable.ic_checkmark_small),
+                tint = MaterialTheme.theme.colors.primaryUi01,
+                contentDescription = ""
             )
         }
     }
@@ -141,5 +335,20 @@ private fun EnableNotificationsPromptScreenPreview(
     EnableNotificationsPromptScreen(
         onDismissClick = {},
         onCtaClick = {},
+    )
+}
+
+@Preview
+@Composable
+private fun EnableNotificationsPromptScreenV2Preview(
+    @PreviewParameter(ThemePreviewParameterProvider::class) themeType: Theme.ThemeType,
+) = AppThemeWithBackground(themeType) {
+    EnableNotificationsPromptScreenNewOnboarding(
+        onDismissClick = {},
+        onCtaClick = {},
+        isNewsletterSelected = true,
+        isNotificationSelected = false,
+        onNotificationChanged = {},
+        onNewsletterChanged = {}
     )
 }

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/notifications/EnableNotificationsPromptViewModel.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/notifications/EnableNotificationsPromptViewModel.kt
@@ -1,0 +1,115 @@
+package au.com.shiftyjelly.pocketcasts.podcasts.viewmodel.notifications
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import au.com.shiftyjelly.pocketcasts.account.viewmodel.NewsletterSource
+import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
+import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTracker
+import au.com.shiftyjelly.pocketcasts.preferences.Settings
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+@HiltViewModel
+class EnableNotificationsPromptViewModel @Inject constructor(
+    private val settings: Settings,
+    private val analyticsTracker: AnalyticsTracker,
+) : ViewModel() {
+
+    private var _stateFlow: MutableStateFlow<UiState> = MutableStateFlow(UiState.PreNewOnboardingState)
+    val stateFlow: StateFlow<UiState> = _stateFlow
+
+    private var _messagesFlow: MutableSharedFlow<UiMessage> = MutableSharedFlow()
+    val messagesFlow: SharedFlow<UiMessage> = _messagesFlow
+
+    init {
+        if (FeatureFlag.isEnabled(Feature.NEW_ONBOARDING_ACCOUNT_CREATION)) {
+            _stateFlow.update {
+                UiState.NewOnboardingState(
+                    isNotificationsChecked = true,
+                    isNewsletterChecked = true,
+                )
+            }
+        }
+    }
+
+    fun onCtaClick() {
+        analyticsTracker.track(AnalyticsEvent.NOTIFICATIONS_PERMISSIONS_ALLOW_TAPPED) // should we report the same?
+        when (val state = stateFlow.value) {
+            is UiState.PreNewOnboardingState -> {
+                viewModelScope.launch {
+                    _messagesFlow.emit(UiMessage.RequestPermission)
+                }
+            }
+
+            is UiState.NewOnboardingState -> {
+                analyticsTracker.track(
+                    AnalyticsEvent.NEWSLETTER_OPT_IN_CHANGED,
+                    mapOf(
+                        "source" to NewsletterSource.WELCOME_NEW_ACCOUNT.analyticsValue,
+                        "enabled" to state.isNewsletterChecked,
+                    ),
+                )
+                settings.marketingOptIn.set(state.isNewsletterChecked, updateModifiedAt = true)
+                viewModelScope.launch {
+                    _messagesFlow.emit(
+                        if (state.isNotificationsChecked) {
+                            UiMessage.RequestPermission
+                        } else {
+                            UiMessage.Dismiss
+                        },
+                    )
+                }
+            }
+        }
+    }
+
+    fun reportShown() {
+        analyticsTracker.track(AnalyticsEvent.NOTIFICATIONS_PERMISSIONS_SHOWN)
+    }
+
+    fun reportNotificationsOptInShown() {
+        analyticsTracker.track(AnalyticsEvent.NOTIFICATIONS_OPT_IN_SHOWN)
+    }
+
+    fun reportNotificationRequestResult(wasEnabled: Boolean) {
+        analyticsTracker.track(if (wasEnabled) AnalyticsEvent.NOTIFICATIONS_OPT_IN_ALLOWED else AnalyticsEvent.NOTIFICATIONS_OPT_IN_DENIED)
+    }
+
+    fun handleDismissedByUser() {
+        settings.notificationsPromptAcknowledged.set(value = true, updateModifiedAt = true)
+        analyticsTracker.track(AnalyticsEvent.NOTIFICATIONS_PERMISSIONS_DISMISSED)
+    }
+
+    fun onNewsletterChanged(isChecked: Boolean) {
+        _stateFlow.update {
+            (it as? UiState.NewOnboardingState)?.copy(isNewsletterChecked = isChecked) ?: it
+        }
+    }
+
+    fun onNotificationsChanged(isChecked: Boolean) {
+        _stateFlow.update {
+            (it as? UiState.NewOnboardingState)?.copy(isNotificationsChecked = isChecked) ?: it
+        }
+    }
+
+    sealed interface UiState {
+        object PreNewOnboardingState : UiState
+        data class NewOnboardingState(
+            val isNewsletterChecked: Boolean,
+            val isNotificationsChecked: Boolean,
+        ) : UiState
+    }
+
+    sealed interface UiMessage {
+        object RequestPermission : UiMessage
+        object Dismiss : UiMessage
+    }
+}

--- a/modules/features/podcasts/src/test/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/notifications/EnableNotificationsPromptViewModelTest.kt
+++ b/modules/features/podcasts/src/test/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/notifications/EnableNotificationsPromptViewModelTest.kt
@@ -1,0 +1,134 @@
+package au.com.shiftyjelly.pocketcasts.podcasts.viewmodel.notifications
+
+import app.cash.turbine.test
+import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTracker
+import au.com.shiftyjelly.pocketcasts.preferences.Settings
+import au.com.shiftyjelly.pocketcasts.preferences.UserSetting
+import au.com.shiftyjelly.pocketcasts.sharedtest.InMemoryFeatureFlagRule
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.Mock
+import org.mockito.MockitoAnnotations
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+
+class EnableNotificationsPromptViewModelTest {
+
+    @get:Rule
+    val featureFlagRule = InMemoryFeatureFlagRule()
+
+    @Mock
+    lateinit var settings: Settings
+
+    @Mock
+    lateinit var mockMarketingSetting: UserSetting<Boolean>
+
+    @Mock
+    lateinit var analyticsTracker: AnalyticsTracker
+
+    @Before
+    fun setup() {
+        MockitoAnnotations.openMocks(this)
+        whenever(settings.marketingOptIn).thenReturn(mockMarketingSetting)
+    }
+
+    @Test
+    fun `should return old state when ff is disabled`() = runTest {
+        FeatureFlag.setEnabled(Feature.NEW_ONBOARDING_ACCOUNT_CREATION, false)
+
+        createViewModel().stateFlow.test {
+            val state = awaitItem()
+
+            assert(state is EnableNotificationsPromptViewModel.UiState.PreNewOnboardingState)
+        }
+    }
+
+    @Test
+    fun `should return new state with defaults when ff is enabled`() = runTest {
+        FeatureFlag.setEnabled(Feature.NEW_ONBOARDING_ACCOUNT_CREATION, true)
+
+        createViewModel().stateFlow.test {
+            val state = awaitItem()
+            val expectedState = EnableNotificationsPromptViewModel.UiState.NewOnboardingState(isNewsletterChecked = true, isNotificationsChecked = true)
+            assertEquals(expectedState, state)
+        }
+    }
+
+    @Test
+    fun `should update state when newsletter changes`() = runTest {
+        FeatureFlag.setEnabled(Feature.NEW_ONBOARDING_ACCOUNT_CREATION, true)
+
+        val viewModel = createViewModel()
+        viewModel.onNewsletterChanged(false)
+
+        viewModel.stateFlow.test {
+            val state = awaitItem()
+            val expectedState = EnableNotificationsPromptViewModel.UiState.NewOnboardingState(isNewsletterChecked = false, isNotificationsChecked = true)
+            assertEquals(expectedState, state)
+        }
+    }
+
+    @Test
+    fun `should update state when notification setting changes`() = runTest {
+        FeatureFlag.setEnabled(Feature.NEW_ONBOARDING_ACCOUNT_CREATION, true)
+
+        val viewModel = createViewModel()
+        viewModel.onNotificationsChanged(false)
+
+        viewModel.stateFlow.test {
+            val state = awaitItem()
+            val expectedState = EnableNotificationsPromptViewModel.UiState.NewOnboardingState(isNewsletterChecked = true, isNotificationsChecked = false)
+            assertEquals(expectedState, state)
+        }
+    }
+
+    @Test
+    fun `should send message to request notifications when ff is off`() = runTest {
+        FeatureFlag.setEnabled(Feature.NEW_ONBOARDING_ACCOUNT_CREATION, false)
+
+        val viewModel = createViewModel()
+        viewModel.messagesFlow.test {
+            viewModel.onCtaClick()
+            val message = awaitItem()
+            assertEquals(EnableNotificationsPromptViewModel.UiMessage.RequestPermission, message)
+        }
+    }
+
+    @Test
+    fun `should send message to request notifications when ff is on and notifications are enabled`() = runTest {
+        FeatureFlag.setEnabled(Feature.NEW_ONBOARDING_ACCOUNT_CREATION, true)
+
+        val viewModel = createViewModel()
+
+        viewModel.messagesFlow.test {
+            viewModel.onCtaClick()
+            val message = awaitItem()
+            assertEquals(EnableNotificationsPromptViewModel.UiMessage.RequestPermission, message)
+        }
+        verify(mockMarketingSetting).set(true, true)
+    }
+
+    @Test
+    fun `should send message to dismiss when ff is on and notifications are disabled`() = runTest {
+        FeatureFlag.setEnabled(Feature.NEW_ONBOARDING_ACCOUNT_CREATION, true)
+
+        val viewModel = createViewModel()
+        viewModel.onNotificationsChanged(false)
+
+        viewModel.messagesFlow.test {
+            viewModel.onCtaClick()
+            val message = awaitItem()
+            assertEquals(EnableNotificationsPromptViewModel.UiMessage.Dismiss, message)
+        }
+    }
+
+    private fun createViewModel() = EnableNotificationsPromptViewModel(
+        settings = settings,
+        analyticsTracker = analyticsTracker,
+    )
+}

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/developer/DeveloperFragment.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/developer/DeveloperFragment.kt
@@ -48,6 +48,7 @@ class DeveloperFragment : BaseFragment() {
                 onResetSuggestedFoldersSuggestion = viewModel::resetSuggestedFoldersSuggestion,
                 onShowNotificationsTestingClick = ::onShowNotificationsTestingClick,
                 onResetPlaylistsOnboarding = viewModel::resetPlaylistsOnboarding,
+                onResetNotificationsPrompt = viewModel::resetNotificationsPrompt,
             )
         }
     }

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/developer/DeveloperPage.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/developer/DeveloperPage.kt
@@ -63,6 +63,7 @@ fun DeveloperPage(
     onShowNotificationsTestingClick: () -> Unit,
     onResetSuggestedFoldersSuggestion: () -> Unit,
     onResetPlaylistsOnboarding: () -> Unit,
+    onResetNotificationsPrompt: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     var openCrashMessageDialog by remember { mutableStateOf(false) }
@@ -110,6 +111,9 @@ fun DeveloperPage(
         }
         item {
             NotificationsTesting(onClick = onShowNotificationsTestingClick)
+        }
+        item {
+            ResetNotificationsPrompt(onClick = onResetNotificationsPrompt)
         }
         item {
             ResetPlaylistsOnboarding(onClick = onResetPlaylistsOnboarding)
@@ -243,6 +247,19 @@ private fun TriggerNotificationSetting(
 }
 
 @Composable
+private fun ResetNotificationsPrompt(
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    SettingRow(
+        primaryText = "Reset notifications prompt",
+        secondaryText = "Show enable notifications prompt on Podcasts when the permission is missing",
+        icon = rememberVectorPainter(Icons.Outlined.Notifications),
+        modifier = modifier.clickable { onClick() },
+    )
+}
+
+@Composable
 private fun DeleteFirstEpisodeSetting(
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
@@ -365,6 +382,7 @@ private fun DeveloperPagePreview() {
         onResetSuggestedFoldersSuggestion = {},
         onShowNotificationsTestingClick = {},
         onResetPlaylistsOnboarding = {},
+        onResetNotificationsPrompt = {},
     )
 }
 

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/developer/DeveloperViewModel.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/developer/DeveloperViewModel.kt
@@ -172,4 +172,8 @@ class DeveloperViewModel
     fun resetPlaylistsOnboarding() {
         settings.showPlaylistsOnboarding.set(true, updateModifiedAt = false)
     }
+
+    fun resetNotificationsPrompt() {
+        settings.notificationsPromptAcknowledged.set(false, updateModifiedAt = false)
+    }
 }

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -2574,5 +2574,9 @@
     <string name="onboarding_preselect_chapters_chapter_title">Chapter %1$d</string>
     <string name="onboarding_upgrade_tnc">Terms\u00A0and\u00A0Conditions</string>
     <string name="onboarding_upgrade_pp">Privacy\u00A0Policy</string>
-
+    <string name="onboarding_notification_popup_newsletter">Subscribe to our Newsletter</string>
+    <string name="onboarding_notification_popup_newsletter_message">Once a month, all podcast goodness</string>
+    <string name="onboarding_notification_popup_notifications">Receive Notifications</string>
+    <string name="onboarding_notification_popup_notifications_message">Receive news, podcast suggestions and more</string>
+    <string name="onboarding_notifications_popup_save">Save Preferences</string>
 </resources>

--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/Feature.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/Feature.kt
@@ -146,6 +146,14 @@ enum class Feature(
         hasFirebaseRemoteFlag = true,
         hasDevToggle = true,
     ),
+    NEW_ONBOARDING_ACCOUNT_CREATION(
+        key = "new_onboarding_account_creation",
+        title = "New Onboarding Account Creation",
+        defaultValue = BuildConfig.DEBUG,
+        tier = FeatureTier.Free,
+        hasFirebaseRemoteFlag = false,
+        hasDevToggle = true,
+    ),
     PLAYLISTS_REBRANDING(
         key = "playlists_rebranding",
         title = "Playlists",


### PR DESCRIPTION
## Description
This PR introduces the new FF `new_onboarding_account_creation` that is currently not connected with Firebase, it defaults to `true` on DEBUG builds.
As the first step, I implemented the changes for the Notification popup and added the checkboxes to the bottom + updated the cta label.
Analytics is yet to be discussed with the team.

Designs: PviUP0aiZctOprDuuYRwpb-fi-5076_14355

Fixes https://linear.app/a8c/issue/PCDROID-86/notifications-popup-changes

## Testing Instructions
1. Launch app
2. Don't allow notifications on the initial prompt
3. Don't need to sign in either 
4. Make sure the FF is ON
5. Navigate to the Podcasts tab to see the prompt
- [ ] prompt matches designs
- [ ] all checkboxes are on by default
6. Tap CTA
- [ ] permission prompt appears
- [ ] newsleter value gets persisted

Now do the same with the FF OFF
- [ ] you see the old popup without the checkboxes

## Screenshots or Screencast 
<img width="1080" height="2400" alt="Screenshot_20250812_170610" src="https://github.com/user-attachments/assets/28dc1a51-9265-4a99-8303-fb2782099a29" />


## Checklist
- [ ] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [ ] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack