### PR TITLE
Filter episodes when adding them to manual playlists

### DIFF
--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/repositories/playlist/PlaylistManagerTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/repositories/playlist/PlaylistManagerTest.kt
@@ -1347,23 +1347,23 @@ class PlaylistManagerTest {
             deleted = false,
             syncModified = 0L,
         )
-        folderDao.insert(baseFolder.copy(uuid = "folder-uuid-1", name = "Folder ABC 1"))
+        folderDao.insert(baseFolder.copy(uuid = "folder-uuid-1", name = "Folder AbC 1"))
 
         podcastDao.insertSuspend(Podcast(uuid = "podcast-uuid-1", title = "Podcast ABC 1", rawFolderUuid = "folder-uuid-1", isSubscribed = true))
-        podcastDao.insertSuspend(Podcast(uuid = "podcast-uuid-2", title = "Podcast ABC 2", isSubscribed = true))
+        podcastDao.insertSuspend(Podcast(uuid = "podcast-uuid-2", title = "Podcast abc 2", isSubscribed = true))
         podcastDao.insertSuspend(Podcast(uuid = "podcast-uuid-3", title = "Podcast DEF 3", rawFolderUuid = "folder-uuid-1", isSubscribed = true))
-        podcastDao.insertSuspend(Podcast(uuid = "podcast-uuid-4", title = "Podcast DEF 4", isSubscribed = true))
+        podcastDao.insertSuspend(Podcast(uuid = "podcast-uuid-4", title = "Podcast def 4", isSubscribed = true))
 
         assertEquals(
             listOf(
                 ManualPlaylistPodcastSource(
                     uuid = "podcast-uuid-2",
-                    title = "Podcast ABC 2",
+                    title = "Podcast abc 2",
                     author = "",
                 ),
                 ManualPlaylistFolderSource(
                     uuid = "folder-uuid-1",
-                    title = "Folder ABC 1",
+                    title = "Folder AbC 1",
                     color = 0,
                     podcastSources = listOf(
                         ManualPlaylistPodcastSource(
@@ -1381,12 +1381,12 @@ class PlaylistManagerTest {
             listOf(
                 ManualPlaylistPodcastSource(
                     uuid = "podcast-uuid-4",
-                    title = "Podcast DEF 4",
+                    title = "Podcast def 4",
                     author = "",
                 ),
                 ManualPlaylistFolderSource(
                     uuid = "folder-uuid-1",
-                    title = "Folder ABC 1",
+                    title = "Folder AbC 1",
                     color = 0,
                     podcastSources = listOf(
                         ManualPlaylistPodcastSource(
@@ -1442,6 +1442,43 @@ class PlaylistManagerTest {
                 ManualPlaylistEpisode.test(playlistUuid = playlistUuid, episodeUuid = "episode-uuid-2", podcastUuid = "podcast-uuid-1"),
             )
             assertEquals(listOf(episode1), awaitItem())
+        }
+    }
+
+    @Test
+    fun filterManualPlaylistAvailableEpisodes() = runTest(testDispatcher) {
+        val playlistUuid = manager.createManualPlaylist("Manual Playlist")
+
+        manager.observeManualPlaylistAvailableEpisodes(playlistUuid, "podcast-uuid-1", "ABC").test {
+            skipItems(1)
+
+            val episode1 = PodcastEpisode(
+                uuid = "episode-uuid-1",
+                podcastUuid = "podcast-uuid-1",
+                title = "episode abc 1",
+                publishedDate = Date(0),
+            )
+            episodeDao.insert(episode1)
+            assertEquals(listOf(episode1), awaitItem())
+
+            val episode2 = PodcastEpisode(
+                uuid = "episode-uuid-2",
+                podcastUuid = "podcast-uuid-1",
+                title = "ABC episode 2",
+                publishedDate = Date(1),
+            )
+            episodeDao.insert(episode2)
+            assertEquals(listOf(episode2, episode1), awaitItem())
+
+            episodeDao.insert(
+                PodcastEpisode(
+                    uuid = "episode-uuid-3",
+                    podcastUuid = "podcast-uuid-2",
+                    title = "AB episode 3",
+                    publishedDate = Date(),
+                ),
+            )
+            expectNoEvents()
         }
     }
 

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/manual/episode/AddEpisodesFragment.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/manual/episode/AddEpisodesFragment.kt
@@ -15,7 +15,6 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
@@ -35,7 +34,6 @@ import au.com.shiftyjelly.pocketcasts.views.fragments.BaseDialogFragment
 import dagger.hilt.android.AndroidEntryPoint
 import dagger.hilt.android.lifecycle.withCreationCallback
 import kotlinx.parcelize.Parcelize
-import timber.log.Timber
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 @AndroidEntryPoint
@@ -76,6 +74,7 @@ class AddEpisodesFragment : BaseDialogFragment() {
                     playlistTitle = uiState.playlist.title,
                     addedEpisodesCount = uiState.addedEpisodeUuids.size,
                     episodeSources = uiState.sources,
+                    folderPodcastsFlow = viewModel::getFolderPodcastsFlow,
                     episodesFlow = viewModel::getEpisodesFlow,
                     useEpisodeArtwork = uiState.useEpisodeArtwork,
                     onAddEpisode = viewModel::addEpisode,

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/manual/episode/AddEpisodesFragment.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/manual/episode/AddEpisodesFragment.kt
@@ -63,6 +63,7 @@ class AddEpisodesFragment : BaseDialogFragment() {
                     episodeSources = uiState.sources,
                     episodesFlow = viewModel::getEpisodesFlow,
                     useEpisodeArtwork = uiState.useEpisodeArtwork,
+                    searchState = viewModel.searchState,
                     onAddEpisode = viewModel::addEpisode,
                     onClose = ::dismiss,
                     modifier = Modifier.fillMaxSize(),

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/manual/episode/AddEpisodesFragment.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/manual/episode/AddEpisodesFragment.kt
@@ -99,8 +99,8 @@ class AddEpisodesFragment : BaseDialogFragment() {
         val backStackEntry by navController.currentBackStackEntryAsState()
         return remember(backStackEntry) {
             when (backStackEntry?.destination?.route) {
-                AddEpisodesRoutes.PODCAST -> viewModel.episodeSearchState
-                else -> viewModel.podcastSearchState
+                AddEpisodesRoutes.PODCAST -> viewModel.episodeSearchState.textState
+                else -> viewModel.podcastSearchState.textState
             }
         }
     }
@@ -122,7 +122,7 @@ class AddEpisodesFragment : BaseDialogFragment() {
         LaunchedEffect(navController) {
             navController.currentBackStackEntryFlow.collect { entry ->
                 if (entry.destination.route != AddEpisodesRoutes.PODCAST) {
-                    viewModel.episodeSearchState.clearText()
+                    viewModel.episodeSearchState.textState.clearText()
                 }
             }
         }

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/manual/episode/AddEpisodesPage.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/manual/episode/AddEpisodesPage.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.text.input.TextFieldState
 import androidx.compose.foundation.text.input.rememberTextFieldState
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
@@ -53,6 +54,7 @@ internal fun AddEpisodesPage(
     episodeSources: List<ManualPlaylistEpisodeSource>,
     episodesFlow: (String) -> StateFlow<List<PodcastEpisode>>,
     useEpisodeArtwork: Boolean,
+    searchState: TextFieldState,
     onAddEpisode: (String) -> Unit,
     onClose: () -> Unit,
     modifier: Modifier = Modifier,
@@ -109,7 +111,7 @@ internal fun AddEpisodesPage(
         )
 
         SearchBar(
-            state = rememberTextFieldState(),
+            state = searchState,
             placeholder = stringResource(LR.string.search),
             style = SearchBarStyle.Small,
             modifier = Modifier

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/manual/episode/AddEpisodesPage.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/manual/episode/AddEpisodesPage.kt
@@ -22,6 +22,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import androidx.navigation.NavHostController
 import androidx.navigation.NavType
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
@@ -54,12 +55,12 @@ internal fun AddEpisodesPage(
     episodeSources: List<ManualPlaylistEpisodeSource>,
     episodesFlow: (String) -> StateFlow<List<PodcastEpisode>>,
     useEpisodeArtwork: Boolean,
-    searchState: TextFieldState,
     onAddEpisode: (String) -> Unit,
-    onClose: () -> Unit,
+    onNavigationClick: () -> Unit,
     modifier: Modifier = Modifier,
+    navController: NavHostController = rememberNavController(),
+    searchState: TextFieldState = rememberTextFieldState(),
 ) {
-    val navController = rememberNavController()
     val backStackEntry by navController.currentBackStackEntryAsState()
     val isTopPageDisplayed = backStackEntry == null || backStackEntry?.destination?.route == AddEpisodesRoutes.HOME
 
@@ -95,7 +96,7 @@ internal fun AddEpisodesPage(
                         .clickable(
                             indication = null,
                             interactionSource = null,
-                            onClick = onClose,
+                            onClick = onNavigationClick,
                         )
                         .padding(end = 16.dp),
                 )
@@ -103,11 +104,7 @@ internal fun AddEpisodesPage(
             style = ThemedTopAppBar.Style.Immersive,
             iconColor = MaterialTheme.theme.colors.primaryIcon02,
             windowInsets = WindowInsets(0),
-            onNavigationClick = {
-                if (!navController.popBackStack()) {
-                    onClose()
-                }
-            },
+            onNavigationClick = onNavigationClick,
         )
 
         SearchBar(
@@ -182,7 +179,7 @@ internal fun AddEpisodesPage(
     }
 }
 
-private object AddEpisodesRoutes {
+internal object AddEpisodesRoutes {
     const val HOME = "home"
 
     private const val FOLDER_BASE = "folder"

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/manual/episode/AddEpisodesPage.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/manual/episode/AddEpisodesPage.kt
@@ -152,6 +152,7 @@ internal fun AddEpisodesPage(
                 val arguments = requireNotNull(backStackEntry.arguments) { "Missing back stack entry arguments" }
                 val folderUuid = requireNotNull(arguments.getString(AddEpisodesRoutes.FOLDER_UUID_ARG)) { "Missing folder uuid argument" }
                 val podcasts by folderPodcastsFlow(folderUuid).collectAsState()
+
                 EpisodeSourcesColumn(
                     sources = podcasts,
                     onClickSource = navigateToSource,
@@ -166,6 +167,7 @@ internal fun AddEpisodesPage(
                 val arguments = requireNotNull(backStackEntry.arguments) { "Missing back stack entry arguments" }
                 val podcastUuid = requireNotNull(arguments.getString(AddEpisodesRoutes.PODCAST_UUID_ARG)) { "Missing podcast uuid argument" }
                 val episodes by episodesFlow(podcastUuid).collectAsState()
+
                 EpisodesColumn(
                     episodes = episodes,
                     useEpisodeArtwork = useEpisodeArtwork,

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/manual/episode/AddEpisodesPage.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/manual/episode/AddEpisodesPage.kt
@@ -15,7 +15,6 @@ import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
@@ -53,6 +52,7 @@ internal fun AddEpisodesPage(
     playlistTitle: String,
     addedEpisodesCount: Int,
     episodeSources: List<ManualPlaylistEpisodeSource>,
+    folderPodcastsFlow: (String) -> StateFlow<List<ManualPlaylistPodcastSource>>,
     episodesFlow: (String) -> StateFlow<List<PodcastEpisode>>,
     useEpisodeArtwork: Boolean,
     onAddEpisode: (String) -> Unit,
@@ -151,9 +151,7 @@ internal fun AddEpisodesPage(
             ) { backStackEntry ->
                 val arguments = requireNotNull(backStackEntry.arguments) { "Missing back stack entry arguments" }
                 val folderUuid = requireNotNull(arguments.getString(AddEpisodesRoutes.FOLDER_UUID_ARG)) { "Missing folder uuid argument" }
-                val podcasts = remember(folderUuid) {
-                    episodeSources.filterIsInstance<ManualPlaylistFolderSource>().find { it.uuid == folderUuid }?.podcastSources.orEmpty()
-                }
+                val podcasts by folderPodcastsFlow(folderUuid).collectAsState()
                 EpisodeSourcesColumn(
                     sources = podcasts,
                     onClickSource = navigateToSource,

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/manual/episode/EpisodeSourcesColumn.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/manual/episode/EpisodeSourcesColumn.kt
@@ -8,9 +8,12 @@ import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material.MaterialTheme
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -39,8 +42,14 @@ internal fun EpisodeSourcesColumn(
     sources: List<ManualPlaylistEpisodeSource>,
     onClickSource: (ManualPlaylistEpisodeSource) -> Unit,
     modifier: Modifier = Modifier,
+    listState: LazyListState = rememberLazyListState(),
 ) {
+    LaunchedEffect(sources) {
+        listState.scrollToItem(0)
+    }
+
     FadedLazyColumn(
+        state = listState,
         modifier = modifier,
     ) {
         item(key = "header", contentType = "header") {

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/manual/episode/EpisodesColumn.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/manual/episode/EpisodesColumn.kt
@@ -11,12 +11,15 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Icon
 import androidx.compose.material.IconButton
 import androidx.compose.material.MaterialTheme
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -57,9 +60,15 @@ internal fun EpisodesColumn(
     useEpisodeArtwork: Boolean,
     onAddEpisode: (PodcastEpisode) -> Unit,
     modifier: Modifier = Modifier,
+    listState: LazyListState = rememberLazyListState(),
 ) {
+    LaunchedEffect(episodes) {
+        listState.scrollToItem(0)
+    }
+
     FadedLazyColumn(
         modifier = modifier,
+        state = listState,
     ) {
         items(
             items = episodes,

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/smart/PlaylistFragment.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/smart/PlaylistFragment.kt
@@ -109,7 +109,7 @@ class PlaylistFragment :
                     playAll()
                 },
             ),
-            searchState = viewModel.searchState,
+            searchState = viewModel.searchState.textState,
             onChangeSearchFocus = { hasFocus, searchTopOffset ->
                 if (hasFocus) {
                     content.smoothScrollToTop(0, offset = -searchTopOffset.roundToInt())

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/smart/PlaylistViewModel.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/smart/PlaylistViewModel.kt
@@ -1,12 +1,11 @@
 package au.com.shiftyjelly.pocketcasts.playlists.smart
 
-import androidx.compose.foundation.text.input.TextFieldState
-import androidx.compose.runtime.snapshotFlow
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTracker
 import au.com.shiftyjelly.pocketcasts.analytics.SourceView
+import au.com.shiftyjelly.pocketcasts.compose.text.SearchFieldState
 import au.com.shiftyjelly.pocketcasts.models.type.PlaylistEpisodeSortType
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.repositories.download.DownloadManager
@@ -25,8 +24,6 @@ import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.asSharedFlow
-import kotlinx.coroutines.flow.debounce
-import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
@@ -57,12 +54,9 @@ class PlaylistViewModel @AssistedInject constructor(
     private val _showSettingsSignal = MutableSharedFlow<Unit>()
     val showSettingsSignal = _showSettingsSignal.asSharedFlow()
 
-    val searchState = TextFieldState()
+    val searchState = SearchFieldState()
 
-    val uiState = snapshotFlow { searchState.text }
-        .map { it.toString().trim() }
-        .debounce { searchTerm -> if (searchTerm.isEmpty()) 0 else 300 }
-        .distinctUntilChanged()
+    val uiState = searchState.textFlow
         .flatMapLatest { searchTerm -> playlistManager.observeSmartPlaylist(playlistUuid, searchTerm) }
         .map { UiState(it) }
         .stateIn(viewModelScope, SharingStarted.Lazily, initialValue = UiState.Empty)

--- a/modules/features/filters/src/test/kotlin/au/com/shiftyjelly/pocketcasts/playlists/create/FakePlaylistManager.kt
+++ b/modules/features/filters/src/test/kotlin/au/com/shiftyjelly/pocketcasts/playlists/create/FakePlaylistManager.kt
@@ -59,9 +59,9 @@ class FakePlaylistManager : PlaylistManager {
 
     override suspend fun updatePlaylistsOrder(sortedUuids: List<String>) = Unit
 
-    override suspend fun getManualPlaylistEpisodeSources(): List<ManualPlaylistEpisodeSource> = emptyList()
+    override suspend fun getManualPlaylistEpisodeSources(searchTerm: String?): List<ManualPlaylistEpisodeSource> = emptyList()
 
-    override fun observeManualPlaylistAvailableEpisodes(playlistUuid: String, podcastUuid: String): Flow<List<PodcastEpisode>> = flowOf(emptyList())
+    override fun observeManualPlaylistAvailableEpisodes(playlistUuid: String, podcastUuid: String, searchTerm: String?): Flow<List<PodcastEpisode>> = flowOf(emptyList())
 
     override suspend fun addManualPlaylistEpisode(playlistUuid: String, episodeUuid: String): Boolean = true
 }

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/text/SearchFieldState.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/text/SearchFieldState.kt
@@ -1,0 +1,33 @@
+package au.com.shiftyjelly.pocketcasts.compose.text
+
+import androidx.compose.foundation.text.input.TextFieldState
+import androidx.compose.foundation.text.input.rememberTextFieldState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.snapshotFlow
+import androidx.compose.ui.text.TextRange
+import kotlinx.coroutines.FlowPreview
+import kotlinx.coroutines.flow.debounce
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.map
+
+@Stable
+class SearchFieldState(
+    val textState: TextFieldState,
+) {
+    constructor(
+        initialText: String = "",
+        initialSelection: TextRange = TextRange(initialText.length),
+    ) : this(TextFieldState(initialText, initialSelection))
+
+    @OptIn(FlowPreview::class)
+    val textFlow = snapshotFlow { textState.text.toString().trim() }
+        .distinctUntilChanged()
+        .debounce { searchTerm -> if (searchTerm.isEmpty()) 0 else 300 }
+}
+
+@Composable
+fun rememberSearchFieldState(
+    initialText: String = "",
+    initialSelection: TextRange = TextRange(initialText.length),
+): SearchFieldState = SearchFieldState(rememberTextFieldState(initialText, initialSelection))

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playlist/PlaylistManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playlist/PlaylistManager.kt
@@ -47,7 +47,7 @@ interface PlaylistManager {
 
     suspend fun getManualPlaylistEpisodeSources(searchTerm: String? = null): List<ManualPlaylistEpisodeSource>
 
-    fun observeManualPlaylistAvailableEpisodes(playlistUuid: String, podcastUuid: String): Flow<List<PodcastEpisode>>
+    fun observeManualPlaylistAvailableEpisodes(playlistUuid: String, podcastUuid: String, searchTerm: String? = null): Flow<List<PodcastEpisode>>
 
     suspend fun addManualPlaylistEpisode(playlistUuid: String, episodeUuid: String): Boolean
 

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playlist/PlaylistManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playlist/PlaylistManager.kt
@@ -45,7 +45,7 @@ interface PlaylistManager {
 
     suspend fun updatePlaylistsOrder(sortedUuids: List<String>)
 
-    suspend fun getManualPlaylistEpisodeSources(): List<ManualPlaylistEpisodeSource>
+    suspend fun getManualPlaylistEpisodeSources(searchTerm: String? = null): List<ManualPlaylistEpisodeSource>
 
     fun observeManualPlaylistAvailableEpisodes(playlistUuid: String, podcastUuid: String): Flow<List<PodcastEpisode>>
 

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playlist/PlaylistManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playlist/PlaylistManagerImpl.kt
@@ -227,9 +227,9 @@ class PlaylistManagerImpl @Inject constructor(
         }
     }
 
-    override suspend fun getManualPlaylistEpisodeSources(): List<ManualPlaylistEpisodeSource> {
+    override suspend fun getManualPlaylistEpisodeSources(searchTerm: String?): List<ManualPlaylistEpisodeSource> {
         val isSubscriber = settings.cachedSubscription.value != null
-        return playlistDao.getManualPlaylistEpisodeSources(useFolders = isSubscriber)
+        return playlistDao.getManualPlaylistEpisodeSources(useFolders = isSubscriber, searchTerm = searchTerm)
     }
 
     override fun observeManualPlaylistAvailableEpisodes(playlistUuid: String, podcastUuid: String): Flow<List<PodcastEpisode>> {

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playlist/PlaylistManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playlist/PlaylistManagerImpl.kt
@@ -30,9 +30,11 @@ import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.repositories.playlist.PlaylistManager.Companion.MANUAL_PLAYLIST_EPISODE_LIMIT
 import au.com.shiftyjelly.pocketcasts.repositories.playlist.PlaylistManager.Companion.PLAYLIST_ARTWORK_EPISODE_LIMIT
 import au.com.shiftyjelly.pocketcasts.repositories.playlist.PlaylistManager.Companion.SMART_PLAYLIST_EPISODE_LIMIT
+import au.com.shiftyjelly.pocketcasts.utils.extensions.escapeLike
 import java.time.Clock
 import java.util.UUID
 import javax.inject.Inject
+import kotlin.text.orEmpty
 import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -229,12 +231,23 @@ class PlaylistManagerImpl @Inject constructor(
 
     override suspend fun getManualPlaylistEpisodeSources(searchTerm: String?): List<ManualPlaylistEpisodeSource> {
         val isSubscriber = settings.cachedSubscription.value != null
-        return playlistDao.getManualPlaylistEpisodeSources(useFolders = isSubscriber, searchTerm = searchTerm)
+        return playlistDao.getManualPlaylistEpisodeSources(
+            useFolders = isSubscriber,
+            searchTerm = searchTerm?.escapeLike('\\').orEmpty(),
+        )
     }
 
-    override fun observeManualPlaylistAvailableEpisodes(playlistUuid: String, podcastUuid: String): Flow<List<PodcastEpisode>> {
+    override fun observeManualPlaylistAvailableEpisodes(
+        playlistUuid: String,
+        podcastUuid: String,
+        searchTerm: String?,
+    ): Flow<List<PodcastEpisode>> {
         return playlistDao
-            .observeManualPlaylistAvailableEpisodes(playlistUuid, podcastUuid)
+            .observeManualPlaylistAvailableEpisodes(
+                playlistUuid = playlistUuid,
+                podcastUuid = podcastUuid,
+                searchTerm = searchTerm?.escapeLike('\\').orEmpty(),
+            )
             .distinctUntilChanged()
     }
 


### PR DESCRIPTION
## Description

This adds search feature when building manual playlists. Podcast/folder search is independent of the episode search.

Closes PCDROID-111
Closes PCDROID-112

## Testing Instructions

1. Create a manual playlist.
2. Tap "Add Episodes".
3. Searching should podcasts and folders. Note: folder search includes podcasts instead the folder.
4. Tap a folder.
5. Search term should still be the same.
6. Go to a podcast.
7. Search term should be cleared.
8. Search for episodes.
9. Go back.
10. Search term should change back to the one you used for podcasts.

## Screenshots or Screencast 

https://github.com/user-attachments/assets/97b5d441-54af-4815-a4a6-c6d3475a9b10

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack