### PR TITLE
Adds feature flags for promotions

### DIFF
--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/UpgradeFeatureItem.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/UpgradeFeatureItem.kt
@@ -25,8 +25,8 @@ enum class PlusUpgradeFeatureItem(
     BannerAds(
         image = IR.drawable.ic_remove_ads,
     ) {
-        override val isYearlyFeature get() = FeatureFlag.isEnabled(Feature.BANNER_ADS)
-        override val isMonthlyFeature get() = FeatureFlag.isEnabled(Feature.BANNER_ADS)
+        override val isYearlyFeature get() = FeatureFlag.isEnabled(Feature.BANNER_ADS_PLAYER) || FeatureFlag.isEnabled(Feature.BANNER_ADS_PODCASTS)
+        override val isMonthlyFeature get() = FeatureFlag.isEnabled(Feature.BANNER_ADS_PLAYER) || FeatureFlag.isEnabled(Feature.BANNER_ADS_PODCASTS)
         override fun title() = LR.string.onboarding_plus_feature_no_banner_ads
     },
     Folders(

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/type/BlazeAdLocation.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/type/BlazeAdLocation.kt
@@ -1,7 +1,6 @@
 package au.com.shiftyjelly.pocketcasts.models.type
 
 import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
-import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
 import com.squareup.moshi.JsonAdapter
 import com.squareup.moshi.JsonReader
 import com.squareup.moshi.JsonWriter

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/type/BlazeAdLocation.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/type/BlazeAdLocation.kt
@@ -1,18 +1,23 @@
 package au.com.shiftyjelly.pocketcasts.models.type
 
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
 import com.squareup.moshi.JsonAdapter
 import com.squareup.moshi.JsonReader
 import com.squareup.moshi.JsonWriter
 
-enum class BlazeAdLocation(val value: String) {
+enum class BlazeAdLocation(val value: String, val feature: Feature?) {
     PodcastList(
         value = "podcastList",
+        feature = Feature.BANNER_ADS_PODCASTS,
     ),
     Player(
         value = "player",
+        feature = Feature.BANNER_ADS_PLAYER,
     ),
     Unknown(
         value = "",
+        feature = null,
     ),
     ;
 

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/ads/BlazeAdsManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/ads/BlazeAdsManagerImpl.kt
@@ -7,7 +7,6 @@ import au.com.shiftyjelly.pocketcasts.models.type.BlazeAdLocation
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.servers.cdn.StaticServiceManager
 import au.com.shiftyjelly.pocketcasts.utils.Util
-import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
 import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
 import com.automattic.android.tracks.crashlogging.CrashLogging
 import dagger.hilt.android.qualifiers.ApplicationContext
@@ -56,9 +55,13 @@ class BlazeAdsManagerImpl @Inject constructor(
 
     @OptIn(ExperimentalCoroutinesApi::class)
     private fun findBlazeAdByLocation(location: BlazeAdLocation): Flow<BlazeAd?> {
+        val featureFlag = location.feature
+        if (location == BlazeAdLocation.Unknown || featureFlag == null) {
+            return flowOf(null)
+        }
         return combine(
             settings.cachedSubscription.flow,
-            FeatureFlag.isEnabledFlow(Feature.BANNER_ADS),
+            FeatureFlag.isEnabledFlow(featureFlag),
             ::Pair,
         ).flatMapLatest { (subscription, isEnabled) ->
             if (isEnabled && subscription == null) {

--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/Feature.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/featureflag/Feature.kt
@@ -122,12 +122,20 @@ enum class Feature(
         hasFirebaseRemoteFlag = true,
         hasDevToggle = true,
     ),
-    BANNER_ADS(
-        key = "banner_ads",
-        title = "Banner Ads",
+    BANNER_ADS_PLAYER(
+        key = "banner_ad_player",
+        title = "Banner Ads Player",
         defaultValue = BuildConfig.DEBUG,
         tier = FeatureTier.Free,
-        hasFirebaseRemoteFlag = false,
+        hasFirebaseRemoteFlag = true,
+        hasDevToggle = true,
+    ),
+    BANNER_ADS_PODCASTS(
+        key = "banner_ad_podcasts",
+        title = "Banner Ads Podcasts",
+        defaultValue = BuildConfig.DEBUG,
+        tier = FeatureTier.Free,
+        hasFirebaseRemoteFlag = true,
         hasDevToggle = true,
     ),
     SMART_CATEGORIES(


### PR DESCRIPTION
## Description

This adds feature flags for the podcast list and player promotions.

<img width="1318" height="396" alt="Screenshot 2025-08-29 at 1 07 16 pm" src="https://github.com/user-attachments/assets/57d23d72-e6f2-4680-a32d-a6eb78bc2680" />

## Testing Instructions
1. Install the `debug` variant
2. ✅  Verify the promotions appear on the podcasts tab and player page
3. Go to Profile tab -> settings -> Beta features
4. Turn off "Banner Ads Player"
5. ✅  Verify the player promotion is hidden
6. Turn off "Banner Ads Podcast" and turn on "Banner Ads Player"
7. ✅  Verify the podcasts lists promotion is hidden

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack
