### PR TITLE
Pass intent.data when receiving/opening a notification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 7.98
 -----
-
+*   Bug Fixes
+    *   Fix Download notifications no longer open app
+        ([#4449](https://github.com/Automattic/pocket-casts-android/pull/4449))
 
 7.97
 -----
@@ -10,7 +12,7 @@
 *   Updates
     *   Improved notification permission experience
         ([#4408](https://github.com/Automattic/pocket-casts-android/pull/4408))
-* Bug Fixes
+*   Bug Fixes
     *   Fix File Settings bottom content being obstructed by the Mini Player.
         ([#4414](https://github.com/Automattic/pocket-casts-android/pull/4414))
     *   Fix podcast image shadow animation.

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/notification/NotificationOpenReceiverActivity.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/notification/NotificationOpenReceiverActivity.kt
@@ -82,6 +82,7 @@ class NotificationOpenReceiverActivity : AppCompatActivity() {
         private fun Intent.copyCommonIntentProps(source: Intent, category: String): Intent {
             flags = source.flags
             action = source.action
+            data = source.data
             putExtras(source)
             source.component?.let {
                 putExtra(EXTRA_ORIGINAL_COMPONENT, it)
@@ -102,6 +103,7 @@ class NotificationOpenReceiverActivity : AppCompatActivity() {
                 Intent().apply {
                     flags = intent.flags
                     action = intent.action
+                    data = intent.data
                     IntentCompat.getParcelableExtra(intent, EXTRA_ORIGINAL_COMPONENT, ComponentName::class.java)?.let {
                         component = it
                     }


### PR DESCRIPTION
## Description
Another issue came up in regards to the notifications, this time a user has reported that the Downloads notification no longer opens the app.
The issue was that I didn't parse the intent's `data` prop when converting the original intent to a wrapper that goes through `NotificationOpenReceiverActivity`. 🤦 
Fixed that and voila, it works again.

Fixes https://linear.app/a8c/issue/PCDROID-138/clicking-on-the-download-in-progress-notification-no-longer-takes-me

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Tap on the Filters tab -->
<!-- 2. Tap on a filter -->
<!-- 3. etc. -->

## Screenshots or Screencast 

https://github.com/user-attachments/assets/c5d92b00-559f-40f8-aeb4-757f740e47c9



## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] ~I have considered whether it makes sense to add tests for my changes~
- [ ] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [ ] ~Any jetpack compose components I added or changed are covered by compose previews~
- [ ] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~
 
