### PR TITLE
Sync device using Protobuf

### DIFF
--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/refresh/RefreshPodcastsThread.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/refresh/RefreshPodcastsThread.kt
@@ -260,6 +260,7 @@ class RefreshPodcastsThread(
                 episodeManager = entryPoint.episodeManager(),
                 folderManager = entryPoint.folderManager(),
                 playbackManager = entryPoint.playbackManager(),
+                statsManager = entryPoint.statsManager(),
                 appDatabase = entryPoint.appDatabase(),
                 settings = entryPoint.settings(),
             )

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/data/DeviceSync.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/data/DeviceSync.kt
@@ -34,7 +34,7 @@ internal class DeviceSync(
                         timeListened = int64Value { value = statsManager.totalListeningTimeSecs }
                         timesStartedAt = int64Value { value = statsManager.statsStartTimeSecs }
                     }
-                }
+                },
             )
         }
     }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/data/DeviceSync.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/data/DeviceSync.kt
@@ -1,0 +1,43 @@
+package au.com.shiftyjelly.pocketcasts.repositories.sync.data
+
+import au.com.shiftyjelly.pocketcasts.preferences.Settings
+import au.com.shiftyjelly.pocketcasts.repositories.user.StatsManager
+import com.google.protobuf.int32Value
+import com.google.protobuf.int64Value
+import com.google.protobuf.stringValue
+import com.pocketcasts.service.api.Record
+import com.pocketcasts.service.api.record
+import com.pocketcasts.service.api.syncUserDevice
+
+internal class DeviceSync(
+    private val statsManager: StatsManager,
+    private val settings: Settings,
+) {
+    suspend fun syncStats() {
+        statsManager.cacheMergedStats()
+        statsManager.setSyncStatus(true)
+    }
+
+    fun incrementalData(): List<Record> {
+        return if (statsManager.isSynced(settings) || statsManager.isEmpty) {
+            emptyList()
+        } else {
+            listOf(
+                record {
+                    device = syncUserDevice {
+                        deviceId = stringValue { value = settings.getUniqueDeviceId() }
+                        deviceType = AndroidDeviceType
+                        timeSilenceRemoval = int64Value { value = statsManager.timeSavedSilenceRemovalSecs }
+                        timeSkipping = int64Value { value = statsManager.timeSavedSkippingSecs }
+                        timeIntroSkipping = int64Value { value = statsManager.timeSavedSkippingIntroSecs }
+                        timeVariableSpeed = int64Value { value = statsManager.timeSavedVariableSpeedSecs }
+                        timeListened = int64Value { value = statsManager.totalListeningTimeSecs }
+                        timesStartedAt = int64Value { value = statsManager.statsStartTimeSecs }
+                    }
+                }
+            )
+        }
+    }
+}
+
+private val AndroidDeviceType = int32Value { value = 2 }


### PR DESCRIPTION
## Description

This is continuation of migration described in #4390.

Relates to PCDROID-119

## Testing Instructions

I don't really understand this behavior and how it works. I just copied the logic from the `PodcastSyncProcess`.

1. Enable the proto syncing feature flag.
2. Listen to something with an increased speed to x5.
3. Pause it after a minute or so.
4. Go to stats from the profile tab.
5. Sync your devices.
6. The other device should reflect the changes.

The current syncing code, which I reused here, has cache stats function:

https://github.com/Automattic/pocket-casts-android/blob/ceb9b511acda8c8429c0f9e3632aab860001bf56/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/PodcastSyncProcess.kt#L641-L644

Which is called during full and incremental sync:

https://github.com/Automattic/pocket-casts-android/blob/ceb9b511acda8c8429c0f9e3632aab860001bf56/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/PodcastSyncProcess.kt#L166-L168

https://github.com/Automattic/pocket-casts-android/blob/ceb9b511acda8c8429c0f9e3632aab860001bf56/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/PodcastSyncProcess.kt#L636-L638

And it also contributes its stats to the incremental changes:

https://github.com/Automattic/pocket-casts-android/blob/ceb9b511acda8c8429c0f9e3632aab860001bf56/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/PodcastSyncProcess.kt#L455-L484

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.