### PR TITLE
Show empty states when adding episodes to playlists

### DIFF
--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/manual/episode/AddEpisodesFragment.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/manual/episode/AddEpisodesFragment.kt
@@ -76,6 +76,7 @@ class AddEpisodesFragment : BaseDialogFragment() {
                     episodeSources = uiState.sources,
                     folderPodcastsFlow = viewModel::getFolderSourcesFlow,
                     episodesFlow = viewModel::getPodcastEpisodesFlow,
+                    hasAnyFolders = uiState.hasAnyFolders,
                     useEpisodeArtwork = uiState.useEpisodeArtwork,
                     onAddEpisode = viewModel::addEpisode,
                     onClickNavigationButton = {

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -953,6 +953,14 @@
     <string name="manual_playlist_no_content_body">Swipe left on an episode to add it to your playlist.</string>
     <string name="manual_playlist_no_content_title">Add episodes to your playlist</string>
     <string name="manual_playlist_no_content_title_alternative">Start building your playlist</string>
+    <string name="manual_playlist_no_available_episode_body">Looks like you’ve added all episodes from this show.</string>
+    <string name="manual_playlist_no_available_episode_title">No available episodes</string>
+    <string name="manual_playlist_search_no_episode_body" translatable="false">@string/podcast_no_episodes_matching</string>
+    <string name="manual_playlist_search_no_episode_title" translatable="false">@string/podcast_no_episodes_found</string>
+    <string name="manual_playlist_search_no_podcast_body">We couldn’t find any podcast for that search. Try another keyword.</string>
+    <string name="manual_playlist_search_no_podcast_title">No podcast found</string>
+    <string name="manual_playlist_search_no_podcast_or_folder_body">We couldn’t find any podcast or folder for that search. Try another keyword.</string>
+    <string name="manual_playlist_search_no_podcast_or_folder_title" translatable="false">@string/manual_playlist_search_no_podcast_title</string>
     <string name="new_playlist">New Playlist</string>
     <string name="new_playlists_title_placeholder">Playlist’s name</string>
     <string name="new_smart_playlist_banner_body">Automatically add episodes based on rules</string>


### PR DESCRIPTION
## Description

This adds different empty states when searching for episodes while building a manual playlist.

Closes PCDROID-142

## Testing Instructions

1. Follow some podcasts.
2. Create a manual playlist.
3. Tap "Add Episodes".
4. Search for something that does not yield a result.
5. Verify that the empty state does not mention folders.
6. Go back and place podcasts in a folder.
7. Return to the playlist.
8. Tap "Add Episodes".
9. Search for something that does not yield a result.
10. Verify that the empty state mentions folders.
11. Clear the search.
12. Go to a folder.
13. Search for something that does not yield a result.
14. Verify that the empty state is shown.
15. Clear the search.
16. Go to a podcast.
17. Search for something that does not yield a result.
18. Verify that the empty state mentions search.
19. Clear the search.
20. Add all episodes from that podcast.
21. Verify that the empty state does not mention search.
22. Search for something.
23. Verify that the empty state does not mention search.

## Screenshots or Screencast 

| Folders | Podcasts | Episodes | All episodes added |
| - | - | - | - |
| <img width="1080" height="2400" alt="image" src="https://github.com/user-attachments/assets/25345d5b-a9ed-4f66-a32e-707686d097bd" /> | <img width="1080" height="2400" alt="image" src="https://github.com/user-attachments/assets/650e82bc-d5e9-444a-88f1-b862b7c41810" /> | <img width="1080" height="2400" alt="image" src="https://github.com/user-attachments/assets/72545cb1-72d9-45a6-a4f6-feba1f923e98" /> | <img width="1080" height="2400" alt="image" src="https://github.com/user-attachments/assets/47b2603d-89f6-474a-9ee4-deba5ee3bdf2" /> |

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack