### PR TITLE
Fix layout spacing in onboarding interests page (#4469)

### DIFF
--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/recommendations/OnboardingInterestsPage.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/recommendations/OnboardingInterestsPage.kt
@@ -147,6 +147,7 @@ private fun Content(
                 .height(IntrinsicSize.Min)
                 .verticalScroll(rememberScrollState())
                 .fillMaxWidth()
+                .weight(1.0f)
                 .animateContentSize(),
             horizontalArrangement = Arrangement.spacedBy(8.dp, alignment = Alignment.CenterHorizontally),
             verticalArrangement = Arrangement.spacedBy(8.dp),
@@ -185,7 +186,7 @@ private fun Content(
                     .padding(horizontal = 4.dp, vertical = 2.dp),
                 fontWeight = FontWeight.W500,
             )
-            Spacer(modifier = Modifier.weight(1f))
+            Spacer(modifier = Modifier.height(24.dp))
         }
 
         RowButton(


### PR DESCRIPTION
## Description
Make the FlowRow layout flexible and fix layout spacing in onboarding interests page

Fixes #4469

## Testing Instructions
* Launch the app
* Click 'Get started'
* Click the "Show more categories" label


## Screenshots or Screencast 
<!-- if applicable -->

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
