### PR TITLE
Simplify folder artwork image

### DIFF
--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/folders/FolderEditColorPage.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/folders/FolderEditColorPage.kt
@@ -130,7 +130,7 @@ private fun FolderPreview(layout: PodcastGridLayoutType, name: String, colorId: 
                 name = name,
                 podcastUuids = podcastUuids,
                 onClick = null,
-                modifier = modifier.padding(vertical = 8.dp),
+                modifier = modifier.padding(vertical = 8.dp, horizontal = 16.dp),
             )
         }
         else -> {

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcasts/FolderListRow.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcasts/FolderListRow.kt
@@ -40,10 +40,9 @@ fun FolderListRow(
             .height(80.dp)
             .fillMaxWidth()
             .background(MaterialTheme.theme.colors.primaryUi01)
-            .padding(horizontal = 16.dp)
             .then(if (onClick == null) Modifier else Modifier.clickable { onClick() }),
     ) {
-        FolderImageSmall(color = color, podcastUuids = podcastUuids, folderImageSize = 64.dp)
+        FolderImageSmall(color = color, podcastUuids = podcastUuids, size = 64.dp)
         Column(
             modifier = Modifier
                 .padding(start = 16.dp)

--- a/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/component/SearchFolderItem.kt
+++ b/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/component/SearchFolderItem.kt
@@ -30,7 +30,6 @@ import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 private val FolderImageSize = 156.dp
-private val PodcastImageSize = 68.dp
 private val SubscribeIconSize = 32.dp
 
 @Composable
@@ -54,8 +53,7 @@ fun SearchFolderItem(
             FolderImageSmall(
                 color = color,
                 podcastUuids = podcasts.map { it.uuid },
-                folderImageSize = FolderImageSize,
-                podcastImageSize = PodcastImageSize,
+                size = FolderImageSize,
             )
 
             val buttonBackgroundColor = Color.Black.copy(alpha = 0.4f)

--- a/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/searchhistory/SearchHistoryPage.kt
+++ b/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/searchhistory/SearchHistoryPage.kt
@@ -262,8 +262,7 @@ fun SearchHistoryFolderView(
             FolderImageSmall(
                 color = color,
                 podcastUuids = entry.podcastIds,
-                folderImageSize = IconSize,
-                podcastImageSize = 20.dp,
+                size = IconSize,
             )
             Column(
                 modifier = Modifier

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/folder/FolderImageSmall.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/folder/FolderImageSmall.kt
@@ -1,135 +1,149 @@
 package au.com.shiftyjelly.pocketcasts.compose.folder
 
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material.Card
+import androidx.compose.material.MaterialTheme
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
-import au.com.shiftyjelly.pocketcasts.compose.components.PodcastImage
-
-private val gradientTop = Color(0x00000000)
-private val gradientBottom = Color(0xFF000000)
-private val topPodcastImageGradient = listOf(Color(0x00000000), Color(0x16000000))
-private val bottomPodcastImageGradient = listOf(Color(0x16000000), Color(0x33000000))
-
-private val FolderImageSize = 56.dp
-private val PodcastImageSize = 23.dp
+import au.com.shiftyjelly.pocketcasts.compose.theme
+import au.com.shiftyjelly.pocketcasts.repositories.images.PocketCastsImageRequestFactory
+import au.com.shiftyjelly.pocketcasts.ui.extensions.themed
+import coil.compose.rememberAsyncImagePainter
 
 @Composable
 fun FolderImageSmall(
     color: Color,
     podcastUuids: List<String>,
     modifier: Modifier = Modifier,
-    folderImageSize: Dp = FolderImageSize,
-    podcastImageSize: Dp = PodcastImageSize,
+    size: Dp = 56.dp,
+    elevation: Dp? = 2.dp,
 ) {
-    Card(
-        elevation = 2.dp,
-        shape = RoundedCornerShape(4.dp),
-        backgroundColor = color,
-        modifier = modifier.size(folderImageSize),
+    val shape = RoundedCornerShape(size / 14)
+    val estimatedPadding = size / 12f
+    val artworkSize = (size - estimatedPadding * 3) / 2
+    FlowRow(
+        verticalArrangement = Arrangement.SpaceEvenly,
+        horizontalArrangement = Arrangement.SpaceEvenly,
+        maxItemsInEachRow = 2,
+        modifier = modifier
+            .size(size)
+            .then(
+                if (elevation != null) {
+                    Modifier.shadow(elevation, shape)
+                } else {
+                    Modifier
+                },
+            )
+            .background(color, shape)
+            .background(BackgroundGradient),
     ) {
-        Box(
-            contentAlignment = Alignment.Center,
-        ) {
-            Box(
-                modifier = Modifier
-                    .alpha(0.2f)
-                    .background(
-                        brush = Brush.verticalGradient(
-                            colors = listOf(
-                                gradientTop,
-                                gradientBottom,
-                            ),
-                        ),
-                    )
-                    .size(folderImageSize),
-            ) {}
-            Row(horizontalArrangement = Arrangement.Center) {
-                val imagePadding = 2.dp
-                Column(horizontalAlignment = Alignment.End) {
-                    FolderPodcastImage(
-                        uuid = podcastUuids.getOrNull(0),
-                        color = color,
-                        gradientColor = topPodcastImageGradient,
-                        modifier = Modifier.size(podcastImageSize),
-                    )
-                    Spacer(modifier = Modifier.height(imagePadding))
-                    FolderPodcastImage(
-                        uuid = podcastUuids.getOrNull(2),
-                        color = color,
-                        gradientColor = bottomPodcastImageGradient,
-                        modifier = Modifier.size(podcastImageSize),
-                    )
-                }
-                Spacer(modifier = Modifier.width(imagePadding))
-                Column(horizontalAlignment = Alignment.Start) {
-                    FolderPodcastImage(
-                        uuid = podcastUuids.getOrNull(1),
-                        color = color,
-                        gradientColor = topPodcastImageGradient,
-                        modifier = Modifier.size(podcastImageSize),
-                    )
-                    Spacer(modifier = Modifier.height(imagePadding))
-                    FolderPodcastImage(
-                        uuid = podcastUuids.getOrNull(3),
-                        color = color,
-                        gradientColor = bottomPodcastImageGradient,
-                        modifier = Modifier.size(podcastImageSize),
-                    )
-                }
-            }
-        }
+        PodcastOrPlaceHolder(
+            podcastUuid = podcastUuids.getOrNull(0),
+            shape = shape,
+            placeholderBrush = TopPlaceholderGradient,
+            modifier = Modifier.size(artworkSize),
+        )
+        PodcastOrPlaceHolder(
+            podcastUuid = podcastUuids.getOrNull(1),
+            shape = shape,
+            placeholderBrush = TopPlaceholderGradient,
+            modifier = Modifier.size(artworkSize),
+        )
+        PodcastOrPlaceHolder(
+            podcastUuid = podcastUuids.getOrNull(2),
+            shape = shape,
+            placeholderBrush = BottomPlaceholderGradient,
+            modifier = Modifier.size(artworkSize),
+        )
+        PodcastOrPlaceHolder(
+            podcastUuid = podcastUuids.getOrNull(3),
+            shape = shape,
+            placeholderBrush = BottomPlaceholderGradient,
+            modifier = Modifier.size(artworkSize),
+        )
     }
 }
 
 @Composable
-private fun FolderPodcastImage(
-    uuid: String?,
-    color: Color,
-    gradientColor: List<Color>,
+private fun PodcastOrPlaceHolder(
+    podcastUuid: String?,
+    shape: Shape,
+    placeholderBrush: Brush,
     modifier: Modifier = Modifier,
 ) {
-    if (uuid == null) {
-        BoxWithConstraints(modifier) {
-            Card(
-                elevation = 1.dp,
-                shape = RoundedCornerShape(3.dp),
-                backgroundColor = color,
-                modifier = Modifier.fillMaxSize(),
-            ) {
-                Box(
-                    modifier = Modifier
-                        .size(maxWidth)
-                        .background(brush = Brush.verticalGradient(colors = gradientColor)),
-                ) {}
-                Box(
-                    modifier = Modifier
-                        .size(maxWidth)
-                        .background(color = Color(0x19000000)),
-                ) {}
-            }
+    if (podcastUuid != null) {
+        val context = LocalContext.current
+        val imageRequest = remember(podcastUuid) {
+            PocketCastsImageRequestFactory(context).themed().createForPodcast(podcastUuid)
         }
+        Image(
+            painter = rememberAsyncImagePainter(imageRequest, contentScale = ContentScale.Crop),
+            contentScale = ContentScale.Crop,
+            contentDescription = null,
+            modifier = modifier.clip(shape),
+        )
     } else {
-        PodcastImage(
-            uuid = uuid,
-            modifier = modifier,
+        Box(
+            modifier = modifier.background(placeholderBrush, shape),
+        )
+    }
+}
+
+private val BackgroundGradient = Brush.verticalGradient(colors = listOf(Color(0x00000000), Color(0x33000000)))
+private val TopPlaceholderGradient = Brush.verticalGradient(colors = listOf(Color(0x08000000), Color(0x16000000)))
+private val BottomPlaceholderGradient = Brush.verticalGradient(colors = listOf(Color(0x16000000), Color(0x32000000)))
+
+@Preview
+@Composable
+private fun FolderImageSmallPreview() {
+    Column(
+        verticalArrangement = Arrangement.spacedBy(16.dp),
+        modifier = Modifier
+            .background(Color.White)
+            .padding(16.dp),
+    ) {
+        FolderImageSmall(
+            color = MaterialTheme.theme.colors.getFolderColor(0),
+            podcastUuids = emptyList(),
+        )
+        FolderImageSmall(
+            color = MaterialTheme.theme.colors.getFolderColor(1),
+            podcastUuids = List(1) { "$it" },
+        )
+        FolderImageSmall(
+            color = MaterialTheme.theme.colors.getFolderColor(2),
+            podcastUuids = List(2) { "$it" },
+        )
+        FolderImageSmall(
+            color = MaterialTheme.theme.colors.getFolderColor(3),
+            podcastUuids = List(3) { "$it" },
+        )
+        FolderImageSmall(
+            color = MaterialTheme.theme.colors.getFolderColor(4),
+            podcastUuids = List(4) { "$it" },
+        )
+        FolderImageSmall(
+            color = MaterialTheme.theme.colors.getFolderColor(5),
+            podcastUuids = List(4) { "$it" },
+            size = 120.dp,
         )
     }
 }

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/folder/FolderImageSmall.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/folder/FolderImageSmall.kt
@@ -53,7 +53,7 @@ fun FolderImageSmall(
                 },
             )
             .background(color, shape)
-            .background(BackgroundGradient),
+            .background(BackgroundGradient, shape),
     ) {
         PodcastOrPlaceHolder(
             podcastUuid = podcastUuids.getOrNull(0),


### PR DESCRIPTION
## Description

Our `FolderImageSmall` could be used for image preview when adding episodes to a playlist but it is written inefficiently and doesn't fully match the specification. This PR fixes both of those problem.

Relates to PCDROID-109

## Testing Instructions

1. Have some folders.
2. Go to podcasts page.
3. Change layout setting from a grid to a list.
4. Folders should display.

## Screenshots or Screencast 

<img width="516" height="1588" alt="image" src="https://github.com/user-attachments/assets/7c4c3896-a302-4a8d-9d9d-d67929e53574" />

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack