### PR TITLE
Display empty state in Manual Playlists

### DIFF
--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/manual/PlaylistFragment.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/manual/PlaylistFragment.kt
@@ -5,12 +5,22 @@ import android.os.Parcelable
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.updateTransition
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material.MaterialTheme
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.util.lerp
 import androidx.core.os.BundleCompat
 import androidx.core.os.bundleOf
@@ -25,7 +35,10 @@ import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import au.com.shiftyjelly.pocketcasts.PlaylistEpisodesAdapterFactory
 import au.com.shiftyjelly.pocketcasts.compose.AppTheme
+import au.com.shiftyjelly.pocketcasts.compose.components.NoContentBanner
+import au.com.shiftyjelly.pocketcasts.compose.components.NoContentData
 import au.com.shiftyjelly.pocketcasts.compose.extensions.setContentWithViewCompositionStrategy
+import au.com.shiftyjelly.pocketcasts.compose.theme
 import au.com.shiftyjelly.pocketcasts.filters.databinding.PlaylistFragmentBinding
 import au.com.shiftyjelly.pocketcasts.playlists.component.PlaylistHeaderAdapter
 import au.com.shiftyjelly.pocketcasts.playlists.component.PlaylistHeaderButtonData
@@ -54,6 +67,7 @@ import timber.log.Timber
 import au.com.shiftyjelly.pocketcasts.images.R as IR
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 import au.com.shiftyjelly.pocketcasts.ui.R as UR
+import au.com.shiftyjelly.pocketcasts.views.R as VR
 
 @AndroidEntryPoint
 class PlaylistFragment :
@@ -74,6 +88,8 @@ class PlaylistFragment :
     )
 
     private var isKeyboardOpen by mutableStateOf(false)
+    private var isAnyPodcastFollowed by mutableStateOf(false)
+    private var contentState by mutableStateOf(ContentState.Uninitialized)
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -82,6 +98,7 @@ class PlaylistFragment :
     ): View {
         val binding = PlaylistFragmentBinding.inflate(inflater, container, false)
         binding.setupContent()
+        binding.setupNoContent()
         binding.setupToolbar()
         return binding.root
     }
@@ -117,8 +134,12 @@ class PlaylistFragment :
             viewModel.uiState
                 .flowWithLifecycle(viewLifecycleOwner.lifecycle)
                 .collect { uiState ->
-                    val episodes = uiState.manualPlaylist?.episodes.orEmpty()
-                    episodesAdapter.submitList(episodes)
+                    contentState = when (uiState.manualPlaylist?.episodes?.size) {
+                        null -> ContentState.Uninitialized
+                        0 -> ContentState.HasNoEpisodes
+                        else -> ContentState.HasEpisode
+                    }
+                    isAnyPodcastFollowed = uiState.isAnyPodcastFollowed
 
                     val playlistHeaderData = uiState.manualPlaylist?.let { playlist ->
                         PlaylistHeaderData(
@@ -131,6 +152,9 @@ class PlaylistFragment :
                         )
                     }
                     headerAdapter.submitHeader(playlistHeaderData)
+
+                    val episodes = uiState.manualPlaylist?.episodes.orEmpty()
+                    episodesAdapter.submitList(episodes)
                 }
         }
 
@@ -153,6 +177,67 @@ class PlaylistFragment :
             windowInsets
         }
         content.hideKeyboardOnScroll()
+    }
+
+    private fun PlaylistFragmentBinding.setupNoContent() {
+        noContentBox.setContentWithViewCompositionStrategy {
+            val noContentData = remember(isAnyPodcastFollowed) {
+                if (isAnyPodcastFollowed) {
+                    NoContentData(
+                        title = getString(LR.string.manual_playlist_no_content_title_alternative),
+                        body = "",
+                        iconId = IR.drawable.ic_playlists,
+                        primaryButton = NoContentData.Button(
+                            text = getString(LR.string.add_episodes),
+                            onClick = ::openEditor,
+                        ),
+                    )
+                } else {
+                    NoContentData(
+                        title = getString(LR.string.manual_playlist_no_content_title),
+                        body = getString(LR.string.manual_playlist_no_content_body),
+                        iconId = IR.drawable.ic_playlists,
+                        primaryButton = NoContentData.Button(
+                            text = getString(LR.string.browse_shows),
+                            onClick = {
+                                val hostListener = (requireActivity() as FragmentHostListener)
+                                hostListener.closeToRoot()
+                                hostListener.openTab(VR.id.navigation_discover)
+                            },
+                        ),
+                    )
+                }
+            }
+            val transition = updateTransition(contentState)
+
+            AppTheme(theme.activeTheme) {
+                Box {
+                    if (transition.currentState == ContentState.Uninitialized) {
+                        Box(
+                            modifier = Modifier
+                                .fillMaxSize()
+                                .background(MaterialTheme.theme.colors.primaryUi02),
+                        )
+                    }
+                    transition.AnimatedVisibility(
+                        visible = { it == ContentState.HasNoEpisodes },
+                        enter = fadeIn(),
+                        exit = fadeOut(),
+                    ) {
+                        Box(
+                            contentAlignment = Alignment.Center,
+                            modifier = Modifier
+                                .fillMaxSize()
+                                .background(MaterialTheme.theme.colors.primaryUi02),
+                        ) {
+                            NoContentBanner(
+                                data = noContentData,
+                            )
+                        }
+                    }
+                }
+            }
+        }
     }
 
     private fun PlaylistFragmentBinding.setupToolbar() {
@@ -191,7 +276,11 @@ class PlaylistFragment :
             AppTheme(theme.activeTheme) {
                 PlaylistToolbar(
                     title = title,
-                    config = ToolbarConfig.ForAlpha(if (isKeyboardOpen) 1f else toolbarAlpha),
+                    config = when (contentState) {
+                        ContentState.Uninitialized -> ToolbarConfig.WithoutTitle
+                        ContentState.HasNoEpisodes -> ToolbarConfig.WithTitle
+                        ContentState.HasEpisode -> ToolbarConfig.ForAlpha(if (isKeyboardOpen) 1f else toolbarAlpha)
+                    },
                     onClickBack = {
                         @Suppress("DEPRECATION")
                         requireActivity().onBackPressed()
@@ -237,4 +326,10 @@ class PlaylistFragment :
             arguments = bundleOf(NEW_INSTANCE_ARGS to Args(playlistUuid))
         }
     }
+}
+
+private enum class ContentState {
+    Uninitialized,
+    HasNoEpisodes,
+    HasEpisode,
 }

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/manual/PlaylistViewModel.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/manual/PlaylistViewModel.kt
@@ -6,38 +6,51 @@ import au.com.shiftyjelly.pocketcasts.compose.text.SearchFieldState
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.repositories.playlist.ManualPlaylist
 import au.com.shiftyjelly.pocketcasts.repositories.playlist.PlaylistManager
+import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.flatMapLatest
-import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 
+@OptIn(ExperimentalCoroutinesApi::class)
 @HiltViewModel(assistedFactory = PlaylistViewModel.Factory::class)
 class PlaylistViewModel @AssistedInject constructor(
     @Assisted private val playlistUuid: String,
     private val playlistManager: PlaylistManager,
+    private val podcastManager: PodcastManager,
     private val settings: Settings,
 ) : ViewModel() {
     val bottomInset = settings.bottomInset
 
     val searchState = SearchFieldState()
 
-    @OptIn(ExperimentalCoroutinesApi::class)
-    val uiState = searchState.textFlow
-        .flatMapLatest { searchTerm -> playlistManager.manualPlaylistFlow(playlistUuid, searchTerm) }
-        .map { UiState(it) }
-        .stateIn(viewModelScope, SharingStarted.Lazily, initialValue = UiState.Empty)
+    private val playlistFlow = searchState.textFlow.flatMapLatest { searchTerm ->
+        playlistManager.manualPlaylistFlow(playlistUuid, searchTerm)
+    }
+
+    val uiState = combine(
+        playlistFlow,
+        podcastManager.countSubscribedFlow(),
+    ) { playlist, followedCount ->
+        UiState(
+            manualPlaylist = playlist,
+            isAnyPodcastFollowed = followedCount > 0,
+        )
+    }.stateIn(viewModelScope, SharingStarted.Lazily, initialValue = UiState.Empty)
 
     data class UiState(
         val manualPlaylist: ManualPlaylist?,
+        val isAnyPodcastFollowed: Boolean,
     ) {
         companion object {
             val Empty = UiState(
                 manualPlaylist = null,
+                isAnyPodcastFollowed = false,
             )
         }
     }

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/ProfileViewModel.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/ProfileViewModel.kt
@@ -29,7 +29,6 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.reactive.asFlow
-import kotlinx.coroutines.rx2.asFlow
 
 @HiltViewModel
 class ProfileViewModel @Inject constructor(
@@ -79,7 +78,7 @@ class ProfileViewModel @Inject constructor(
 
     internal val profileStatsState = combine(
         refreshStatsTrigger.onStart { emit(Unit) },
-        podcastManager.countSubscribedRxFlowable().asFlow(),
+        podcastManager.countSubscribedFlow(),
     ) { _, count ->
         ProfileStatsState(
             podcastsCount = count,

--- a/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/NoContentBanner.kt
+++ b/modules/services/compose/src/main/java/au/com/shiftyjelly/pocketcasts/compose/components/NoContentBanner.kt
@@ -129,8 +129,8 @@ fun NoContentBanner(
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.spacedBy(itemSpaceHeight),
         modifier = modifier
-            .padding(horizontal = 32.dp)
-            .widthIn(max = if (isTablet || isLandscape) 450.dp else 330.dp),
+            .padding(horizontal = 16.dp)
+            .widthIn(max = if (isTablet || isLandscape) 450.dp else 360.dp),
     ) {
         if (isPortraitOrTablet) {
             Image(

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -230,6 +230,7 @@
     <string name="add_episodes">Add Episodes</string>
     <string name="your_podcasts">Your Podcasts</string>
     <string name="unavailable">Unavailable</string>
+    <string name="browse_shows">Browse Shows</string>
 
     <string name="multiselect_actions_shown">Shortcut in toolbar</string>
     <string name="multiselect_actions_hidden">In overflow</string>
@@ -949,6 +950,9 @@
     <string name="episode_status_rule_description">%1$s + %2$d</string>
     <string name="increment_longer_than_duration">Increment \"longer than\" duration</string>
     <string name="increment_shorter_than_duration">Increment \"shorter than\" duration</string>
+    <string name="manual_playlist_no_content_body">Swipe left on an episode to add it to your playlist.</string>
+    <string name="manual_playlist_no_content_title">Add episodes to your playlist</string>
+    <string name="manual_playlist_no_content_title_alternative">Start building your playlist</string>
     <string name="new_playlist">New Playlist</string>
     <string name="new_playlists_title_placeholder">Playlist’s name</string>
     <string name="new_smart_playlist_banner_body">Automatically add episodes based on rules</string>

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/PlaylistDao.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/PlaylistDao.kt
@@ -115,9 +115,7 @@ abstract class PlaylistDao {
         FROM playlists AS playlist
         JOIN manual_playlist_episodes AS playlistEpisode ON playlistEpisode.playlist_uuid IS playlist.uuid
         LEFT JOIN podcast_episodes AS podcastEpisode ON podcastEpisode.uuid IS playlistEpisode.episode_uuid
-        WHERE
-          playlist.uuid IS :playlistUuid
-          AND IFNULL(podcastEpisode.archived, 0) IS 0
+        WHERE playlist.uuid IS :playlistUuid
     """,
     )
     abstract fun manualPlaylistMetadataFlow(playlistUuid: String): Flow<PlaylistEpisodeMetadata>

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/PodcastDao.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/PodcastDao.kt
@@ -317,7 +317,7 @@ abstract class PodcastDao {
     abstract fun countSubscribedRxSingle(): Single<Int>
 
     @Query("SELECT COUNT(*) FROM podcasts WHERE subscribed = 1")
-    abstract fun countSubscribedRxFlowable(): Flowable<Int>
+    abstract fun countSubscribedFlow(): Flow<Int>
 
     @Query("SELECT COUNT(*) FROM podcasts WHERE subscribed = 1 AND show_notifications = 1")
     abstract fun countNotificationsOnBlocking(): Int

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PodcastManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PodcastManager.kt
@@ -122,7 +122,7 @@ interface PodcastManager {
     fun countPodcastsBlocking(): Int
     suspend fun countSubscribed(): Int
     fun countSubscribedRxSingle(): Single<Int>
-    fun countSubscribedRxFlowable(): Flowable<Int>
+    fun countSubscribedFlow(): Flow<Int>
     fun countDownloadStatusBlocking(downloadStatus: Int): Int
     suspend fun hasEpisodesWithAutoDownloadStatus(downloadStatus: Int): Boolean
     fun countDownloadStatusRxSingle(downloadStatus: Int): Single<Int>

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PodcastManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PodcastManagerImpl.kt
@@ -492,8 +492,8 @@ class PodcastManagerImpl @Inject constructor(
         return podcastDao.countSubscribedRxSingle()
     }
 
-    override fun countSubscribedRxFlowable(): Flowable<Int> {
-        return podcastDao.countSubscribedRxFlowable()
+    override fun countSubscribedFlow(): Flow<Int> {
+        return podcastDao.countSubscribedFlow()
     }
 
     override fun countDownloadStatusBlocking(downloadStatus: Int): Int {


### PR DESCRIPTION
## Description

As the title says. States aren't top aligned because it's not possible without hardcoding some top padding. In practice it doesn't matter because they are never displayed next to each other so it's better to just center them in the UI.

Designs: 5sC4z4Mu42LvL4MAAIbQVi-fi-3618_25973

Closes PCDROID-113 

## Testing Instructions

1. Don't have any podcasts followed.
2. Create a playlist.
3. Tap the CTA button.
4. You should see Discover.
5. Follow any podcast.
6. Go back to the playlist.

## Screenshots or Screencast 

| No followed | Followed |
| - | - |
| <img width="1080" height="2400" alt="image" src="https://github.com/user-attachments/assets/8f0d03a2-21cd-4db9-8e34-35f494a1b1d0" /> | <img width="1080" height="2400" alt="image" src="https://github.com/user-attachments/assets/8cfd0f3b-b28f-4c2c-8160-b06e139c661e" /> |

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack