### PR TITLE
Prepare database for Manual Playlists

### DIFF
--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/models/db/AppDatabaseTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/models/db/AppDatabaseTest.kt
@@ -186,6 +186,7 @@ class AppDatabaseTest {
                 AppDatabase.MIGRATION_114_115,
                 AppDatabase.MIGRATION_115_116,
                 AppDatabase.MIGRATION_116_117,
+                AppDatabase.MIGRATION_117_118,
             )
             .build()
         // close the database and release any stream resources when the test finishes

--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/repositories/playlist/PlaylistManagerTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/repositories/playlist/PlaylistManagerTest.kt
@@ -11,17 +11,17 @@ import au.com.shiftyjelly.pocketcasts.models.di.ModelModule
 import au.com.shiftyjelly.pocketcasts.models.di.addTypeConverters
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
-import au.com.shiftyjelly.pocketcasts.models.entity.SmartPlaylist.Companion.ANYTIME
-import au.com.shiftyjelly.pocketcasts.models.entity.SmartPlaylist.Companion.AUDIO_VIDEO_FILTER_ALL
-import au.com.shiftyjelly.pocketcasts.models.entity.SmartPlaylist.Companion.AUDIO_VIDEO_FILTER_AUDIO_ONLY
-import au.com.shiftyjelly.pocketcasts.models.entity.SmartPlaylist.Companion.AUDIO_VIDEO_FILTER_VIDEO_ONLY
-import au.com.shiftyjelly.pocketcasts.models.entity.SmartPlaylist.Companion.LAST_24_HOURS
-import au.com.shiftyjelly.pocketcasts.models.entity.SmartPlaylist.Companion.LAST_2_WEEKS
-import au.com.shiftyjelly.pocketcasts.models.entity.SmartPlaylist.Companion.LAST_3_DAYS
-import au.com.shiftyjelly.pocketcasts.models.entity.SmartPlaylist.Companion.LAST_MONTH
-import au.com.shiftyjelly.pocketcasts.models.entity.SmartPlaylist.Companion.LAST_WEEK
-import au.com.shiftyjelly.pocketcasts.models.entity.SmartPlaylist.Companion.SYNC_STATUS_NOT_SYNCED
-import au.com.shiftyjelly.pocketcasts.models.entity.SmartPlaylist.Companion.SYNC_STATUS_SYNCED
+import au.com.shiftyjelly.pocketcasts.models.entity.PlaylistEntity.Companion.ANYTIME
+import au.com.shiftyjelly.pocketcasts.models.entity.PlaylistEntity.Companion.AUDIO_VIDEO_FILTER_ALL
+import au.com.shiftyjelly.pocketcasts.models.entity.PlaylistEntity.Companion.AUDIO_VIDEO_FILTER_AUDIO_ONLY
+import au.com.shiftyjelly.pocketcasts.models.entity.PlaylistEntity.Companion.AUDIO_VIDEO_FILTER_VIDEO_ONLY
+import au.com.shiftyjelly.pocketcasts.models.entity.PlaylistEntity.Companion.LAST_24_HOURS
+import au.com.shiftyjelly.pocketcasts.models.entity.PlaylistEntity.Companion.LAST_2_WEEKS
+import au.com.shiftyjelly.pocketcasts.models.entity.PlaylistEntity.Companion.LAST_3_DAYS
+import au.com.shiftyjelly.pocketcasts.models.entity.PlaylistEntity.Companion.LAST_MONTH
+import au.com.shiftyjelly.pocketcasts.models.entity.PlaylistEntity.Companion.LAST_WEEK
+import au.com.shiftyjelly.pocketcasts.models.entity.PlaylistEntity.Companion.SYNC_STATUS_NOT_SYNCED
+import au.com.shiftyjelly.pocketcasts.models.entity.PlaylistEntity.Companion.SYNC_STATUS_SYNCED
 import au.com.shiftyjelly.pocketcasts.models.type.EpisodePlayingStatus
 import au.com.shiftyjelly.pocketcasts.models.type.PlaylistEpisodeSortType
 import au.com.shiftyjelly.pocketcasts.models.type.SmartRules
@@ -47,7 +47,7 @@ import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
-import au.com.shiftyjelly.pocketcasts.models.entity.SmartPlaylist as DbPlaylist
+import au.com.shiftyjelly.pocketcasts.models.entity.PlaylistEntity as DbPlaylist
 
 class PlaylistManagerTest {
     private val testDispatcher = StandardTestDispatcher()

--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/repositories/playlist/PlaylistManagerTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/repositories/playlist/PlaylistManagerTest.kt
@@ -630,15 +630,12 @@ class PlaylistManagerTest {
             deleted = false,
             syncStatus = SYNC_STATUS_NOT_SYNCED,
             autoDownload = false,
-            autoDownloadUnmeteredOnly = false,
-            autoDownloadPowerOnly = false,
             autodownloadLimit = 10,
             unplayed = true,
             partiallyPlayed = true,
             finished = true,
             downloaded = true,
             notDownloaded = true,
-            downloading = true,
             audioVideo = AUDIO_VIDEO_FILTER_ALL,
             filterHours = ANYTIME,
             starred = false,
@@ -663,9 +660,9 @@ class PlaylistManagerTest {
         assertPlaylist(index = 20, "Unplayed") { it.copy(unplayed = true, partiallyPlayed = false, finished = false) }
         assertPlaylist(index = 19, "In progress") { it.copy(unplayed = false, partiallyPlayed = true, finished = false) }
         assertPlaylist(index = 18, "Played") { it.copy(unplayed = false, partiallyPlayed = false, finished = true) }
-        assertPlaylist(index = 17, "Any downloaded status") { it.copy(downloaded = true, notDownloaded = true, downloading = true) }
-        assertPlaylist(index = 16, "Downloaded") { it.copy(downloaded = true, notDownloaded = false, downloading = false) }
-        assertPlaylist(index = 15, "Not downloaded") { it.copy(downloaded = false, notDownloaded = true, downloading = true) }
+        assertPlaylist(index = 17, "Any downloaded status") { it.copy(downloaded = true, notDownloaded = true) }
+        assertPlaylist(index = 16, "Downloaded") { it.copy(downloaded = true, notDownloaded = false) }
+        assertPlaylist(index = 15, "Not downloaded") { it.copy(downloaded = false, notDownloaded = true) }
         assertPlaylist(index = 14, "Audio / Video") { it.copy(audioVideo = AUDIO_VIDEO_FILTER_ALL) }
         assertPlaylist(index = 13, "Audio") { it.copy(audioVideo = AUDIO_VIDEO_FILTER_AUDIO_ONLY) }
         assertPlaylist(index = 12, "Video") { it.copy(audioVideo = AUDIO_VIDEO_FILTER_VIDEO_ONLY) }
@@ -701,15 +698,12 @@ class PlaylistManagerTest {
                 deleted = false,
                 syncStatus = SYNC_STATUS_SYNCED,
                 autoDownload = false,
-                autoDownloadUnmeteredOnly = false,
-                autoDownloadPowerOnly = false,
                 autodownloadLimit = 10,
                 unplayed = true,
                 partiallyPlayed = true,
                 finished = true,
                 downloaded = true,
                 notDownloaded = true,
-                downloading = true,
                 audioVideo = AUDIO_VIDEO_FILTER_ALL,
                 filterHours = LAST_2_WEEKS,
                 starred = false,
@@ -741,15 +735,12 @@ class PlaylistManagerTest {
                 deleted = false,
                 syncStatus = SYNC_STATUS_SYNCED,
                 autoDownload = false,
-                autoDownloadUnmeteredOnly = false,
-                autoDownloadPowerOnly = false,
                 autodownloadLimit = 10,
                 unplayed = false,
                 partiallyPlayed = true,
                 finished = false,
                 downloaded = true,
                 notDownloaded = true,
-                downloading = true,
                 audioVideo = AUDIO_VIDEO_FILTER_ALL,
                 filterHours = LAST_MONTH,
                 starred = false,

--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/repositories/playlist/PlaylistManagerTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/repositories/playlist/PlaylistManagerTest.kt
@@ -9,8 +9,6 @@ import au.com.shiftyjelly.pocketcasts.models.db.dao.PlaylistDao
 import au.com.shiftyjelly.pocketcasts.models.db.dao.PodcastDao
 import au.com.shiftyjelly.pocketcasts.models.di.ModelModule
 import au.com.shiftyjelly.pocketcasts.models.di.addTypeConverters
-import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
-import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.models.entity.PlaylistEntity.Companion.ANYTIME
 import au.com.shiftyjelly.pocketcasts.models.entity.PlaylistEntity.Companion.AUDIO_VIDEO_FILTER_ALL
 import au.com.shiftyjelly.pocketcasts.models.entity.PlaylistEntity.Companion.AUDIO_VIDEO_FILTER_AUDIO_ONLY
@@ -22,6 +20,8 @@ import au.com.shiftyjelly.pocketcasts.models.entity.PlaylistEntity.Companion.LAS
 import au.com.shiftyjelly.pocketcasts.models.entity.PlaylistEntity.Companion.LAST_WEEK
 import au.com.shiftyjelly.pocketcasts.models.entity.PlaylistEntity.Companion.SYNC_STATUS_NOT_SYNCED
 import au.com.shiftyjelly.pocketcasts.models.entity.PlaylistEntity.Companion.SYNC_STATUS_SYNCED
+import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
+import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.models.type.EpisodePlayingStatus
 import au.com.shiftyjelly.pocketcasts.models.type.PlaylistEpisodeSortType
 import au.com.shiftyjelly.pocketcasts.models.type.SmartRules

--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/ui/PlaybackServiceTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/ui/PlaybackServiceTest.kt
@@ -10,7 +10,7 @@ import androidx.test.rule.ServiceTestRule
 import au.com.shiftyjelly.pocketcasts.PocketCastsApplication
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
-import au.com.shiftyjelly.pocketcasts.models.entity.SmartPlaylist
+import au.com.shiftyjelly.pocketcasts.models.entity.PlaylistEntity
 import au.com.shiftyjelly.pocketcasts.preferences.Settings.NotificationId
 import au.com.shiftyjelly.pocketcasts.repositories.notification.NotificationHelper
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackService
@@ -74,7 +74,7 @@ class PlaybackServiceTest {
             PodcastEpisode(uuid = UUID.randomUUID().toString(), podcastUuid = podcastTwo.uuid, publishedDate = Date(), title = "Episode 2"),
             PodcastEpisode(uuid = UUID.randomUUID().toString(), podcastUuid = podcastOne.uuid, publishedDate = Date(), title = "Episode 3"),
         )
-        val filter = SmartPlaylist(uuid = UUID.randomUUID().toString(), title = "New Releases")
+        val filter = PlaylistEntity(uuid = UUID.randomUUID().toString(), title = "New Releases")
         val filters = listOf(filter)
         val filterEpisodes = listOf(
             PodcastEpisode(uuid = UUID.randomUUID().toString(), podcastUuid = podcastOne.uuid, publishedDate = Date(), title = "Episode 4"),
@@ -101,7 +101,7 @@ class PlaybackServiceTest {
         val smartPlaylistManager = mock<SmartPlaylistManager> {
             onBlocking { findAll() }.doReturn(filters)
             onBlocking { findByUuid(filter.uuid) }.doReturn(filter)
-            on { findEpisodesBlocking(smartPlaylist = filters.first(), episodeManager = episodeManager, playbackManager = service.playbackManager) }.doReturn(filterEpisodes)
+            on { findEpisodesBlocking(playlist = filters.first(), episodeManager = episodeManager, playbackManager = service.playbackManager) }.doReturn(filterEpisodes)
         }
         service.smartPlaylistManager = smartPlaylistManager
 

--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/ui/PlaybackServiceTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/ui/PlaybackServiceTest.kt
@@ -8,9 +8,9 @@ import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.rule.ServiceTestRule
 import au.com.shiftyjelly.pocketcasts.PocketCastsApplication
+import au.com.shiftyjelly.pocketcasts.models.entity.PlaylistEntity
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
-import au.com.shiftyjelly.pocketcasts.models.entity.PlaylistEntity
 import au.com.shiftyjelly.pocketcasts.preferences.Settings.NotificationId
 import au.com.shiftyjelly.pocketcasts.repositories.notification.NotificationHelper
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackService

--- a/app/src/test/java/au/com/shiftyjelly/pocketcasts/filters/FiltersFragmentViewModelTest.kt
+++ b/app/src/test/java/au/com/shiftyjelly/pocketcasts/filters/FiltersFragmentViewModelTest.kt
@@ -1,6 +1,6 @@
 package au.com.shiftyjelly.pocketcasts.filters
 
-import au.com.shiftyjelly.pocketcasts.models.entity.SmartPlaylist
+import au.com.shiftyjelly.pocketcasts.models.entity.PlaylistEntity
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.preferences.UserSetting
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
@@ -27,8 +27,8 @@ class FiltersFragmentViewModelTest {
     val coroutineRule = MainCoroutineRule()
 
     private val defaultFilters = listOf(
-        SmartPlaylist(id = 1, uuid = Playlist.NEW_RELEASES_UUID),
-        SmartPlaylist(id = 2, uuid = Playlist.IN_PROGRESS_UUID),
+        PlaylistEntity(id = 1, uuid = Playlist.NEW_RELEASES_UUID),
+        PlaylistEntity(id = 2, uuid = Playlist.IN_PROGRESS_UUID),
     )
 
     @Before
@@ -59,7 +59,7 @@ class FiltersFragmentViewModelTest {
     @Test
     fun `should not show tooltip if created custom filter`() = runTest {
         var showTooltip = false
-        viewModel.shouldShowTooltip(defaultFilters + listOf(SmartPlaylist(id = 3, uuid = "custom"))) {
+        viewModel.shouldShowTooltip(defaultFilters + listOf(PlaylistEntity(id = 3, uuid = "custom"))) {
             showTooltip = true
         }
 

--- a/automotive/src/androidTest/java/au/com/shiftyjelly/pocketcasts/AutoPlaybackServiceTest.kt
+++ b/automotive/src/androidTest/java/au/com/shiftyjelly/pocketcasts/AutoPlaybackServiceTest.kt
@@ -7,7 +7,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.rule.ServiceTestRule
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
-import au.com.shiftyjelly.pocketcasts.models.entity.SmartPlaylist
+import au.com.shiftyjelly.pocketcasts.models.entity.PlaylistEntity
 import au.com.shiftyjelly.pocketcasts.models.type.Subscription
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.preferences.UserSetting
@@ -70,13 +70,13 @@ class AutoPlaybackServiceTest {
     @Test
     fun testLoadFilters() {
         runBlocking {
-            val smartPlaylist = SmartPlaylist(uuid = UUID.randomUUID().toString(), title = "Test title", iconId = 0)
-            service.smartPlaylistManager = mock { on { findAllBlocking() }.doReturn(listOf(smartPlaylist)) }
+            val playlist = PlaylistEntity(uuid = UUID.randomUUID().toString(), title = "Test title", iconId = 0)
+            service.smartPlaylistManager = mock { on { findAllBlocking() }.doReturn(listOf(playlist)) }
 
             val filtersRoot = service.loadFiltersRoot()
             assertTrue("Filters should not be empty", filtersRoot.isNotEmpty())
-            assertTrue("Filter uuid should be equal", filtersRoot[0].mediaId == smartPlaylist.uuid)
-            assertTrue("Filter title should be correct", filtersRoot[0].description.title == smartPlaylist.title)
+            assertTrue("Filter uuid should be equal", filtersRoot[0].mediaId == playlist.uuid)
+            assertTrue("Filter title should be correct", filtersRoot[0].description.title == playlist.title)
             assertTrue("Filter should have an icon", filtersRoot[0].description.iconUri != null)
         }
     }

--- a/automotive/src/androidTest/java/au/com/shiftyjelly/pocketcasts/AutoPlaybackServiceTest.kt
+++ b/automotive/src/androidTest/java/au/com/shiftyjelly/pocketcasts/AutoPlaybackServiceTest.kt
@@ -5,9 +5,9 @@ import android.os.IBinder
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.rule.ServiceTestRule
+import au.com.shiftyjelly.pocketcasts.models.entity.PlaylistEntity
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
-import au.com.shiftyjelly.pocketcasts.models.entity.PlaylistEntity
 import au.com.shiftyjelly.pocketcasts.models.type.Subscription
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.preferences.UserSetting

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/CreateFilterChipFragment.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/CreateFilterChipFragment.kt
@@ -105,7 +105,7 @@ class CreateFilterChipFragment :
     }
 
     private fun observePlaylist() {
-        viewModel.smartPlaylist?.observe(viewLifecycleOwner) { playlist ->
+        viewModel.playlist?.observe(viewLifecycleOwner) { playlist ->
             val color = playlist.getColor(context)
 
             val chipPodcasts = binding.chipPodcasts

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/CreateFilterContainerFragment.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/CreateFilterContainerFragment.kt
@@ -15,7 +15,7 @@ import androidx.lifecycle.repeatOnLifecycle
 import androidx.viewpager2.adapter.FragmentStateAdapter
 import androidx.viewpager2.widget.ViewPager2
 import au.com.shiftyjelly.pocketcasts.filters.databinding.FragmentCreateContainerBinding
-import au.com.shiftyjelly.pocketcasts.models.entity.SmartPlaylist
+import au.com.shiftyjelly.pocketcasts.models.entity.PlaylistEntity
 import au.com.shiftyjelly.pocketcasts.ui.extensions.getThemeColor
 import au.com.shiftyjelly.pocketcasts.ui.extensions.getTintedDrawable
 import au.com.shiftyjelly.pocketcasts.ui.extensions.setupKeyboardModePan
@@ -105,7 +105,7 @@ class CreateFilterContainerFragment : BaseFragment() {
     }
 
     private fun updateToolbarColors() {
-        val colorResId = SmartPlaylist.themeColors.getOrNull(viewModel.colorIndex.value) ?: UR.attr.filter_01
+        val colorResId = PlaylistEntity.themeColors.getOrNull(viewModel.colorIndex.value) ?: UR.attr.filter_01
         val tintColor = view?.context?.getThemeColor(colorResId) ?: return
         val iconRes = if (binding.viewPager.currentItem == 0) IR.drawable.ic_close else IR.drawable.ic_arrow_back
         val backIcon = context?.getTintedDrawable(iconRes, ThemeColor.filterIcon01(theme.activeTheme, tintColor))
@@ -129,7 +129,7 @@ class CreateFilterContainerFragment : BaseFragment() {
     }
 
     private fun observePlaylist(adapter: CreatePagerAdapter) {
-        viewModel.smartPlaylist?.observe(viewLifecycleOwner) {
+        viewModel.playlist?.observe(viewLifecycleOwner) {
             binding.btnCreate.isEnabled = !adapter.lockedToFirstPage
         }
     }
@@ -150,7 +150,7 @@ class CreateFilterContainerFragment : BaseFragment() {
         lifecycleScope.launch {
             repeatOnLifecycle(Lifecycle.State.STARTED) {
                 viewModel.colorIndex.collect {
-                    val colorResId = SmartPlaylist.themeColors.getOrNull(it) ?: UR.attr.filter_01
+                    val colorResId = PlaylistEntity.themeColors.getOrNull(it) ?: UR.attr.filter_01
                     val tintColor = requireContext().getThemeColor(colorResId)
                     val stateList = ColorStateList(
                         arrayOf(

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/CreateFilterFragment.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/CreateFilterFragment.kt
@@ -18,7 +18,7 @@ import androidx.lifecycle.repeatOnLifecycle
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import au.com.shiftyjelly.pocketcasts.filters.databinding.FragmentCreateFilterBinding
-import au.com.shiftyjelly.pocketcasts.models.entity.SmartPlaylist
+import au.com.shiftyjelly.pocketcasts.models.entity.PlaylistEntity
 import au.com.shiftyjelly.pocketcasts.repositories.extensions.colorIndex
 import au.com.shiftyjelly.pocketcasts.repositories.extensions.drawableIndex
 import au.com.shiftyjelly.pocketcasts.repositories.extensions.iconDrawables
@@ -54,7 +54,7 @@ class CreateFilterFragment :
     CoroutineScope {
     sealed class Mode(val string: String) {
         object Create : Mode("create")
-        data class Edit(val smartPlaylist: SmartPlaylist) : Mode("edit")
+        data class Edit(val playlist: PlaylistEntity) : Mode("edit")
     }
 
     private var rootView: View? = null
@@ -65,7 +65,7 @@ class CreateFilterFragment :
             return CreateFilterFragment().apply {
                 arguments = bundleOf(
                     ARG_MODE to mode.string,
-                    ARG_PLAYLIST_UUID to (mode as? Mode.Edit)?.smartPlaylist?.uuid,
+                    ARG_PLAYLIST_UUID to (mode as? Mode.Edit)?.playlist?.uuid,
                 )
             }
         }
@@ -136,15 +136,15 @@ class CreateFilterFragment :
             runBlocking { viewModel.setup(playlistUUID) }
         }
 
-        val colors = SmartPlaylist.getColors(context)
+        val colors = PlaylistEntity.getColors(context)
         colorAdapter = ColorAdapter(colors.toIntArray(), false) { index, fromUserInteraction ->
-            tintColor = context?.getThemeColor(SmartPlaylist.themeColors[index]) ?: Color.WHITE
+            tintColor = context?.getThemeColor(PlaylistEntity.themeColors[index]) ?: Color.WHITE
             viewModel.colorIndex.value = index
             if (fromUserInteraction) {
                 viewModel.userChangedColor()
             }
         }
-        tintColor = view.context.getThemeColor(SmartPlaylist.themeColors.first())
+        tintColor = view.context.getThemeColor(PlaylistEntity.themeColors.first())
 
         setupIconViews()
 
@@ -222,8 +222,8 @@ class CreateFilterFragment :
         val context = context ?: return
         val binding = binding ?: return
 
-        SmartPlaylist.iconDrawables.forEachIndexed { index, _ ->
-            val imgRes = SmartPlaylist.iconDrawables[index]
+        PlaylistEntity.iconDrawables.forEachIndexed { index, _ ->
+            val imgRes = PlaylistEntity.iconDrawables[index]
             val view = IconView(context)
             val layoutParams = RecyclerView.LayoutParams(44.dpToPx(context), 44.dpToPx(context))
             layoutParams.marginEnd = 16.dpToPx(context)
@@ -281,7 +281,7 @@ class CreateFilterFragment :
     }
 
     private fun observePlaylist() {
-        viewModel.smartPlaylist?.observe(viewLifecycleOwner) { filter ->
+        viewModel.playlist?.observe(viewLifecycleOwner) { filter ->
             if (binding == null) return@observe
 
             if (filter.title.isEmpty()) {
@@ -314,7 +314,7 @@ class CreateFilterFragment :
             repeatOnLifecycle(Lifecycle.State.RESUMED) {
                 viewModel.colorIndex.collect {
                     if (binding == null) return@collect
-                    val colorResId = SmartPlaylist.themeColors.getOrNull(it) ?: 0
+                    val colorResId = PlaylistEntity.themeColors.getOrNull(it) ?: 0
                     val tintColor = requireContext().getThemeColor(colorResId)
                     binding!!.nameInputLayout.boxStrokeColor = tintColor
                     TextViewCompat.setCompoundDrawableTintList(binding!!.txtName, ColorStateList.valueOf(tintColor))

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/CreateFilterViewModel.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/CreateFilterViewModel.kt
@@ -5,8 +5,8 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.toLiveData
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTracker
-import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.models.entity.PlaylistEntity
+import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.repositories.extensions.calculateCombinedIconId
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/DurationOptionsFragment.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/DurationOptionsFragment.kt
@@ -7,7 +7,7 @@ import android.view.View
 import android.view.ViewGroup
 import au.com.shiftyjelly.pocketcasts.filters.databinding.DurationOptionsFragmentBinding
 import au.com.shiftyjelly.pocketcasts.localization.helper.TimeHelper
-import au.com.shiftyjelly.pocketcasts.models.entity.SmartPlaylist
+import au.com.shiftyjelly.pocketcasts.models.entity.PlaylistEntity
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.PlaylistProperty
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.PlaylistUpdateSource
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.SmartPlaylistManager
@@ -29,9 +29,9 @@ private const val ARG_PLAYLIST_UUID = "playlist_uuid"
 @AndroidEntryPoint
 class DurationOptionsFragment : BaseFragment() {
     companion object {
-        fun newInstance(smartPlaylist: SmartPlaylist): DurationOptionsFragment {
+        fun newInstance(playlist: PlaylistEntity): DurationOptionsFragment {
             val bundle = Bundle()
-            bundle.putString(ARG_PLAYLIST_UUID, smartPlaylist.uuid)
+            bundle.putString(ARG_PLAYLIST_UUID, playlist.uuid)
             val fragment = DurationOptionsFragment()
             fragment.arguments = bundle
             return fragment
@@ -39,7 +39,7 @@ class DurationOptionsFragment : BaseFragment() {
     }
 
     @Inject lateinit var smartPlaylistManager: SmartPlaylistManager
-    var smartPlaylist: SmartPlaylist? = null
+    var playlist: PlaylistEntity? = null
 
     private var binding: DurationOptionsFragmentBinding? = null
     private var userChanged = false
@@ -91,7 +91,7 @@ class DurationOptionsFragment : BaseFragment() {
 
         val switchDuration = binding.switchDuration
         switchDuration.setOnCheckedChangeListener { _, isChecked ->
-            smartPlaylist?.filterDuration = isChecked
+            playlist?.filterDuration = isChecked
             enableDurations(isChecked)
             if (switchDurationInitialized) {
                 userChanged = true
@@ -102,7 +102,7 @@ class DurationOptionsFragment : BaseFragment() {
 
         launch {
             val playlist = smartPlaylistManager.findByUuid(requireArguments().getString(ARG_PLAYLIST_UUID)!!) ?: return@launch
-            this@DurationOptionsFragment.smartPlaylist = playlist
+            this@DurationOptionsFragment.playlist = playlist
 
             enableDurations(playlist.filterDuration)
             switchDurationInitialized = false
@@ -142,9 +142,9 @@ class DurationOptionsFragment : BaseFragment() {
                 return@setOnClickListener
             }
 
-            smartPlaylist?.let { playlist ->
+            playlist?.let { playlist ->
                 launch(Dispatchers.Default) {
-                    playlist.syncStatus = SmartPlaylist.SYNC_STATUS_NOT_SYNCED
+                    playlist.syncStatus = PlaylistEntity.SYNC_STATUS_NOT_SYNCED
                     playlist.shorterThan = shorterValue
                     playlist.longerThan = longerValue
                     val userPlaylistUpdate = if (userChanged) {

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/EpisodeOptionsFragment.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/EpisodeOptionsFragment.kt
@@ -8,7 +8,7 @@ import android.view.ViewGroup
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import au.com.shiftyjelly.pocketcasts.filters.databinding.FilterOptionsFragmentBinding
-import au.com.shiftyjelly.pocketcasts.models.entity.SmartPlaylist
+import au.com.shiftyjelly.pocketcasts.models.entity.PlaylistEntity
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.PlaylistProperty
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.PlaylistUpdateSource
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.SmartPlaylistManager
@@ -33,9 +33,9 @@ class EpisodeOptionsFragment :
     BaseFragment(),
     CoroutineScope {
     companion object {
-        fun newInstance(smartPlaylist: SmartPlaylist): EpisodeOptionsFragment {
+        fun newInstance(playlist: PlaylistEntity): EpisodeOptionsFragment {
             val bundle = Bundle()
-            bundle.putString(ARG_PLAYLIST_UUID, smartPlaylist.uuid)
+            bundle.putString(ARG_PLAYLIST_UUID, playlist.uuid)
             val fragment = EpisodeOptionsFragment()
             fragment.arguments = bundle
             return fragment
@@ -47,7 +47,7 @@ class EpisodeOptionsFragment :
 
     @Inject lateinit var smartPlaylistManager: SmartPlaylistManager
 
-    var smartPlaylist: SmartPlaylist? = null
+    var playlist: PlaylistEntity? = null
     private var binding: FilterOptionsFragmentBinding? = null
     private var userChanged = false
 
@@ -76,7 +76,7 @@ class EpisodeOptionsFragment :
             val uuid = requireArguments().getString(ARG_PLAYLIST_UUID)!!
             Timber.d("Loading playlist $uuid")
             val playlist = smartPlaylistManager.findByUuid(uuid) ?: return@launch
-            this@EpisodeOptionsFragment.smartPlaylist = playlist
+            this@EpisodeOptionsFragment.playlist = playlist
 
             val unplayedOption = FilterOption(LR.string.unplayed, playlist.unplayed, { v, _ ->
                 playlist.unplayed = v
@@ -106,9 +106,9 @@ class EpisodeOptionsFragment :
         }
 
         btnSave.setOnClickListener {
-            smartPlaylist?.let { playlist ->
+            playlist?.let { playlist ->
                 launch(Dispatchers.Default) {
-                    playlist.syncStatus = SmartPlaylist.SYNC_STATUS_NOT_SYNCED
+                    playlist.syncStatus = PlaylistEntity.SYNC_STATUS_NOT_SYNCED
 
                     val userPlaylistUpdate = if (userChanged) {
                         UserPlaylistUpdate(

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/FilterEpisodeListFragment.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/FilterEpisodeListFragment.kt
@@ -25,8 +25,8 @@ import au.com.shiftyjelly.pocketcasts.analytics.SourceView
 import au.com.shiftyjelly.pocketcasts.filters.databinding.FragmentFilterBinding
 import au.com.shiftyjelly.pocketcasts.localization.extensions.getStringPluralPodcasts
 import au.com.shiftyjelly.pocketcasts.models.entity.BaseEpisode
-import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.models.entity.PlaylistEntity
+import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.models.type.EpisodeViewSource
 import au.com.shiftyjelly.pocketcasts.models.type.PlaylistEpisodeSortType
 import au.com.shiftyjelly.pocketcasts.podcasts.view.components.PlayButton

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/FilterEpisodeListFragment.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/FilterEpisodeListFragment.kt
@@ -26,7 +26,7 @@ import au.com.shiftyjelly.pocketcasts.filters.databinding.FragmentFilterBinding
 import au.com.shiftyjelly.pocketcasts.localization.extensions.getStringPluralPodcasts
 import au.com.shiftyjelly.pocketcasts.models.entity.BaseEpisode
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
-import au.com.shiftyjelly.pocketcasts.models.entity.SmartPlaylist
+import au.com.shiftyjelly.pocketcasts.models.entity.PlaylistEntity
 import au.com.shiftyjelly.pocketcasts.models.type.EpisodeViewSource
 import au.com.shiftyjelly.pocketcasts.models.type.PlaylistEpisodeSortType
 import au.com.shiftyjelly.pocketcasts.podcasts.view.components.PlayButton
@@ -76,13 +76,13 @@ private const val STATE_LAYOUT_MANAGER = "layout_manager"
 @AndroidEntryPoint
 class FilterEpisodeListFragment : BaseFragment() {
     companion object {
-        fun newInstance(smartPlaylist: SmartPlaylist, isNewFilter: Boolean, context: Context): FilterEpisodeListFragment {
+        fun newInstance(playlist: PlaylistEntity, isNewFilter: Boolean, context: Context): FilterEpisodeListFragment {
             val fragment = FilterEpisodeListFragment()
             val bundle = Bundle()
-            bundle.putString(ARG_PLAYLIST_UUID, smartPlaylist.uuid)
-            bundle.putString(ARG_PLAYLIST_TITLE, smartPlaylist.title)
+            bundle.putString(ARG_PLAYLIST_UUID, playlist.uuid)
+            bundle.putString(ARG_PLAYLIST_TITLE, playlist.title)
             bundle.putBoolean(ARG_FILTER_IS_NEW, isNewFilter)
-            bundle.putInt(ARG_COLOR, smartPlaylist.getColor(context))
+            bundle.putInt(ARG_COLOR, playlist.getColor(context))
             fragment.arguments = bundle
             return fragment
         }
@@ -313,7 +313,7 @@ class FilterEpisodeListFragment : BaseFragment() {
             updateUIColors(color)
         }
 
-        viewModel.smartPlaylist.observe(viewLifecycleOwner) { playlist ->
+        viewModel.playlist.observe(viewLifecycleOwner) { playlist ->
             toolbar.title = playlist.title
 
             val color = playlist.getColor(context)
@@ -583,7 +583,7 @@ class FilterEpisodeListFragment : BaseFragment() {
     }
 
     fun showSortOptions() {
-        viewModel.smartPlaylist.value?.let {
+        viewModel.playlist.value?.let {
             val dialog = OptionsDialog()
                 .setTitle(getString(LR.string.sort_by))
                 .addCheckedOption(
@@ -611,7 +611,7 @@ class FilterEpisodeListFragment : BaseFragment() {
     }
 
     fun showFilterSettings() {
-        viewModel.smartPlaylist.value?.let {
+        viewModel.playlist.value?.let {
             val fragment = CreateFilterFragment.newInstance(CreateFilterFragment.Mode.Edit(it))
             (activity as? FragmentHostListener)?.addFragment(fragment)
         }
@@ -689,7 +689,7 @@ class FilterEpisodeListFragment : BaseFragment() {
 
     private fun clearSelectedFilter() {
         // Only clear the selected filter if the currently displayed filter is the selected filter
-        if (settings.selectedFilter() == viewModel.smartPlaylist.value?.uuid) {
+        if (settings.selectedFilter() == viewModel.playlist.value?.uuid) {
             settings.setSelectedFilter(null)
         }
     }

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/FilterEpisodeListViewModel.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/FilterEpisodeListViewModel.kt
@@ -7,8 +7,8 @@ import androidx.lifecycle.toLiveData
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTracker
 import au.com.shiftyjelly.pocketcasts.analytics.SourceView
-import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.models.entity.PlaylistEntity
+import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.models.type.PlaylistEpisodeSortType
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.repositories.download.DownloadManager

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/FilterEpisodeListViewModel.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/FilterEpisodeListViewModel.kt
@@ -8,7 +8,7 @@ import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTracker
 import au.com.shiftyjelly.pocketcasts.analytics.SourceView
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
-import au.com.shiftyjelly.pocketcasts.models.entity.SmartPlaylist
+import au.com.shiftyjelly.pocketcasts.models.entity.PlaylistEntity
 import au.com.shiftyjelly.pocketcasts.models.type.PlaylistEpisodeSortType
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.repositories.download.DownloadManager
@@ -56,7 +56,7 @@ class FilterEpisodeListViewModel @Inject constructor(
         get() = Dispatchers.Default
 
     lateinit var episodesList: LiveData<List<PodcastEpisode>>
-    val smartPlaylist: MutableLiveData<SmartPlaylist> = MutableLiveData()
+    val playlist: MutableLiveData<PlaylistEntity> = MutableLiveData()
     val playlistDeleted: MutableLiveData<Boolean> = MutableLiveData(false)
 
     lateinit var playlistUUID: String
@@ -71,10 +71,10 @@ class FilterEpisodeListViewModel @Inject constructor(
             .toFlowable(BackpressureStrategy.LATEST)
             .switchMap { smartPlaylistManager.findByUuidAsListRxFlowable(playlistUUID) }
             .switchMap { playlists ->
-                Timber.d("Loading playlist $smartPlaylist")
+                Timber.d("Loading playlist $playlist")
                 val playlist = playlists.firstOrNull() // We observe as a list to get notified on delete
                 if (playlist != null) {
-                    this.smartPlaylist.postValue(playlist)
+                    this.playlist.postValue(playlist)
                     smartPlaylistManager.observeEpisodesBlocking(playlist, episodeManager, playbackManager)
                 } else {
                     this.playlistDeleted.postValue(true)
@@ -114,7 +114,7 @@ class FilterEpisodeListViewModel @Inject constructor(
 
     fun changeSort(sortOrder: PlaylistEpisodeSortType) {
         launch {
-            smartPlaylist.value?.let { playlist ->
+            playlist.value?.let { playlist ->
                 playlist.sortType = sortOrder
 
                 val userPlaylistUpdate = UserPlaylistUpdate(
@@ -128,7 +128,7 @@ class FilterEpisodeListViewModel @Inject constructor(
 
     fun starredChipTapped() {
         launch {
-            smartPlaylist.value?.let { playlist ->
+            playlist.value?.let { playlist ->
                 playlist.starred = !playlist.starred
 
                 val userPlaylistUpdate = UserPlaylistUpdate(

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/FiltersAdapter.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/FiltersAdapter.kt
@@ -7,24 +7,24 @@ import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
 import au.com.shiftyjelly.pocketcasts.filters.databinding.FiltersRowFiltersBinding
 import au.com.shiftyjelly.pocketcasts.localization.extensions.getStringPluralEpisodes
-import au.com.shiftyjelly.pocketcasts.models.entity.SmartPlaylist
+import au.com.shiftyjelly.pocketcasts.models.entity.PlaylistEntity
 import au.com.shiftyjelly.pocketcasts.views.helper.PlaylistHelper
 import io.reactivex.Flowable
 import io.reactivex.android.schedulers.AndroidSchedulers
 import io.reactivex.disposables.Disposable
 import io.reactivex.schedulers.Schedulers
 
-private val differ: DiffUtil.ItemCallback<SmartPlaylist> = object : DiffUtil.ItemCallback<SmartPlaylist>() {
-    override fun areItemsTheSame(oldItem: SmartPlaylist, newItem: SmartPlaylist): Boolean {
+private val differ: DiffUtil.ItemCallback<PlaylistEntity> = object : DiffUtil.ItemCallback<PlaylistEntity>() {
+    override fun areItemsTheSame(oldItem: PlaylistEntity, newItem: PlaylistEntity): Boolean {
         return oldItem.uuid == newItem.uuid
     }
 
-    override fun areContentsTheSame(oldItem: SmartPlaylist, newItem: SmartPlaylist): Boolean {
+    override fun areContentsTheSame(oldItem: PlaylistEntity, newItem: PlaylistEntity): Boolean {
         return oldItem == newItem
     }
 }
 
-class FiltersAdapter(val generateCountFlowable: (SmartPlaylist) -> (Flowable<Int>), val onRowClick: (SmartPlaylist) -> Unit) : ListAdapter<SmartPlaylist, FiltersAdapter.FilterViewHolder>(differ) {
+class FiltersAdapter(val generateCountFlowable: (PlaylistEntity) -> (Flowable<Int>), val onRowClick: (PlaylistEntity) -> Unit) : ListAdapter<PlaylistEntity, FiltersAdapter.FilterViewHolder>(differ) {
 
     class FilterViewHolder(val binding: FiltersRowFiltersBinding) : RecyclerView.ViewHolder(binding.root) {
         var playlistDisposable: Disposable? = null

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/FiltersFragment.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/FiltersFragment.kt
@@ -46,7 +46,7 @@ import au.com.shiftyjelly.pocketcasts.compose.components.TipPosition
 import au.com.shiftyjelly.pocketcasts.compose.components.Tooltip
 import au.com.shiftyjelly.pocketcasts.compose.extensions.setContentWithViewCompositionStrategy
 import au.com.shiftyjelly.pocketcasts.filters.databinding.FragmentFiltersBinding
-import au.com.shiftyjelly.pocketcasts.models.entity.SmartPlaylist
+import au.com.shiftyjelly.pocketcasts.models.entity.PlaylistEntity
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.repositories.chromecast.CastManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.SmartPlaylistManager
@@ -83,7 +83,7 @@ class FiltersFragment :
     private var trackFilterListShown = false
     var filterCount: Int? = null
     var lastFilterUuidShown: String? = null
-    var previousLastFilter: SmartPlaylist? = null
+    var previousLastFilter: PlaylistEntity? = null
 
     private var binding: FragmentFiltersBinding? = null
 
@@ -242,13 +242,13 @@ class FiltersFragment :
         (activity as FragmentHostListener).showModal(fragment)
     }
 
-    fun openPlaylist(smartPlaylist: SmartPlaylist, isNewFilter: Boolean = false) {
+    fun openPlaylist(playlist: PlaylistEntity, isNewFilter: Boolean = false) {
         val context = context ?: return
 
-        lastFilterUuidShown = smartPlaylist.uuid
-        settings.setSelectedFilter(smartPlaylist.uuid)
+        lastFilterUuidShown = playlist.uuid
+        settings.setSelectedFilter(playlist.uuid)
 
-        val playlistFragment = FilterEpisodeListFragment.newInstance(smartPlaylist, isNewFilter, context)
+        val playlistFragment = FilterEpisodeListFragment.newInstance(playlist, isNewFilter, context)
         (activity as? FragmentHostListener)?.addFragment(playlistFragment)
 
         playlistFragment.view?.requestFocus() // Jump to new page for talk back

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/FiltersFragmentViewModel.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/FiltersFragmentViewModel.kt
@@ -6,7 +6,7 @@ import androidx.lifecycle.toLiveData
 import androidx.lifecycle.viewModelScope
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTracker
-import au.com.shiftyjelly.pocketcasts.models.entity.SmartPlaylist
+import au.com.shiftyjelly.pocketcasts.models.entity.PlaylistEntity
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
 import au.com.shiftyjelly.pocketcasts.repositories.playlist.Playlist
@@ -51,14 +51,14 @@ class FiltersFragmentViewModel @Inject constructor(
     override val coroutineContext: CoroutineContext
         get() = Dispatchers.Default
 
-    val filters: LiveData<List<SmartPlaylist>> = smartPlaylistManager.findAllRxFlowable().toLiveData()
+    val filters: LiveData<List<PlaylistEntity>> = smartPlaylistManager.findAllRxFlowable().toLiveData()
 
-    val countGenerator = { smartPlaylist: SmartPlaylist ->
-        smartPlaylistManager.countEpisodesRxFlowable(smartPlaylist, episodeManager, playbackManager).onErrorReturn { 0 }
+    val countGenerator = { playlist: PlaylistEntity ->
+        smartPlaylistManager.countEpisodesRxFlowable(playlist, episodeManager, playbackManager).onErrorReturn { 0 }
     }
 
-    var adapterState: MutableList<SmartPlaylist> = mutableListOf()
-    fun movePlaylist(fromPosition: Int, toPosition: Int): List<SmartPlaylist> {
+    var adapterState: MutableList<PlaylistEntity> = mutableListOf()
+    fun movePlaylist(fromPosition: Int, toPosition: Int): List<PlaylistEntity> {
         if (fromPosition < toPosition) {
             for (index in fromPosition until toPosition) {
                 Collections.swap(adapterState, index, index + 1)
@@ -76,7 +76,7 @@ class FiltersFragmentViewModel @Inject constructor(
 
         playlists.forEachIndexed { index, playlist ->
             playlist.sortPosition = index
-            playlist.syncStatus = SmartPlaylist.SYNC_STATUS_NOT_SYNCED
+            playlist.syncStatus = PlaylistEntity.SYNC_STATUS_NOT_SYNCED
         }
 
         runBlocking(Dispatchers.Default) {
@@ -96,7 +96,7 @@ class FiltersFragmentViewModel @Inject constructor(
         analyticsTracker.track(AnalyticsEvent.FILTER_LIST_SHOWN, properties)
     }
 
-    fun findPlaylistByUuid(playlistUuid: String, onSuccess: (SmartPlaylist) -> Unit) {
+    fun findPlaylistByUuid(playlistUuid: String, onSuccess: (PlaylistEntity) -> Unit) {
         viewModelScope.launch {
             val playlist = smartPlaylistManager.findByUuid(playlistUuid) ?: return@launch
             onSuccess(playlist)
@@ -111,13 +111,13 @@ class FiltersFragmentViewModel @Inject constructor(
         analyticsTracker.track(AnalyticsEvent.FILTER_TOOLTIP_SHOWN)
     }
 
-    fun shouldShowTooltip(filters: List<SmartPlaylist>, onShowTooltip: () -> Unit) {
+    fun shouldShowTooltip(filters: List<PlaylistEntity>, onShowTooltip: () -> Unit) {
         viewModelScope.launch {
             shouldShowTooltipSuspend(filters, onShowTooltip)
         }
     }
 
-    suspend fun shouldShowTooltipSuspend(filters: List<SmartPlaylist>, onShowTooltip: () -> Unit) {
+    suspend fun shouldShowTooltipSuspend(filters: List<PlaylistEntity>, onShowTooltip: () -> Unit) {
         if (!settings.showEmptyFiltersListTooltip.value) return
         if (filters.size > 2) return
 

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/PodcastOptionsFragment.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/PodcastOptionsFragment.kt
@@ -12,7 +12,7 @@ import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTracker
 import au.com.shiftyjelly.pocketcasts.analytics.SourceView
 import au.com.shiftyjelly.pocketcasts.filters.databinding.PodcastOptionsFragmentBinding
-import au.com.shiftyjelly.pocketcasts.models.entity.SmartPlaylist
+import au.com.shiftyjelly.pocketcasts.models.entity.PlaylistEntity
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.PlaylistProperty
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.PlaylistUpdateSource
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
@@ -44,9 +44,9 @@ class PodcastOptionsFragment :
     PodcastSelectFragment.Listener,
     CoroutineScope {
     companion object {
-        fun newInstance(smartPlaylist: SmartPlaylist): PodcastOptionsFragment {
+        fun newInstance(playlist: PlaylistEntity): PodcastOptionsFragment {
             val bundle = Bundle()
-            bundle.putString(ARG_PLAYLIST_UUID, smartPlaylist.uuid)
+            bundle.putString(ARG_PLAYLIST_UUID, playlist.uuid)
             val fragment = PodcastOptionsFragment()
             fragment.arguments = bundle
             return fragment
@@ -63,7 +63,7 @@ class PodcastOptionsFragment :
     @Inject lateinit var analyticsTracker: AnalyticsTracker
 
     var podcastSelection: List<String> = listOf()
-    var smartPlaylist: SmartPlaylist? = null
+    var playlist: PlaylistEntity? = null
     private var binding: PodcastOptionsFragmentBinding? = null
     private var userChanged = false
 
@@ -90,7 +90,7 @@ class PodcastOptionsFragment :
             val subscribedPodcasts = withContext(Dispatchers.Default) { podcastManager.findSubscribedBlocking() }.map { it.uuid }
             val playlistUuid = requireArguments().getString(ARG_PLAYLIST_UUID) ?: return@launch
             val playlist = smartPlaylistManager.findByUuid(playlistUuid) ?: return@launch
-            this@PodcastOptionsFragment.smartPlaylist = playlist
+            this@PodcastOptionsFragment.playlist = playlist
 
             val color = playlist.getColor(context)
 
@@ -130,11 +130,11 @@ class PodcastOptionsFragment :
         }
 
         btnSave.setOnClickListener {
-            smartPlaylist?.let { playlist ->
+            playlist?.let { playlist ->
                 playlist.podcastUuidList = podcastSelection
                 playlist.allPodcasts = switchAllPodcasts.isChecked || podcastSelection.isEmpty()
                 launch(Dispatchers.Default) {
-                    playlist.syncStatus = SmartPlaylist.SYNC_STATUS_NOT_SYNCED
+                    playlist.syncStatus = PlaylistEntity.SYNC_STATUS_NOT_SYNCED
 
                     val podcastSelectFragment = childFragmentManager.findFragmentById(R.id.podcastSelectFrame) as? PodcastSelectFragment
                     if (podcastSelectFragment == null) {

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/TimeOptionsFragment.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/filters/TimeOptionsFragment.kt
@@ -9,7 +9,7 @@ import androidx.annotation.StringRes
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import au.com.shiftyjelly.pocketcasts.filters.databinding.FilterOptionsFragmentBinding
-import au.com.shiftyjelly.pocketcasts.models.entity.SmartPlaylist
+import au.com.shiftyjelly.pocketcasts.models.entity.PlaylistEntity
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.PlaylistProperty
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.PlaylistUpdateSource
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.SmartPlaylistManager
@@ -40,9 +40,9 @@ class TimeOptionsFragment :
     }
 
     companion object {
-        fun newInstance(smartPlaylist: SmartPlaylist, options: OptionsType): TimeOptionsFragment {
+        fun newInstance(playlist: PlaylistEntity, options: OptionsType): TimeOptionsFragment {
             val bundle = Bundle()
-            bundle.putString(ARG_PLAYLIST_UUID, smartPlaylist.uuid)
+            bundle.putString(ARG_PLAYLIST_UUID, playlist.uuid)
             bundle.putString(ARG_OPTIONS_TYPE, options.type)
             val fragment = TimeOptionsFragment()
             fragment.arguments = bundle
@@ -70,7 +70,7 @@ class TimeOptionsFragment :
     private lateinit var options: List<FilterOption>
     private var binding: FilterOptionsFragmentBinding? = null
 
-    var smartPlaylist: SmartPlaylist? = null
+    var playlist: PlaylistEntity? = null
     var adapter: FilterOptionsAdapter? = null
     var selectedPosition: Int = 0
 
@@ -95,19 +95,19 @@ class TimeOptionsFragment :
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        val anytime = filterOptionForTitle(LR.string.filters_time_anytime, SmartPlaylist.ANYTIME)
-        val last24Hours = filterOptionForTitle(LR.string.filters_time_24_hours, SmartPlaylist.LAST_24_HOURS)
-        val last3Days = filterOptionForTitle(LR.string.filters_time_3_days, SmartPlaylist.LAST_3_DAYS)
-        val lastWeek = filterOptionForTitle(LR.string.filters_time_week, SmartPlaylist.LAST_WEEK)
-        val last2Weeks = filterOptionForTitle(LR.string.filters_time_2_weeks, SmartPlaylist.LAST_2_WEEKS)
-        val lastMonth = filterOptionForTitle(LR.string.filters_time_month, SmartPlaylist.LAST_MONTH)
+        val anytime = filterOptionForTitle(LR.string.filters_time_anytime, PlaylistEntity.ANYTIME)
+        val last24Hours = filterOptionForTitle(LR.string.filters_time_24_hours, PlaylistEntity.LAST_24_HOURS)
+        val last3Days = filterOptionForTitle(LR.string.filters_time_3_days, PlaylistEntity.LAST_3_DAYS)
+        val lastWeek = filterOptionForTitle(LR.string.filters_time_week, PlaylistEntity.LAST_WEEK)
+        val last2Weeks = filterOptionForTitle(LR.string.filters_time_2_weeks, PlaylistEntity.LAST_2_WEEKS)
+        val lastMonth = filterOptionForTitle(LR.string.filters_time_month, PlaylistEntity.LAST_MONTH)
 
         val downloadAll = FilterOption(
             LR.string.all,
             false,
             { v, position ->
-                smartPlaylist?.downloaded = true
-                smartPlaylist?.notDownloaded = true
+                playlist?.downloaded = true
+                playlist?.notDownloaded = true
                 onCheckedChanged(v, position)
             },
         )
@@ -116,8 +116,8 @@ class TimeOptionsFragment :
             LR.string.downloaded,
             false,
             { v, position ->
-                smartPlaylist?.downloaded = true
-                smartPlaylist?.notDownloaded = false
+                playlist?.downloaded = true
+                playlist?.notDownloaded = false
                 onCheckedChanged(v, position)
             },
         )
@@ -125,8 +125,8 @@ class TimeOptionsFragment :
             LR.string.not_downloaded,
             false,
             { v, position ->
-                smartPlaylist?.downloaded = false
-                smartPlaylist?.notDownloaded = true
+                playlist?.downloaded = false
+                playlist?.notDownloaded = true
                 onCheckedChanged(v, position)
             },
         )
@@ -136,7 +136,7 @@ class TimeOptionsFragment :
             false,
             { v, position ->
                 if (v) {
-                    smartPlaylist?.audioVideo = SmartPlaylist.AUDIO_VIDEO_FILTER_ALL
+                    playlist?.audioVideo = PlaylistEntity.AUDIO_VIDEO_FILTER_ALL
                     onCheckedChanged(v, position)
                 }
             },
@@ -146,7 +146,7 @@ class TimeOptionsFragment :
             false,
             { v, position ->
                 if (v) {
-                    smartPlaylist?.audioVideo = SmartPlaylist.AUDIO_VIDEO_FILTER_AUDIO_ONLY
+                    playlist?.audioVideo = PlaylistEntity.AUDIO_VIDEO_FILTER_AUDIO_ONLY
                     onCheckedChanged(v, position)
                 }
             },
@@ -156,7 +156,7 @@ class TimeOptionsFragment :
             false,
             { v, position ->
                 if (v) {
-                    smartPlaylist?.audioVideo = SmartPlaylist.AUDIO_VIDEO_FILTER_VIDEO_ONLY
+                    playlist?.audioVideo = PlaylistEntity.AUDIO_VIDEO_FILTER_VIDEO_ONLY
                     onCheckedChanged(v, position)
                 }
             },
@@ -183,7 +183,7 @@ class TimeOptionsFragment :
 
         launch {
             val playlist = smartPlaylistManager.findByUuid(requireArguments().getString(ARG_PLAYLIST_UUID)!!) ?: return@launch
-            this@TimeOptionsFragment.smartPlaylist = playlist
+            this@TimeOptionsFragment.playlist = playlist
 
             selectedPosition = when (optionType) {
                 OptionsType.Time -> options.indexOfFirst { it.playlistValue!! >= playlist.filterHours }
@@ -194,9 +194,9 @@ class TimeOptionsFragment :
                 } else {
                     2
                 }
-                OptionsType.AudioVideo -> if (playlist.audioVideo == SmartPlaylist.AUDIO_VIDEO_FILTER_ALL) {
+                OptionsType.AudioVideo -> if (playlist.audioVideo == PlaylistEntity.AUDIO_VIDEO_FILTER_ALL) {
                     0
-                } else if (playlist.audioVideo == SmartPlaylist.AUDIO_VIDEO_FILTER_AUDIO_ONLY) {
+                } else if (playlist.audioVideo == PlaylistEntity.AUDIO_VIDEO_FILTER_AUDIO_ONLY) {
                     1
                 } else {
                     2
@@ -219,7 +219,7 @@ class TimeOptionsFragment :
         }
 
         btnSave.setOnClickListener {
-            smartPlaylist?.let { playlist ->
+            playlist?.let { playlist ->
                 when (optionType) {
                     OptionsType.Time -> {
                         playlist.filterHours = options[selectedPosition].playlistValue ?: 0
@@ -243,14 +243,14 @@ class TimeOptionsFragment :
                     }
 
                     OptionsType.AudioVideo -> when (selectedPosition) {
-                        0 -> playlist.audioVideo = SmartPlaylist.AUDIO_VIDEO_FILTER_ALL
-                        1 -> playlist.audioVideo = SmartPlaylist.AUDIO_VIDEO_FILTER_AUDIO_ONLY
-                        2 -> playlist.audioVideo = SmartPlaylist.AUDIO_VIDEO_FILTER_VIDEO_ONLY
+                        0 -> playlist.audioVideo = PlaylistEntity.AUDIO_VIDEO_FILTER_ALL
+                        1 -> playlist.audioVideo = PlaylistEntity.AUDIO_VIDEO_FILTER_AUDIO_ONLY
+                        2 -> playlist.audioVideo = PlaylistEntity.AUDIO_VIDEO_FILTER_VIDEO_ONLY
                     }
                 }
 
                 launch(Dispatchers.Default) {
-                    playlist.syncStatus = SmartPlaylist.SYNC_STATUS_NOT_SYNCED
+                    playlist.syncStatus = PlaylistEntity.SYNC_STATUS_NOT_SYNCED
 
                     val playlistProperty = when (optionType) {
                         OptionsType.AudioVideo -> PlaylistProperty.MediaType

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastSettingsFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastSettingsFragment.kt
@@ -17,7 +17,7 @@ import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTracker
 import au.com.shiftyjelly.pocketcasts.localization.extensions.getStringPluralSeconds
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
-import au.com.shiftyjelly.pocketcasts.models.entity.SmartPlaylist
+import au.com.shiftyjelly.pocketcasts.models.entity.PlaylistEntity
 import au.com.shiftyjelly.pocketcasts.models.type.EpisodeStatusEnum
 import au.com.shiftyjelly.pocketcasts.podcasts.R
 import au.com.shiftyjelly.pocketcasts.podcasts.viewmodel.PodcastSettingsViewModel
@@ -497,7 +497,7 @@ class PodcastSettingsFragment :
         preferenceSkipLast?.icon = context.getTintedDrawable(R.drawable.ic_skip_outro, tintColor)
     }
 
-    private fun updateFiltersSummary(includedFilters: List<SmartPlaylist>, availableFilters: List<SmartPlaylist>) {
+    private fun updateFiltersSummary(includedFilters: List<PlaylistEntity>, availableFilters: List<PlaylistEntity>) {
         val filterTitles = includedFilters.map { it.title }
         if (filterTitles.isEmpty()) {
             preferenceFilters?.summary = getString(LR.string.podcast_not_in_filters)

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastSettingsFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastSettingsFragment.kt
@@ -16,8 +16,8 @@ import androidx.preference.SwitchPreference
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTracker
 import au.com.shiftyjelly.pocketcasts.localization.extensions.getStringPluralSeconds
-import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.entity.PlaylistEntity
+import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.type.EpisodeStatusEnum
 import au.com.shiftyjelly.pocketcasts.podcasts.R
 import au.com.shiftyjelly.pocketcasts.podcasts.viewmodel.PodcastSettingsViewModel

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/PodcastSettingsViewModel.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/PodcastSettingsViewModel.kt
@@ -9,7 +9,7 @@ import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTracker
 import au.com.shiftyjelly.pocketcasts.analytics.SourceView
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
-import au.com.shiftyjelly.pocketcasts.models.entity.SmartPlaylist
+import au.com.shiftyjelly.pocketcasts.models.entity.PlaylistEntity
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.PlaylistProperty
@@ -41,8 +41,8 @@ class PodcastSettingsViewModel @Inject constructor(
 
     var podcastUuid: String? = null
     lateinit var podcast: LiveData<Podcast>
-    lateinit var includedFilters: LiveData<List<SmartPlaylist>>
-    lateinit var availableFilters: LiveData<List<SmartPlaylist>>
+    lateinit var includedFilters: LiveData<List<PlaylistEntity>>
+    lateinit var availableFilters: LiveData<List<PlaylistEntity>>
 
     val globalSettings = settings.autoAddUpNextLimit.flow
         .combine(settings.autoAddUpNextLimitBehaviour.flow, ::Pair)
@@ -146,7 +146,7 @@ class PodcastSettingsViewModel @Inject constructor(
 
                     if (isUpdated) {
                         playlist.podcastUuidList = currentSelection
-                        playlist.syncStatus = SmartPlaylist.SYNC_STATUS_NOT_SYNCED
+                        playlist.syncStatus = PlaylistEntity.SYNC_STATUS_NOT_SYNCED
                         val userPlaylistUpdate = UserPlaylistUpdate(
                             listOf(PlaylistProperty.Podcasts),
                             PlaylistUpdateSource.PODCAST_SETTINGS,

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/PodcastSettingsViewModel.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/PodcastSettingsViewModel.kt
@@ -8,8 +8,8 @@ import androidx.lifecycle.viewModelScope
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTracker
 import au.com.shiftyjelly.pocketcasts.analytics.SourceView
-import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.entity.PlaylistEntity
+import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.PlaylistProperty

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/AutoDownloadFiltersFragment.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/AutoDownloadFiltersFragment.kt
@@ -8,7 +8,7 @@ import androidx.core.view.updatePadding
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
-import au.com.shiftyjelly.pocketcasts.models.entity.SmartPlaylist
+import au.com.shiftyjelly.pocketcasts.models.entity.PlaylistEntity
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.SmartPlaylistManager
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
@@ -37,7 +37,7 @@ class AutoDownloadFiltersFragment :
 
     @Inject lateinit var settings: Settings
 
-    private val filters = mutableListOf<SmartPlaylist>()
+    private val filters = mutableListOf<PlaylistEntity>()
     private val adapter = FilterAutoDownloadAdapter(filters, this, theme.isDarkTheme)
     private val disposables = CompositeDisposable()
 
@@ -77,8 +77,8 @@ class AutoDownloadFiltersFragment :
             .firstOrError()
             .subscribeOn(Schedulers.io())
             .observeOn(AndroidSchedulers.mainThread())
-            .subscribeWith(object : DisposableSingleObserver<List<SmartPlaylist>>() {
-                override fun onSuccess(list: List<SmartPlaylist>) {
+            .subscribeWith(object : DisposableSingleObserver<List<PlaylistEntity>>() {
+                override fun onSuccess(list: List<PlaylistEntity>) {
                     filters.clear()
                     filters.addAll(list)
                     adapter.notifyDataSetChanged()
@@ -90,7 +90,7 @@ class AutoDownloadFiltersFragment :
             }).addTo(disposables)
     }
 
-    override fun onAutoDownloadChanged(filter: SmartPlaylist, on: Boolean) {
+    override fun onAutoDownloadChanged(filter: PlaylistEntity, on: Boolean) {
         smartPlaylistManager.updateAutoDownloadStatusRxCompletable(filter, on)
             .subscribeOn(Schedulers.io())
             .observeOn(AndroidSchedulers.mainThread())

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/AutoDownloadFiltersFragment.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/AutoDownloadFiltersFragment.kt
@@ -91,7 +91,7 @@ class AutoDownloadFiltersFragment :
     }
 
     override fun onAutoDownloadChanged(filter: SmartPlaylist, on: Boolean) {
-        smartPlaylistManager.updateAutoDownloadStatusRxCompletable(filter, on, true, false)
+        smartPlaylistManager.updateAutoDownloadStatusRxCompletable(filter, on)
             .subscribeOn(Schedulers.io())
             .observeOn(AndroidSchedulers.mainThread())
             .subscribeWith(object : DisposableCompletableObserver() {
@@ -104,12 +104,5 @@ class AutoDownloadFiltersFragment :
                 }
             })
             .addTo(disposables)
-    }
-
-    override fun onSettingsClicked(filter: SmartPlaylist) {
-//        val intent = Intent(activity, PlaylistEditActivity::class.java)
-//        intent.putExtra(PlaylistEditActivity.EXTRA_PLAYLIST_ID, filter.id)
-//        intent.putExtra(PlaylistEditActivity.EXTRA_PLAYLIST_TITLE, filter.title)
-//        activity?.startActivity(intent)
     }
 }

--- a/modules/features/taskerplugin/src/main/java/au/com/shiftyjelly/pocketcasts/taskerplugin/queryfilters/ActionRunnerQueryFilters.kt
+++ b/modules/features/taskerplugin/src/main/java/au/com/shiftyjelly/pocketcasts/taskerplugin/queryfilters/ActionRunnerQueryFilters.kt
@@ -12,7 +12,7 @@ class ActionRunnerQueryFilters : TaskerPluginRunnerAction<InputQueryFilters, Arr
     override fun run(context: Context, input: TaskerInput<InputQueryFilters>): TaskerPluginResult<Array<OutputQueryFilters>> {
         val playlistManager = context.smartPlaylistManager
         val output = playlistManager.findAllBlocking().map {
-            OutputQueryFilters(it.uuid, it.title, it.episodeCount)
+            OutputQueryFilters(it.uuid, it.title)
         }.toTypedArray()
         return TaskerPluginResultSucess(output)
     }

--- a/modules/features/taskerplugin/src/main/java/au/com/shiftyjelly/pocketcasts/taskerplugin/queryfilters/IOQueryFilters.kt
+++ b/modules/features/taskerplugin/src/main/java/au/com/shiftyjelly/pocketcasts/taskerplugin/queryfilters/IOQueryFilters.kt
@@ -9,8 +9,7 @@ class InputQueryFilters
 private const val OUTPUT_PREFIX = "filter_"
 
 @TaskerOutputObject
-class OutputQueryFilters constructor(
+class OutputQueryFilters(
     @get:TaskerOutputVariable("${OUTPUT_PREFIX}uuid", labelResIdName = "filter_id", htmlLabelResIdName = "filter_id_description") var id: String?,
     @get:TaskerOutputVariable("${OUTPUT_PREFIX}title", labelResIdName = "filter_title") var title: String?,
-    @get:TaskerOutputVariable("${OUTPUT_PREFIX}episode_count", labelResIdName = "episode_count") var episodeCount: Int?,
 )

--- a/modules/services/model/schemas/au.com.shiftyjelly.pocketcasts.models.db.AppDatabase/118.json
+++ b/modules/services/model/schemas/au.com.shiftyjelly.pocketcasts.models.db.AppDatabase/118.json
@@ -1,0 +1,1895 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 118,
+    "identityHash": "49d05d7d0fb9ebc814308b894bad9900",
+    "entities": [
+      {
+        "tableName": "bump_stats",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`name` TEXT NOT NULL, `event_time` INTEGER NOT NULL, `custom_event_props` TEXT NOT NULL, PRIMARY KEY(`name`, `event_time`, `custom_event_props`))",
+        "fields": [
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "eventTime",
+            "columnName": "event_time",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "customEventProps",
+            "columnName": "custom_event_props",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "name",
+            "event_time",
+            "custom_event_props"
+          ]
+        }
+      },
+      {
+        "tableName": "bookmarks",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`uuid` TEXT NOT NULL, `podcast_uuid` TEXT NOT NULL, `episode_uuid` TEXT NOT NULL, `time` INTEGER NOT NULL, `created_at` INTEGER NOT NULL, `title` TEXT NOT NULL, `title_modified` INTEGER, `deleted` INTEGER NOT NULL, `deleted_modified` INTEGER, `sync_status` INTEGER NOT NULL, PRIMARY KEY(`uuid`))",
+        "fields": [
+          {
+            "fieldPath": "uuid",
+            "columnName": "uuid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "podcastUuid",
+            "columnName": "podcast_uuid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "episodeUuid",
+            "columnName": "episode_uuid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timeSecs",
+            "columnName": "time",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "titleModified",
+            "columnName": "title_modified",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "deleted",
+            "columnName": "deleted",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deletedModified",
+            "columnName": "deleted_modified",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "syncStatus",
+            "columnName": "sync_status",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "uuid"
+          ]
+        },
+        "indices": [
+          {
+            "name": "bookmarks_podcast_uuid",
+            "unique": false,
+            "columnNames": [
+              "podcast_uuid"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `bookmarks_podcast_uuid` ON `${TABLE_NAME}` (`podcast_uuid`)"
+          }
+        ]
+      },
+      {
+        "tableName": "podcast_episodes",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`uuid` TEXT NOT NULL, `episode_description` TEXT NOT NULL, `published_date` INTEGER NOT NULL, `title` TEXT NOT NULL, `size_in_bytes` INTEGER NOT NULL, `episode_status` INTEGER NOT NULL, `file_type` TEXT, `duration` REAL NOT NULL, `download_url` TEXT, `downloaded_file_path` TEXT, `downloaded_error_details` TEXT, `play_error_details` TEXT, `played_up_to` REAL NOT NULL, `playing_status` INTEGER NOT NULL, `podcast_id` TEXT NOT NULL, `added_date` INTEGER NOT NULL, `auto_download_status` INTEGER NOT NULL, `starred` INTEGER NOT NULL, `thumbnail_status` INTEGER NOT NULL, `last_download_attempt_date` INTEGER, `playing_status_modified` INTEGER, `played_up_to_modified` INTEGER, `duration_modified` INTEGER, `starred_modified` INTEGER, `archived` INTEGER NOT NULL, `archived_modified` INTEGER, `season` INTEGER, `number` INTEGER, `type` TEXT, `cleanTitle` TEXT, `last_playback_interaction_date` INTEGER, `last_playback_interaction_sync_status` INTEGER NOT NULL, `exclude_from_episode_limit` INTEGER NOT NULL, `download_task_id` TEXT, `last_archive_interaction_date` INTEGER, `image_url` TEXT, `deselected_chapters` TEXT NOT NULL, `deselected_chapters_modified` INTEGER, `slug` TEXT NOT NULL, PRIMARY KEY(`uuid`))",
+        "fields": [
+          {
+            "fieldPath": "uuid",
+            "columnName": "uuid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "episodeDescription",
+            "columnName": "episode_description",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "publishedDate",
+            "columnName": "published_date",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sizeInBytes",
+            "columnName": "size_in_bytes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "episodeStatus",
+            "columnName": "episode_status",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fileType",
+            "columnName": "file_type",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "duration",
+            "columnName": "duration",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "downloadUrl",
+            "columnName": "download_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "downloadedFilePath",
+            "columnName": "downloaded_file_path",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "downloadErrorDetails",
+            "columnName": "downloaded_error_details",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "playErrorDetails",
+            "columnName": "play_error_details",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "playedUpTo",
+            "columnName": "played_up_to",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playingStatus",
+            "columnName": "playing_status",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "podcastUuid",
+            "columnName": "podcast_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedDate",
+            "columnName": "added_date",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "autoDownloadStatus",
+            "columnName": "auto_download_status",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isStarred",
+            "columnName": "starred",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "thumbnailStatus",
+            "columnName": "thumbnail_status",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastDownloadAttemptDate",
+            "columnName": "last_download_attempt_date",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "playingStatusModified",
+            "columnName": "playing_status_modified",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "playedUpToModified",
+            "columnName": "played_up_to_modified",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "durationModified",
+            "columnName": "duration_modified",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "starredModified",
+            "columnName": "starred_modified",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "isArchived",
+            "columnName": "archived",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "archivedModified",
+            "columnName": "archived_modified",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "season",
+            "columnName": "season",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "number",
+            "columnName": "number",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "cleanTitle",
+            "columnName": "cleanTitle",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "lastPlaybackInteraction",
+            "columnName": "last_playback_interaction_date",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "lastPlaybackInteractionSyncStatus",
+            "columnName": "last_playback_interaction_sync_status",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "excludeFromEpisodeLimit",
+            "columnName": "exclude_from_episode_limit",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "downloadTaskId",
+            "columnName": "download_task_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "lastArchiveInteraction",
+            "columnName": "last_archive_interaction_date",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "imageUrl",
+            "columnName": "image_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "deselectedChapters",
+            "columnName": "deselected_chapters",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deselectedChaptersModified",
+            "columnName": "deselected_chapters_modified",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "slug",
+            "columnName": "slug",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "uuid"
+          ]
+        },
+        "indices": [
+          {
+            "name": "episode_last_download_attempt_date",
+            "unique": false,
+            "columnNames": [
+              "last_download_attempt_date"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `episode_last_download_attempt_date` ON `${TABLE_NAME}` (`last_download_attempt_date`)"
+          },
+          {
+            "name": "episode_podcast_id",
+            "unique": false,
+            "columnNames": [
+              "podcast_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `episode_podcast_id` ON `${TABLE_NAME}` (`podcast_id`)"
+          },
+          {
+            "name": "episode_published_date",
+            "unique": false,
+            "columnNames": [
+              "published_date"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `episode_published_date` ON `${TABLE_NAME}` (`published_date`)"
+          }
+        ]
+      },
+      {
+        "tableName": "folders",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`uuid` TEXT NOT NULL, `name` TEXT NOT NULL, `color` INTEGER NOT NULL, `added_date` INTEGER NOT NULL, `sort_position` INTEGER NOT NULL, `podcasts_sort_type` INTEGER NOT NULL, `deleted` INTEGER NOT NULL, `sync_modified` INTEGER NOT NULL, PRIMARY KEY(`uuid`))",
+        "fields": [
+          {
+            "fieldPath": "uuid",
+            "columnName": "uuid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "color",
+            "columnName": "color",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedDate",
+            "columnName": "added_date",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sortPosition",
+            "columnName": "sort_position",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "podcastsSortType",
+            "columnName": "podcasts_sort_type",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deleted",
+            "columnName": "deleted",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "syncModified",
+            "columnName": "sync_modified",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "uuid"
+          ]
+        }
+      },
+      {
+        "tableName": "suggested_folders",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`folder_name` TEXT NOT NULL, `podcast_uuid` TEXT NOT NULL, PRIMARY KEY(`folder_name`, `podcast_uuid`))",
+        "fields": [
+          {
+            "fieldPath": "name",
+            "columnName": "folder_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "podcastUuid",
+            "columnName": "podcast_uuid",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "folder_name",
+            "podcast_uuid"
+          ]
+        }
+      },
+      {
+        "tableName": "playlists",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`_id` INTEGER, `uuid` TEXT NOT NULL, `title` TEXT NOT NULL, `iconId` INTEGER NOT NULL, `sortPosition` INTEGER, `sortId` INTEGER NOT NULL, `manual` INTEGER NOT NULL, `draft` INTEGER NOT NULL, `deleted` INTEGER NOT NULL, `syncStatus` INTEGER NOT NULL, `autoDownload` INTEGER NOT NULL, `autoDownloadLimit` INTEGER NOT NULL, `unplayed` INTEGER NOT NULL, `partiallyPlayed` INTEGER NOT NULL, `finished` INTEGER NOT NULL, `downloaded` INTEGER NOT NULL, `notDownloaded` INTEGER NOT NULL, `audioVideo` INTEGER NOT NULL, `filterHours` INTEGER NOT NULL, `starred` INTEGER NOT NULL, `allPodcasts` INTEGER NOT NULL, `podcastUuids` TEXT, `filterDuration` INTEGER NOT NULL, `longerThan` INTEGER NOT NULL, `shorterThan` INTEGER NOT NULL, PRIMARY KEY(`_id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "_id",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "uuid",
+            "columnName": "uuid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "iconId",
+            "columnName": "iconId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sortPosition",
+            "columnName": "sortPosition",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "sortType",
+            "columnName": "sortId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "manual",
+            "columnName": "manual",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "draft",
+            "columnName": "draft",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deleted",
+            "columnName": "deleted",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "syncStatus",
+            "columnName": "syncStatus",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "autoDownload",
+            "columnName": "autoDownload",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "autodownloadLimit",
+            "columnName": "autoDownloadLimit",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "unplayed",
+            "columnName": "unplayed",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "partiallyPlayed",
+            "columnName": "partiallyPlayed",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "finished",
+            "columnName": "finished",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "downloaded",
+            "columnName": "downloaded",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "notDownloaded",
+            "columnName": "notDownloaded",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "audioVideo",
+            "columnName": "audioVideo",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "filterHours",
+            "columnName": "filterHours",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "starred",
+            "columnName": "starred",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "allPodcasts",
+            "columnName": "allPodcasts",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "podcastUuids",
+            "columnName": "podcastUuids",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "filterDuration",
+            "columnName": "filterDuration",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "longerThan",
+            "columnName": "longerThan",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "shorterThan",
+            "columnName": "shorterThan",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "playlists_uuid",
+            "unique": false,
+            "columnNames": [
+              "uuid"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `playlists_uuid` ON `${TABLE_NAME}` (`uuid`)"
+          }
+        ]
+      },
+      {
+        "tableName": "filter_episodes",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`_id` INTEGER PRIMARY KEY AUTOINCREMENT, `playlistId` INTEGER NOT NULL, `episodeUuid` TEXT NOT NULL, `position` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "_id",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "playlistId",
+            "columnName": "playlistId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "episodeUuid",
+            "columnName": "episodeUuid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "position",
+            "columnName": "position",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "filter_episodes_playlist_id",
+            "unique": false,
+            "columnNames": [
+              "playlistId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `filter_episodes_playlist_id` ON `${TABLE_NAME}` (`playlistId`)"
+          }
+        ]
+      },
+      {
+        "tableName": "podcasts",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`uuid` TEXT NOT NULL, `added_date` INTEGER, `thumbnail_url` TEXT, `title` TEXT NOT NULL, `podcast_url` TEXT, `podcast_description` TEXT NOT NULL, `podcast_html_description` TEXT NOT NULL, `podcast_category` TEXT NOT NULL, `podcast_language` TEXT NOT NULL, `media_type` TEXT, `latest_episode_uuid` TEXT, `author` TEXT NOT NULL, `sort_order` INTEGER NOT NULL, `episodes_sort_order` INTEGER NOT NULL, `episodes_sort_order_modified` INTEGER, `latest_episode_date` INTEGER, `episodes_to_keep` INTEGER NOT NULL, `override_global_settings` INTEGER NOT NULL, `override_global_effects` INTEGER NOT NULL, `override_global_effects_modified` INTEGER, `start_from` INTEGER NOT NULL, `start_from_modified` INTEGER, `playback_speed` REAL NOT NULL, `playback_speed_modified` INTEGER, `volume_boosted` INTEGER NOT NULL, `volume_boosted_modified` INTEGER, `is_folder` INTEGER NOT NULL, `subscribed` INTEGER NOT NULL, `show_notifications` INTEGER NOT NULL, `show_notifications_modified` INTEGER, `auto_download_status` INTEGER NOT NULL, `auto_add_to_up_next` INTEGER NOT NULL, `auto_add_to_up_next_modified` INTEGER, `most_popular_color` INTEGER NOT NULL, `primary_color` INTEGER NOT NULL, `secondary_color` INTEGER NOT NULL, `light_overlay_color` INTEGER NOT NULL, `fab_for_light_bg` INTEGER NOT NULL, `link_for_dark_bg` INTEGER NOT NULL, `link_for_light_bg` INTEGER NOT NULL, `color_version` INTEGER NOT NULL, `color_last_downloaded` INTEGER NOT NULL, `sync_status` INTEGER NOT NULL, `exclude_from_auto_archive` INTEGER NOT NULL, `override_global_archive` INTEGER NOT NULL, `override_global_archive_modified` INTEGER, `auto_archive_played_after` INTEGER NOT NULL, `auto_archive_played_after_modified` INTEGER, `auto_archive_inactive_after` INTEGER NOT NULL, `auto_archive_inactive_after_modified` INTEGER, `auto_archive_episode_limit` INTEGER NOT NULL, `auto_archive_episode_limit_modified` INTEGER, `estimated_next_episode` INTEGER, `episode_frequency` TEXT, `grouping` INTEGER NOT NULL, `grouping_modified` INTEGER, `skip_last` INTEGER NOT NULL, `skip_last_modified` INTEGER, `show_archived` INTEGER NOT NULL, `show_archived_modified` INTEGER, `trim_silence_level` INTEGER NOT NULL, `trim_silence_level_modified` INTEGER, `refresh_available` INTEGER NOT NULL, `folder_uuid` TEXT, `licensing` INTEGER NOT NULL, `isPaid` INTEGER NOT NULL, `is_private` INTEGER NOT NULL, `is_header_expanded` INTEGER NOT NULL DEFAULT 1, `funding_url` TEXT, `slug` TEXT NOT NULL, `bundleuuid` TEXT, `bundlebundleUrl` TEXT, `bundlepaymentUrl` TEXT, `bundledescription` TEXT, `bundlepodcastUuid` TEXT, `bundlepaidType` TEXT, PRIMARY KEY(`uuid`))",
+        "fields": [
+          {
+            "fieldPath": "uuid",
+            "columnName": "uuid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedDate",
+            "columnName": "added_date",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "thumbnailUrl",
+            "columnName": "thumbnail_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "podcastUrl",
+            "columnName": "podcast_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "podcastDescription",
+            "columnName": "podcast_description",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "podcastHtmlDescription",
+            "columnName": "podcast_html_description",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "podcastCategory",
+            "columnName": "podcast_category",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "podcastLanguage",
+            "columnName": "podcast_language",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mediaType",
+            "columnName": "media_type",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "latestEpisodeUuid",
+            "columnName": "latest_episode_uuid",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "author",
+            "columnName": "author",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sortPosition",
+            "columnName": "sort_order",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "episodesSortType",
+            "columnName": "episodes_sort_order",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "episodesSortTypeModified",
+            "columnName": "episodes_sort_order_modified",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "latestEpisodeDate",
+            "columnName": "latest_episode_date",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "episodesToKeep",
+            "columnName": "episodes_to_keep",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "overrideGlobalSettings",
+            "columnName": "override_global_settings",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "overrideGlobalEffects",
+            "columnName": "override_global_effects",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "overrideGlobalEffectsModified",
+            "columnName": "override_global_effects_modified",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "startFromSecs",
+            "columnName": "start_from",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startFromModified",
+            "columnName": "start_from_modified",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "playbackSpeed",
+            "columnName": "playback_speed",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playbackSpeedModified",
+            "columnName": "playback_speed_modified",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "isVolumeBoosted",
+            "columnName": "volume_boosted",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "volumeBoostedModified",
+            "columnName": "volume_boosted_modified",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "isFolder",
+            "columnName": "is_folder",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isSubscribed",
+            "columnName": "subscribed",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isShowNotifications",
+            "columnName": "show_notifications",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "showNotificationsModified",
+            "columnName": "show_notifications_modified",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "autoDownloadStatus",
+            "columnName": "auto_download_status",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "autoAddToUpNext",
+            "columnName": "auto_add_to_up_next",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "autoAddToUpNextModified",
+            "columnName": "auto_add_to_up_next_modified",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "backgroundColor",
+            "columnName": "most_popular_color",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tintColorForLightBg",
+            "columnName": "primary_color",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tintColorForDarkBg",
+            "columnName": "secondary_color",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fabColorForDarkBg",
+            "columnName": "light_overlay_color",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fabColorForLightBg",
+            "columnName": "fab_for_light_bg",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "linkColorForLightBg",
+            "columnName": "link_for_dark_bg",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "linkColorForDarkBg",
+            "columnName": "link_for_light_bg",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "colorVersion",
+            "columnName": "color_version",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "colorLastDownloaded",
+            "columnName": "color_last_downloaded",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "syncStatus",
+            "columnName": "sync_status",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "excludeFromAutoArchive",
+            "columnName": "exclude_from_auto_archive",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "overrideGlobalArchive",
+            "columnName": "override_global_archive",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "overrideGlobalArchiveModified",
+            "columnName": "override_global_archive_modified",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "rawAutoArchiveAfterPlaying",
+            "columnName": "auto_archive_played_after",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "autoArchiveAfterPlayingModified",
+            "columnName": "auto_archive_played_after_modified",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "rawAutoArchiveInactive",
+            "columnName": "auto_archive_inactive_after",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "autoArchiveInactiveModified",
+            "columnName": "auto_archive_inactive_after_modified",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "rawAutoArchiveEpisodeLimit",
+            "columnName": "auto_archive_episode_limit",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "autoArchiveEpisodeLimitModified",
+            "columnName": "auto_archive_episode_limit_modified",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "estimatedNextEpisode",
+            "columnName": "estimated_next_episode",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "episodeFrequency",
+            "columnName": "episode_frequency",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "grouping",
+            "columnName": "grouping",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "groupingModified",
+            "columnName": "grouping_modified",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "skipLastSecs",
+            "columnName": "skip_last",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "skipLastModified",
+            "columnName": "skip_last_modified",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "showArchived",
+            "columnName": "show_archived",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "showArchivedModified",
+            "columnName": "show_archived_modified",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "trimMode",
+            "columnName": "trim_silence_level",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "trimModeModified",
+            "columnName": "trim_silence_level_modified",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "refreshAvailable",
+            "columnName": "refresh_available",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "rawFolderUuid",
+            "columnName": "folder_uuid",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "licensing",
+            "columnName": "licensing",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isPaid",
+            "columnName": "isPaid",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isPrivate",
+            "columnName": "is_private",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isHeaderExpanded",
+            "columnName": "is_header_expanded",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "1"
+          },
+          {
+            "fieldPath": "fundingUrl",
+            "columnName": "funding_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "slug",
+            "columnName": "slug",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "singleBundle.uuid",
+            "columnName": "bundleuuid",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "singleBundle.bundleUrl",
+            "columnName": "bundlebundleUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "singleBundle.paymentUrl",
+            "columnName": "bundlepaymentUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "singleBundle.description",
+            "columnName": "bundledescription",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "singleBundle.podcastUuid",
+            "columnName": "bundlepodcastUuid",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "singleBundle.paidType",
+            "columnName": "bundlepaidType",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "uuid"
+          ]
+        }
+      },
+      {
+        "tableName": "search_history",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`_id` INTEGER PRIMARY KEY AUTOINCREMENT, `modified` INTEGER NOT NULL, `term` TEXT, `podcast_uuid` TEXT, `podcast_title` TEXT, `podcast_author` TEXT, `folder_uuid` TEXT, `folder_title` TEXT, `folder_color` INTEGER, `folder_podcastIds` TEXT, `episode_uuid` TEXT, `episode_title` TEXT, `episode_duration` REAL, `episode_podcastUuid` TEXT, `episode_podcastTitle` TEXT, `episode_artworkUrl` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "_id",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "modified",
+            "columnName": "modified",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "term",
+            "columnName": "term",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "podcast.uuid",
+            "columnName": "podcast_uuid",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "podcast.title",
+            "columnName": "podcast_title",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "podcast.author",
+            "columnName": "podcast_author",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "folder.uuid",
+            "columnName": "folder_uuid",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "folder.title",
+            "columnName": "folder_title",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "folder.color",
+            "columnName": "folder_color",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "folder.podcastIds",
+            "columnName": "folder_podcastIds",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "episode.uuid",
+            "columnName": "episode_uuid",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "episode.title",
+            "columnName": "episode_title",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "episode.duration",
+            "columnName": "episode_duration",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "episode.podcastUuid",
+            "columnName": "episode_podcastUuid",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "episode.podcastTitle",
+            "columnName": "episode_podcastTitle",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "episode.artworkUrl",
+            "columnName": "episode_artworkUrl",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_search_history_term",
+            "unique": true,
+            "columnNames": [
+              "term"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_search_history_term` ON `${TABLE_NAME}` (`term`)"
+          },
+          {
+            "name": "index_search_history_podcast_uuid",
+            "unique": true,
+            "columnNames": [
+              "podcast_uuid"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_search_history_podcast_uuid` ON `${TABLE_NAME}` (`podcast_uuid`)"
+          },
+          {
+            "name": "index_search_history_folder_uuid",
+            "unique": true,
+            "columnNames": [
+              "folder_uuid"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_search_history_folder_uuid` ON `${TABLE_NAME}` (`folder_uuid`)"
+          },
+          {
+            "name": "index_search_history_episode_uuid",
+            "unique": true,
+            "columnNames": [
+              "episode_uuid"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_search_history_episode_uuid` ON `${TABLE_NAME}` (`episode_uuid`)"
+          }
+        ]
+      },
+      {
+        "tableName": "up_next_changes",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`_id` INTEGER PRIMARY KEY AUTOINCREMENT, `type` INTEGER NOT NULL, `uuid` TEXT, `uuids` TEXT, `modified` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "_id",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "uuid",
+            "columnName": "uuid",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "uuids",
+            "columnName": "uuids",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "modified",
+            "columnName": "modified",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "_id"
+          ]
+        }
+      },
+      {
+        "tableName": "up_next_episodes",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`_id` INTEGER PRIMARY KEY AUTOINCREMENT, `episodeUuid` TEXT NOT NULL, `position` INTEGER NOT NULL, `playlistId` INTEGER, `title` TEXT NOT NULL, `publishedDate` INTEGER, `downloadUrl` TEXT, `podcastUuid` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "_id",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "episodeUuid",
+            "columnName": "episodeUuid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "position",
+            "columnName": "position",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playlistId",
+            "columnName": "playlistId",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "publishedDate",
+            "columnName": "publishedDate",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "downloadUrl",
+            "columnName": "downloadUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "podcastUuid",
+            "columnName": "podcastUuid",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "up_next_episode_episodeUuid",
+            "unique": false,
+            "columnNames": [
+              "episodeUuid"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `up_next_episode_episodeUuid` ON `${TABLE_NAME}` (`episodeUuid`)"
+          }
+        ]
+      },
+      {
+        "tableName": "user_episodes",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`uuid` TEXT NOT NULL, `published_date` INTEGER NOT NULL, `episode_description` TEXT NOT NULL, `title` TEXT NOT NULL, `size_in_bytes` INTEGER NOT NULL, `episode_status` INTEGER NOT NULL, `file_type` TEXT, `duration` REAL NOT NULL, `download_url` TEXT, `played_up_to` REAL NOT NULL, `playing_status` INTEGER NOT NULL, `added_date` INTEGER NOT NULL, `auto_download_status` INTEGER NOT NULL, `last_download_attempt_date` INTEGER, `archived` INTEGER NOT NULL, `download_task_id` TEXT, `downloaded_file_path` TEXT, `playing_status_modified` INTEGER, `played_up_to_modified` INTEGER, `artwork_url` TEXT, `play_error_details` TEXT, `server_status` INTEGER NOT NULL, `upload_error_details` TEXT, `downloaded_error_details` TEXT, `tint_color_index` INTEGER NOT NULL, `has_custom_image` INTEGER NOT NULL, `upload_task_id` TEXT, `deselected_chapters` TEXT NOT NULL, `deselected_chapters_modified` INTEGER, PRIMARY KEY(`uuid`))",
+        "fields": [
+          {
+            "fieldPath": "uuid",
+            "columnName": "uuid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "publishedDate",
+            "columnName": "published_date",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "episodeDescription",
+            "columnName": "episode_description",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sizeInBytes",
+            "columnName": "size_in_bytes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "episodeStatus",
+            "columnName": "episode_status",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fileType",
+            "columnName": "file_type",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "duration",
+            "columnName": "duration",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "downloadUrl",
+            "columnName": "download_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "playedUpTo",
+            "columnName": "played_up_to",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playingStatus",
+            "columnName": "playing_status",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedDate",
+            "columnName": "added_date",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "autoDownloadStatus",
+            "columnName": "auto_download_status",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastDownloadAttemptDate",
+            "columnName": "last_download_attempt_date",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "isArchived",
+            "columnName": "archived",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "downloadTaskId",
+            "columnName": "download_task_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "downloadedFilePath",
+            "columnName": "downloaded_file_path",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "playingStatusModified",
+            "columnName": "playing_status_modified",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "playedUpToModified",
+            "columnName": "played_up_to_modified",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "artworkUrl",
+            "columnName": "artwork_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "playErrorDetails",
+            "columnName": "play_error_details",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "serverStatus",
+            "columnName": "server_status",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "uploadErrorDetails",
+            "columnName": "upload_error_details",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "downloadErrorDetails",
+            "columnName": "downloaded_error_details",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "tintColorIndex",
+            "columnName": "tint_color_index",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "hasCustomImage",
+            "columnName": "has_custom_image",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "uploadTaskId",
+            "columnName": "upload_task_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "deselectedChapters",
+            "columnName": "deselected_chapters",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deselectedChaptersModified",
+            "columnName": "deselected_chapters_modified",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "uuid"
+          ]
+        },
+        "indices": [
+          {
+            "name": "user_episode_last_download_attempt_date",
+            "unique": false,
+            "columnNames": [
+              "last_download_attempt_date"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `user_episode_last_download_attempt_date` ON `${TABLE_NAME}` (`last_download_attempt_date`)"
+          },
+          {
+            "name": "user_episode_published_date",
+            "unique": false,
+            "columnNames": [
+              "published_date"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `user_episode_published_date` ON `${TABLE_NAME}` (`published_date`)"
+          }
+        ]
+      },
+      {
+        "tableName": "podcast_ratings",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`podcast_uuid` TEXT NOT NULL, `average` REAL, `total` INTEGER, PRIMARY KEY(`podcast_uuid`))",
+        "fields": [
+          {
+            "fieldPath": "podcastUuid",
+            "columnName": "podcast_uuid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "average",
+            "columnName": "average",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "total",
+            "columnName": "total",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "podcast_uuid"
+          ]
+        }
+      },
+      {
+        "tableName": "episode_chapters",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`chapter_index` INTEGER NOT NULL, `episode_uuid` TEXT NOT NULL, `start_time` INTEGER NOT NULL, `end_time` INTEGER, `title` TEXT, `image_url` TEXT, `url` TEXT, `is_embedded` INTEGER NOT NULL, PRIMARY KEY(`episode_uuid`, `chapter_index`))",
+        "fields": [
+          {
+            "fieldPath": "index",
+            "columnName": "chapter_index",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "episodeUuid",
+            "columnName": "episode_uuid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startTimeMs",
+            "columnName": "start_time",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "endTimeMs",
+            "columnName": "end_time",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "imageUrl",
+            "columnName": "image_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "isEmbedded",
+            "columnName": "is_embedded",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "episode_uuid",
+            "chapter_index"
+          ]
+        },
+        "indices": [
+          {
+            "name": "chapter_episode_uuid_index",
+            "unique": false,
+            "columnNames": [
+              "episode_uuid"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `chapter_episode_uuid_index` ON `${TABLE_NAME}` (`episode_uuid`)"
+          }
+        ]
+      },
+      {
+        "tableName": "curated_podcasts",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`list_id` TEXT NOT NULL, `list_title` TEXT NOT NULL, `podcast_id` TEXT NOT NULL, `podcast_title` TEXT NOT NULL, `podcast_description` TEXT, PRIMARY KEY(`list_id`, `podcast_id`))",
+        "fields": [
+          {
+            "fieldPath": "listId",
+            "columnName": "list_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "listTitle",
+            "columnName": "list_title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "podcastId",
+            "columnName": "podcast_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "podcastTitle",
+            "columnName": "podcast_title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "podcastDescription",
+            "columnName": "podcast_description",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "list_id",
+            "podcast_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "curated_podcasts_list_id_index",
+            "unique": false,
+            "columnNames": [
+              "list_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `curated_podcasts_list_id_index` ON `${TABLE_NAME}` (`list_id`)"
+          },
+          {
+            "name": "curated_podcasts_podcast_id_index",
+            "unique": false,
+            "columnNames": [
+              "podcast_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `curated_podcasts_podcast_id_index` ON `${TABLE_NAME}` (`podcast_id`)"
+          }
+        ]
+      },
+      {
+        "tableName": "episode_transcript",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`episode_uuid` TEXT NOT NULL, `url` TEXT NOT NULL, `type` TEXT NOT NULL, `is_generated` INTEGER NOT NULL, `language` TEXT, PRIMARY KEY(`episode_uuid`, `url`))",
+        "fields": [
+          {
+            "fieldPath": "episodeUuid",
+            "columnName": "episode_uuid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isGenerated",
+            "columnName": "is_generated",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "language",
+            "columnName": "language",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "episode_uuid",
+            "url"
+          ]
+        }
+      },
+      {
+        "tableName": "user_podcast_ratings",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`podcast_uuid` TEXT NOT NULL, `rating` INTEGER NOT NULL, `modified_at` INTEGER NOT NULL, PRIMARY KEY(`podcast_uuid`))",
+        "fields": [
+          {
+            "fieldPath": "podcastUuid",
+            "columnName": "podcast_uuid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "rating",
+            "columnName": "rating",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "modifiedAt",
+            "columnName": "modified_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "podcast_uuid"
+          ]
+        }
+      },
+      {
+        "tableName": "up_next_history",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`episodeUuid` TEXT NOT NULL, `position` INTEGER NOT NULL, `playlistId` INTEGER, `title` TEXT NOT NULL, `publishedDate` INTEGER, `downloadUrl` TEXT, `podcastUuid` TEXT, `addedDate` INTEGER NOT NULL, PRIMARY KEY(`episodeUuid`, `addedDate`))",
+        "fields": [
+          {
+            "fieldPath": "episodeUuid",
+            "columnName": "episodeUuid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "position",
+            "columnName": "position",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playlistId",
+            "columnName": "playlistId",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "publishedDate",
+            "columnName": "publishedDate",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "downloadUrl",
+            "columnName": "downloadUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "podcastUuid",
+            "columnName": "podcastUuid",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "addedDate",
+            "columnName": "addedDate",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "episodeUuid",
+            "addedDate"
+          ]
+        }
+      },
+      {
+        "tableName": "user_notifications",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`notification_id` INTEGER NOT NULL, `sent_this_week` INTEGER NOT NULL, `last_sent_at` INTEGER NOT NULL, `interacted_at` INTEGER, PRIMARY KEY(`notification_id`))",
+        "fields": [
+          {
+            "fieldPath": "notificationId",
+            "columnName": "notification_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sentThisWeek",
+            "columnName": "sent_this_week",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastSentAt",
+            "columnName": "last_sent_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "interactedAt",
+            "columnName": "interacted_at",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "notification_id"
+          ]
+        }
+      },
+      {
+        "tableName": "user_category_visits",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`category_id` INTEGER NOT NULL, `total_visits` INTEGER NOT NULL, PRIMARY KEY(`category_id`))",
+        "fields": [
+          {
+            "fieldPath": "categoryId",
+            "columnName": "category_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalVisits",
+            "columnName": "total_visits",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "category_id"
+          ]
+        }
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '49d05d7d0fb9ebc814308b894bad9900')"
+    ]
+  }
+}

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/AppDatabase.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/AppDatabase.kt
@@ -64,7 +64,7 @@ import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastRatings
 import au.com.shiftyjelly.pocketcasts.models.entity.SearchHistoryItem
-import au.com.shiftyjelly.pocketcasts.models.entity.SmartPlaylist
+import au.com.shiftyjelly.pocketcasts.models.entity.PlaylistEntity
 import au.com.shiftyjelly.pocketcasts.models.entity.SuggestedFolder
 import au.com.shiftyjelly.pocketcasts.models.entity.Transcript
 import au.com.shiftyjelly.pocketcasts.models.entity.UpNextChange
@@ -87,7 +87,7 @@ import au.com.shiftyjelly.pocketcasts.localization.R as LR
         PodcastEpisode::class,
         Folder::class,
         SuggestedFolder::class,
-        SmartPlaylist::class,
+        PlaylistEntity::class,
         PlaylistEpisode::class,
         Podcast::class,
         SearchHistoryItem::class,

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/AppDatabase.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/AppDatabase.kt
@@ -59,12 +59,12 @@ import au.com.shiftyjelly.pocketcasts.models.entity.Bookmark
 import au.com.shiftyjelly.pocketcasts.models.entity.ChapterIndices
 import au.com.shiftyjelly.pocketcasts.models.entity.CuratedPodcast
 import au.com.shiftyjelly.pocketcasts.models.entity.Folder
+import au.com.shiftyjelly.pocketcasts.models.entity.PlaylistEntity
 import au.com.shiftyjelly.pocketcasts.models.entity.PlaylistEpisode
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastRatings
 import au.com.shiftyjelly.pocketcasts.models.entity.SearchHistoryItem
-import au.com.shiftyjelly.pocketcasts.models.entity.PlaylistEntity
 import au.com.shiftyjelly.pocketcasts.models.entity.SuggestedFolder
 import au.com.shiftyjelly.pocketcasts.models.entity.Transcript
 import au.com.shiftyjelly.pocketcasts.models.entity.UpNextChange

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/PlaylistDao.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/PlaylistDao.kt
@@ -7,10 +7,10 @@ import androidx.room.RoomRawQuery
 import androidx.room.Transaction
 import androidx.room.Upsert
 import au.com.shiftyjelly.pocketcasts.models.db.AppDatabase
-import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
-import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.models.entity.PlaylistEntity
 import au.com.shiftyjelly.pocketcasts.models.entity.PlaylistEntity.Companion.SYNC_STATUS_NOT_SYNCED
+import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
+import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.models.to.PlaylistEpisodeMetadata
 import au.com.shiftyjelly.pocketcasts.models.to.PlaylistShortcut
 import au.com.shiftyjelly.pocketcasts.models.type.PlaylistEpisodeSortType

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/PlaylistDao.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/PlaylistDao.kt
@@ -31,22 +31,22 @@ abstract class PlaylistDao {
     @Upsert
     abstract suspend fun upsertAllPlaylists(playlists: List<SmartPlaylist>)
 
-    @Query("SELECT uuid FROM smart_playlists ORDER BY sortPosition ASC")
+    @Query("SELECT uuid FROM playlists ORDER BY sortPosition ASC")
     abstract suspend fun getAllPlaylistUuids(): List<String>
 
-    @Query("SELECT * FROM smart_playlists WHERE manual = 0 AND deleted = 0 AND draft = 0 AND uuid = :uuid")
+    @Query("SELECT * FROM playlists WHERE manual = 0 AND deleted = 0 AND draft = 0 AND uuid = :uuid")
     abstract fun observeSmartPlaylist(uuid: String): Flow<SmartPlaylist?>
 
-    @Query("SELECT * FROM smart_playlists WHERE manual = 0 AND deleted = 0 AND draft = 0 ORDER BY sortPosition ASC")
+    @Query("SELECT * FROM playlists WHERE manual = 0 AND deleted = 0 AND draft = 0 ORDER BY sortPosition ASC")
     abstract fun observeSmartPlaylists(): Flow<List<SmartPlaylist>>
 
-    @Query("SELECT * FROM smart_playlists WHERE manual = 0 AND deleted = 0 AND draft = 0 ORDER BY sortPosition ASC")
+    @Query("SELECT * FROM playlists WHERE manual = 0 AND deleted = 0 AND draft = 0 ORDER BY sortPosition ASC")
     abstract suspend fun getSmartPlaylists(): List<SmartPlaylist>
 
     @Query(
         """
         SELECT playlist.uuid, playlist.title, playlist.iconId
-        FROM smart_playlists AS playlist
+        FROM playlists AS playlist
         WHERE manual = 0 AND deleted = 0 AND draft = 0
         ORDER BY sortPosition ASC 
         LIMIT 1
@@ -54,7 +54,7 @@ abstract class PlaylistDao {
     )
     abstract fun observerPlaylistShortcut(): Flow<PlaylistShortcut?>
 
-    @Query("SELECT * FROM smart_playlists WHERE uuid IN (:uuids)")
+    @Query("SELECT * FROM playlists WHERE uuid IN (:uuids)")
     protected abstract suspend fun getAllPlaylistsUnsafe(uuids: Collection<String>): List<SmartPlaylist>
 
     @Transaction
@@ -64,31 +64,31 @@ abstract class PlaylistDao {
         }
     }
 
-    @Query("SELECT * FROM smart_playlists WHERE draft = 0 AND manual = 0 AND syncStatus = $SYNC_STATUS_NOT_SYNCED")
+    @Query("SELECT * FROM playlists WHERE draft = 0 AND manual = 0 AND syncStatus = $SYNC_STATUS_NOT_SYNCED")
     abstract suspend fun getAllUnsynced(): List<SmartPlaylist>
 
-    @Query("UPDATE smart_playlists SET sortPosition = :position, syncStatus = $SYNC_STATUS_NOT_SYNCED WHERE uuid = :uuid")
+    @Query("UPDATE playlists SET sortPosition = :position, syncStatus = $SYNC_STATUS_NOT_SYNCED WHERE uuid = :uuid")
     abstract suspend fun updateSortPosition(uuid: String, position: Int)
 
-    @Query("UPDATE smart_playlists SET sortId = :sortType, syncStatus = $SYNC_STATUS_NOT_SYNCED WHERE uuid = :uuid")
+    @Query("UPDATE playlists SET sortId = :sortType, syncStatus = $SYNC_STATUS_NOT_SYNCED WHERE uuid = :uuid")
     abstract suspend fun updateSortType(uuid: String, sortType: PlaylistEpisodeSortType)
 
-    @Query("UPDATE smart_playlists SET autoDownload = :isEnabled, syncStatus = $SYNC_STATUS_NOT_SYNCED WHERE uuid = :uuid")
+    @Query("UPDATE playlists SET autoDownload = :isEnabled, syncStatus = $SYNC_STATUS_NOT_SYNCED WHERE uuid = :uuid")
     abstract suspend fun updateAutoDownload(uuid: String, isEnabled: Boolean)
 
-    @Query("UPDATE smart_playlists SET autoDownloadLimit = :limit, syncStatus = $SYNC_STATUS_NOT_SYNCED WHERE uuid = :uuid")
+    @Query("UPDATE playlists SET autoDownloadLimit = :limit, syncStatus = $SYNC_STATUS_NOT_SYNCED WHERE uuid = :uuid")
     abstract suspend fun updateAutoDownloadLimit(uuid: String, limit: Int)
 
-    @Query("UPDATE smart_playlists SET title = :name, syncStatus = $SYNC_STATUS_NOT_SYNCED WHERE uuid = :uuid")
+    @Query("UPDATE playlists SET title = :name, syncStatus = $SYNC_STATUS_NOT_SYNCED WHERE uuid = :uuid")
     abstract suspend fun updateName(uuid: String, name: String)
 
-    @Query("UPDATE smart_playlists SET deleted = 1, syncStatus = $SYNC_STATUS_NOT_SYNCED WHERE uuid = :uuid")
+    @Query("UPDATE playlists SET deleted = 1, syncStatus = $SYNC_STATUS_NOT_SYNCED WHERE uuid = :uuid")
     abstract suspend fun markPlaylistAsDeleted(uuid: String)
 
-    @Query("DELETE FROM smart_playlists WHERE deleted = 1")
+    @Query("DELETE FROM playlists WHERE deleted = 1")
     abstract suspend fun deleteMarkedPlaylists()
 
-    @Query("DELETE FROM smart_playlists WHERE uuid IN (:uuids)")
+    @Query("DELETE FROM playlists WHERE uuid IN (:uuids)")
     protected abstract suspend fun deleteAllUnsafe(uuids: Collection<String>)
 
     @Transaction

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/PlaylistDao.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/PlaylistDao.kt
@@ -9,8 +9,8 @@ import androidx.room.Upsert
 import au.com.shiftyjelly.pocketcasts.models.db.AppDatabase
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
-import au.com.shiftyjelly.pocketcasts.models.entity.SmartPlaylist
-import au.com.shiftyjelly.pocketcasts.models.entity.SmartPlaylist.Companion.SYNC_STATUS_NOT_SYNCED
+import au.com.shiftyjelly.pocketcasts.models.entity.PlaylistEntity
+import au.com.shiftyjelly.pocketcasts.models.entity.PlaylistEntity.Companion.SYNC_STATUS_NOT_SYNCED
 import au.com.shiftyjelly.pocketcasts.models.to.PlaylistEpisodeMetadata
 import au.com.shiftyjelly.pocketcasts.models.to.PlaylistShortcut
 import au.com.shiftyjelly.pocketcasts.models.type.PlaylistEpisodeSortType
@@ -26,22 +26,22 @@ import kotlinx.coroutines.flow.Flow
 @Dao
 abstract class PlaylistDao {
     @Upsert
-    abstract suspend fun upsertPlaylist(playlist: SmartPlaylist)
+    abstract suspend fun upsertPlaylist(playlist: PlaylistEntity)
 
     @Upsert
-    abstract suspend fun upsertAllPlaylists(playlists: List<SmartPlaylist>)
+    abstract suspend fun upsertAllPlaylists(playlists: List<PlaylistEntity>)
 
     @Query("SELECT uuid FROM playlists ORDER BY sortPosition ASC")
     abstract suspend fun getAllPlaylistUuids(): List<String>
 
     @Query("SELECT * FROM playlists WHERE manual = 0 AND deleted = 0 AND draft = 0 AND uuid = :uuid")
-    abstract fun observeSmartPlaylist(uuid: String): Flow<SmartPlaylist?>
+    abstract fun observeSmartPlaylist(uuid: String): Flow<PlaylistEntity?>
 
     @Query("SELECT * FROM playlists WHERE manual = 0 AND deleted = 0 AND draft = 0 ORDER BY sortPosition ASC")
-    abstract fun observeSmartPlaylists(): Flow<List<SmartPlaylist>>
+    abstract fun observeSmartPlaylists(): Flow<List<PlaylistEntity>>
 
     @Query("SELECT * FROM playlists WHERE manual = 0 AND deleted = 0 AND draft = 0 ORDER BY sortPosition ASC")
-    abstract suspend fun getSmartPlaylists(): List<SmartPlaylist>
+    abstract suspend fun getSmartPlaylists(): List<PlaylistEntity>
 
     @Query(
         """
@@ -55,17 +55,17 @@ abstract class PlaylistDao {
     abstract fun observerPlaylistShortcut(): Flow<PlaylistShortcut?>
 
     @Query("SELECT * FROM playlists WHERE uuid IN (:uuids)")
-    protected abstract suspend fun getAllPlaylistsUnsafe(uuids: Collection<String>): List<SmartPlaylist>
+    protected abstract suspend fun getAllPlaylistsUnsafe(uuids: Collection<String>): List<PlaylistEntity>
 
     @Transaction
-    open suspend fun getAllPlaylists(uuids: Collection<String>): List<SmartPlaylist> {
+    open suspend fun getAllPlaylists(uuids: Collection<String>): List<PlaylistEntity> {
         return uuids.chunked(AppDatabase.SQLITE_BIND_ARG_LIMIT).flatMap { chunk ->
             getAllPlaylistsUnsafe(chunk)
         }
     }
 
     @Query("SELECT * FROM playlists WHERE draft = 0 AND manual = 0 AND syncStatus = $SYNC_STATUS_NOT_SYNCED")
-    abstract suspend fun getAllUnsynced(): List<SmartPlaylist>
+    abstract suspend fun getAllUnsynced(): List<PlaylistEntity>
 
     @Query("UPDATE playlists SET sortPosition = :position, syncStatus = $SYNC_STATUS_NOT_SYNCED WHERE uuid = :uuid")
     abstract suspend fun updateSortPosition(uuid: String, position: Int)

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/SmartPlaylistDao.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/SmartPlaylistDao.kt
@@ -7,7 +7,7 @@ import androidx.room.OnConflictStrategy
 import androidx.room.Query
 import androidx.room.Transaction
 import androidx.room.Update
-import au.com.shiftyjelly.pocketcasts.models.entity.SmartPlaylist
+import au.com.shiftyjelly.pocketcasts.models.entity.PlaylistEntity
 import io.reactivex.Flowable
 import io.reactivex.Maybe
 import kotlinx.coroutines.flow.Flow
@@ -16,34 +16,34 @@ import kotlinx.coroutines.flow.Flow
 abstract class SmartPlaylistDao {
 
     @Query("SELECT * FROM playlists WHERE _id = :id")
-    abstract fun findByIdBlocking(id: Long): SmartPlaylist?
+    abstract fun findByIdBlocking(id: Long): PlaylistEntity?
 
     @Query("SELECT * FROM playlists WHERE manual = 0 AND deleted = 0 AND draft = 0 ORDER BY sortPosition ASC")
-    abstract fun findAllBlocking(): List<SmartPlaylist>
+    abstract fun findAllBlocking(): List<PlaylistEntity>
 
     @Query("SELECT * FROM playlists WHERE manual = 0 AND deleted = 0 AND draft = 0 ORDER BY sortPosition ASC")
-    abstract suspend fun findAll(): List<SmartPlaylist>
+    abstract suspend fun findAll(): List<PlaylistEntity>
 
     @Query("SELECT * FROM playlists WHERE manual = 0 AND deleted = 0 AND draft = 0 ORDER BY sortPosition ASC")
-    abstract fun findAllFlow(): Flow<List<SmartPlaylist>>
+    abstract fun findAllFlow(): Flow<List<PlaylistEntity>>
 
     @Query("SELECT * FROM playlists WHERE manual = 0 AND deleted = 0 AND draft = 0 ORDER BY sortPosition ASC")
-    abstract fun findAllRxFlowable(): Flowable<List<SmartPlaylist>>
+    abstract fun findAllRxFlowable(): Flowable<List<PlaylistEntity>>
 
     @Query("SELECT * FROM playlists WHERE uuid = :uuid LIMIT 1")
-    abstract fun findByUuidBlocking(uuid: String): SmartPlaylist?
+    abstract fun findByUuidBlocking(uuid: String): PlaylistEntity?
 
     @Query("SELECT * FROM playlists WHERE uuid = :uuid LIMIT 1")
-    abstract suspend fun findByUuid(uuid: String): SmartPlaylist?
+    abstract suspend fun findByUuid(uuid: String): PlaylistEntity?
 
     @Query("SELECT * FROM playlists WHERE uuid = :uuid LIMIT 1")
-    abstract fun findByUuidRxMaybe(uuid: String): Maybe<SmartPlaylist>
+    abstract fun findByUuidRxMaybe(uuid: String): Maybe<PlaylistEntity>
 
     @Query("SELECT * FROM playlists WHERE uuid = :uuid LIMIT 1")
-    abstract fun findByUuidRxFlowable(uuid: String): Flowable<SmartPlaylist>
+    abstract fun findByUuidRxFlowable(uuid: String): Flowable<PlaylistEntity>
 
     @Query("SELECT * FROM playlists WHERE uuid = :uuid")
-    abstract fun findByUuidAsListRxFlowable(uuid: String): Flowable<List<SmartPlaylist>>
+    abstract fun findByUuidAsListRxFlowable(uuid: String): Flowable<List<PlaylistEntity>>
 
     @Query("SELECT COUNT(*) FROM playlists")
     abstract suspend fun count(): Int
@@ -52,19 +52,19 @@ abstract class SmartPlaylistDao {
     abstract fun countBlocking(): Int
 
     @Update
-    abstract suspend fun update(smartPlaylist: SmartPlaylist)
+    abstract suspend fun update(playlist: PlaylistEntity)
 
     @Update
-    abstract fun updateBlocking(smartPlaylist: SmartPlaylist)
+    abstract fun updateBlocking(playlist: PlaylistEntity)
 
     @Update
-    abstract fun updateAllBlocking(smartPlaylists: List<SmartPlaylist>)
+    abstract fun updateAllBlocking(playlists: List<PlaylistEntity>)
 
     @Delete
-    abstract suspend fun delete(smartPlaylist: SmartPlaylist)
+    abstract suspend fun delete(playlist: PlaylistEntity)
 
     @Delete
-    abstract fun deleteBlocking(smartPlaylist: SmartPlaylist)
+    abstract fun deleteBlocking(playlist: PlaylistEntity)
 
     @Query("DELETE FROM playlists")
     abstract suspend fun deleteAll()
@@ -73,10 +73,10 @@ abstract class SmartPlaylistDao {
     abstract fun deleteDeletedBlocking()
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
-    abstract suspend fun insert(smartPlaylist: SmartPlaylist): Long
+    abstract suspend fun insert(playlist: PlaylistEntity): Long
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
-    abstract fun insertBlocking(smartPlaylist: SmartPlaylist): Long
+    abstract fun insertBlocking(playlist: PlaylistEntity): Long
 
     @Query("UPDATE playlists SET sortPosition = :position WHERE uuid = :uuid")
     abstract fun updateSortPositionBlocking(position: Int, uuid: String)
@@ -88,20 +88,20 @@ abstract class SmartPlaylistDao {
     abstract suspend fun updateAllSyncStatus(syncStatus: Int)
 
     @Query("SELECT * FROM playlists WHERE UPPER(title) = UPPER(:title)")
-    abstract fun searchByTitleBlocking(title: String): SmartPlaylist?
+    abstract fun searchByTitleBlocking(title: String): PlaylistEntity?
 
-    @Query("SELECT * FROM playlists WHERE manual = 0 AND draft = 0 AND syncStatus = " + SmartPlaylist.SYNC_STATUS_NOT_SYNCED)
-    abstract fun findNotSyncedBlocking(): List<SmartPlaylist>
+    @Query("SELECT * FROM playlists WHERE manual = 0 AND draft = 0 AND syncStatus = " + PlaylistEntity.SYNC_STATUS_NOT_SYNCED)
+    abstract fun findNotSyncedBlocking(): List<PlaylistEntity>
 
     @Transaction
-    open fun updateSortPositionsBlocking(smartPlaylists: List<SmartPlaylist>) {
-        for (index in smartPlaylists.indices) {
-            val playlist = smartPlaylists[index]
+    open fun updateSortPositionsBlocking(playlists: List<PlaylistEntity>) {
+        for (index in playlists.indices) {
+            val playlist = playlists[index]
             val position = index + 1
             playlist.sortPosition = position
-            playlist.syncStatus = SmartPlaylist.SYNC_STATUS_NOT_SYNCED
+            playlist.syncStatus = PlaylistEntity.SYNC_STATUS_NOT_SYNCED
             updateSortPositionBlocking(position, playlist.uuid)
-            updateSyncStatusBlocking(SmartPlaylist.SYNC_STATUS_NOT_SYNCED, playlist.uuid)
+            updateSyncStatusBlocking(PlaylistEntity.SYNC_STATUS_NOT_SYNCED, playlist.uuid)
         }
     }
 }

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/SmartPlaylistDao.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/SmartPlaylistDao.kt
@@ -15,40 +15,40 @@ import kotlinx.coroutines.flow.Flow
 @Dao
 abstract class SmartPlaylistDao {
 
-    @Query("SELECT * FROM smart_playlists WHERE _id = :id")
+    @Query("SELECT * FROM playlists WHERE _id = :id")
     abstract fun findByIdBlocking(id: Long): SmartPlaylist?
 
-    @Query("SELECT * FROM smart_playlists WHERE manual = 0 AND deleted = 0 AND draft = 0 ORDER BY sortPosition ASC")
+    @Query("SELECT * FROM playlists WHERE manual = 0 AND deleted = 0 AND draft = 0 ORDER BY sortPosition ASC")
     abstract fun findAllBlocking(): List<SmartPlaylist>
 
-    @Query("SELECT * FROM smart_playlists WHERE manual = 0 AND deleted = 0 AND draft = 0 ORDER BY sortPosition ASC")
+    @Query("SELECT * FROM playlists WHERE manual = 0 AND deleted = 0 AND draft = 0 ORDER BY sortPosition ASC")
     abstract suspend fun findAll(): List<SmartPlaylist>
 
-    @Query("SELECT * FROM smart_playlists WHERE manual = 0 AND deleted = 0 AND draft = 0 ORDER BY sortPosition ASC")
+    @Query("SELECT * FROM playlists WHERE manual = 0 AND deleted = 0 AND draft = 0 ORDER BY sortPosition ASC")
     abstract fun findAllFlow(): Flow<List<SmartPlaylist>>
 
-    @Query("SELECT * FROM smart_playlists WHERE manual = 0 AND deleted = 0 AND draft = 0 ORDER BY sortPosition ASC")
+    @Query("SELECT * FROM playlists WHERE manual = 0 AND deleted = 0 AND draft = 0 ORDER BY sortPosition ASC")
     abstract fun findAllRxFlowable(): Flowable<List<SmartPlaylist>>
 
-    @Query("SELECT * FROM smart_playlists WHERE uuid = :uuid LIMIT 1")
+    @Query("SELECT * FROM playlists WHERE uuid = :uuid LIMIT 1")
     abstract fun findByUuidBlocking(uuid: String): SmartPlaylist?
 
-    @Query("SELECT * FROM smart_playlists WHERE uuid = :uuid LIMIT 1")
+    @Query("SELECT * FROM playlists WHERE uuid = :uuid LIMIT 1")
     abstract suspend fun findByUuid(uuid: String): SmartPlaylist?
 
-    @Query("SELECT * FROM smart_playlists WHERE uuid = :uuid LIMIT 1")
+    @Query("SELECT * FROM playlists WHERE uuid = :uuid LIMIT 1")
     abstract fun findByUuidRxMaybe(uuid: String): Maybe<SmartPlaylist>
 
-    @Query("SELECT * FROM smart_playlists WHERE uuid = :uuid LIMIT 1")
+    @Query("SELECT * FROM playlists WHERE uuid = :uuid LIMIT 1")
     abstract fun findByUuidRxFlowable(uuid: String): Flowable<SmartPlaylist>
 
-    @Query("SELECT * FROM smart_playlists WHERE uuid = :uuid")
+    @Query("SELECT * FROM playlists WHERE uuid = :uuid")
     abstract fun findByUuidAsListRxFlowable(uuid: String): Flowable<List<SmartPlaylist>>
 
-    @Query("SELECT COUNT(*) FROM smart_playlists")
+    @Query("SELECT COUNT(*) FROM playlists")
     abstract suspend fun count(): Int
 
-    @Query("SELECT COUNT(*) FROM smart_playlists")
+    @Query("SELECT COUNT(*) FROM playlists")
     abstract fun countBlocking(): Int
 
     @Update
@@ -66,10 +66,10 @@ abstract class SmartPlaylistDao {
     @Delete
     abstract fun deleteBlocking(smartPlaylist: SmartPlaylist)
 
-    @Query("DELETE FROM smart_playlists")
+    @Query("DELETE FROM playlists")
     abstract suspend fun deleteAll()
 
-    @Query("DELETE FROM smart_playlists WHERE deleted = 1")
+    @Query("DELETE FROM playlists WHERE deleted = 1")
     abstract fun deleteDeletedBlocking()
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
@@ -78,19 +78,19 @@ abstract class SmartPlaylistDao {
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     abstract fun insertBlocking(smartPlaylist: SmartPlaylist): Long
 
-    @Query("UPDATE smart_playlists SET sortPosition = :position WHERE uuid = :uuid")
+    @Query("UPDATE playlists SET sortPosition = :position WHERE uuid = :uuid")
     abstract fun updateSortPositionBlocking(position: Int, uuid: String)
 
-    @Query("UPDATE smart_playlists SET syncStatus = :syncStatus WHERE uuid = :uuid")
+    @Query("UPDATE playlists SET syncStatus = :syncStatus WHERE uuid = :uuid")
     abstract fun updateSyncStatusBlocking(syncStatus: Int, uuid: String)
 
-    @Query("UPDATE smart_playlists SET syncStatus = :syncStatus")
+    @Query("UPDATE playlists SET syncStatus = :syncStatus")
     abstract suspend fun updateAllSyncStatus(syncStatus: Int)
 
-    @Query("SELECT * FROM smart_playlists WHERE UPPER(title) = UPPER(:title)")
+    @Query("SELECT * FROM playlists WHERE UPPER(title) = UPPER(:title)")
     abstract fun searchByTitleBlocking(title: String): SmartPlaylist?
 
-    @Query("SELECT * FROM smart_playlists WHERE manual = 0 AND draft = 0 AND syncStatus = " + SmartPlaylist.SYNC_STATUS_NOT_SYNCED)
+    @Query("SELECT * FROM playlists WHERE manual = 0 AND draft = 0 AND syncStatus = " + SmartPlaylist.SYNC_STATUS_NOT_SYNCED)
     abstract fun findNotSyncedBlocking(): List<SmartPlaylist>
 
     @Transaction

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/entity/ManualPlaylistEpisode.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/entity/ManualPlaylistEpisode.kt
@@ -1,0 +1,30 @@
+package au.com.shiftyjelly.pocketcasts.models.entity
+
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.Index
+import java.time.Instant
+
+@Entity(
+    tableName = "manual_playlist_episodes",
+    primaryKeys = ["playlist_uuid", "episode_uuid"],
+    indices = [
+        Index(value = ["playlist_uuid"], name = "manual_playlist_episodes_playlist_uuid_index", unique = false),
+        Index(value = ["episode_uuid"], name = "manual_playlist_episodes_episode_uuid_index", unique = false),
+        Index(value = ["podcast_uuid"], name = "manual_playlist_episodes_podcast_uuid_index", unique = false),
+        Index(value = ["playlist_uuid", "is_synced"], name = "manual_playlist_episodes_playlist_uuid_is_synced_index", unique = false),
+    ],
+)
+data class ManualPlaylistEpisode(
+    @ColumnInfo(name = "playlist_uuid") val playlistUuid: String,
+    @ColumnInfo(name = "episode_uuid") val episodeUuid: String,
+    @ColumnInfo(name = "podcast_uuid") val podcastUuid: String,
+    @ColumnInfo(name = "title") val title: String,
+    @ColumnInfo(name = "added_at") val addedAt: Instant,
+    @ColumnInfo(name = "published_at") val publishedAt: Instant,
+    @ColumnInfo(name = "download_url") val downloadUrl: String?,
+    @ColumnInfo(name = "episode_slug") val episodeSlug: String,
+    @ColumnInfo(name = "podcast_slug") val podcastSlug: String,
+    @ColumnInfo(name = "sort_position") val sortPosition: Int,
+    @ColumnInfo(name = "is_synced") val isSynced: Boolean,
+)

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/entity/PlaylistEntity.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/entity/PlaylistEntity.kt
@@ -15,7 +15,7 @@ import au.com.shiftyjelly.pocketcasts.localization.R as LR
         Index(name = "playlists_uuid", value = arrayOf("uuid")),
     ],
 )
-data class SmartPlaylist(
+data class PlaylistEntity(
     @PrimaryKey @ColumnInfo(name = "_id") var id: Long? = null,
     @ColumnInfo(name = "uuid") var uuid: String = "",
     @ColumnInfo(name = "title") var title: String = "",

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/entity/Podcast.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/entity/Podcast.kt
@@ -98,6 +98,7 @@ data class Podcast(
     @ColumnInfo(name = "is_private") var isPrivate: Boolean = false,
     @ColumnInfo(name = "is_header_expanded", defaultValue = "1") var isHeaderExpanded: Boolean = true,
     @ColumnInfo(name = "funding_url") var fundingUrl: String? = null,
+    @ColumnInfo(name = "slug") var slug: String = "",
     @Embedded(prefix = "bundle") var singleBundle: Bundle? = null,
     @Ignore val episodes: MutableList<PodcastEpisode> = mutableListOf(),
 ) : Serializable {

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/entity/PodcastEpisode.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/entity/PodcastEpisode.kt
@@ -61,6 +61,7 @@ data class PodcastEpisode(
     @ColumnInfo(name = "image_url") var imageUrl: String? = null,
     @ColumnInfo(name = "deselected_chapters") override var deselectedChapters: ChapterIndices = ChapterIndices(),
     @ColumnInfo(name = "deselected_chapters_modified") override var deselectedChaptersModified: Date? = null,
+    @ColumnInfo(name = "slug") var slug: String = "",
 ) : BaseEpisode,
     Serializable {
 

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/entity/SmartPlaylist.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/entity/SmartPlaylist.kt
@@ -2,7 +2,6 @@ package au.com.shiftyjelly.pocketcasts.models.entity
 
 import androidx.room.ColumnInfo
 import androidx.room.Entity
-import androidx.room.Ignore
 import androidx.room.Index
 import androidx.room.PrimaryKey
 import au.com.shiftyjelly.pocketcasts.models.type.PlaylistEpisodeSortType
@@ -11,9 +10,9 @@ import java.io.Serializable
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 @Entity(
-    tableName = "smart_playlists",
+    tableName = "playlists",
     indices = [
-        Index(name = "smart_playlists_uuid", value = arrayOf("uuid")),
+        Index(name = "playlists_uuid", value = arrayOf("uuid")),
     ],
 )
 data class SmartPlaylist(
@@ -29,16 +28,13 @@ data class SmartPlaylist(
     @ColumnInfo(name = "syncStatus") var syncStatus: Int = SYNC_STATUS_SYNCED,
     // Auto download configuration
     @ColumnInfo(name = "autoDownload") var autoDownload: Boolean = false,
-    @ColumnInfo(name = "autoDownloadWifiOnly") var autoDownloadUnmeteredOnly: Boolean = false,
-    @ColumnInfo(name = "autoDownloadPowerOnly") var autoDownloadPowerOnly: Boolean = false,
     @ColumnInfo(name = "autoDownloadLimit") var autodownloadLimit: Int = 10,
-    // Filter rules
+    // Smart playlist configuration
     @ColumnInfo(name = "unplayed") var unplayed: Boolean = true,
     @ColumnInfo(name = "partiallyPlayed") var partiallyPlayed: Boolean = true,
     @ColumnInfo(name = "finished") var finished: Boolean = true,
     @ColumnInfo(name = "downloaded") var downloaded: Boolean = true,
     @ColumnInfo(name = "notDownloaded") var notDownloaded: Boolean = true,
-    @ColumnInfo(name = "downloading") var downloading: Boolean = true, // Legacy field
     @ColumnInfo(name = "audioVideo") var audioVideo: Int = AUDIO_VIDEO_FILTER_ALL,
     @ColumnInfo(name = "filterHours") var filterHours: Int = 0,
     @ColumnInfo(name = "starred") var starred: Boolean = false,
@@ -63,12 +59,6 @@ data class SmartPlaylist(
         const val LAST_2_WEEKS = 14 * 24
         const val LAST_MONTH = 31 * 24
     }
-
-    @Ignore
-    var episodeUuids: String? = null
-
-    @Ignore
-    var episodeCount: Int = 0
 
     val isAudioOnly: Boolean
         get() = audioVideo == AUDIO_VIDEO_FILTER_AUDIO_ONLY

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/extensions/Playlist.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/extensions/Playlist.kt
@@ -1,6 +1,6 @@
 package au.com.shiftyjelly.pocketcasts.repositories.extensions
 
-import au.com.shiftyjelly.pocketcasts.models.entity.SmartPlaylist
+import au.com.shiftyjelly.pocketcasts.models.entity.PlaylistEntity
 import au.com.shiftyjelly.pocketcasts.models.to.PlaylistShortcut
 import au.com.shiftyjelly.pocketcasts.images.R as IR
 
@@ -50,33 +50,33 @@ private val AUTOMOTIVE_DRAWABLES = arrayOf(
     IR.drawable.automotive_filter_star,
 )
 
-val SmartPlaylist.drawableIndex: Int
+val PlaylistEntity.drawableIndex: Int
     get() = iconId / FILTER_COLOR_SIZE % ICON_DRAWABLES.size
 
 val PlaylistShortcut.drawableIndex: Int
     get() = iconId / FILTER_COLOR_SIZE % ICON_DRAWABLES.size
 
-val SmartPlaylist.shortcutDrawableId: Int
+val PlaylistEntity.shortcutDrawableId: Int
     get() = SHORTCUT_DRAWABLES.getOrNull(drawableIndex) ?: SHORTCUT_DRAWABLES.first()
 
 val PlaylistShortcut.shortcutDrawableId: Int
     get() = SHORTCUT_DRAWABLES.getOrNull(drawableIndex) ?: SHORTCUT_DRAWABLES.first()
 
-val SmartPlaylist.drawableId: Int
+val PlaylistEntity.drawableId: Int
     get() = ICON_DRAWABLES.getOrNull(drawableIndex) ?: ICON_DRAWABLES.first()
 
-val SmartPlaylist.autoDrawableId: Int
+val PlaylistEntity.autoDrawableId: Int
     get() = AUTO_DRAWABLES.getOrNull(drawableIndex) ?: AUTO_DRAWABLES.first()
 
-val SmartPlaylist.automotiveDrawableId: Int
+val PlaylistEntity.automotiveDrawableId: Int
     get() = AUTOMOTIVE_DRAWABLES.getOrNull(drawableIndex) ?: AUTOMOTIVE_DRAWABLES.first()
 
-val SmartPlaylist.colorIndex: Int
+val PlaylistEntity.colorIndex: Int
     get() = iconId % FILTER_COLOR_SIZE
 
-val SmartPlaylist.Companion.iconDrawables: List<Int>
+val PlaylistEntity.Companion.iconDrawables: List<Int>
     get() = ICON_DRAWABLES
 
-fun SmartPlaylist.Companion.calculateCombinedIconId(colorIndex: Int, iconIndex: Int): Int {
+fun PlaylistEntity.Companion.calculateCombinedIconId(colorIndex: Int, iconIndex: Int): Int {
     return iconIndex * FILTER_COLOR_SIZE + colorIndex
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/auto/AutoConverter.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/auto/AutoConverter.kt
@@ -26,7 +26,7 @@ import au.com.shiftyjelly.pocketcasts.models.entity.BaseEpisode
 import au.com.shiftyjelly.pocketcasts.models.entity.Folder
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
-import au.com.shiftyjelly.pocketcasts.models.entity.SmartPlaylist
+import au.com.shiftyjelly.pocketcasts.models.entity.PlaylistEntity
 import au.com.shiftyjelly.pocketcasts.models.entity.UserEpisode
 import au.com.shiftyjelly.pocketcasts.models.type.EpisodePlayingStatus
 import au.com.shiftyjelly.pocketcasts.repositories.extensions.autoDrawableId
@@ -119,11 +119,11 @@ object AutoConverter {
         }
     }
 
-    fun convertPlaylistToMediaItem(context: Context, smartPlaylist: SmartPlaylist): MediaBrowserCompat.MediaItem {
+    fun convertPlaylistToMediaItem(context: Context, playlist: PlaylistEntity): MediaBrowserCompat.MediaItem {
         val mediaDescription = MediaDescriptionCompat.Builder()
-            .setTitle(smartPlaylist.title.tryToLocaliseFilters(context.resources))
-            .setMediaId(smartPlaylist.uuid)
-            .setIconUri(getPlaylistBitmapUri(smartPlaylist, context))
+            .setTitle(playlist.title.tryToLocaliseFilters(context.resources))
+            .setMediaId(playlist.uuid)
+            .setIconUri(getPlaylistBitmapUri(playlist, context))
             .build()
 
         return MediaBrowserCompat.MediaItem(mediaDescription, MediaBrowserCompat.MediaItem.FLAG_BROWSABLE)
@@ -189,12 +189,12 @@ object AutoConverter {
         return getBitmapUri(drawable = IR.drawable.auto_tab_podcasts, context = context)
     }
 
-    fun getPlaylistBitmapUri(smartPlaylist: SmartPlaylist?, context: Context): Uri {
+    fun getPlaylistBitmapUri(playlist: PlaylistEntity?, context: Context): Uri {
         val drawableId = if (Util.isAutomotive(context)) {
             // the Automotive UI displays the icon in a list that requires more padding around the icon
-            smartPlaylist?.automotiveDrawableId ?: IR.drawable.automotive_filter_play
+            playlist?.automotiveDrawableId ?: IR.drawable.automotive_filter_play
         } else {
-            smartPlaylist?.autoDrawableId ?: IR.drawable.auto_filter_play
+            playlist?.autoDrawableId ?: IR.drawable.auto_filter_play
         }
         return getBitmapUri(drawableId, context)
     }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/auto/AutoConverter.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/auto/AutoConverter.kt
@@ -24,9 +24,9 @@ import au.com.shiftyjelly.pocketcasts.localization.helper.RelativeDateFormatter
 import au.com.shiftyjelly.pocketcasts.localization.helper.tryToLocaliseFilters
 import au.com.shiftyjelly.pocketcasts.models.entity.BaseEpisode
 import au.com.shiftyjelly.pocketcasts.models.entity.Folder
+import au.com.shiftyjelly.pocketcasts.models.entity.PlaylistEntity
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
-import au.com.shiftyjelly.pocketcasts.models.entity.PlaylistEntity
 import au.com.shiftyjelly.pocketcasts.models.entity.UserEpisode
 import au.com.shiftyjelly.pocketcasts.models.type.EpisodePlayingStatus
 import au.com.shiftyjelly.pocketcasts.repositories.extensions.autoDrawableId

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playlist/PlaylistManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playlist/PlaylistManagerImpl.kt
@@ -279,7 +279,6 @@ class PlaylistManagerImpl @Inject constructor(
         finished = rules.episodeStatus.completed,
         downloaded = rules.downloadStatus in listOf(DownloadStatusRule.Downloaded, DownloadStatusRule.Any),
         notDownloaded = rules.downloadStatus in listOf(DownloadStatusRule.NotDownloaded, DownloadStatusRule.Any),
-        downloading = rules.downloadStatus in listOf(DownloadStatusRule.NotDownloaded, DownloadStatusRule.Any),
         audioVideo = when (rules.mediaType) {
             MediaTypeRule.Any -> AUDIO_VIDEO_FILTER_ALL
             MediaTypeRule.Audio -> AUDIO_VIDEO_FILTER_AUDIO_ONLY

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playlist/PlaylistManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playlist/PlaylistManagerImpl.kt
@@ -2,7 +2,6 @@ package au.com.shiftyjelly.pocketcasts.repositories.playlist
 
 import androidx.room.withTransaction
 import au.com.shiftyjelly.pocketcasts.models.db.AppDatabase
-import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.models.entity.PlaylistEntity.Companion.ANYTIME
 import au.com.shiftyjelly.pocketcasts.models.entity.PlaylistEntity.Companion.AUDIO_VIDEO_FILTER_ALL
 import au.com.shiftyjelly.pocketcasts.models.entity.PlaylistEntity.Companion.AUDIO_VIDEO_FILTER_AUDIO_ONLY
@@ -14,6 +13,7 @@ import au.com.shiftyjelly.pocketcasts.models.entity.PlaylistEntity.Companion.LAS
 import au.com.shiftyjelly.pocketcasts.models.entity.PlaylistEntity.Companion.LAST_WEEK
 import au.com.shiftyjelly.pocketcasts.models.entity.PlaylistEntity.Companion.SYNC_STATUS_NOT_SYNCED
 import au.com.shiftyjelly.pocketcasts.models.entity.PlaylistEntity.Companion.SYNC_STATUS_SYNCED
+import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.models.to.PlaylistEpisodeMetadata
 import au.com.shiftyjelly.pocketcasts.models.type.PlaylistEpisodeSortType
 import au.com.shiftyjelly.pocketcasts.models.type.SmartRules

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playlist/PlaylistManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playlist/PlaylistManagerImpl.kt
@@ -3,17 +3,17 @@ package au.com.shiftyjelly.pocketcasts.repositories.playlist
 import androidx.room.withTransaction
 import au.com.shiftyjelly.pocketcasts.models.db.AppDatabase
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
-import au.com.shiftyjelly.pocketcasts.models.entity.SmartPlaylist.Companion.ANYTIME
-import au.com.shiftyjelly.pocketcasts.models.entity.SmartPlaylist.Companion.AUDIO_VIDEO_FILTER_ALL
-import au.com.shiftyjelly.pocketcasts.models.entity.SmartPlaylist.Companion.AUDIO_VIDEO_FILTER_AUDIO_ONLY
-import au.com.shiftyjelly.pocketcasts.models.entity.SmartPlaylist.Companion.AUDIO_VIDEO_FILTER_VIDEO_ONLY
-import au.com.shiftyjelly.pocketcasts.models.entity.SmartPlaylist.Companion.LAST_24_HOURS
-import au.com.shiftyjelly.pocketcasts.models.entity.SmartPlaylist.Companion.LAST_2_WEEKS
-import au.com.shiftyjelly.pocketcasts.models.entity.SmartPlaylist.Companion.LAST_3_DAYS
-import au.com.shiftyjelly.pocketcasts.models.entity.SmartPlaylist.Companion.LAST_MONTH
-import au.com.shiftyjelly.pocketcasts.models.entity.SmartPlaylist.Companion.LAST_WEEK
-import au.com.shiftyjelly.pocketcasts.models.entity.SmartPlaylist.Companion.SYNC_STATUS_NOT_SYNCED
-import au.com.shiftyjelly.pocketcasts.models.entity.SmartPlaylist.Companion.SYNC_STATUS_SYNCED
+import au.com.shiftyjelly.pocketcasts.models.entity.PlaylistEntity.Companion.ANYTIME
+import au.com.shiftyjelly.pocketcasts.models.entity.PlaylistEntity.Companion.AUDIO_VIDEO_FILTER_ALL
+import au.com.shiftyjelly.pocketcasts.models.entity.PlaylistEntity.Companion.AUDIO_VIDEO_FILTER_AUDIO_ONLY
+import au.com.shiftyjelly.pocketcasts.models.entity.PlaylistEntity.Companion.AUDIO_VIDEO_FILTER_VIDEO_ONLY
+import au.com.shiftyjelly.pocketcasts.models.entity.PlaylistEntity.Companion.LAST_24_HOURS
+import au.com.shiftyjelly.pocketcasts.models.entity.PlaylistEntity.Companion.LAST_2_WEEKS
+import au.com.shiftyjelly.pocketcasts.models.entity.PlaylistEntity.Companion.LAST_3_DAYS
+import au.com.shiftyjelly.pocketcasts.models.entity.PlaylistEntity.Companion.LAST_MONTH
+import au.com.shiftyjelly.pocketcasts.models.entity.PlaylistEntity.Companion.LAST_WEEK
+import au.com.shiftyjelly.pocketcasts.models.entity.PlaylistEntity.Companion.SYNC_STATUS_NOT_SYNCED
+import au.com.shiftyjelly.pocketcasts.models.entity.PlaylistEntity.Companion.SYNC_STATUS_SYNCED
 import au.com.shiftyjelly.pocketcasts.models.to.PlaylistEpisodeMetadata
 import au.com.shiftyjelly.pocketcasts.models.type.PlaylistEpisodeSortType
 import au.com.shiftyjelly.pocketcasts.models.type.SmartRules
@@ -37,7 +37,7 @@ import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flowOf
-import au.com.shiftyjelly.pocketcasts.models.entity.SmartPlaylist as DbPlaylist
+import au.com.shiftyjelly.pocketcasts.models.entity.PlaylistEntity as DbPlaylist
 
 @OptIn(ExperimentalCoroutinesApi::class, FlowPreview::class)
 class PlaylistManagerImpl @Inject constructor(

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PlaylistUpdateAnalytics.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PlaylistUpdateAnalytics.kt
@@ -2,7 +2,7 @@ package au.com.shiftyjelly.pocketcasts.repositories.podcast
 
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTracker
-import au.com.shiftyjelly.pocketcasts.models.entity.SmartPlaylist
+import au.com.shiftyjelly.pocketcasts.models.entity.PlaylistEntity
 import au.com.shiftyjelly.pocketcasts.models.type.PlaylistEpisodeSortType
 import au.com.shiftyjelly.pocketcasts.repositories.extensions.colorIndex
 import au.com.shiftyjelly.pocketcasts.repositories.extensions.drawableId
@@ -15,43 +15,43 @@ class PlaylistUpdateAnalytics @Inject constructor(
 ) {
 
     fun update(
-        smartPlaylist: SmartPlaylist,
+        playlist: PlaylistEntity,
         userPlaylistUpdate: UserPlaylistUpdate?,
         isCreatingFilter: Boolean,
     ) {
         when {
-            isCreatingFilter -> sendPlaylistCreatedEvent(smartPlaylist)
+            isCreatingFilter -> sendPlaylistCreatedEvent(playlist)
 
             // If the playlist is a draft, then we are in the middle of the filter creation flow and
             // we don't want to send update events
-            !smartPlaylist.draft -> sendPlaylistUpdateEvent(userPlaylistUpdate)
+            !playlist.draft -> sendPlaylistUpdateEvent(userPlaylistUpdate)
         }
     }
 
-    private fun sendPlaylistCreatedEvent(smartPlaylist: SmartPlaylist) {
+    private fun sendPlaylistCreatedEvent(playlist: PlaylistEntity) {
         val properties = buildMap<String, Any> {
-            put(Key.ALL_PODCASTS, smartPlaylist.allPodcasts)
-            colorAnalyticsValue(smartPlaylist)?.let {
+            put(Key.ALL_PODCASTS, playlist.allPodcasts)
+            colorAnalyticsValue(playlist)?.let {
                 put(Key.COLOR, it)
             }
-            put(Key.DOWNLOADED, smartPlaylist.downloaded)
-            put(Key.NOT_DOWNLOADED, smartPlaylist.notDownloaded)
-            put(Key.DURATION, smartPlaylist.filterDuration)
-            if (smartPlaylist.filterDuration) {
-                put(Key.DURATION_LONGER_THAN, smartPlaylist.longerThan)
-                put(Key.DURATION_SHORTER_THAN, smartPlaylist.shorterThan)
+            put(Key.DOWNLOADED, playlist.downloaded)
+            put(Key.NOT_DOWNLOADED, playlist.notDownloaded)
+            put(Key.DURATION, playlist.filterDuration)
+            if (playlist.filterDuration) {
+                put(Key.DURATION_LONGER_THAN, playlist.longerThan)
+                put(Key.DURATION_SHORTER_THAN, playlist.shorterThan)
             }
-            put(Key.EPISODE_STATUS_IN_PROGRESS, smartPlaylist.partiallyPlayed)
-            put(Key.EPISODE_STATUS_PLAYED, smartPlaylist.finished)
-            put(Key.EPISODE_STATUS_UNPLAYED, smartPlaylist.unplayed)
-            iconAnalyticsValue(smartPlaylist)?.let {
+            put(Key.EPISODE_STATUS_IN_PROGRESS, playlist.partiallyPlayed)
+            put(Key.EPISODE_STATUS_PLAYED, playlist.finished)
+            put(Key.EPISODE_STATUS_UNPLAYED, playlist.unplayed)
+            iconAnalyticsValue(playlist)?.let {
                 put(Key.ICON_NAME, it)
             }
-            mediaTypeAnalyticsValue(smartPlaylist)?.let {
+            mediaTypeAnalyticsValue(playlist)?.let {
                 put(Key.MEDIA_TYPE, it)
             }
-            put(Key.STARRED, smartPlaylist.starred)
-            releaseDateAnalyticsValue(smartPlaylist)?.let {
+            put(Key.STARRED, playlist.starred)
+            releaseDateAnalyticsValue(playlist)?.let {
                 put(Key.RELEASE_DATE, it)
             }
         }
@@ -59,7 +59,7 @@ class PlaylistUpdateAnalytics @Inject constructor(
         analyticsTracker.track(AnalyticsEvent.FILTER_CREATED, properties)
     }
 
-    private fun iconAnalyticsValue(smartPlaylist: SmartPlaylist) = when (smartPlaylist.drawableId) {
+    private fun iconAnalyticsValue(playlist: PlaylistEntity) = when (playlist.drawableId) {
         IR.drawable.ic_filters_list -> Value.IconName.LIST
         IR.drawable.ic_filters_headphones -> Value.IconName.HEADPHONES
         IR.drawable.ic_filters_clock -> Value.IconName.CLOCK
@@ -74,30 +74,30 @@ class PlaylistUpdateAnalytics @Inject constructor(
         }
     }
 
-    private fun mediaTypeAnalyticsValue(smartPlaylist: SmartPlaylist) = when (smartPlaylist.audioVideo) {
-        SmartPlaylist.AUDIO_VIDEO_FILTER_ALL -> Value.MediaType.ALL
-        SmartPlaylist.AUDIO_VIDEO_FILTER_AUDIO_ONLY -> Value.MediaType.AUDIO
-        SmartPlaylist.AUDIO_VIDEO_FILTER_VIDEO_ONLY -> Value.MediaType.VIDEO
+    private fun mediaTypeAnalyticsValue(playlist: PlaylistEntity) = when (playlist.audioVideo) {
+        PlaylistEntity.AUDIO_VIDEO_FILTER_ALL -> Value.MediaType.ALL
+        PlaylistEntity.AUDIO_VIDEO_FILTER_AUDIO_ONLY -> Value.MediaType.AUDIO
+        PlaylistEntity.AUDIO_VIDEO_FILTER_VIDEO_ONLY -> Value.MediaType.VIDEO
         else -> {
             Timber.e("No match found for audioVideo Int")
             null
         }
     }
 
-    private fun releaseDateAnalyticsValue(smartPlaylist: SmartPlaylist) = when (smartPlaylist.filterHours) {
-        SmartPlaylist.ANYTIME -> Value.ReleaseDate.ANYTIME
-        SmartPlaylist.LAST_24_HOURS -> Value.ReleaseDate.TWENTY_FOUR_HOURS
-        SmartPlaylist.LAST_3_DAYS -> Value.ReleaseDate.THREE_DAYS
-        SmartPlaylist.LAST_WEEK -> Value.ReleaseDate.WEEK
-        SmartPlaylist.LAST_2_WEEKS -> Value.ReleaseDate.TWO_WEEKS
-        SmartPlaylist.LAST_MONTH -> Value.ReleaseDate.MONTH
+    private fun releaseDateAnalyticsValue(playlist: PlaylistEntity) = when (playlist.filterHours) {
+        PlaylistEntity.ANYTIME -> Value.ReleaseDate.ANYTIME
+        PlaylistEntity.LAST_24_HOURS -> Value.ReleaseDate.TWENTY_FOUR_HOURS
+        PlaylistEntity.LAST_3_DAYS -> Value.ReleaseDate.THREE_DAYS
+        PlaylistEntity.LAST_WEEK -> Value.ReleaseDate.WEEK
+        PlaylistEntity.LAST_2_WEEKS -> Value.ReleaseDate.TWO_WEEKS
+        PlaylistEntity.LAST_MONTH -> Value.ReleaseDate.MONTH
         else -> {
             Timber.e("Unexpected filter hours value")
             null
         }
     }
 
-    private fun colorAnalyticsValue(smartPlaylist: SmartPlaylist) = when (smartPlaylist.colorIndex) {
+    private fun colorAnalyticsValue(playlist: PlaylistEntity) = when (playlist.colorIndex) {
         0 -> Value.Color.RED
         1 -> Value.Color.BLUE
         2 -> Value.Color.GREEN

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/SmartPlaylistManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/SmartPlaylistManager.kt
@@ -32,8 +32,8 @@ interface SmartPlaylistManager {
     suspend fun update(smartPlaylist: SmartPlaylist, userPlaylistUpdate: UserPlaylistUpdate?, isCreatingFilter: Boolean = false)
     fun updateBlocking(smartPlaylist: SmartPlaylist, userPlaylistUpdate: UserPlaylistUpdate?, isCreatingFilter: Boolean = false)
 
-    fun updateAutoDownloadStatus(smartPlaylist: SmartPlaylist, autoDownloadEnabled: Boolean, unmeteredOnly: Boolean, powerOnly: Boolean)
-    fun updateAutoDownloadStatusRxCompletable(smartPlaylist: SmartPlaylist, autoDownloadEnabled: Boolean, unmeteredOnly: Boolean, powerOnly: Boolean): Completable
+    fun updateAutoDownloadStatus(smartPlaylist: SmartPlaylist, autoDownloadEnabled: Boolean)
+    fun updateAutoDownloadStatusRxCompletable(smartPlaylist: SmartPlaylist, autoDownloadEnabled: Boolean): Completable
 
     fun deleteBlocking(smartPlaylist: SmartPlaylist)
     suspend fun resetDb()

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/SmartPlaylistManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/SmartPlaylistManager.kt
@@ -1,7 +1,7 @@
 package au.com.shiftyjelly.pocketcasts.repositories.podcast
 
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
-import au.com.shiftyjelly.pocketcasts.models.entity.SmartPlaylist
+import au.com.shiftyjelly.pocketcasts.models.entity.PlaylistEntity
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
 import io.reactivex.Completable
 import io.reactivex.Flowable
@@ -9,40 +9,40 @@ import io.reactivex.Maybe
 import kotlinx.coroutines.flow.Flow
 
 interface SmartPlaylistManager {
-    fun findAllBlocking(): List<SmartPlaylist>
-    suspend fun findAll(): List<SmartPlaylist>
-    fun findAllFlow(): Flow<List<SmartPlaylist>>
-    fun findAllRxFlowable(): Flowable<List<SmartPlaylist>>
+    fun findAllBlocking(): List<PlaylistEntity>
+    suspend fun findAll(): List<PlaylistEntity>
+    fun findAllFlow(): Flow<List<PlaylistEntity>>
+    fun findAllRxFlowable(): Flowable<List<PlaylistEntity>>
 
-    fun findByIdBlocking(id: Long): SmartPlaylist?
-    suspend fun findByUuid(playlistUuid: String): SmartPlaylist?
-    fun findByUuidBlocking(playlistUuid: String): SmartPlaylist?
-    fun findByUuidRxMaybe(playlistUuid: String): Maybe<SmartPlaylist>
-    fun findByUuidRxFlowable(playlistUuid: String): Flowable<SmartPlaylist>
-    fun findByUuidAsListRxFlowable(playlistUuid: String): Flowable<List<SmartPlaylist>>
+    fun findByIdBlocking(id: Long): PlaylistEntity?
+    suspend fun findByUuid(playlistUuid: String): PlaylistEntity?
+    fun findByUuidBlocking(playlistUuid: String): PlaylistEntity?
+    fun findByUuidRxMaybe(playlistUuid: String): Maybe<PlaylistEntity>
+    fun findByUuidRxFlowable(playlistUuid: String): Flowable<PlaylistEntity>
+    fun findByUuidAsListRxFlowable(playlistUuid: String): Flowable<List<PlaylistEntity>>
 
-    fun findFirstByTitleBlocking(title: String): SmartPlaylist?
-    fun findPlaylistsToSyncBlocking(): List<SmartPlaylist>
-    fun findEpisodesBlocking(smartPlaylist: SmartPlaylist, episodeManager: EpisodeManager, playbackManager: PlaybackManager): List<PodcastEpisode>
-    fun observeEpisodesBlocking(smartPlaylist: SmartPlaylist, episodeManager: EpisodeManager, playbackManager: PlaybackManager): Flowable<List<PodcastEpisode>>
+    fun findFirstByTitleBlocking(title: String): PlaylistEntity?
+    fun findPlaylistsToSyncBlocking(): List<PlaylistEntity>
+    fun findEpisodesBlocking(playlist: PlaylistEntity, episodeManager: EpisodeManager, playbackManager: PlaybackManager): List<PodcastEpisode>
+    fun observeEpisodesBlocking(playlist: PlaylistEntity, episodeManager: EpisodeManager, playbackManager: PlaybackManager): Flowable<List<PodcastEpisode>>
 
-    fun createPlaylistBlocking(name: String, iconId: Int, draft: Boolean): SmartPlaylist
+    fun createPlaylistBlocking(name: String, iconId: Int, draft: Boolean): PlaylistEntity
 
-    suspend fun create(smartPlaylist: SmartPlaylist): Long
-    suspend fun update(smartPlaylist: SmartPlaylist, userPlaylistUpdate: UserPlaylistUpdate?, isCreatingFilter: Boolean = false)
-    fun updateBlocking(smartPlaylist: SmartPlaylist, userPlaylistUpdate: UserPlaylistUpdate?, isCreatingFilter: Boolean = false)
+    suspend fun create(playlist: PlaylistEntity): Long
+    suspend fun update(playlist: PlaylistEntity, userPlaylistUpdate: UserPlaylistUpdate?, isCreatingFilter: Boolean = false)
+    fun updateBlocking(playlist: PlaylistEntity, userPlaylistUpdate: UserPlaylistUpdate?, isCreatingFilter: Boolean = false)
 
-    fun updateAutoDownloadStatus(smartPlaylist: SmartPlaylist, autoDownloadEnabled: Boolean)
-    fun updateAutoDownloadStatusRxCompletable(smartPlaylist: SmartPlaylist, autoDownloadEnabled: Boolean): Completable
+    fun updateAutoDownloadStatus(playlist: PlaylistEntity, autoDownloadEnabled: Boolean)
+    fun updateAutoDownloadStatusRxCompletable(playlist: PlaylistEntity, autoDownloadEnabled: Boolean): Completable
 
-    fun deleteBlocking(smartPlaylist: SmartPlaylist)
+    fun deleteBlocking(playlist: PlaylistEntity)
     suspend fun resetDb()
     fun deleteSyncedBlocking()
-    suspend fun deleteSynced(smartPlaylist: SmartPlaylist)
-    fun deleteSyncedBlocking(smartPlaylist: SmartPlaylist)
+    suspend fun deleteSynced(playlist: PlaylistEntity)
+    fun deleteSyncedBlocking(playlist: PlaylistEntity)
 
     fun countEpisodesBlocking(id: Long?, episodeManager: EpisodeManager, playbackManager: PlaybackManager): Int
-    fun countEpisodesRxFlowable(smartPlaylist: SmartPlaylist, episodeManager: EpisodeManager, playbackManager: PlaybackManager): Flowable<Int>
+    fun countEpisodesRxFlowable(playlist: PlaylistEntity, episodeManager: EpisodeManager, playbackManager: PlaybackManager): Flowable<Int>
 
     fun checkForEpisodesToDownloadBlocking(episodeManager: EpisodeManager, playbackManager: PlaybackManager)
 
@@ -50,6 +50,6 @@ interface SmartPlaylistManager {
 
     suspend fun markAllSynced()
 
-    fun updateAllBlocking(smartPlaylists: List<SmartPlaylist>)
-    fun observeEpisodesPreviewBlocking(smartPlaylist: SmartPlaylist, episodeManager: EpisodeManager, playbackManager: PlaybackManager): Flowable<List<PodcastEpisode>>
+    fun updateAllBlocking(playlists: List<PlaylistEntity>)
+    fun observeEpisodesPreviewBlocking(playlist: PlaylistEntity, episodeManager: EpisodeManager, playbackManager: PlaybackManager): Flowable<List<PodcastEpisode>>
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/SmartPlaylistManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/SmartPlaylistManager.kt
@@ -1,7 +1,7 @@
 package au.com.shiftyjelly.pocketcasts.repositories.podcast
 
-import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.models.entity.PlaylistEntity
+import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
 import io.reactivex.Completable
 import io.reactivex.Flowable

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/SmartPlaylistManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/SmartPlaylistManagerImpl.kt
@@ -158,19 +158,12 @@ class SmartPlaylistManagerImpl @Inject constructor(
         playlistDao.updateAllBlocking(smartPlaylists)
     }
 
-    override fun updateAutoDownloadStatus(smartPlaylist: SmartPlaylist, autoDownloadEnabled: Boolean, unmeteredOnly: Boolean, powerOnly: Boolean) {
+    override fun updateAutoDownloadStatus(smartPlaylist: SmartPlaylist, autoDownloadEnabled: Boolean) {
         smartPlaylist.autoDownload = autoDownloadEnabled
-        smartPlaylist.autoDownloadUnmeteredOnly = unmeteredOnly
-        smartPlaylist.autoDownloadPowerOnly = powerOnly
-        val attrs = HashMap<String, Any>()
-        attrs["autoDownload"] = autoDownloadEnabled
-        attrs["autoDownloadWifiOnly"] = unmeteredOnly
-        attrs["autoDownloadPowerOnly"] = powerOnly
-        attrs["syncStatus"] = SmartPlaylist.SYNC_STATUS_NOT_SYNCED
     }
 
-    override fun updateAutoDownloadStatusRxCompletable(smartPlaylist: SmartPlaylist, autoDownloadEnabled: Boolean, unmeteredOnly: Boolean, powerOnly: Boolean): Completable {
-        return Completable.fromAction { updateAutoDownloadStatus(smartPlaylist, autoDownloadEnabled, unmeteredOnly, powerOnly) }
+    override fun updateAutoDownloadStatusRxCompletable(smartPlaylist: SmartPlaylist, autoDownloadEnabled: Boolean): Completable {
+        return Completable.fromAction { updateAutoDownloadStatus(smartPlaylist, autoDownloadEnabled) }
     }
 
     override fun createPlaylistBlocking(name: String, iconId: Int, draft: Boolean): SmartPlaylist {

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/SmartPlaylistManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/SmartPlaylistManagerImpl.kt
@@ -4,7 +4,7 @@ import android.content.Context
 import au.com.shiftyjelly.pocketcasts.analytics.SourceView
 import au.com.shiftyjelly.pocketcasts.models.db.AppDatabase
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
-import au.com.shiftyjelly.pocketcasts.models.entity.SmartPlaylist
+import au.com.shiftyjelly.pocketcasts.models.entity.PlaylistEntity
 import au.com.shiftyjelly.pocketcasts.models.type.EpisodePlayingStatus
 import au.com.shiftyjelly.pocketcasts.models.type.EpisodeStatusEnum
 import au.com.shiftyjelly.pocketcasts.models.type.PlaylistEpisodeSortType
@@ -43,69 +43,69 @@ class SmartPlaylistManagerImpl @Inject constructor(
 
     private val playlistDao = appDatabase.smartPlaylistDao()
 
-    override fun findAllBlocking(): List<SmartPlaylist> {
+    override fun findAllBlocking(): List<PlaylistEntity> {
         return playlistDao.findAllBlocking()
     }
 
-    override suspend fun findAll(): List<SmartPlaylist> {
+    override suspend fun findAll(): List<PlaylistEntity> {
         return playlistDao.findAll()
     }
 
-    override fun findAllFlow(): Flow<List<SmartPlaylist>> {
+    override fun findAllFlow(): Flow<List<PlaylistEntity>> {
         return playlistDao.findAllFlow()
     }
 
-    override fun findAllRxFlowable(): Flowable<List<SmartPlaylist>> {
+    override fun findAllRxFlowable(): Flowable<List<PlaylistEntity>> {
         return playlistDao.findAllRxFlowable()
     }
 
-    override fun findByUuidBlocking(playlistUuid: String): SmartPlaylist? {
+    override fun findByUuidBlocking(playlistUuid: String): PlaylistEntity? {
         return playlistDao.findByUuidBlocking(playlistUuid)
     }
 
-    override suspend fun findByUuid(playlistUuid: String): SmartPlaylist? {
+    override suspend fun findByUuid(playlistUuid: String): PlaylistEntity? {
         return playlistDao.findByUuid(playlistUuid)
     }
 
-    override fun findByUuidRxMaybe(playlistUuid: String): Maybe<SmartPlaylist> {
+    override fun findByUuidRxMaybe(playlistUuid: String): Maybe<PlaylistEntity> {
         return playlistDao.findByUuidRxMaybe(playlistUuid)
     }
 
-    override fun findByUuidRxFlowable(playlistUuid: String): Flowable<SmartPlaylist> {
+    override fun findByUuidRxFlowable(playlistUuid: String): Flowable<PlaylistEntity> {
         return playlistDao.findByUuidRxFlowable(playlistUuid)
     }
 
-    override fun findByUuidAsListRxFlowable(playlistUuid: String): Flowable<List<SmartPlaylist>> {
+    override fun findByUuidAsListRxFlowable(playlistUuid: String): Flowable<List<PlaylistEntity>> {
         return playlistDao.findByUuidAsListRxFlowable(playlistUuid)
     }
 
-    override fun findByIdBlocking(id: Long): SmartPlaylist? {
+    override fun findByIdBlocking(id: Long): PlaylistEntity? {
         return playlistDao.findByIdBlocking(id)
     }
 
-    override fun findEpisodesBlocking(smartPlaylist: SmartPlaylist, episodeManager: EpisodeManager, playbackManager: PlaybackManager): List<PodcastEpisode> {
-        val where = buildPlaylistWhere(smartPlaylist, playbackManager)
-        val orderBy = getPlaylistOrderByString(smartPlaylist)
+    override fun findEpisodesBlocking(playlist: PlaylistEntity, episodeManager: EpisodeManager, playbackManager: PlaybackManager): List<PodcastEpisode> {
+        val where = buildPlaylistWhere(playlist, playbackManager)
+        val orderBy = getPlaylistOrderByString(playlist)
         return episodeManager.findEpisodesWhereBlocking("$where ORDER BY $orderBy LIMIT 500")
     }
 
-    private fun getPlaylistQuery(smartPlaylist: SmartPlaylist, limit: Int?, playbackManager: PlaybackManager): String {
-        val where = buildPlaylistWhere(smartPlaylist, playbackManager)
-        val orderBy = getPlaylistOrderByString(smartPlaylist)
+    private fun getPlaylistQuery(playlist: PlaylistEntity, limit: Int?, playbackManager: PlaybackManager): String {
+        val where = buildPlaylistWhere(playlist, playbackManager)
+        val orderBy = getPlaylistOrderByString(playlist)
         return "$where ORDER BY $orderBy" + if (limit != null) " LIMIT $limit" else ""
     }
 
-    override fun observeEpisodesBlocking(smartPlaylist: SmartPlaylist, episodeManager: EpisodeManager, playbackManager: PlaybackManager): Flowable<List<PodcastEpisode>> {
-        val queryAfterWhere = getPlaylistQuery(smartPlaylist, limit = 500, playbackManager = playbackManager)
+    override fun observeEpisodesBlocking(playlist: PlaylistEntity, episodeManager: EpisodeManager, playbackManager: PlaybackManager): Flowable<List<PodcastEpisode>> {
+        val queryAfterWhere = getPlaylistQuery(playlist, limit = 500, playbackManager = playbackManager)
         return episodeManager.findEpisodesWhereRxFlowable(queryAfterWhere)
     }
 
-    override fun observeEpisodesPreviewBlocking(smartPlaylist: SmartPlaylist, episodeManager: EpisodeManager, playbackManager: PlaybackManager): Flowable<List<PodcastEpisode>> {
-        val queryAfterWhere = getPlaylistQuery(smartPlaylist, limit = 100, playbackManager = playbackManager)
+    override fun observeEpisodesPreviewBlocking(playlist: PlaylistEntity, episodeManager: EpisodeManager, playbackManager: PlaybackManager): Flowable<List<PodcastEpisode>> {
+        val queryAfterWhere = getPlaylistQuery(playlist, limit = 100, playbackManager = playbackManager)
         return episodeManager.findEpisodesWhereRxFlowable(queryAfterWhere)
     }
 
-    private fun getPlaylistOrderByString(smartPlaylist: SmartPlaylist): String? = when (val sortType = smartPlaylist.sortType) {
+    private fun getPlaylistOrderByString(playlist: PlaylistEntity): String? = when (val sortType = playlist.sortType) {
         PlaylistEpisodeSortType.NewestToOldest,
         PlaylistEpisodeSortType.OldestToNewest,
         -> {
@@ -124,15 +124,15 @@ class SmartPlaylistManagerImpl @Inject constructor(
         }
     }
 
-    override suspend fun create(smartPlaylist: SmartPlaylist): Long {
-        return playlistDao.insert(smartPlaylist)
+    override suspend fun create(playlist: PlaylistEntity): Long {
+        return playlistDao.insert(playlist)
     }
 
     /**
      * A null userPlayListUpdate parameter indicates that  the user did not initiate this update
      */
     override fun updateBlocking(
-        smartPlaylist: SmartPlaylist,
+        playlist: PlaylistEntity,
         userPlaylistUpdate: UserPlaylistUpdate?,
         isCreatingFilter: Boolean,
     ) {
@@ -141,35 +141,35 @@ class SmartPlaylistManagerImpl @Inject constructor(
                 notificationManager.updateUserFeatureInteraction(OnboardingNotificationType.Filters)
             }
         }
-        playlistDao.updateBlocking(smartPlaylist)
-        playlistUpdateAnalytics.update(smartPlaylist, userPlaylistUpdate, isCreatingFilter)
+        playlistDao.updateBlocking(playlist)
+        playlistUpdateAnalytics.update(playlist, userPlaylistUpdate, isCreatingFilter)
     }
 
     override suspend fun update(
-        smartPlaylist: SmartPlaylist,
+        playlist: PlaylistEntity,
         userPlaylistUpdate: UserPlaylistUpdate?,
         isCreatingFilter: Boolean,
     ) {
-        playlistDao.update(smartPlaylist)
-        playlistUpdateAnalytics.update(smartPlaylist, userPlaylistUpdate, isCreatingFilter)
+        playlistDao.update(playlist)
+        playlistUpdateAnalytics.update(playlist, userPlaylistUpdate, isCreatingFilter)
     }
 
-    override fun updateAllBlocking(smartPlaylists: List<SmartPlaylist>) {
-        playlistDao.updateAllBlocking(smartPlaylists)
+    override fun updateAllBlocking(playlists: List<PlaylistEntity>) {
+        playlistDao.updateAllBlocking(playlists)
     }
 
-    override fun updateAutoDownloadStatus(smartPlaylist: SmartPlaylist, autoDownloadEnabled: Boolean) {
-        smartPlaylist.autoDownload = autoDownloadEnabled
+    override fun updateAutoDownloadStatus(playlist: PlaylistEntity, autoDownloadEnabled: Boolean) {
+        playlist.autoDownload = autoDownloadEnabled
     }
 
-    override fun updateAutoDownloadStatusRxCompletable(smartPlaylist: SmartPlaylist, autoDownloadEnabled: Boolean): Completable {
-        return Completable.fromAction { updateAutoDownloadStatus(smartPlaylist, autoDownloadEnabled) }
+    override fun updateAutoDownloadStatusRxCompletable(playlist: PlaylistEntity, autoDownloadEnabled: Boolean): Completable {
+        return Completable.fromAction { updateAutoDownloadStatus(playlist, autoDownloadEnabled) }
     }
 
-    override fun createPlaylistBlocking(name: String, iconId: Int, draft: Boolean): SmartPlaylist {
-        val smartPlaylist = SmartPlaylist(
+    override fun createPlaylistBlocking(name: String, iconId: Int, draft: Boolean): PlaylistEntity {
+        val playlist = PlaylistEntity(
             uuid = UUID.randomUUID().toString(),
-            syncStatus = SmartPlaylist.SYNC_STATUS_NOT_SYNCED,
+            syncStatus = PlaylistEntity.SYNC_STATUS_NOT_SYNCED,
             title = name,
             sortPosition = countPlaylistsBlocking() + 1,
             manual = false,
@@ -177,24 +177,24 @@ class SmartPlaylistManagerImpl @Inject constructor(
             draft = draft,
         )
 
-        Timber.d("Creating playlist ${smartPlaylist.uuid}")
-        smartPlaylist.id = playlistDao.insertBlocking(smartPlaylist)
-        return smartPlaylist
+        Timber.d("Creating playlist ${playlist.uuid}")
+        playlist.id = playlistDao.insertBlocking(playlist)
+        return playlist
     }
 
-    override fun deleteBlocking(smartPlaylist: SmartPlaylist) {
+    override fun deleteBlocking(playlist: PlaylistEntity) {
         val loggedIn = syncManager.isLoggedIn()
         if (loggedIn) {
-            smartPlaylist.deleted = true
-            markAsNotSyncedBlocking(smartPlaylist)
+            playlist.deleted = true
+            markAsNotSyncedBlocking(playlist)
 
             // user initiated filter deletion, not update of any playlist properties, so this
             // is not a user initiated update
-            updateBlocking(smartPlaylist, userPlaylistUpdate = null)
+            updateBlocking(playlist, userPlaylistUpdate = null)
         }
 
         if (!loggedIn) {
-            deleteSyncedBlocking(smartPlaylist)
+            deleteSyncedBlocking(playlist)
         }
     }
 
@@ -207,16 +207,16 @@ class SmartPlaylistManagerImpl @Inject constructor(
         playlistsInitializater.initialize(force = true)
     }
 
-    override suspend fun deleteSynced(smartPlaylist: SmartPlaylist) {
-        playlistDao.delete(smartPlaylist)
+    override suspend fun deleteSynced(playlist: PlaylistEntity) {
+        playlistDao.delete(playlist)
     }
 
-    override fun deleteSyncedBlocking(smartPlaylist: SmartPlaylist) {
-        playlistDao.deleteBlocking(smartPlaylist)
+    override fun deleteSyncedBlocking(playlist: PlaylistEntity) {
+        playlistDao.deleteBlocking(playlist)
     }
 
-    override fun countEpisodesRxFlowable(smartPlaylist: SmartPlaylist, episodeManager: EpisodeManager, playbackManager: PlaybackManager): Flowable<Int> {
-        val query = getPlaylistQuery(smartPlaylist, limit = null, playbackManager = playbackManager)
+    override fun countEpisodesRxFlowable(playlist: PlaylistEntity, episodeManager: EpisodeManager, playbackManager: PlaybackManager): Flowable<Int> {
+        val query = getPlaylistQuery(playlist, limit = null, playbackManager = playbackManager)
         return episodeManager.episodeCountRxFlowable(query)
     }
 
@@ -260,44 +260,44 @@ class SmartPlaylistManagerImpl @Inject constructor(
             if (podcastUuids.contains(podcastUuid)) {
                 podcastUuids.remove(podcastUuid)
 
-                playlist.syncStatus = SmartPlaylist.SYNC_STATUS_NOT_SYNCED
+                playlist.syncStatus = PlaylistEntity.SYNC_STATUS_NOT_SYNCED
                 playlist.podcastUuidList = podcastUuids
                 playlistDao.update(playlist)
             }
         }
     }
 
-    override fun findFirstByTitleBlocking(title: String): SmartPlaylist? {
+    override fun findFirstByTitleBlocking(title: String): PlaylistEntity? {
         return playlistDao.searchByTitleBlocking(title)
     }
 
-    override fun findPlaylistsToSyncBlocking(): List<SmartPlaylist> {
+    override fun findPlaylistsToSyncBlocking(): List<PlaylistEntity> {
         return playlistDao.findNotSyncedBlocking()
     }
 
     /**
      * Build the SQL query for a playlist
-     * @param smartPlaylist The playlist to generate the query for
+     * @param playlist The playlist to generate the query for
      * @param playbackManager Required if the filter needs to include the currently playing episode regardless of if it meets the filter conditions.
      */
-    private fun buildPlaylistWhere(smartPlaylist: SmartPlaylist, playbackManager: PlaybackManager?): String {
+    private fun buildPlaylistWhere(playlist: PlaylistEntity, playbackManager: PlaybackManager?): String {
         val where = StringBuilder()
-        buildFilterEpisodeWhere(smartPlaylist, where, playbackManager)
+        buildFilterEpisodeWhere(playlist, where, playbackManager)
         return where.toString()
     }
 
-    private fun buildFilterEpisodeWhere(smartPlaylist: SmartPlaylist, where: StringBuilder, playbackManager: PlaybackManager?) {
-        val unplayed = smartPlaylist.unplayed
-        val finished = smartPlaylist.finished
-        val partiallyPlayed = smartPlaylist.partiallyPlayed
-        val downloaded = smartPlaylist.downloaded
-        val downloading = smartPlaylist.notDownloaded // regular filters no longer have a downloading but the not downloaded one should show in progress downloads
-        val notDownloaded = smartPlaylist.notDownloaded
-        val audioVideo = smartPlaylist.audioVideo
-        val filterHours = smartPlaylist.filterHours
-        val starred = smartPlaylist.starred
-        val allPodcasts = smartPlaylist.allPodcasts
-        val podcastUuids = smartPlaylist.podcastUuidList
+    private fun buildFilterEpisodeWhere(playlist: PlaylistEntity, where: StringBuilder, playbackManager: PlaybackManager?) {
+        val unplayed = playlist.unplayed
+        val finished = playlist.finished
+        val partiallyPlayed = playlist.partiallyPlayed
+        val downloaded = playlist.downloaded
+        val downloading = playlist.notDownloaded // regular filters no longer have a downloading but the not downloaded one should show in progress downloads
+        val notDownloaded = playlist.notDownloaded
+        val audioVideo = playlist.audioVideo
+        val filterHours = playlist.filterHours
+        val starred = playlist.starred
+        val allPodcasts = playlist.allPodcasts
+        val podcastUuids = playlist.podcastUuidList
 
         // don't do any constraint if they are all unticked or ticked
         if (!(unplayed && partiallyPlayed && finished) && (unplayed || partiallyPlayed || finished)) {
@@ -356,14 +356,14 @@ class SmartPlaylistManagerImpl @Inject constructor(
             where.append("(").append(sectionWhere).append(")")
         }
 
-        if (audioVideo != SmartPlaylist.AUDIO_VIDEO_FILTER_ALL) {
-            if (audioVideo == SmartPlaylist.AUDIO_VIDEO_FILTER_VIDEO_ONLY) {
+        if (audioVideo != PlaylistEntity.AUDIO_VIDEO_FILTER_ALL) {
+            if (audioVideo == PlaylistEntity.AUDIO_VIDEO_FILTER_VIDEO_ONLY) {
                 if (where.isNotEmpty()) {
                     where.append(" AND ")
                 }
                 where.append("file_type LIKE 'video/%'")
             }
-            if (audioVideo == SmartPlaylist.AUDIO_VIDEO_FILTER_AUDIO_ONLY) {
+            if (audioVideo == PlaylistEntity.AUDIO_VIDEO_FILTER_AUDIO_ONLY) {
                 if (where.isNotEmpty()) {
                     where.append(" AND ")
                 }
@@ -396,13 +396,13 @@ class SmartPlaylistManagerImpl @Inject constructor(
             where.append(")")
         }
 
-        if (smartPlaylist.filterDuration) {
+        if (playlist.filterDuration) {
             if (where.isNotEmpty()) {
                 where.append(" AND ")
             }
-            val longerThan = smartPlaylist.longerThan * 60
+            val longerThan = playlist.longerThan * 60
             // we add 59s here to account for how the formatter doesn't show "10m" until you get to 10*60 seconds, that way our visual representation lines up with the filter times
-            val shorterThan = smartPlaylist.shorterThan * 60 + 59
+            val shorterThan = playlist.shorterThan * 60 + 59
 
             where.append("(duration >= $longerThan AND duration <= $shorterThan) ")
         }
@@ -415,15 +415,15 @@ class SmartPlaylistManagerImpl @Inject constructor(
 
         val playingEpisode = playbackManager?.getCurrentEpisode()?.uuid
         val lastLoadedFromPodcastOrFilterUuid = settings.lastAutoPlaySource.value.id
-        if (playingEpisode != null && lastLoadedFromPodcastOrFilterUuid == smartPlaylist.uuid) {
+        if (playingEpisode != null && lastLoadedFromPodcastOrFilterUuid == playlist.uuid) {
             where.insert(0, "(podcast_episodes.uuid = '$playingEpisode' OR (")
             where.append("))")
         }
     }
 
-    private fun markAsNotSyncedBlocking(smartPlaylist: SmartPlaylist) {
-        smartPlaylist.syncStatus = SmartPlaylist.SYNC_STATUS_NOT_SYNCED
-        playlistDao.updateSyncStatusBlocking(SmartPlaylist.SYNC_STATUS_NOT_SYNCED, smartPlaylist.uuid)
+    private fun markAsNotSyncedBlocking(playlist: PlaylistEntity) {
+        playlist.syncStatus = PlaylistEntity.SYNC_STATUS_NOT_SYNCED
+        playlistDao.updateSyncStatusBlocking(PlaylistEntity.SYNC_STATUS_NOT_SYNCED, playlist.uuid)
     }
 
     fun countPlaylists(): Int {
@@ -435,6 +435,6 @@ class SmartPlaylistManagerImpl @Inject constructor(
     }
 
     override suspend fun markAllSynced() {
-        playlistDao.updateAllSyncStatus(SmartPlaylist.SYNC_STATUS_SYNCED)
+        playlistDao.updateAllSyncStatus(PlaylistEntity.SYNC_STATUS_SYNCED)
     }
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/SmartPlaylistManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/SmartPlaylistManagerImpl.kt
@@ -3,8 +3,8 @@ package au.com.shiftyjelly.pocketcasts.repositories.podcast
 import android.content.Context
 import au.com.shiftyjelly.pocketcasts.analytics.SourceView
 import au.com.shiftyjelly.pocketcasts.models.db.AppDatabase
-import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.models.entity.PlaylistEntity
+import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.models.type.EpisodePlayingStatus
 import au.com.shiftyjelly.pocketcasts.models.type.EpisodeStatusEnum
 import au.com.shiftyjelly.pocketcasts.models.type.PlaylistEpisodeSortType

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/support/Support.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/support/Support.kt
@@ -412,7 +412,7 @@ class Support @Inject constructor(
                     val playlists = smartPlaylistManager.findAllBlocking()
                     for (playlist in playlists) {
                         output.append(playlist.title).append(eol)
-                        output.append("Auto Download? ").append(playlist.autoDownload).append(" Unmetered only? ").append(playlist.autoDownloadUnmeteredOnly).append(" Power only? ").append(playlist.autoDownloadPowerOnly).append(eol)
+                        output.append("Auto Download? ").append(playlist.autoDownload).append(eol)
                         output.append(eol)
                     }
                 } catch (e: Exception) {

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/PodcastSyncProcess.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/PodcastSyncProcess.kt
@@ -14,7 +14,7 @@ import au.com.shiftyjelly.pocketcasts.models.entity.ChapterIndices
 import au.com.shiftyjelly.pocketcasts.models.entity.Folder
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
-import au.com.shiftyjelly.pocketcasts.models.entity.SmartPlaylist
+import au.com.shiftyjelly.pocketcasts.models.entity.PlaylistEntity
 import au.com.shiftyjelly.pocketcasts.models.entity.UserPodcastRating
 import au.com.shiftyjelly.pocketcasts.models.to.StatsBundle
 import au.com.shiftyjelly.pocketcasts.models.type.EpisodePlayingStatus
@@ -614,7 +614,7 @@ class PodcastSyncProcess(
         return rxCompletable { markAllLocalItemsSynced(episodes) }
             .andThen(importEpisodes(response.episodes))
             .andThen(importPodcasts(response.podcasts))
-            .andThen(rxCompletable { importFilters(response.smartPlaylists) })
+            .andThen(rxCompletable { importFilters(response.playlists) })
             .andThen(importFolders(response.folders))
             .andThen(rxCompletable { importBookmarks(response.bookmarks) })
             .andThen(updateSettings(response))
@@ -667,8 +667,8 @@ class PodcastSyncProcess(
             .ignoreElements()
     }
 
-    private suspend fun importFilters(smartPlaylists: List<SmartPlaylist>) {
-        for (playlist in smartPlaylists) {
+    private suspend fun importFilters(playlists: List<PlaylistEntity>) {
+        for (playlist in playlists) {
             importPlaylist(playlist)
         }
     }
@@ -694,7 +694,7 @@ class PodcastSyncProcess(
         }
     }
 
-    private suspend fun importPlaylist(sync: SmartPlaylist): SmartPlaylist? {
+    private suspend fun importPlaylist(sync: PlaylistEntity): PlaylistEntity? {
         val uuid = sync.uuid
         if (uuid.isBlank()) {
             return null
@@ -711,7 +711,7 @@ class PodcastSyncProcess(
         }
 
         if (playlist == null) {
-            playlist = SmartPlaylist(uuid = sync.uuid)
+            playlist = PlaylistEntity(uuid = sync.uuid)
         }
 
         with(playlist) {
@@ -730,7 +730,7 @@ class PodcastSyncProcess(
             allPodcasts = sync.allPodcasts
             podcastUuids = sync.podcastUuids
             filterHours = sync.filterHours
-            syncStatus = SmartPlaylist.SYNC_STATUS_SYNCED
+            syncStatus = PlaylistEntity.SYNC_STATUS_SYNCED
             filterDuration = sync.filterDuration
             longerThan = sync.longerThan
             shorterThan = sync.shorterThan

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/PodcastSyncProcess.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/PodcastSyncProcess.kt
@@ -408,7 +408,6 @@ class PodcastSyncProcess(
                     fields.put("audio_video", playlist.audioVideo)
                     fields.put("not_downloaded", if (playlist.notDownloaded) "1" else "0")
                     fields.put("downloaded", if (playlist.downloaded) "1" else "0")
-                    fields.put("downloading", if (playlist.downloading) "1" else "0")
                     fields.put("finished", if (playlist.finished) "1" else "0")
                     fields.put("partially_played", if (playlist.partiallyPlayed) "1" else "0")
                     fields.put("unplayed", if (playlist.unplayed) "1" else "0")
@@ -720,7 +719,6 @@ class PodcastSyncProcess(
             audioVideo = sync.audioVideo
             notDownloaded = sync.notDownloaded
             downloaded = sync.downloaded
-            downloading = sync.downloading
             finished = sync.finished
             partiallyPlayed = sync.partiallyPlayed
             unplayed = sync.unplayed

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/PodcastSyncProcess.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/PodcastSyncProcess.kt
@@ -12,9 +12,9 @@ import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTracker
 import au.com.shiftyjelly.pocketcasts.models.entity.Bookmark
 import au.com.shiftyjelly.pocketcasts.models.entity.ChapterIndices
 import au.com.shiftyjelly.pocketcasts.models.entity.Folder
+import au.com.shiftyjelly.pocketcasts.models.entity.PlaylistEntity
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
-import au.com.shiftyjelly.pocketcasts.models.entity.PlaylistEntity
 import au.com.shiftyjelly.pocketcasts.models.entity.UserPodcastRating
 import au.com.shiftyjelly.pocketcasts.models.to.StatsBundle
 import au.com.shiftyjelly.pocketcasts.models.type.EpisodePlayingStatus

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/SyncManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/SyncManager.kt
@@ -2,7 +2,7 @@ package au.com.shiftyjelly.pocketcasts.repositories.sync
 
 import android.accounts.Account
 import au.com.shiftyjelly.pocketcasts.models.entity.Bookmark
-import au.com.shiftyjelly.pocketcasts.models.entity.SmartPlaylist
+import au.com.shiftyjelly.pocketcasts.models.entity.PlaylistEntity
 import au.com.shiftyjelly.pocketcasts.models.entity.UserEpisode
 import au.com.shiftyjelly.pocketcasts.models.to.HistorySyncRequest
 import au.com.shiftyjelly.pocketcasts.models.to.HistorySyncResponse
@@ -113,7 +113,7 @@ interface SyncManager : NamedSettingsCaller {
 
     // Other
     suspend fun exchangeSonos(): ExchangeSonosResponse
-    suspend fun getFilters(): List<SmartPlaylist>
+    suspend fun getFilters(): List<PlaylistEntity>
     suspend fun loadStats(): StatsBundle
     suspend fun upNextSync(request: UpNextSyncRequest): UpNextSyncResponse
     suspend fun getBookmarks(): List<Bookmark>

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/SyncManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/SyncManagerImpl.kt
@@ -6,7 +6,7 @@ import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTracker
 import au.com.shiftyjelly.pocketcasts.analytics.TracksAnalyticsTracker
 import au.com.shiftyjelly.pocketcasts.models.entity.Bookmark
-import au.com.shiftyjelly.pocketcasts.models.entity.SmartPlaylist
+import au.com.shiftyjelly.pocketcasts.models.entity.PlaylistEntity
 import au.com.shiftyjelly.pocketcasts.models.entity.UserEpisode
 import au.com.shiftyjelly.pocketcasts.models.to.HistorySyncRequest
 import au.com.shiftyjelly.pocketcasts.models.to.HistorySyncResponse
@@ -403,7 +403,7 @@ class SyncManagerImpl @Inject constructor(
         syncServiceManager.exchangeSonos(token)
     }
 
-    override suspend fun getFilters(): List<SmartPlaylist> = getCacheTokenOrLogin { token ->
+    override suspend fun getFilters(): List<PlaylistEntity> = getCacheTokenOrLogin { token ->
         syncServiceManager.getFilters(token)
     }
 

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/data/PlaylistSync.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/data/PlaylistSync.kt
@@ -2,7 +2,7 @@ package au.com.shiftyjelly.pocketcasts.repositories.sync.data
 
 import androidx.room.withTransaction
 import au.com.shiftyjelly.pocketcasts.models.db.AppDatabase
-import au.com.shiftyjelly.pocketcasts.models.entity.SmartPlaylist
+import au.com.shiftyjelly.pocketcasts.models.entity.PlaylistEntity
 import au.com.shiftyjelly.pocketcasts.models.type.PlaylistEpisodeSortType
 import au.com.shiftyjelly.pocketcasts.repositories.sync.SyncManager
 import com.google.protobuf.boolValue
@@ -66,7 +66,7 @@ internal class PlaylistSync(
         getUuid: (T) -> String,
         isDeleted: (T) -> Boolean,
         isManual: (T) -> Boolean,
-        applyServerPlaylist: (SmartPlaylist, T) -> SmartPlaylist,
+        applyServerPlaylist: (PlaylistEntity, T) -> PlaylistEntity,
     ) {
         val deletedPlaylists = serverPlaylists.filter(isDeleted)
         val remainingPlaylist = serverPlaylists - deletedPlaylists
@@ -78,14 +78,14 @@ internal class PlaylistSync(
             playlistDao.deleteAll(deletedPlaylists.map(getUuid))
 
             val existingPlaylists = playlistDao.getAllPlaylists(smartPlaylists.map(getUuid))
-            val existingPlaylistUuids = existingPlaylists.map(SmartPlaylist::uuid)
+            val existingPlaylistUuids = existingPlaylists.map(PlaylistEntity::uuid)
             existingPlaylists.forEach { playlist ->
                 val serverPlaylist = remainingPlaylistsMap[playlist.uuid] ?: return@forEach
                 applyServerPlaylist(playlist, serverPlaylist)
             }
             val newPlaylists = smartPlaylists.mapNotNull { serverPlaylist ->
                 if (getUuid(serverPlaylist) !in existingPlaylistUuids) {
-                    applyServerPlaylist(SmartPlaylist(), serverPlaylist)
+                    applyServerPlaylist(PlaylistEntity(), serverPlaylist)
                 } else {
                     null
                 }
@@ -168,8 +168,8 @@ internal class PlaylistSync(
     }
 }
 
-private fun SmartPlaylist.applyServerPlaylist(serverPlaylist: PlaylistSyncResponse) = apply {
-    syncStatus = SmartPlaylist.SYNC_STATUS_SYNCED
+private fun PlaylistEntity.applyServerPlaylist(serverPlaylist: PlaylistSyncResponse) = apply {
+    syncStatus = PlaylistEntity.SYNC_STATUS_SYNCED
     uuid = serverPlaylist.uuid
     title = serverPlaylist.title
     serverPlaylist.manualOrNull?.value?.let { value ->
@@ -223,8 +223,8 @@ private fun SmartPlaylist.applyServerPlaylist(serverPlaylist: PlaylistSyncRespon
     }
 }
 
-private fun SmartPlaylist.applyServerPlaylist(serverPlaylist: SyncUserPlaylist) = apply {
-    syncStatus = SmartPlaylist.SYNC_STATUS_SYNCED
+private fun PlaylistEntity.applyServerPlaylist(serverPlaylist: SyncUserPlaylist) = apply {
+    syncStatus = PlaylistEntity.SYNC_STATUS_SYNCED
     uuid = serverPlaylist.uuid
     serverPlaylist.titleOrNull?.value?.let { value ->
         title = value

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/SmartPlaylistManagerImplTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/SmartPlaylistManagerImplTest.kt
@@ -3,7 +3,7 @@ package au.com.shiftyjelly.pocketcasts.repositories.podcast
 import android.content.Context
 import au.com.shiftyjelly.pocketcasts.models.db.AppDatabase
 import au.com.shiftyjelly.pocketcasts.models.db.dao.SmartPlaylistDao
-import au.com.shiftyjelly.pocketcasts.models.entity.SmartPlaylist
+import au.com.shiftyjelly.pocketcasts.models.entity.PlaylistEntity
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.repositories.download.DownloadManager
 import au.com.shiftyjelly.pocketcasts.repositories.notification.NotificationManager
@@ -39,7 +39,7 @@ class SmartPlaylistManagerImplTest {
         val playlistManager = initManager()
 
         playlistManager.updateBlocking(
-            smartPlaylist = SmartPlaylist(),
+            playlist = PlaylistEntity(),
             userPlaylistUpdate = UserPlaylistUpdate(listOf(PlaylistProperty.Color), PlaylistUpdateSource.AUTO_DOWNLOAD_SETTINGS),
             isCreatingFilter = true,
         )
@@ -54,7 +54,7 @@ class SmartPlaylistManagerImplTest {
         val playlistManager = initManager()
 
         playlistManager.updateBlocking(
-            smartPlaylist = SmartPlaylist(),
+            playlist = PlaylistEntity(),
             userPlaylistUpdate = UserPlaylistUpdate(listOf(PlaylistProperty.Color), PlaylistUpdateSource.AUTO_DOWNLOAD_SETTINGS),
             isCreatingFilter = false,
         )

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/FilterListResponse.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/FilterListResponse.kt
@@ -51,7 +51,6 @@ data class FilterResponse(
         allPodcasts?.let { filter.allPodcasts = it }
         podcastUuids?.let { filter.podcastUuids = it }
         downloaded?.let { filter.downloaded = it }
-        downloading?.let { filter.downloading = it }
         notDownloaded?.let { filter.notDownloaded = it }
         sortType?.let(PlaylistEpisodeSortType::fromServerId)?.let { filter.sortType = it }
         iconId?.let { filter.iconId = it }

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/FilterListResponse.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/FilterListResponse.kt
@@ -1,6 +1,6 @@
 package au.com.shiftyjelly.pocketcasts.servers.sync
 
-import au.com.shiftyjelly.pocketcasts.models.entity.SmartPlaylist
+import au.com.shiftyjelly.pocketcasts.models.entity.PlaylistEntity
 import au.com.shiftyjelly.pocketcasts.models.type.PlaylistEpisodeSortType
 import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
@@ -36,11 +36,11 @@ data class FilterResponse(
     @Json(name = "shorterThan") val shorterThan: Int?,
 ) {
 
-    fun toFilter(): SmartPlaylist? {
+    fun toFilter(): PlaylistEntity? {
         if (uuid == null) {
             return null
         }
-        val filter = SmartPlaylist(uuid = uuid)
+        val filter = PlaylistEntity(uuid = uuid)
         title?.let { filter.title = it }
         sortPosition?.let { filter.sortPosition = it }
         manual?.let { filter.manual = it }

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/SyncServiceManager.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/SyncServiceManager.kt
@@ -1,8 +1,7 @@
 package au.com.shiftyjelly.pocketcasts.servers.sync
 
 import android.os.Build
-import au.com.shiftyjelly.pocketcasts.models.entity.Bookmark
-import au.com.shiftyjelly.pocketcasts.models.entity.SmartPlaylist
+import au.com.shiftyjelly.pocketcasts.models.entity.PlaylistEntity
 import au.com.shiftyjelly.pocketcasts.models.entity.UserEpisode
 import au.com.shiftyjelly.pocketcasts.models.to.HistorySyncRequest
 import au.com.shiftyjelly.pocketcasts.models.to.HistorySyncResponse
@@ -12,7 +11,6 @@ import au.com.shiftyjelly.pocketcasts.preferences.RefreshToken
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.servers.di.Cached
 import au.com.shiftyjelly.pocketcasts.servers.di.SyncServiceRetrofit
-import au.com.shiftyjelly.pocketcasts.servers.sync.bookmark.toBookmark
 import au.com.shiftyjelly.pocketcasts.servers.sync.forgotpassword.ForgotPasswordRequest
 import au.com.shiftyjelly.pocketcasts.servers.sync.forgotpassword.ForgotPasswordResponse
 import au.com.shiftyjelly.pocketcasts.servers.sync.history.HistoryYearResponse
@@ -34,7 +32,6 @@ import com.pocketcasts.service.api.ReferralRedemptionRequest
 import com.pocketcasts.service.api.ReferralRedemptionResponse
 import com.pocketcasts.service.api.ReferralValidationResponse
 import com.pocketcasts.service.api.SupportFeedbackRequest
-import com.pocketcasts.service.api.UserPlaylistListRequest
 import com.pocketcasts.service.api.UserPlaylistListResponse
 import com.pocketcasts.service.api.UserPodcastListResponse
 import com.pocketcasts.service.api.WinbackResponse
@@ -174,7 +171,7 @@ open class SyncServiceManager @Inject constructor(
         return service.getPodcastEpisodes(addBearer(token), request)
     }
 
-    suspend fun getFilters(token: AccessToken): List<SmartPlaylist> {
+    suspend fun getFilters(token: AccessToken): List<PlaylistEntity> {
         val response = service.getFilterList(addBearer(token), buildBasicRequest())
         return response.filters?.mapNotNull { it.toFilter() } ?: emptyList()
     }

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/update/SyncUpdateResponse.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/update/SyncUpdateResponse.kt
@@ -3,14 +3,14 @@ package au.com.shiftyjelly.pocketcasts.servers.sync.update
 import au.com.shiftyjelly.pocketcasts.models.entity.Bookmark
 import au.com.shiftyjelly.pocketcasts.models.entity.ChapterIndices
 import au.com.shiftyjelly.pocketcasts.models.entity.Folder
-import au.com.shiftyjelly.pocketcasts.models.entity.SmartPlaylist
+import au.com.shiftyjelly.pocketcasts.models.entity.PlaylistEntity
 import au.com.shiftyjelly.pocketcasts.models.type.EpisodePlayingStatus
 import java.util.Date
 
 data class SyncUpdateResponse(
     var lastModified: String? = null,
     var token: String? = null,
-    val smartPlaylists: MutableList<SmartPlaylist> = mutableListOf(),
+    val playlists: MutableList<PlaylistEntity> = mutableListOf(),
     val episodes: MutableList<EpisodeSync> = mutableListOf(),
     val podcasts: MutableList<PodcastSync> = mutableListOf(),
     val folders: MutableList<Folder> = mutableListOf(),

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/update/SyncUpdateResponseParser.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/update/SyncUpdateResponseParser.kt
@@ -172,13 +172,11 @@ class SyncUpdateResponseParser : JsonAdapter<SyncUpdateResponse>() {
                 "audio_video" -> smartPlaylist.audioVideo = reader.nextIntOrDefault(0)
                 "not_downloaded" -> smartPlaylist.notDownloaded = reader.nextBooleanOrDefault(false)
                 "downloaded" -> smartPlaylist.downloaded = reader.nextBooleanOrDefault(false)
-                "downloading" -> smartPlaylist.downloading = reader.nextBooleanOrDefault(false)
                 "finished" -> smartPlaylist.finished = reader.nextBooleanOrDefault(false)
                 "partially_played" -> smartPlaylist.partiallyPlayed = reader.nextBooleanOrDefault(false)
                 "unplayed" -> smartPlaylist.unplayed = reader.nextBooleanOrDefault(false)
                 "starred" -> smartPlaylist.starred = reader.nextBooleanOrDefault(false)
                 "manual" -> smartPlaylist.manual = reader.nextBooleanOrDefault(false)
-                "episode_uuids" -> smartPlaylist.episodeUuids = reader.nextStringOrNull()
                 "sort_position" -> smartPlaylist.sortPosition = reader.nextIntOrDefault(0)
                 "sort_type" -> smartPlaylist.sortType = reader.nextIntOrNull()?.let(PlaylistEpisodeSortType::fromServerId) ?: PlaylistEpisodeSortType.NewestToOldest
                 "icon_id" -> smartPlaylist.iconId = reader.nextIntOrDefault(0)

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/update/SyncUpdateResponseParser.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/update/SyncUpdateResponseParser.kt
@@ -3,7 +3,7 @@ package au.com.shiftyjelly.pocketcasts.servers.sync.update
 import au.com.shiftyjelly.pocketcasts.models.entity.Bookmark
 import au.com.shiftyjelly.pocketcasts.models.entity.ChapterIndices
 import au.com.shiftyjelly.pocketcasts.models.entity.Folder
-import au.com.shiftyjelly.pocketcasts.models.entity.SmartPlaylist
+import au.com.shiftyjelly.pocketcasts.models.entity.PlaylistEntity
 import au.com.shiftyjelly.pocketcasts.models.type.EpisodePlayingStatus
 import au.com.shiftyjelly.pocketcasts.models.type.PlaylistEpisodeSortType
 import au.com.shiftyjelly.pocketcasts.models.type.PodcastsSortType
@@ -160,36 +160,36 @@ class SyncUpdateResponseParser : JsonAdapter<SyncUpdateResponse>() {
     }
 
     private fun readPlaylist(reader: JsonReader, response: SyncUpdateResponse) {
-        val smartPlaylist = SmartPlaylist()
-        smartPlaylist.allPodcasts = true
+        val playlist = PlaylistEntity()
+        playlist.allPodcasts = true
         reader.beginObject()
         while (reader.hasNext()) {
             when (reader.nextName()) {
-                "uuid" -> smartPlaylist.uuid = reader.nextStringOrNull() ?: ""
-                "title" -> smartPlaylist.title = reader.nextStringOrNull() ?: ""
-                "all_podcasts" -> smartPlaylist.allPodcasts = reader.nextBooleanOrDefault(true)
-                "podcast_uuids" -> smartPlaylist.podcastUuids = reader.nextStringOrNull()
-                "audio_video" -> smartPlaylist.audioVideo = reader.nextIntOrDefault(0)
-                "not_downloaded" -> smartPlaylist.notDownloaded = reader.nextBooleanOrDefault(false)
-                "downloaded" -> smartPlaylist.downloaded = reader.nextBooleanOrDefault(false)
-                "finished" -> smartPlaylist.finished = reader.nextBooleanOrDefault(false)
-                "partially_played" -> smartPlaylist.partiallyPlayed = reader.nextBooleanOrDefault(false)
-                "unplayed" -> smartPlaylist.unplayed = reader.nextBooleanOrDefault(false)
-                "starred" -> smartPlaylist.starred = reader.nextBooleanOrDefault(false)
-                "manual" -> smartPlaylist.manual = reader.nextBooleanOrDefault(false)
-                "sort_position" -> smartPlaylist.sortPosition = reader.nextIntOrDefault(0)
-                "sort_type" -> smartPlaylist.sortType = reader.nextIntOrNull()?.let(PlaylistEpisodeSortType::fromServerId) ?: PlaylistEpisodeSortType.NewestToOldest
-                "icon_id" -> smartPlaylist.iconId = reader.nextIntOrDefault(0)
-                "is_deleted" -> smartPlaylist.deleted = reader.nextBooleanOrDefault(false)
-                "filter_hours" -> smartPlaylist.filterHours = reader.nextIntOrDefault(0)
-                "filter_duration" -> smartPlaylist.filterDuration = reader.nextBooleanOrDefault(false)
-                "shorter_than" -> smartPlaylist.shorterThan = reader.nextIntOrDefault(0)
-                "longer_than" -> smartPlaylist.longerThan = reader.nextIntOrDefault(0)
+                "uuid" -> playlist.uuid = reader.nextStringOrNull() ?: ""
+                "title" -> playlist.title = reader.nextStringOrNull() ?: ""
+                "all_podcasts" -> playlist.allPodcasts = reader.nextBooleanOrDefault(true)
+                "podcast_uuids" -> playlist.podcastUuids = reader.nextStringOrNull()
+                "audio_video" -> playlist.audioVideo = reader.nextIntOrDefault(0)
+                "not_downloaded" -> playlist.notDownloaded = reader.nextBooleanOrDefault(false)
+                "downloaded" -> playlist.downloaded = reader.nextBooleanOrDefault(false)
+                "finished" -> playlist.finished = reader.nextBooleanOrDefault(false)
+                "partially_played" -> playlist.partiallyPlayed = reader.nextBooleanOrDefault(false)
+                "unplayed" -> playlist.unplayed = reader.nextBooleanOrDefault(false)
+                "starred" -> playlist.starred = reader.nextBooleanOrDefault(false)
+                "manual" -> playlist.manual = reader.nextBooleanOrDefault(false)
+                "sort_position" -> playlist.sortPosition = reader.nextIntOrDefault(0)
+                "sort_type" -> playlist.sortType = reader.nextIntOrNull()?.let(PlaylistEpisodeSortType::fromServerId) ?: PlaylistEpisodeSortType.NewestToOldest
+                "icon_id" -> playlist.iconId = reader.nextIntOrDefault(0)
+                "is_deleted" -> playlist.deleted = reader.nextBooleanOrDefault(false)
+                "filter_hours" -> playlist.filterHours = reader.nextIntOrDefault(0)
+                "filter_duration" -> playlist.filterDuration = reader.nextBooleanOrDefault(false)
+                "shorter_than" -> playlist.shorterThan = reader.nextIntOrDefault(0)
+                "longer_than" -> playlist.longerThan = reader.nextIntOrDefault(0)
                 else -> reader.skipValue()
             }
         }
         reader.endObject()
-        response.smartPlaylists.add(smartPlaylist)
+        response.playlists.add(playlist)
     }
 
     private fun readFolder(reader: JsonReader, response: SyncUpdateResponse) {

--- a/modules/services/ui/src/main/java/au/com/shiftyjelly/pocketcasts/ui/extensions/Playlist.kt
+++ b/modules/services/ui/src/main/java/au/com/shiftyjelly/pocketcasts/ui/extensions/Playlist.kt
@@ -3,7 +3,7 @@ package au.com.shiftyjelly.pocketcasts.ui.extensions
 import android.content.Context
 import android.graphics.Color
 import au.com.shiftyjelly.pocketcasts.localization.helper.TimeHelper
-import au.com.shiftyjelly.pocketcasts.models.entity.SmartPlaylist
+import au.com.shiftyjelly.pocketcasts.models.entity.PlaylistEntity
 import au.com.shiftyjelly.pocketcasts.repositories.extensions.colorIndex
 import au.com.shiftyjelly.pocketcasts.ui.R
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
@@ -16,7 +16,7 @@ private val filterThemeColors = listOf(
     R.attr.filter_03,
 )
 
-fun SmartPlaylist.getStringForDuration(context: Context?): String {
+fun PlaylistEntity.getStringForDuration(context: Context?): String {
     return when {
         context == null -> ""
         !filterDuration -> context.getString(LR.string.filters_duration)
@@ -28,14 +28,14 @@ fun SmartPlaylist.getStringForDuration(context: Context?): String {
     }
 }
 
-val SmartPlaylist.Companion.themeColors: List<Int>
+val PlaylistEntity.Companion.themeColors: List<Int>
     get() = filterThemeColors
 
-fun SmartPlaylist.getColor(context: Context?): Int {
+fun PlaylistEntity.getColor(context: Context?): Int {
     val themeColor = filterThemeColors.getOrNull(colorIndex) ?: return Color.WHITE
     return context?.getThemeColor(themeColor) ?: Color.WHITE
 }
 
-fun SmartPlaylist.Companion.getColors(context: Context?): List<Int> {
+fun PlaylistEntity.Companion.getColors(context: Context?): List<Int> {
     return filterThemeColors.mapNotNull { context?.getThemeColor(it) }
 }

--- a/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/adapter/FilterAutoDownloadAdapter.kt
+++ b/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/adapter/FilterAutoDownloadAdapter.kt
@@ -47,7 +47,6 @@ class FilterAutoDownloadAdapter(private val filters: List<SmartPlaylist>, privat
 
     interface ClickListener {
         fun onAutoDownloadChanged(filter: SmartPlaylist, on: Boolean)
-        fun onSettingsClicked(filter: SmartPlaylist)
     }
 
     inner class ViewHolder(view: View) :
@@ -72,8 +71,6 @@ class FilterAutoDownloadAdapter(private val filters: List<SmartPlaylist>, privat
             }
             if (view.id == R.id.checkbox || view.id == R.id.row_button) {
                 clickListener.onAutoDownloadChanged(filter, checkBox.isChecked)
-            } else if (view.id == R.id.settings_button) {
-                clickListener.onSettingsClicked(filter)
             }
         }
     }

--- a/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/adapter/FilterAutoDownloadAdapter.kt
+++ b/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/adapter/FilterAutoDownloadAdapter.kt
@@ -6,11 +6,11 @@ import android.view.ViewGroup
 import android.widget.CheckBox
 import android.widget.ImageView
 import android.widget.TextView
-import au.com.shiftyjelly.pocketcasts.models.entity.SmartPlaylist
+import au.com.shiftyjelly.pocketcasts.models.entity.PlaylistEntity
 import au.com.shiftyjelly.pocketcasts.views.R
 import au.com.shiftyjelly.pocketcasts.views.helper.PlaylistHelper
 
-class FilterAutoDownloadAdapter(private val filters: List<SmartPlaylist>, private val clickListener: ClickListener, val isDarkTheme: Boolean) : androidx.recyclerview.widget.RecyclerView.Adapter<FilterAutoDownloadAdapter.ViewHolder>() {
+class FilterAutoDownloadAdapter(private val filters: List<PlaylistEntity>, private val clickListener: ClickListener, val isDarkTheme: Boolean) : androidx.recyclerview.widget.RecyclerView.Adapter<FilterAutoDownloadAdapter.ViewHolder>() {
 
     init {
         setHasStableIds(true)
@@ -40,13 +40,13 @@ class FilterAutoDownloadAdapter(private val filters: List<SmartPlaylist>, privat
         return filters[position].id ?: androidx.recyclerview.widget.RecyclerView.NO_ID
     }
 
-    private fun addTalkBack(filter: SmartPlaylist, view: View) {
+    private fun addTalkBack(filter: PlaylistEntity, view: View) {
         val status = if (filter.autoDownload) "on" else "off"
         view.contentDescription = "${filter.title} auto downloads $status."
     }
 
     interface ClickListener {
-        fun onAutoDownloadChanged(filter: SmartPlaylist, on: Boolean)
+        fun onAutoDownloadChanged(filter: PlaylistEntity, on: Boolean)
     }
 
     inner class ViewHolder(view: View) :

--- a/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/fragments/FilterSelectFragment.kt
+++ b/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/fragments/FilterSelectFragment.kt
@@ -11,7 +11,7 @@ import androidx.fragment.app.viewModels
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import au.com.shiftyjelly.pocketcasts.localization.extensions.getStringPlural
-import au.com.shiftyjelly.pocketcasts.models.entity.SmartPlaylist
+import au.com.shiftyjelly.pocketcasts.models.entity.PlaylistEntity
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.SmartPlaylistManager
 import au.com.shiftyjelly.pocketcasts.utils.extensions.getSerializableCompat
 import au.com.shiftyjelly.pocketcasts.views.databinding.FragmentFilterSelectBinding
@@ -165,11 +165,11 @@ class FilterSelectFragment private constructor() : BaseFragment() {
     }
 }
 
-private data class SelectableFilter(val filter: SmartPlaylist, var selected: Boolean)
-private class FilterSelectAdapter(val isDarkTheme: Boolean, val list: List<SelectableFilter>, val onSelectionChanged: (selected: List<SmartPlaylist>) -> Unit) : RecyclerView.Adapter<FilterSelectAdapter.FilterViewHolder>() {
+private data class SelectableFilter(val filter: PlaylistEntity, var selected: Boolean)
+private class FilterSelectAdapter(val isDarkTheme: Boolean, val list: List<SelectableFilter>, val onSelectionChanged: (selected: List<PlaylistEntity>) -> Unit) : RecyclerView.Adapter<FilterSelectAdapter.FilterViewHolder>() {
     class FilterViewHolder(val binding: SettingsRowFilterBinding) : RecyclerView.ViewHolder(binding.root)
 
-    val selectedFilters: List<SmartPlaylist>
+    val selectedFilters: List<PlaylistEntity>
         get() = list.filter { it.selected }.map { it.filter }
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): FilterViewHolder {

--- a/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/helper/PlaylistHelper.kt
+++ b/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/helper/PlaylistHelper.kt
@@ -3,17 +3,17 @@ package au.com.shiftyjelly.pocketcasts.views.helper
 import android.content.res.ColorStateList
 import android.widget.ImageView
 import androidx.core.widget.ImageViewCompat
-import au.com.shiftyjelly.pocketcasts.models.entity.SmartPlaylist
+import au.com.shiftyjelly.pocketcasts.models.entity.PlaylistEntity
 import au.com.shiftyjelly.pocketcasts.repositories.extensions.drawableId
 import au.com.shiftyjelly.pocketcasts.ui.extensions.getColor
 
 object PlaylistHelper {
-    fun updateImageView(smartPlaylist: SmartPlaylist, imageView: ImageView?) {
+    fun updateImageView(playlist: PlaylistEntity, imageView: ImageView?) {
         if (imageView == null) {
             return
         }
-        imageView.setImageResource(smartPlaylist.drawableId)
-        val color = smartPlaylist.getColor(imageView.context)
+        imageView.setImageResource(playlist.drawableId)
+        val color = playlist.getColor(imageView.context)
         ImageViewCompat.setImageTintList(imageView, ColorStateList.valueOf(color))
     }
 }

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/theme/WearColors.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/theme/WearColors.kt
@@ -2,7 +2,7 @@ package au.com.shiftyjelly.pocketcasts.wear.theme
 
 import androidx.compose.ui.graphics.Color
 import au.com.shiftyjelly.pocketcasts.compose.ThemeExtraDarkColors
-import au.com.shiftyjelly.pocketcasts.models.entity.SmartPlaylist
+import au.com.shiftyjelly.pocketcasts.models.entity.PlaylistEntity
 import au.com.shiftyjelly.pocketcasts.repositories.extensions.colorIndex
 
 object WearColors {
@@ -15,5 +15,5 @@ object WearColors {
     val downloadedIcon = Color(0xFF54C483)
 
     fun getFolderColor(id: Int): Color = ThemeExtraDarkColors.getFolderColor(id)
-    fun getFilterColor(smartPlaylist: SmartPlaylist): Color = ThemeExtraDarkColors.getFilterColor(smartPlaylist.colorIndex)
+    fun getFilterColor(playlist: PlaylistEntity): Color = ThemeExtraDarkColors.getFilterColor(playlist.colorIndex)
 }

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/filter/FilterViewModel.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/filter/FilterViewModel.kt
@@ -4,7 +4,7 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
-import au.com.shiftyjelly.pocketcasts.models.entity.SmartPlaylist
+import au.com.shiftyjelly.pocketcasts.models.entity.PlaylistEntity
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
@@ -32,10 +32,10 @@ class FilterViewModel @Inject constructor(
     sealed class UiState {
         object Loading : UiState()
         data class Empty(
-            val filter: SmartPlaylist? = null,
+            val filter: PlaylistEntity? = null,
         ) : UiState()
         data class Loaded(
-            val filter: SmartPlaylist,
+            val filter: PlaylistEntity,
             val episodes: List<PodcastEpisode>,
         ) : UiState()
     }

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/filter/FilterViewModel.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/filter/FilterViewModel.kt
@@ -3,8 +3,8 @@ package au.com.shiftyjelly.pocketcasts.wear.ui.filter
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.models.entity.PlaylistEntity
+import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/filters/FiltersScreen.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/filters/FiltersScreen.kt
@@ -12,7 +12,7 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.wear.compose.foundation.lazy.items
-import au.com.shiftyjelly.pocketcasts.models.entity.SmartPlaylist
+import au.com.shiftyjelly.pocketcasts.models.entity.PlaylistEntity
 import au.com.shiftyjelly.pocketcasts.repositories.extensions.drawableId
 import au.com.shiftyjelly.pocketcasts.wear.theme.WearColors
 import au.com.shiftyjelly.pocketcasts.wear.ui.component.LoadingScreen
@@ -49,7 +49,7 @@ fun FiltersScreen(
 @Composable
 private fun Content(
     columnState: ScalingLazyColumnState,
-    filters: List<SmartPlaylist>,
+    filters: List<PlaylistEntity>,
     onFilterTap: (String) -> Unit,
     modifier: Modifier = Modifier,
 ) {

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/filters/FiltersViewModel.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/filters/FiltersViewModel.kt
@@ -2,7 +2,7 @@ package au.com.shiftyjelly.pocketcasts.wear.ui.filters
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import au.com.shiftyjelly.pocketcasts.models.entity.SmartPlaylist
+import au.com.shiftyjelly.pocketcasts.models.entity.PlaylistEntity
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.SmartPlaylistManager
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
@@ -17,7 +17,7 @@ class FiltersViewModel @Inject constructor(
 
     sealed class UiState {
         object Loading : UiState()
-        data class Loaded(val filters: List<SmartPlaylist>) : UiState()
+        data class Loaded(val filters: List<PlaylistEntity>) : UiState()
     }
 
     val uiState = smartPlaylistManager.findAllFlow()


### PR DESCRIPTION
## Description

This adds all the necessary structures to persist Manual Playlists:
- Delete any potentially lingering old manual playlists.
- Remove unused auto download columns.
- Remove unused `episodeUuids` column.
- Add `manual_playlist_episodes` junction table.
- Add `slug` columns to podcast and episode tables.
- Rename `SmartPlaylist` database class to `PlaylistEntity`. I chose the `Entity` suffix to avoid confusion in auto-complete, since there is a `Playlist` sealed interface in the repository layer that will be used in higher layers.

Closes PCDROID-102

## Testing Instructions

1. Install the app from `main`.
2. Sign in to your account.
3. Install the app from `mehow/task/manual-playlists-db`.
4. There should be no crashes and you should still see your playlists and podcasts.

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.