### PR TITLE
Fix transcript fade on podcaster transcripts

### DIFF
--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/sharing/SharingClientTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/sharing/SharingClientTest.kt
@@ -1044,6 +1044,7 @@ class SharingClientTest {
     fun shareTranscript() = runTest {
         val transcriptText = "This is a sample transcript content for testing purposes."
         val request = SharingRequest.transcript(
+            podcastUuid = "podcast-uuid",
             episodeUuid = "episode-uuid",
             episodeTitle = "Episode Title",
             transcript = transcriptText,

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/PlayerHeaderFragment.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/view/PlayerHeaderFragment.kt
@@ -930,7 +930,7 @@ class PlayerHeaderFragment :
                     )
                     transcriptViewModel.track(AnalyticsEvent.TRANSCRIPT_SHOWN, properties)
                 },
-                onShowTransciptPaywall = {
+                onShowTranscriptPaywall = {
                     transcriptViewModel.track(AnalyticsEvent.TRANSCRIPT_GENERATED_PAYWALL_SHOWN)
                 },
                 toolbarTrailingContent = { toolbarColors ->

--- a/modules/features/transcripts/src/main/kotlin/au/com/shiftyjelly/pocketcasts/transcripts/TranscriptFragment.kt
+++ b/modules/features/transcripts/src/main/kotlin/au/com/shiftyjelly/pocketcasts/transcripts/TranscriptFragment.kt
@@ -1,31 +1,21 @@
 package au.com.shiftyjelly.pocketcasts.transcripts
 
-import android.content.Intent
 import android.os.Bundle
 import android.os.Parcelable
 import android.view.LayoutInflater
 import android.view.ViewGroup
-import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.material.Icon
-import androidx.compose.material.IconButton
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Share
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.unit.dp
-import androidx.core.content.FileProvider
 import androidx.core.content.res.ResourcesCompat
 import androidx.core.os.BundleCompat
 import androidx.core.os.bundleOf
@@ -44,19 +34,15 @@ import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingUpgradeSourc
 import au.com.shiftyjelly.pocketcasts.transcripts.ui.ToolbarColors
 import au.com.shiftyjelly.pocketcasts.transcripts.ui.TranscriptPage
 import au.com.shiftyjelly.pocketcasts.transcripts.ui.TranscriptShareButton
-import au.com.shiftyjelly.pocketcasts.utils.FileUtil
 import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
 import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
 import au.com.shiftyjelly.pocketcasts.views.fragments.BaseDialogFragment
 import dagger.hilt.android.AndroidEntryPoint
 import dagger.hilt.android.lifecycle.withCreationCallback
-import java.io.File
 import javax.inject.Inject
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 import kotlinx.parcelize.Parcelize
-import timber.log.Timber
-import au.com.shiftyjelly.pocketcasts.localization.R as LR
 import au.com.shiftyjelly.pocketcasts.ui.R as UR
 
 @AndroidEntryPoint
@@ -136,7 +122,7 @@ class TranscriptFragment : BaseDialogFragment() {
                     )
                     viewModel.track(AnalyticsEvent.TRANSCRIPT_SHOWN, properties)
                 },
-                onShowTransciptPaywall = {
+                onShowTranscriptPaywall = {
                     viewModel.track(AnalyticsEvent.TRANSCRIPT_GENERATED_PAYWALL_SHOWN)
                 },
                 toolbarTrailingContent = { toolbarColors ->

--- a/modules/features/transcripts/src/main/kotlin/au/com/shiftyjelly/pocketcasts/transcripts/TranscriptViewModel.kt
+++ b/modules/features/transcripts/src/main/kotlin/au/com/shiftyjelly/pocketcasts/transcripts/TranscriptViewModel.kt
@@ -211,6 +211,7 @@ class TranscriptViewModel @AssistedInject constructor(
 
             val request = SharingRequest
                 .transcript(
+                    podcastUuid = episode?.podcastUuid,
                     episodeUuid = transcript.episodeUuid,
                     episodeTitle = episode?.title.orEmpty(),
                     transcript = text,

--- a/modules/features/transcripts/src/main/kotlin/au/com/shiftyjelly/pocketcasts/transcripts/ui/TranscriptLines.kt
+++ b/modules/features/transcripts/src/main/kotlin/au/com/shiftyjelly/pocketcasts/transcripts/ui/TranscriptLines.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -95,6 +96,8 @@ internal fun TranscriptLines(
                                 theme = theme,
                                 modifier = Modifier.padding(bottom = 16.dp),
                             )
+                        } else {
+                            Spacer(Modifier.height(8.dp))
                         }
                     }
                     itemsIndexed(transcript.entries) { index, entry ->

--- a/modules/features/transcripts/src/main/kotlin/au/com/shiftyjelly/pocketcasts/transcripts/ui/TranscriptPage.kt
+++ b/modules/features/transcripts/src/main/kotlin/au/com/shiftyjelly/pocketcasts/transcripts/ui/TranscriptPage.kt
@@ -36,7 +36,7 @@ fun TranscriptPage(
     onHideSearchBar: () -> Unit,
     onClickSubscribe: () -> Unit,
     onShowTranscript: (Transcript) -> Unit,
-    onShowTransciptPaywall: (Transcript) -> Unit,
+    onShowTranscriptPaywall: (Transcript) -> Unit,
     modifier: Modifier = Modifier,
     toolbarPadding: PaddingValues = PaddingValues(0.dp),
     transcriptPadding: PaddingValues = PaddingValues(0.dp),
@@ -100,7 +100,7 @@ fun TranscriptPage(
     ShowTranscriptEffect(
         uiState = uiState,
         onShowTranscript = onShowTranscript,
-        onShowTransciptPaywall = onShowTransciptPaywall,
+        onShowTranscriptPaywall = onShowTranscriptPaywall,
     )
 }
 
@@ -178,12 +178,12 @@ private fun ScrollToItemEffect(
 private fun ShowTranscriptEffect(
     uiState: UiState,
     onShowTranscript: (Transcript) -> Unit,
-    onShowTransciptPaywall: (Transcript) -> Unit,
+    onShowTranscriptPaywall: (Transcript) -> Unit,
 ) {
     val transcript = (uiState.transcriptState as? TranscriptState.Loaded)?.transcript
     if (transcript != null) {
         val isPaywallVisible = uiState.isPaywallVisible
-        LaunchedEffect(transcript, isPaywallVisible, onShowTranscript, onShowTransciptPaywall) {
+        LaunchedEffect(transcript, isPaywallVisible, onShowTranscript, onShowTranscriptPaywall) {
             // This delay is necessary due to how transcript loading works in the player.
             //
             // We trigger the page open animation and transcript loading at the same time.
@@ -201,7 +201,7 @@ private fun ShowTranscriptEffect(
             delay(100)
 
             if (isPaywallVisible) {
-                onShowTransciptPaywall(transcript)
+                onShowTranscriptPaywall(transcript)
             } else {
                 onShowTranscript(transcript)
             }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/transcript/TranscriptManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/transcript/TranscriptManagerImpl.kt
@@ -94,7 +94,7 @@ class TranscriptManagerImpl @Inject constructor(
         val (parser, transcript) = parserWithTranscript
         val podcastUuid = episodeManager.findByUuid(transcript.episodeUuid)?.podcastUuid
 
-        return runCatching { transcriptService.getTranscriptOrThrow(transcript.url, CacheControl.FORCE_NETWORK) }
+        return runCatching { transcriptService.getTranscriptOrThrow(transcript.url) }
             .recoverCatching { transcriptService.getTranscriptOrThrow(transcript.url, CacheControl.FORCE_CACHE) }
             .mapCatching { body ->
                 val transcriptEntries = withContext(Dispatchers.Default) {

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/transcript/TranscriptManagerTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/transcript/TranscriptManagerTest.kt
@@ -372,7 +372,7 @@ private class TestParser(
 private class TestTranscriptService : TranscriptService {
     var shouldThrow = false
 
-    override suspend fun getTranscriptOrThrow(url: String, cacheControl: CacheControl): ResponseBody {
+    override suspend fun getTranscriptOrThrow(url: String, cacheControl: CacheControl?): ResponseBody {
         return if (shouldThrow) {
             error("Test exception")
         } else {

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/podcast/TranscriptService.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/podcast/TranscriptService.kt
@@ -10,6 +10,6 @@ interface TranscriptService {
     @GET
     suspend fun getTranscriptOrThrow(
         @Url url: String,
-        @Header("Cache-Control") cacheControl: CacheControl,
+        @Header("Cache-Control") cacheControl: CacheControl? = null,
     ): ResponseBody
 }

--- a/modules/services/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/SharingClient.kt
+++ b/modules/services/sharing/src/main/kotlin/au/com/shiftyjelly/pocketcasts/sharing/SharingClient.kt
@@ -440,11 +440,14 @@ data class SharingRequest internal constructor(
             .addAnalyticsProperty("year", year.value)
 
         fun transcript(
+            podcastUuid: String?,
             episodeUuid: String,
             episodeTitle: String,
             transcript: String,
         ) = Builder(Data.Transcript(episodeUuid, episodeTitle, transcript))
             .setAnalyticsEvent(AnalyticsEvent.TRANSCRIPT_SHARED)
+            .addAnalyticsProperty("podcast_uuid", podcastUuid.orEmpty())
+            .addAnalyticsProperty("episode_uuid", episodeUuid)
     }
 
     class Builder internal constructor(


### PR DESCRIPTION
## Description

This includes the following changes:

- With the podcasters' transcripts, the fade was always hiding the header. I caused this when I moved the generated transcript warning into the list.
- Every time the episode dialog was opened, a server call to get the transcript would happen, causing a delay in displaying the view transcript button. 
- Added missing analytics properties for the share transcript button.
- Fixed some minor typos.

## Testing Instructions

#### Testing the fade issue
- Go to a podcast that has their own transcripts. For example The Rework Podcast.
- Tap on an episode row and the "View transcript" button.
- ✅  Verify the first line of the transcript is not hidden by the fade. 

#### Testing the network cache
- Go to a podcast with transcripts.
- Tap on an episode row that you haven't been to before but recent enough it has a transcript.
- ✅ Notice there is a delay before the "View transcript" button appears.
- Close the episode dialog and open it again.
- ✅ Verify there is no delay showing the "View transcript" button.
- Turn on airplane mode.
- Close the episode dialog and open it again.
- ✅ Verify the "View transcript" button is shown.

## Screenshots 

| Before | After |
| --- | --- |
| <img width="1198" height="2531" alt="Screenshot_20250819_094515" src="https://github.com/user-attachments/assets/7e3ec7f0-4f3f-4cfd-a7cd-996738852c5d" /> | <img width="1198" height="2531" alt="Screenshot_20250819_093537" src="https://github.com/user-attachments/assets/4fce1957-0ab1-477a-abde-b6a76586f3cc" /> | 

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack
