### PR TITLE
Create deeplink for beta settings

### DIFF
--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/deeplink/DeepLinkFactoryTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/deeplink/DeepLinkFactoryTest.kt
@@ -1166,4 +1166,14 @@ class DeepLinkFactoryTest {
 
         assertEquals(DeveloperOptionsDeeplink, deeplink)
     }
+
+    @Test
+    fun betaSettings() {
+        val intent = Intent(ACTION_VIEW)
+            .setData(Uri.parse("pktc://beta_settings"))
+
+        val deeplink = factory.create(intent)
+
+        assertEquals(BetaSettingsDeeplink, deeplink)
+    }
 }

--- a/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
+++ b/app/src/main/java/au/com/shiftyjelly/pocketcasts/ui/MainActivity.kt
@@ -59,6 +59,7 @@ import au.com.shiftyjelly.pocketcasts.databinding.ActivityMainBinding
 import au.com.shiftyjelly.pocketcasts.deeplink.AddBookmarkDeepLink
 import au.com.shiftyjelly.pocketcasts.deeplink.AppOpenDeepLink
 import au.com.shiftyjelly.pocketcasts.deeplink.AssistantDeepLink
+import au.com.shiftyjelly.pocketcasts.deeplink.BetaSettingsDeeplink
 import au.com.shiftyjelly.pocketcasts.deeplink.ChangeBookmarkTitleDeepLink
 import au.com.shiftyjelly.pocketcasts.deeplink.CloudFilesDeepLink
 import au.com.shiftyjelly.pocketcasts.deeplink.CreateAccountDeepLink
@@ -159,6 +160,7 @@ import au.com.shiftyjelly.pocketcasts.servers.ServiceManager
 import au.com.shiftyjelly.pocketcasts.servers.discover.PodcastSearch
 import au.com.shiftyjelly.pocketcasts.servers.model.NetworkLoadableList.Companion.TRENDING
 import au.com.shiftyjelly.pocketcasts.settings.AppearanceSettingsFragment
+import au.com.shiftyjelly.pocketcasts.settings.BetaFeaturesFragment
 import au.com.shiftyjelly.pocketcasts.settings.ExportSettingsFragment
 import au.com.shiftyjelly.pocketcasts.settings.SettingsFragment
 import au.com.shiftyjelly.pocketcasts.settings.developer.DeveloperFragment
@@ -1577,6 +1579,10 @@ class MainActivity :
                     addFragment(DeveloperFragment())
                 }
 
+                is BetaSettingsDeeplink -> {
+                    closePlayer()
+                    addFragment(BetaFeaturesFragment())
+                }
                 null -> {
                     LogBuffer.i("DeepLink", "Did not find any matching deep link for: $intent")
                 }

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/developer/DeveloperFragment.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/developer/DeveloperFragment.kt
@@ -1,6 +1,5 @@
 package au.com.shiftyjelly.pocketcasts.settings.developer
 
-import android.content.Intent
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.ViewGroup

--- a/modules/services/deeplink/src/main/kotlin/au/com/shiftyjelly/pocketcasts/deeplink/DeepLink.kt
+++ b/modules/services/deeplink/src/main/kotlin/au/com/shiftyjelly/pocketcasts/deeplink/DeepLink.kt
@@ -322,6 +322,11 @@ data object DeveloperOptionsDeeplink : IntentableDeepLink {
         .setData(Uri.parse("pktc://developer_options"))
 }
 
+data object BetaSettingsDeeplink : IntentableDeepLink {
+    override fun toIntent(context: Context) = Intent(ACTION_VIEW)
+        .setData(Uri.parse("pktc://beta_settings"))
+}
+
 private val Context.launcherIntent get() = requireNotNull(packageManager.getLaunchIntentForPackage(packageName)) {
     "Missing launcher intent for $packageName"
 }

--- a/modules/services/deeplink/src/main/kotlin/au/com/shiftyjelly/pocketcasts/deeplink/DeepLinkFactory.kt
+++ b/modules/services/deeplink/src/main/kotlin/au/com/shiftyjelly/pocketcasts/deeplink/DeepLinkFactory.kt
@@ -72,6 +72,7 @@ class DeepLinkFactory(
         AppOpenAdapter(),
         CreateAccountAdapter(),
         DeveloperOptionsAdapter(),
+        BetaSettingsAdapter(),
     )
 
     fun create(intent: Intent): DeepLink? {
@@ -483,6 +484,7 @@ private class ShareLinkNativeAdapter : DeepLinkAdapter {
             "discover",
             "features",
             "developer_options",
+            "beta_settings",
         )
     }
 }
@@ -611,6 +613,7 @@ private class OpmlAdapter(
             "signup",
             "features",
             "developer_options",
+            "beta_settings",
         )
     }
 }
@@ -768,6 +771,20 @@ private class DeveloperOptionsAdapter : DeepLinkAdapter {
 
         return if (intent.action == ACTION_VIEW && scheme == "pktc" && host == "developer_options") {
             DeveloperOptionsDeeplink
+        } else {
+            null
+        }
+    }
+}
+
+private class BetaSettingsAdapter : DeepLinkAdapter {
+    override fun create(intent: Intent): DeepLink? {
+        val uriData = intent.data ?: return null
+        val scheme = uriData.scheme
+        val host = uriData.host
+
+        return if (intent.action == ACTION_VIEW && scheme == "pktc" && host == "beta_settings") {
+            BetaSettingsDeeplink
         } else {
             null
         }


### PR DESCRIPTION
## Description
Small utility/QoL change: adding a new deeplink that opens the beta settings screen.
It would be useful to toggle some FFs on the Prod app, alas this PR.

Fixes https://linear.app/a8c/issue/PCDROID-144/add-secret-deeplink-to-beta-settings

## Testing Instructions
1. Download a notes app that supports markups (e.g. Obisidian)
2. Add this entry: `[Beta settings](pktc://beta_settings)` 
3. Save the note and tap the link
4. ✅  app should open the beta settings

Or alternatively via adb:
`adb shell am start -a android.intent.action.VIEW -d pktc://beta_settings`

## Screenshots or Screencast 

https://github.com/user-attachments/assets/7356974b-d9fe-4ad2-830c-f21a351710c9



## Checklist
- [ ] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [ ] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [ ] ~Any jetpack compose components I added or changed are covered by compose previews~
- [ ] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~
 
