### PR TITLE
Fix interests spacing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@
         ([#4414](https://github.com/Automattic/pocket-casts-android/pull/4414))
     *   Fix podcast image shadow animation.
         ([#4429](https://github.com/Automattic/pocket-casts-android/pull/4429))
+    *   Fix layout spacing in onboarding interests page
+        ([#4471](https://github.com/Automattic/pocket-casts-android/pull/4471))
+        
 
 7.96
 -----

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/recommendations/OnboardingInterestsPage.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/recommendations/OnboardingInterestsPage.kt
@@ -9,8 +9,10 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.systemBarsPadding
 import androidx.compose.foundation.layout.wrapContentWidth
@@ -76,7 +78,7 @@ fun OnboardingInterestsPage(
     }
 
     Content(
-        modifier = modifier,
+        modifier = modifier.fillMaxSize(),
         state = state,
         onCategorySelectionChange = viewModel::updateSelectedCategory,
         onContinuePress = {
@@ -145,9 +147,9 @@ private fun Content(
         FlowRow(
             modifier = Modifier
                 .height(IntrinsicSize.Min)
+                .weight(3f, fill = false)
                 .verticalScroll(rememberScrollState())
                 .fillMaxWidth()
-                .weight(1.0f)
                 .animateContentSize(),
             horizontalArrangement = Arrangement.spacedBy(8.dp, alignment = Alignment.CenterHorizontally),
             verticalArrangement = Arrangement.spacedBy(8.dp),
@@ -186,7 +188,9 @@ private fun Content(
                     .padding(horizontal = 4.dp, vertical = 2.dp),
                 fontWeight = FontWeight.W500,
             )
-            Spacer(modifier = Modifier.height(24.dp))
+            Spacer(
+                modifier = Modifier.weight(1f)
+            )
         }
 
         RowButton(

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/recommendations/OnboardingInterestsPage.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/recommendations/OnboardingInterestsPage.kt
@@ -189,7 +189,7 @@ private fun Content(
                 fontWeight = FontWeight.W500,
             )
             Spacer(
-                modifier = Modifier.weight(1f)
+                modifier = Modifier.weight(1f),
             )
         }
 

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/recommendations/OnboardingInterestsPage.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/recommendations/OnboardingInterestsPage.kt
@@ -147,6 +147,7 @@ private fun Content(
                 .height(IntrinsicSize.Min)
                 .verticalScroll(rememberScrollState())
                 .fillMaxWidth()
+                .weight(1.0f)
                 .animateContentSize(),
             horizontalArrangement = Arrangement.spacedBy(8.dp, alignment = Alignment.CenterHorizontally),
             verticalArrangement = Arrangement.spacedBy(8.dp),
@@ -185,7 +186,7 @@ private fun Content(
                     .padding(horizontal = 4.dp, vertical = 2.dp),
                 fontWeight = FontWeight.W500,
             )
-            Spacer(modifier = Modifier.weight(1f))
+            Spacer(modifier = Modifier.height(24.dp))
         }
 
         RowButton(


### PR DESCRIPTION
## Description

Credits/original PR: https://github.com/Automattic/pocket-casts-android/pull/4471 🙇 

Make the FlowRow layout flexible and fix layout spacing in onboarding interests page.

Fixes #4469

Designs: PviUP0aiZctOprDuuYRwpb-fi-5109_15632

## Testing Instructions
* Launch the app
* Click 'Get started'
* Click the "Show more categories" label


## Screenshots or Screencast 
| Small collapsed | Small expanded | Modern collapsed | Modern expanded |
| --- | --- | --- | --- |
| <img width="720" height="1280" alt="Screenshot_20250909_183307" src="https://github.com/user-attachments/assets/21e306d7-eefa-48e2-8939-638a1a9fac76" /> | <img width="720" height="1280" alt="Screenshot_20250909_183313" src="https://github.com/user-attachments/assets/963f80e4-965a-4b90-a2e0-354f01293f71" /> | <img width="1080" height="2400" alt="Screenshot_20250909_183845" src="https://github.com/user-attachments/assets/0e74730f-483a-4e78-a4d0-cfa7c34fc047" /> | <img width="1080" height="2400" alt="Screenshot_20250909_183851" src="https://github.com/user-attachments/assets/0072487f-1c31-4fdc-a9b2-97a14e294159" /> |


## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] Any jetpack compose components I added or changed are covered by compose previews
 
#### I have tested any UI changes...
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size