### PR TITLE
[Onboarding] Add Create Account analytics

### DIFF
--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/OnboardingLoginPage.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/OnboardingLoginPage.kt
@@ -38,6 +38,7 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import au.com.shiftyjelly.pocketcasts.account.onboarding.components.ContinueWithGoogleButton
 import au.com.shiftyjelly.pocketcasts.account.viewmodel.GoogleSignInState
 import au.com.shiftyjelly.pocketcasts.account.viewmodel.OnboardingLogInViewModel
+import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
 import au.com.shiftyjelly.pocketcasts.compose.AppThemeWithBackground
 import au.com.shiftyjelly.pocketcasts.compose.CallOnce
 import au.com.shiftyjelly.pocketcasts.compose.bars.SystemBarsStyles
@@ -142,7 +143,10 @@ internal fun NewOnboardingLoginPage(
                 color = MaterialTheme.theme.colors.primaryInteractive01,
                 fontWeight = FontWeight.W400,
                 modifier = Modifier
-                    .clickable { onForgotPasswordClick() },
+                    .clickable {
+                        viewModel.onForgotPasswordTapped(flow)
+                        onForgotPasswordClick()
+                    },
             )
 
             Spacer(modifier = Modifier.height(16.dp))
@@ -150,7 +154,10 @@ internal fun NewOnboardingLoginPage(
             RowButton(
                 text = stringResource(LR.string.onboarding_login_continue_with_email),
                 enabled = state.enableSubmissionFields,
-                onClick = { viewModel.logIn(onLoginComplete) },
+                onClick = {
+                    viewModel.onSignInButtonTapped(flow)
+                    viewModel.logIn(onLoginComplete)
+                },
                 includePadding = false,
             )
             if (viewModel.showContinueWithGoogleButton) {
@@ -183,6 +190,7 @@ internal fun NewOnboardingLoginPage(
                     includePadding = false,
                     flow = flow,
                     onComplete = onContinueWithGoogleComplete,
+                    event = AnalyticsEvent.SIGNIN_BUTTON_TAPPED,
                 )
             }
         }

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/components/ContinueWithGoogleButton.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/components/ContinueWithGoogleButton.kt
@@ -15,6 +15,7 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import au.com.shiftyjelly.pocketcasts.account.viewmodel.GoogleSignInButtonViewModel
 import au.com.shiftyjelly.pocketcasts.account.viewmodel.GoogleSignInState
+import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
 import au.com.shiftyjelly.pocketcasts.compose.buttons.RowOutlinedButton
 import au.com.shiftyjelly.pocketcasts.compose.theme
 import au.com.shiftyjelly.pocketcasts.models.type.Subscription
@@ -34,6 +35,7 @@ fun ContinueWithGoogleButton(
     fontSize: TextUnit? = null,
     includePadding: Boolean = true,
     viewModel: GoogleSignInButtonViewModel = hiltViewModel(),
+    event: AnalyticsEvent = AnalyticsEvent.SETUP_ACCOUNT_BUTTON_TAPPED,
     label: String = stringResource(LR.string.onboarding_continue_with_google),
 ) {
     val context = LocalContext.current
@@ -84,6 +86,7 @@ fun ContinueWithGoogleButton(
                     onError = showError,
                 )
             },
+            event = event,
         )
     }
 

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/NewOnboardingFlow.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/NewOnboardingFlow.kt
@@ -1,5 +1,6 @@
 package au.com.shiftyjelly.pocketcasts.account.onboarding.upgrade
 
+import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavType
@@ -11,6 +12,9 @@ import au.com.shiftyjelly.pocketcasts.account.onboarding.NewOnboardingLoginPage
 import au.com.shiftyjelly.pocketcasts.account.onboarding.OnboardingCreateAccountPage
 import au.com.shiftyjelly.pocketcasts.account.onboarding.OnboardingForgotPasswordPage
 import au.com.shiftyjelly.pocketcasts.account.onboarding.recommendations.OnboardingRecommendationsFlow
+import au.com.shiftyjelly.pocketcasts.account.viewmodel.OnboardingCreateAccountViewModel
+import au.com.shiftyjelly.pocketcasts.account.viewmodel.OnboardingLogInViewModel
+import au.com.shiftyjelly.pocketcasts.account.viewmodel.OnboardingLoginOrSignUpViewModel
 import au.com.shiftyjelly.pocketcasts.account.viewmodel.OnboardingUpgradeFeaturesState
 import au.com.shiftyjelly.pocketcasts.account.viewmodel.OnboardingUpgradeFeaturesViewModel
 import au.com.shiftyjelly.pocketcasts.compose.bars.SystemBarsStyles
@@ -62,28 +66,41 @@ object NewOnboardingFlow {
         onLoginToExistingAccount: (OnboardingFlow, Subscription?, (OnboardingExitInfo) -> Unit) -> Unit,
     ) {
         composable(ROUTE_INTRO_CAROUSEL) {
+            val viewModel: OnboardingLoginOrSignUpViewModel = hiltViewModel()
             NewOnboardingGetStartedPage(
+                viewModel = viewModel,
                 displayTheme = theme,
                 flow = flow,
                 onGetStartedClick = {
+                    viewModel.onGetStartedClicked(flow)
                     if (flow is OnboardingFlow.Upsell || flow is OnboardingFlow.LoggedOut) {
                         navController.navigate(ROUTE_SIGN_UP)
                     } else {
                         navController.navigate(OnboardingRecommendationsFlow.ROUTE)
                     }
                 },
-                onLoginClick = { navController.navigate(ROUTE_LOG_IN) },
+                onLoginClick = {
+                    viewModel.onLoginClicked(flow)
+                    navController.navigate(ROUTE_LOG_IN)
+                },
                 onUpdateSystemBars = onUpdateSystemBars,
             )
         }
 
         composable(ROUTE_SIGN_UP) {
+            val viewModel: OnboardingCreateAccountViewModel = hiltViewModel()
             NewOnboardingCreateAccountPage(
+                viewModel = viewModel,
                 theme = theme,
                 flow = flow,
-                onBackPress = { navController.popBackStack() },
+                onBackPress = {
+                    navController.popBackStack()
+                },
                 onSkip = finishOnboardingFlow,
-                onCreateAccount = { navController.navigate(OldOnboardingFlow.CREATE_FREE_ACCOUNT) },
+                onCreateAccount = {
+                    viewModel.onSignUpEmailPressed(flow)
+                    navController.navigate(OldOnboardingFlow.CREATE_FREE_ACCOUNT)
+                },
                 onUpdateSystemBars = onUpdateSystemBars,
                 onContinueWithGoogleComplete = { state, subscription ->
                     if (state.isNewAccount) {
@@ -105,10 +122,14 @@ object NewOnboardingFlow {
         }
 
         composable(ROUTE_LOG_IN) {
+            val viewModel: OnboardingLogInViewModel = hiltViewModel()
             NewOnboardingLoginPage(
+                viewModel = viewModel,
                 theme = theme,
                 flow = flow,
-                onBackPress = { navController.popBackStack() },
+                onBackPress = {
+                    navController.popBackStack()
+                },
                 onLoginComplete = { subscription ->
                     onLoginToExistingAccount(flow, subscription, exitOnboarding)
                 },

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/GoogleSignInButtonViewModel.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/GoogleSignInButtonViewModel.kt
@@ -54,12 +54,13 @@ class GoogleSignInButtonViewModel @Inject constructor(
         flow: OnboardingFlow?,
         onSuccess: (IntentSenderRequest) -> Unit,
         onError: suspend () -> Unit,
+        event: AnalyticsEvent = AnalyticsEvent.SETUP_ACCOUNT_BUTTON_TAPPED,
     ) {
         if (flow != null) {
             analyticsTracker.track(AnalyticsEvent.SSO_STARTED, mapOf("source" to "google"))
 
             analyticsTracker.track(
-                AnalyticsEvent.SETUP_ACCOUNT_BUTTON_TAPPED,
+                event,
                 mapOf(
                     OnboardingLoginOrSignUpViewModel.Companion.AnalyticsProp.flow(flow),
                     OnboardingLoginOrSignUpViewModel.Companion.AnalyticsProp.ButtonTapped.continueWithGoogle,

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/OnboardingCreateAccountViewModel.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/OnboardingCreateAccountViewModel.kt
@@ -4,6 +4,7 @@ import android.app.Application
 import android.content.Context
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
+import au.com.shiftyjelly.pocketcasts.account.viewmodel.OnboardingLoginOrSignUpViewModel.Companion.AnalyticsProp
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTracker
 import au.com.shiftyjelly.pocketcasts.analytics.experiments.ExperimentProvider
@@ -12,6 +13,7 @@ import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
 import au.com.shiftyjelly.pocketcasts.repositories.subscription.SubscriptionManager
 import au.com.shiftyjelly.pocketcasts.repositories.sync.LoginResult
 import au.com.shiftyjelly.pocketcasts.repositories.sync.SyncManager
+import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingFlow
 import au.com.shiftyjelly.pocketcasts.utils.Network
 import au.com.shiftyjelly.pocketcasts.utils.extensions.isGooglePlayServicesAvailableSuccess
 import com.google.android.gms.common.GoogleApiAvailability
@@ -57,6 +59,13 @@ class OnboardingCreateAccountViewModel @Inject constructor(
 
     fun onBackPressed() {
         analyticsTracker.track(AnalyticsEvent.CREATE_ACCOUNT_DISMISSED)
+    }
+
+    fun onSignUpEmailPressed(flow: OnboardingFlow) {
+        analyticsTracker.track(
+            AnalyticsEvent.SETUP_ACCOUNT_BUTTON_TAPPED,
+            mapOf(AnalyticsProp.flow(flow), AnalyticsProp.ButtonTapped.createAccount),
+        )
     }
 
     fun updateEmail(email: String) {

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/OnboardingLogInViewModel.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/OnboardingLogInViewModel.kt
@@ -4,6 +4,7 @@ import android.app.Application
 import android.content.Context
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
+import au.com.shiftyjelly.pocketcasts.account.viewmodel.OnboardingLoginOrSignUpViewModel.Companion.AnalyticsProp
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTracker
 import au.com.shiftyjelly.pocketcasts.analytics.experiments.ExperimentProvider
@@ -14,6 +15,7 @@ import au.com.shiftyjelly.pocketcasts.repositories.subscription.SubscriptionMana
 import au.com.shiftyjelly.pocketcasts.repositories.sync.LoginResult
 import au.com.shiftyjelly.pocketcasts.repositories.sync.SignInSource
 import au.com.shiftyjelly.pocketcasts.repositories.sync.SyncManager
+import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingFlow
 import au.com.shiftyjelly.pocketcasts.utils.Network
 import au.com.shiftyjelly.pocketcasts.utils.extensions.isGooglePlayServicesAvailableSuccess
 import com.google.android.gms.common.GoogleApiAvailability
@@ -60,6 +62,20 @@ class OnboardingLogInViewModel @Inject constructor(
 
     fun updatePassword(password: String) {
         _state.update { it.copy(password = password) }
+    }
+
+    fun onSignInButtonTapped(flow: OnboardingFlow) {
+        analyticsTracker.track(
+            AnalyticsEvent.SIGNIN_BUTTON_TAPPED,
+            mapOf(AnalyticsProp.flow(flow), AnalyticsProp.ButtonTapped.signIn),
+        )
+    }
+
+    fun onForgotPasswordTapped(flow: OnboardingFlow) {
+        analyticsTracker.track(
+            AnalyticsEvent.SIGNIN_FORGOT_PASSWORD_TAPPED,
+            mapOf(AnalyticsProp.flow(flow)),
+        )
     }
 
     fun logIn(onSuccessfulLogin: (Subscription?) -> Unit) {

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/OnboardingLoginOrSignUpViewModel.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/OnboardingLoginOrSignUpViewModel.kt
@@ -75,6 +75,13 @@ class OnboardingLoginOrSignUpViewModel @Inject constructor(
         )
     }
 
+    fun onGetStartedClicked(flow: OnboardingFlow) {
+        analyticsTracker.track(
+            AnalyticsEvent.SETUP_ACCOUNT_BUTTON_TAPPED,
+            mapOf(AnalyticsProp.flow(flow), AnalyticsProp.ButtonTapped.getStarted),
+        )
+    }
+
     fun onLoginClicked(flow: OnboardingFlow) {
         analyticsTracker.track(
             AnalyticsEvent.SETUP_ACCOUNT_BUTTON_TAPPED,
@@ -98,6 +105,7 @@ class OnboardingLoginOrSignUpViewModel @Inject constructor(
                 val signIn = BUTTON to "sign_in"
                 val createAccount = BUTTON to "create_account"
                 val continueWithGoogle = BUTTON to "continue_with_google"
+                val getStarted = BUTTON to "get_started"
             }
         }
     }

--- a/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
+++ b/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
@@ -66,6 +66,8 @@ enum class AnalyticsEvent(val key: String) {
     /* Sign in */
     SIGNIN_SHOWN("signin_shown"),
     SIGNIN_DISMISSED("signin_dismissed"),
+    SIGNIN_BUTTON_TAPPED("signin_button_tapped"),
+    SIGNIN_FORGOT_PASSWORD_TAPPED("signin_forgot_password_tapped"),
 
     /* Create Account */
     CREATE_ACCOUNT_SHOWN("create_account_shown"),


### PR DESCRIPTION
## Description
This PR adds the analytics events for the new onboarding screens.
We've agreed to just reuse the existing events with some minor changes:
- `setup_account_button_tapped` event now has another possible `button` prop value:  `get_started`  for the intro carousel's get started button
- `signin_forgot_password_tapped`  new event when the 'I forgot my password' pressed on the login page
- `signin_button_tapped` new event when the Log in or Continue with google tapped on the login page

Slack: p1755680546324499-slack-C0932TFPUDC

Fixes https://linear.app/a8c/issue/PCDROID-101/analytics

## Testing Instructions
1. Build `debug` version so the FF will be enabled
2. Tap the CTAs through onboarding and see logcat with the 'Tracked' filter


## Checklist
- [ ] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] ~I have considered whether it makes sense to add tests for my changes~
- [ ] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [ ] ~Any jetpack compose components I added or changed are covered by compose previews~
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
