### PR TITLE
Fix playlist syncing

### DIFF
--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/data/PlaylistSync.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/sync/data/PlaylistSync.kt
@@ -44,7 +44,7 @@ internal class PlaylistSync(
     suspend fun fullSync() {
         processServerPlaylists(
             serverPlaylists = syncManager.getPlaylistsOrThrow().playlistsList,
-            getUuid = { playlist -> playlist.uuid },
+            getUuid = { playlist -> playlist.originalUuid },
             isDeleted = { playlist -> playlist.isDeletedOrNull?.value == true },
             isManual = { playlist -> playlist.manualOrNull?.value == true },
             applyServerPlaylist = { localPlaylist, serverPlaylist -> localPlaylist.applyServerPlaylist(serverPlaylist) },
@@ -54,7 +54,7 @@ internal class PlaylistSync(
     suspend fun processIncrementalResponse(serverPlaylists: List<SyncUserPlaylist>) {
         processServerPlaylists(
             serverPlaylists = serverPlaylists,
-            getUuid = { playlist -> playlist.uuid },
+            getUuid = { playlist -> playlist.originalUuid },
             isDeleted = { playlist -> playlist.isDeletedOrNull?.value == true },
             isManual = { playlist -> playlist.manualOrNull?.value == true },
             applyServerPlaylist = { localPlaylist, serverPlaylist -> localPlaylist.applyServerPlaylist(serverPlaylist) },
@@ -100,8 +100,10 @@ internal class PlaylistSync(
             playlists.map { localPlaylist ->
                 record {
                     playlist = syncUserPlaylist {
+                        // Set both UUIDs as it is important server side due to case sensitivity
                         uuid = localPlaylist.uuid
                         originalUuid = localPlaylist.uuid
+
                         isDeleted = boolValue {
                             value = localPlaylist.deleted
                         }
@@ -170,7 +172,7 @@ internal class PlaylistSync(
 
 private fun PlaylistEntity.applyServerPlaylist(serverPlaylist: PlaylistSyncResponse) = apply {
     syncStatus = PlaylistEntity.SYNC_STATUS_SYNCED
-    uuid = serverPlaylist.uuid
+    uuid = serverPlaylist.originalUuid
     title = serverPlaylist.title
     serverPlaylist.manualOrNull?.value?.let { value ->
         manual = value
@@ -225,7 +227,7 @@ private fun PlaylistEntity.applyServerPlaylist(serverPlaylist: PlaylistSyncRespo
 
 private fun PlaylistEntity.applyServerPlaylist(serverPlaylist: SyncUserPlaylist) = apply {
     syncStatus = PlaylistEntity.SYNC_STATUS_SYNCED
-    uuid = serverPlaylist.uuid
+    uuid = serverPlaylist.originalUuid
     serverPlaylist.titleOrNull?.value?.let { value ->
         title = value
     }


### PR DESCRIPTION
## Description

Playlists have both `uuid` and `originalUuid` due to legacy case-sensitivity reasons. In the protobuf sync, I mistakenly used `uuid` instead of `originalUuid` when reading the server’s response. This caused duplicate entries in some cases.

## Testing Instructions

1. Create a new account.
2. Navigate to the playlists.
3. Reorder two of the pre-made ones.
4. Go to your profile.
5. Sync your account.
6. Return to the playlists.
7. You should not see any duplicates.

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.