### PR TITLE
Try requesting permission via the system prompt first

### DIFF
--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/notifications/EnableNotificationsPromptFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/notifications/EnableNotificationsPromptFragment.kt
@@ -12,6 +12,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import androidx.core.content.PermissionChecker
 import androidx.fragment.app.viewModels
 import androidx.fragment.compose.content
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -112,11 +113,16 @@ internal class EnableNotificationsPromptFragment : BaseDialogFragment() {
 
     private fun requestPermission() {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-            if (shouldShowRequestPermissionRationale(Manifest.permission.POST_NOTIFICATIONS)) {
-                permissionRequester.launch(Manifest.permission.POST_NOTIFICATIONS)
-                viewModel.reportNotificationsOptInShown()
-            } else {
-                notificationHelper.openNotificationSettings(requireActivity())
+            when {
+                PermissionChecker.checkSelfPermission(requireActivity(), Manifest.permission.POST_NOTIFICATIONS) == PermissionChecker.PERMISSION_GRANTED -> Unit
+                shouldShowRequestPermissionRationale(Manifest.permission.POST_NOTIFICATIONS) -> {
+                    notificationHelper.openNotificationSettings(requireActivity())
+                }
+
+                else -> {
+                    permissionRequester.launch(Manifest.permission.POST_NOTIFICATIONS)
+                    viewModel.reportNotificationsOptInShown()
+                }
             }
         }
     }

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/notifications/EnableNotificationsPromptViewModel.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/viewmodel/notifications/EnableNotificationsPromptViewModel.kt
@@ -48,7 +48,7 @@ class EnableNotificationsPromptViewModel @Inject constructor(
     }
 
     fun handleCtaClick() {
-        analyticsTracker.track(AnalyticsEvent.NOTIFICATIONS_PERMISSIONS_ALLOW_TAPPED) // TODO discuss analytics with the team
+        analyticsTracker.track(AnalyticsEvent.NOTIFICATIONS_PERMISSIONS_ALLOW_TAPPED)
         when (val state = stateFlow.value) {
             is UiState.PreNewOnboarding -> {
                 viewModelScope.launch {


### PR DESCRIPTION
## Description
This PR enhances the enable notification popup in order to provide a more streamlined experience to request notificaiton permissions.
Previously we took the user to the System/App/permission screen, now we'll try to request the permission on the system propmt first.

## Testing Instructions
1. Clean install app
2. Go through onboarding (fastest way is Get started -> Not now)
3. Select Podcasts tab to see the popup
4. Make sure checkbox is checked then tap Save
- [ ] propt appears
5. Deny permission
6. Profile -> Settings -> Developer -> REset notification prompt
7. Repeat steps 3-4
- [ ] now you'll go to the system screen

## Screenshots or Screencast 

https://github.com/user-attachments/assets/55d6eff8-8293-4510-9a5b-184d804aa687


## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] ~I have considered whether it makes sense to add tests for my changes~
- [ ] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [ ] ~Any jetpack compose components I added or changed are covered by compose previews~
- [ ] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~
 
