### PR TITLE
Add episodes to manual playlists

### DIFF
--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/manual/PlaylistFragment.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/manual/PlaylistFragment.kt
@@ -19,8 +19,11 @@ import au.com.shiftyjelly.pocketcasts.playlists.component.PlaylistHeaderAdapter
 import au.com.shiftyjelly.pocketcasts.playlists.component.PlaylistHeaderButtonData
 import au.com.shiftyjelly.pocketcasts.playlists.component.PlaylistHeaderData
 import au.com.shiftyjelly.pocketcasts.playlists.manual.episode.AddEpisodesFragment
+import au.com.shiftyjelly.pocketcasts.repositories.playlist.PlaylistManager
+import au.com.shiftyjelly.pocketcasts.ui.helper.FragmentHostListener
 import au.com.shiftyjelly.pocketcasts.views.extensions.hideKeyboardOnScroll
 import au.com.shiftyjelly.pocketcasts.views.fragments.BaseFragment
+import com.google.android.material.snackbar.Snackbar
 import dagger.hilt.android.AndroidEntryPoint
 import dagger.hilt.android.lifecycle.withCreationCallback
 import kotlin.time.Duration
@@ -119,6 +122,12 @@ class PlaylistFragment : BaseFragment() {
     }
 
     private fun openEditor() {
+        val episodeCount = viewModel.uiState.value.manualPlaylist?.totalEpisodeCount ?: Int.MAX_VALUE
+        if (episodeCount >= PlaylistManager.MANUAL_PLAYLIST_EPISODE_LIMIT) {
+            val snackbarView = (requireActivity() as FragmentHostListener).snackBarView()
+            Snackbar.make(snackbarView, getString(LR.string.add_to_playlist_failure_message), Snackbar.LENGTH_LONG).show()
+            return
+        }
         if (parentFragmentManager.findFragmentByTag("playlist_episode_editor") != null) {
             return
         }

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/manual/episode/AddEpisodesFragment.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/manual/episode/AddEpisodesFragment.kt
@@ -71,7 +71,7 @@ class AddEpisodesFragment : BaseDialogFragment() {
 
             ThemedSnackbarHost(
                 hostState = snackbarHostState,
-                modifier = Modifier.align(Alignment.BottomCenter)
+                modifier = Modifier.align(Alignment.BottomCenter),
             )
         }
     }

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/manual/episode/AddEpisodesPage.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/manual/episode/AddEpisodesPage.kt
@@ -16,6 +16,7 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
@@ -43,15 +44,16 @@ import au.com.shiftyjelly.pocketcasts.models.entity.ManualPlaylistFolderSource
 import au.com.shiftyjelly.pocketcasts.models.entity.ManualPlaylistPodcastSource
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import kotlinx.coroutines.flow.StateFlow
-import timber.log.Timber
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 @Composable
 internal fun AddEpisodesPage(
     playlistTitle: String,
+    addedEpisodesCount: Int,
     episodeSources: List<ManualPlaylistEpisodeSource>,
     episodesFlow: (String) -> StateFlow<List<PodcastEpisode>>,
     useEpisodeArtwork: Boolean,
+    onAddEpisode: (String) -> Unit,
     onClose: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -66,7 +68,15 @@ internal fun AddEpisodesPage(
             navigationButton = NavigationButton.CloseBack(isClose = isTopPageDisplayed),
             title = {
                 TextH40(
-                    text = stringResource(LR.string.add_to_playlist, playlistTitle),
+                    text = if (addedEpisodesCount == 0) {
+                        stringResource(LR.string.add_to_playlist, playlistTitle)
+                    } else {
+                        stringResource(
+                            LR.string.added_to_playlist,
+                            pluralStringResource(LR.plurals.episode_count, addedEpisodesCount, addedEpisodesCount),
+                            playlistTitle,
+                        )
+                    },
                     textAlign = TextAlign.Center,
                     color = MaterialTheme.theme.colors.primaryText01,
                     maxLines = 2,
@@ -162,9 +172,7 @@ internal fun AddEpisodesPage(
                 EpisodesColumn(
                     episodes = episodes,
                     useEpisodeArtwork = useEpisodeArtwork,
-                    onAddEpisode = { episode ->
-                        Timber.tag("Add episode: ${episode.title}")
-                    },
+                    onAddEpisode = { episode -> onAddEpisode(episode.uuid) },
                     modifier = Modifier.fillMaxSize(),
                 )
             }

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/manual/episode/EpisodesColumn.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/manual/episode/EpisodesColumn.kt
@@ -69,6 +69,7 @@ internal fun EpisodesColumn(
                 episode = episode,
                 onClickAdd = { onAddEpisode(episode) },
                 useEpisodeArtwork = useEpisodeArtwork,
+                modifier = Modifier.animateItem(),
             )
         }
     }

--- a/modules/features/filters/src/test/kotlin/au/com/shiftyjelly/pocketcasts/playlists/create/FakePlaylistManager.kt
+++ b/modules/features/filters/src/test/kotlin/au/com/shiftyjelly/pocketcasts/playlists/create/FakePlaylistManager.kt
@@ -62,4 +62,6 @@ class FakePlaylistManager : PlaylistManager {
     override suspend fun getManualPlaylistEpisodeSources(): List<ManualPlaylistEpisodeSource> = emptyList()
 
     override fun observeManualPlaylistAvailableEpisodes(playlistUuid: String, podcastUuid: String): Flow<List<PodcastEpisode>> = flowOf(emptyList())
+
+    override suspend fun addManualPlaylistEpisode(playlistUuid: String, episodeUuid: String): Boolean = true
 }

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/ThemedSnackbarHost.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/ThemedSnackbarHost.kt
@@ -1,0 +1,55 @@
+package au.com.shiftyjelly.pocketcasts.compose.components
+
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Snackbar
+import androidx.compose.material.SnackbarData
+import androidx.compose.material.SnackbarHost
+import androidx.compose.material.SnackbarHostState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import au.com.shiftyjelly.pocketcasts.compose.theme
+
+@Composable
+fun ThemedSnackbarHost(
+    hostState: SnackbarHostState,
+    modifier: Modifier = Modifier,
+    snackbar: @Composable (SnackbarData, SnackbarTheme) -> Unit = { data, theme ->
+        Snackbar(
+            snackbarData = data,
+            backgroundColor = theme.surfaceColor,
+            contentColor = theme.textColor,
+        )
+    },
+) {
+    val theme = rememberSnackbarTheme()
+    SnackbarHost(
+        hostState = hostState,
+        snackbar = { data -> snackbar(data, theme) },
+        modifier = modifier,
+    )
+}
+
+data class SnackbarTheme(
+    val surfaceColor: Color,
+    val textColor: Color,
+)
+
+@Composable
+private fun rememberSnackbarTheme(): SnackbarTheme {
+    val isDarkTheme = MaterialTheme.theme.isDark
+    return remember(isDarkTheme) {
+        if (isDarkTheme) {
+            SnackbarTheme(
+                surfaceColor = Color.White,
+                textColor = Color(0xFF292B2E),
+            )
+        } else {
+            SnackbarTheme(
+                surfaceColor = Color(0xFF292B2E),
+                textColor = Color.White,
+            )
+        }
+    }
+}

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -934,8 +934,11 @@
 
     <!-- %1$s is a playlist title  -->
     <string name="add_to_playlist">Add to “%1$s”</string>
+    <!-- %1$s is episode count like "1 episode", "7 episodes". %2$s is a playlist title  -->
+    <string name="added_to_playlist">%1$s added to “%2$s”</string>
     <!-- Accessibility description. %1$s is an episode title-->
     <string name="add_to_playlist_episode_desc">Add %1$s to playlist</string>
+    <string name="add_to_playlist_failure_message">This playlist is full. Remove a few episodes or start a new one.</string>
     <string name="create_playlist">Create Playlist</string>
     <string name="create_smart_playlist">Create Smart Playlist</string>
     <string name="decrement_longer_than_duration">Decrement \"longer than\" duration</string>

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/PlaylistDao.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/PlaylistDao.kt
@@ -123,11 +123,17 @@ abstract class PlaylistDao {
         JOIN manual_playlist_episodes AS playlistEpisode ON playlistEpisode.playlist_uuid IS playlist.uuid
         LEFT JOIN podcast_episodes AS podcastEpisode ON podcastEpisode.uuid IS playlistEpisode.episode_uuid
         WHERE
-          playlist.uuid IS :playlistId
+          playlist.uuid IS :playlistUuid
           AND IFNULL(podcastEpisode.archived, 0) IS 0
     """,
     )
-    abstract fun observeManualEpisodeMetadata(playlistId: String): Flow<PlaylistEpisodeMetadata>
+    abstract fun observeManualEpisodeMetadata(playlistUuid: String): Flow<PlaylistEpisodeMetadata>
+
+    @Query("SELECT episode_uuid FROM manual_playlist_episodes WHERE playlist_uuid IS :playlistUuid")
+    abstract suspend fun getManualPlaylistEpisodeUuids(playlistUuid: String): List<String>
+
+    @Query("SELECT * FROM manual_playlist_episodes WHERE playlist_uuid IS :playlistUuid")
+    abstract suspend fun getManualPlaylistEpisodes(playlistUuid: String): List<ManualPlaylistEpisode>
 
     @Query(
         """
@@ -239,7 +245,7 @@ abstract class PlaylistDao {
         JOIN podcast_episodes AS podcastEpisode ON podcastEpisode.uuid IS playlistEpisode.episode_uuid
         JOIN podcasts AS podcast ON podcast.uuid IS playlistEpisode.podcast_uuid
         WHERE
-          playlist.uuid IS :playlistId
+          playlist.uuid IS :playlistUuid
           AND podcastEpisode.archived IS 0
         ORDER BY
           -- newest to oldest
@@ -257,7 +263,7 @@ abstract class PlaylistDao {
         LIMIT 4
     """,
     )
-    abstract fun observeManualPlaylistPodcasts(playlistId: String): Flow<List<String>>
+    abstract fun observeManualPlaylistPodcasts(playlistUuid: String): Flow<List<String>>
 
     @Query(
         """

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playlist/PlaylistManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playlist/PlaylistManager.kt
@@ -48,4 +48,12 @@ interface PlaylistManager {
     suspend fun getManualPlaylistEpisodeSources(): List<ManualPlaylistEpisodeSource>
 
     fun observeManualPlaylistAvailableEpisodes(playlistUuid: String, podcastUuid: String): Flow<List<PodcastEpisode>>
+
+    suspend fun addManualPlaylistEpisode(playlistUuid: String, episodeUuid: String): Boolean
+
+    companion object {
+        const val PLAYLIST_ARTWORK_EPISODE_LIMIT = 4
+        const val SMART_PLAYLIST_EPISODE_LIMIT = 1000
+        const val MANUAL_PLAYLIST_EPISODE_LIMIT = 1000
+    }
 }


### PR DESCRIPTION
## Description

As the title says. Note that the snackbar doesn't show the alert icon as the designs didn't account for Android components that we use. This was clarified here: 5sC4z4Mu42LvL4MAAIbQVi-fi-831_13279#1363225140

Designs: 5sC4z4Mu42LvL4MAAIbQVi-fi-2600_36431

Closes PCDROID-110

## Testing Instructions

1. Apply [this patch](https://github.com/user-attachments/files/22092522/ep-limit.patch).
```
curl -L https://github.com/user-attachments/files/22092522/ep-limit.patch | git apply
```
2. Create a manual playlist.
3. Tap "Add Episodes".
4. Navigate to any podcast.
5. Start adding episodes.
6. The sheet's title should update with added episodes.
7. When you reach limit you should see a snackbar.
8. Close the sheet.
9. Tap "Add Episodes".
10. You should see a snackbar.
11. You can test added episodes by inspecting the `manual_playlist_episodes` table.

## Screenshots or Screencast 

| A | B |
| - | - |
| <img width="1080" height="2400" alt="image" src="https://github.com/user-attachments/assets/4d62f61d-7d96-4fb9-8685-2581d6d0cebf" /> | <img width="1080" height="2400" alt="image" src="https://github.com/user-attachments/assets/cf6bcf14-f034-4667-9371-1f108df826ed" /> |

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [ ] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [ ] with different themes
- [ ] with a landscape orientation
- [ ] with the device set to have a large display and font size
- [ ] for accessibility with TalkBack