### PR TITLE
Insert new playlists first in order

### DIFF
--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/repositories/playlist/PlaylistManagerTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/repositories/playlist/PlaylistManagerTest.kt
@@ -612,18 +612,18 @@ class PlaylistManagerTest {
                 ),
             ),
         )
-        drafts.forEach { draft -> manager.upsertSmartPlaylist(draft) }
+        drafts.forEach { draft -> manager.insertSmartPlaylist(draft) }
         val playlists = playlistDao.observeSmartPlaylists().first()
 
         // Check that UUIDs are unique
         assertEquals(playlists, playlists.distinctBy { it.uuid })
 
         val defaultPlaylist = DbPlaylist(
-            id = playlists[0].id,
-            uuid = playlists[0].uuid,
+            id = playlists.last().id,
+            uuid = playlists.last().uuid,
             title = "Title",
             iconId = 0,
-            sortPosition = playlists[0].sortPosition,
+            sortPosition = playlists.last().sortPosition,
             sortType = PlaylistEpisodeSortType.NewestToOldest,
             manual = false,
             draft = false,
@@ -659,33 +659,33 @@ class PlaylistManagerTest {
             assertEquals(message, func(indexedPlaylist), playlist)
         }
 
-        assertPlaylist(index = 0, "Default") { defaultPlaylist }
-        assertPlaylist(index = 1, "Unplayed") { it.copy(unplayed = true, partiallyPlayed = false, finished = false) }
-        assertPlaylist(index = 2, "In progress") { it.copy(unplayed = false, partiallyPlayed = true, finished = false) }
-        assertPlaylist(index = 3, "Played") { it.copy(unplayed = false, partiallyPlayed = false, finished = true) }
-        assertPlaylist(index = 4, "Any downloaded status") { it.copy(downloaded = true, notDownloaded = true, downloading = true) }
-        assertPlaylist(index = 5, "Downloaded") { it.copy(downloaded = true, notDownloaded = false, downloading = false) }
-        assertPlaylist(index = 6, "Not downloaded") { it.copy(downloaded = false, notDownloaded = true, downloading = true) }
-        assertPlaylist(index = 7, "Audio / Video") { it.copy(audioVideo = AUDIO_VIDEO_FILTER_ALL) }
-        assertPlaylist(index = 8, "Audio") { it.copy(audioVideo = AUDIO_VIDEO_FILTER_AUDIO_ONLY) }
-        assertPlaylist(index = 9, "Video") { it.copy(audioVideo = AUDIO_VIDEO_FILTER_VIDEO_ONLY) }
-        assertPlaylist(index = 10, "Released any time") { it.copy(filterHours = ANYTIME) }
-        assertPlaylist(index = 11, "Last day") { it.copy(filterHours = LAST_24_HOURS) }
-        assertPlaylist(index = 12, "Last 3 days") { it.copy(filterHours = LAST_3_DAYS) }
-        assertPlaylist(index = 13, "Last week") { it.copy(filterHours = LAST_WEEK) }
-        assertPlaylist(index = 14, "Last 2 weeks") { it.copy(filterHours = LAST_2_WEEKS) }
-        assertPlaylist(index = 15, "Last month") { it.copy(filterHours = LAST_MONTH) }
-        assertPlaylist(index = 16, "Any starred status") { it.copy(starred = false) }
-        assertPlaylist(index = 17, "Starred") { it.copy(starred = true) }
-        assertPlaylist(index = 18, "All podcasts") { it.copy(allPodcasts = true, podcastUuids = null) }
-        assertPlaylist(index = 19, "Selected podcasts") { it.copy(allPodcasts = false, podcastUuids = "id-1,id-2") }
-        assertPlaylist(index = 20, "Any duration") { it.copy(filterDuration = false, longerThan = 20, shorterThan = 40) }
-        assertPlaylist(index = 21, "Limited duration") { it.copy(filterDuration = true, longerThan = 50, shorterThan = 60) }
+        assertPlaylist(index = 21, "Default") { defaultPlaylist }
+        assertPlaylist(index = 20, "Unplayed") { it.copy(unplayed = true, partiallyPlayed = false, finished = false) }
+        assertPlaylist(index = 19, "In progress") { it.copy(unplayed = false, partiallyPlayed = true, finished = false) }
+        assertPlaylist(index = 18, "Played") { it.copy(unplayed = false, partiallyPlayed = false, finished = true) }
+        assertPlaylist(index = 17, "Any downloaded status") { it.copy(downloaded = true, notDownloaded = true, downloading = true) }
+        assertPlaylist(index = 16, "Downloaded") { it.copy(downloaded = true, notDownloaded = false, downloading = false) }
+        assertPlaylist(index = 15, "Not downloaded") { it.copy(downloaded = false, notDownloaded = true, downloading = true) }
+        assertPlaylist(index = 14, "Audio / Video") { it.copy(audioVideo = AUDIO_VIDEO_FILTER_ALL) }
+        assertPlaylist(index = 13, "Audio") { it.copy(audioVideo = AUDIO_VIDEO_FILTER_AUDIO_ONLY) }
+        assertPlaylist(index = 12, "Video") { it.copy(audioVideo = AUDIO_VIDEO_FILTER_VIDEO_ONLY) }
+        assertPlaylist(index = 11, "Released any time") { it.copy(filterHours = ANYTIME) }
+        assertPlaylist(index = 10, "Last day") { it.copy(filterHours = LAST_24_HOURS) }
+        assertPlaylist(index = 9, "Last 3 days") { it.copy(filterHours = LAST_3_DAYS) }
+        assertPlaylist(index = 8, "Last week") { it.copy(filterHours = LAST_WEEK) }
+        assertPlaylist(index = 7, "Last 2 weeks") { it.copy(filterHours = LAST_2_WEEKS) }
+        assertPlaylist(index = 6, "Last month") { it.copy(filterHours = LAST_MONTH) }
+        assertPlaylist(index = 5, "Any starred status") { it.copy(starred = false) }
+        assertPlaylist(index = 4, "Starred") { it.copy(starred = true) }
+        assertPlaylist(index = 3, "All podcasts") { it.copy(allPodcasts = true, podcastUuids = null) }
+        assertPlaylist(index = 2, "Selected podcasts") { it.copy(allPodcasts = false, podcastUuids = "id-1,id-2") }
+        assertPlaylist(index = 1, "Any duration") { it.copy(filterDuration = false, longerThan = 20, shorterThan = 40) }
+        assertPlaylist(index = 0, "Limited duration") { it.copy(filterDuration = true, longerThan = 50, shorterThan = 60) }
     }
 
     @Test
     fun createDefaultNewReleasesPlaylist() = runTest(testDispatcher) {
-        manager.upsertSmartPlaylist(SmartPlaylistDraft.NewReleases)
+        manager.insertSmartPlaylist(SmartPlaylistDraft.NewReleases)
         val playlists = playlistDao.observeSmartPlaylists().first()
 
         assertEquals(
@@ -725,7 +725,7 @@ class PlaylistManagerTest {
 
     @Test
     fun createDefaultInProgressPlaylist() = runTest(testDispatcher) {
-        manager.upsertSmartPlaylist(SmartPlaylistDraft.InProgress)
+        manager.insertSmartPlaylist(SmartPlaylistDraft.InProgress)
         val playlists = playlistDao.observeSmartPlaylists().first()
 
         assertEquals(

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/create/CreatePlaylistViewModel.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/create/CreatePlaylistViewModel.kt
@@ -154,7 +154,7 @@ class CreatePlaylistViewModel @AssistedInject constructor(
             rules = rules,
         )
         viewModelScope.launch {
-            val playlistUuid = playlistManager.upsertSmartPlaylist(draft)
+            val playlistUuid = playlistManager.insertSmartPlaylist(draft)
             _createdSmartPlaylistUuid.complete(playlistUuid)
         }
     }

--- a/modules/features/filters/src/test/kotlin/au/com/shiftyjelly/pocketcasts/playlists/create/FakePlaylistManager.kt
+++ b/modules/features/filters/src/test/kotlin/au/com/shiftyjelly/pocketcasts/playlists/create/FakePlaylistManager.kt
@@ -40,7 +40,7 @@ class FakePlaylistManager : PlaylistManager {
     override suspend fun deletePlaylist(uuid: String) = Unit
 
     val upsertSmartPlaylistTurbine = Turbine<SmartPlaylistDraft>(name = "upsertSmartPlaylist")
-    override suspend fun upsertSmartPlaylist(draft: SmartPlaylistDraft): String {
+    override suspend fun insertSmartPlaylist(draft: SmartPlaylistDraft): String {
         upsertSmartPlaylistTurbine.add(draft)
         return UUID.randomUUID().toString()
     }

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/PlaylistDao.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/PlaylistDao.kt
@@ -27,7 +27,7 @@ abstract class PlaylistDao {
     @Upsert
     abstract suspend fun upsertSmartPlaylists(playlists: List<SmartPlaylist>)
 
-    @Query("SELECT uuid FROM smart_playlists")
+    @Query("SELECT uuid FROM smart_playlists ORDER BY sortPosition ASC")
     abstract suspend fun getAllPlaylistUuids(): List<String>
 
     @Query("SELECT * FROM smart_playlists WHERE manual = 0 AND deleted = 0 AND draft = 0 AND uuid = :uuid")

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playlist/DefaultPlaylistsInitializater.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playlist/DefaultPlaylistsInitializater.kt
@@ -15,8 +15,8 @@ class DefaultPlaylistsInitializater @Inject constructor(
 
     suspend fun initialize(force: Boolean = false) = mutex.withLock {
         if (force || !settings.getBooleanForKey(CREATED_DEFAULT_PLAYLISTS_KEY, false)) {
-            playlistManager.upsertSmartPlaylist(SmartPlaylistDraft.NewReleases)
-            playlistManager.upsertSmartPlaylist(SmartPlaylistDraft.InProgress)
+            playlistManager.insertSmartPlaylist(SmartPlaylistDraft.InProgress)
+            playlistManager.insertSmartPlaylist(SmartPlaylistDraft.NewReleases)
             settings.setBooleanForKey(CREATED_DEFAULT_PLAYLISTS_KEY, true)
         }
     }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playlist/PlaylistManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playlist/PlaylistManager.kt
@@ -27,7 +27,7 @@ interface PlaylistManager {
 
     suspend fun deletePlaylist(uuid: String)
 
-    suspend fun upsertSmartPlaylist(draft: SmartPlaylistDraft): String
+    suspend fun insertSmartPlaylist(draft: SmartPlaylistDraft): String
 
     suspend fun updatePlaylistsOrder(sortedUuids: List<String>)
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playlist/PlaylistManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playlist/PlaylistManagerImpl.kt
@@ -143,7 +143,7 @@ class PlaylistManagerImpl @Inject constructor(
         playlistDao.markPlaylistAsDeleted(uuid)
     }
 
-    override suspend fun upsertSmartPlaylist(draft: SmartPlaylistDraft): String {
+    override suspend fun insertSmartPlaylist(draft: SmartPlaylistDraft): String {
         return appDatabase.withTransaction {
             val uuids = playlistDao.getAllPlaylistUuids()
             val uuid = if (draft === SmartPlaylistDraft.NewReleases) {
@@ -153,8 +153,11 @@ class PlaylistManagerImpl @Inject constructor(
             } else {
                 generateUniqueUuid(uuids)
             }
-            val playlist = draft.toSmartPlaylist(uuid, sortPosition = uuids.size + 1)
+            val playlist = draft.toSmartPlaylist(uuid, sortPosition = 1)
             playlistDao.upsertSmartPlaylist(playlist)
+            uuids.forEachIndexed { index, uuid ->
+                playlistDao.updateSortPosition(uuid, index + 2)
+            }
             uuid
         }
     }


### PR DESCRIPTION
## Description

This adds inserting new playlists to the top instead of to the bottom.

Context: p1754604672773389/1754589090.779989-slack-C093RV9N8DR

## Testing Instructions

1. Go to playlists page.
2. Create a new one.
3. Go back to the playlists page.
4. Your new playlist should be at the top.

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.