### PR TITLE
Display episode sources header

### DIFF
--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/manual/episode/AddEpisodesFragment.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/manual/episode/AddEpisodesFragment.kt
@@ -47,7 +47,9 @@ class AddEpisodesFragment : BaseDialogFragment() {
                 exit = fadeOut,
             ) { uiState ->
                 AddEpisodesPage(
+                    playlistTitle = uiState.playlist.title,
                     episodeSources = uiState.sources,
+                    onClose = ::dismiss,
                     modifier = Modifier.fillMaxSize(),
                 )
             }

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/manual/episode/AddEpisodesPage.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/manual/episode/AddEpisodesPage.kt
@@ -1,74 +1,155 @@
 package au.com.shiftyjelly.pocketcasts.playlists.manual.episode
 
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.text.input.rememberTextFieldState
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.input.nestedscroll.nestedScroll
-import androidx.compose.ui.platform.rememberNestedScrollInteropConnection
-import androidx.core.os.BundleCompat
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
 import androidx.navigation.NavType
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
+import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
 import androidx.navigation.navArgument
+import au.com.shiftyjelly.pocketcasts.compose.bars.NavigationButton
+import au.com.shiftyjelly.pocketcasts.compose.bars.ThemedTopAppBar
+import au.com.shiftyjelly.pocketcasts.compose.components.SearchBar
+import au.com.shiftyjelly.pocketcasts.compose.components.SearchBarStyle
+import au.com.shiftyjelly.pocketcasts.compose.components.TextH40
+import au.com.shiftyjelly.pocketcasts.compose.extensions.nonScaledSp
 import au.com.shiftyjelly.pocketcasts.compose.navigation.navigateOnce
 import au.com.shiftyjelly.pocketcasts.compose.navigation.slideInToEnd
 import au.com.shiftyjelly.pocketcasts.compose.navigation.slideInToStart
 import au.com.shiftyjelly.pocketcasts.compose.navigation.slideOutToEnd
 import au.com.shiftyjelly.pocketcasts.compose.navigation.slideOutToStart
+import au.com.shiftyjelly.pocketcasts.compose.theme
 import au.com.shiftyjelly.pocketcasts.models.entity.ManualPlaylistEpisodeSource
 import au.com.shiftyjelly.pocketcasts.models.entity.ManualPlaylistFolderSource
 import au.com.shiftyjelly.pocketcasts.models.entity.ManualPlaylistPodcastSource
 import timber.log.Timber
+import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 @Composable
 internal fun AddEpisodesPage(
+    playlistTitle: String,
     episodeSources: List<ManualPlaylistEpisodeSource>,
+    onClose: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val navController = rememberNavController()
+    val backStackEntry by navController.currentBackStackEntryAsState()
+    val isTopPageDisplayed = backStackEntry == null || backStackEntry?.destination?.route == AddEpisodesRoutes.HOME
 
-    NavHost(
-        navController = navController,
-        startDestination = AddEpisodesRoutes.HOME,
-        enterTransition = { slideInToStart() },
-        exitTransition = { slideOutToStart() },
-        popEnterTransition = { slideInToEnd() },
-        popExitTransition = { slideOutToEnd() },
+    Column(
         modifier = modifier,
     ) {
-        val navigateToSource = { source: ManualPlaylistEpisodeSource ->
-            when (source) {
-                is ManualPlaylistFolderSource -> {
-                    navController.navigateOnce(AddEpisodesRoutes.folderRoute(source.uuid))
+        ThemedTopAppBar(
+            navigationButton = NavigationButton.CloseBack(isClose = isTopPageDisplayed),
+            title = {
+                TextH40(
+                    text = stringResource(LR.string.add_to_playlist, playlistTitle),
+                    textAlign = TextAlign.Center,
+                    color = MaterialTheme.theme.colors.primaryText01,
+                    maxLines = 2,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+            },
+            actions = {
+                Text(
+                    text = stringResource(LR.string.done),
+                    fontSize = 17.nonScaledSp,
+                    fontWeight = FontWeight(590),
+                    color = MaterialTheme.theme.colors.primaryIcon01,
+                    modifier = Modifier
+                        .clickable(
+                            indication = null,
+                            interactionSource = null,
+                            onClick = onClose,
+                        )
+                        .padding(end = 16.dp),
+                )
+            },
+            style = ThemedTopAppBar.Style.Immersive,
+            iconColor = MaterialTheme.theme.colors.primaryIcon01,
+            windowInsets = WindowInsets(0),
+            onNavigationClick = {
+                if (!navController.popBackStack()) {
+                    onClose()
                 }
+            },
+        )
 
-                is ManualPlaylistPodcastSource -> {
-                    Timber.i("Go to podcast: ${source.title}")
+        SearchBar(
+            state = rememberTextFieldState(),
+            placeholder = stringResource(LR.string.search),
+            style = SearchBarStyle.Small,
+            modifier = Modifier
+                .padding(horizontal = 16.dp)
+                .fillMaxWidth(),
+        )
+
+        Spacer(
+            modifier = Modifier.height(24.dp),
+        )
+
+        NavHost(
+            navController = navController,
+            startDestination = AddEpisodesRoutes.HOME,
+            enterTransition = { slideInToStart() },
+            exitTransition = { slideOutToStart() },
+            popEnterTransition = { slideInToEnd() },
+            popExitTransition = { slideOutToEnd() },
+            modifier = Modifier.weight(1f),
+        ) {
+            val navigateToSource = { source: ManualPlaylistEpisodeSource ->
+                when (source) {
+                    is ManualPlaylistFolderSource -> {
+                        navController.navigateOnce(AddEpisodesRoutes.folderRoute(source.uuid))
+                    }
+
+                    is ManualPlaylistPodcastSource -> {
+                        Timber.i("Go to podcast: ${source.title}")
+                    }
                 }
             }
-        }
 
-        composable(AddEpisodesRoutes.HOME) {
-            EpisodeSourcesColumn(
-                sources = episodeSources,
-                onClickSource = navigateToSource,
-            )
-        }
-
-        composable(
-            AddEpisodesRoutes.FOLDER,
-            listOf(navArgument(AddEpisodesRoutes.FOLDER_UUID_ARG) { type = NavType.StringType }),
-        ) { backStackEntry ->
-            val arguments = requireNotNull(backStackEntry.arguments) { "Missing back stack entry arguments" }
-            val folderUuid = requireNotNull(arguments.getString(AddEpisodesRoutes.FOLDER_UUID_ARG)) { "Missing folder uuid argument" }
-            val podcasts = remember(folderUuid) {
-                episodeSources.filterIsInstance<ManualPlaylistFolderSource>().find { it.uuid == folderUuid }?.podcastSources.orEmpty()
+            composable(AddEpisodesRoutes.HOME) {
+                EpisodeSourcesColumn(
+                    sources = episodeSources,
+                    onClickSource = navigateToSource,
+                    modifier = Modifier.fillMaxSize(),
+                )
             }
-            EpisodeSourcesColumn(
-                sources = podcasts,
-                onClickSource = navigateToSource,
-            )
+
+            composable(
+                AddEpisodesRoutes.FOLDER,
+                listOf(navArgument(AddEpisodesRoutes.FOLDER_UUID_ARG) { type = NavType.StringType }),
+            ) { backStackEntry ->
+                val arguments = requireNotNull(backStackEntry.arguments) { "Missing back stack entry arguments" }
+                val folderUuid = requireNotNull(arguments.getString(AddEpisodesRoutes.FOLDER_UUID_ARG)) { "Missing folder uuid argument" }
+                val podcasts = remember(folderUuid) {
+                    episodeSources.filterIsInstance<ManualPlaylistFolderSource>().find { it.uuid == folderUuid }?.podcastSources.orEmpty()
+                }
+                EpisodeSourcesColumn(
+                    sources = podcasts,
+                    onClickSource = navigateToSource,
+                    modifier = Modifier.fillMaxSize(),
+                )
+            }
         }
     }
 }

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/bars/ThemedTopAppBar.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/bars/ThemedTopAppBar.kt
@@ -85,6 +85,56 @@ object ThemedTopAppBar {
 @Composable
 fun ThemedTopAppBar(
     modifier: Modifier = Modifier,
+    title: @Composable () -> Unit = {},
+    navigationButton: NavigationButton? = NavigationButton.Back,
+    onNavigationClick: (() -> Unit)? = null,
+    style: ThemedTopAppBar.Style = ThemedTopAppBar.Style.Solid,
+    iconColor: Color = when (style) {
+        ThemedTopAppBar.Style.Solid -> MaterialTheme.theme.colors.secondaryIcon01
+        ThemedTopAppBar.Style.Immersive -> MaterialTheme.theme.colors.primaryIcon01
+    },
+    backgroundColor: Color = when (style) {
+        ThemedTopAppBar.Style.Solid -> MaterialTheme.theme.colors.secondaryUi01
+        ThemedTopAppBar.Style.Immersive -> MaterialTheme.theme.colors.primaryUi01
+    },
+    bottomShadow: Boolean = false,
+    windowInsets: WindowInsets = AppBarDefaults.topAppBarWindowInsets,
+    actions: @Composable RowScope.(Color) -> Unit = {},
+) {
+    CompositionLocalProvider(
+        LocalRippleConfiguration provides RippleConfiguration(color = iconColor),
+    ) {
+        TopAppBar(
+            navigationIcon = if (navigationButton != null) {
+                {
+                    NavigationIconButton(
+                        onClick = onNavigationClick ?: {},
+                        navigationButton = navigationButton,
+                        tint = iconColor,
+                    )
+                }
+            } else {
+                null
+            },
+            title = title,
+            actions = { actions(iconColor) },
+            backgroundColor = backgroundColor,
+            elevation = 0.dp,
+            windowInsets = windowInsets,
+            modifier = if (bottomShadow) {
+                modifier
+                    .zIndex(1f)
+                    .shadow(4.dp)
+            } else {
+                modifier
+            },
+        )
+    }
+}
+
+@Composable
+fun ThemedTopAppBar(
+    modifier: Modifier = Modifier,
     title: String? = null,
     navigationButton: NavigationButton? = NavigationButton.Back,
     onNavigationClick: (() -> Unit)? = null,
@@ -106,43 +156,26 @@ fun ThemedTopAppBar(
     windowInsets: WindowInsets = AppBarDefaults.topAppBarWindowInsets,
     actions: @Composable RowScope.(Color) -> Unit = {},
 ) {
-    CompositionLocalProvider(
-        LocalRippleConfiguration provides RippleConfiguration(color = iconColor),
-    ) {
-        TopAppBar(
-            navigationIcon = if (navigationButton != null) {
-                {
-                    NavigationIconButton(
-                        onClick = onNavigationClick ?: {},
-                        navigationButton = navigationButton,
-                        tint = iconColor,
-                    )
-                }
-            } else {
-                null
-            },
-            title = {
-                if (title != null) {
-                    Text(
-                        text = title,
-                        color = textColor,
-                        overflow = titleOverflow,
-                    )
-                }
-            },
-            actions = { actions(iconColor) },
-            backgroundColor = backgroundColor,
-            elevation = 0.dp,
-            windowInsets = windowInsets,
-            modifier = if (bottomShadow) {
-                modifier
-                    .zIndex(1f)
-                    .shadow(4.dp)
-            } else {
-                modifier
-            },
-        )
-    }
+    ThemedTopAppBar(
+        title = {
+            if (title != null) {
+                Text(
+                    text = title,
+                    color = textColor,
+                    overflow = titleOverflow,
+                )
+            }
+        },
+        navigationButton = navigationButton,
+        onNavigationClick = onNavigationClick,
+        style = style,
+        iconColor = iconColor,
+        backgroundColor = backgroundColor,
+        bottomShadow = bottomShadow,
+        windowInsets = windowInsets,
+        actions = actions,
+        modifier = modifier,
+    )
 }
 
 @Composable

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/SearchBar.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/SearchBar.kt
@@ -4,12 +4,14 @@ import android.view.KeyEvent
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.text.KeyboardActions
@@ -18,16 +20,20 @@ import androidx.compose.foundation.text.input.TextFieldDecorator
 import androidx.compose.foundation.text.input.TextFieldLineLimits
 import androidx.compose.foundation.text.input.TextFieldState
 import androidx.compose.foundation.text.input.clearText
+import androidx.compose.foundation.text.input.rememberTextFieldState
 import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.material.Icon
 import androidx.compose.material.IconButton
+import androidx.compose.material.LocalMinimumInteractiveComponentEnforcement
 import androidx.compose.material.LocalTextStyle
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.material.TextFieldColors
 import androidx.compose.material.TextFieldDefaults
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.SolidColor
@@ -47,9 +53,12 @@ import androidx.compose.ui.text.input.KeyboardCapitalization
 import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
-import au.com.shiftyjelly.pocketcasts.compose.AppTheme
+import androidx.compose.ui.unit.sp
+import au.com.shiftyjelly.pocketcasts.compose.AppThemeWithBackground
+import au.com.shiftyjelly.pocketcasts.compose.preview.ThemePreviewParameterProvider
 import au.com.shiftyjelly.pocketcasts.compose.theme
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import au.com.shiftyjelly.pocketcasts.utils.extensions.removeNewLines
@@ -87,6 +96,70 @@ object SearchBarDefaults {
         unfocusedBorderColor = unfocusedBorderColor,
         disabledBorderColor = disabledBorderColorColor,
     )
+}
+
+enum class SearchBarStyle {
+    Small,
+    Regular,
+    ;
+
+    internal val backgroundShape
+        get() = when (this) {
+            Small -> RoundedCornerShape(8.dp)
+            Regular -> RoundedCornerShape(10.dp)
+        }
+
+    @get:Composable
+    internal val textStyle
+        get() = when (this) {
+            Small -> LocalTextStyle.current.copy(
+                fontSize = 14.sp,
+            )
+
+            Regular -> LocalTextStyle.current
+        }
+
+    private val iconBoxSize
+        get() = when (this) {
+            Small -> 32.dp
+            Regular -> 42.dp
+        }
+
+    private val iconSize
+        get() = when (this) {
+            Small -> 16.dp
+            Regular -> 24.dp
+        }
+
+    @Composable
+    internal fun LeadingIcon() {
+        Box(
+            contentAlignment = Alignment.Center,
+            modifier = Modifier.size(iconBoxSize),
+        ) {
+            Icon(
+                painter = painterResource(IR.drawable.ic_search),
+                contentDescription = null,
+                modifier = Modifier.size(iconSize),
+            )
+        }
+    }
+
+    @Composable
+    internal fun TrailingIcon(onClick: () -> Unit) {
+        Box(
+            contentAlignment = Alignment.Center,
+            modifier = Modifier
+                .size(iconBoxSize)
+                .clickable(onClick = onClick),
+        ) {
+            Icon(
+                painter = painterResource(IR.drawable.ic_cancel),
+                contentDescription = stringResource(LR.string.clear),
+                modifier = Modifier.size(iconSize),
+            )
+        }
+    }
 }
 
 @OptIn(ExperimentalMaterialApi::class)
@@ -199,8 +272,7 @@ fun SearchBar(
     modifier: Modifier = Modifier,
     enabled: Boolean = true,
     placeholder: String = "",
-    textStyle: TextStyle = LocalTextStyle.current,
-    cornerRadius: Dp = 10.dp,
+    style: SearchBarStyle = SearchBarStyle.Regular,
     colors: TextFieldColors = SearchBarDefaults.colors(),
     lineLimits: TextFieldLineLimits = TextFieldLineLimits.SingleLine,
     keyboardOptions: KeyboardOptions = KeyboardOptions(
@@ -213,79 +285,65 @@ fun SearchBar(
     ),
     onClickClear: () -> Unit = {},
     onSearch: () -> Unit = {},
-    leadingContent: @Composable (() -> Unit)? = null,
-    trailingContent: @Composable (() -> Unit)? = null,
 ) {
     val focusManager = LocalFocusManager.current
-    val textColor = textStyle.color.takeOrElse {
-        colors.textColor(enabled).value
-    }
-    val mergedTextStyle = textStyle.merge(TextStyle(color = textColor))
+    val textStyle = style.textStyle.merge(
+        color = colors.textColor(enabled).value,
+    )
 
-    val shape = RoundedCornerShape(cornerRadius)
-    BasicTextField(
-        state = state,
-        keyboardOptions = keyboardOptions,
-        onKeyboardAction = {
-            onSearch()
-            focusManager.clearFocus()
-        },
-        lineLimits = lineLimits,
-        enabled = enabled,
-        textStyle = mergedTextStyle,
-        cursorBrush = SolidColor(colors.cursorColor(false).value),
-        modifier = modifier
-            .background(colors.backgroundColor(enabled).value, shape)
-            .defaultMinSize(
-                minWidth = TextFieldDefaults.MinWidth,
-                minHeight = 42.dp,
-            ),
-        decorator = object : TextFieldDecorator {
-            @Composable
-            override fun Decoration(innerTextField: @Composable (() -> Unit)) {
-                TextFieldDefaults.OutlinedTextFieldDecorationBox(
-                    value = state.text.toString(),
-                    innerTextField = innerTextField,
-                    placeholder = {
-                        Text(
-                            placeholder,
-                            maxLines = 1,
-                            overflow = TextOverflow.Ellipsis,
-                        )
-                    },
-                    leadingIcon = leadingContent ?: {
-                        Icon(
-                            painter = painterResource(IR.drawable.ic_search),
-                            contentDescription = null,
-                        )
-                    },
-                    trailingIcon = trailingContent ?: {
-                        if (state.text.isNotEmpty()) {
-                            IconButton(
-                                onClick = {
-                                    onClickClear()
-                                    state.clearText()
-                                    focusManager.clearFocus()
-                                },
-                            ) {
-                                Icon(
-                                    painter = painterResource(IR.drawable.ic_cancel),
-                                    contentDescription = stringResource(LR.string.clear),
+    CompositionLocalProvider(LocalMinimumInteractiveComponentEnforcement provides false) {
+        BasicTextField(
+            state = state,
+            keyboardOptions = keyboardOptions,
+            onKeyboardAction = {
+                onSearch()
+                focusManager.clearFocus()
+            },
+            lineLimits = lineLimits,
+            enabled = enabled,
+            textStyle = textStyle,
+            cursorBrush = SolidColor(colors.cursorColor(false).value),
+            modifier = modifier.background(colors.backgroundColor(enabled).value, style.backgroundShape),
+            decorator = object : TextFieldDecorator {
+                @Composable
+                override fun Decoration(innerTextField: @Composable (() -> Unit)) {
+                    TextFieldDefaults.OutlinedTextFieldDecorationBox(
+                        value = state.text.toString(),
+                        innerTextField = innerTextField,
+                        placeholder = {
+                            Text(
+                                text = placeholder,
+                                fontSize = textStyle.fontSize,
+                                maxLines = 1,
+                                overflow = TextOverflow.Ellipsis,
+                            )
+                        },
+                        leadingIcon = {
+                            style.LeadingIcon()
+                        },
+                        trailingIcon = {
+                            if (state.text.isNotEmpty()) {
+                                style.TrailingIcon(
+                                    onClick = {
+                                        onClickClear()
+                                        state.clearText()
+                                        focusManager.clearFocus()
+                                    },
                                 )
                             }
-                        }
-                    },
-                    enabled = enabled,
-                    colors = colors,
-                    singleLine = true,
-                    interactionSource = remember { MutableInteractionSource() },
-                    visualTransformation = VisualTransformation.None,
-                    contentPadding = contentPadding,
-                    shape = shape,
-                )
-            }
-        },
-    )
+                        },
+                        enabled = enabled,
+                        colors = colors,
+                        singleLine = true,
+                        interactionSource = remember { MutableInteractionSource() },
+                        visualTransformation = VisualTransformation.None,
+                        contentPadding = contentPadding,
+                        shape = style.backgroundShape,
+                    )
+                }
+            },
+        )
+    }
 }
 
 @Composable
@@ -320,26 +378,36 @@ fun SearchBarButton(
     }
 }
 
-@Preview(showBackground = true)
+@Preview
 @Composable
-private fun SearchBarLightPreview() {
-    AppTheme(Theme.ThemeType.LIGHT) {
-        SearchBarPreview()
-    }
-}
-
-@Preview(showBackground = true, backgroundColor = 0xFF000000)
-@Composable
-private fun SearchBarDarkPreview() {
-    AppTheme(Theme.ThemeType.DARK) {
-        SearchBarPreview()
-    }
-}
-
-@Composable
-private fun SearchBarPreview() {
-    Column(modifier = Modifier.padding(8.dp)) {
-        SearchBar("Material", onTextChange = {}, modifier = Modifier.padding(bottom = 8.dp))
-        SearchBar("", onTextChange = {})
+private fun SearchBarPreview(
+    @PreviewParameter(ThemePreviewParameterProvider::class) themeType: Theme.ThemeType,
+) {
+    AppThemeWithBackground(themeType) {
+        Column(
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+            modifier = Modifier.padding(8.dp),
+        ) {
+            SearchBar(
+                state = rememberTextFieldState(initialText = "Search term"),
+                modifier = Modifier.fillMaxWidth(),
+            )
+            SearchBar(
+                state = rememberTextFieldState(),
+                placeholder = "Search…",
+                modifier = Modifier.fillMaxWidth(),
+            )
+            SearchBar(
+                state = rememberTextFieldState(initialText = "Small search term"),
+                style = SearchBarStyle.Small,
+                modifier = Modifier.fillMaxWidth(),
+            )
+            SearchBar(
+                state = rememberTextFieldState(),
+                placeholder = "Small search…",
+                style = SearchBarStyle.Small,
+                modifier = Modifier.fillMaxWidth(),
+            )
+        }
     }
 }

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -932,6 +932,8 @@
 
     <!-- Playlists -->
 
+    <!-- %1$s is a playlist title  -->
+    <string name="add_to_playlist">Add to “%1$s”</string>
     <string name="create_playlist">Create Playlist</string>
     <string name="create_smart_playlist">Create Smart Playlist</string>
     <string name="decrement_longer_than_duration">Decrement \"longer than\" duration</string>


### PR DESCRIPTION
## Description

This PR adds the toolbar UI to the manual playlist episode selection flow.

Note: The title is aligned between the navigation button and the Done text, rather than centered within the toolbar. Centering it in the middle would either cause overlap with content or result in unused space.

Relates to PCDROID-110

## Testing Instructions

1. Create a manual playlist.
2. Tap "Add episodes"
3. You should see the toolbar.
4. Navigating to a folder should change the close button to the back button.

## Screenshots or Screencast 

| A | B |
| - | - |
| <img width="1080" height="2400" alt="image" src="https://github.com/user-attachments/assets/448553e9-35e9-4e6c-98e5-c45d438eba78" /> | <img width="1080" height="2400" alt="image" src="https://github.com/user-attachments/assets/399a2108-a98b-4441-acf6-e58234f7059b" /> |

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack