### PR TITLE
Add Up Next syncing to new sync

### DIFF
--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/refresh/RefreshPodcastsThread.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/refresh/RefreshPodcastsThread.kt
@@ -263,6 +263,7 @@ class RefreshPodcastsThread(
                 statsManager = entryPoint.statsManager(),
                 appDatabase = entryPoint.appDatabase(),
                 settings = entryPoint.settings(),
+                context = context,
             )
             val result = runBlocking {
                 process.sync()

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/data/DataSyncProcess.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/data/DataSyncProcess.kt
@@ -144,12 +144,6 @@ class DataSyncProcess(
         }
     }
 
-    private suspend fun syncSettings(lastSyncTime: Instant) {
-        logProcess("settings") {
-            SyncSettingsTask.run(settings, lastSyncTime, syncManager).getOrThrow()
-        }
-    }
-
     private suspend fun syncUpNext() {
         logProcess("up-next") {
             val operation = UpNextSyncWorker.enqueue(syncManager, context)
@@ -170,6 +164,12 @@ class DataSyncProcess(
                     else -> logInfo("Unexpected Up Next sync state: $state")
                 }
             }
+        }
+    }
+
+    private suspend fun syncSettings(lastSyncTime: Instant) {
+        logProcess("settings") {
+            SyncSettingsTask.run(settings, lastSyncTime, syncManager).getOrThrow()
         }
     }
 

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/data/DataSyncProcess.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/data/DataSyncProcess.kt
@@ -62,12 +62,12 @@ class DataSyncProcess(
                 } else {
                     val lastSyncTime = getLastSyncTime()
                     val newSyncTime = syncData(lastSyncTime)
+                    settings.setLastModified(newSyncTime.toString())
                     syncSettings(lastSyncTime)
                     Timber.d("Sync cloud files")
                     Timber.d("Sync broken files")
                     Timber.d("Sync playback history")
                     Timber.d("Sync podcast ratings")
-                    settings.setLastModified(newSyncTime.toString())
                 }
             }
         }
@@ -146,7 +146,7 @@ class DataSyncProcess(
 
     private suspend fun syncSettings(lastSyncTime: Instant) {
         logProcess("settings") {
-            SyncSettingsTask.run(settings, lastSyncTime, syncManager)
+            SyncSettingsTask.run(settings, lastSyncTime, syncManager).getOrThrow()
         }
     }
 

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/data/DataSyncProcess.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/data/DataSyncProcess.kt
@@ -13,7 +13,9 @@ import au.com.shiftyjelly.pocketcasts.repositories.sync.SyncManager
 import au.com.shiftyjelly.pocketcasts.repositories.sync.UpNextSyncWorker
 import au.com.shiftyjelly.pocketcasts.repositories.user.StatsManager
 import au.com.shiftyjelly.pocketcasts.servers.sync.SyncSettingsTask
+import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
 import com.pocketcasts.service.api.Record
+import com.pocketcasts.service.api.SyncUpdateRequest
 import com.pocketcasts.service.api.bookmarkOrNull
 import com.pocketcasts.service.api.episodeOrNull
 import com.pocketcasts.service.api.folderOrNull
@@ -21,7 +23,10 @@ import com.pocketcasts.service.api.playlistOrNull
 import com.pocketcasts.service.api.podcastOrNull
 import com.pocketcasts.service.api.syncUpdateRequest
 import java.time.Instant
+import java.util.UUID
 import kotlin.time.Duration.Companion.minutes
+import kotlin.time.measureTimedValue
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
@@ -42,6 +47,7 @@ class DataSyncProcess(
     private val settings: Settings,
     private val context: Context,
 ) {
+    private val logger = DataSyncLogger()
     private val podcastSync = PodcastSync(podcastManager, playbackManager, missingPodcastsSemaphore = Semaphore(permits = 10))
     private val folderSync = FoldersSync(folderManager)
     private val episodeSync = EpisodeSync(episodeManager, podcastManager, playbackManager, settings)
@@ -50,20 +56,21 @@ class DataSyncProcess(
     private val deviceSync = DeviceSync(statsManager, settings)
 
     suspend fun sync(): Result<Unit> {
-        if (!syncManager.isLoggedIn()) {
-            appDatabase.playlistDao().deleteMarkedPlaylists()
-            return Result.success(Unit)
-        }
-
-        return runCatching {
-            val lastSyncTime = getLastSyncTime()
-            val newSyncTime = syncData(lastSyncTime)
-            syncSettings(lastSyncTime)
-            Timber.d("Sync cloud files")
-            Timber.d("Sync broken files")
-            Timber.d("Sync playback history")
-            Timber.d("Sync podcast ratings")
-            settings.setLastModified(newSyncTime.toString())
+        return logProcess("data") {
+            runCatching {
+                if (!syncManager.isLoggedIn()) {
+                    appDatabase.playlistDao().deleteMarkedPlaylists()
+                } else {
+                    val lastSyncTime = getLastSyncTime()
+                    val newSyncTime = syncData(lastSyncTime)
+                    syncSettings(lastSyncTime)
+                    Timber.d("Sync cloud files")
+                    Timber.d("Sync broken files")
+                    Timber.d("Sync playback history")
+                    Timber.d("Sync podcast ratings")
+                    settings.setLastModified(newSyncTime.toString())
+                }
+            }
         }
     }
 
@@ -83,71 +90,140 @@ class DataSyncProcess(
     }
 
     private suspend fun syncFullData(): Instant {
-        val lastSyncAt = syncManager.getLastSyncAtOrThrow()
-
-        deviceSync.syncStats()
-        val homePageData = syncManager.getHomeFolderOrThrow()
-        podcastSync.fullSync(homePageData.podcastsList)
-        folderSync.fullSync(homePageData.foldersList)
-        playlistSync.fullSync()
-        bookmarkSync.fullSync()
-
-        return runCatching { Instant.parse(lastSyncAt) }.getOrDefault(Instant.now())
+        return logProcess("data-full") {
+            val lastSyncAt = logProcess("request-last-sync-data-full") {
+                syncManager.getLastSyncAtOrThrow()
+            }
+            logProcess("device-data-full") {
+                deviceSync.syncStats()
+            }
+            val homePageData = logProcess("request-home-data-full") {
+                syncManager.getHomeFolderOrThrow()
+            }
+            logProcess("podcasts-data-full") {
+                podcastSync.fullSync(homePageData.podcastsList)
+            }
+            logProcess("folders-data-full") {
+                folderSync.fullSync(homePageData.foldersList)
+            }
+            logProcess("playlists-data-full") {
+                playlistSync.fullSync()
+            }
+            logProcess("bookmarks-data-full") {
+                bookmarkSync.fullSync()
+            }
+            runCatching { Instant.parse(lastSyncAt) }.getOrDefault(Instant.now())
+        }
     }
 
     private suspend fun syncIncrementalData(lastSyncTime: Instant): Instant {
-        val request = coroutineScope {
-            syncUpdateRequest {
-                deviceUtcTimeMs = System.currentTimeMillis()
-                lastModified = lastSyncTime.toEpochMilli()
-                deviceId = settings.getUniqueDeviceId()
-                records.addAll(
-                    listOf(
-                        async { podcastSync.incrementalData() },
-                        async { folderSync.incrementalData() },
-                        async { episodeSync.incrementalData() },
-                        async { playlistSync.incrementalData() },
-                        async { bookmarkSync.incrementalData() },
-                        async { deviceSync.incrementalData() },
-                    ).awaitAll().flatten(),
-                )
+        return logProcess("data-incremental") {
+            val response = logProcess("request-data-incremental") {
+                val request = createIncrementalRequest(lastSyncTime)
+                syncManager.syncUpdateOrThrow(request)
             }
+            val records = response.recordsList
+            logProcess("episode-data-incremental") {
+                episodeSync.processIncrementalResponse(records.mapNotNull(Record::episodeOrNull))
+            }
+            logProcess("podcasts-data-incremental") {
+                podcastSync.processIncrementalResponse(records.mapNotNull(Record::podcastOrNull))
+            }
+            logProcess("folders-data-incremental") {
+                folderSync.processIncrementalResponse(records.mapNotNull(Record::folderOrNull))
+            }
+            logProcess("playlists-data-incremental") {
+                playlistSync.processIncrementalResponse(records.mapNotNull(Record::playlistOrNull))
+            }
+            logProcess("bookmarks-data-incremental") {
+                bookmarkSync.processIncrementalResponse(records.mapNotNull(Record::bookmarkOrNull))
+            }
+            logProcess("device-data-incremental") {
+                deviceSync.syncStats()
+            }
+            Instant.ofEpochMilli(response.lastModified)
         }
-        val response = syncManager.syncUpdateOrThrow(request)
-        val records = response.recordsList
-        episodeSync.processIncrementalResponse(records.mapNotNull(Record::episodeOrNull))
-        podcastSync.processIncrementalResponse(records.mapNotNull(Record::podcastOrNull))
-        folderSync.processIncrementalResponse(records.mapNotNull(Record::folderOrNull))
-        playlistSync.processIncrementalResponse(records.mapNotNull(Record::playlistOrNull))
-        bookmarkSync.processIncrementalResponse(records.mapNotNull(Record::bookmarkOrNull))
-        deviceSync.syncStats()
-        return Instant.ofEpochMilli(response.lastModified)
     }
 
     private suspend fun syncSettings(lastSyncTime: Instant) {
-        SyncSettingsTask.run(settings, lastSyncTime, syncManager)
+        logProcess("settings") {
+            SyncSettingsTask.run(settings, lastSyncTime, syncManager)
+        }
     }
 
     private suspend fun syncUpNext() {
-        val workId = UpNextSyncWorker.enqueue(syncManager, context)
-        if (workId != null) {
-            val workInfo = withTimeoutOrNull(5.minutes) {
-                WorkManager.getInstance(context)
-                    .getWorkInfoByIdFlow(workId)
-                    .filterNotNull()
-                    .first { workInfo -> workInfo.state.isFinished }
+        logProcess("up-next") {
+            val workId = UpNextSyncWorker.enqueue(syncManager, context)
+            if (workId != null) {
+                val workInfo = withTimeoutOrNull(5.minutes) {
+                    WorkManager.getInstance(context)
+                        .getWorkInfoByIdFlow(workId)
+                        .filterNotNull()
+                        .first { workInfo -> workInfo.state.isFinished }
+                }
+                when (val workState = workInfo?.state) {
+                    WorkInfo.State.SUCCEEDED -> Unit
+                    WorkInfo.State.FAILED -> error("Up next sync failed")
+                    WorkInfo.State.CANCELLED -> error("Up Next sync was cancelled")
+                    WorkInfo.State.ENQUEUED, WorkInfo.State.RUNNING, WorkInfo.State.BLOCKED -> error("Unexpected state: $workState")
+                    null -> error("Up Next didn't sync in time")
+                }
             }
-            when (val workState = workInfo?.state) {
-                WorkInfo.State.SUCCEEDED -> Unit
-                WorkInfo.State.FAILED -> error("Up next sync failed")
-                WorkInfo.State.CANCELLED -> error("Up Next sync was cancelled")
-                WorkInfo.State.ENQUEUED, WorkInfo.State.RUNNING, WorkInfo.State.BLOCKED -> error("Unexpected state: $workState")
-                null -> error("Up Next didn't sync in time")
-            }
+        }
+    }
+
+    private suspend fun createIncrementalRequest(lastSyncTime: Instant): SyncUpdateRequest = coroutineScope {
+        syncUpdateRequest {
+            deviceUtcTimeMs = System.currentTimeMillis()
+            lastModified = lastSyncTime.toEpochMilli()
+            deviceId = settings.getUniqueDeviceId()
+            records.addAll(
+                listOf(
+                    async { podcastSync.incrementalData() },
+                    async { folderSync.incrementalData() },
+                    async { episodeSync.incrementalData() },
+                    async { playlistSync.incrementalData() },
+                    async { bookmarkSync.incrementalData() },
+                    async { deviceSync.incrementalData() },
+                ).awaitAll().flatten(),
+            )
         }
     }
 
     private fun getLastSyncTime() = runCatching {
         Instant.parse(settings.getLastModified())
     }.getOrDefault(Instant.EPOCH)
+
+    private inline fun <T> logProcess(name: String, process: DataSyncLogger.() -> T): T {
+        return logger.logProcess(name) { logger.process() }
+    }
+}
+
+internal class DataSyncLogger {
+    private val uuid = UUID.randomUUID()
+
+    inline fun <T> logProcess(name: String, process: () -> T): T {
+        logInfo("$name sync start")
+        return runCatching { measureTimedValue { process() } }
+            .onSuccess { (_, duration) ->
+                logInfo("$name sync done - $duration")
+            }
+            .onFailure { failure ->
+                if (failure is CancellationException) {
+                    logInfo("$name sync cancelled")
+                } else {
+                    logError("$name sync failed", failure)
+                }
+            }
+            .getOrThrow()
+            .value
+    }
+
+    fun logInfo(message: String) {
+        LogBuffer.i("DataSync", "$message - $uuid")
+    }
+
+    fun logError(message: String, error: Throwable) {
+        LogBuffer.e("DataSync", error, "$message - $uuid")
+    }
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/data/PodcastSync.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/data/PodcastSync.kt
@@ -35,7 +35,6 @@ internal class PodcastSync(
     private val playbackManager: PlaybackManager,
     private val missingPodcastsSemaphore: Semaphore,
 ) {
-
     suspend fun fullSync(serverPodcasts: List<UserPodcastResponse>) {
         val localPodcasts = podcastManager.findSubscribedNoOrder()
         val serverPodcastMap = serverPodcasts.associateBy(UserPodcastResponse::getUuid)


### PR DESCRIPTION
## Description

This is a continuation of the migration described in #4390. Adding syncing was fairly simple, as it only required calling `UpNextSyncWorker` during the sync process. However, I noticed a potential bug: our `UpNextSyncWorker` was cancellable, and enqueuing one work item would cancel another. Since syncing could be interrupted at any point, this might have left the process in an incomplete state.

To address this, I changed the Up Next syncing to use a unique work with the `APPEND_OR_REPLACE` policy. This ensures that all enqueued changes are processed sequentially, even if they occur too frequently or if the sync process overlaps with the periodic Up Next sync.

Additionally, I added extensive logging and improved error handling to the entire data sync process in this PR.

Relates to PCDROID-119

## Testing Instructions

1. Sign in on devices A and B with the same account.  
2. Sync the devices.  
3. On both devices, go to Beta Features and enable the **`Sync data using Protobuf`** feature flag.  
4. Test syncing Up Next. It might be a bit tricky to test it through the data sync since Up Next has its own periodic syncing mechanism so you can apply [this patch](https://github.com/user-attachments/files/21902068/up-next-sync.patch) that disables this mechanism.
```
curl -L https://github.com/user-attachments/files/21902068/up-next-sync.patch | git apply
``` 
5. Preview logs using `DataSync` tag to see sync timings, etc.

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.