### PR TITLE
Fix File Settings accessibility issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
         ([#4405](https://github.com/Automattic/pocket-casts-android/pull/4405))
 * Bug Fixes
     *   Fix File Settings bottom content being obstructed by the Mini Player.
-        ([#4262](https://github.com/Automattic/pocket-casts-android/pull/4262))
+        ([#4414](https://github.com/Automattic/pocket-casts-android/pull/4414))
 
 7.96
 -----

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 *   New Features
     *   Onboarding Account Creation Improvements
         ([#4405](https://github.com/Automattic/pocket-casts-android/pull/4405))
+* Bug Fixes
+    *   Fix File Settings bottom content being obstructed by the Mini Player.
+        ([#4262](https://github.com/Automattic/pocket-casts-android/pull/4262))
 
 7.96
 -----

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/cloud/CloudSettingsFragment.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/cloud/CloudSettingsFragment.kt
@@ -8,7 +8,10 @@ import android.view.ViewGroup
 import androidx.appcompat.content.res.AppCompatResources
 import androidx.core.content.ContextCompat
 import androidx.core.view.isVisible
+import androidx.core.view.updatePadding
 import androidx.fragment.app.viewModels
+import androidx.lifecycle.flowWithLifecycle
+import androidx.lifecycle.lifecycleScope
 import au.com.shiftyjelly.pocketcasts.analytics.SourceView
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.profile.R
@@ -21,6 +24,7 @@ import au.com.shiftyjelly.pocketcasts.views.fragments.BaseFragment
 import au.com.shiftyjelly.pocketcasts.views.helper.NavigationIcon.BackArrow
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
+import kotlinx.coroutines.launch
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 import au.com.shiftyjelly.pocketcasts.ui.R as UR
 
@@ -137,6 +141,14 @@ class CloudSettingsFragment : BaseFragment() {
             binding.lblFindMore,
         ).forEach {
             it.setOnClickListener { openUpgradeSheet() }
+        }
+
+        val scrollContainer = binding.scrollContainer
+        val initialPadding = scrollContainer.paddingBottom
+        viewLifecycleOwner.lifecycleScope.launch {
+            settings.bottomInset
+                .flowWithLifecycle(viewLifecycleOwner.lifecycle)
+                .collect { inset -> scrollContainer.updatePadding(bottom = initialPadding + inset) }
         }
     }
 

--- a/modules/features/profile/src/main/res/layout/fragment_cloud_settings.xml
+++ b/modules/features/profile/src/main/res/layout/fragment_cloud_settings.xml
@@ -25,6 +25,7 @@
     </com.google.android.material.appbar.AppBarLayout>
 
     <ScrollView
+        android:id="@+id/scrollContainer"
         android:layout_width="match_parent"
         android:layout_height="match_parent">
 


### PR DESCRIPTION
## Description

File Settings page wasn't setting bottom padding to the page.

Closes PCDROID-134

## Testing Instructions

1. Increase font on your device.
2. Play something so that the Mini Player is present.
3. Go to File Settings.
4. You should be able to scroll to the bottom and see the "Only On WiFi" setting.

## Screenshots or Screencast 

| Before | After |
| - | - |
| <img width="1080" height="2400" alt="image" src="https://github.com/user-attachments/assets/fd5a4db0-d8d0-4399-99b3-f20444eb47a6" /> | <img width="1080" height="2400" alt="image" src="https://github.com/user-attachments/assets/bb690ebe-6792-4880-90df-00ab7f519525" /> |

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/07jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack
