### PR TITLE
Fix broken podcast image animation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
     *   Fix File Settings bottom content being obstructed by the Mini Player.
         ([#4414](https://github.com/Automattic/pocket-casts-android/pull/4414))
     *   Fix podcast image shadow animation.
-        ([#4414](https://github.com/Automattic/pocket-casts-android/pull/4414))
+        ([#4429](https://github.com/Automattic/pocket-casts-android/pull/4429))
 
 7.96
 -----

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 * Bug Fixes
     *   Fix File Settings bottom content being obstructed by the Mini Player.
         ([#4414](https://github.com/Automattic/pocket-casts-android/pull/4414))
+    *   Fix podcast image shadow animation.
+        ([#4414](https://github.com/Automattic/pocket-casts-android/pull/4414))
 
 7.96
 -----

--- a/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/compose/PodcastRow.kt
+++ b/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/compose/PodcastRow.kt
@@ -55,6 +55,7 @@ internal fun PodcastRow(
             horizontalArrangement = Arrangement.spacedBy(8.dp),
             modifier = Modifier.padding(contentPadding),
         ) {
+            @Suppress("DEPRECATION")
             PodcastImageDeprecated(
                 uuid = podcast.uuid,
                 cornerSize = 4.dp,

--- a/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/compose/PodcastRow.kt
+++ b/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/compose/PodcastRow.kt
@@ -28,7 +28,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.dp
 import au.com.shiftyjelly.pocketcasts.compose.AppThemeWithBackground
-import au.com.shiftyjelly.pocketcasts.compose.components.PodcastImage
+import au.com.shiftyjelly.pocketcasts.compose.components.PodcastImageDeprecated
 import au.com.shiftyjelly.pocketcasts.compose.components.TextP40
 import au.com.shiftyjelly.pocketcasts.compose.components.TextP50
 import au.com.shiftyjelly.pocketcasts.compose.preview.ThemePreviewParameterProvider
@@ -55,7 +55,7 @@ internal fun PodcastRow(
             horizontalArrangement = Arrangement.spacedBy(8.dp),
             modifier = Modifier.padding(contentPadding),
         ) {
-            PodcastImage(
+            PodcastImageDeprecated(
                 uuid = podcast.uuid,
                 cornerSize = 4.dp,
                 modifier = Modifier.size(56.dp),

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/ui/LongestEpisodeStory.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/ui/LongestEpisodeStory.kt
@@ -209,6 +209,7 @@ private fun PodcastCover(
     modifier: Modifier = Modifier,
 ) {
     if (!LocalInspectionMode.current) {
+        @Suppress("DEPRECATION")
         PodcastImageDeprecated(
             uuid = episode.podcastId,
             elevation = 0.dp,

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/ui/LongestEpisodeStory.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/ui/LongestEpisodeStory.kt
@@ -40,7 +40,7 @@ import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import au.com.shiftyjelly.pocketcasts.compose.Devices
-import au.com.shiftyjelly.pocketcasts.compose.components.PodcastImage
+import au.com.shiftyjelly.pocketcasts.compose.components.PodcastImageDeprecated
 import au.com.shiftyjelly.pocketcasts.compose.components.TextH10
 import au.com.shiftyjelly.pocketcasts.compose.components.TextP40
 import au.com.shiftyjelly.pocketcasts.endofyear.StoryCaptureController
@@ -209,7 +209,7 @@ private fun PodcastCover(
     modifier: Modifier = Modifier,
 ) {
     if (!LocalInspectionMode.current) {
-        PodcastImage(
+        PodcastImageDeprecated(
             uuid = episode.podcastId,
             elevation = 0.dp,
             cornerSize = 8.dp,

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/ui/NumberOfShowsStory.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/ui/NumberOfShowsStory.kt
@@ -26,7 +26,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import au.com.shiftyjelly.pocketcasts.compose.Devices
 import au.com.shiftyjelly.pocketcasts.compose.components.HorizontalDirection
-import au.com.shiftyjelly.pocketcasts.compose.components.PodcastImage
+import au.com.shiftyjelly.pocketcasts.compose.components.PodcastImageDeprecated
 import au.com.shiftyjelly.pocketcasts.compose.components.ScrollSpeed
 import au.com.shiftyjelly.pocketcasts.compose.components.ScrollingRow
 import au.com.shiftyjelly.pocketcasts.compose.components.TextH10
@@ -140,7 +140,7 @@ private fun PodcastCoverCarousel(
         horizontalArrangement = Arrangement.spacedBy(spacingSize),
         modifier = modifier,
     ) { podcastId ->
-        PodcastImage(
+        PodcastImageDeprecated(
             uuid = podcastId,
             elevation = coverElevation,
             cornerSize = 4.dp,

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/ui/NumberOfShowsStory.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/ui/NumberOfShowsStory.kt
@@ -140,6 +140,7 @@ private fun PodcastCoverCarousel(
         horizontalArrangement = Arrangement.spacedBy(spacingSize),
         modifier = modifier,
     ) { podcastId ->
+        @Suppress("DEPRECATION")
         PodcastImageDeprecated(
             uuid = podcastId,
             elevation = coverElevation,

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/ui/TopShowStory.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/ui/TopShowStory.kt
@@ -105,6 +105,7 @@ private fun ColumnScope.TopShowCover(
             .weight(1f)
             .background(story.backgroundColor),
     ) {
+        @Suppress("DEPRECATION")
         PodcastImageDeprecated(
             uuid = story.show.uuid,
             elevation = 0.dp,

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/ui/TopShowStory.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/ui/TopShowStory.kt
@@ -40,7 +40,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import au.com.shiftyjelly.pocketcasts.compose.Devices
-import au.com.shiftyjelly.pocketcasts.compose.components.PodcastImage
+import au.com.shiftyjelly.pocketcasts.compose.components.PodcastImageDeprecated
 import au.com.shiftyjelly.pocketcasts.compose.components.TextH10
 import au.com.shiftyjelly.pocketcasts.compose.components.TextP40
 import au.com.shiftyjelly.pocketcasts.endofyear.StoryCaptureController
@@ -105,7 +105,7 @@ private fun ColumnScope.TopShowCover(
             .weight(1f)
             .background(story.backgroundColor),
     ) {
-        PodcastImage(
+        PodcastImageDeprecated(
             uuid = story.show.uuid,
             elevation = 0.dp,
             roundCorners = false,

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/ui/TopShowsStory.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/ui/TopShowsStory.kt
@@ -191,6 +191,7 @@ private fun PodcastItem(
                 painter = painterResource(stickers[index % stickers.size]),
                 contentDescription = null,
             )
+            @Suppress("DEPRECATION")
             PodcastImageDeprecated(
                 uuid = podcast.uuid,
                 elevation = 0.dp,

--- a/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/ui/TopShowsStory.kt
+++ b/modules/features/endofyear/src/main/java/au/com/shiftyjelly/pocketcasts/endofyear/ui/TopShowsStory.kt
@@ -42,7 +42,7 @@ import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import au.com.shiftyjelly.pocketcasts.compose.Devices
-import au.com.shiftyjelly.pocketcasts.compose.components.PodcastImage
+import au.com.shiftyjelly.pocketcasts.compose.components.PodcastImageDeprecated
 import au.com.shiftyjelly.pocketcasts.compose.components.TextH10
 import au.com.shiftyjelly.pocketcasts.compose.components.TextH20
 import au.com.shiftyjelly.pocketcasts.compose.components.TextP40
@@ -191,7 +191,7 @@ private fun PodcastItem(
                 painter = painterResource(stickers[index % stickers.size]),
                 contentDescription = null,
             )
-            PodcastImage(
+            PodcastImageDeprecated(
                 uuid = podcast.uuid,
                 elevation = 0.dp,
                 cornerSize = 4.dp,

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/smart/rules/PodcastsRulePage.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/smart/rules/PodcastsRulePage.kt
@@ -239,6 +239,7 @@ private fun PodcastRow(
             )
             .padding(horizontal = 16.dp, vertical = 12.dp),
     ) {
+        @Suppress("DEPRECATION")
         PodcastImageDeprecated(
             uuid = uuid,
             cornerSize = 4.dp,

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/smart/rules/PodcastsRulePage.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/smart/rules/PodcastsRulePage.kt
@@ -41,7 +41,7 @@ import androidx.compose.ui.unit.sp
 import au.com.shiftyjelly.pocketcasts.compose.AppThemeWithBackground
 import au.com.shiftyjelly.pocketcasts.compose.PreviewRegularDevice
 import au.com.shiftyjelly.pocketcasts.compose.components.FadedLazyColumn
-import au.com.shiftyjelly.pocketcasts.compose.components.PodcastImage
+import au.com.shiftyjelly.pocketcasts.compose.components.PodcastImageDeprecated
 import au.com.shiftyjelly.pocketcasts.compose.components.TextH30
 import au.com.shiftyjelly.pocketcasts.compose.components.TextH40
 import au.com.shiftyjelly.pocketcasts.compose.components.TextH60
@@ -239,7 +239,7 @@ private fun PodcastRow(
             )
             .padding(horizontal = 16.dp, vertical = 12.dp),
     ) {
-        PodcastImage(
+        PodcastImageDeprecated(
             uuid = uuid,
             cornerSize = 4.dp,
             elevation = 2.dp,

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/folders/FolderEditPodcastsPage.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/folders/FolderEditPodcastsPage.kt
@@ -36,7 +36,7 @@ import au.com.shiftyjelly.pocketcasts.compose.bars.BottomSheetAppBar
 import au.com.shiftyjelly.pocketcasts.compose.bars.NavigationButton
 import au.com.shiftyjelly.pocketcasts.compose.buttons.RowButton
 import au.com.shiftyjelly.pocketcasts.compose.components.HorizontalDivider
-import au.com.shiftyjelly.pocketcasts.compose.components.PodcastImage
+import au.com.shiftyjelly.pocketcasts.compose.components.PodcastImageDeprecated
 import au.com.shiftyjelly.pocketcasts.compose.components.PodcastSelectedText
 import au.com.shiftyjelly.pocketcasts.compose.components.SearchBar
 import au.com.shiftyjelly.pocketcasts.compose.components.TextP40
@@ -192,7 +192,7 @@ private fun PodcastSelectRow(
         Box(
             modifier = Modifier.padding(start = 16.dp, end = 8.dp, top = 8.dp, bottom = 8.dp),
         ) {
-            PodcastImage(
+            PodcastImageDeprecated(
                 uuid = podcast.uuid,
                 modifier = Modifier.size(56.dp),
             )

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/folders/FolderEditPodcastsPage.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/folders/FolderEditPodcastsPage.kt
@@ -192,6 +192,7 @@ private fun PodcastSelectRow(
         Box(
             modifier = Modifier.padding(start = 16.dp, end = 8.dp, top = 8.dp, bottom = 8.dp),
         ) {
+            @Suppress("DEPRECATION")
             PodcastImageDeprecated(
                 uuid = podcast.uuid,
                 modifier = Modifier.size(56.dp),

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/folders/SuggestedFolderPodcastsPage.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/folders/SuggestedFolderPodcastsPage.kt
@@ -27,7 +27,7 @@ import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.dp
 import au.com.shiftyjelly.pocketcasts.compose.AppThemeWithBackground
 import au.com.shiftyjelly.pocketcasts.compose.Devices
-import au.com.shiftyjelly.pocketcasts.compose.components.PodcastImage
+import au.com.shiftyjelly.pocketcasts.compose.components.PodcastImageDeprecated
 import au.com.shiftyjelly.pocketcasts.compose.components.TextH30
 import au.com.shiftyjelly.pocketcasts.compose.components.TextP40
 import au.com.shiftyjelly.pocketcasts.compose.preview.ThemePreviewParameterProvider
@@ -91,7 +91,7 @@ fun SuggestedFolderPodcastsPage(
                     .padding(horizontal = 16.dp),
             ) {
                 items(folder.podcastIds) { podcastId ->
-                    PodcastImage(podcastId)
+                    PodcastImageDeprecated(podcastId)
                 }
             }
         } else {

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/folders/SuggestedFolderPodcastsPage.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/folders/SuggestedFolderPodcastsPage.kt
@@ -91,6 +91,7 @@ fun SuggestedFolderPodcastsPage(
                     .padding(horizontal = 16.dp),
             ) {
                 items(folder.podcastIds) { podcastId ->
+                    @Suppress("DEPRECATION")
                     PodcastImageDeprecated(podcastId)
                 }
             }

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastHeader.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastHeader.kt
@@ -99,6 +99,7 @@ import androidx.compose.ui.unit.sp
 import au.com.shiftyjelly.pocketcasts.compose.AppThemeWithBackground
 import au.com.shiftyjelly.pocketcasts.compose.Devices
 import au.com.shiftyjelly.pocketcasts.compose.components.ExpandableText
+import au.com.shiftyjelly.pocketcasts.compose.components.PodcastImage
 import au.com.shiftyjelly.pocketcasts.compose.components.PodcastImageDeprecated
 import au.com.shiftyjelly.pocketcasts.compose.components.TextH20
 import au.com.shiftyjelly.pocketcasts.compose.components.TextH40
@@ -174,13 +175,11 @@ internal fun PodcastHeader(
                 .fillMaxWidth()
                 .padding(contentPadding),
         ) {
-            @Suppress("DEPRECATION")
-            PodcastImageDeprecated(
+            PodcastImage(
                 uuid = uuid,
-                cornerSize = 8.dp,
+                imageSize = coverSize,
                 elevation = 16.dp,
                 modifier = Modifier
-                    .size(coverSize)
                     .combinedClickable(
                         indication = null,
                         interactionSource = null,

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastHeader.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastHeader.kt
@@ -174,6 +174,7 @@ internal fun PodcastHeader(
                 .fillMaxWidth()
                 .padding(contentPadding),
         ) {
+            @Suppress("DEPRECATION")
             PodcastImageDeprecated(
                 uuid = uuid,
                 cornerSize = 8.dp,

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastHeader.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcast/PodcastHeader.kt
@@ -99,7 +99,7 @@ import androidx.compose.ui.unit.sp
 import au.com.shiftyjelly.pocketcasts.compose.AppThemeWithBackground
 import au.com.shiftyjelly.pocketcasts.compose.Devices
 import au.com.shiftyjelly.pocketcasts.compose.components.ExpandableText
-import au.com.shiftyjelly.pocketcasts.compose.components.PodcastImage
+import au.com.shiftyjelly.pocketcasts.compose.components.PodcastImageDeprecated
 import au.com.shiftyjelly.pocketcasts.compose.components.TextH20
 import au.com.shiftyjelly.pocketcasts.compose.components.TextH40
 import au.com.shiftyjelly.pocketcasts.compose.components.TextP60
@@ -174,7 +174,7 @@ internal fun PodcastHeader(
                 .fillMaxWidth()
                 .padding(contentPadding),
         ) {
-            PodcastImage(
+            PodcastImageDeprecated(
                 uuid = uuid,
                 cornerSize = 8.dp,
                 elevation = 16.dp,

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/share/ShareListCreateBuildingPage.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/share/ShareListCreateBuildingPage.kt
@@ -96,6 +96,7 @@ private fun CreateBuildingContent(
 
 @Composable
 private fun SharePodcastImage(podcast: Podcast, modifier: Modifier = Modifier) {
+    @Suppress("DEPRECATION")
     PodcastImageDeprecated(uuid = podcast.uuid, modifier = modifier.size(100.dp))
 }
 

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/share/ShareListCreateBuildingPage.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/share/ShareListCreateBuildingPage.kt
@@ -27,7 +27,7 @@ import androidx.compose.ui.unit.dp
 import au.com.shiftyjelly.pocketcasts.compose.AppThemeWithBackground
 import au.com.shiftyjelly.pocketcasts.compose.bars.NavigationButton
 import au.com.shiftyjelly.pocketcasts.compose.bars.ThemedTopAppBar
-import au.com.shiftyjelly.pocketcasts.compose.components.PodcastImage
+import au.com.shiftyjelly.pocketcasts.compose.components.PodcastImageDeprecated
 import au.com.shiftyjelly.pocketcasts.compose.components.TextH30
 import au.com.shiftyjelly.pocketcasts.compose.preview.ThemePreviewParameterProvider
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
@@ -96,7 +96,7 @@ private fun CreateBuildingContent(
 
 @Composable
 private fun SharePodcastImage(podcast: Podcast, modifier: Modifier = Modifier) {
-    PodcastImage(uuid = podcast.uuid, modifier = modifier.size(100.dp))
+    PodcastImageDeprecated(uuid = podcast.uuid, modifier = modifier.size(100.dp))
 }
 
 @Preview(showBackground = true)

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/share/ShareListCreateTitlePage.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/share/ShareListCreateTitlePage.kt
@@ -124,6 +124,7 @@ private fun ShareListCreateTitleContent(
                 }
             }
             items(items = podcasts) { podcast ->
+                @Suppress("DEPRECATION")
                 PodcastImageDeprecated(
                     uuid = podcast.uuid,
                     title = podcast.title,

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/share/ShareListCreateTitlePage.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/share/ShareListCreateTitlePage.kt
@@ -33,7 +33,7 @@ import au.com.shiftyjelly.pocketcasts.compose.bars.NavigationButton
 import au.com.shiftyjelly.pocketcasts.compose.bars.ThemedTopAppBar
 import au.com.shiftyjelly.pocketcasts.compose.components.FormField
 import au.com.shiftyjelly.pocketcasts.compose.components.FormFieldDefaults
-import au.com.shiftyjelly.pocketcasts.compose.components.PodcastImage
+import au.com.shiftyjelly.pocketcasts.compose.components.PodcastImageDeprecated
 import au.com.shiftyjelly.pocketcasts.compose.extensions.header
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
@@ -124,7 +124,7 @@ private fun ShareListCreateTitleContent(
                 }
             }
             items(items = podcasts) { podcast ->
-                PodcastImage(
+                PodcastImageDeprecated(
                     uuid = podcast.uuid,
                     title = podcast.title,
                     showTitle = true,

--- a/modules/features/reimagine/src/main/kotlin/au/com/shiftyjelly/pocketcasts/reimagine/ui/CardData.kt
+++ b/modules/features/reimagine/src/main/kotlin/au/com/shiftyjelly/pocketcasts/reimagine/ui/CardData.kt
@@ -45,6 +45,7 @@ internal data class PodcastCardData(
     ).joinToString(" · ")
 
     @Composable
+    @Suppress("DEPRECATION")
     override fun Image(modifier: Modifier) = PodcastImageDeprecated(
         uuid = podcast.uuid,
         title = stringResource(LR.string.podcast_cover_description, podcast.title),

--- a/modules/features/reimagine/src/main/kotlin/au/com/shiftyjelly/pocketcasts/reimagine/ui/CardData.kt
+++ b/modules/features/reimagine/src/main/kotlin/au/com/shiftyjelly/pocketcasts/reimagine/ui/CardData.kt
@@ -7,7 +7,7 @@ import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
 import au.com.shiftyjelly.pocketcasts.compose.components.EpisodeImage
-import au.com.shiftyjelly.pocketcasts.compose.components.PodcastImage
+import au.com.shiftyjelly.pocketcasts.compose.components.PodcastImageDeprecated
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.repositories.images.PocketCastsImageRequestFactory.PlaceholderType
@@ -45,7 +45,7 @@ internal data class PodcastCardData(
     ).joinToString(" · ")
 
     @Composable
-    override fun Image(modifier: Modifier) = PodcastImage(
+    override fun Image(modifier: Modifier) = PodcastImageDeprecated(
         uuid = podcast.uuid,
         title = stringResource(LR.string.podcast_cover_description, podcast.title),
         placeholderType = if (LocalInspectionMode.current) PlaceholderType.Large else PlaceholderType.None,

--- a/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/component/SearchEpisodeRow.kt
+++ b/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/component/SearchEpisodeRow.kt
@@ -13,7 +13,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 import au.com.shiftyjelly.pocketcasts.compose.components.HorizontalDivider
-import au.com.shiftyjelly.pocketcasts.compose.components.PodcastImage
+import au.com.shiftyjelly.pocketcasts.compose.components.PodcastImageDeprecated
 import au.com.shiftyjelly.pocketcasts.compose.components.TextC50
 import au.com.shiftyjelly.pocketcasts.compose.components.TextH40
 import au.com.shiftyjelly.pocketcasts.compose.components.TextH60
@@ -43,7 +43,7 @@ fun SearchEpisodeItem(
                 .clickable { onClick(episode) }
                 .padding(16.dp),
         ) {
-            PodcastImage(
+            PodcastImageDeprecated(
                 uuid = episode.podcastUuid,
                 modifier = Modifier.size(IconSize),
             )

--- a/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/component/SearchEpisodeRow.kt
+++ b/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/component/SearchEpisodeRow.kt
@@ -43,6 +43,7 @@ fun SearchEpisodeItem(
                 .clickable { onClick(episode) }
                 .padding(16.dp),
         ) {
+            @Suppress("DEPRECATION")
             PodcastImageDeprecated(
                 uuid = episode.podcastUuid,
                 modifier = Modifier.size(IconSize),

--- a/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/searchhistory/SearchHistoryPage.kt
+++ b/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/searchhistory/SearchHistoryPage.kt
@@ -211,6 +211,7 @@ fun SearchHistoryEpisodeView(
                 .fillMaxWidth()
                 .padding(start = 16.dp, top = 12.dp, bottom = 12.dp),
         ) {
+            @Suppress("DEPRECATION")
             PodcastImageDeprecated(
                 uuid = entry.podcastUuid,
                 modifier = Modifier.size(IconSize),
@@ -308,6 +309,7 @@ fun SearchHistoryPodcastView(
                 .fillMaxWidth()
                 .padding(start = 16.dp, top = 12.dp, bottom = 12.dp),
         ) {
+            @Suppress("DEPRECATION")
             PodcastImageDeprecated(
                 uuid = entry.uuid,
                 modifier = Modifier

--- a/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/searchhistory/SearchHistoryPage.kt
+++ b/modules/features/search/src/main/java/au/com/shiftyjelly/pocketcasts/search/searchhistory/SearchHistoryPage.kt
@@ -33,7 +33,7 @@ import androidx.compose.ui.unit.dp
 import au.com.shiftyjelly.pocketcasts.compose.AppTheme
 import au.com.shiftyjelly.pocketcasts.compose.bars.NavigationButton
 import au.com.shiftyjelly.pocketcasts.compose.components.HorizontalDivider
-import au.com.shiftyjelly.pocketcasts.compose.components.PodcastImage
+import au.com.shiftyjelly.pocketcasts.compose.components.PodcastImageDeprecated
 import au.com.shiftyjelly.pocketcasts.compose.components.TextH20
 import au.com.shiftyjelly.pocketcasts.compose.components.TextH40
 import au.com.shiftyjelly.pocketcasts.compose.components.TextH50
@@ -211,7 +211,7 @@ fun SearchHistoryEpisodeView(
                 .fillMaxWidth()
                 .padding(start = 16.dp, top = 12.dp, bottom = 12.dp),
         ) {
-            PodcastImage(
+            PodcastImageDeprecated(
                 uuid = entry.podcastUuid,
                 modifier = Modifier.size(IconSize),
             )
@@ -308,7 +308,7 @@ fun SearchHistoryPodcastView(
                 .fillMaxWidth()
                 .padding(start = 16.dp, top = 12.dp, bottom = 12.dp),
         ) {
-            PodcastImage(
+            PodcastImageDeprecated(
                 uuid = entry.uuid,
                 modifier = Modifier
                     .size(IconSize),

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/PodcastCover.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/PodcastCover.kt
@@ -24,7 +24,7 @@ fun PodcastCover(
     cornerRadius: Dp? = null,
 ) {
     val cornerRadiusSize = cornerRadius ?: if (coverSize == CoverSize.SMALL) 4.dp else 8.dp
-    PodcastImage(
+    PodcastImageDeprecated(
         uuid = uuid,
         elevation = if (coverSize == CoverSize.SMALL) 4.dp else 8.dp,
         cornerSize = cornerRadiusSize,

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/PodcastCover.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/PodcastCover.kt
@@ -24,6 +24,7 @@ fun PodcastCover(
     cornerRadius: Dp? = null,
 ) {
     val cornerRadiusSize = cornerRadius ?: if (coverSize == CoverSize.SMALL) 4.dp else 8.dp
+    @Suppress("DEPRECATION")
     PodcastImageDeprecated(
         uuid = uuid,
         elevation = if (coverSize == CoverSize.SMALL) 4.dp else 8.dp,

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/PodcastImage.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/PodcastImage.kt
@@ -1,15 +1,22 @@
 package au.com.shiftyjelly.pocketcasts.compose.components
 
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Card
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.RectangleShape
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.role
@@ -19,6 +26,7 @@ import androidx.compose.ui.unit.dp
 import au.com.shiftyjelly.pocketcasts.repositories.images.PocketCastsImageRequestFactory
 import au.com.shiftyjelly.pocketcasts.repositories.images.PocketCastsImageRequestFactory.PlaceholderType
 import au.com.shiftyjelly.pocketcasts.ui.extensions.themed
+import coil.compose.rememberAsyncImagePainter
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 fun podcastImageCornerSize(width: Dp): Dp {
@@ -29,7 +37,47 @@ fun podcastImageCornerSize(width: Dp): Dp {
     }
 }
 
-@Deprecated(message = "Don't use this component in new UI")
+@Composable
+fun PodcastImage(
+    uuid: String,
+    modifier: Modifier = Modifier,
+    imageSize: Dp = 56.dp,
+    cornerSize: Dp? = imageSize / 14,
+    elevation: Dp? = 2.dp,
+    placeholderType: PlaceholderType = if (imageSize > 200.dp) {
+        PlaceholderType.Large
+    } else {
+        PlaceholderType.Small
+    },
+) {
+    val context = LocalContext.current
+    val imageRequest = remember(uuid, placeholderType) {
+        PocketCastsImageRequestFactory(context, placeholderType = placeholderType).themed().createForPodcast(uuid)
+    }
+    val shape = if (cornerSize != null) {
+        RoundedCornerShape(cornerSize)
+    } else {
+        RectangleShape
+    }
+    Image(
+        painter = rememberAsyncImagePainter(imageRequest, contentScale = ContentScale.Crop),
+        contentScale = ContentScale.Crop,
+        alignment = Alignment.BottomCenter,
+        contentDescription = stringResource(LR.string.podcast_artwork_description),
+        modifier = modifier
+            .size(imageSize)
+            .then(
+                if (elevation != null) {
+                    Modifier.shadow(elevation, shape)
+                } else {
+                    Modifier
+                },
+            )
+            .clip(shape),
+    )
+}
+
+@Deprecated(message = "This component is fundamentally broken. Please use PodcastImage in new UI instead.")
 @Composable
 fun PodcastImageDeprecated(
     uuid: String,

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/PodcastImage.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/PodcastImage.kt
@@ -29,6 +29,7 @@ fun podcastImageCornerSize(width: Dp): Dp {
     }
 }
 
+@Deprecated(message = "Don't use this component in new UI")
 @Composable
 fun PodcastImageDeprecated(
     uuid: String,

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/PodcastImage.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/PodcastImage.kt
@@ -8,7 +8,6 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Card
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.shadow
@@ -62,7 +61,6 @@ fun PodcastImage(
     Image(
         painter = rememberAsyncImagePainter(imageRequest, contentScale = ContentScale.Crop),
         contentScale = ContentScale.Crop,
-        alignment = Alignment.BottomCenter,
         contentDescription = stringResource(LR.string.podcast_artwork_description),
         modifier = modifier
             .size(imageSize)

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/PodcastImage.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/PodcastImage.kt
@@ -30,7 +30,7 @@ fun podcastImageCornerSize(width: Dp): Dp {
 }
 
 @Composable
-fun PodcastImage(
+fun PodcastImageDeprecated(
     uuid: String,
     modifier: Modifier = Modifier,
     title: String = "", // also used as the image's content description

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/PodcastItem.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/PodcastItem.kt
@@ -45,7 +45,7 @@ fun PodcastItem(
                 .then(if (onClick == null) Modifier else Modifier.clickable { onClick() })
                 .padding(horizontal = 16.dp, vertical = 8.dp),
         ) {
-            PodcastImage(
+            PodcastImageDeprecated(
                 uuid = podcast.uuid,
                 modifier = Modifier.size(iconSize),
             )

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/PodcastItem.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/PodcastItem.kt
@@ -45,6 +45,7 @@ fun PodcastItem(
                 .then(if (onClick == null) Modifier else Modifier.clickable { onClick() })
                 .padding(horizontal = 16.dp, vertical = 8.dp),
         ) {
+            @Suppress("DEPRECATION")
             PodcastImageDeprecated(
                 uuid = podcast.uuid,
                 modifier = Modifier.size(iconSize),

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/folder/FolderImage.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/folder/FolderImage.kt
@@ -35,7 +35,7 @@ import androidx.compose.ui.unit.TextUnit
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import au.com.shiftyjelly.pocketcasts.compose.AppThemeWithBackground
-import au.com.shiftyjelly.pocketcasts.compose.components.PodcastImage
+import au.com.shiftyjelly.pocketcasts.compose.components.PodcastImageDeprecated
 import au.com.shiftyjelly.pocketcasts.compose.extensions.nonScaledSp
 import au.com.shiftyjelly.pocketcasts.compose.images.CountBadge
 import au.com.shiftyjelly.pocketcasts.compose.images.CountBadgeStyle
@@ -204,7 +204,7 @@ private fun FolderPodcastImage(
             }
         }
     } else {
-        PodcastImage(
+        PodcastImageDeprecated(
             uuid = uuid,
             modifier = modifier,
         )

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/folder/FolderImage.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/folder/FolderImage.kt
@@ -204,6 +204,7 @@ private fun FolderPodcastImage(
             }
         }
     } else {
+        @Suppress("DEPRECATION")
         PodcastImageDeprecated(
             uuid = uuid,
             modifier = modifier,

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/folder/FolderImageSmall.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/folder/FolderImageSmall.kt
@@ -1,6 +1,5 @@
 package au.com.shiftyjelly.pocketcasts.compose.folder
 
-import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -11,22 +10,15 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.MaterialTheme
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.Shape
-import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import au.com.shiftyjelly.pocketcasts.compose.components.PodcastImage
 import au.com.shiftyjelly.pocketcasts.compose.theme
-import au.com.shiftyjelly.pocketcasts.repositories.images.PocketCastsImageRequestFactory
-import au.com.shiftyjelly.pocketcasts.ui.extensions.themed
-import coil.compose.rememberAsyncImagePainter
 
 @Composable
 fun FolderImageSmall(
@@ -36,7 +28,8 @@ fun FolderImageSmall(
     size: Dp = 56.dp,
     elevation: Dp? = 2.dp,
 ) {
-    val shape = RoundedCornerShape(size / 14)
+    val cornerSize = size / 14
+    val shape = RoundedCornerShape(cornerSize)
     val estimatedPadding = size / 12f
     val artworkSize = (size - estimatedPadding * 3) / 2
     FlowRow(
@@ -57,27 +50,27 @@ fun FolderImageSmall(
     ) {
         PodcastOrPlaceHolder(
             podcastUuid = podcastUuids.getOrNull(0),
-            shape = shape,
+            size = artworkSize,
+            cornerSize = cornerSize,
             placeholderBrush = TopPlaceholderGradient,
-            modifier = Modifier.size(artworkSize),
         )
         PodcastOrPlaceHolder(
             podcastUuid = podcastUuids.getOrNull(1),
-            shape = shape,
+            size = artworkSize,
+            cornerSize = cornerSize,
             placeholderBrush = TopPlaceholderGradient,
-            modifier = Modifier.size(artworkSize),
         )
         PodcastOrPlaceHolder(
             podcastUuid = podcastUuids.getOrNull(2),
-            shape = shape,
+            size = artworkSize,
+            cornerSize = cornerSize,
             placeholderBrush = BottomPlaceholderGradient,
-            modifier = Modifier.size(artworkSize),
         )
         PodcastOrPlaceHolder(
             podcastUuid = podcastUuids.getOrNull(3),
-            shape = shape,
+            size = artworkSize,
+            cornerSize = cornerSize,
             placeholderBrush = BottomPlaceholderGradient,
-            modifier = Modifier.size(artworkSize),
         )
     }
 }
@@ -85,24 +78,22 @@ fun FolderImageSmall(
 @Composable
 private fun PodcastOrPlaceHolder(
     podcastUuid: String?,
-    shape: Shape,
+    size: Dp,
+    cornerSize: Dp,
     placeholderBrush: Brush,
-    modifier: Modifier = Modifier,
 ) {
     if (podcastUuid != null) {
-        val context = LocalContext.current
-        val imageRequest = remember(podcastUuid) {
-            PocketCastsImageRequestFactory(context).themed().createForPodcast(podcastUuid)
-        }
-        Image(
-            painter = rememberAsyncImagePainter(imageRequest, contentScale = ContentScale.Crop),
-            contentScale = ContentScale.Crop,
-            contentDescription = null,
-            modifier = modifier.clip(shape),
+        PodcastImage(
+            uuid = podcastUuid,
+            imageSize = size,
+            cornerSize = cornerSize,
+            elevation = null,
         )
     } else {
         Box(
-            modifier = modifier.background(placeholderBrush, shape),
+            modifier = Modifier
+                .size(size)
+                .background(placeholderBrush, RoundedCornerShape(cornerSize)),
         )
     }
 }

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/podcast/ListPodcastSubscribeRow.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/podcast/ListPodcastSubscribeRow.kt
@@ -43,6 +43,7 @@ fun ListPodcastSubscribeRow(
         verticalAlignment = Alignment.CenterVertically,
         modifier = modifier.clickable { onRowClick() },
     ) {
+        @Suppress("DEPRECATION")
         PodcastImageDeprecated(
             uuid = uuid,
             modifier = Modifier

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/podcast/ListPodcastSubscribeRow.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/podcast/ListPodcastSubscribeRow.kt
@@ -20,7 +20,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.dp
 import au.com.shiftyjelly.pocketcasts.compose.AppThemeWithBackground
-import au.com.shiftyjelly.pocketcasts.compose.components.PodcastImage
+import au.com.shiftyjelly.pocketcasts.compose.components.PodcastImageDeprecated
 import au.com.shiftyjelly.pocketcasts.compose.components.TextP40
 import au.com.shiftyjelly.pocketcasts.compose.components.TextP50
 import au.com.shiftyjelly.pocketcasts.compose.preview.ThemePreviewParameterProvider
@@ -43,7 +43,7 @@ fun ListPodcastSubscribeRow(
         verticalAlignment = Alignment.CenterVertically,
         modifier = modifier.clickable { onRowClick() },
     ) {
-        PodcastImage(
+        PodcastImageDeprecated(
             uuid = uuid,
             modifier = Modifier
                 .padding(horizontal = 16.dp, vertical = 8.dp)

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/podcast/PodcastSelectImage.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/podcast/PodcastSelectImage.kt
@@ -28,7 +28,7 @@ import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import au.com.shiftyjelly.pocketcasts.compose.AppTheme
-import au.com.shiftyjelly.pocketcasts.compose.components.PodcastImage
+import au.com.shiftyjelly.pocketcasts.compose.components.PodcastImageDeprecated
 import au.com.shiftyjelly.pocketcasts.compose.components.podcastImageCornerSize
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
@@ -52,7 +52,7 @@ fun PodcastSelectImage(
             .semantics(mergeDescendants = true) {},
         contentAlignment = Alignment.Center,
     ) {
-        PodcastImage(
+        PodcastImageDeprecated(
             uuid = podcast.uuid,
             title = podcast.title,
             showTitle = true,

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/podcast/PodcastSelectImage.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/podcast/PodcastSelectImage.kt
@@ -52,6 +52,7 @@ fun PodcastSelectImage(
             .semantics(mergeDescendants = true) {},
         contentAlignment = Alignment.Center,
     ) {
+        @Suppress("DEPRECATION")
         PodcastImageDeprecated(
             uuid = podcast.uuid,
             title = podcast.title,

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/podcast/PodcastSubscribeImage.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/podcast/PodcastSubscribeImage.kt
@@ -24,7 +24,7 @@ import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import au.com.shiftyjelly.pocketcasts.compose.AppThemeWithBackground
-import au.com.shiftyjelly.pocketcasts.compose.components.PodcastImage
+import au.com.shiftyjelly.pocketcasts.compose.components.PodcastImageDeprecated
 import au.com.shiftyjelly.pocketcasts.compose.preview.ThemePreviewParameterProvider
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import au.com.shiftyjelly.pocketcasts.images.R as IR
@@ -64,7 +64,7 @@ fun PodcastSubscribeImage(
         modifier = rootModifier,
         contentAlignment = Alignment.Center,
     ) {
-        PodcastImage(
+        PodcastImageDeprecated(
             uuid = podcastUuid,
             title = podcastTitle,
             showTitle = true,

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/podcast/PodcastSubscribeImage.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/podcast/PodcastSubscribeImage.kt
@@ -64,6 +64,7 @@ fun PodcastSubscribeImage(
         modifier = rootModifier,
         contentAlignment = Alignment.Center,
     ) {
+        @Suppress("DEPRECATION")
         PodcastImageDeprecated(
             uuid = podcastUuid,
             title = podcastTitle,

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/podcast/PodcastScreen.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/podcast/PodcastScreen.kt
@@ -23,7 +23,7 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.wear.compose.foundation.lazy.items
 import androidx.wear.compose.material.MaterialTheme
 import androidx.wear.compose.material.Text
-import au.com.shiftyjelly.pocketcasts.compose.components.PodcastImage
+import au.com.shiftyjelly.pocketcasts.compose.components.PodcastImageDeprecated
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
@@ -87,7 +87,7 @@ private fun Content(
         ) {
             item { Spacer(Modifier.height(4.dp)) }
             item {
-                PodcastImage(
+                PodcastImageDeprecated(
                     uuid = podcast.uuid,
                     modifier = Modifier.size(PodcastScreen.podcastImageSize),
                 )

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/podcast/PodcastScreen.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/podcast/PodcastScreen.kt
@@ -87,6 +87,7 @@ private fun Content(
         ) {
             item { Spacer(Modifier.height(4.dp)) }
             item {
+                @Suppress("DEPRECATION")
                 PodcastImageDeprecated(
                     uuid = podcast.uuid,
                     modifier = Modifier.size(PodcastScreen.podcastImageSize),

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/podcasts/PodcastsScreen.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/podcasts/PodcastsScreen.kt
@@ -25,7 +25,7 @@ import androidx.wear.compose.material.Chip
 import androidx.wear.compose.material.ChipDefaults
 import androidx.wear.compose.material.MaterialTheme
 import androidx.wear.compose.material.Text
-import au.com.shiftyjelly.pocketcasts.compose.components.PodcastImage
+import au.com.shiftyjelly.pocketcasts.compose.components.PodcastImageDeprecated
 import au.com.shiftyjelly.pocketcasts.compose.extensions.darker
 import au.com.shiftyjelly.pocketcasts.models.to.FolderItem
 import au.com.shiftyjelly.pocketcasts.wear.theme.WearColors
@@ -156,7 +156,7 @@ private fun PodcastChip(
             ChipText(podcast.title)
         },
         icon = {
-            PodcastImage(
+            PodcastImageDeprecated(
                 uuid = podcast.uuid,
                 dropShadow = false,
                 modifier = Modifier.size(32.dp),

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/podcasts/PodcastsScreen.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/podcasts/PodcastsScreen.kt
@@ -156,6 +156,7 @@ private fun PodcastChip(
             ChipText(podcast.title)
         },
         icon = {
+            @Suppress("DEPRECATION")
             PodcastImageDeprecated(
                 uuid = podcast.uuid,
                 dropShadow = false,


### PR DESCRIPTION
## Description

Our current `PodcastImage` is fundamentally broken but I'm worried that fixing it will break stuff in our app as it might be relying on its incorrect behavior or some quirks. This PR deprecates it and introduces a new component.

Fixes PCDROID-52
Relates to PCDROID-109

## Testing Instructions

1. Follow a podcast.
2. Collapse the header / artwork.
3. Go back to the podcasts grid.
4. Go back to the podcast page.
5. Expand the header / artwork.
6. There should be no UI glitches.

## Screenshots or Screencast 

| Before | After |
| - | - |
|  <img width="1080" height="2400" alt="image" src="https://github.com/user-attachments/assets/1463aa24-3d25-44d7-9beb-d101ddd131e3" /> | <img width="1080" height="2400" alt="image" src="https://github.com/user-attachments/assets/4d779a28-6b60-4a16-aeed-bba00a99030a" /> |


## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack