### PR TITLE
Update promotion analytics property

### DIFF
--- a/modules/features/ads/src/main/kotlin/au/com/shiftyjelly/pocketcasts/ads/AdReportFragment.kt
+++ b/modules/features/ads/src/main/kotlin/au/com/shiftyjelly/pocketcasts/ads/AdReportFragment.kt
@@ -88,9 +88,9 @@ class AdReportFragment : BaseDialogFragment() {
         analyticsTracker.track(
             AnalyticsEvent.BANNER_AD_REPORT,
             mapOf(
-                "ad_id" to args.ad.id,
+                "id" to args.ad.id,
                 "reason" to reason.analyticsName,
-                "source" to args.ad.location.analyticsName,
+                "location" to args.ad.location.analyticsName,
             ),
         )
 

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/PlayerViewModel.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/PlayerViewModel.kt
@@ -764,7 +764,7 @@ class PlayerViewModel @Inject constructor(
         analyticsTracker.track(
             AnalyticsEvent.BANNER_AD_IMPRESSION,
             mapOf(
-                "promotion" to "player",
+                "location" to "player",
                 "id" to ad.id,
             ),
         )
@@ -774,7 +774,7 @@ class PlayerViewModel @Inject constructor(
         analyticsTracker.track(
             AnalyticsEvent.BANNER_AD_TAPPED,
             mapOf(
-                "promotion" to "player",
+                "location" to "player",
                 "id" to ad.id,
             ),
         )

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcasts/PodcastsFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/podcasts/PodcastsFragment.kt
@@ -720,7 +720,7 @@ class PodcastsFragment :
         analyticsTracker.track(
             AnalyticsEvent.BANNER_AD_IMPRESSION,
             mapOf(
-                "promotion" to "podcast_list",
+                "location" to "podcast_list",
                 "id" to ad.id,
             ),
         )
@@ -730,7 +730,7 @@ class PodcastsFragment :
         analyticsTracker.track(
             AnalyticsEvent.BANNER_AD_TAPPED,
             mapOf(
-                "promotion" to "podcast_list",
+                "location" to "podcast_list",
                 "id" to ad.id,
             ),
         )

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/type/BlazeAdLocation.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/type/BlazeAdLocation.kt
@@ -8,7 +8,7 @@ import com.squareup.moshi.JsonWriter
 enum class BlazeAdLocation(val value: String, val analyticsName: String, val feature: Feature?) {
     PodcastList(
         value = "podcastList",
-        analyticsName = "podcasts_list",
+        analyticsName = "podcast_list",
         feature = Feature.BANNER_ADS_PODCASTS,
     ),
     Player(


### PR DESCRIPTION
## Description

This makes sure the promotion analytics are consistent across the apps. 

Internal discussion p1756961957022369/1756960083.671219-slack-C08U02AG7C5

## Testing Instructions
1. Filter logcat by `banner_ad_`
2. View and tap the banner on the podcast list
3. ✅ Verify the property is `location` with the value `podcast_list`
4. View and tap the banner on the player page
5. ✅ Verify the property is `location` with the value `podcast_list`
6. Report the ad
7.  ✅ Verify the `location` property is correct, and the `id` property contains the ad ID

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 