### PR TITLE
[Onboarding] Interests frame

### DIFF
--- a/modules/features/account/build.gradle.kts
+++ b/modules/features/account/build.gradle.kts
@@ -47,6 +47,7 @@ dependencies {
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.preference.ktx)
     implementation(libs.coil)
+    implementation(libs.coil.compose)
     implementation(libs.compose.activity)
     implementation(libs.compose.animation)
     implementation(libs.compose.constraintlayout)

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/components/InterestCategoryPill.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/components/InterestCategoryPill.kt
@@ -1,0 +1,209 @@
+package au.com.shiftyjelly.pocketcasts.account.onboarding.components
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.selection.toggleable
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.drawWithCache
+import androidx.compose.ui.graphics.BlendMode
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.CompositingStrategy
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalInspectionMode
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewParameter
+import androidx.compose.ui.unit.dp
+import au.com.shiftyjelly.pocketcasts.compose.AppThemeWithBackground
+import au.com.shiftyjelly.pocketcasts.compose.components.TextP30
+import au.com.shiftyjelly.pocketcasts.compose.preview.ThemePreviewParameterProvider
+import au.com.shiftyjelly.pocketcasts.compose.theme
+import au.com.shiftyjelly.pocketcasts.repositories.images.PocketCastsImageRequestFactory
+import au.com.shiftyjelly.pocketcasts.servers.model.DiscoverCategory
+import au.com.shiftyjelly.pocketcasts.ui.extensions.themed
+import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
+import coil.compose.rememberAsyncImagePainter
+
+@Composable
+fun InterestCategoryPill(
+    category: DiscoverCategory,
+    isSelected: Boolean,
+    index: Int,
+    onSelectedChange: (Boolean) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val colorConfig = colors[index % colors.size]
+    SelectablePillContainer(
+        isSelected = isSelected,
+        onSelectedChange = onSelectedChange,
+        selectedGradient = colorConfig.gradient.toList(),
+        modifier = modifier,
+    ) {
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            GradientImage(
+                colorConfig = colorConfig,
+                isSelected = isSelected,
+                url = category.icon,
+                modifier = Modifier.size(21.dp),
+            )
+            TextP30(
+                text = category.name,
+                color = if (isSelected) {
+                    colorConfig.selectedTextColor ?: MaterialTheme.theme.colors.primaryUi01Active
+                } else {
+                    MaterialTheme.theme.colors.secondaryText02
+                },
+            )
+        }
+    }
+}
+
+private data class ColorConfig(
+    val gradient: Pair<Color, Color>,
+    val selectedTextColor: Color? = null,
+)
+
+private val colors = listOf(
+    ColorConfig(
+        gradient = Color(0xFFF43769) to Color(0xFFFB5246),
+    ),
+    ColorConfig(
+        gradient = Color(0xFFFED745) to Color(0xFFFEB525),
+        selectedTextColor = Color(0xFFA85605),
+    ),
+    ColorConfig(
+        gradient = Color(0xFF6046E9) to Color(0xFFE74B8A),
+    ),
+    ColorConfig(
+        gradient = Color(0xFF03A9F4) to Color(0xFF50D0F1),
+    ),
+    ColorConfig(
+        Color(0xFF78D549) to Color(0xFF9BE45E),
+        selectedTextColor = Color(0xFF1E4316),
+    ),
+)
+
+@Composable
+private fun GradientImage(
+    colorConfig: ColorConfig,
+    isSelected: Boolean,
+    url: String,
+    modifier: Modifier = Modifier,
+) {
+    val context = LocalContext.current
+    val isPreview = LocalInspectionMode.current
+    val factory = remember(context) {
+        val placeholderType = if (isPreview) {
+            PocketCastsImageRequestFactory.PlaceholderType.Small
+        } else {
+            PocketCastsImageRequestFactory.PlaceholderType.None
+        }
+        PocketCastsImageRequestFactory(context, placeholderType = placeholderType).themed()
+    }
+    val imageRequest = remember(colorConfig, isSelected, url, factory) {
+        factory.createForFileOrUrl(
+            filePathOrUrl = url,
+        )
+    }
+
+    val fallback = MaterialTheme.theme.colors.primaryUi01Active
+
+    Image(
+        painter = rememberAsyncImagePainter(
+            model = imageRequest,
+            contentScale = ContentScale.Fit,
+        ),
+        contentDescription = null,
+        modifier = modifier
+            .graphicsLayer {
+                compositingStrategy = CompositingStrategy.Offscreen
+            }
+            .drawWithCache {
+                val brush = if (!isSelected) {
+                    Brush.horizontalGradient(colorConfig.gradient.toList())
+                } else {
+                    Brush.horizontalGradient((0..1).map { colorConfig.selectedTextColor ?: fallback })
+                }
+                onDrawWithContent {
+                    drawContent()
+                    drawRect(brush = brush, blendMode = BlendMode.SrcIn)
+                }
+            },
+    )
+}
+
+@Composable
+private fun SelectablePillContainer(
+    isSelected: Boolean,
+    onSelectedChange: (Boolean) -> Unit,
+    selectedGradient: List<Color>,
+    modifier: Modifier = Modifier,
+    content: @Composable () -> Unit,
+) {
+    Box(
+        modifier = modifier
+            .height(48.dp)
+            .clip(RoundedCornerShape(percent = 100))
+            .then(
+                if (isSelected) {
+                    Modifier.background(brush = Brush.horizontalGradient(selectedGradient))
+                } else {
+                    Modifier.border(
+                        width = 2.dp,
+                        color = MaterialTheme.theme.colors.primaryUi05,
+                        shape = RoundedCornerShape(percent = 100),
+                    )
+                }
+                    .toggleable(value = isSelected, onValueChange = onSelectedChange)
+                    .padding(horizontal = 16.dp, vertical = 12.dp),
+            ),
+        contentAlignment = Alignment.Center,
+    ) {
+        content()
+    }
+}
+
+private val demoCategories = List(10) {
+    DiscoverCategory(
+        id = it,
+        name = "Category $it",
+        icon = "",
+        source = "",
+    )
+}
+
+@Preview
+@Composable
+private fun PreviewCategoryPill(
+    @PreviewParameter(ThemePreviewParameterProvider::class) themeType: Theme.ThemeType,
+) = AppThemeWithBackground(themeType) {
+    Column(modifier = Modifier.padding(32.dp)) {
+        demoCategories.forEachIndexed { index, category ->
+            InterestCategoryPill(
+                category = category,
+                isSelected = index / colors.size == 0,
+                onSelectedChange = {},
+                index = index,
+            )
+        }
+    }
+}

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/recommendations/OnboardingInterestsPage.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/recommendations/OnboardingInterestsPage.kt
@@ -8,15 +8,14 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.systemBarsPadding
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.wrapContentWidth
-import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.LazyRow
-import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.selection.toggleable
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.MaterialTheme
@@ -131,22 +130,20 @@ private fun Content(
         )
         Spacer(modifier = Modifier.height(24.dp))
 
-        LazyColumn(
+        FlowRow(
+            horizontalArrangement = Arrangement.Center,
             verticalArrangement = Arrangement.spacedBy(8.dp),
-            horizontalAlignment = Alignment.CenterHorizontally,
+            maxItemsInEachRow = 3,
         ) {
-            items(state.availableCategories.chunked(2)) { row ->
-                LazyRow(
-                    horizontalArrangement = Arrangement.spacedBy(8.dp),
-                ) {
-                    items(row) {
-                        CategoryPill(
-                            modifier = Modifier.wrapContentWidth(),
-                            category = it,
-                            isSelected = state.selectedCategories.contains(it),
-                            onSelectedChange = { isSelected -> onCategorySelectionChange(it, isSelected) },
-                        )
-                    }
+            state.availableCategories.forEachIndexed { index, item ->
+                CategoryPill(
+                    modifier = Modifier.wrapContentWidth(),
+                    category = item,
+                    isSelected = state.selectedCategories.contains(item),
+                    onSelectedChange = { isSelected -> onCategorySelectionChange(item, isSelected) },
+                )
+                if (index % 2 == 0) {
+                    Spacer(modifier = Modifier.width(8.dp))
                 }
             }
         }
@@ -207,7 +204,11 @@ private fun SelectablePillContainer(
                 if (isSelected) {
                     Modifier.background(color = Color.Green.copy(alpha = .3f))
                 } else {
-                    Modifier.border(width = 1.dp, color = MaterialTheme.theme.colors.primaryText02, shape = RoundedCornerShape(percent = 100))
+                    Modifier.border(
+                        width = 1.dp,
+                        color = MaterialTheme.theme.colors.primaryText02,
+                        shape = RoundedCornerShape(percent = 100)
+                    )
                 }
                     .toggleable(value = isSelected, onValueChange = onSelectedChange)
                     .padding(horizontal = 16.dp),

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/recommendations/OnboardingInterestsPage.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/recommendations/OnboardingInterestsPage.kt
@@ -2,11 +2,9 @@ package au.com.shiftyjelly.pocketcasts.account.onboarding.recommendations
 
 import androidx.activity.SystemBarStyle
 import androidx.activity.compose.BackHandler
-import androidx.compose.foundation.background
-import androidx.compose.foundation.border
+import androidx.compose.animation.animateContentSize
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Spacer
@@ -16,8 +14,8 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.systemBarsPadding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.wrapContentWidth
-import androidx.compose.foundation.selection.toggleable
-import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -25,8 +23,6 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
@@ -34,16 +30,17 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
+import au.com.shiftyjelly.pocketcasts.account.onboarding.components.InterestCategoryPill
 import au.com.shiftyjelly.pocketcasts.compose.AppThemeWithBackground
 import au.com.shiftyjelly.pocketcasts.compose.bars.SystemBarsStyles
 import au.com.shiftyjelly.pocketcasts.compose.bars.singleAuto
 import au.com.shiftyjelly.pocketcasts.compose.bars.transparent
 import au.com.shiftyjelly.pocketcasts.compose.buttons.RowButton
 import au.com.shiftyjelly.pocketcasts.compose.components.TextH10
-import au.com.shiftyjelly.pocketcasts.compose.components.TextP30
 import au.com.shiftyjelly.pocketcasts.compose.components.TextP40
 import au.com.shiftyjelly.pocketcasts.compose.preview.ThemePreviewParameterProvider
 import au.com.shiftyjelly.pocketcasts.compose.theme
+import au.com.shiftyjelly.pocketcasts.servers.model.DiscoverCategory
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
@@ -89,7 +86,7 @@ fun OnboardingInterestsPage(
 @Composable
 private fun Content(
     state: OnboardingInterestsViewModel.State,
-    onCategorySelectionChange: (String, Boolean) -> Unit,
+    onCategorySelectionChange: (DiscoverCategory, Boolean) -> Unit,
     onNotNowPress: () -> Unit,
     onContinuePress: () -> Unit,
     onShowMoreCategories: () -> Unit,
@@ -104,10 +101,12 @@ private fun Content(
         TextP40(
             modifier = Modifier
                 .align(Alignment.End)
-                .padding(top = 12.dp, end = 4.dp)
-                .clickable(onClick = onNotNowPress),
+                .padding(top = 10.dp)
+                .clickable(onClick = onNotNowPress)
+                .padding(horizontal = 4.dp, vertical = 2.dp),
             text = stringResource(LR.string.not_now),
             color = MaterialTheme.theme.colors.primaryInteractive01,
+            fontWeight = FontWeight.W500,
         )
         Spacer(modifier = Modifier.height(24.dp))
         TextH10(
@@ -131,109 +130,50 @@ private fun Content(
         Spacer(modifier = Modifier.height(24.dp))
 
         FlowRow(
-            horizontalArrangement = Arrangement.Center,
+            modifier = Modifier
+                .then(
+                    if (state.isShowingAllCategories) {
+                        Modifier
+                            .weight(1f)
+                            .verticalScroll(rememberScrollState())
+                    } else {
+                        Modifier
+                    },
+                )
+                .animateContentSize(),
+            horizontalArrangement = Arrangement.spacedBy(8.dp, alignment = Alignment.CenterHorizontally),
             verticalArrangement = Arrangement.spacedBy(8.dp),
-            maxItemsInEachRow = 3,
+            maxItemsInEachRow = 2,
         ) {
-            state.availableCategories.forEachIndexed { index, item ->
-                CategoryPill(
+            state.displayedCategories.forEachIndexed { index, item ->
+                InterestCategoryPill(
                     modifier = Modifier.wrapContentWidth(),
                     category = item,
                     isSelected = state.selectedCategories.contains(item),
                     onSelectedChange = { isSelected -> onCategorySelectionChange(item, isSelected) },
+                    index = index,
                 )
-                if (index % 2 == 0) {
-                    Spacer(modifier = Modifier.width(8.dp))
-                }
             }
         }
 
+        Spacer(modifier = Modifier.height(32.dp))
+
         if (!state.isShowingAllCategories) {
-            Spacer(modifier = Modifier.height(24.dp))
             TextP40(
                 text = stringResource(LR.string.onboarding_interests_show_more),
                 color = MaterialTheme.theme.colors.primaryInteractive01,
-                modifier = Modifier.clickable(onClick = onShowMoreCategories),
+                modifier = Modifier
+                    .clickable(onClick = onShowMoreCategories)
+                    .padding(horizontal = 4.dp, vertical = 2.dp),
+                fontWeight = FontWeight.W500,
             )
+            Spacer(modifier = Modifier.weight(1f))
         }
 
-        Spacer(modifier = Modifier.weight(1f))
         RowButton(
             text = stringResource(state.ctaLabelResId),
             enabled = state.isCtaEnabled,
             onClick = onContinuePress,
-        )
-    }
-}
-
-@Composable
-private fun CategoryPill(
-    category: String,
-    isSelected: Boolean,
-    onSelectedChange: (Boolean) -> Unit,
-    modifier: Modifier = Modifier,
-) {
-    SelectablePillContainer(
-        isSelected = isSelected,
-        onSelectedChange = onSelectedChange,
-        modifier = modifier,
-    ) {
-        TextP30(
-            text = category,
-            color = if (isSelected) {
-                MaterialTheme.theme.colors.primaryUi01Active
-            } else {
-                MaterialTheme.theme.colors.primaryText02
-            },
-        )
-    }
-}
-
-@Composable
-private fun SelectablePillContainer(
-    isSelected: Boolean,
-    onSelectedChange: (Boolean) -> Unit,
-    modifier: Modifier = Modifier,
-    content: @Composable () -> Unit,
-) {
-    Box(
-        modifier = modifier
-            .height(48.dp)
-            .clip(RoundedCornerShape(percent = 100))
-            .then(
-                if (isSelected) {
-                    Modifier.background(color = Color.Green.copy(alpha = .3f))
-                } else {
-                    Modifier.border(
-                        width = 1.dp,
-                        color = MaterialTheme.theme.colors.primaryText02,
-                        shape = RoundedCornerShape(percent = 100),
-                    )
-                }
-                    .toggleable(value = isSelected, onValueChange = onSelectedChange)
-                    .padding(horizontal = 16.dp),
-            ),
-        contentAlignment = Alignment.Center,
-    ) {
-        content()
-    }
-}
-
-@Preview
-@Composable
-private fun PreviewCategoryPill(
-    @PreviewParameter(ThemePreviewParameterProvider::class) themeType: Theme.ThemeType,
-) = AppThemeWithBackground(themeType) {
-    Column(modifier = Modifier.padding(32.dp)) {
-        CategoryPill(
-            category = "Category",
-            isSelected = false,
-            onSelectedChange = {},
-        )
-        CategoryPill(
-            category = "Selected Category",
-            isSelected = true,
-            onSelectedChange = {},
         )
     }
 }
@@ -245,7 +185,7 @@ private fun PreviewInterestsScreen(
 ) = AppThemeWithBackground(themeType) {
     Content(
         modifier = Modifier.padding(32.dp),
-        state = OnboardingInterestsViewModel.State(availableCategories = List(4) { "Category $it" }, isShowingAllCategories = false),
+        state = OnboardingInterestsViewModel.State(allCategories = emptyList(), displayedCategories = emptyList()),
         onContinuePress = {},
         onNotNowPress = {},
         onShowMoreCategories = {},

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/recommendations/OnboardingInterestsPage.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/recommendations/OnboardingInterestsPage.kt
@@ -207,7 +207,7 @@ private fun SelectablePillContainer(
                     Modifier.border(
                         width = 1.dp,
                         color = MaterialTheme.theme.colors.primaryText02,
-                        shape = RoundedCornerShape(percent = 100)
+                        shape = RoundedCornerShape(percent = 100),
                     )
                 }
                     .toggleable(value = isSelected, onValueChange = onSelectedChange)

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/recommendations/OnboardingInterestsPage.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/recommendations/OnboardingInterestsPage.kt
@@ -1,0 +1,253 @@
+package au.com.shiftyjelly.pocketcasts.account.onboarding.recommendations
+
+import androidx.activity.SystemBarStyle
+import androidx.activity.compose.BackHandler
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.systemBarsPadding
+import androidx.compose.foundation.layout.wrapContentWidth
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.selection.toggleable
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewParameter
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import au.com.shiftyjelly.pocketcasts.compose.AppThemeWithBackground
+import au.com.shiftyjelly.pocketcasts.compose.bars.SystemBarsStyles
+import au.com.shiftyjelly.pocketcasts.compose.bars.singleAuto
+import au.com.shiftyjelly.pocketcasts.compose.bars.transparent
+import au.com.shiftyjelly.pocketcasts.compose.buttons.RowButton
+import au.com.shiftyjelly.pocketcasts.compose.components.TextH10
+import au.com.shiftyjelly.pocketcasts.compose.components.TextP30
+import au.com.shiftyjelly.pocketcasts.compose.components.TextP40
+import au.com.shiftyjelly.pocketcasts.compose.preview.ThemePreviewParameterProvider
+import au.com.shiftyjelly.pocketcasts.compose.theme
+import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
+import au.com.shiftyjelly.pocketcasts.localization.R as LR
+
+@Composable
+fun OnboardingInterestsPage(
+    theme: Theme.ThemeType,
+    onBackPress: () -> Unit,
+    onShowRecommendations: () -> Unit,
+    onUpdateSystemBars: (SystemBarsStyles) -> Unit,
+    modifier: Modifier = Modifier,
+    viewModel: OnboardingInterestsViewModel = hiltViewModel(),
+) {
+    val state by viewModel.state.collectAsState()
+
+    val pocketCastsTheme = MaterialTheme.theme
+
+    LaunchedEffect(onUpdateSystemBars) {
+        val statusBar = SystemBarStyle.singleAuto(pocketCastsTheme.colors.primaryUi01.copy(alpha = 0.9f)) { theme.darkTheme }
+        val navigationBar = SystemBarStyle.transparent { theme.darkTheme }
+        onUpdateSystemBars(SystemBarsStyles(statusBar, navigationBar))
+    }
+
+    BackHandler {
+        onBackPress()
+    }
+
+    Content(
+        modifier = modifier,
+        state = state,
+        onCategorySelectionChange = viewModel::updateSelectedCategory,
+        onContinuePress = {
+            viewModel.saveInterests()
+            onShowRecommendations()
+        },
+        onNotNowPress = {
+            viewModel.skipSelection()
+            onShowRecommendations()
+        },
+        onShowMoreCategories = viewModel::showMore,
+    )
+}
+
+@Composable
+private fun Content(
+    state: OnboardingInterestsViewModel.State,
+    onCategorySelectionChange: (String, Boolean) -> Unit,
+    onNotNowPress: () -> Unit,
+    onContinuePress: () -> Unit,
+    onShowMoreCategories: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier
+            .systemBarsPadding()
+            .padding(horizontal = 16.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        TextP40(
+            modifier = Modifier
+                .align(Alignment.End)
+                .padding(top = 12.dp, end = 4.dp)
+                .clickable(onClick = onNotNowPress),
+            text = stringResource(LR.string.not_now),
+            color = MaterialTheme.theme.colors.primaryInteractive01,
+        )
+        Spacer(modifier = Modifier.height(24.dp))
+        TextH10(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 32.dp),
+            text = stringResource(LR.string.onboarding_interests_title),
+            textAlign = TextAlign.Center,
+            color = MaterialTheme.theme.colors.primaryText01,
+        )
+        Spacer(modifier = Modifier.height(16.dp))
+        TextP40(
+            text = stringResource(LR.string.onboarding_interests_description),
+            color = MaterialTheme.theme.colors.primaryText02,
+            textAlign = TextAlign.Center,
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 38.dp),
+            fontWeight = FontWeight.W500,
+        )
+        Spacer(modifier = Modifier.height(24.dp))
+
+        LazyColumn(
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+        ) {
+            items(state.availableCategories.chunked(2)) { row ->
+                LazyRow(
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                ) {
+                    items(row) {
+                        CategoryPill(
+                            modifier = Modifier.wrapContentWidth(),
+                            category = it,
+                            isSelected = state.selectedCategories.contains(it),
+                            onSelectedChange = { isSelected -> onCategorySelectionChange(it, isSelected) },
+                        )
+                    }
+                }
+            }
+        }
+
+        if (!state.isShowingAllCategories) {
+            Spacer(modifier = Modifier.height(24.dp))
+            TextP40(
+                text = stringResource(LR.string.onboarding_interests_show_more),
+                color = MaterialTheme.theme.colors.primaryInteractive01,
+                modifier = Modifier.clickable(onClick = onShowMoreCategories),
+            )
+        }
+
+        Spacer(modifier = Modifier.weight(1f))
+        RowButton(
+            text = stringResource(state.ctaLabelResId),
+            enabled = state.isCtaEnabled,
+            onClick = onContinuePress,
+        )
+    }
+}
+
+@Composable
+private fun CategoryPill(
+    category: String,
+    isSelected: Boolean,
+    onSelectedChange: (Boolean) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    SelectablePillContainer(
+        isSelected = isSelected,
+        onSelectedChange = onSelectedChange,
+        modifier = modifier,
+    ) {
+        TextP30(
+            text = category,
+            color = if (isSelected) {
+                MaterialTheme.theme.colors.primaryUi01Active
+            } else {
+                MaterialTheme.theme.colors.primaryText02
+            },
+        )
+    }
+}
+
+@Composable
+private fun SelectablePillContainer(
+    isSelected: Boolean,
+    onSelectedChange: (Boolean) -> Unit,
+    modifier: Modifier = Modifier,
+    content: @Composable () -> Unit,
+) {
+    Box(
+        modifier = modifier
+            .height(48.dp)
+            .clip(RoundedCornerShape(percent = 100))
+            .then(
+                if (isSelected) {
+                    Modifier.background(color = Color.Green.copy(alpha = .3f))
+                } else {
+                    Modifier.border(width = 1.dp, color = MaterialTheme.theme.colors.primaryText02, shape = RoundedCornerShape(percent = 100))
+                }
+                    .toggleable(value = isSelected, onValueChange = onSelectedChange)
+                    .padding(horizontal = 16.dp),
+            ),
+        contentAlignment = Alignment.Center,
+    ) {
+        content()
+    }
+}
+
+@Preview
+@Composable
+private fun PreviewCategoryPill(
+    @PreviewParameter(ThemePreviewParameterProvider::class) themeType: Theme.ThemeType,
+) = AppThemeWithBackground(themeType) {
+    Column(modifier = Modifier.padding(32.dp)) {
+        CategoryPill(
+            category = "Category",
+            isSelected = false,
+            onSelectedChange = {},
+        )
+        CategoryPill(
+            category = "Selected Category",
+            isSelected = true,
+            onSelectedChange = {},
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun PreviewInterestsScreen(
+    @PreviewParameter(ThemePreviewParameterProvider::class) themeType: Theme.ThemeType,
+) = AppThemeWithBackground(themeType) {
+    Content(
+        modifier = Modifier.padding(32.dp),
+        state = OnboardingInterestsViewModel.State(availableCategories = List(4) { "Category $it" }, isShowingAllCategories = false),
+        onContinuePress = {},
+        onNotNowPress = {},
+        onShowMoreCategories = {},
+        onCategorySelectionChange = { _, _ -> },
+    )
+}

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/recommendations/OnboardingInterestsViewModel.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/recommendations/OnboardingInterestsViewModel.kt
@@ -1,0 +1,56 @@
+package au.com.shiftyjelly.pocketcasts.account.onboarding.recommendations
+
+import androidx.lifecycle.ViewModel
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import au.com.shiftyjelly.pocketcasts.localization.R as LR
+
+@HiltViewModel
+class OnboardingInterestsViewModel @Inject constructor() : ViewModel() {
+
+    private val _state = MutableStateFlow(State(availableCategories = listOf("True Crime", "Comedy", "Society & Culture", "Fiction"), isShowingAllCategories = false))
+    val state = _state.asStateFlow()
+
+    fun skipSelection() {
+    }
+
+    fun updateSelectedCategory(category: String, isSelected: Boolean) {
+        _state.update {
+            it.copy(
+                selectedCategories = if (isSelected) {
+                    it.selectedCategories + category
+                } else {
+                    it.selectedCategories - category
+                },
+            )
+        }
+    }
+
+    fun showMore() {
+        _state.update {
+            it.copy(
+                isShowingAllCategories = true,
+                availableCategories = it.availableCategories + listOf("Arts", "Education", "Sports", "TV & Film"),
+            )
+        }
+    }
+
+    fun saveInterests() {
+    }
+
+    data class State(
+        val selectedCategories: Set<String> = emptySet(),
+        val availableCategories: List<String>,
+        val isShowingAllCategories: Boolean,
+    ) {
+        val isCtaEnabled: Boolean = selectedCategories.size >= 3
+        val ctaLabelResId: Int = if (isCtaEnabled) {
+            LR.string.navigation_continue
+        } else {
+            LR.string.onboarding_interests_select_at_least_label
+        }
+    }
+}

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/recommendations/OnboardingInterestsViewModel.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/recommendations/OnboardingInterestsViewModel.kt
@@ -1,23 +1,38 @@
 package au.com.shiftyjelly.pocketcasts.account.onboarding.recommendations
 
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import au.com.shiftyjelly.pocketcasts.repositories.categories.CategoriesManager
+import au.com.shiftyjelly.pocketcasts.servers.model.DiscoverCategory
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 @HiltViewModel
-class OnboardingInterestsViewModel @Inject constructor() : ViewModel() {
+class OnboardingInterestsViewModel @Inject constructor(
+    private val categoriesManager: CategoriesManager,
+) : ViewModel() {
 
-    private val _state = MutableStateFlow(State(availableCategories = listOf("True Crime", "Comedy", "Society & Culture", "Fiction"), isShowingAllCategories = false))
+    private val _state = MutableStateFlow(
+        State(
+            allCategories = emptyList(),
+            displayedCategories = emptyList(),
+        ),
+    )
     val state = _state.asStateFlow()
+
+    init {
+        fetchCategories()
+    }
 
     fun skipSelection() {
     }
 
-    fun updateSelectedCategory(category: String, isSelected: Boolean) {
+    fun updateSelectedCategory(category: DiscoverCategory, isSelected: Boolean) {
         _state.update {
             it.copy(
                 selectedCategories = if (isSelected) {
@@ -32,8 +47,7 @@ class OnboardingInterestsViewModel @Inject constructor() : ViewModel() {
     fun showMore() {
         _state.update {
             it.copy(
-                isShowingAllCategories = true,
-                availableCategories = it.availableCategories + listOf("Arts", "Education", "Sports", "TV & Film"),
+                displayedCategories = it.allCategories,
             )
         }
     }
@@ -41,10 +55,23 @@ class OnboardingInterestsViewModel @Inject constructor() : ViewModel() {
     fun saveInterests() {
     }
 
+    private fun fetchCategories() {
+        viewModelScope.launch {
+            categoriesManager.state.collect { categState ->
+                _state.update {
+                    it.copy(
+                        allCategories = categState.allCategories,
+                        displayedCategories = categState.allCategories.take(10),
+                    )
+                }
+            }
+        }
+    }
+
     data class State(
-        val selectedCategories: Set<String> = emptySet(),
-        val availableCategories: List<String>,
-        val isShowingAllCategories: Boolean,
+        val selectedCategories: Set<DiscoverCategory> = emptySet(),
+        val allCategories: List<DiscoverCategory>,
+        val displayedCategories: List<DiscoverCategory>,
     ) {
         val isCtaEnabled: Boolean = selectedCategories.size >= 3
         val ctaLabelResId: Int = if (isCtaEnabled) {
@@ -52,5 +79,6 @@ class OnboardingInterestsViewModel @Inject constructor() : ViewModel() {
         } else {
             LR.string.onboarding_interests_select_at_least_label
         }
+        val isShowingAllCategories: Boolean = displayedCategories.size == allCategories.size
     }
 }

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/recommendations/OnboardingRecommendationsFlow.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/recommendations/OnboardingRecommendationsFlow.kt
@@ -12,12 +12,15 @@ import au.com.shiftyjelly.pocketcasts.compose.bars.SystemBarsStyles
 import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingFlow
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import au.com.shiftyjelly.pocketcasts.utils.Network
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 object OnboardingRecommendationsFlow {
     const val ROUTE = "onboardingRecommendationsFlow"
 
-    private const val START = "start"
+    private const val INTERESTS = "interests"
+    private const val RECOMMENDATIONS = "recommendations"
     private const val SEARCH = "search"
 
     fun NavGraphBuilder.onboardingRecommendationsFlowGraph(
@@ -28,13 +31,27 @@ object OnboardingRecommendationsFlow {
         navController: NavController,
         onUpdateSystemBars: (SystemBarsStyles) -> Unit,
     ) {
+        val root = if (FeatureFlag.isEnabled(Feature.NEW_ONBOARDING_RECOMMENDATIONS)) {
+            INTERESTS
+        } else {
+            RECOMMENDATIONS
+        }
         navigation(
             route = this@OnboardingRecommendationsFlow.ROUTE,
-            startDestination = START,
+            startDestination = root,
         ) {
             importFlowGraph(theme, navController, flow, onUpdateSystemBars)
 
-            composable(START) {
+            composable(INTERESTS) {
+                OnboardingInterestsPage(
+                    theme = theme,
+                    onBackPress = { navController.popBackStack() },
+                    onShowRecommendations = { navController.navigate(RECOMMENDATIONS) },
+                    onUpdateSystemBars = onUpdateSystemBars,
+                )
+            }
+
+            composable(RECOMMENDATIONS) {
                 OnboardingRecommendationsStartPage(
                     theme,
                     onImportClick = { navController.navigate(OnboardingImportFlow.ROUTE) },

--- a/modules/features/account/src/test/java/au/com/shiftyjelly/pocketcasts/account/onboarding/recommendations/OnboardingInterestsViewModelTest.kt
+++ b/modules/features/account/src/test/java/au/com/shiftyjelly/pocketcasts/account/onboarding/recommendations/OnboardingInterestsViewModelTest.kt
@@ -1,0 +1,87 @@
+package au.com.shiftyjelly.pocketcasts.account.onboarding.recommendations
+
+import app.cash.turbine.test
+import au.com.shiftyjelly.pocketcasts.repositories.categories.CategoriesManager
+import au.com.shiftyjelly.pocketcasts.servers.model.DiscoverCategory
+import au.com.shiftyjelly.pocketcasts.sharedtest.MainCoroutineRule
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.junit.MockitoJUnitRunner
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+
+@RunWith(MockitoJUnitRunner::class)
+class OnboardingInterestsViewModelTest {
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @get:Rule
+    val coroutineRule = MainCoroutineRule()
+
+    private val categoriesManager = mock<CategoriesManager>()
+    val stateFlow = MutableStateFlow(CategoriesManager.State.Idle(featuredCategories = emptyList(), allCategories = emptyList(), areAllCategoriesShown = true))
+
+    @Before
+    fun setup() {
+        whenever(categoriesManager.state).thenReturn(stateFlow)
+    }
+
+    @Test
+    fun `should fetch categories on init`() = runTest {
+        stateFlow.value = CategoriesManager.State.Idle(allCategories = demoCategories, featuredCategories = emptyList(), areAllCategoriesShown = true)
+        val viewModel = OnboardingInterestsViewModel(categoriesManager)
+
+        viewModel.state.test {
+            val item = awaitItem()
+            assert(item.displayedCategories.size == 10)
+            assert(item.allCategories.size == demoCategories.size)
+            assert(item.selectedCategories.isEmpty())
+        }
+    }
+
+    @Test
+    fun `should update categories on more selected`() = runTest {
+        stateFlow.value = CategoriesManager.State.Idle(allCategories = demoCategories, featuredCategories = emptyList(), areAllCategoriesShown = true)
+        val viewModel = OnboardingInterestsViewModel(categoriesManager)
+
+        viewModel.state.test {
+            val item = awaitItem()
+            assert(!item.isShowingAllCategories)
+
+            viewModel.showMore()
+
+            val nextItem = awaitItem()
+            assert(nextItem.isShowingAllCategories)
+        }
+    }
+
+    @Test
+    fun `should update selected categories on selecting some`() = runTest {
+        stateFlow.value = CategoriesManager.State.Idle(allCategories = demoCategories, featuredCategories = emptyList(), areAllCategoriesShown = true)
+        val viewModel = OnboardingInterestsViewModel(categoriesManager)
+
+        viewModel.state.test {
+            val item = awaitItem()
+            assert(item.selectedCategories.isEmpty())
+
+            viewModel.updateSelectedCategory(demoCategories[0], true)
+            val nextItem = awaitItem()
+            assert(nextItem.selectedCategories.isNotEmpty())
+        }
+    }
+
+    private companion object {
+        val demoCategories = List(20) {
+            DiscoverCategory(
+                id = it,
+                name = "Category $it",
+                icon = "",
+                source = "",
+            )
+        }
+    }
+}

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -2597,4 +2597,8 @@
     <string name="onboarding_create_account_message">Your podcasts, always in sync. Keep your library safe, and enjoy Pocket\u00A0Casts on web and desktop.</string>
     <string name="onboarding_create_account_sign_up_email">Sign up with email</string>
     <string name="onboarding_create_account_sign_up_google">Sign up with Google</string>
+    <string name="onboarding_interests_title">Tell us about your favourite topics</string>
+    <string name="onboarding_interests_description">Great podcasts, handpicked by real people, are coming your way!</string>
+    <string name="onboarding_interests_show_more">Show more categories</string>
+    <string name="onboarding_interests_select_at_least_label">Select at least 3</string>
 </resources>

--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/Feature.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/Feature.kt
@@ -154,6 +154,14 @@ enum class Feature(
         hasFirebaseRemoteFlag = true,
         hasDevToggle = true,
     ),
+    NEW_ONBOARDING_RECOMMENDATIONS(
+        key = "new_onboarding_recommendations_changes",
+        title = "New Onboarding Recommendation Changes",
+        defaultValue = BuildConfig.DEBUG,
+        tier = FeatureTier.Free,
+        hasFirebaseRemoteFlag = false,
+        hasDevToggle = true,
+    ),
     PLAYLISTS_REBRANDING(
         key = "playlists_rebranding",
         title = "Playlists",


### PR DESCRIPTION
## Description
This PR adds the interets screen with hardcoded data and very simple category pill selectors.
Upcoming PRs will take care of the rest.

Fixes https://linear.app/a8c/issue/PCDROID-129/implement-interest-selection-frame

## Testing Instructions
1. Build `debug` version of the app so the FF will be enabled by default
2. Clean intall the app to see the new onboarding 
3. Press Get started on the intro carousel

## Screenshots or Screencast 

https://github.com/user-attachments/assets/714ac3f5-45c8-4d5a-b51b-1087c63f6b87



## Checklist
- [ ] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] ~I have considered whether it makes sense to add tests for my changes~
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [ ] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack
