### PR TITLE
Adds analytics to the promotions

### DIFF
--- a/modules/features/ads/src/main/kotlin/au/com/shiftyjelly/pocketcasts/ads/AdReportFragment.kt
+++ b/modules/features/ads/src/main/kotlin/au/com/shiftyjelly/pocketcasts/ads/AdReportFragment.kt
@@ -12,12 +12,15 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
 import androidx.core.os.BundleCompat
 import androidx.core.os.bundleOf
+import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
+import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTracker
 import au.com.shiftyjelly.pocketcasts.compose.LocalPodcastColors
 import au.com.shiftyjelly.pocketcasts.compose.PodcastColors
 import au.com.shiftyjelly.pocketcasts.compose.ad.AdReportContent
 import au.com.shiftyjelly.pocketcasts.compose.ad.rememberAdColors
 import au.com.shiftyjelly.pocketcasts.compose.extensions.contentWithoutConsumedInsets
 import au.com.shiftyjelly.pocketcasts.models.entity.BlazeAd
+import au.com.shiftyjelly.pocketcasts.models.type.AdReportReason
 import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingFlow
 import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingLauncher
 import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingUpgradeSource
@@ -25,6 +28,7 @@ import au.com.shiftyjelly.pocketcasts.ui.helper.FragmentHostListener
 import au.com.shiftyjelly.pocketcasts.views.fragments.BaseDialogFragment
 import com.google.android.material.snackbar.Snackbar
 import dagger.hilt.android.AndroidEntryPoint
+import javax.inject.Inject
 import kotlinx.parcelize.Parcelize
 import timber.log.Timber
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
@@ -32,6 +36,10 @@ import com.google.android.material.R as MR
 
 @AndroidEntryPoint
 class AdReportFragment : BaseDialogFragment() {
+
+    @Inject
+    internal lateinit var analyticsTracker: AnalyticsTracker
+
     companion object {
         const val NEW_INSTANCE_KEY = "new_instance_key"
 
@@ -65,12 +73,7 @@ class AdReportFragment : BaseDialogFragment() {
                         OnboardingLauncher.openOnboardingFlow(requireActivity(), OnboardingFlow.Upsell(OnboardingUpgradeSource.BANNER_AD))
                         dismiss()
                     },
-                    onReportAd = { reason ->
-                        Timber.i("Report ad: $reason, ${args.ad.id}")
-                        val snackbarView = (requireActivity() as FragmentHostListener).snackBarView()
-                        Snackbar.make(snackbarView, getString(LR.string.ad_report_confirmation), Snackbar.LENGTH_LONG).show()
-                        dismiss()
-                    },
+                    onReportAd = ::reportAd,
                 )
 
                 val surfaceColor = sheetColors.surface
@@ -79,6 +82,21 @@ class AdReportFragment : BaseDialogFragment() {
                 }
             }
         }
+    }
+
+    private fun reportAd(reason: AdReportReason) {
+        analyticsTracker.track(
+            AnalyticsEvent.BANNER_AD_REPORT,
+            mapOf(
+                "ad_id" to args.ad.id,
+                "reason" to reason.analyticsName,
+                "source" to args.ad.location.analyticsName,
+            ),
+        )
+
+        val snackbarView = (requireActivity() as FragmentHostListener).snackBarView()
+        Snackbar.make(snackbarView, getString(LR.string.ad_report_confirmation), Snackbar.LENGTH_LONG).show()
+        dismiss()
     }
 
     private fun refreshSystemColors(color: Color) {

--- a/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
+++ b/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/AnalyticsEvent.kt
@@ -822,4 +822,5 @@ enum class AnalyticsEvent(val key: String) {
     /* Banner Ads */
     BANNER_AD_IMPRESSION("banner_ad_impression"),
     BANNER_AD_TAPPED("banner_ad_tapped"),
+    BANNER_AD_REPORT("banner_ad_report"),
 }

--- a/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/FirebaseAnalyticsTracker.kt
+++ b/modules/services/analytics/src/main/java/au/com/shiftyjelly/pocketcasts/analytics/FirebaseAnalyticsTracker.kt
@@ -23,6 +23,9 @@ class FirebaseAnalyticsTracker @Inject constructor(
             AnalyticsEvent.PLUS_PROMOTION_NOT_NOW_BUTTON_TAPPED,
             AnalyticsEvent.PLAYBACK_PLAY,
             AnalyticsEvent.PODCAST_SUBSCRIBED,
+            AnalyticsEvent.BANNER_AD_IMPRESSION,
+            AnalyticsEvent.BANNER_AD_TAPPED,
+            AnalyticsEvent.BANNER_AD_REPORT,
         )
 
         private fun shouldTrack(event: AnalyticsEvent) = EVENTS.contains(event)

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/type/AdReportReason.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/type/AdReportReason.kt
@@ -1,8 +1,8 @@
 package au.com.shiftyjelly.pocketcasts.models.type
 
-enum class AdReportReason {
-    Broken,
-    Malicious,
-    TooFrequent,
-    Other,
+enum class AdReportReason(val analyticsName: String) {
+    Broken(analyticsName = "broken"),
+    Malicious(analyticsName = "malicious"),
+    TooFrequent(analyticsName = "too_often"),
+    Other(analyticsName = "other"),
 }

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/type/BlazeAdLocation.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/type/BlazeAdLocation.kt
@@ -5,17 +5,20 @@ import com.squareup.moshi.JsonAdapter
 import com.squareup.moshi.JsonReader
 import com.squareup.moshi.JsonWriter
 
-enum class BlazeAdLocation(val value: String, val feature: Feature?) {
+enum class BlazeAdLocation(val value: String, val analyticsName: String, val feature: Feature?) {
     PodcastList(
         value = "podcastList",
+        analyticsName = "podcasts_list",
         feature = Feature.BANNER_ADS_PODCASTS,
     ),
     Player(
         value = "player",
+        analyticsName = "player",
         feature = Feature.BANNER_ADS_PLAYER,
     ),
     Unknown(
         value = "",
+        analyticsName = "unknown",
         feature = null,
     ),
     ;


### PR DESCRIPTION
## Description

This change sends the user's response to report ads to Tracks.

## Testing Instructions

1. Filter logcat by `Tracked`
2. Tap the promotion cross icon
3. Tap "Report ad"
4. Choose a reason
5. ✅ Verify the event `banner_ad_report` is sent with the properties 
    - `ad_id`
    - `source`: [podcasts_list, player]
    - `reason`: [broken, malicious, too_often, other]

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack
