### PR TITLE
Fix episode sorting order

### DIFF
--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/repositories/playlist/PlaylistManagerManualTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/repositories/playlist/PlaylistManagerManualTest.kt
@@ -536,6 +536,44 @@ class PlaylistManagerManualTest {
     }
 
     @Test
+    fun fixSortOrderWhenAddingEpisodes() = dsl.test {
+        insertManualPlaylist(index = 0)
+        insertPodcast(index = 0)
+        repeat(4) { index ->
+            insertPodcastEpisode(index = index, podcastIndex = 0)
+            insertPodcastEpisode(index = index, podcastIndex = 1)
+        }
+
+        manager.addManualEpisode("playlist-id-0", "episode-id-0")
+        manager.addManualEpisode("playlist-id-0", "episode-id-1")
+        manager.addManualEpisode("playlist-id-0", "episode-id-2")
+        manager.deleteManualEpisode("playlist-id-0", "episode-id-1")
+
+        manager.addManualEpisode("playlist-id-0", "episode-id-3")
+        expectManualEpisodes(
+            playlistIndex = 0,
+            manualPlaylistEpisode(index = 0, podcastIndex = 0, playlistIndex = 0) {
+                it.copy(
+                    sortPosition = 0,
+                    isSynced = false,
+                )
+            },
+            manualPlaylistEpisode(index = 2, podcastIndex = 0, playlistIndex = 0) {
+                it.copy(
+                    sortPosition = 2,
+                    isSynced = false,
+                )
+            },
+            manualPlaylistEpisode(index = 3, podcastIndex = 0, playlistIndex = 0) {
+                it.copy(
+                    sortPosition = 3,
+                    isSynced = false,
+                )
+            },
+        )
+    }
+
+    @Test
     fun doNotAddUnavailableEpisodes() = dsl.test {
         insertManualPlaylist(index = 0)
         insertPodcast(index = 0)


### PR DESCRIPTION
## Description

When testing I noticed that adding new episodes results in them being in a wrong position. It happened because a new episode position was based on episode list size and not on the last sort position. This PR fixed that.

Closes PCDROID-118

## Testing Instructions

1. Create a manual playlist.
2. Add 5 episodes to it.
3. Tap overflow menu.
4. Tap rearrange option.
5. Do not rearrange any episodes.
6. Delete episode 2, 3, and 4.
7. Go back to the playlist.
8. Add a new episode.
9. It should be displayed at the bottom of the list.

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.