### PR TITLE
[Onboarding] Respect user's interests on Recommendations

### DIFF
--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/recommendations/OnboardingInterestsPage.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/recommendations/OnboardingInterestsPage.kt
@@ -72,12 +72,14 @@ fun OnboardingInterestsPage(
         state = state,
         onCategorySelectionChange = viewModel::updateSelectedCategory,
         onContinuePress = {
-            viewModel.saveInterests()
-            onShowRecommendations()
+            viewModel.saveInterests {
+                onShowRecommendations()
+            }
         },
         onNotNowPress = {
-            viewModel.skipSelection()
-            onShowRecommendations()
+            viewModel.skipSelection {
+                onShowRecommendations()
+            }
         },
         onShowMoreCategories = viewModel::showMore,
     )

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/recommendations/OnboardingInterestsPage.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/recommendations/OnboardingInterestsPage.kt
@@ -12,7 +12,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.systemBarsPadding
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
@@ -72,14 +71,12 @@ fun OnboardingInterestsPage(
         state = state,
         onCategorySelectionChange = viewModel::updateSelectedCategory,
         onContinuePress = {
-            viewModel.saveInterests {
-                onShowRecommendations()
-            }
+            viewModel.saveInterests()
+            onShowRecommendations()
         },
         onNotNowPress = {
-            viewModel.skipSelection {
-                onShowRecommendations()
-            }
+            viewModel.skipSelection()
+            onShowRecommendations()
         },
         onShowMoreCategories = viewModel::showMore,
     )

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/recommendations/OnboardingInterestsViewModel.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/recommendations/OnboardingInterestsViewModel.kt
@@ -5,11 +5,11 @@ import androidx.lifecycle.viewModelScope
 import au.com.shiftyjelly.pocketcasts.repositories.categories.CategoriesManager
 import au.com.shiftyjelly.pocketcasts.servers.model.DiscoverCategory
 import dagger.hilt.android.lifecycle.HiltViewModel
-import javax.inject.Inject
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import javax.inject.Inject
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 @HiltViewModel
@@ -29,7 +29,10 @@ class OnboardingInterestsViewModel @Inject constructor(
         fetchCategories()
     }
 
-    fun skipSelection() {
+    fun skipSelection(doWhenFinished: () -> Unit) {
+        viewModelScope.launch {
+            doWhenFinished()
+        }
     }
 
     fun updateSelectedCategory(category: DiscoverCategory, isSelected: Boolean) {
@@ -52,16 +55,21 @@ class OnboardingInterestsViewModel @Inject constructor(
         }
     }
 
-    fun saveInterests() {
+    fun saveInterests(doWhenFinished: () -> Unit) {
+        viewModelScope.launch {
+            categoriesManager.setInterestCategories(_state.value.selectedCategories)
+            doWhenFinished()
+        }
     }
 
     private fun fetchCategories() {
         viewModelScope.launch {
-            categoriesManager.state.collect { categState ->
+            categoriesManager.state.collect { categoryState ->
                 _state.update {
                     it.copy(
-                        allCategories = categState.allCategories,
-                        displayedCategories = categState.allCategories.take(10),
+                        // TODO sort categories by their popularity, as soon as we've introduced the new field to backend.
+                        allCategories = categoryState.allCategories,
+                        displayedCategories = categoryState.allCategories.take(10),
                     )
                 }
             }

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/recommendations/OnboardingInterestsViewModel.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/recommendations/OnboardingInterestsViewModel.kt
@@ -29,11 +29,8 @@ class OnboardingInterestsViewModel @Inject constructor(
         fetchCategories()
     }
 
-    fun skipSelection(doWhenFinished: () -> Unit) {
-        viewModelScope.launch {
-            categoriesManager.setInterestCategories(emptySet())
-            doWhenFinished()
-        }
+    fun skipSelection() {
+        categoriesManager.setInterestCategories(emptySet())
     }
 
     fun updateSelectedCategory(category: DiscoverCategory, isSelected: Boolean) {
@@ -56,11 +53,8 @@ class OnboardingInterestsViewModel @Inject constructor(
         }
     }
 
-    fun saveInterests(doWhenFinished: () -> Unit) {
-        viewModelScope.launch {
-            categoriesManager.setInterestCategories(_state.value.selectedCategories)
-            doWhenFinished()
-        }
+    fun saveInterests() {
+        categoriesManager.setInterestCategories(_state.value.selectedCategories)
     }
 
     private fun fetchCategories() {

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/recommendations/OnboardingInterestsViewModel.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/recommendations/OnboardingInterestsViewModel.kt
@@ -5,11 +5,11 @@ import androidx.lifecycle.viewModelScope
 import au.com.shiftyjelly.pocketcasts.repositories.categories.CategoriesManager
 import au.com.shiftyjelly.pocketcasts.servers.model.DiscoverCategory
 import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
-import javax.inject.Inject
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 @HiltViewModel
@@ -31,6 +31,7 @@ class OnboardingInterestsViewModel @Inject constructor(
 
     fun skipSelection(doWhenFinished: () -> Unit) {
         viewModelScope.launch {
+            categoriesManager.setInterestCategories(emptySet())
             doWhenFinished()
         }
     }

--- a/modules/features/account/src/test/java/au/com/shiftyjelly/pocketcasts/account/onboarding/recommendations/OnboardingRecommendationsStartPageViewModelTest.kt
+++ b/modules/features/account/src/test/java/au/com/shiftyjelly/pocketcasts/account/onboarding/recommendations/OnboardingRecommendationsStartPageViewModelTest.kt
@@ -1,0 +1,189 @@
+package au.com.shiftyjelly.pocketcasts.account.onboarding.recommendations
+
+import android.app.Application
+import android.content.res.Resources
+import app.cash.turbine.test
+import au.com.shiftyjelly.pocketcasts.account.viewmodel.OnboardingRecommendationsStartPageViewModel
+import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTracker
+import au.com.shiftyjelly.pocketcasts.preferences.Settings
+import au.com.shiftyjelly.pocketcasts.preferences.UserSetting
+import au.com.shiftyjelly.pocketcasts.repositories.categories.CategoriesManager
+import au.com.shiftyjelly.pocketcasts.repositories.lists.ListRepository
+import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
+import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
+import au.com.shiftyjelly.pocketcasts.servers.model.Discover
+import au.com.shiftyjelly.pocketcasts.servers.model.DiscoverCategory
+import au.com.shiftyjelly.pocketcasts.servers.model.DiscoverPodcast
+import au.com.shiftyjelly.pocketcasts.servers.model.DiscoverRegion
+import au.com.shiftyjelly.pocketcasts.servers.model.DiscoverRow
+import au.com.shiftyjelly.pocketcasts.servers.model.DisplayStyle
+import au.com.shiftyjelly.pocketcasts.servers.model.ExpandedStyle
+import au.com.shiftyjelly.pocketcasts.servers.model.ListFeed
+import au.com.shiftyjelly.pocketcasts.servers.model.ListType
+import au.com.shiftyjelly.pocketcasts.sharedtest.InMemoryFeatureFlagRule
+import au.com.shiftyjelly.pocketcasts.sharedtest.MainCoroutineRule
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
+import io.reactivex.Flowable
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class OnboardingRecommendationsStartPageViewModelTest {
+    @get:Rule
+    val featureFlagRule = InMemoryFeatureFlagRule()
+
+    @get:Rule
+    val coroutineRule = MainCoroutineRule()
+
+    private val podcastManager = mock<PodcastManager>()
+    private val playbackManager = mock<PlaybackManager>()
+    private val analyticsTracker = mock<AnalyticsTracker>()
+    private val repository = mock<ListRepository>()
+    private val settings = mock<Settings>()
+    private val categoriesManager = mock<CategoriesManager>()
+    private val application = mock<Application>()
+
+    @Before
+    fun setup() = runTest {
+        whenever(podcastManager.subscribedRxFlowable()).thenReturn(Flowable.just(emptyList()))
+        whenever(repository.getDiscoverFeed()).thenReturn(mockDiscover)
+        whenever(repository.getCategoriesList(any())).thenReturn(mockCategories)
+        whenever(repository.getListFeed(any(), any())).thenReturn(mockListFeed)
+        val discoverCountryCodeMock = mock<UserSetting<String>>()
+        whenever(discoverCountryCodeMock.value).thenReturn("US")
+        whenever(settings.discoverCountryCode).thenReturn(discoverCountryCodeMock)
+        val mockResources = mock<Resources>()
+        whenever(mockResources.getString(any())).thenReturn("")
+        whenever(application.resources).thenReturn(mockResources)
+    }
+
+    @Test
+    fun `should prioritize interest categories when FF is on and interests are set`() = runTest {
+        FeatureFlag.setEnabled(Feature.NEW_ONBOARDING_RECOMMENDATIONS, true)
+        whenever(categoriesManager.interestCategories).thenReturn(MutableStateFlow(mockCategories.takeLast(3).toSet()).asStateFlow())
+
+        val viewModel = createViewModel()
+        val state = viewModel.state.value
+        // assert(state.sections.take(3).map { it.title }.all { it in mockCategories.takeLast(3).map { it.title } })
+        viewModel.state.test {
+            val item = awaitItem()
+            assert(item.sections.take(3).map { it.title }.all { it in mockCategories.takeLast(3).map { it.title } })
+        }
+    }
+
+    @Test
+    fun `should return normal recommendations when FF is on but interests are empty`() = runTest {
+        FeatureFlag.setEnabled(Feature.NEW_ONBOARDING_RECOMMENDATIONS, true)
+        whenever(categoriesManager.interestCategories).thenReturn(MutableStateFlow(emptySet()))
+
+        val viewModel = createViewModel()
+        viewModel.state.test {
+            val item = awaitItem()
+            assert(item.sections.take(3).map { it.title }.all { it in mockCategories.take(3).map { it.title } })
+        }
+    }
+
+    @Test
+    fun `should return normal recommendations when FF is off`() = runTest {
+        FeatureFlag.setEnabled(Feature.NEW_ONBOARDING_RECOMMENDATIONS, false)
+        whenever(categoriesManager.interestCategories).thenReturn(MutableStateFlow(emptySet()))
+
+        val viewModel = createViewModel()
+        viewModel.state.test {
+            val item = awaitItem()
+            assert(item.sections.take(2).map { it.title }.all { it in mockCategories.take(3).map { it.title } })
+        }
+    }
+
+    private fun createViewModel() = OnboardingRecommendationsStartPageViewModel(
+        podcastManager = podcastManager,
+        playbackManager = playbackManager,
+        analyticsTracker = analyticsTracker,
+        repository = repository,
+        settings = settings,
+        app = application,
+        categoriesManager = categoriesManager,
+    )
+
+    private companion object {
+        val mockDiscover = Discover(
+            layout = listOf(
+                DiscoverRow(
+                    id = "id",
+                    type = ListType.Categories,
+                    displayStyle = DisplayStyle.Category(),
+                    expandedStyle = ExpandedStyle.GridList(),
+                    expandedTopItemLabel = null,
+                    title = "title",
+                    source = "source",
+                    listUuid = "listUuid",
+                    categoryId = 1,
+                    regions = listOf("US"),
+                    sponsored = false,
+                    curated = false,
+                    mostPopularCategoriesId = null,
+                    sponsoredCategoryIds = null,
+                ),
+            ),
+            regions = mapOf(
+                "US" to DiscoverRegion(
+                    name = "name",
+                    flag = "",
+                    code = "US",
+                ),
+            ),
+            regionCodeToken = "{nope}",
+            regionNameToken = "{nope}",
+            defaultRegionCode = "US",
+        )
+
+        val mockCategories = List(10) {
+            DiscoverCategory(
+                id = it,
+                name = "Category $it",
+                icon = "",
+                source = "",
+            )
+        }
+
+        val mockListFeed = ListFeed(
+            title = "title",
+            subtitle = "subtitle",
+            description = "description",
+            shortDescription = "shortDescription",
+            date = "date",
+            podcasts = List(4) {
+                DiscoverPodcast(
+                    uuid = "uuid $it",
+                    title = "podcast $it",
+                    url = "",
+                    author = "",
+                    category = "",
+                    description = "description",
+                    language = "language",
+                    mediaType = "mediaType",
+                )
+            },
+            episodes = emptyList(),
+            podroll = null,
+            collectionImageUrl = null,
+            collectionRectangleImageUrl = null,
+            featureImage = null,
+            headerImageUrl = null,
+            tintColors = null,
+            collageImages = null,
+            webLinkUrl = null,
+            webLinkTitle = null,
+            promotion = null,
+        )
+    }
+}

--- a/modules/features/account/src/test/java/au/com/shiftyjelly/pocketcasts/account/onboarding/recommendations/OnboardingRecommendationsStartPageViewModelTest.kt
+++ b/modules/features/account/src/test/java/au/com/shiftyjelly/pocketcasts/account/onboarding/recommendations/OnboardingRecommendationsStartPageViewModelTest.kt
@@ -73,7 +73,6 @@ class OnboardingRecommendationsStartPageViewModelTest {
 
         val viewModel = createViewModel()
         val state = viewModel.state.value
-        // assert(state.sections.take(3).map { it.title }.all { it in mockCategories.takeLast(3).map { it.title } })
         viewModel.state.test {
             val item = awaitItem()
             assert(item.sections.take(3).map { it.title }.all { it in mockCategories.takeLast(3).map { it.title } })

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/categories/CategoriesManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/categories/CategoriesManager.kt
@@ -14,6 +14,8 @@ import kotlin.time.TimeSource
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.map
@@ -31,6 +33,8 @@ class CategoriesManager @Inject constructor(
     private val discoverRowInfo = MutableStateFlow(DiscoverRowInfo())
     private val selectedId = MutableStateFlow<Int?>(null)
     private val areAllCategoriesShown = MutableStateFlow(false)
+    private val _interestCategories = MutableStateFlow<Set<DiscoverCategory>>(emptySet())
+    val interestCategories = _interestCategories.asStateFlow()
 
     private var lastUpdate: TimeSource.Monotonic.ValueTimeMark? = null
 
@@ -127,6 +131,10 @@ class CategoriesManager @Inject constructor(
 
     fun setAllCategoriesShown(areShown: Boolean) {
         areAllCategoriesShown.value = areShown
+    }
+
+    fun setInterestCategories(categories: Set<DiscoverCategory>) {
+        _interestCategories.value = categories
     }
 
     private fun areCategoriesStale() = (lastUpdate?.elapsedNow() ?: Duration.INFINITE) > 1.days


### PR DESCRIPTION
## Description
Prioritize selected interest categories on the recommendations page.
When the user has selected at least 3 interest categories, we should promote them to the top of the recommendations list. Promoted categories will be followed by the regular recommendations (Featured, Trending, and the rest of discover categories)
If there aren't any interests selected, or the FF is disabled, we should return the usual recommendations (Featured, Trending, discover categories)
Bonus: Added tests to verify this behavior

Fixes https://linear.app/a8c/issue/PCDROID-131/adapt-to-interests-on-recommendations

## Testing Instructions
1. build `debug` so the FF will be enabled
2. On the intro carousel, select Get started
3. On the interests screen, try two scenarios:
- A - tap Not now
- B - select at least 3 then continue
4. Observe recommendations

## Screenshots or Screencast 


https://github.com/user-attachments/assets/af76ee8a-f53b-4cd7-a154-3506a05d38e6


## Checklist
- [ ] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [ ] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [ ] ~Any jetpack compose components I added or changed are covered by compose previews~
- [ ] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~
 