### PR TITLE
[Onboarding] Functional Interests screen

### DIFF
--- a/modules/features/account/build.gradle.kts
+++ b/modules/features/account/build.gradle.kts
@@ -47,6 +47,7 @@ dependencies {
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.preference.ktx)
     implementation(libs.coil)
+    implementation(libs.coil.compose)
     implementation(libs.compose.activity)
     implementation(libs.compose.animation)
     implementation(libs.compose.constraintlayout)

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/components/InterestCategoryPill.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/components/InterestCategoryPill.kt
@@ -1,0 +1,124 @@
+package au.com.shiftyjelly.pocketcasts.account.onboarding.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.selection.toggleable
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewParameter
+import androidx.compose.ui.unit.dp
+import au.com.shiftyjelly.pocketcasts.compose.AppThemeWithBackground
+import au.com.shiftyjelly.pocketcasts.compose.components.TextP30
+import au.com.shiftyjelly.pocketcasts.compose.preview.ThemePreviewParameterProvider
+import au.com.shiftyjelly.pocketcasts.compose.theme
+import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
+
+@Composable
+fun InterestCategoryPill(
+    category: String,
+    isSelected: Boolean,
+    index: Int,
+    onSelectedChange: (Boolean) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val colorConfig = colors[index % colors.size]
+    SelectablePillContainer(
+        isSelected = isSelected,
+        onSelectedChange = onSelectedChange,
+        selectedGradient = colorConfig.gradient.toList(),
+        modifier = modifier,
+    ) {
+        TextP30(
+            text = category,
+            color = if (isSelected) {
+                colorConfig.selectedTextColor ?: MaterialTheme.theme.colors.primaryUi01Active
+            } else {
+                MaterialTheme.theme.colors.secondaryText02
+            },
+        )
+    }
+}
+
+private data class ColorConfig(
+    val gradient: Pair<Color, Color>,
+    val selectedTextColor: Color? = null
+)
+
+private val colors = listOf(
+    ColorConfig(
+        gradient = Color(0xFFF43769) to Color(0xFFFB5246),
+    ),
+    ColorConfig(
+        gradient = Color(0xFFFED745) to Color(0xFFFEB525),
+        selectedTextColor = Color(0xFFA85605),
+    ),
+    ColorConfig(
+        gradient = Color(0xFF6046E9) to Color(0xFFE74B8A),
+    ),
+    ColorConfig(
+        gradient = Color(0xFF03A9F4) to Color(0xFF50D0F1),
+    ),
+    ColorConfig(
+        Color(0xFF78D549) to Color(0xFF9BE45E),
+        selectedTextColor = Color(0xFF1E4316),
+    ),
+)
+
+@Composable
+private fun SelectablePillContainer(
+    isSelected: Boolean,
+    onSelectedChange: (Boolean) -> Unit,
+    selectedGradient: List<Color>,
+    modifier: Modifier = Modifier,
+    content: @Composable () -> Unit,
+) {
+    Box(
+        modifier = modifier
+            .height(48.dp)
+            .clip(RoundedCornerShape(percent = 100))
+            .then(
+                if (isSelected) {
+                    Modifier.background(brush = Brush.horizontalGradient(selectedGradient))
+                } else {
+                    Modifier.border(
+                        width = 2.dp,
+                        color = MaterialTheme.theme.colors.primaryUi05,
+                        shape = RoundedCornerShape(percent = 100)
+                    )
+                }
+                    .toggleable(value = isSelected, onValueChange = onSelectedChange)
+                    .padding(horizontal = 16.dp, vertical = 12.dp),
+            ),
+        contentAlignment = Alignment.Center,
+    ) {
+        content()
+    }
+}
+
+@Preview
+@Composable
+private fun PreviewCategoryPill(
+    @PreviewParameter(ThemePreviewParameterProvider::class) themeType: Theme.ThemeType,
+) = AppThemeWithBackground(themeType) {
+    Column(modifier = Modifier.padding(32.dp)) {
+        List(10) {
+            InterestCategoryPill(
+                category = "Category $it",
+                isSelected = it / colors.size == 0,
+                onSelectedChange = {},
+                index = it
+            )
+        }
+    }
+}

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/recommendations/OnboardingInterestsPage.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/recommendations/OnboardingInterestsPage.kt
@@ -163,7 +163,6 @@ private fun Content(
     }
 }
 
-
 @Preview
 @Composable
 private fun PreviewInterestsScreen(

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/recommendations/OnboardingInterestsPage.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/recommendations/OnboardingInterestsPage.kt
@@ -14,6 +14,8 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.systemBarsPadding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.wrapContentWidth
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -99,10 +101,12 @@ private fun Content(
         TextP40(
             modifier = Modifier
                 .align(Alignment.End)
-                .padding(top = 12.dp, end = 4.dp)
-                .clickable(onClick = onNotNowPress),
+                .padding(top = 10.dp)
+                .clickable(onClick = onNotNowPress)
+                .padding(horizontal = 4.dp, vertical = 2.dp),
             text = stringResource(LR.string.not_now),
             color = MaterialTheme.theme.colors.primaryInteractive01,
+            fontWeight = FontWeight.W500,
         )
         Spacer(modifier = Modifier.height(24.dp))
         TextH10(
@@ -126,10 +130,20 @@ private fun Content(
         Spacer(modifier = Modifier.height(24.dp))
 
         FlowRow(
-            modifier = Modifier.animateContentSize(),
-            horizontalArrangement = Arrangement.Center,
+            modifier = Modifier
+                .then(
+                    if (state.isShowingAllCategories) {
+                        Modifier
+                            .weight(1f)
+                            .verticalScroll(rememberScrollState())
+                    } else {
+                        Modifier
+                    },
+                )
+                .animateContentSize(),
+            horizontalArrangement = Arrangement.spacedBy(8.dp, alignment = Alignment.CenterHorizontally),
             verticalArrangement = Arrangement.spacedBy(8.dp),
-            maxItemsInEachRow = 3,
+            maxItemsInEachRow = 2,
         ) {
             state.displayedCategories.forEachIndexed { index, item ->
                 InterestCategoryPill(
@@ -139,22 +153,23 @@ private fun Content(
                     onSelectedChange = { isSelected -> onCategorySelectionChange(item, isSelected) },
                     index = index,
                 )
-                if (index % 2 == 0) {
-                    Spacer(modifier = Modifier.width(8.dp))
-                }
             }
         }
 
+        Spacer(modifier = Modifier.height(32.dp))
+
         if (!state.isShowingAllCategories) {
-            Spacer(modifier = Modifier.height(24.dp))
             TextP40(
                 text = stringResource(LR.string.onboarding_interests_show_more),
                 color = MaterialTheme.theme.colors.primaryInteractive01,
-                modifier = Modifier.clickable(onClick = onShowMoreCategories),
+                modifier = Modifier
+                    .clickable(onClick = onShowMoreCategories)
+                    .padding(horizontal = 4.dp, vertical = 2.dp),
+                fontWeight = FontWeight.W500,
             )
+            Spacer(modifier = Modifier.weight(1f))
         }
 
-        Spacer(modifier = Modifier.weight(1f))
         RowButton(
             text = stringResource(state.ctaLabelResId),
             enabled = state.isCtaEnabled,

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/recommendations/OnboardingInterestsPage.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/recommendations/OnboardingInterestsPage.kt
@@ -131,7 +131,7 @@ private fun Content(
             verticalArrangement = Arrangement.spacedBy(8.dp),
             maxItemsInEachRow = 3,
         ) {
-            state.availableCategories.forEachIndexed { index, item ->
+            state.displayedCategories.forEachIndexed { index, item ->
                 InterestCategoryPill(
                     modifier = Modifier.wrapContentWidth(),
                     category = item,

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/recommendations/OnboardingInterestsPage.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/recommendations/OnboardingInterestsPage.kt
@@ -3,11 +3,8 @@ package au.com.shiftyjelly.pocketcasts.account.onboarding.recommendations
 import androidx.activity.SystemBarStyle
 import androidx.activity.compose.BackHandler
 import androidx.compose.animation.animateContentSize
-import androidx.compose.foundation.background
-import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Spacer
@@ -17,8 +14,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.systemBarsPadding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.wrapContentWidth
-import androidx.compose.foundation.selection.toggleable
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -26,8 +21,6 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
@@ -35,13 +28,13 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
+import au.com.shiftyjelly.pocketcasts.account.onboarding.components.InterestCategoryPill
 import au.com.shiftyjelly.pocketcasts.compose.AppThemeWithBackground
 import au.com.shiftyjelly.pocketcasts.compose.bars.SystemBarsStyles
 import au.com.shiftyjelly.pocketcasts.compose.bars.singleAuto
 import au.com.shiftyjelly.pocketcasts.compose.bars.transparent
 import au.com.shiftyjelly.pocketcasts.compose.buttons.RowButton
 import au.com.shiftyjelly.pocketcasts.compose.components.TextH10
-import au.com.shiftyjelly.pocketcasts.compose.components.TextP30
 import au.com.shiftyjelly.pocketcasts.compose.components.TextP40
 import au.com.shiftyjelly.pocketcasts.compose.preview.ThemePreviewParameterProvider
 import au.com.shiftyjelly.pocketcasts.compose.theme
@@ -138,11 +131,12 @@ private fun Content(
             maxItemsInEachRow = 3,
         ) {
             state.availableCategories.forEachIndexed { index, item ->
-                CategoryPill(
+                InterestCategoryPill(
                     modifier = Modifier.wrapContentWidth(),
                     category = item,
                     isSelected = state.selectedCategories.contains(item),
                     onSelectedChange = { isSelected -> onCategorySelectionChange(item, isSelected) },
+                    index = index,
                 )
                 if (index % 2 == 0) {
                     Spacer(modifier = Modifier.width(8.dp))
@@ -168,77 +162,6 @@ private fun Content(
     }
 }
 
-@Composable
-private fun CategoryPill(
-    category: String,
-    isSelected: Boolean,
-    onSelectedChange: (Boolean) -> Unit,
-    modifier: Modifier = Modifier,
-) {
-    SelectablePillContainer(
-        isSelected = isSelected,
-        onSelectedChange = onSelectedChange,
-        modifier = modifier,
-    ) {
-        TextP30(
-            text = category,
-            color = if (isSelected) {
-                MaterialTheme.theme.colors.primaryUi01Active
-            } else {
-                MaterialTheme.theme.colors.primaryText02
-            },
-        )
-    }
-}
-
-@Composable
-private fun SelectablePillContainer(
-    isSelected: Boolean,
-    onSelectedChange: (Boolean) -> Unit,
-    modifier: Modifier = Modifier,
-    content: @Composable () -> Unit,
-) {
-    Box(
-        modifier = modifier
-            .height(48.dp)
-            .clip(RoundedCornerShape(percent = 100))
-            .then(
-                if (isSelected) {
-                    Modifier.background(color = Color.Green.copy(alpha = .3f))
-                } else {
-                    Modifier.border(
-                        width = 1.dp,
-                        color = MaterialTheme.theme.colors.primaryText02,
-                        shape = RoundedCornerShape(percent = 100),
-                    )
-                }
-                    .toggleable(value = isSelected, onValueChange = onSelectedChange)
-                    .padding(horizontal = 16.dp),
-            ),
-        contentAlignment = Alignment.Center,
-    ) {
-        content()
-    }
-}
-
-@Preview
-@Composable
-private fun PreviewCategoryPill(
-    @PreviewParameter(ThemePreviewParameterProvider::class) themeType: Theme.ThemeType,
-) = AppThemeWithBackground(themeType) {
-    Column(modifier = Modifier.padding(32.dp)) {
-        CategoryPill(
-            category = "Category",
-            isSelected = false,
-            onSelectedChange = {},
-        )
-        CategoryPill(
-            category = "Selected Category",
-            isSelected = true,
-            onSelectedChange = {},
-        )
-    }
-}
 
 @Preview
 @Composable

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/recommendations/OnboardingInterestsPage.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/recommendations/OnboardingInterestsPage.kt
@@ -2,6 +2,7 @@ package au.com.shiftyjelly.pocketcasts.account.onboarding.recommendations
 
 import androidx.activity.SystemBarStyle
 import androidx.activity.compose.BackHandler
+import androidx.compose.animation.animateContentSize
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
@@ -131,6 +132,7 @@ private fun Content(
         Spacer(modifier = Modifier.height(24.dp))
 
         FlowRow(
+            modifier = Modifier.animateContentSize(),
             horizontalArrangement = Arrangement.Center,
             verticalArrangement = Arrangement.spacedBy(8.dp),
             maxItemsInEachRow = 3,

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/recommendations/OnboardingInterestsPage.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/recommendations/OnboardingInterestsPage.kt
@@ -38,6 +38,7 @@ import au.com.shiftyjelly.pocketcasts.compose.components.TextH10
 import au.com.shiftyjelly.pocketcasts.compose.components.TextP40
 import au.com.shiftyjelly.pocketcasts.compose.preview.ThemePreviewParameterProvider
 import au.com.shiftyjelly.pocketcasts.compose.theme
+import au.com.shiftyjelly.pocketcasts.servers.model.DiscoverCategory
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
@@ -83,7 +84,7 @@ fun OnboardingInterestsPage(
 @Composable
 private fun Content(
     state: OnboardingInterestsViewModel.State,
-    onCategorySelectionChange: (String, Boolean) -> Unit,
+    onCategorySelectionChange: (DiscoverCategory, Boolean) -> Unit,
     onNotNowPress: () -> Unit,
     onContinuePress: () -> Unit,
     onShowMoreCategories: () -> Unit,
@@ -170,7 +171,7 @@ private fun PreviewInterestsScreen(
 ) = AppThemeWithBackground(themeType) {
     Content(
         modifier = Modifier.padding(32.dp),
-        state = OnboardingInterestsViewModel.State(availableCategories = List(4) { "Category $it" }, isShowingAllCategories = false),
+        state = OnboardingInterestsViewModel.State(allCategories = emptyList(), displayedCategories = emptyList()),
         onContinuePress = {},
         onNotNowPress = {},
         onShowMoreCategories = {},

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/recommendations/OnboardingInterestsViewModel.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/recommendations/OnboardingInterestsViewModel.kt
@@ -21,7 +21,7 @@ class OnboardingInterestsViewModel @Inject constructor(
         State(
             allCategories = emptyList(),
             displayedCategories = emptyList(),
-        )
+        ),
     )
     val state = _state.asStateFlow()
 
@@ -47,7 +47,7 @@ class OnboardingInterestsViewModel @Inject constructor(
     fun showMore() {
         _state.update {
             it.copy(
-                displayedCategories = it.allCategories
+                displayedCategories = it.allCategories,
             )
         }
     }
@@ -61,7 +61,7 @@ class OnboardingInterestsViewModel @Inject constructor(
                 _state.update {
                     it.copy(
                         allCategories = categState.allCategories,
-                        displayedCategories = categState.allCategories.take(10)
+                        displayedCategories = categState.allCategories.take(10),
                     )
                 }
             }

--- a/modules/features/account/src/test/java/au/com/shiftyjelly/pocketcasts/account/onboarding/recommendations/OnboardingInterestsViewModelTest.kt
+++ b/modules/features/account/src/test/java/au/com/shiftyjelly/pocketcasts/account/onboarding/recommendations/OnboardingInterestsViewModelTest.kt
@@ -1,0 +1,87 @@
+package au.com.shiftyjelly.pocketcasts.account.onboarding.recommendations
+
+import app.cash.turbine.test
+import au.com.shiftyjelly.pocketcasts.repositories.categories.CategoriesManager
+import au.com.shiftyjelly.pocketcasts.servers.model.DiscoverCategory
+import au.com.shiftyjelly.pocketcasts.sharedtest.MainCoroutineRule
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.junit.MockitoJUnitRunner
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+
+@RunWith(MockitoJUnitRunner::class)
+class OnboardingInterestsViewModelTest {
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @get:Rule
+    val coroutineRule = MainCoroutineRule()
+
+    private val categoriesManager = mock<CategoriesManager>()
+    val stateFlow = MutableStateFlow(CategoriesManager.State.Idle(featuredCategories = emptyList(), allCategories = emptyList(), areAllCategoriesShown = true))
+
+    @Before
+    fun setup() {
+        whenever(categoriesManager.state).thenReturn(stateFlow)
+    }
+
+    @Test
+    fun `should fetch categories on init`() = runTest {
+        stateFlow.value = CategoriesManager.State.Idle(allCategories = demoCategories, featuredCategories = emptyList(), areAllCategoriesShown = true)
+        val viewModel = OnboardingInterestsViewModel(categoriesManager)
+
+        viewModel.state.test {
+            val item = awaitItem()
+            assert(item.displayedCategories.size == 10)
+            assert(item.allCategories.size == demoCategories.size)
+            assert(item.selectedCategories.isEmpty())
+        }
+    }
+
+    @Test
+    fun `should update categories on more selected`() = runTest {
+        stateFlow.value = CategoriesManager.State.Idle(allCategories = demoCategories, featuredCategories = emptyList(), areAllCategoriesShown = true)
+        val viewModel = OnboardingInterestsViewModel(categoriesManager)
+
+        viewModel.state.test {
+            val item = awaitItem()
+            assert(!item.isShowingAllCategories)
+
+            viewModel.showMore()
+
+            val nextItem = awaitItem()
+            assert(nextItem.isShowingAllCategories)
+        }
+    }
+
+    @Test
+    fun `should update selected categories on selecting some`() = runTest {
+        stateFlow.value = CategoriesManager.State.Idle(allCategories = demoCategories, featuredCategories = emptyList(), areAllCategoriesShown = true)
+        val viewModel = OnboardingInterestsViewModel(categoriesManager)
+
+        viewModel.state.test {
+            val item = awaitItem()
+            assert(item.selectedCategories.isEmpty())
+
+            viewModel.updateSelectedCategory(demoCategories[0], true)
+            val nextItem = awaitItem()
+            assert(nextItem.selectedCategories.isNotEmpty())
+        }
+    }
+
+    private companion object {
+        val demoCategories = List(20) {
+            DiscoverCategory(
+                id = it,
+                name = "Category $it",
+                icon = "",
+                source = "",
+            )
+        }
+    }
+}


### PR DESCRIPTION
## Description
The interests screen is now populated from `CategoriesManager`. Please note that this might change in the future as we're planning to introduce a new API to get the data from. Context: p1755858078317389-slack-C0932TFPUDC

Designs: PviUP0aiZctOprDuuYRwpb-fi-5109_15632

Fixes https://linear.app/a8c/issue/PCDROID-130/implement-interest-items

## Testing Instructions
1. build `debug` version so the FF will be enabled
2. Tap 'Get started' on the intro carousel
3. Check the screen

## Screenshots or Screencast 

https://github.com/user-attachments/assets/dd8779b7-47a1-4db6-aa30-4798a70b0fb8



## Checklist
- [ ] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [ ] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [ ] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack