### PR TITLE
Show unavailable episode modal

### DIFF
--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/repositories/playlist/PlaylistManagerManualTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/repositories/playlist/PlaylistManagerManualTest.kt
@@ -558,4 +558,23 @@ class PlaylistManagerManualTest {
         val isAdded = manager.addManualEpisode("playlist-id-0", "episode-id-0")
         assertTrue(isAdded)
     }
+
+    @Test
+    fun deleteManualEpisodes() = dsl.test {
+        insertManualPlaylist(index = 0)
+        insertManualEpisode(index = 0, podcastIndex = 0, playlistIndex = 0)
+        insertManualEpisode(index = 1, podcastIndex = 0, playlistIndex = 0)
+        insertManualEpisode(index = 2, podcastIndex = 0, playlistIndex = 0)
+        insertManualEpisode(index = 3, podcastIndex = 0, playlistIndex = 0)
+        insertPodcastEpisode(index = 1, podcastIndex = 0)
+        insertPodcastEpisode(index = 3, podcastIndex = 0)
+
+        manager.deleteManualEpisodes("playlist-id-0", setOf("episode-id-0", "episode-id-1"))
+
+        expectManualEpisodes(
+            playlistIndex = 0,
+            manualPlaylistEpisode(index = 2, podcastIndex = 0, playlistIndex = 0),
+            manualPlaylistEpisode(index = 3, podcastIndex = 0, playlistIndex = 0),
+        )
+    }
 }

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/PlaylistEpisodesAdapterFactory.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/PlaylistEpisodesAdapterFactory.kt
@@ -13,6 +13,7 @@ import au.com.shiftyjelly.pocketcasts.models.entity.BaseEpisode
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.models.to.PlaylistEpisode
 import au.com.shiftyjelly.pocketcasts.models.type.EpisodeViewSource
+import au.com.shiftyjelly.pocketcasts.playlists.manual.UnavailableEpisodeFragment
 import au.com.shiftyjelly.pocketcasts.podcasts.view.components.PlayButton
 import au.com.shiftyjelly.pocketcasts.podcasts.view.episode.EpisodeContainerFragment
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
@@ -88,8 +89,10 @@ class PlaylistEpisodesAdapterFactory @Inject constructor(
                         ).show(parentFragmentManager, "episode_card")
                     }
 
-                    is PlaylistEpisode.Unavailable -> {
-                        Timber.i("Show sheet for unavailable $episodeWrapper")
+                    is PlaylistEpisode.Unavailable -> if (childFragmentManager.findFragmentByTag("unavailable_episode_sheet") == null) {
+                        UnavailableEpisodeFragment.newInstance(
+                            episodeUuid = episodeWrapper.uuid,
+                        ).show(childFragmentManager, "unavailable_episode_sheet")
                     }
                 }
             },

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/PlaylistFragment.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/PlaylistFragment.kt
@@ -485,7 +485,7 @@ class PlaylistFragment :
     ) : Parcelable
 
     companion object {
-        private const val NEW_INSTANCE_ARGS = "SmartPlaylistsFragmentArgs"
+        private const val NEW_INSTANCE_ARGS = "PlaylistsFragmentArgs"
 
         fun newInstance(
             uuid: String,

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/PlaylistViewModel.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/PlaylistViewModel.kt
@@ -109,15 +109,21 @@ class PlaylistViewModel @AssistedInject constructor(
         }
     }
 
+    fun deleteEpisode(episodeUuid: String) {
+        viewModelScope.launch {
+            playlistManager.deleteManualEpisode(playlistUuid, episodeUuid)
+        }
+    }
+
     fun updateSortType(type: PlaylistEpisodeSortType) {
-        viewModelScope.launch(NonCancellable) {
+        viewModelScope.launch {
             playlistManager.updateSortType(playlistUuid, type)
             trackSortByChanged(type)
         }
     }
 
     fun updateAutoDownload(isEnabled: Boolean) {
-        viewModelScope.launch(NonCancellable) {
+        viewModelScope.launch {
             playlistManager.updateAutoDownload(playlistUuid, isEnabled)
             isAutoDownloadChanged = true
             trackAutoDownloadChanged(isEnabled)
@@ -125,7 +131,7 @@ class PlaylistViewModel @AssistedInject constructor(
     }
 
     fun updateAutoDownloadLimit(limit: Int) {
-        viewModelScope.launch(NonCancellable) {
+        viewModelScope.launch {
             playlistManager.updateAutoDownloadLimit(playlistUuid, limit)
             isAutoDownloadLimitChanged = true
             trackAutoDownloadLimitChanged(limit)
@@ -137,7 +143,7 @@ class PlaylistViewModel @AssistedInject constructor(
         if (sanitizedName.isEmpty()) {
             return
         }
-        viewModelScope.launch(NonCancellable) {
+        viewModelScope.launch {
             isNameChanged = true
             playlistManager.updateName(playlistUuid, sanitizedName)
         }

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/manual/UnavailableEpisodeFragment.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/manual/UnavailableEpisodeFragment.kt
@@ -1,0 +1,87 @@
+package au.com.shiftyjelly.pocketcasts.playlists.manual
+
+import android.os.Bundle
+import android.os.Parcelable
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.MaterialTheme
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.nestedscroll.nestedScroll
+import androidx.compose.ui.platform.rememberNestedScrollInteropConnection
+import androidx.compose.ui.unit.dp
+import androidx.core.os.BundleCompat
+import androidx.core.os.bundleOf
+import androidx.fragment.app.viewModels
+import androidx.fragment.compose.content
+import au.com.shiftyjelly.pocketcasts.compose.theme
+import au.com.shiftyjelly.pocketcasts.playlists.PlaylistViewModel
+import au.com.shiftyjelly.pocketcasts.views.fragments.BaseDialogFragment
+import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.parcelize.Parcelize
+
+@AndroidEntryPoint
+class UnavailableEpisodeFragment : BaseDialogFragment() {
+    private val viewModel by viewModels<PlaylistViewModel>({ requireParentFragment() })
+
+    private val args get() = requireNotNull(arguments?.let { BundleCompat.getParcelable(it, NEW_INSTANCE_ARGS, Args::class.java) })
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?,
+    ) = content {
+        DialogBox(
+            fillMaxHeight = false,
+            modifier = Modifier.nestedScroll(rememberNestedScrollInteropConnection()),
+        ) {
+            Column(
+                horizontalAlignment = Alignment.CenterHorizontally,
+                modifier = Modifier.verticalScroll(rememberScrollState()),
+            ) {
+                Box(
+                    modifier = Modifier
+                        .padding(top = 8.dp)
+                        .background(MaterialTheme.theme.colors.primaryUi05, CircleShape)
+                        .size(56.dp, 4.dp),
+                )
+                UnavailableEpisodePage(
+                    onClickRemove = {
+                        viewModel.deleteEpisode(args.episodeUuid)
+                    },
+                    modifier = Modifier.padding(
+                        top = 24.dp,
+                        bottom = 16.dp,
+                        start = 16.dp,
+                        end = 16.dp,
+                    ),
+                )
+            }
+        }
+    }
+
+    @Parcelize
+    private class Args(
+        val episodeUuid: String,
+    ) : Parcelable
+
+    companion object {
+        private const val NEW_INSTANCE_ARGS = "UnavailableEpisodeFragmentArgs"
+
+        fun newInstance(
+            uuid: String,
+        ) = UnavailableEpisodeFragment().apply {
+            arguments = bundleOf(NEW_INSTANCE_ARGS to Args(uuid))
+        }
+    }
+}

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/manual/UnavailableEpisodeFragment.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/manual/UnavailableEpisodeFragment.kt
@@ -58,12 +58,13 @@ class UnavailableEpisodeFragment : BaseDialogFragment() {
                 UnavailableEpisodePage(
                     onClickRemove = {
                         viewModel.deleteEpisode(args.episodeUuid)
+                        dismiss()
                     },
                     modifier = Modifier.padding(
                         top = 24.dp,
                         bottom = 16.dp,
-                        start = 16.dp,
-                        end = 16.dp,
+                        start = 20.dp,
+                        end = 20.dp,
                     ),
                 )
             }
@@ -79,9 +80,9 @@ class UnavailableEpisodeFragment : BaseDialogFragment() {
         private const val NEW_INSTANCE_ARGS = "UnavailableEpisodeFragmentArgs"
 
         fun newInstance(
-            uuid: String,
+            episodeUuid: String,
         ) = UnavailableEpisodeFragment().apply {
-            arguments = bundleOf(NEW_INSTANCE_ARGS to Args(uuid))
+            arguments = bundleOf(NEW_INSTANCE_ARGS to Args(episodeUuid))
         }
     }
 }

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/manual/UnavailableEpisodePage.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/manual/UnavailableEpisodePage.kt
@@ -13,6 +13,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
@@ -25,6 +26,7 @@ import au.com.shiftyjelly.pocketcasts.compose.preview.ThemePreviewParameterProvi
 import au.com.shiftyjelly.pocketcasts.compose.theme
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme.ThemeType
 import au.com.shiftyjelly.pocketcasts.images.R as IR
+import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 @Composable
 internal fun UnavailableEpisodePage(
@@ -45,21 +47,22 @@ internal fun UnavailableEpisodePage(
             modifier = Modifier.height(24.dp),
         )
         TextH20(
-            text = "Episode unavailable",
+            text = stringResource(LR.string.playlist_episode_unavailable_title),
         )
         Spacer(
             modifier = Modifier.height(8.dp),
         )
         TextP40(
-            text = "The podcast creator deleted this episode. It will stay in your playlist until you remove it.",
+            text = stringResource(LR.string.playlist_episode_unavailable_description),
             textAlign = TextAlign.Center,
             color = MaterialTheme.theme.colors.primaryText02,
+            modifier = Modifier.padding(horizontal = 20.dp),
         )
         Spacer(
-            modifier = Modifier.height(40.dp),
+            modifier = Modifier.height(48.dp),
         )
         RowButton(
-            text = "Remove from playlist",
+            text = stringResource(LR.string.playlist_episode_unavailable_cta),
             onClick = onClickRemove,
             includePadding = false,
         )

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/manual/UnavailableEpisodePage.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/manual/UnavailableEpisodePage.kt
@@ -1,0 +1,79 @@
+package au.com.shiftyjelly.pocketcasts.playlists.manual
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewParameter
+import androidx.compose.ui.unit.dp
+import au.com.shiftyjelly.pocketcasts.compose.AppThemeWithBackground
+import au.com.shiftyjelly.pocketcasts.compose.buttons.RowButton
+import au.com.shiftyjelly.pocketcasts.compose.components.TextH20
+import au.com.shiftyjelly.pocketcasts.compose.components.TextP40
+import au.com.shiftyjelly.pocketcasts.compose.preview.ThemePreviewParameterProvider
+import au.com.shiftyjelly.pocketcasts.compose.theme
+import au.com.shiftyjelly.pocketcasts.ui.theme.Theme.ThemeType
+import au.com.shiftyjelly.pocketcasts.images.R as IR
+
+@Composable
+internal fun UnavailableEpisodePage(
+    onClickRemove: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        horizontalAlignment = Alignment.CenterHorizontally,
+        modifier = modifier.fillMaxWidth(),
+    ) {
+        Image(
+            painter = painterResource(IR.drawable.ic_exclamation_circle),
+            colorFilter = ColorFilter.tint(MaterialTheme.theme.colors.primaryIcon01),
+            contentDescription = null,
+            modifier = Modifier.size(32.dp),
+        )
+        Spacer(
+            modifier = Modifier.height(24.dp),
+        )
+        TextH20(
+            text = "Episode unavailable",
+        )
+        Spacer(
+            modifier = Modifier.height(8.dp),
+        )
+        TextP40(
+            text = "The podcast creator deleted this episode. It will stay in your playlist until you remove it.",
+            textAlign = TextAlign.Center,
+            color = MaterialTheme.theme.colors.primaryText02,
+        )
+        Spacer(
+            modifier = Modifier.height(40.dp),
+        )
+        RowButton(
+            text = "Remove from playlist",
+            onClick = onClickRemove,
+            includePadding = false,
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun UnavailableEpisodePagePreview(
+    @PreviewParameter(ThemePreviewParameterProvider::class) themeType: ThemeType,
+) {
+    AppThemeWithBackground(themeType) {
+        UnavailableEpisodePage(
+            onClickRemove = {},
+        )
+    }
+}

--- a/modules/features/filters/src/test/kotlin/au/com/shiftyjelly/pocketcasts/playlists/create/FakePlaylistManager.kt
+++ b/modules/features/filters/src/test/kotlin/au/com/shiftyjelly/pocketcasts/playlists/create/FakePlaylistManager.kt
@@ -86,4 +86,6 @@ class FakePlaylistManager : PlaylistManager {
     override suspend fun addManualEpisode(playlistUuid: String, episodeUuid: String): Boolean {
         return true
     }
+
+    override suspend fun deleteManualEpisodes(playlistUuid: String, episodeUuids: Collection<String>) = Unit
 }

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -970,6 +970,9 @@
     <string name="playlist_artwork_description">Playlist’s artwork</string>
     <string name="playlist_download_all">Download All</string>
     <string name="playlist_edit" translatable="false">@string/edit</string>
+    <string name="playlist_episode_unavailable_title">Episode unavailable</string>
+    <string name="playlist_episode_unavailable_description">The podcast creator deleted this episode. It will stay in your playlist until you remove it.</string>
+    <string name="playlist_episode_unavailable_cta">Remove from playlist</string>
     <string name="playlist_options">Playlist Options</string>
     <string name="playlist_play_all">Play All</string>
     <string name="playlist_select_episodes">Select Episodes</string>

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/PlaylistDao.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/PlaylistDao.kt
@@ -30,7 +30,6 @@ import au.com.shiftyjelly.pocketcasts.models.type.SmartRules
 import au.com.shiftyjelly.pocketcasts.utils.extensions.escapeLike
 import java.time.Clock
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.map
 
 @Dao
@@ -106,6 +105,15 @@ abstract class PlaylistDao {
     open suspend fun deleteAllPlaylistsIn(uuids: Collection<String>) {
         uuids.chunked(AppDatabase.SQLITE_BIND_ARG_LIMIT).forEach { chunk ->
             deleteAllPlaylistsInUnsafe(chunk)
+        }
+    }
+
+    @Query("DELETE FROM manual_playlist_episodes WHERE playlist_uuid IS :playlistUuid AND episode_uuid IN (:episodeUuids)")
+    protected abstract suspend fun deleteAllManualEpisodesInUnsafe(playlistUuid: String, episodeUuids: Collection<String>)
+
+    open suspend fun deleteAllManualEpisodesIn(playlistUuid: String, episodeUuids: Collection<String>) {
+        episodeUuids.chunked(AppDatabase.SQLITE_BIND_ARG_LIMIT - 1).forEach { chunk ->
+            deleteAllManualEpisodesInUnsafe(playlistUuid, chunk)
         }
     }
 

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playlist/PlaylistManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playlist/PlaylistManager.kt
@@ -53,6 +53,8 @@ interface PlaylistManager {
     fun notAddedManualEpisodesFlow(playlistUuid: String, podcastUuid: String, searchTerm: String? = null): Flow<List<PodcastEpisode>>
 
     suspend fun addManualEpisode(playlistUuid: String, episodeUuid: String): Boolean
+
+    suspend fun deleteManualEpisodes(playlistUuid: String, episodeUuids: Collection<String>)
     // </editor-fold>
 
     companion object {

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playlist/PlaylistManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playlist/PlaylistManager.kt
@@ -55,6 +55,8 @@ interface PlaylistManager {
     suspend fun addManualEpisode(playlistUuid: String, episodeUuid: String): Boolean
 
     suspend fun deleteManualEpisodes(playlistUuid: String, episodeUuids: Collection<String>)
+
+    suspend fun deleteManualEpisode(playlistUuid: String, episodeUuid: String) = deleteManualEpisodes(playlistUuid, listOf(episodeUuid))
     // </editor-fold>
 
     companion object {

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playlist/PlaylistManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playlist/PlaylistManagerImpl.kt
@@ -299,6 +299,10 @@ class PlaylistManagerImpl(
         }
     }
 
+    override suspend fun deleteManualEpisodes(playlistUuid: String, episodeUuids: Collection<String>) {
+        playlistDao.deleteAllManualEpisodesIn(playlistUuid, episodeUuids)
+    }
+
     private fun createPreviewsFlow(playlists: List<PlaylistEntity>) = combine(
         playlists.map { playlist ->
             val flow = if (playlist.manual) {


### PR DESCRIPTION
## Description

As the title says.

Designs: 5sC4z4Mu42LvL4MAAIbQVi-fi-2615_52293

Closes PCDROID-145

## Testing Instructions

1. Create a manual playlist.
2. Execute this query.
```sql
INSERT OR REPLACE INTO manual_playlist_episodes(playlist_uuid, episode_uuid, podcast_uuid, title, added_at, published_at, download_url, episode_slug, podcast_slug, sort_position, is_synced)
VALUES ((SELECT uuid FROM playlists WHERE deleted IS 0 AND manual IS 1 LIMIT 1), 'mock-uuid', 'mock-uuid', 'Mock episode', (SELECT strftime('%s','now') * 1000), (SELECT strftime('%s','now') * 1000), '', '', '', 0, false)
```
3. Tap on the unavailable episode.
4. You should see modal.
5. Dismiss it.
6. Tap again on the episode.
7. Confirm episode deletion.
8. The episode should be removed.

## Screenshots or Screencast 

<img width="540" alt="image" src="https://github.com/user-attachments/assets/5e85397a-55bb-4568-90d0-a9965c470fc4" />

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack