### PR TITLE
Load episode sources for manual playlists

### DIFF
--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/repositories/playlist/PlaylistManagerTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/repositories/playlist/PlaylistManagerTest.kt
@@ -1,15 +1,21 @@
 package au.com.shiftyjelly.pocketcasts.repositories.playlist
 
+import android.content.Context
 import androidx.room.Room
 import androidx.test.platform.app.InstrumentationRegistry
 import app.cash.turbine.test
 import au.com.shiftyjelly.pocketcasts.models.db.AppDatabase
 import au.com.shiftyjelly.pocketcasts.models.db.dao.EpisodeDao
+import au.com.shiftyjelly.pocketcasts.models.db.dao.FolderDao
 import au.com.shiftyjelly.pocketcasts.models.db.dao.PlaylistDao
 import au.com.shiftyjelly.pocketcasts.models.db.dao.PodcastDao
 import au.com.shiftyjelly.pocketcasts.models.di.ModelModule
 import au.com.shiftyjelly.pocketcasts.models.di.addTypeConverters
+import au.com.shiftyjelly.pocketcasts.models.entity.Folder
 import au.com.shiftyjelly.pocketcasts.models.entity.ManualPlaylistEpisode
+import au.com.shiftyjelly.pocketcasts.models.entity.ManualPlaylistEpisodeSource
+import au.com.shiftyjelly.pocketcasts.models.entity.ManualPlaylistFolderSource
+import au.com.shiftyjelly.pocketcasts.models.entity.ManualPlaylistPodcastSource
 import au.com.shiftyjelly.pocketcasts.models.entity.PlaylistEntity.Companion.ANYTIME
 import au.com.shiftyjelly.pocketcasts.models.entity.PlaylistEntity.Companion.AUDIO_VIDEO_FILTER_ALL
 import au.com.shiftyjelly.pocketcasts.models.entity.PlaylistEntity.Companion.AUDIO_VIDEO_FILTER_AUDIO_ONLY
@@ -25,6 +31,7 @@ import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.models.type.EpisodePlayingStatus
 import au.com.shiftyjelly.pocketcasts.models.type.PlaylistEpisodeSortType
+import au.com.shiftyjelly.pocketcasts.models.type.PodcastsSortType
 import au.com.shiftyjelly.pocketcasts.models.type.SmartRules
 import au.com.shiftyjelly.pocketcasts.models.type.SmartRules.DownloadStatusRule
 import au.com.shiftyjelly.pocketcasts.models.type.SmartRules.EpisodeDurationRule
@@ -33,8 +40,12 @@ import au.com.shiftyjelly.pocketcasts.models.type.SmartRules.MediaTypeRule
 import au.com.shiftyjelly.pocketcasts.models.type.SmartRules.PodcastsRule
 import au.com.shiftyjelly.pocketcasts.models.type.SmartRules.ReleaseDateRule
 import au.com.shiftyjelly.pocketcasts.models.type.SmartRules.StarredRule
+import au.com.shiftyjelly.pocketcasts.models.type.Subscription
+import au.com.shiftyjelly.pocketcasts.preferences.Settings
+import au.com.shiftyjelly.pocketcasts.preferences.SettingsImpl
+import au.com.shiftyjelly.pocketcasts.servers.di.ServersModule
 import au.com.shiftyjelly.pocketcasts.sharedtest.MutableClock
-import com.squareup.moshi.Moshi
+import com.google.firebase.remoteconfig.FirebaseRemoteConfig
 import java.util.Date
 import java.util.UUID
 import kotlin.time.Duration
@@ -57,13 +68,15 @@ class PlaylistManagerTest {
     private lateinit var podcastDao: PodcastDao
     private lateinit var episodeDao: EpisodeDao
     private lateinit var playlistDao: PlaylistDao
+    private lateinit var folderDao: FolderDao
+    private lateinit var settings: Settings
 
     private lateinit var manager: PlaylistManager
 
     @Before
     fun setup() {
         val context = InstrumentationRegistry.getInstrumentation().targetContext
-        val moshi = Moshi.Builder().build()
+        val moshi = ServersModule().provideMoshi()
         val appDatabase = Room.inMemoryDatabaseBuilder(context, AppDatabase::class.java)
             .addTypeConverters(ModelModule.provideRoomConverters(moshi))
             .setQueryCoroutineContext(testDispatcher)
@@ -71,8 +84,22 @@ class PlaylistManagerTest {
         podcastDao = appDatabase.podcastDao()
         episodeDao = appDatabase.episodeDao()
         playlistDao = appDatabase.playlistDao()
+        folderDao = appDatabase.folderDao()
+
+        val sharedPreferences = context.getSharedPreferences("test_prefst", Context.MODE_PRIVATE)
+        sharedPreferences.edit().clear().commit()
+        val firebaseRemoteConfig = FirebaseRemoteConfig.getInstance()
+        settings = SettingsImpl(
+            sharedPreferences = sharedPreferences,
+            privatePreferences = sharedPreferences,
+            context = context,
+            firebaseRemoteConfig = firebaseRemoteConfig,
+            moshi = moshi,
+        )
+
         manager = PlaylistManagerImpl(
             appDatabase = appDatabase,
+            settings = settings,
             clock = clock,
         )
     }
@@ -1223,6 +1250,75 @@ class PlaylistManagerTest {
             "backslash character",
             listOf(backslashEpisode),
             getSmartEpisodes(searchTerm = "\\"),
+        )
+    }
+
+    @Test
+    fun getManualPlaylistEpisodeSource() = runTest(testDispatcher) {
+        assertEquals(
+            emptyList<ManualPlaylistEpisodeSource>(),
+            manager.getManualPlaylistEpisodeSources(),
+        )
+
+        podcastDao.insertSuspend(Podcast("podcast-id-0", title = "Podcast Title 0", author = "Podcast Author 0", isSubscribed = false))
+        podcastDao.insertSuspend(Podcast("podcast-id-1", title = "Podcast Title 1", author = "Podcast Author 1", isSubscribed = true))
+        podcastDao.insertSuspend(Podcast("podcast-id-2", title = "Podcast Title 2", author = "Podcast Author 2", rawFolderUuid = "folder-id-1", isSubscribed = true))
+        podcastDao.insertSuspend(Podcast("podcast-id-3", title = "Podcast Title 3", author = "Podcast Author 3", rawFolderUuid = "folder-id-2", isSubscribed = true))
+        podcastDao.insertSuspend(Podcast("podcast-id-4", title = "Podcast Title 4", author = "Podcast Author 4", rawFolderUuid = "folder-id-1", isSubscribed = false))
+        val baseFolder = Folder(
+            uuid = "folder-id-0",
+            name = "Folder Name 0",
+            color = 0,
+            addedDate = Date(0),
+            sortPosition = 0,
+            podcastsSortType = PodcastsSortType.RECENTLY_PLAYED,
+            deleted = false,
+            syncModified = 0L,
+        )
+        folderDao.insert(baseFolder.copy(uuid = "folder-id-1", name = "Folder Name 1"))
+        folderDao.insert(baseFolder.copy(uuid = "folder-id-2", name = "Folder Name 2", deleted = true))
+
+        assertEquals(
+            listOf(
+                ManualPlaylistPodcastSource(
+                    uuid = "podcast-id-1",
+                    title = "Podcast Title 1",
+                    author = "Podcast Author 1",
+                ),
+                ManualPlaylistPodcastSource(
+                    uuid = "podcast-id-2",
+                    title = "Podcast Title 2",
+                    author = "Podcast Author 2",
+                ),
+                ManualPlaylistPodcastSource(
+                    uuid = "podcast-id-3",
+                    title = "Podcast Title 3",
+                    author = "Podcast Author 3",
+                ),
+            ),
+            manager.getManualPlaylistEpisodeSources(),
+        )
+
+        settings.cachedSubscription.set(Subscription.PlusPreview, updateModifiedAt = false)
+        assertEquals(
+            listOf(
+                ManualPlaylistPodcastSource(
+                    uuid = "podcast-id-1",
+                    title = "Podcast Title 1",
+                    author = "Podcast Author 1",
+                ),
+                ManualPlaylistPodcastSource(
+                    uuid = "podcast-id-3",
+                    title = "Podcast Title 3",
+                    author = "Podcast Author 3",
+                ),
+                ManualPlaylistFolderSource(
+                    uuid = "folder-id-1",
+                    title = "Folder Name 1",
+                    podcastUuids = listOf("podcast-id-2"),
+                ),
+            ),
+            manager.getManualPlaylistEpisodeSources(),
         )
     }
 }

--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/repositories/playlist/PlaylistManagerTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/repositories/playlist/PlaylistManagerTest.kt
@@ -1276,7 +1276,8 @@ class PlaylistManagerTest {
             syncModified = 0L,
         )
         folderDao.insert(baseFolder.copy(uuid = "folder-id-1", name = "Folder Name 1"))
-        folderDao.insert(baseFolder.copy(uuid = "folder-id-2", name = "Folder Name 2", deleted = true))
+        folderDao.insert(baseFolder.copy(uuid = "folder-id-2", name = "Folder Name 2"))
+        folderDao.insert(baseFolder.copy(uuid = "folder-id-3", name = "Folder Name 3", deleted = true))
 
         assertEquals(
             listOf(
@@ -1315,7 +1316,13 @@ class PlaylistManagerTest {
                 ManualPlaylistFolderSource(
                     uuid = "folder-id-1",
                     title = "Folder Name 1",
-                    podcastUuids = listOf("podcast-id-2"),
+                    podcastSources = listOf(
+                        ManualPlaylistPodcastSource(
+                            uuid = "podcast-id-3",
+                            title = "Podcast Title 3",
+                            author = "Podcast Author 3",
+                        ),
+                    ),
                 ),
             ),
             manager.getManualPlaylistEpisodeSources(),

--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/repositories/playlist/PlaylistManagerTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/repositories/playlist/PlaylistManagerTest.kt
@@ -1263,7 +1263,7 @@ class PlaylistManagerTest {
         podcastDao.insertSuspend(Podcast("podcast-id-0", title = "Podcast Title 0", author = "Podcast Author 0", isSubscribed = false))
         podcastDao.insertSuspend(Podcast("podcast-id-1", title = "Podcast Title 1", author = "Podcast Author 1", isSubscribed = true))
         podcastDao.insertSuspend(Podcast("podcast-id-2", title = "Podcast Title 2", author = "Podcast Author 2", rawFolderUuid = "folder-id-1", isSubscribed = true))
-        podcastDao.insertSuspend(Podcast("podcast-id-3", title = "Podcast Title 3", author = "Podcast Author 3", rawFolderUuid = "folder-id-2", isSubscribed = true))
+        podcastDao.insertSuspend(Podcast("podcast-id-3", title = "Podcast Title 3", author = "Podcast Author 3", isSubscribed = true))
         podcastDao.insertSuspend(Podcast("podcast-id-4", title = "Podcast Title 4", author = "Podcast Author 4", rawFolderUuid = "folder-id-1", isSubscribed = false))
         val baseFolder = Folder(
             uuid = "folder-id-0",
@@ -1318,9 +1318,9 @@ class PlaylistManagerTest {
                     title = "Folder Name 1",
                     podcastSources = listOf(
                         ManualPlaylistPodcastSource(
-                            uuid = "podcast-id-3",
-                            title = "Podcast Title 3",
-                            author = "Podcast Author 3",
+                            uuid = "podcast-id-2",
+                            title = "Podcast Title 2",
+                            author = "Podcast Author 2",
                         ),
                     ),
                 ),

--- a/modules/features/filters/src/test/kotlin/au/com/shiftyjelly/pocketcasts/playlists/create/FakePlaylistManager.kt
+++ b/modules/features/filters/src/test/kotlin/au/com/shiftyjelly/pocketcasts/playlists/create/FakePlaylistManager.kt
@@ -1,6 +1,7 @@
 package au.com.shiftyjelly.pocketcasts.playlists.create
 
 import app.cash.turbine.Turbine
+import au.com.shiftyjelly.pocketcasts.models.entity.ManualPlaylistEpisodeSource
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.models.to.PlaylistEpisodeMetadata
 import au.com.shiftyjelly.pocketcasts.models.type.PlaylistEpisodeSortType
@@ -56,4 +57,6 @@ class FakePlaylistManager : PlaylistManager {
     }
 
     override suspend fun updatePlaylistsOrder(sortedUuids: List<String>) = Unit
+
+    override suspend fun getManualPlaylistEpisodeSources(): List<ManualPlaylistEpisodeSource> = emptyList()
 }

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/entity/ManualPlaylistEpisodeSource.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/entity/ManualPlaylistEpisodeSource.kt
@@ -13,7 +13,7 @@ data class ManualPlaylistPodcastSource(
 data class ManualPlaylistFolderSource(
     val uuid: String,
     val title: String,
-    val podcastUuids: List<String>,
+    val podcastSources: List<ManualPlaylistPodcastSource>,
 ) : ManualPlaylistEpisodeSource
 
 internal data class ManualPlaylistPartialFolderSource(

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/entity/ManualPlaylistEpisodeSource.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/entity/ManualPlaylistEpisodeSource.kt
@@ -1,0 +1,22 @@
+package au.com.shiftyjelly.pocketcasts.models.entity
+
+import androidx.room.ColumnInfo
+
+sealed interface ManualPlaylistEpisodeSource
+
+data class ManualPlaylistPodcastSource(
+    @ColumnInfo(name = "uuid") val uuid: String,
+    @ColumnInfo(name = "title") val title: String,
+    @ColumnInfo(name = "author") val author: String,
+) : ManualPlaylistEpisodeSource
+
+data class ManualPlaylistFolderSource(
+    val uuid: String,
+    val title: String,
+    val podcastUuids: List<String>,
+) : ManualPlaylistEpisodeSource
+
+internal data class ManualPlaylistPartialFolderSource(
+    @ColumnInfo(name = "uuid") val uuid: String,
+    @ColumnInfo(name = "name") val title: String,
+)

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/type/Subscription.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/type/Subscription.kt
@@ -5,6 +5,7 @@ import au.com.shiftyjelly.pocketcasts.payment.SubscriptionTier
 import com.squareup.moshi.JsonClass
 import java.time.Instant
 import java.time.temporal.ChronoUnit
+import java.util.Date
 
 @JsonClass(generateAdapter = true)
 data class Subscription(
@@ -27,7 +28,7 @@ data class Subscription(
                 tier = SubscriptionTier.Plus,
                 billingCycle = BillingCycle.Monthly,
                 platform = SubscriptionPlatform.Android,
-                expiryDate = Instant.MAX,
+                expiryDate = Instant.EPOCH,
                 isAutoRenewing = true,
                 giftDays = 0,
             )
@@ -37,7 +38,7 @@ data class Subscription(
                 tier = SubscriptionTier.Patron,
                 billingCycle = BillingCycle.Monthly,
                 platform = SubscriptionPlatform.Android,
-                expiryDate = Instant.MAX,
+                expiryDate = Instant.EPOCH,
                 isAutoRenewing = true,
                 giftDays = 0,
             )

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playlist/PlaylistManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playlist/PlaylistManager.kt
@@ -1,5 +1,6 @@
 package au.com.shiftyjelly.pocketcasts.repositories.playlist
 
+import au.com.shiftyjelly.pocketcasts.models.entity.ManualPlaylistEpisodeSource
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.models.to.PlaylistEpisodeMetadata
 import au.com.shiftyjelly.pocketcasts.models.type.PlaylistEpisodeSortType
@@ -43,4 +44,6 @@ interface PlaylistManager {
     suspend fun createManualPlaylist(name: String): String
 
     suspend fun updatePlaylistsOrder(sortedUuids: List<String>)
+
+    suspend fun getManualPlaylistEpisodeSources(): List<ManualPlaylistEpisodeSource>
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playlist/PlaylistManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playlist/PlaylistManagerImpl.kt
@@ -2,6 +2,7 @@ package au.com.shiftyjelly.pocketcasts.repositories.playlist
 
 import androidx.room.withTransaction
 import au.com.shiftyjelly.pocketcasts.models.db.AppDatabase
+import au.com.shiftyjelly.pocketcasts.models.entity.ManualPlaylistEpisodeSource
 import au.com.shiftyjelly.pocketcasts.models.entity.PlaylistEntity
 import au.com.shiftyjelly.pocketcasts.models.entity.PlaylistEntity.Companion.ANYTIME
 import au.com.shiftyjelly.pocketcasts.models.entity.PlaylistEntity.Companion.AUDIO_VIDEO_FILTER_ALL
@@ -24,6 +25,7 @@ import au.com.shiftyjelly.pocketcasts.models.type.SmartRules.MediaTypeRule
 import au.com.shiftyjelly.pocketcasts.models.type.SmartRules.PodcastsRule
 import au.com.shiftyjelly.pocketcasts.models.type.SmartRules.ReleaseDateRule
 import au.com.shiftyjelly.pocketcasts.models.type.SmartRules.StarredRule
+import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import java.time.Clock
 import java.util.UUID
 import javax.inject.Inject
@@ -42,6 +44,7 @@ import kotlinx.coroutines.flow.flowOf
 @OptIn(ExperimentalCoroutinesApi::class, FlowPreview::class)
 class PlaylistManagerImpl @Inject constructor(
     private val appDatabase: AppDatabase,
+    private val settings: Settings,
     private val clock: Clock,
 ) : PlaylistManager {
     private val playlistDao = appDatabase.playlistDao()
@@ -216,6 +219,11 @@ class PlaylistManagerImpl @Inject constructor(
                 playlistDao.updateSortPosition(playlist.uuid, position)
             }
         }
+    }
+
+    override suspend fun getManualPlaylistEpisodeSources(): List<ManualPlaylistEpisodeSource> {
+        val isSubscriber = settings.cachedSubscription.value != null
+        return playlistDao.getManualPlaylistEpisodeSources(useFolders = isSubscriber)
     }
 
     private fun List<PlaylistEntity>.toPreviewFlows() = map { playlist ->


### PR DESCRIPTION
## Description

This PR adds support to fetch data for this flow: 5sC4z4Mu42LvL4MAAIbQVi-fi-764_7768 

Relates to PCDROID-109

## Testing Instructions

Code review my changes. There is nothing to test manually yet.

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.