### PR TITLE
[Onboarding] Update intro carousel behavior

### DIFF
--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/OnboardingLoginOrSignUpPage.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/OnboardingLoginOrSignUpPage.kt
@@ -86,6 +86,8 @@ fun NewOnboardingGetStartedPage(
 ) {
     val pocketCastsTheme = MaterialTheme.theme
 
+    val trackingConsentRequired by viewModel.isTrackingConsentRequired.collectAsState(initial = false)
+
     CallOnce {
         viewModel.onShown(flow)
     }
@@ -114,6 +116,20 @@ fun NewOnboardingGetStartedPage(
             modifier = Modifier.padding(horizontal = 16.dp),
         )
         LogInButton(onClick = onLoginClick)
+
+        if (trackingConsentRequired &&
+            flow == OnboardingFlow.InitialOnboarding &&
+            FeatureFlag.isEnabled(Feature.APPSFLYER_ANALYTICS)
+        ) {
+            TrackingConsentDialog(
+                onAllow = {
+                    viewModel.updateTrackingConsent(true)
+                },
+                onAskAppNotToTrack = {
+                    viewModel.updateTrackingConsent(false)
+                },
+            )
+        }
     }
 }
 

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/components/CarouselAnimations.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/components/CarouselAnimations.kt
@@ -46,18 +46,18 @@ import au.com.shiftyjelly.pocketcasts.compose.theme
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
-import kotlin.time.Duration.Companion.seconds
-import kotlinx.coroutines.delay
 import au.com.shiftyjelly.pocketcasts.images.R as IR
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 @Composable
 fun BestAppAnimation(
-    itemDisplayDuration: Duration,
+    isAppearing: Boolean,
+    disappearAnimDuration: Duration,
     modifier: Modifier = Modifier,
 ) {
     AnimatedCarouselItemContainer(
-        itemDisplayDuration = itemDisplayDuration,
+        isAppearing = isAppearing,
+        disappearAnimDuration = disappearAnimDuration,
         modifier = modifier,
         title = stringResource(LR.string.onboarding_intro_carousel_best_app_title),
         content = {
@@ -81,11 +81,13 @@ fun BestAppAnimation(
 
 @Composable
 fun CustomizationIsInsaneAnimation(
-    itemDisplayDuration: Duration,
+    isAppearing: Boolean,
+    disappearAnimDuration: Duration,
     modifier: Modifier = Modifier,
 ) {
     AnimatedCarouselItemContainer(
-        itemDisplayDuration = itemDisplayDuration,
+        isAppearing = isAppearing,
+        disappearAnimDuration = disappearAnimDuration,
         modifier = modifier,
         title = stringResource(LR.string.onboarding_intro_carousel_customization_insane_title),
         content = {
@@ -119,11 +121,13 @@ fun CustomizationIsInsaneAnimation(
 
 @Composable
 fun OrganizingPodcastsAnimation(
-    itemDisplayDuration: Duration,
+    isAppearing: Boolean,
+    disappearAnimDuration: Duration,
     modifier: Modifier = Modifier,
 ) {
     AnimatedCarouselItemContainer(
-        itemDisplayDuration = itemDisplayDuration,
+        isAppearing = isAppearing,
+        disappearAnimDuration = disappearAnimDuration,
         modifier = modifier,
         title = stringResource(LR.string.onboarding_intro_carousel_organizing_podcasts_title),
         content = {
@@ -140,40 +144,36 @@ fun OrganizingPodcastsAnimation(
     )
 }
 
-private enum class AnimationState {
-    Invisible,
-    Appearing,
-    Disappearing,
-}
-
 @Composable
 private fun AnimatedCarouselItemContainer(
-    itemDisplayDuration: Duration,
     title: String,
+    isAppearing: Boolean,
     modifier: Modifier = Modifier,
     disappearAnimDuration: Duration = 300.milliseconds,
     appearAnimDuration: Duration = 600.milliseconds,
     subTitle: String = stringResource(LR.string.onboarding_intro_carousel_pc_user),
     content: @Composable ColumnScope.() -> Unit,
 ) {
-    var animationState by remember { mutableStateOf(AnimationState.Invisible) }
-
-    LaunchedEffect(itemDisplayDuration, disappearAnimDuration) {
-        animationState = AnimationState.Appearing
-        delay(itemDisplayDuration.inWholeMilliseconds - disappearAnimDuration.inWholeMilliseconds)
-        animationState = AnimationState.Disappearing
+    var isVisible by remember {
+        mutableStateOf(
+            !isAppearing,
+        )
     }
 
-    val transition = updateTransition(animationState)
+    LaunchedEffect(isVisible, isAppearing) {
+        isVisible = isAppearing
+    }
+
+    val transition = updateTransition(isVisible)
     val contentAlpha by transition.animateFloat(
         label = "contentAlpha",
         transitionSpec = {
             tween(
-                durationMillis = animationState.durationMillis(
+                durationMillis = isVisible.durationMillis(
                     appearAnimDuration = appearAnimDuration,
                     disappearAnimDuration = disappearAnimDuration,
                 ),
-                easing = animationState.easing,
+                easing = isVisible.easing,
             )
         },
     ) {
@@ -183,11 +183,11 @@ private fun AnimatedCarouselItemContainer(
         label = "contentYOffset",
         transitionSpec = {
             tween(
-                durationMillis = animationState.durationMillis(
+                durationMillis = isVisible.durationMillis(
                     appearAnimDuration = appearAnimDuration,
                     disappearAnimDuration = disappearAnimDuration,
                 ),
-                easing = animationState.easing,
+                easing = isVisible.easing,
             )
         },
     ) {
@@ -197,12 +197,12 @@ private fun AnimatedCarouselItemContainer(
         label = "mainTextAlpha",
         transitionSpec = {
             tween(
-                durationMillis = animationState.durationMillis(
+                durationMillis = isVisible.durationMillis(
                     appearAnimDuration = appearAnimDuration,
                     disappearAnimDuration = disappearAnimDuration,
                 ),
-                delayMillis = animationState.textAnimDelay(300.milliseconds),
-                easing = animationState.easing,
+                delayMillis = isVisible.textAnimDelay(300.milliseconds),
+                easing = isVisible.easing,
             )
         },
     ) {
@@ -212,12 +212,12 @@ private fun AnimatedCarouselItemContainer(
         label = "mainTextYOffset",
         transitionSpec = {
             tween(
-                durationMillis = animationState.durationMillis(
+                durationMillis = isVisible.durationMillis(
                     appearAnimDuration = appearAnimDuration,
                     disappearAnimDuration = disappearAnimDuration,
                 ),
-                delayMillis = animationState.textAnimDelay(300.milliseconds),
-                easing = animationState.easing,
+                delayMillis = isVisible.textAnimDelay(300.milliseconds),
+                easing = isVisible.easing,
             )
         },
     ) {
@@ -227,12 +227,12 @@ private fun AnimatedCarouselItemContainer(
         label = "secondaryTextAlpha",
         transitionSpec = {
             tween(
-                durationMillis = animationState.durationMillis(
+                durationMillis = isVisible.durationMillis(
                     appearAnimDuration = appearAnimDuration,
                     disappearAnimDuration = disappearAnimDuration,
                 ),
-                delayMillis = animationState.textAnimDelay(600.milliseconds),
-                easing = animationState.easing,
+                delayMillis = isVisible.textAnimDelay(600.milliseconds),
+                easing = isVisible.easing,
             )
         },
     ) {
@@ -242,12 +242,12 @@ private fun AnimatedCarouselItemContainer(
         label = "secondaryTextYOffset",
         transitionSpec = {
             tween(
-                durationMillis = animationState.durationMillis(
+                durationMillis = isVisible.durationMillis(
                     appearAnimDuration = appearAnimDuration,
                     disappearAnimDuration = disappearAnimDuration,
                 ),
-                delayMillis = animationState.textAnimDelay(600.milliseconds),
-                easing = animationState.easing,
+                delayMillis = isVisible.textAnimDelay(600.milliseconds),
+                easing = isVisible.easing,
             )
         },
     ) {
@@ -308,68 +308,39 @@ private fun AnimatedCarouselItemContainer(
     }
 }
 
-private val AnimationState.alpha
-    get() = when (this) {
-        AnimationState.Appearing -> 1f
-        AnimationState.Invisible,
-        AnimationState.Disappearing,
-        -> 0f
-    }
+private val Boolean.alpha
+    get() = if (this) 1f else 0f
 
-private val AnimationState.textOffsetY
-    get() = when (this) {
-        AnimationState.Appearing -> (-6).dp
-        AnimationState.Invisible,
-        AnimationState.Disappearing,
-        -> 6.dp
-    }
+private val Boolean.textOffsetY
+    get() = if (this) (-6).dp else 6.dp
 
-private val AnimationState.contentOffsetY
-    get() = when (this) {
-        AnimationState.Appearing -> (-16).dp
-        AnimationState.Invisible,
-        AnimationState.Disappearing,
-        -> 16.dp
-    }
+private val Boolean.contentOffsetY
+    get() = if (this) (-16).dp else 16.dp
 
-private val AnimationState.easing
-    get() = when (this) {
-        AnimationState.Appearing -> FastOutSlowInEasing
-        AnimationState.Invisible,
-        AnimationState.Disappearing,
-        -> FastOutLinearInEasing
-    }
+private val Boolean.easing
+    get() = if (this) FastOutSlowInEasing else FastOutLinearInEasing
 
-private fun AnimationState.durationMillis(
+private fun Boolean.durationMillis(
     appearAnimDuration: Duration,
     disappearAnimDuration: Duration,
-) = when (this) {
-    AnimationState.Invisible -> 0
-    AnimationState.Appearing -> appearAnimDuration.inWholeMilliseconds.toInt()
-    AnimationState.Disappearing -> disappearAnimDuration.inWholeMilliseconds.toInt()
-}
+) = if (this) appearAnimDuration.inWholeMilliseconds.toInt() else disappearAnimDuration.inWholeMilliseconds.toInt()
 
-private fun AnimationState.textAnimDelay(additionalDelay: Duration) = when (this) {
-    AnimationState.Appearing -> additionalDelay.inWholeMilliseconds.toInt()
-    AnimationState.Invisible,
-    AnimationState.Disappearing,
-    -> 0
-}
+private fun Boolean.textAnimDelay(additionalDelay: Duration) = if (this) additionalDelay.inWholeMilliseconds.toInt() else 0
 
 @Preview
 @Composable
 private fun PreviewBestAppAnim() = AppThemeWithBackground(Theme.ThemeType.LIGHT) {
-    BestAppAnimation(modifier = Modifier.fillMaxWidth(), itemDisplayDuration = 5.seconds)
+    BestAppAnimation(modifier = Modifier.fillMaxWidth(), isAppearing = false, disappearAnimDuration = 300.milliseconds)
 }
 
 @Preview
 @Composable
 private fun PreviewCustomizationAppAnim() = AppThemeWithBackground(Theme.ThemeType.LIGHT) {
-    CustomizationIsInsaneAnimation(modifier = Modifier.fillMaxWidth(), itemDisplayDuration = 5.seconds)
+    CustomizationIsInsaneAnimation(modifier = Modifier.fillMaxWidth(), isAppearing = false, disappearAnimDuration = 300.milliseconds)
 }
 
 @Preview
 @Composable
 private fun PreviewOrganizingAppAnim() = AppThemeWithBackground(Theme.ThemeType.LIGHT) {
-    OrganizingPodcastsAnimation(modifier = Modifier.fillMaxWidth(), itemDisplayDuration = 5.seconds)
+    OrganizingPodcastsAnimation(modifier = Modifier.fillMaxWidth(), isAppearing = false, disappearAnimDuration = 300.milliseconds)
 }

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/components/FeatureCarousel.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/components/FeatureCarousel.kt
@@ -5,28 +5,38 @@ import androidx.compose.animation.Crossfade
 import androidx.compose.animation.core.FastOutLinearInEasing
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.State
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.produceState
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import au.com.shiftyjelly.pocketcasts.compose.AppThemeWithBackground
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+import kotlin.math.max
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
-import kotlinx.coroutines.delay
 
 private const val CAROUSEL_ITEM_COUNT = 3
 
@@ -35,9 +45,10 @@ fun FeatureCarousel(
     modifier: Modifier = Modifier,
 ) {
     val delayBetweenCycles = 4.seconds
-    val activeItemIndex by cyclicCounter(
+    val (activeItemIndex, sendEvent) = storyCoordinator(
         cycleRange = 0 until CAROUSEL_ITEM_COUNT,
         delayBetweenCycles = delayBetweenCycles,
+        isPerpetual = false,
     )
 
     Column(
@@ -45,44 +56,119 @@ fun FeatureCarousel(
     ) {
         CarouselActiveItemIndicatorBar(
             itemCount = CAROUSEL_ITEM_COUNT,
-            activeItemIndex = activeItemIndex,
+            activeItemIndex = activeItemIndex.value,
         )
-        Crossfade(
-            targetState = activeItemIndex,
-            modifier = Modifier.fillMaxSize(),
-        ) { index ->
-            when (index) {
-                0 -> BestAppAnimation(
-                    modifier = Modifier.padding(top = 64.dp),
-                    itemDisplayDuration = delayBetweenCycles,
-                )
+        Box {
+            Crossfade(
+                targetState = activeItemIndex.value,
+                modifier = Modifier.fillMaxSize(),
+            ) { index ->
+                when (index) {
+                    0 -> BestAppAnimation(
+                        modifier = Modifier.padding(top = 64.dp),
+                        itemDisplayDuration = delayBetweenCycles,
+                    )
 
-                1 -> CustomizationIsInsaneAnimation(
-                    modifier = Modifier.padding(top = 24.dp),
-                    itemDisplayDuration = delayBetweenCycles,
-                )
+                    1 -> CustomizationIsInsaneAnimation(
+                        modifier = Modifier.padding(top = 24.dp),
+                        itemDisplayDuration = delayBetweenCycles,
+                    )
 
-                2 -> OrganizingPodcastsAnimation(
-                    modifier = Modifier.padding(top = 24.dp),
-                    itemDisplayDuration = delayBetweenCycles,
-                )
+                    2 -> OrganizingPodcastsAnimation(
+                        modifier = Modifier.padding(top = 24.dp),
+                        itemDisplayDuration = delayBetweenCycles,
+                    )
+                }
             }
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth(.2f)
+                    .fillMaxHeight()
+                    .align(Alignment.CenterStart)
+                    .clickable(
+                        indication = null,
+                        interactionSource = remember { MutableInteractionSource() },
+                        role = Role.Button,
+                        onClick = {
+                            sendEvent(CounterEvent.Decrement)
+                        },
+                    )
+            )
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth(.2f)
+                    .fillMaxHeight()
+                    .align(Alignment.CenterEnd)
+                    .clickable(
+                        indication = null,
+                        interactionSource = remember { MutableInteractionSource() },
+                        role = Role.Button,
+                        onClick = {
+                            sendEvent(CounterEvent.Increment)
+                        },
+                    )
+            )
         }
     }
 }
 
+sealed interface CounterEvent {
+    data object Increment : CounterEvent
+    data object Decrement : CounterEvent
+    data object InternalTick: CounterEvent
+}
+
 @Composable
-fun cyclicCounter(
+fun storyCoordinator(
     cycleRange: IntRange,
     delayBetweenCycles: Duration = 3.seconds,
     isPerpetual: Boolean = true,
-): State<Int> {
-    return produceState(cycleRange.start) {
-        while (true) {
-            delay(delayBetweenCycles.inWholeMilliseconds)
-            val nextValue = (value + 1) % cycleRange.count()
-            if (nextValue == 0 && !isPerpetual) break
-            value = nextValue
+): Pair<State<Int>, (CounterEvent) -> Unit> {
+    val index = remember { mutableIntStateOf(cycleRange.start) }
+    val scope = rememberCoroutineScope()
+    val events = remember { Channel<CounterEvent>(Channel.BUFFERED) }
+
+    LaunchedEffect(cycleRange, delayBetweenCycles, isPerpetual) {
+        fun startTicker() = launch {
+            while (isActive) {
+                delay(delayBetweenCycles.inWholeMilliseconds)
+                events.send(CounterEvent.InternalTick)
+            }
+        }
+
+        var ticker = startTicker()
+
+        for (event in events) {
+            val change = when (event) {
+                CounterEvent.InternalTick,
+                CounterEvent.Increment -> 1
+                CounterEvent.Decrement -> -1
+            }
+            val newValue = max(0, (index.intValue + change) % cycleRange.count())
+
+            val allowedValue = if (newValue == 0) {
+                if (isPerpetual || event is CounterEvent.Decrement) {
+                    ticker.cancel()
+                    0
+                } else {
+                    index.intValue
+                }
+            } else {
+                newValue
+            }
+
+             if (event !is CounterEvent.InternalTick) {
+                ticker.cancel()
+                ticker = startTicker()
+            }
+
+            index.intValue = allowedValue
+        }
+    }
+
+    return index to {
+        scope.launch {
+            events.send(it)
         }
     }
 }


### PR DESCRIPTION
## Description
This PR addresses the latest design feedbacks on the carousel behavior.
We now support manual stepping when the user taps the horizontal edges of the carosel (left edge steps to previous page, right edge steps to next one)
Also, the carousel no longer infinitely loops, it will stop when reaches the last item.
I've simplified the animation states of `CarouselAnimations` and created a state machine for the carousel to contain all the stepping logic.

Figma + questions: PviUP0aiZctOprDuuYRwpb-fi-5076_9088

Related to https://linear.app/a8c/issue/PCDROID-83/feature-carousel

## Testing Instructions
1. Build a `debug` version => FF is enabled in debug builds by default
2. Launch the app
- [x] play with the intro carousel

## Screenshots or Screencast 

https://github.com/user-attachments/assets/11a999ff-c116-4046-a969-c89e5102c56a



## Checklist
- [ ] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] ~I have considered whether it makes sense to add tests for my changes~
- [ ] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [ ] ~Any jetpack compose components I added or changed are covered by compose previews~
- [ ] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~
 
