### PR TITLE
Handle playlist swipe actions

### DIFF
--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/PlaylistFragment.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/PlaylistFragment.kt
@@ -71,7 +71,6 @@ import kotlin.math.roundToInt
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 import kotlinx.parcelize.Parcelize
-import timber.log.Timber
 import au.com.shiftyjelly.pocketcasts.images.R as IR
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 import au.com.shiftyjelly.pocketcasts.ui.R as UR
@@ -205,11 +204,9 @@ class PlaylistFragment :
     private fun createEpisodesAdapter(binding: PlaylistFragmentBinding): PlaylistEpisodeAdapter {
         return adapterFactory.create(
             playlistType = args.type,
+            playlistUuid = args.uuid,
             multiSelectToolbar = binding.multiSelectToolbar,
             getEpisodes = { viewModel.uiState.value.playlist?.episodes.orEmpty() },
-            onSwipeAction = { episode, action ->
-                Timber.i("Handle $action")
-            },
         )
     }
 

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/component/EpisodeAvailableViewHolder.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/component/EpisodeAvailableViewHolder.kt
@@ -119,14 +119,16 @@ class EpisodeAvailableViewHolder(
             swipeLayout.clearTranslation()
         }
         this.episodeWrapper = episodeWrapper
-        this.isMultiSelectEnabled = isMultiSelectEnabled
         this.streamByDefault = streamByDefault
 
-        if (isMultiSelectEnabled) {
-            swipeLayout.clearTranslation()
-            swipeLayout.lock()
-        } else {
-            swipeLayout.unlock()
+        if (this.isMultiSelectEnabled != isMultiSelectEnabled) {
+            this.isMultiSelectEnabled = isMultiSelectEnabled
+            if (isMultiSelectEnabled) {
+                swipeLayout.clearTranslation()
+                swipeLayout.lock()
+            } else {
+                swipeLayout.unlock()
+            }
         }
 
         disposable.clear()

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/component/EpisodeUnavailableViewHolder.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/component/EpisodeUnavailableViewHolder.kt
@@ -36,6 +36,8 @@ class EpisodeUnavailableViewHolder(
         swipeLayout.addOnSwipeActionListener { action -> onSwipeAction(requireNotNull(episodeWrapper), action) }
     }
 
+    private var isMultiSelectEnabled = false
+
     fun bind(
         episodeWrapper: PlaylistEpisode.Unavailable,
         isMultiSelectEnabled: Boolean,
@@ -45,11 +47,14 @@ class EpisodeUnavailableViewHolder(
         }
         this.episodeWrapper = episodeWrapper
 
-        if (isMultiSelectEnabled) {
-            swipeLayout.clearTranslation()
-            swipeLayout.lock()
-        } else {
-            swipeLayout.unlock()
+        if (this.isMultiSelectEnabled != isMultiSelectEnabled) {
+            this.isMultiSelectEnabled = isMultiSelectEnabled
+            if (isMultiSelectEnabled) {
+                swipeLayout.clearTranslation()
+                swipeLayout.lock()
+            } else {
+                swipeLayout.unlock()
+            }
         }
 
         binding.titleLabel.text = episodeWrapper.episode.title

--- a/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/swipe/SwipeAction.kt
+++ b/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/swipe/SwipeAction.kt
@@ -2,19 +2,22 @@ package au.com.shiftyjelly.pocketcasts.views.swipe
 
 import android.content.Context
 import android.graphics.Color
+import au.com.shiftyjelly.pocketcasts.models.to.PlaylistEpisode
 import au.com.shiftyjelly.pocketcasts.ui.extensions.getThemeColor
 import au.com.shiftyjelly.pocketcasts.images.R as IR
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 import au.com.shiftyjelly.pocketcasts.ui.R as UR
 
-enum class SwipeAction : SwipeButton.UiState {
-    AddToUpNextTop,
-    AddToUpNextBottom,
-    RemoveFromUpNext,
-    Share,
-    Archive,
-    Unarchive,
-    RemoveFromPlaylist,
+enum class SwipeAction(
+    val analyticsValue: String,
+) : SwipeButton.UiState {
+    AddToUpNextTop("up_next_add_top"),
+    AddToUpNextBottom("up_next_add_bottom"),
+    RemoveFromUpNext("up_next_remove"),
+    Share("share"),
+    Archive("archive"),
+    Unarchive("unarchive"),
+    RemoveFromPlaylist("playlist_remove"),
     ;
 
     override fun contentDescription(context: Context) = when (this) {

--- a/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/swipe/SwipeActionViewModel.kt
+++ b/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/swipe/SwipeActionViewModel.kt
@@ -1,0 +1,152 @@
+package au.com.shiftyjelly.pocketcasts.views.swipe
+
+import androidx.fragment.app.FragmentManager
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
+import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsTracker
+import au.com.shiftyjelly.pocketcasts.analytics.SourceView
+import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
+import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
+import au.com.shiftyjelly.pocketcasts.repositories.playlist.PlaylistManager
+import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
+import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
+import au.com.shiftyjelly.pocketcasts.views.dialog.ShareDialogFactory
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedFactory
+import dagger.assisted.AssistedInject
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+
+@HiltViewModel(assistedFactory = SwipeActionViewModel.Factory::class)
+class SwipeActionViewModel @AssistedInject constructor(
+    private val playbackManager: PlaybackManager,
+    private val podcastManager: PodcastManager,
+    private val episodeManager: EpisodeManager,
+    private val playlistManager: PlaylistManager,
+    private val shareDialogFactory: ShareDialogFactory,
+    private val tracker: AnalyticsTracker,
+    @Assisted private val swipeSource: SwipeSource,
+    @Assisted private val playlistUuid: String?,
+) : ViewModel() {
+    fun addToUpNextTop(episodeUuid: String) {
+        trackAction(SwipeAction.AddToUpNextTop)
+
+        viewModelScope.launch {
+            val episode = episodeManager.findEpisodeByUuid(episodeUuid) ?: return@launch
+            playbackManager.playNext(episode, swipeSource.toSourceView())
+        }
+    }
+
+    fun addToUpNextBottom(episodeUuid: String) {
+        trackAction(SwipeAction.AddToUpNextBottom)
+
+        viewModelScope.launch {
+            val episode = episodeManager.findEpisodeByUuid(episodeUuid) ?: return@launch
+            playbackManager.playLast(episode, swipeSource.toSourceView())
+        }
+    }
+
+    fun removeFromUpNext(episodeUuid: String) {
+        trackAction(SwipeAction.RemoveFromPlaylist)
+
+        viewModelScope.launch {
+            val episode = episodeManager.findEpisodeByUuid(episodeUuid) ?: return@launch
+            playbackManager.removeEpisode(episode, swipeSource.toSourceView())
+        }
+    }
+
+    fun archive(episodeUuid: String) {
+        trackAction(SwipeAction.Archive)
+
+        viewModelScope.launch {
+            val episode = episodeManager.findEpisodeByUuid(episodeUuid) as? PodcastEpisode ?: return@launch
+            withContext(Dispatchers.IO) {
+                episodeManager.archiveBlocking(episode, playbackManager)
+            }
+        }
+    }
+
+    fun unarchive(episodeUuid: String) {
+        trackAction(SwipeAction.Unarchive)
+
+        viewModelScope.launch {
+            val episode = episodeManager.findEpisodeByUuid(episodeUuid) as? PodcastEpisode ?: return@launch
+            withContext(Dispatchers.IO) {
+                episodeManager.unarchiveBlocking(episode)
+            }
+        }
+    }
+
+    fun removeFromPlaylist(episodeUuid: String) {
+        trackAction(SwipeAction.RemoveFromPlaylist)
+
+        val playlistUuid = playlistUuid ?: return
+        viewModelScope.launch {
+            playlistManager.deleteManualEpisode(
+                episodeUuid = episodeUuid,
+                playlistUuid = playlistUuid,
+            )
+        }
+    }
+
+    // Unlike other functions this one is suspending because it needs FragmentManager
+    // to share an episode.
+    //
+    // If it was executed in view model's scope it could memory leaks if the manager was
+    // retained in memory the underlying fragment gets destroyed.
+    suspend fun shareEpisode(episodeUuid: String, fragmentManager: FragmentManager) {
+        trackAction(SwipeAction.Share)
+
+        val episode = episodeManager.findEpisodeByUuid(episodeUuid) as? PodcastEpisode ?: return
+        val podcast = podcastManager.findPodcastByUuid(episode.podcastUuid) ?: return
+
+        shareDialogFactory
+            .shareEpisode(podcast, episode, SourceView.EPISODE_SWIPE_ACTION)
+            .show(fragmentManager, "share_dialog")
+    }
+
+    private fun trackAction(action: SwipeAction) {
+        tracker.track(
+            AnalyticsEvent.EPISODE_SWIPE_ACTION_PERFORMED,
+            mapOf(
+                "action" to action.analyticsValue,
+                "source" to swipeSource.analyticsValue,
+            ),
+        )
+    }
+
+    @AssistedFactory
+    interface Factory {
+        fun create(
+            @Assisted swipeSource: SwipeSource,
+            @Assisted playlistUuid: String?,
+        ): SwipeActionViewModel
+    }
+}
+
+suspend fun SwipeActionViewModel.handleAction(
+    action: SwipeAction,
+    episodeUuid: String,
+    fragmentManager: FragmentManager,
+) = when (action) {
+    SwipeAction.AddToUpNextTop -> addToUpNextTop(episodeUuid)
+    SwipeAction.AddToUpNextBottom -> addToUpNextBottom(episodeUuid)
+    SwipeAction.RemoveFromUpNext -> removeFromUpNext(episodeUuid)
+    SwipeAction.Share -> shareEpisode(episodeUuid, fragmentManager)
+    SwipeAction.Archive -> archive(episodeUuid)
+    SwipeAction.Unarchive -> unarchive(episodeUuid)
+    SwipeAction.RemoveFromPlaylist -> removeFromPlaylist(episodeUuid)
+}
+
+private fun SwipeSource.toSourceView() = when (this) {
+    SwipeSource.PodcastDetails -> SourceView.PODCAST_SCREEN
+    SwipeSource.Filters -> SourceView.FILTERS
+    SwipeSource.Downloads -> SourceView.DOWNLOADS
+    SwipeSource.ListeningHistory -> SourceView.LISTENING_HISTORY
+    SwipeSource.Starred -> SourceView.STARRED
+    SwipeSource.Files -> SourceView.FILES
+    SwipeSource.UpNext -> SourceView.UP_NEXT
+}

--- a/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/swipe/SwipeSource.kt
+++ b/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/swipe/SwipeSource.kt
@@ -1,0 +1,13 @@
+package au.com.shiftyjelly.pocketcasts.views.swipe
+
+enum class SwipeSource(
+    val analyticsValue: String,
+) {
+    PodcastDetails("podcast_details"),
+    Filters("filters"),
+    Downloads("downloads"),
+    ListeningHistory("listening_history"),
+    Starred("starred"),
+    Files("files"),
+    UpNext("up_next"),
+}


### PR DESCRIPTION
## Description

This adds support for playlist swipe actions.

Closes PCDROID-117

## Testing Instructions

Test different swipe actions for both manual and smart playlists.

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.