### PR TITLE
[Onboarding] Animate interest pills upon selection

### DIFF
--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/components/InterestCategoryPill.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/components/InterestCategoryPill.kt
@@ -1,5 +1,8 @@
 package au.com.shiftyjelly.pocketcasts.account.onboarding.components
 
+import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.Spring
+import androidx.compose.animation.core.spring
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
@@ -14,7 +17,12 @@ import androidx.compose.foundation.selection.toggleable
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.MaterialTheme
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -23,6 +31,7 @@ import androidx.compose.ui.graphics.BlendMode
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.CompositingStrategy
+import androidx.compose.ui.graphics.TransformOrigin
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
@@ -39,6 +48,7 @@ import au.com.shiftyjelly.pocketcasts.servers.model.DiscoverCategory
 import au.com.shiftyjelly.pocketcasts.ui.extensions.themed
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import coil.compose.rememberAsyncImagePainter
+import kotlinx.coroutines.launch
 
 @Composable
 fun InterestCategoryPill(
@@ -48,12 +58,64 @@ fun InterestCategoryPill(
     onSelectedChange: (Boolean) -> Unit,
     modifier: Modifier = Modifier,
 ) {
+    var animateState by remember { mutableStateOf(false) }
+    val scope = rememberCoroutineScope()
+    val scaleAnim = remember { Animatable(1f) }
+    val rotationAnim = remember { Animatable(0f) }
+
+    LaunchedEffect(animateState) {
+        if (animateState) {
+            scope.launch {
+                scaleAnim.animateTo(
+                    targetValue = 1.15f,
+                    animationSpec = spring(
+                        dampingRatio = Spring.DampingRatioLowBouncy,
+                        stiffness = Spring.StiffnessMedium,
+                    ),
+                )
+                scaleAnim.animateTo(
+                    targetValue = 1f,
+                    animationSpec = spring(
+                        dampingRatio = Spring.DampingRatioMediumBouncy,
+                        stiffness = Spring.StiffnessHigh,
+                    ),
+                )
+            }
+            scope.launch {
+                rotationAnim.animateTo(
+                    targetValue = -5f,
+                    animationSpec = spring(
+                        dampingRatio = Spring.DampingRatioLowBouncy,
+                        stiffness = Spring.StiffnessHigh,
+                    ),
+                )
+                rotationAnim.animateTo(
+                    targetValue = 0f,
+                    animationSpec = spring(
+                        dampingRatio = Spring.DampingRatioMediumBouncy,
+                        stiffness = Spring.StiffnessMedium,
+                    ),
+                )
+            }
+        }
+    }
+
     val colorConfig = colors[index % colors.size]
     SelectablePillContainer(
         isSelected = isSelected,
-        onSelectedChange = onSelectedChange,
+        onSelectedChange = {
+            animateState = it
+            onSelectedChange(it)
+        },
         selectedGradient = colorConfig.gradient.toList(),
-        modifier = modifier,
+        modifier = modifier
+            .graphicsLayer {
+                scaleY = scaleAnim.value
+                scaleX = scaleAnim.value
+
+                transformOrigin = TransformOrigin(0.5f, 1f)
+                rotationZ = rotationAnim.value
+            },
     ) {
         Row(
             verticalAlignment = Alignment.CenterVertically,

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/components/InterestCategoryPill.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/components/InterestCategoryPill.kt
@@ -6,6 +6,7 @@ import androidx.compose.animation.core.spring
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -235,7 +236,12 @@ private fun SelectablePillContainer(
                         shape = RoundedCornerShape(percent = 100),
                     )
                 }
-                    .toggleable(value = isSelected, onValueChange = onSelectedChange)
+                    .toggleable(
+                        value = isSelected,
+                        onValueChange = onSelectedChange,
+                        indication = null,
+                        interactionSource = remember { MutableInteractionSource() },
+                    )
                     .padding(horizontal = 16.dp, vertical = 12.dp),
             ),
         contentAlignment = Alignment.Center,

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/recommendations/OnboardingInterestsPage.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/recommendations/OnboardingInterestsPage.kt
@@ -12,7 +12,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.systemBarsPadding
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
@@ -127,7 +126,7 @@ private fun Content(
                 .padding(horizontal = 38.dp),
             fontWeight = FontWeight.W500,
         )
-        Spacer(modifier = Modifier.height(24.dp))
+        Spacer(modifier = Modifier.height(16.dp))
 
         FlowRow(
             modifier = Modifier
@@ -146,6 +145,12 @@ private fun Content(
             maxItemsInEachRow = 2,
         ) {
             state.displayedCategories.forEachIndexed { index, item ->
+                // add internal padding to prevent children being clipped during select animation
+                if (index == state.displayedCategories.indices.first) {
+                    repeat(2) {
+                        Spacer(modifier = Modifier.height(8.dp))
+                    }
+                }
                 InterestCategoryPill(
                     modifier = Modifier.wrapContentWidth(),
                     category = item,
@@ -153,10 +158,16 @@ private fun Content(
                     onSelectedChange = { isSelected -> onCategorySelectionChange(item, isSelected) },
                     index = index,
                 )
+                // add internal padding ot prevent children being clipped during select animation
+                if (index == state.displayedCategories.indices.last) {
+                    repeat(2) {
+                        Spacer(modifier = Modifier.height(8.dp))
+                    }
+                }
             }
         }
 
-        Spacer(modifier = Modifier.height(32.dp))
+        Spacer(modifier = Modifier.height(24.dp))
 
         if (!state.isShowingAllCategories) {
             TextP40(


### PR DESCRIPTION
## Description
This PR adds the last bits linked to the interests screen visuals: animations!
The pills are now animated when the user selects them.
The animation is a spring-like combination of scale-up and rotate.

Animation expectations: https://www.figma.com/proto/PviUP0aiZctOprDuuYRwpb/Onboarding?page-id=5104%3A13933&node-id=5109-16262&viewport=538%2C659%2C0.25&t=98NAUVqpaKl4YL9f-1&scaling=min-zoom&content-scaling=fixed&starting-point-node-id=5109%3A16262

Fixes https://linear.app/a8c/issue/PCDROID-130/implement-interest-items

## Testing Instructions
1. Build `debug` version so the FF will be ON by default
2. Fresh install app, tap 'Get started' on the intro carousel
3. Tippy-tap those interest pills

## Screenshots or Screencast 

https://github.com/user-attachments/assets/29011ece-2625-4315-827e-a5b8e5ce6fc0



## Checklist
- [ ] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] ~I have considered whether it makes sense to add tests for my changes~
- [ ] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [ ] ~Any jetpack compose components I added or changed are covered by compose previews~
- [ ] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~
 
