### PR TITLE
Do not cleanup manual playlists data

### DIFF
--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/viewmodel/ManualCleanupViewModel.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/viewmodel/ManualCleanupViewModel.kt
@@ -123,7 +123,6 @@ class ManualCleanupViewModel
                 episodeManager.deleteEpisodeFiles(
                     episodes = episodesToDelete,
                     playbackManager = playbackManager,
-                    removeFromUpNext = false,
                 )
                 _snackbarMessage.emit(LR.string.settings_manage_downloads_deleting)
             }

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/PlaylistDao.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/PlaylistDao.kt
@@ -136,6 +136,26 @@ abstract class PlaylistDao {
 
     @Query(
         """
+        SELECT DISTINCT episode.podcast_uuid
+        FROM playlists AS playlist
+        JOIN manual_playlist_episodes AS episode ON episode.playlist_uuid IS playlist.uuid
+        WHERE playlist.deleted IS 0 AND playlist.manual IS NOT 0
+    """,
+    )
+    abstract suspend fun getPodcastsAddedToManualPlaylists(): List<String>
+
+    @Query(
+        """
+        SELECT DISTINCT episode.episode_uuid
+        FROM playlists AS playlist
+        JOIN manual_playlist_episodes AS episode ON episode.playlist_uuid IS playlist.uuid
+        WHERE playlist.deleted IS 0 AND playlist.manual IS NOT 0
+    """,
+    )
+    abstract suspend fun getEpisodesAddedToManualPlaylists(): List<String>
+
+    @Query(
+        """
         SELECT manual_episode.*
         FROM playlists AS playlist
         JOIN manual_playlist_episodes AS manual_episode ON manual_episode.playlist_uuid IS playlist.uuid

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManager.kt
@@ -119,7 +119,9 @@ interface EpisodeManager {
     fun countEpisodesWhereBlocking(queryAfterWhere: String): Int
     fun downloadMissingEpisodeRxMaybe(episodeUuid: String, podcastUuid: String, skeletonEpisode: PodcastEpisode, podcastManager: PodcastManager, downloadMetaData: Boolean, source: SourceView): Maybe<BaseEpisode>
 
-    fun deleteEpisodesAsync(episodes: List<PodcastEpisode>, playbackManager: PlaybackManager)
+    fun deleteEpisodeFilesAsync(episodes: List<PodcastEpisode>, playbackManager: PlaybackManager)
+    suspend fun deleteEpisodeFiles(episodes: List<PodcastEpisode>, playbackManager: PlaybackManager)
+
     fun unarchiveAllInListBlocking(episodes: List<PodcastEpisode>)
     fun findPlaybackHistoryEpisodesRxFlowable(): Flowable<List<PodcastEpisode>>
     fun filteredPlaybackHistoryEpisodesFlow(query: String): Flow<List<PodcastEpisode>>
@@ -134,7 +136,6 @@ interface EpisodeManager {
     fun setDownloadFailedBlocking(episode: BaseEpisode, errorMessage: String)
     fun episodeCountRxFlowable(queryAfterWhere: String): Flowable<Int>
     suspend fun updatePlaybackInteractionDate(episode: BaseEpisode?)
-    suspend fun deleteEpisodeFiles(episodes: List<PodcastEpisode>, playbackManager: PlaybackManager, removeFromUpNext: Boolean = true)
     suspend fun findStaleDownloads(): List<PodcastEpisode>
     suspend fun calculatePlayedUptoSumInSecsWithinDays(days: Int): Double
 

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManagerImpl.kt
@@ -527,7 +527,7 @@ class EpisodeManagerImpl @Inject constructor(
         episode ?: return
 
         runBlocking {
-            deleteEpisodeFile(episode, playbackManager, false, false)
+            deleteEpisodeFile(episode, playbackManager, disableAutoDownload = false, updateDatabase = false)
         }
 
         episodeDao.deleteBlocking(episode)
@@ -780,16 +780,15 @@ class EpisodeManagerImpl @Inject constructor(
         episodeDao.deleteAll()
     }
 
-    override fun deleteEpisodesAsync(episodes: List<PodcastEpisode>, playbackManager: PlaybackManager) {
-        val episodesCopy = episodes.toList()
+    override fun deleteEpisodeFilesAsync(episodes: List<PodcastEpisode>, playbackManager: PlaybackManager) {
         launch {
-            deleteEpisodeFiles(episodesCopy, playbackManager)
+            deleteEpisodeFiles(episodes, playbackManager)
         }
     }
 
-    override suspend fun deleteEpisodeFiles(episodes: List<PodcastEpisode>, playbackManager: PlaybackManager, removeFromUpNext: Boolean) = withContext(Dispatchers.IO) {
+    override suspend fun deleteEpisodeFiles(episodes: List<PodcastEpisode>, playbackManager: PlaybackManager) = withContext(Dispatchers.IO) {
         episodes.toList().forEach {
-            deleteEpisodeFile(it, playbackManager, removeFromUpNext = removeFromUpNext, disableAutoDownload = false)
+            deleteEpisodeFile(it, playbackManager, removeFromUpNext = false, disableAutoDownload = false)
         }
     }
 


### PR DESCRIPTION
## Description

This adapts our removal podcast and episode clean up logic to account for episodes in manual playlists.

Closes PCDROID-143

## Testing Instructions

## Testing Instructions

1. Test with `debugProd`.
2. Start the app in a clean state without being signed in.
3. Follow the [Radiolab](https://pca.st/radiolab) podcast.
4. Create a manual playlist.
5. Add some Radiolab episodes to the playlist.
6. Unfollow Radiolab.
7. Return to the playlist.
8. Episodes should still be available.
9. Create an account.
10. Go to Discover.
11. Follow any podcast other than Radiolab.
12. Execute the query.
```sql
UPDATE podcasts SET added_date = 1600000000000 WHERE uuid IS 'f5b97290-0422-012e-f9a0-00163e1b201c'
```
13. Go to the Profile tab and sync the account.
14. Return to the playlists.
15. Episodes should still be available.

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.