### PR TITLE
Create manual playlist

### DIFF
--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/repositories/playlist/PlaylistManagerTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/repositories/playlist/PlaylistManagerTest.kt
@@ -502,7 +502,7 @@ class PlaylistManagerTest {
     }
 
     @Test
-    fun createPlaylists() = runTest(testDispatcher) {
+    fun createSmartPlaylist() = runTest(testDispatcher) {
         val drafts = listOf(
             SmartPlaylistDraft(
                 title = "Title",
@@ -647,7 +647,7 @@ class PlaylistManagerTest {
                 ),
             ),
         )
-        drafts.forEach { draft -> manager.insertSmartPlaylist(draft) }
+        drafts.forEach { draft -> manager.createSmartPlaylist(draft) }
         val playlists = playlistDao.observePlaylists().first()
 
         // Check that UUIDs are unique
@@ -717,7 +717,7 @@ class PlaylistManagerTest {
 
     @Test
     fun createDefaultNewReleasesPlaylist() = runTest(testDispatcher) {
-        manager.insertSmartPlaylist(SmartPlaylistDraft.NewReleases)
+        manager.createSmartPlaylist(SmartPlaylistDraft.NewReleases)
         val playlists = playlistDao.observePlaylists().first()
 
         assertEquals(
@@ -754,7 +754,7 @@ class PlaylistManagerTest {
 
     @Test
     fun createDefaultInProgressPlaylist() = runTest(testDispatcher) {
-        manager.insertSmartPlaylist(SmartPlaylistDraft.InProgress)
+        manager.createSmartPlaylist(SmartPlaylistDraft.InProgress)
         val playlists = playlistDao.observePlaylists().first()
 
         assertEquals(
@@ -787,6 +787,15 @@ class PlaylistManagerTest {
             ),
             playlists[0],
         )
+    }
+
+    @Test
+    fun createManualPlaylist() = runTest(testDispatcher) {
+        manager.createManualPlaylist("Playlist name")
+        val playlist = playlistDao.observePlaylists().first().first()
+
+        assertEquals("Playlist name", playlist.title)
+        assertTrue(playlist.manual)
     }
 
     @Test

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/CreatePlaylistFragment.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/CreatePlaylistFragment.kt
@@ -27,17 +27,18 @@ import au.com.shiftyjelly.pocketcasts.compose.navigation.navigateOnce
 import au.com.shiftyjelly.pocketcasts.models.type.SmartRules.DownloadStatusRule
 import au.com.shiftyjelly.pocketcasts.models.type.SmartRules.MediaTypeRule
 import au.com.shiftyjelly.pocketcasts.models.type.SmartRules.ReleaseDateRule
-import au.com.shiftyjelly.pocketcasts.playlists.smart.PlaylistFragment
 import au.com.shiftyjelly.pocketcasts.playlists.smart.rules.ManageSmartRulesListener
 import au.com.shiftyjelly.pocketcasts.playlists.smart.rules.ManageSmartRulesPage
 import au.com.shiftyjelly.pocketcasts.playlists.smart.rules.ManageSmartRulesRoutes
 import au.com.shiftyjelly.pocketcasts.playlists.smart.rules.RuleType
+import au.com.shiftyjelly.pocketcasts.repositories.playlist.PlaylistPreview
 import au.com.shiftyjelly.pocketcasts.ui.helper.FragmentHostListener
 import au.com.shiftyjelly.pocketcasts.views.fragments.BaseDialogFragment
 import dagger.hilt.android.AndroidEntryPoint
 import dagger.hilt.android.lifecycle.withCreationCallback
-import timber.log.Timber
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
+import au.com.shiftyjelly.pocketcasts.playlists.manual.PlaylistFragment as ManualPlaylistFragment
+import au.com.shiftyjelly.pocketcasts.playlists.smart.PlaylistFragment as SmartPlaylistFragment
 
 @AndroidEntryPoint
 class CreatePlaylistFragment : BaseDialogFragment() {
@@ -90,7 +91,7 @@ class CreatePlaylistFragment : BaseDialogFragment() {
                         titleState = viewModel.playlistNameState,
                         onCreateManualPlaylist = {
                             viewModel.trackCreateManualPlaylist()
-                            Timber.i("Create Manual Playlist")
+                            viewModel.createManualPlaylist()
                         },
                         onContinueToSmartPlaylist = {
                             viewModel.trackCreateSmartPlaylist()
@@ -155,10 +156,13 @@ class CreatePlaylistFragment : BaseDialogFragment() {
     @Composable
     private fun OpenCreatedPlaylistEffect() {
         LaunchedEffect(Unit) {
-            val uuid = viewModel.createdSmartPlaylistUuid.await()
+            val createdPlaylist = viewModel.createdPlaylist.await()
             isPlaylistCreated = true
             dismiss()
-            val fragment = PlaylistFragment.newInstance(uuid)
+            val fragment = when (createdPlaylist.type) {
+                PlaylistPreview.Type.Manual -> ManualPlaylistFragment.newInstance(createdPlaylist.uuid)
+                PlaylistPreview.Type.Smart -> SmartPlaylistFragment.newInstance(createdPlaylist.uuid)
+            }
             (requireActivity() as FragmentHostListener).addFragment(fragment)
         }
     }

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/PlaylistsFragment.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/PlaylistsFragment.kt
@@ -13,7 +13,6 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.lifecycleScope
 import au.com.shiftyjelly.pocketcasts.compose.AppThemeWithBackground
 import au.com.shiftyjelly.pocketcasts.compose.extensions.contentWithoutConsumedInsets
-import au.com.shiftyjelly.pocketcasts.playlists.smart.PlaylistFragment
 import au.com.shiftyjelly.pocketcasts.repositories.playlist.PlaylistPreview
 import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingFlow
 import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingLauncher
@@ -24,7 +23,8 @@ import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
-import timber.log.Timber
+import au.com.shiftyjelly.pocketcasts.playlists.manual.PlaylistFragment as ManualPlaylistFragment
+import au.com.shiftyjelly.pocketcasts.playlists.smart.PlaylistFragment as SmartPlaylistFragment
 
 @AndroidEntryPoint
 class PlaylistsFragment :
@@ -58,15 +58,11 @@ class PlaylistsFragment :
                 },
                 onDeletePlaylist = { playlist -> viewModel.deletePlaylist(playlist.uuid) },
                 onOpenPlaylist = { playlist ->
-                    when (playlist.type) {
-                        PlaylistPreview.Type.Manual -> {
-                            Timber.i("Open manual playlist")
-                        }
-                        PlaylistPreview.Type.Smart -> {
-                            val fragment = PlaylistFragment.newInstance(playlist.uuid)
-                            (requireActivity() as FragmentHostListener).addFragment(fragment)
-                        }
+                    val fragment = when (playlist.type) {
+                        PlaylistPreview.Type.Manual -> ManualPlaylistFragment.newInstance(playlist.uuid)
+                        PlaylistPreview.Type.Smart -> SmartPlaylistFragment.newInstance(playlist.uuid)
                     }
+                    (requireActivity() as FragmentHostListener).addFragment(fragment)
                 },
                 onReorderPlaylists = viewModel::updatePlaylistsOrder,
                 onShowPlaylists = { playlists -> viewModel.trackPlaylistsShown(playlists.size) },

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/manual/PlaylistFragment.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/manual/PlaylistFragment.kt
@@ -1,0 +1,48 @@
+package au.com.shiftyjelly.pocketcasts.playlists.manual
+
+import android.os.Bundle
+import android.os.Parcelable
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.core.os.BundleCompat
+import androidx.core.os.bundleOf
+import au.com.shiftyjelly.pocketcasts.compose.AppThemeWithBackground
+import au.com.shiftyjelly.pocketcasts.compose.components.TextP40
+import au.com.shiftyjelly.pocketcasts.compose.extensions.contentWithoutConsumedInsets
+import au.com.shiftyjelly.pocketcasts.views.fragments.BaseFragment
+import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.parcelize.Parcelize
+
+@AndroidEntryPoint
+class PlaylistFragment : BaseFragment() {
+    private val args get() = requireNotNull(arguments?.let { BundleCompat.getParcelable(it, NEW_INSTANCE_ARGS, Args::class.java) })
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?,
+    ) = contentWithoutConsumedInsets {
+        AppThemeWithBackground(theme.activeTheme) {
+            Box(modifier = Modifier.fillMaxSize()) {
+                TextP40("Manual playlist: ${args.playlistUuid}", modifier = Modifier.align(Alignment.Center))
+            }
+        }
+    }
+
+    @Parcelize
+    private class Args(
+        val playlistUuid: String,
+    ) : Parcelable
+
+    companion object {
+        private const val NEW_INSTANCE_ARGS = "ManualPlaylistsFragmentArgs"
+
+        fun newInstance(playlistUuid: String) = PlaylistFragment().apply {
+            arguments = bundleOf(NEW_INSTANCE_ARGS to Args(playlistUuid))
+        }
+    }
+}

--- a/modules/features/filters/src/test/kotlin/au/com/shiftyjelly/pocketcasts/playlists/create/FakePlaylistManager.kt
+++ b/modules/features/filters/src/test/kotlin/au/com/shiftyjelly/pocketcasts/playlists/create/FakePlaylistManager.kt
@@ -39,9 +39,15 @@ class FakePlaylistManager : PlaylistManager {
 
     override suspend fun deletePlaylist(uuid: String) = Unit
 
-    val upsertSmartPlaylistTurbine = Turbine<SmartPlaylistDraft>(name = "upsertSmartPlaylist")
-    override suspend fun insertSmartPlaylist(draft: SmartPlaylistDraft): String {
-        upsertSmartPlaylistTurbine.add(draft)
+    val createSmartPlaylistTurbine = Turbine<SmartPlaylistDraft>(name = "createSmartPlaylistTurbine")
+    override suspend fun createSmartPlaylist(draft: SmartPlaylistDraft): String {
+        createSmartPlaylistTurbine.add(draft)
+        return UUID.randomUUID().toString()
+    }
+
+    val createManualPlaylistTurbine = Turbine<String>(name = "createManualPlaylistTurbine")
+    override suspend fun createManualPlaylist(name: String): String {
+        createManualPlaylistTurbine.add(name)
         return UUID.randomUUID().toString()
     }
 

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playlist/DefaultPlaylistsInitializater.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playlist/DefaultPlaylistsInitializater.kt
@@ -15,8 +15,8 @@ class DefaultPlaylistsInitializater @Inject constructor(
 
     suspend fun initialize(force: Boolean = false) = mutex.withLock {
         if (force || !settings.getBooleanForKey(CREATED_DEFAULT_PLAYLISTS_KEY, false)) {
-            playlistManager.insertSmartPlaylist(SmartPlaylistDraft.InProgress)
-            playlistManager.insertSmartPlaylist(SmartPlaylistDraft.NewReleases)
+            playlistManager.createSmartPlaylist(SmartPlaylistDraft.InProgress)
+            playlistManager.createSmartPlaylist(SmartPlaylistDraft.NewReleases)
             settings.setBooleanForKey(CREATED_DEFAULT_PLAYLISTS_KEY, true)
         }
     }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playlist/PlaylistManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playlist/PlaylistManager.kt
@@ -34,7 +34,9 @@ interface PlaylistManager {
 
     suspend fun deletePlaylist(uuid: String)
 
-    suspend fun insertSmartPlaylist(draft: SmartPlaylistDraft): String
+    suspend fun createSmartPlaylist(draft: SmartPlaylistDraft): String
+
+    suspend fun createManualPlaylist(name: String): String
 
     suspend fun updatePlaylistsOrder(sortedUuids: List<String>)
 }


### PR DESCRIPTION
## Description

This adds inserting new Manual Playlists to the database.

Closes PCDROID-108

## Testing Instructions

1. Go to playlists page.
2. Start creation process.
3. Change the name.
4. Tap the create button.
5. You should see a mock page.
6. Go back to playlists.
7. Tap on your new playlist.
8. You should see a mock page.

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.