### PR TITLE
[Onboarding] Animate carousel progress indicators

### DIFF
--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/components/FeatureCarousel.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/components/FeatureCarousel.kt
@@ -64,6 +64,8 @@ fun FeatureCarousel(
         modifier = modifier.padding(top = 11.dp),
     ) {
         CarouselActiveItemIndicatorBar(
+            modifier = Modifier.fillMaxWidth()
+                .padding(horizontal = 12.dp),
             itemCount = CAROUSEL_ITEM_COUNT,
             activeItemIndex = activeItem.value.selectedIndex,
             pageShowDuration = ITEM_SHOW_DURATION,

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/components/FeatureCarousel.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/components/FeatureCarousel.kt
@@ -1,8 +1,8 @@
 package au.com.shiftyjelly.pocketcasts.account.onboarding.components
 
-import androidx.compose.animation.Animatable
 import androidx.compose.animation.Crossfade
-import androidx.compose.animation.core.FastOutLinearInEasing
+import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.LinearEasing
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
@@ -19,11 +19,15 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.State
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.produceState
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.tooling.preview.Preview
@@ -62,6 +66,7 @@ fun FeatureCarousel(
         CarouselActiveItemIndicatorBar(
             itemCount = CAROUSEL_ITEM_COUNT,
             activeItemIndex = activeItem.value.selectedIndex,
+            pageDuration = delayBetweenCycles,
         )
         Box {
             Crossfade(
@@ -208,16 +213,36 @@ fun carouselCoordinator(
 private fun CarouselActiveItemIndicatorBar(
     itemCount: Int,
     activeItemIndex: Int,
+    pageDuration: Duration,
     modifier: Modifier = Modifier,
 ) {
+    var progressPercentAnim by remember(activeItemIndex) { mutableStateOf(Animatable(0f)) }
+
+    LaunchedEffect(progressPercentAnim, pageDuration) {
+        progressPercentAnim.animateTo(
+            targetValue = 1f,
+            animationSpec = tween(
+                easing = LinearEasing,
+                durationMillis = pageDuration.inWholeMilliseconds.toInt(),
+            ),
+        )
+    }
+
     Row(
         modifier = modifier,
         horizontalArrangement = Arrangement.spacedBy(4.dp),
     ) {
         (0 until itemCount).forEach { index ->
             CarouselActiveItemIndicator(
+                index = index,
                 modifier = Modifier.weight(1f),
-                isActive = activeItemIndex == index,
+                progressPercent = if (index < activeItemIndex) {
+                    1f
+                } else if (index == activeItemIndex) {
+                    progressPercentAnim.value
+                } else {
+                    0f
+                },
             )
         }
     }
@@ -225,23 +250,24 @@ private fun CarouselActiveItemIndicatorBar(
 
 @Composable
 private fun CarouselActiveItemIndicator(
-    isActive: Boolean,
+    progressPercent: Float,
+    index: Int,
     modifier: Modifier = Modifier,
     activeColor: Color = Color(0xff5B5B5B),
     inactiveColor: Color = Color(0xffD9D9D9),
 ) {
-    val colorAnim = remember { Animatable(if (isActive) activeColor else inactiveColor) }
-    LaunchedEffect(isActive) {
-        colorAnim.animateTo(
-            targetValue = if (isActive) activeColor else inactiveColor,
-            animationSpec = tween(durationMillis = 200, easing = FastOutLinearInEasing),
-        )
-    }
-
+    val normalizedProgress = progressPercent.coerceIn(0f, 1f)
     Box(
         modifier = modifier
             .height(4.dp)
-            .background(color = colorAnim.value),
+            .background(
+                brush = Brush.horizontalGradient(
+                    0f to activeColor,
+                    normalizedProgress to activeColor,
+                    normalizedProgress to inactiveColor,
+                    1f to inactiveColor,
+                ),
+            ),
     )
 }
 

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/components/FeatureCarousel.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/components/FeatureCarousel.kt
@@ -95,7 +95,7 @@ fun FeatureCarousel(
             }
             Box(
                 modifier = Modifier
-                    .fillMaxWidth(.2f)
+                    .fillMaxWidth(.5f)
                     .fillMaxHeight()
                     .align(Alignment.CenterStart)
                     .clickable(
@@ -109,7 +109,7 @@ fun FeatureCarousel(
             )
             Box(
                 modifier = Modifier
-                    .fillMaxWidth(.2f)
+                    .fillMaxWidth(.5f)
                     .fillMaxHeight()
                     .align(Alignment.CenterEnd)
                     .clickable(

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/components/FeatureCarousel.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/components/FeatureCarousel.kt
@@ -47,15 +47,15 @@ import kotlinx.coroutines.selects.select
 
 private const val CAROUSEL_ITEM_COUNT = 3
 private val DISAPPEAR_DELAY = 300.milliseconds
+private val ITEM_SHOW_DURATION = 7.seconds
 
 @Composable
 fun FeatureCarousel(
     modifier: Modifier = Modifier,
 ) {
-    val delayBetweenCycles = 4.seconds
     val (activeItem, sendEvent) = carouselCoordinator(
         cycleRange = 0 until CAROUSEL_ITEM_COUNT,
-        delayBetweenCycles = delayBetweenCycles,
+        timeBetweenCycles = ITEM_SHOW_DURATION,
         isPerpetual = false,
         disappearDuration = DISAPPEAR_DELAY,
     )
@@ -66,7 +66,7 @@ fun FeatureCarousel(
         CarouselActiveItemIndicatorBar(
             itemCount = CAROUSEL_ITEM_COUNT,
             activeItemIndex = activeItem.value.selectedIndex,
-            pageDuration = delayBetweenCycles,
+            pageShowDuration = ITEM_SHOW_DURATION,
         )
         Box {
             Crossfade(
@@ -140,7 +140,7 @@ data class CarouselState(
 fun carouselCoordinator(
     cycleRange: IntRange,
     disappearDuration: Duration,
-    delayBetweenCycles: Duration = 3.seconds,
+    timeBetweenCycles: Duration = 3.seconds,
     isPerpetual: Boolean = true,
 ): Pair<State<CarouselState>, (CarouselEvent) -> Unit> {
     val scope = rememberCoroutineScope()
@@ -149,7 +149,7 @@ fun carouselCoordinator(
     val state = produceState(
         initialValue = CarouselState(cycleRange.first, isAppearing = true),
         cycleRange,
-        delayBetweenCycles,
+        timeBetweenCycles,
         isPerpetual,
         disappearDuration,
     ) {
@@ -157,7 +157,7 @@ fun carouselCoordinator(
 
         while (isActive) {
             val event: CarouselEvent? = select {
-                onTimeout(delayBetweenCycles) { CarouselEvent.Next }
+                onTimeout(timeBetweenCycles) { CarouselEvent.Next }
                 events.onReceive {
                     it
                 }
@@ -213,17 +213,17 @@ fun carouselCoordinator(
 private fun CarouselActiveItemIndicatorBar(
     itemCount: Int,
     activeItemIndex: Int,
-    pageDuration: Duration,
+    pageShowDuration: Duration,
     modifier: Modifier = Modifier,
 ) {
     var progressPercentAnim by remember(activeItemIndex) { mutableStateOf(Animatable(0f)) }
 
-    LaunchedEffect(progressPercentAnim, pageDuration) {
+    LaunchedEffect(progressPercentAnim, pageShowDuration) {
         progressPercentAnim.animateTo(
             targetValue = 1f,
             animationSpec = tween(
                 easing = LinearEasing,
-                durationMillis = pageDuration.inWholeMilliseconds.toInt(),
+                durationMillis = pageShowDuration.inWholeMilliseconds.toInt(),
             ),
         )
     }


### PR DESCRIPTION
## Description
Design has requested to animate the carousel index indicator similarly to Instagram.

> ... we should animate the gray bars on top, same as Instagram stories
They fill up as the time for the next story progresses

Context: p1755525987234659-slack-C0932TFPUDC

## Testing Instructions
1. Build and install `debug` variant
2. Observe the progress indicators on the landing page

## Screenshots or Screencast 

https://github.com/user-attachments/assets/b9e0a28c-73e1-448a-b3fa-21db49345604



## Checklist
- [ ] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] ~I have considered whether it makes sense to add tests for my changes~
- [ ] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [ ] ~Any jetpack compose components I added or changed are covered by compose previews~
- [ ] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~
 
