### PR TITLE
Update Smart Playlists empty state

### DIFF
--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/CreatePlaylistFragment.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/CreatePlaylistFragment.kt
@@ -147,7 +147,7 @@ class CreatePlaylistFragment : BaseDialogFragment() {
 
             override fun onApplyRule(rule: RuleType) = viewModel.applyRule(rule)
 
-            override fun onCreatePlaylist() = viewModel.createSmartPlaylist()
+            override fun createPlaylistCallback() = { viewModel.createSmartPlaylist() }
 
             override fun onClose() = dismiss()
         }

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/component/PlaylistHeader.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/component/PlaylistHeader.kt
@@ -178,17 +178,15 @@ internal fun PlaylistHeader(
                 Spacer(
                     modifier = Modifier.height(24.dp),
                 )
-                if (data.totalEpisodeCount > 0) {
-                    PlaylistSearchBar(
-                        searchState = searchState,
-                        contentTopPadding = contentTopPadding,
-                        onChangeSearchFocus = onChangeSearchFocus,
-                        onMeasureSearchTopOffset = onMeasureSearchTopOffset,
-                    )
-                    Spacer(
-                        modifier = Modifier.height(16.dp),
-                    )
-                }
+                PlaylistSearchBar(
+                    searchState = searchState,
+                    contentTopPadding = contentTopPadding,
+                    onChangeSearchFocus = onChangeSearchFocus,
+                    onMeasureSearchTopOffset = onMeasureSearchTopOffset,
+                )
+                Spacer(
+                    modifier = Modifier.height(16.dp),
+                )
                 AnimatedVisibility(
                     visible = data.totalEpisodeCount != 0 && data.displayedEpisodeCount == 0,
                     enter = noContentEnterTransition,

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/component/PlaylistHeader.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/component/PlaylistHeader.kt
@@ -395,7 +395,7 @@ private fun ActionButtons(
             contentAlignment = Alignment.TopStart,
             modifier = Modifier
                 .weight(1f)
-                .fillMaxHeight()
+                .fillMaxHeight(),
         )
     }
 }

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/component/PlaylistHeader.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/component/PlaylistHeader.kt
@@ -4,11 +4,8 @@ import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.Crossfade
 import androidx.compose.animation.core.Spring
 import androidx.compose.animation.core.animateDpAsState
-import androidx.compose.animation.core.animateFloat
-import androidx.compose.animation.core.animateIntOffset
 import androidx.compose.animation.core.spring
 import androidx.compose.animation.core.tween
-import androidx.compose.animation.core.updateTransition
 import androidx.compose.animation.expandVertically
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
@@ -29,7 +26,6 @@ import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
@@ -45,7 +41,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.ReadOnlyComposable
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
@@ -53,7 +48,6 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.BlurredEdgeTreatment
-import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.blur
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.drawWithContent
@@ -72,7 +66,6 @@ import androidx.compose.ui.layout.positionInParent
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalInspectionMode
-import androidx.compose.ui.platform.LocalWindowInfo
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
@@ -81,7 +74,6 @@ import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.Dp
-import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.constrainHeight
 import androidx.compose.ui.unit.constrainWidth
 import androidx.compose.ui.unit.dp
@@ -180,7 +172,6 @@ internal fun PlaylistHeader(
             )
             if (data != null) {
                 ActionButtons(
-                    hasAnyEpisodes = data.displayedEpisodeCount > 0,
                     leftButton = leftButton,
                     rightButton = rightButton,
                 )
@@ -196,18 +187,6 @@ internal fun PlaylistHeader(
                     )
                     Spacer(
                         modifier = Modifier.height(16.dp),
-                    )
-                }
-                AnimatedVisibility(
-                    visible = data.totalEpisodeCount == 0,
-                    enter = noContentEnterTransition,
-                    exit = noContentExitTransition,
-                ) {
-                    NoContentBanner(
-                        title = stringResource(LR.string.smart_playlist_no_content_title),
-                        body = stringResource(LR.string.smart_playlist_no_content_body),
-                        iconResourceId = IR.drawable.ic_info,
-                        modifier = Modifier.padding(top = 60.dp, bottom = 24.dp),
                     )
                 }
                 AnimatedVisibility(
@@ -391,34 +370,16 @@ private fun PlaylistInfoText(
 
 @Composable
 private fun ActionButtons(
-    hasAnyEpisodes: Boolean,
     leftButton: PlaylistHeaderButtonData,
     rightButton: PlaylistHeaderButtonData,
     modifier: Modifier = Modifier,
 ) {
-    val density = LocalDensity.current
-    val windowWidth = density.run { LocalWindowInfo.current.containerSize.width.toDp() }
-    val buttonWidth = minOf((windowWidth - actionButtonsOuterPadding * 2) / 2, actionButtonMaxWidth)
-    val targetOffset = buttonWidth / 2 + actionButtonsInnerPadding / 2
-    val targetOffsetPx = density.run { targetOffset.roundToPx() }
-
-    val transition = updateTransition(hasAnyEpisodes)
-    val offset by transition.animateIntOffset(
-        transitionSpec = { actionButtonsOffsetSpec },
-        targetValueByState = { hasEpisodes -> if (hasEpisodes) IntOffset.Zero else IntOffset(targetOffsetPx, 0) },
-    )
-    val alpha by transition.animateFloat(
-        transitionSpec = { actionButtonsAlphaSpec },
-        targetValueByState = { hasEpisodes -> if (hasEpisodes) 1f else 0f },
-    )
-
     Row(
         horizontalArrangement = Arrangement.spacedBy(
             space = actionButtonsInnerPadding,
             alignment = Alignment.CenterHorizontally,
         ),
         modifier = modifier
-            .offset { offset }
             .height(IntrinsicSize.Max)
             .padding(horizontal = actionButtonsOuterPadding),
     ) {
@@ -434,11 +395,9 @@ private fun ActionButtons(
             data = rightButton,
             style = ActionButtonStyle.Solid,
             contentAlignment = Alignment.TopStart,
-            isEnabled = hasAnyEpisodes,
             modifier = Modifier
                 .weight(1f)
                 .fillMaxHeight()
-                .alpha(alpha),
         )
     }
 }
@@ -503,7 +462,6 @@ private fun ActionButton(
     contentAlignment: Alignment,
     style: ActionButtonStyle,
     modifier: Modifier = Modifier,
-    isEnabled: Boolean = true,
 ) {
     CompositionLocalProvider(LocalRippleConfiguration provides style.rememberRippleConfiguration()) {
         Box(
@@ -520,7 +478,6 @@ private fun ActionButton(
                     .background(style.backgroundColor(), actionButtonShape)
                     .border(2.dp, style.borderColor(), actionButtonShape)
                     .clickable(
-                        enabled = isEnabled,
                         role = Role.Button,
                         onClick = data.onClick,
                     )
@@ -592,8 +549,6 @@ private val actionButtonShape = RoundedCornerShape(8.dp)
 private val actionButtonMaxWidth = 200.dp
 private val actionButtonsInnerPadding = 8.dp
 private val actionButtonsOuterPadding = 32.dp
-private val actionButtonsOffsetSpec = spring<IntOffset>(stiffness = Spring.StiffnessLow)
-private val actionButtonsAlphaSpec = spring<Float>(stiffness = Spring.StiffnessLow)
 
 private val noContentEnterTransition =
     fadeIn(spring(stiffness = Spring.StiffnessLow)) + expandVertically(spring(stiffness = Spring.StiffnessLow))
@@ -614,44 +569,6 @@ private val previewColors = listOf(
     Color(0xFFFEB144),
     Color(0xFFFF6663),
 )
-
-@PreviewRegularDevice
-@Composable
-private fun PlaylistHeaderNoEpisodesPreview() {
-    var episodeCount by remember { mutableIntStateOf(0) }
-
-    AppTheme(ThemeType.LIGHT) {
-        Box(
-            modifier = Modifier
-                .background(MaterialTheme.theme.colors.primaryUi02)
-                .fillMaxSize(),
-        ) {
-            PlaylistHeader(
-                data = PlaylistHeaderData(
-                    title = "My Playlist",
-                    totalEpisodeCount = episodeCount,
-                    displayedEpisodeCount = episodeCount,
-                    playbackDurationLeft = 0.seconds,
-                    artworkPodcastUuids = emptyList(),
-                ),
-                leftButton = PlaylistHeaderButtonData(
-                    iconId = IR.drawable.sleep_timer_cog,
-                    label = "Smart Rules",
-                    onClick = { episodeCount = 1 },
-                ),
-                rightButton = PlaylistHeaderButtonData(
-                    iconId = IR.drawable.ic_filters_play,
-                    label = "Play All",
-                    onClick = { episodeCount = 0 },
-                ),
-                searchState = rememberTextFieldState(),
-                useBlurredArtwork = false,
-                onMeasureSearchTopOffset = {},
-                onChangeSearchFocus = {},
-            )
-        }
-    }
-}
 
 @PreviewRegularDevice
 @Composable

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/component/PlaylistHeaderAdapter.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/component/PlaylistHeaderAdapter.kt
@@ -5,7 +5,6 @@ import android.view.ViewGroup
 import androidx.compose.foundation.background
 import androidx.compose.foundation.text.input.TextFieldState
 import androidx.compose.material.MaterialTheme
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -19,7 +18,6 @@ import au.com.shiftyjelly.pocketcasts.compose.AppTheme
 import au.com.shiftyjelly.pocketcasts.compose.theme
 import au.com.shiftyjelly.pocketcasts.ui.R
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
-import kotlinx.coroutines.flow.MutableStateFlow
 
 // This adapter uses an unconventional configuration: it has only a single view holder, and data is provided via a Flow.
 // Updating data through the regular adapter mechanisms causes the UI to flicker, because setContent() is called again,
@@ -32,11 +30,11 @@ internal class PlaylistHeaderAdapter(
     private val searchState: TextFieldState,
     private val onChangeSearchFocus: (Boolean, Float) -> Unit,
 ) : RecyclerView.Adapter<RecyclerView.ViewHolder>() {
-    private val headerDataFlow = MutableStateFlow<PlaylistHeaderData?>(null)
+    private var headerData by mutableStateOf<PlaylistHeaderData?>(null)
     private var searchTopOffset = 0f
 
     fun submitHeader(data: PlaylistHeaderData?) {
-        headerDataFlow.value = data
+        headerData = data
     }
 
     override fun getItemCount() = 1
@@ -59,7 +57,6 @@ internal class PlaylistHeaderAdapter(
 
         fun bind() {
             composeView.setContent {
-                val headerData by headerDataFlow.collectAsState()
                 var isFocused by remember { mutableStateOf<Boolean?>(null) }
                 val keyboard = LocalSoftwareKeyboardController.current
 

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/component/PlaylistToolbar.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/component/PlaylistToolbar.kt
@@ -2,6 +2,9 @@ package au.com.shiftyjelly.pocketcasts.playlists.component
 
 import androidx.annotation.DrawableRes
 import androidx.annotation.FloatRange
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
@@ -42,15 +45,33 @@ import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import au.com.shiftyjelly.pocketcasts.images.R as IR
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
+internal sealed interface ToolbarConfig {
+    val showTitle: Boolean
+
+    data object WithoutTitle : ToolbarConfig {
+        override val showTitle = false
+    }
+
+    data object WithTitle : ToolbarConfig {
+        override val showTitle = true
+    }
+
+    data class ForAlpha(
+        @FloatRange(0.0, 1.0) val alpha: Float,
+    ) : ToolbarConfig {
+        override val showTitle = true
+    }
+}
+
 @Composable
 internal fun PlaylistToolbar(
     title: String,
-    @FloatRange(0.0, 1.0) backgroundAlpha: Float,
+    config: ToolbarConfig,
     onClickBack: () -> Unit,
     onClickOptions: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    val colors = rememberToolbarColors(backgroundAlpha)
+    val colors = rememberToolbarColors(config)
     TopAppBar(
         navigationIcon = {
             ToolbarButton(
@@ -63,18 +84,24 @@ internal fun PlaylistToolbar(
             )
         },
         title = {
-            val textStyle = LocalTextStyle.current
-            val nonScaledTextStyle = textStyle.merge(
-                fontSize = textStyle.fontSize.value.nonScaledSp,
-                lineHeight = textStyle.lineHeight.value.nonScaledSp,
-            )
-            Text(
-                text = title,
-                style = nonScaledTextStyle,
-                color = colors.titleColor,
-                maxLines = 1,
-                overflow = TextOverflow.Ellipsis,
-            )
+            AnimatedVisibility(
+                visible = config.showTitle,
+                enter = fadeIn(),
+                exit = fadeOut(),
+            ) {
+                val textStyle = LocalTextStyle.current
+                val nonScaledTextStyle = textStyle.merge(
+                    fontSize = textStyle.fontSize.value.nonScaledSp,
+                    lineHeight = textStyle.lineHeight.value.nonScaledSp,
+                )
+                Text(
+                    text = title,
+                    style = nonScaledTextStyle,
+                    color = colors.titleColor,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+            }
         },
         actions = {
             ToolbarButton(
@@ -131,36 +158,46 @@ private data class PlaylistToolbarColors(
 )
 
 @Composable
-private fun rememberToolbarColors(alpha: Float): PlaylistToolbarColors {
+private fun rememberToolbarColors(config: ToolbarConfig): PlaylistToolbarColors {
     val backgroundColor = MaterialTheme.theme.colors.secondaryUi01
     val buttonIconColor = MaterialTheme.theme.colors.secondaryIcon01
     val titleColor = MaterialTheme.theme.colors.secondaryText01
 
-    return remember(alpha) {
-        PlaylistToolbarColors(
-            backgroundColor = backgroundColor.copy(alpha = alpha),
-            titleColor = Color(
-                ColorUtils.blendARGB(
-                    titleColor.toArgb(),
-                    Color.Transparent.toArgb(),
-                    1f - alpha,
+    return remember(config) {
+        when (config) {
+            is ToolbarConfig.WithTitle, is ToolbarConfig.WithoutTitle -> PlaylistToolbarColors(
+                backgroundColor = Color.Transparent,
+                titleColor = titleColor,
+                buttonBackgroundColor = Color.Black.copy(alpha = 0.32f),
+                buttonIconColor = Color.White,
+            )
+
+
+            is ToolbarConfig.ForAlpha -> PlaylistToolbarColors(
+                backgroundColor = backgroundColor.copy(alpha = config.alpha),
+                titleColor = Color(
+                    ColorUtils.blendARGB(
+                        titleColor.toArgb(),
+                        Color.Transparent.toArgb(),
+                        1f - config.alpha,
+                    ),
                 ),
-            ),
-            buttonBackgroundColor = Color(
-                ColorUtils.blendARGB(
-                    Color.Transparent.toArgb(),
-                    Color.Black.copy(alpha = 0.32f).toArgb(),
-                    1f - alpha,
+                buttonBackgroundColor = Color(
+                    ColorUtils.blendARGB(
+                        Color.Transparent.toArgb(),
+                        Color.Black.copy(alpha = 0.32f).toArgb(),
+                        1f - config.alpha,
+                    ),
                 ),
-            ),
-            buttonIconColor = Color(
-                ColorUtils.blendARGB(
-                    buttonIconColor.toArgb(),
-                    Color.White.toArgb(),
-                    1f - alpha,
+                buttonIconColor = Color(
+                    ColorUtils.blendARGB(
+                        buttonIconColor.toArgb(),
+                        Color.White.toArgb(),
+                        1f - config.alpha,
+                    ),
                 ),
-            ),
-        )
+            )
+        }
     }
 }
 
@@ -174,20 +211,32 @@ private fun PodcastToolbarPreview(
     ) {
         Column {
             PlaylistToolbar(
+                title = "Without title",
+                config = ToolbarConfig.WithoutTitle,
+                onClickBack = {},
+                onClickOptions = {},
+            )
+            PlaylistToolbar(
+                title = "With title",
+                config = ToolbarConfig.WithTitle,
+                onClickBack = {},
+                onClickOptions = {},
+            )
+            PlaylistToolbar(
                 title = "Transparent",
-                backgroundAlpha = 0f,
+                config = ToolbarConfig.ForAlpha(0f),
                 onClickBack = {},
                 onClickOptions = {},
             )
             PlaylistToolbar(
                 title = "Semi Transparent",
-                backgroundAlpha = 0.5f,
+                config = ToolbarConfig.ForAlpha(5f),
                 onClickBack = {},
                 onClickOptions = {},
             )
             PlaylistToolbar(
                 title = "Opaque",
-                backgroundAlpha = 1f,
+                config = ToolbarConfig.ForAlpha(1f),
                 onClickBack = {},
                 onClickOptions = {},
             )

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/component/PlaylistToolbar.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/component/PlaylistToolbar.kt
@@ -230,7 +230,7 @@ private fun PodcastToolbarPreview(
             )
             PlaylistToolbar(
                 title = "Semi Transparent",
-                config = ToolbarConfig.ForAlpha(5f),
+                config = ToolbarConfig.ForAlpha(0.5f),
                 onClickBack = {},
                 onClickOptions = {},
             )

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/component/PlaylistToolbar.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/component/PlaylistToolbar.kt
@@ -172,7 +172,6 @@ private fun rememberToolbarColors(config: ToolbarConfig): PlaylistToolbarColors 
                 buttonIconColor = Color.White,
             )
 
-
             is ToolbarConfig.ForAlpha -> PlaylistToolbarColors(
                 backgroundColor = backgroundColor.copy(alpha = config.alpha),
                 titleColor = Color(

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/manual/PlaylistFragment.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/manual/PlaylistFragment.kt
@@ -218,11 +218,7 @@ class PlaylistFragment :
     }
 
     override fun onBackPressed(): Boolean {
-        return if (adapterFactory.onBackPressed()) {
-            true
-        } else {
-            super.onBackPressed()
-        }
+        return adapterFactory.onBackPressed() || super.onBackPressed()
     }
 
     override fun getBackstackCount(): Int {

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/manual/PlaylistFragment.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/manual/PlaylistFragment.kt
@@ -31,6 +31,7 @@ import au.com.shiftyjelly.pocketcasts.playlists.component.PlaylistHeaderAdapter
 import au.com.shiftyjelly.pocketcasts.playlists.component.PlaylistHeaderButtonData
 import au.com.shiftyjelly.pocketcasts.playlists.component.PlaylistHeaderData
 import au.com.shiftyjelly.pocketcasts.playlists.component.PlaylistToolbar
+import au.com.shiftyjelly.pocketcasts.playlists.component.ToolbarConfig
 import au.com.shiftyjelly.pocketcasts.playlists.manual.episode.AddEpisodesFragment
 import au.com.shiftyjelly.pocketcasts.repositories.playlist.PlaylistManager
 import au.com.shiftyjelly.pocketcasts.ui.helper.FragmentHostListener
@@ -190,7 +191,7 @@ class PlaylistFragment :
             AppTheme(theme.activeTheme) {
                 PlaylistToolbar(
                     title = title,
-                    backgroundAlpha = if (isKeyboardOpen) 1f else toolbarAlpha,
+                    config = ToolbarConfig.ForAlpha(if (isKeyboardOpen) 1f else toolbarAlpha),
                     onClickBack = {
                         @Suppress("DEPRECATION")
                         requireActivity().onBackPressed()

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/smart/PlaylistFragment.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/smart/PlaylistFragment.kt
@@ -363,11 +363,7 @@ class PlaylistFragment :
     }
 
     override fun onBackPressed(): Boolean {
-        return if (adapterFactory.onBackPressed()) {
-            true
-        } else {
-            super.onBackPressed()
-        }
+        return adapterFactory.onBackPressed() || super.onBackPressed()
     }
 
     override fun getBackstackCount(): Int {

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/smart/PlaylistFragment.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/smart/PlaylistFragment.kt
@@ -205,10 +205,7 @@ class PlaylistFragment :
             iconId = IR.drawable.ic_info,
             primaryButton = NoContentData.Button(
                 text = getString(LR.string.smart_rules),
-                onClick = {
-                    viewModel.trackEditRulesTapped()
-                    openEditor()
-                },
+                onClick = ::openEditor,
             ),
         )
 

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/smart/PlaylistFragment.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/smart/PlaylistFragment.kt
@@ -241,7 +241,6 @@ class PlaylistFragment :
                         }
                     }
                 }
-
             }
         }
     }

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/smart/PlaylistFragment.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/smart/PlaylistFragment.kt
@@ -46,6 +46,7 @@ import au.com.shiftyjelly.pocketcasts.playlists.component.PlaylistHeaderAdapter
 import au.com.shiftyjelly.pocketcasts.playlists.component.PlaylistHeaderButtonData
 import au.com.shiftyjelly.pocketcasts.playlists.component.PlaylistHeaderData
 import au.com.shiftyjelly.pocketcasts.playlists.component.PlaylistToolbar
+import au.com.shiftyjelly.pocketcasts.playlists.component.ToolbarConfig
 import au.com.shiftyjelly.pocketcasts.playlists.smart.rules.EditRulesFragment
 import au.com.shiftyjelly.pocketcasts.utils.extensions.dpToPx
 import au.com.shiftyjelly.pocketcasts.views.dialog.ConfirmationDialog
@@ -281,7 +282,11 @@ class PlaylistFragment :
             AppTheme(theme.activeTheme) {
                 PlaylistToolbar(
                     title = title,
-                    backgroundAlpha = if (isKeyboardOpen) 1f else toolbarAlpha,
+                    config = when (contentState) {
+                        ContentState.Uninitialized -> ToolbarConfig.WithoutTitle
+                        ContentState.HasNoEpisodes -> ToolbarConfig.WithTitle
+                        ContentState.HasEpisode -> ToolbarConfig.ForAlpha(if (isKeyboardOpen) 1f else toolbarAlpha)
+                    },
                     onClickBack = {
                         @Suppress("DEPRECATION")
                         requireActivity().onBackPressed()

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/smart/rules/EditRulesFragment.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/smart/rules/EditRulesFragment.kt
@@ -119,7 +119,7 @@ class EditRulesFragment : BaseDialogFragment() {
 
             override fun onApplyRule(rule: RuleType) = viewModel.applyRule(rule)
 
-            override fun onCreatePlaylist() = Unit
+            override fun createPlaylistCallback() = null
 
             override fun onClose() = dismiss()
         }

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/smart/rules/ManageSmartRulesPage.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/smart/rules/ManageSmartRulesPage.kt
@@ -61,7 +61,7 @@ internal fun ManageSmartRulesPage(
                 totalEpisodeCount = totalEpisodeCount,
                 useEpisodeArtwork = useEpisodeArtwork,
                 areOtherOptionsExpanded = areOtherOptionsExpanded,
-                onCreatePlaylist = listener::onCreatePlaylist,
+                onCreatePlaylist = listener.createPlaylistCallback(),
                 onClickRule = { rule -> navController.navigateOnce(rule.toNavigationRoute()) },
                 toggleOtherOptions = { areOtherOptionsExpanded = !areOtherOptionsExpanded },
                 onClickClose = listener::onClose,
@@ -200,7 +200,7 @@ internal interface ManageSmartRulesListener {
 
     fun onApplyRule(rule: RuleType)
 
-    fun onCreatePlaylist()
+    fun createPlaylistCallback(): (() -> Unit)?
 
     fun onClose()
 }

--- a/modules/features/filters/src/main/res/layout/playlist_fragment.xml
+++ b/modules/features/filters/src/main/res/layout/playlist_fragment.xml
@@ -21,6 +21,11 @@
         app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager" />
 
     <androidx.compose.ui.platform.ComposeView
+        android:id="@+id/noContentBox"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent" />
+
+    <androidx.compose.ui.platform.ComposeView
         android:id="@+id/playlistToolbar"
         android:layout_width="match_parent"
         android:layout_height="wrap_content" />

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/NoContentBanner.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/NoContentBanner.kt
@@ -76,6 +76,38 @@ data class NoContentBannerColors(
     }
 }
 
+data class NoContentData(
+    val title: String,
+    val body: String,
+    @DrawableRes val iconId: Int,
+    val primaryButton: Button? = null,
+    val secondaryButton: Button? = null,
+) {
+    data class Button(
+        val text: String,
+        val onClick: () -> Unit,
+    )
+}
+
+@Composable
+fun NoContentBanner(
+    data: NoContentData,
+    modifier: Modifier = Modifier,
+    colors: NoContentBannerColors = NoContentBannerColors.default(MaterialTheme.theme.colors),
+) {
+    NoContentBanner(
+        title = data.title,
+        body = data.body,
+        iconResourceId = data.iconId,
+        primaryButtonText = data.primaryButton?.text,
+        onPrimaryButtonClick = data.primaryButton?.onClick,
+        secondaryButtonText = data.secondaryButton?.text,
+        onSecondaryButtonClick = data.secondaryButton?.onClick,
+        colors = colors,
+        modifier = modifier,
+    )
+}
+
 @Composable
 fun NoContentBanner(
     title: String,


### PR DESCRIPTION
## Description

This changes the empty state UI for smart playlists. The empty state icon has a bit different colors but it is because designs do not account for how we're styling icon. Having it this way makes it consistent with other empty states in the app.

Designs: 5sC4z4Mu42LvL4MAAIbQVi-fi-3622_26652

Closes PCDROID-146

## Testing Instructions

1. Have a smart playlists without any episodes.
2. Notice empty state.
3. Tapping button should allow you to edit rules.

## Screenshots or Screencast 

<img width="540" alt="image" src="https://github.com/user-attachments/assets/fe3bc242-98cd-4793-a30d-66d775f2bd37" />

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack