### PR TITLE
Update manual playlist edit option copy

### DIFF
--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/OptionsFragment.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/OptionsFragment.kt
@@ -7,6 +7,7 @@ import androidx.compose.animation.AnimatedContent
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
@@ -63,7 +64,9 @@ class OptionsFragment : BaseDialogFragment() {
         ) {
             Column(
                 horizontalAlignment = Alignment.CenterHorizontally,
-                modifier = Modifier.verticalScroll(rememberScrollState()),
+                modifier = Modifier
+                    .verticalScroll(rememberScrollState())
+                    .navigationBarsPadding(),
             ) {
                 Box(
                     modifier = Modifier
@@ -139,7 +142,7 @@ class OptionsFragment : BaseDialogFragment() {
                 if (hasEpisodes && playlistType == Playlist.Type.Manual) {
                     add(
                         PlaylistOption(
-                            title = getString(LR.string.edit),
+                            title = getString(LR.string.playlist_edit_episodes),
                             iconId = IR.drawable.ic_playlist_edit,
                             onClick = {
                                 dismiss()

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/manual/EditPlaylistPage.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/manual/EditPlaylistPage.kt
@@ -100,7 +100,7 @@ internal fun EditPlaylistPage(
     ) {
         ThemedTopAppBar(
             modifier = Modifier.fillMaxWidth(),
-            title = stringResource(LR.string.playlist_edit_title),
+            title = stringResource(LR.string.playlist_edit_episodes_title),
             navigationButton = NavigationButton.Back,
             style = ThemedTopAppBar.Style.Immersive,
             backgroundColor = Color.Transparent,

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -969,8 +969,8 @@
     <string name="playlist_archive_all">Archive All</string>
     <string name="playlist_artwork_description">Playlist’s artwork</string>
     <string name="playlist_download_all">Download All</string>
-    <string name="playlist_edit" translatable="false">@string/edit</string>
-    <string name="playlist_edit_title">Edit playlist</string>
+    <string name="playlist_edit_episodes">Rearrange Episodes</string>
+    <string name="playlist_edit_episodes_title">Edit playlist</string>
     <string name="playlist_episode_unavailable_title">Episode unavailable</string>
     <string name="playlist_episode_unavailable_description">The podcast creator deleted this episode. It will stay in your playlist until you remove it.</string>
     <string name="playlist_episode_unavailable_cta">Remove from playlist</string>


### PR DESCRIPTION
## Description

Some small changes based on feedback. See: p1757488118358409-slack-C093RV9N8DR

## Testing Instructions

Code review should be enough.

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.