### PR TITLE
Add toolbar button animation

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -75,6 +75,7 @@ coil-compose = { module = "io.coil-kt:coil-compose", version.ref = "coil" }
 # Compose
 compose-activity = "androidx.activity:activity-compose:1.9.3"
 compose-animation = { module = "androidx.compose.animation:animation" }
+compose-animation-graphics = { module = "androidx.compose.animation:animation-graphics" }
 compose-bom = { module = "androidx.compose:compose-bom", version.ref = "compose" }
 compose-constraintlayout = "androidx.constraintlayout:constraintlayout-compose:1.0.1"
 compose-foundation = { module = "androidx.compose.foundation:foundation" }

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/AccountBenefitsPage.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/AccountBenefitsPage.kt
@@ -107,9 +107,9 @@ private fun LogoWithCloseButton(
             modifier = Modifier.weight(1f),
         ) {
             NavigationIconButton(
-                iconColor = MaterialTheme.theme.colors.primaryText01,
+                tint = MaterialTheme.theme.colors.primaryText01,
                 navigationButton = NavigationButton.Close,
-                onNavigationClick = onClose,
+                onClick = onClose,
             )
         }
 

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/OnboardingCreateAccountPage.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/OnboardingCreateAccountPage.kt
@@ -109,9 +109,9 @@ internal fun NewOnboardingCreateAccountPage(
                 modifier = Modifier
                     .align(Alignment.End)
                     .padding(horizontal = 8.dp),
-                iconColor = MaterialTheme.theme.colors.primaryInteractive01,
+                tint = MaterialTheme.theme.colors.primaryInteractive01,
                 navigationButton = NavigationButton.Close,
-                onNavigationClick = onSkip,
+                onClick = onSkip,
             )
         } else {
             TextP40(

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/OnboardingLoginOrSignUpPage.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/OnboardingLoginOrSignUpPage.kt
@@ -219,9 +219,9 @@ private fun Content(
             ) {
                 Box(Modifier.weight(1f)) {
                     NavigationIconButton(
-                        iconColor = MaterialTheme.theme.colors.primaryText01,
+                        tint = MaterialTheme.theme.colors.primaryText01,
                         navigationButton = NavigationButton.Close,
-                        onNavigationClick = onNavigationClick,
+                        onClick = onNavigationClick,
                     )
                 }
 

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeFeaturesPage.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/upgrade/OnboardingUpgradeFeaturesPage.kt
@@ -1,7 +1,6 @@
 package au.com.shiftyjelly.pocketcasts.account.onboarding.upgrade
 
 import androidx.activity.SystemBarStyle
-import androidx.compose.animation.ExperimentalSharedTransitionApi
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.Image
@@ -225,8 +224,8 @@ private fun UpgradeLayout(
                         verticalAlignment = Alignment.CenterVertically,
                     ) {
                         NavigationIconButton(
-                            onNavigationClick = onBackPress,
-                            iconColor = Color.White,
+                            onClick = onBackPress,
+                            tint = Color.White,
                             modifier = Modifier
                                 .height(48.dp)
                                 .width(48.dp),
@@ -587,8 +586,8 @@ private fun NoSubscriptionsLayout(
             verticalAlignment = Alignment.CenterVertically,
         ) {
             NavigationIconButton(
-                onNavigationClick = onBackPress,
-                iconColor = MaterialTheme.theme.colors.primaryText01,
+                onClick = onBackPress,
+                tint = MaterialTheme.theme.colors.primaryText01,
                 modifier = Modifier
                     .height(48.dp)
                     .width(48.dp),

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/components/ratings/GiveRatingNotAllowedToRateScreen.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/components/ratings/GiveRatingNotAllowedToRateScreen.kt
@@ -97,9 +97,9 @@ fun GiveRatingNotAllowedToRate(
         }
 
         NavigationIconButton(
-            iconColor = MaterialTheme.theme.colors.primaryText01,
+            tint = MaterialTheme.theme.colors.primaryText01,
             navigationButton = NavigationButton.Close,
-            onNavigationClick = onDismiss,
+            onClick = onDismiss,
             modifier = Modifier
                 .align(Alignment.TopStart)
                 .padding(16.dp),

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/components/ratings/GiveRatingScreen.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/components/ratings/GiveRatingScreen.kt
@@ -113,9 +113,9 @@ fun GiveRatingScreen(
         }
 
         NavigationIconButton(
-            iconColor = MaterialTheme.theme.colors.primaryText01,
+            tint = MaterialTheme.theme.colors.primaryText01,
             navigationButton = NavigationButton.Close,
-            onNavigationClick = onDismiss,
+            onClick = onDismiss,
             modifier = Modifier
                 .align(Alignment.TopStart)
                 .padding(16.dp),

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/components/ratings/GiveRatingsErrorScreen.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/components/ratings/GiveRatingsErrorScreen.kt
@@ -34,9 +34,9 @@ fun GiveRatingErrorScreen(
         )
 
         NavigationIconButton(
-            iconColor = MaterialTheme.theme.colors.primaryText01,
+            tint = MaterialTheme.theme.colors.primaryText01,
             navigationButton = NavigationButton.Close,
-            onNavigationClick = onDismiss,
+            onClick = onDismiss,
             modifier = Modifier
                 .align(Alignment.TopStart),
         )

--- a/modules/services/compose/build.gradle.kts
+++ b/modules/services/compose/build.gradle.kts
@@ -29,6 +29,7 @@ dependencies {
     implementation(libs.coil.compose)
     implementation(libs.compose.activity)
     implementation(libs.compose.animation)
+    implementation(libs.compose.animation.graphics)
     implementation(libs.compose.material)
     implementation(libs.compose.material.icons.extended)
     implementation(libs.compose.ui)

--- a/modules/services/images/src/main/res/drawable/ic_anim_close_back.xml
+++ b/modules/services/images/src/main/res/drawable/ic_anim_close_back.xml
@@ -1,0 +1,169 @@
+<animated-vector
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:aapt="http://schemas.android.com/aapt">
+    <aapt:attr name="android:drawable">
+        <vector
+            android:name="vector"
+            android:width="24dp"
+            android:height="24dp"
+            android:viewportWidth="24"
+            android:viewportHeight="24">
+            <group
+                android:name="sw_group"
+                android:pivotX="12"
+                android:pivotY="12">
+                <path
+                    android:name="sw_leg"
+                    android:pathData="M 13.414 12 L 7.05 18.364 C 6.861 18.546 6.609 18.647 6.347 18.645 C 6.084 18.642 5.834 18.537 5.648 18.352 C 5.463 18.166 5.358 17.916 5.355 17.653 C 5.353 17.391 5.454 17.139 5.636 16.95 L 12 10.586 Z"
+                    android:fillColor="#ff00ff"/>
+            </group>
+            <group
+                android:name="nw_group"
+                android:pivotX="12"
+                android:pivotY="12">
+                <path
+                    android:name="nw_leg"
+                    android:pathData="M 12 13.414 L 5.636 7.05 C 5.454 6.861 5.353 6.609 5.355 6.347 C 5.358 6.084 5.463 5.834 5.648 5.648 C 5.834 5.463 6.084 5.358 6.347 5.355 C 6.609 5.353 6.861 5.454 7.05 5.636 L 13.414 12 Z"
+                    android:fillColor="#ff00ff"/>
+            </group>
+            <group
+                android:name="se_group"
+                android:pivotX="12"
+                android:pivotY="12">
+                <path
+                    android:name="se_leg"
+                    android:pathData="M 12 10.586 L 18.364 16.95 C 18.546 17.139 18.647 17.391 18.645 17.653 C 18.642 17.916 18.537 18.166 18.352 18.352 C 18.166 18.537 17.916 18.642 17.653 18.645 C 17.391 18.647 17.139 18.546 16.95 18.364 L 10.586 12 Z"
+                    android:fillColor="#ff00ff"/>
+            </group>
+            <group
+                android:name="ne_group"
+                android:pivotX="12"
+                android:pivotY="12">
+                <path
+                    android:name="ne_leg"
+                    android:pathData="M 10.586 12 L 12 13.414 L 18.364 7.05 C 18.546 6.861 18.647 6.609 18.645 6.347 C 18.642 6.084 18.537 5.834 18.352 5.648 C 18.166 5.463 17.916 5.358 17.653 5.355 C 17.391 5.353 17.139 5.454 16.95 5.636 Z"
+                    android:fillColor="#ff00ff"/>
+            </group>
+        </vector>
+    </aapt:attr>
+    <target android:name="sw_group">
+        <aapt:attr name="android:animation">
+            <set>
+                <objectAnimator
+                    android:propertyName="rotation"
+                    android:duration="300"
+                    android:valueFrom="0"
+                    android:valueTo="-90"
+                    android:valueType="floatType"
+                    android:interpolator="@android:interpolator/fast_out_slow_in"/>
+                <objectAnimator
+                    android:propertyName="translateX"
+                    android:duration="300"
+                    android:valueFrom="0"
+                    android:valueTo="-5.25"
+                    android:valueType="floatType"
+                    android:interpolator="@android:interpolator/fast_out_slow_in"/>
+                <objectAnimator
+                    android:propertyName="translateY"
+                    android:duration="300"
+                    android:valueFrom="0"
+                    android:valueTo="1.35"
+                    android:valueType="floatType"
+                    android:interpolator="@android:interpolator/fast_out_slow_in"/>
+            </set>
+        </aapt:attr>
+    </target>
+    <target android:name="sw_leg">
+        <aapt:attr name="android:animation">
+            <objectAnimator
+                android:propertyName="pathData"
+                android:duration="300"
+                android:valueFrom="M 13.414 12 L 7.05 18.364 C 6.861 18.546 6.609 18.647 6.347 18.645 C 6.084 18.642 5.834 18.537 5.648 18.352 C 5.463 18.166 5.358 17.916 5.355 17.653 C 5.353 17.391 5.454 17.139 5.636 16.95 L 12 10.586 Z"
+                android:valueTo="M 14.764 10.65 L 7.05 18.364 C 6.861 18.546 6.609 18.647 6.347 18.645 C 6.084 18.642 5.834 18.537 5.648 18.352 C 5.463 18.166 5.358 17.916 5.355 17.653 C 5.353 17.391 5.454 17.139 5.636 16.95 L 13.35 9.246 Z"
+                android:valueType="pathType"
+                android:interpolator="@android:interpolator/fast_out_slow_in"/>
+        </aapt:attr>
+    </target>
+    <target android:name="nw_group">
+        <aapt:attr name="android:animation">
+            <set>
+                <objectAnimator
+                    android:propertyName="rotation"
+                    android:duration="300"
+                    android:valueFrom="0"
+                    android:valueTo="90"
+                    android:valueType="floatType"
+                    android:interpolator="@android:interpolator/fast_out_slow_in"/>
+                <objectAnimator
+                    android:propertyName="translateX"
+                    android:duration="300"
+                    android:valueFrom="0"
+                    android:valueTo="-5.25"
+                    android:valueType="floatType"
+                    android:interpolator="@android:interpolator/fast_out_slow_in"/>
+                <objectAnimator
+                    android:propertyName="translateY"
+                    android:duration="300"
+                    android:valueFrom="0"
+                    android:valueTo="-1.35"
+                    android:valueType="floatType"
+                    android:interpolator="@android:interpolator/fast_out_slow_in"/>
+            </set>
+        </aapt:attr>
+    </target>
+    <target android:name="nw_leg">
+        <aapt:attr name="android:animation">
+            <objectAnimator
+                android:propertyName="pathData"
+                android:duration="300"
+                android:valueFrom="M 12 13.414 L 5.636 7.05 C 5.454 6.861 5.353 6.609 5.355 6.347 C 5.358 6.084 5.463 5.834 5.648 5.648 C 5.834 5.463 6.084 5.358 6.347 5.355 C 6.609 5.353 6.861 5.454 7.05 5.636 L 13.414 12 Z"
+                android:valueTo="M 13.35 14.764 L 5.636 7.05 C 5.454 6.861 5.353 6.609 5.355 6.347 C 5.358 6.084 5.463 5.834 5.648 5.648 C 5.834 5.463 6.084 5.358 6.347 5.355 C 6.609 5.353 6.861 5.454 7.05 5.636 L 14.764 13.35 Z"
+                android:valueType="pathType"
+                android:interpolator="@android:interpolator/fast_out_slow_in"/>
+        </aapt:attr>
+    </target>
+    <target android:name="se_group">
+        <aapt:attr name="android:animation">
+            <objectAnimator
+                android:propertyName="rotation"
+                android:duration="300"
+                android:valueFrom="0"
+                android:valueTo="-45"
+                android:valueType="floatType"
+                android:interpolator="@android:interpolator/fast_out_slow_in"/>
+        </aapt:attr>
+    </target>
+    <target android:name="se_leg">
+        <aapt:attr name="android:animation">
+            <objectAnimator
+                android:propertyName="pathData"
+                android:duration="300"
+                android:valueFrom="M 12 10.586 L 18.364 16.95 C 18.546 17.139 18.647 17.391 18.645 17.653 C 18.642 17.916 18.537 18.166 18.352 18.352 C 18.166 18.537 17.916 18.642 17.653 18.645 C 17.391 18.647 17.139 18.546 16.95 18.364 L 10.586 12 Z"
+                android:valueTo="M 9 7.586 L 17.964 16.55 C 18.146 16.739 18.247 16.991 18.245 17.253 C 18.242 17.516 18.137 17.766 17.952 17.952 C 17.766 18.137 17.516 18.242 17.253 18.245 C 16.991 18.247 16.739 18.146 16.55 17.964 L 7.586 9 Z"
+                android:valueType="pathType"
+                android:interpolator="@android:interpolator/fast_out_slow_in"/>
+        </aapt:attr>
+    </target>
+    <target android:name="ne_group">
+        <aapt:attr name="android:animation">
+            <objectAnimator
+                android:propertyName="rotation"
+                android:duration="300"
+                android:valueFrom="0"
+                android:valueTo="45"
+                android:valueType="floatType"
+                android:interpolator="@android:interpolator/fast_out_slow_in"/>
+        </aapt:attr>
+    </target>
+    <target android:name="ne_leg">
+        <aapt:attr name="android:animation">
+            <objectAnimator
+                android:propertyName="pathData"
+                android:duration="300"
+                android:valueFrom="M 10.586 12 L 12 13.414 L 18.364 7.05 C 18.546 6.861 18.647 6.609 18.645 6.347 C 18.642 6.084 18.537 5.834 18.352 5.648 C 18.166 5.463 17.916 5.358 17.653 5.355 C 17.391 5.353 17.139 5.454 16.95 5.636 Z"
+                android:valueTo="M 7.586 15 L 9 16.414 L 17.964 7.45 C 18.146 7.261 18.247 7.009 18.245 6.747 C 18.242 6.484 18.137 6.234 17.952 6.048 C 17.766 5.863 17.516 5.758 17.253 5.755 C 16.991 5.753 16.739 5.854 16.55 6.036 Z"
+                android:valueType="pathType"
+                android:interpolator="@android:interpolator/fast_out_slow_in"/>
+        </aapt:attr>
+    </target>
+</animated-vector>


### PR DESCRIPTION
## Description

This adds new button type for the toolbar which can animate between back and close actions.

Relates to PCDROID-110

## Testing Instructions

Code review my changes. You can test the animation with the Compose preview in IDE if you want to.

## Screenshots or Screencast 

https://github.com/user-attachments/assets/9f128820-9b16-4fae-a1f4-141adf9220fb

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.