### PR TITLE
Show episodes in manual playlist build flow

### DIFF
--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/manual/episode/AddEpisodesFragment.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/manual/episode/AddEpisodesFragment.kt
@@ -49,6 +49,8 @@ class AddEpisodesFragment : BaseDialogFragment() {
                 AddEpisodesPage(
                     playlistTitle = uiState.playlist.title,
                     episodeSources = uiState.sources,
+                    episodesFlow = viewModel::getEpisodesFlow,
+                    useEpisodeArtwork = uiState.useEpisodeArtwork,
                     onClose = ::dismiss,
                     modifier = Modifier.fillMaxSize(),
                 )

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/manual/episode/AddEpisodesPage.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/manual/episode/AddEpisodesPage.kt
@@ -89,7 +89,7 @@ internal fun AddEpisodesPage(
                 )
             },
             style = ThemedTopAppBar.Style.Immersive,
-            iconColor = MaterialTheme.theme.colors.primaryIcon01,
+            iconColor = MaterialTheme.theme.colors.primaryIcon02,
             windowInsets = WindowInsets(0),
             onNavigationClick = {
                 if (!navController.popBackStack()) {

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/manual/episode/AddEpisodesViewModel.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/manual/episode/AddEpisodesViewModel.kt
@@ -3,6 +3,9 @@ package au.com.shiftyjelly.pocketcasts.playlists.manual.episode
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import au.com.shiftyjelly.pocketcasts.models.entity.ManualPlaylistEpisodeSource
+import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
+import au.com.shiftyjelly.pocketcasts.preferences.Settings
+import au.com.shiftyjelly.pocketcasts.preferences.model.ArtworkConfiguration
 import au.com.shiftyjelly.pocketcasts.repositories.playlist.ManualPlaylist
 import au.com.shiftyjelly.pocketcasts.repositories.playlist.PlaylistManager
 import dagger.assisted.Assisted
@@ -11,6 +14,8 @@ import dagger.assisted.AssistedInject
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.emitAll
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.map
@@ -20,13 +25,20 @@ import kotlinx.coroutines.flow.stateIn
 class AddEpisodesViewModel @AssistedInject constructor(
     @Assisted private val playlistUuid: String,
     private val playlistManager: PlaylistManager,
+    private val settings: Settings,
 ) : ViewModel() {
     val uiState = flow {
-        val uiStates = playlistManager.observeManualPlaylist(playlistUuid).map { playlist ->
+        val playlistFlow = playlistManager.observeManualPlaylist(playlistUuid)
+
+        val uiStates = combine(
+            playlistFlow,
+            settings.artworkConfiguration.flow,
+        ) { playlist, artworkConfig ->
             if (playlist != null) {
                 UiState(
                     playlist = playlist,
                     sources = playlistManager.getManualPlaylistEpisodeSources(),
+                    useEpisodeArtwork = artworkConfig.useEpisodeArtwork(ArtworkConfiguration.Element.Filters),
                 )
             } else {
                 null
@@ -38,9 +50,19 @@ class AddEpisodesViewModel @AssistedInject constructor(
         emitAll(uiStates)
     }.stateIn(viewModelScope, SharingStarted.Eagerly, initialValue = null)
 
+    private val episodeFlowsCache = mutableMapOf<String, StateFlow<List<PodcastEpisode>>>()
+
+    fun getEpisodesFlow(podcastUuid: String): StateFlow<List<PodcastEpisode>> {
+        return episodeFlowsCache.getOrPut(podcastUuid) {
+            val flow = playlistManager.observeManualPlaylistAvailableEpisodes(playlistUuid, podcastUuid)
+            flow.stateIn(viewModelScope, SharingStarted.WhileSubscribed(stopTimeoutMillis = 300), initialValue = emptyList())
+        }
+    }
+
     data class UiState(
         val playlist: ManualPlaylist,
         val sources: List<ManualPlaylistEpisodeSource>,
+        val useEpisodeArtwork: Boolean,
     )
 
     @AssistedFactory

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/manual/episode/EpisodeSourcesColumn.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/manual/episode/EpisodeSourcesColumn.kt
@@ -164,7 +164,7 @@ private fun BaseSourceRow(
 
 @Preview
 @Composable
-private fun EpisodesSourcesColumnPreview(
+private fun EpisodeSourcesColumnPreview(
     @PreviewParameter(ThemePreviewParameterProvider::class) themeType: Theme.ThemeType,
 ) {
     AppThemeWithBackground(themeType) {

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/manual/episode/EpisodesColumn.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/manual/episode/EpisodesColumn.kt
@@ -1,4 +1,4 @@
-package au.com.shiftyjelly.pocketcasts.playlists.smart.rules
+package au.com.shiftyjelly.pocketcasts.playlists.manual.episode
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -6,11 +6,15 @@ import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.Icon
+import androidx.compose.material.IconButton
 import androidx.compose.material.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
@@ -18,6 +22,8 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
@@ -25,6 +31,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import au.com.shiftyjelly.pocketcasts.compose.AppThemeWithBackground
 import au.com.shiftyjelly.pocketcasts.compose.components.EpisodeImage
+import au.com.shiftyjelly.pocketcasts.compose.components.FadedLazyColumn
 import au.com.shiftyjelly.pocketcasts.compose.components.HorizontalDivider
 import au.com.shiftyjelly.pocketcasts.compose.components.TextC70
 import au.com.shiftyjelly.pocketcasts.compose.components.TextH40
@@ -38,14 +45,40 @@ import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.repositories.extensions.getSummaryText
 import au.com.shiftyjelly.pocketcasts.repositories.images.PocketCastsImageRequestFactory.PlaceholderType
 import au.com.shiftyjelly.pocketcasts.ui.extensions.getThemeColor
-import au.com.shiftyjelly.pocketcasts.ui.theme.Theme.ThemeType
+import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import java.util.Date
+import au.com.shiftyjelly.pocketcasts.images.R as IR
+import au.com.shiftyjelly.pocketcasts.localization.R as LR
 import au.com.shiftyjelly.pocketcasts.ui.R as UR
 
 @Composable
-internal fun SmartEpisodeRow(
+internal fun EpisodesColumn(
+    episodes: List<PodcastEpisode>,
+    useEpisodeArtwork: Boolean,
+    onAddEpisode: (PodcastEpisode) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    FadedLazyColumn(
+        modifier = modifier,
+    ) {
+        items(
+            items = episodes,
+            key = { episode -> episode.uuid },
+        ) { episode ->
+            EpisodeRow(
+                episode = episode,
+                onClickAdd = { onAddEpisode(episode) },
+                useEpisodeArtwork = useEpisodeArtwork,
+            )
+        }
+    }
+}
+
+@Composable
+private fun EpisodeRow(
     episode: PodcastEpisode,
     useEpisodeArtwork: Boolean,
+    onClickAdd: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Column(
@@ -54,6 +87,7 @@ internal fun SmartEpisodeRow(
         Row(
             verticalAlignment = Alignment.CenterVertically,
             modifier = Modifier
+                .fillMaxWidth()
                 .height(IntrinsicSize.Min)
                 .padding(vertical = 12.dp, horizontal = 12.dp),
         ) {
@@ -71,7 +105,9 @@ internal fun SmartEpisodeRow(
             )
             Column(
                 verticalArrangement = Arrangement.SpaceBetween,
-                modifier = Modifier.fillMaxHeight(),
+                modifier = Modifier
+                    .weight(1f)
+                    .fillMaxHeight(),
             ) {
                 TextC70(
                     text = episode.rememberHeaderText(),
@@ -84,6 +120,18 @@ internal fun SmartEpisodeRow(
                 TextH60(
                     text = episode.rememberTimeLeftText(),
                     color = MaterialTheme.theme.colors.primaryText02,
+                )
+            }
+            Spacer(
+                modifier = Modifier.width(12.dp),
+            )
+            IconButton(
+                onClick = onClickAdd,
+            ) {
+                Icon(
+                    painter = painterResource(IR.drawable.ic_add_episode),
+                    contentDescription = stringResource(LR.string.add_to_playlist_episode_desc, episode.title),
+                    tint = MaterialTheme.theme.colors.primaryText01,
                 )
             }
         }
@@ -114,18 +162,21 @@ private fun PodcastEpisode.rememberTimeLeftText(): String {
 
 @Preview
 @Composable
-private fun SmartEpisodeRowPreview(
-    @PreviewParameter(ThemePreviewParameterProvider::class) themeType: ThemeType,
+private fun EpisodesColumnPreview(
+    @PreviewParameter(ThemePreviewParameterProvider::class) themeType: Theme.ThemeType,
 ) {
     AppThemeWithBackground(themeType) {
-        SmartEpisodeRow(
-            episode = PodcastEpisode(
-                uuid = "uuid",
-                title = "Episode Title",
-                duration = 6000.0,
-                publishedDate = Date(0),
-            ),
+        EpisodesColumn(
+            episodes = List(3) { index ->
+                PodcastEpisode(
+                    uuid = "uuid-$index",
+                    title = "Episode $index",
+                    duration = 1200.0,
+                    publishedDate = Date(0),
+                )
+            },
             useEpisodeArtwork = false,
+            onAddEpisode = {},
         )
     }
 }

--- a/modules/features/filters/src/test/kotlin/au/com/shiftyjelly/pocketcasts/playlists/create/FakePlaylistManager.kt
+++ b/modules/features/filters/src/test/kotlin/au/com/shiftyjelly/pocketcasts/playlists/create/FakePlaylistManager.kt
@@ -15,6 +15,7 @@ import java.util.UUID
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.flowOf
 
 class FakePlaylistManager : PlaylistManager {
     val playlistPreviews = MutableStateFlow(emptyList<PlaylistPreview>())
@@ -59,4 +60,6 @@ class FakePlaylistManager : PlaylistManager {
     override suspend fun updatePlaylistsOrder(sortedUuids: List<String>) = Unit
 
     override suspend fun getManualPlaylistEpisodeSources(): List<ManualPlaylistEpisodeSource> = emptyList()
+
+    override fun observeManualPlaylistAvailableEpisodes(playlistUuid: String, podcastUuid: String): Flow<List<PodcastEpisode>> = flowOf(emptyList())
 }

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/navigation/NavController.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/navigation/NavController.kt
@@ -4,7 +4,8 @@ import androidx.navigation.NavController
 import androidx.navigation.NavOptionsBuilder
 
 fun NavController.navigateOnce(route: String, builder: NavOptionsBuilder.() -> Unit = {}) {
-    if (currentDestination?.route != route) {
-        navigate(route, builder)
+    navigate(route) {
+        builder()
+        launchSingleTop = true
     }
 }

--- a/modules/services/images/src/main/res/drawable/ic_add_episode.xml
+++ b/modules/services/images/src/main/res/drawable/ic_add_episode.xml
@@ -1,0 +1,18 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="30dp"
+    android:height="30dp"
+    android:viewportWidth="30"
+    android:viewportHeight="30">
+    <path
+        android:fillAlpha="0.5"
+        android:fillColor="#ff00ff"
+        android:fillType="evenOdd"
+        android:pathData="M15,28.125C22.249,28.125 28.125,22.249 28.125,15C28.125,7.751 22.249,1.875 15,1.875C7.751,1.875 1.875,7.751 1.875,15C1.875,22.249 7.751,28.125 15,28.125ZM15,30C23.284,30 30,23.284 30,15C30,6.716 23.284,0 15,0C6.716,0 0,6.716 0,15C0,23.284 6.716,30 15,30Z"
+        android:strokeAlpha="0.5" />
+    <path
+        android:fillColor="#ff00ff"
+        android:pathData="M19.688,15L19.688,15A0.938,0.938 0,0 1,18.75 15.938L11.25,15.938A0.938,0.938 0,0 1,10.313 15L10.313,15A0.938,0.938 0,0 1,11.25 14.063L18.75,14.063A0.938,0.938 0,0 1,19.688 15z" />
+    <path
+        android:fillColor="#ff00ff"
+        android:pathData="M15,19.688L15,19.688A0.938,0.938 0,0 1,14.063 18.75L14.063,11.25A0.938,0.938 0,0 1,15 10.313L15,10.313A0.938,0.938 0,0 1,15.938 11.25L15.938,18.75A0.938,0.938 0,0 1,15 19.688z" />
+</vector>

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -934,6 +934,8 @@
 
     <!-- %1$s is a playlist title  -->
     <string name="add_to_playlist">Add to “%1$s”</string>
+    <!-- Accessibility description. %1$s is an episode title-->
+    <string name="add_to_playlist_episode_desc">Add %1$s to playlist</string>
     <string name="create_playlist">Create Playlist</string>
     <string name="create_smart_playlist">Create Smart Playlist</string>
     <string name="decrement_longer_than_duration">Decrement \"longer than\" duration</string>

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/PlaylistDao.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/PlaylistDao.kt
@@ -194,6 +194,25 @@ abstract class PlaylistDao {
         return podcasts + folders
     }
 
+    @Query(
+        """
+        SELECT episode.*
+        FROM podcast_episodes AS episode
+        WHERE
+          episode.podcast_id IS :podcastUuid 
+          AND episode.uuid NOT IN (
+            SELECT manual_episode.episode_uuid
+            FROM manual_playlist_episodes AS manual_episode
+            WHERE manual_episode.playlist_uuid IS :playlistUuid AND manual_episode.podcast_uuid IS :podcastUuid
+          )
+        ORDER BY
+          episode.published_date DESC,
+          episode.added_date DESC,
+          episode.title ASC
+    """,
+    )
+    abstract fun observeManualPlaylistAvailableEpisodes(playlistUuid: String, podcastUuid: String): Flow<List<PodcastEpisode>>
+
     @RawQuery(observedEntities = [Podcast::class, PodcastEpisode::class])
     protected abstract fun observeSmartEpisodeMetadata(query: RoomRawQuery): Flow<PlaylistEpisodeMetadata>
 

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playlist/PlaylistManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playlist/PlaylistManager.kt
@@ -46,4 +46,6 @@ interface PlaylistManager {
     suspend fun updatePlaylistsOrder(sortedUuids: List<String>)
 
     suspend fun getManualPlaylistEpisodeSources(): List<ManualPlaylistEpisodeSource>
+
+    fun observeManualPlaylistAvailableEpisodes(playlistUuid: String, podcastUuid: String): Flow<List<PodcastEpisode>>
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playlist/PlaylistManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playlist/PlaylistManagerImpl.kt
@@ -226,6 +226,12 @@ class PlaylistManagerImpl @Inject constructor(
         return playlistDao.getManualPlaylistEpisodeSources(useFolders = isSubscriber)
     }
 
+    override fun observeManualPlaylistAvailableEpisodes(playlistUuid: String, podcastUuid: String): Flow<List<PodcastEpisode>> {
+        return playlistDao
+            .observeManualPlaylistAvailableEpisodes(playlistUuid, podcastUuid)
+            .distinctUntilChanged()
+    }
+
     private fun List<PlaylistEntity>.toPreviewFlows() = map { playlist ->
         val type = if (playlist.manual) {
             PlaylistPreview.Type.Manual


### PR DESCRIPTION
## Description

This adds episode preview when build manual playlists.

Designs: 5sC4z4Mu42LvL4MAAIbQVi-fi-764_7821

Relates to PCDROID-110

## Testing Instructions

1. Create a manual playlist.
2. Tap "Add episodes"
3. Select any podcast.
4. You should see its episodes.

## Screenshots or Screencast 

<img width="540" alt="image" src="https://github.com/user-attachments/assets/6a206628-ebef-4925-b975-f262cc9b0e04" />

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack