### PR TITLE
Refactor playlist preview

### DIFF
--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/repositories/playlist/PlaylistManagerDsl.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/repositories/playlist/PlaylistManagerDsl.kt
@@ -23,7 +23,6 @@ import au.com.shiftyjelly.pocketcasts.models.type.SmartRules
 import au.com.shiftyjelly.pocketcasts.models.type.Subscription
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.preferences.SettingsImpl
-import au.com.shiftyjelly.pocketcasts.repositories.playlist.Playlist.Type
 import au.com.shiftyjelly.pocketcasts.servers.di.ServersModule
 import au.com.shiftyjelly.pocketcasts.sharedtest.MutableClock
 import com.google.firebase.remoteconfig.FirebaseRemoteConfig
@@ -283,29 +282,38 @@ class PlaylistManagerDsl : TestWatcher() {
         ).copy(manual = true)
     }
 
-    fun smartPreview(index: Int, builder: (PlaylistPreview) -> (PlaylistPreview) = { it }): PlaylistPreview {
+    fun smartPreview(index: Int, builder: (SmartPlaylistPreview) -> (SmartPlaylistPreview) = { it }): SmartPlaylistPreview {
         val preview = builder(
-            PlaylistPreview(
+            SmartPlaylistPreview(
                 uuid = "playlist-id-$index",
                 title = "Playlist title $index",
                 episodeCount = 0,
                 artworkPodcastUuids = emptyList(),
-                type = Type.Smart,
+                settings = Playlist.Settings(
+                    sortType = PlaylistEpisodeSortType.NewestToOldest,
+                    isAutoDownloadEnabled = false,
+                    autoDownloadLimit = 10,
+                ),
+                smartRules = SmartRules.Default,
             ),
-        ).copy(type = Type.Smart)
+        )
         return preview
     }
 
-    fun manualPreview(index: Int, builder: (PlaylistPreview) -> (PlaylistPreview) = { it }): PlaylistPreview {
+    fun manualPreview(index: Int, builder: (ManualPlaylistPreview) -> (ManualPlaylistPreview) = { it }): ManualPlaylistPreview {
         val preview = builder(
-            PlaylistPreview(
+            ManualPlaylistPreview(
                 uuid = "playlist-id-$index",
                 title = "Playlist title $index",
                 episodeCount = 0,
                 artworkPodcastUuids = emptyList(),
-                type = Type.Manual,
+                settings = Playlist.Settings(
+                    sortType = PlaylistEpisodeSortType.DragAndDrop,
+                    isAutoDownloadEnabled = false,
+                    autoDownloadLimit = 10,
+                ),
             ),
-        ).copy(type = Type.Manual)
+        )
         return preview
     }
 

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/PlaylistsPage.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/PlaylistsPage.kt
@@ -54,11 +54,15 @@ import au.com.shiftyjelly.pocketcasts.compose.components.NoContentBanner
 import au.com.shiftyjelly.pocketcasts.compose.preview.ThemePreviewParameterProvider
 import au.com.shiftyjelly.pocketcasts.compose.reorderable.rememberReorderableLazyListDataSource
 import au.com.shiftyjelly.pocketcasts.compose.theme
+import au.com.shiftyjelly.pocketcasts.models.type.SmartRules
 import au.com.shiftyjelly.pocketcasts.playlists.PlaylistsViewModel.PlaylistsState
 import au.com.shiftyjelly.pocketcasts.playlists.PlaylistsViewModel.UiState
 import au.com.shiftyjelly.pocketcasts.playlists.component.PlaylistPreviewRow
+import au.com.shiftyjelly.pocketcasts.repositories.playlist.ManualPlaylistPreview
+import au.com.shiftyjelly.pocketcasts.repositories.playlist.Playlist
 import au.com.shiftyjelly.pocketcasts.repositories.playlist.Playlist.Type
 import au.com.shiftyjelly.pocketcasts.repositories.playlist.PlaylistPreview
+import au.com.shiftyjelly.pocketcasts.repositories.playlist.SmartPlaylistPreview
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme.ThemeType
 import sh.calvin.reorderable.ReorderableItem
 import au.com.shiftyjelly.pocketcasts.images.R as IR
@@ -411,19 +415,23 @@ private fun PlaylistPagePreview(
         PlaylistsPage(
             uiState = UiState(
                 playlists = PlaylistsState.Loaded(
-                    value = List(3) { index ->
-                        PlaylistPreview(
-                            uuid = "uuid-$index",
-                            title = "Playlist $index",
-                            episodeCount = index,
+                    value = listOf(
+                        ManualPlaylistPreview(
+                            uuid = "uuid-0",
+                            title = "Playlist 0",
+                            episodeCount = 0,
                             artworkPodcastUuids = emptyList(),
-                            type = if (index % 2 == 0) {
-                                Type.Smart
-                            } else {
-                                Type.Manual
-                            },
-                        )
-                    },
+                            settings = Playlist.Settings.ForPreview,
+                        ),
+                        SmartPlaylistPreview(
+                            uuid = "uuid-1",
+                            title = "Playlist 1",
+                            episodeCount = 253,
+                            artworkPodcastUuids = emptyList(),
+                            settings = Playlist.Settings.ForPreview,
+                            smartRules = SmartRules.Default,
+                        ),
+                    ),
                 ),
                 showOnboarding = false,
                 showFreeAccountBanner = true,

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/component/PlaylistPreviewRow.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/component/PlaylistPreviewRow.kt
@@ -57,8 +57,12 @@ import au.com.shiftyjelly.pocketcasts.compose.components.TipPosition
 import au.com.shiftyjelly.pocketcasts.compose.components.TooltipPopup
 import au.com.shiftyjelly.pocketcasts.compose.preview.ThemePreviewParameterProvider
 import au.com.shiftyjelly.pocketcasts.compose.theme
+import au.com.shiftyjelly.pocketcasts.models.type.SmartRules
+import au.com.shiftyjelly.pocketcasts.repositories.playlist.ManualPlaylistPreview
+import au.com.shiftyjelly.pocketcasts.repositories.playlist.Playlist
 import au.com.shiftyjelly.pocketcasts.repositories.playlist.Playlist.Type
 import au.com.shiftyjelly.pocketcasts.repositories.playlist.PlaylistPreview
+import au.com.shiftyjelly.pocketcasts.repositories.playlist.SmartPlaylistPreview
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import kotlin.math.absoluteValue
 import kotlin.math.roundToInt
@@ -266,12 +270,13 @@ private fun PlaylistPreviewRowPreview(
     AppThemeWithBackground(themeType) {
         Column {
             PlaylistPreviewRow(
-                playlist = PlaylistPreview(
+                playlist = SmartPlaylistPreview(
                     uuid = "",
                     title = "New Releases",
                     episodeCount = 0,
                     artworkPodcastUuids = emptyList(),
-                    type = Type.Smart,
+                    settings = Playlist.Settings.ForPreview,
+                    smartRules = SmartRules.Default,
                 ),
                 showTooltip = false,
                 showDivider = true,
@@ -281,12 +286,12 @@ private fun PlaylistPreviewRowPreview(
                 modifier = Modifier.fillMaxWidth(),
             )
             PlaylistPreviewRow(
-                playlist = PlaylistPreview(
+                playlist = ManualPlaylistPreview(
                     uuid = "",
                     title = "In progress",
                     episodeCount = 1,
                     artworkPodcastUuids = List(1) { "podcast-uuid-$it" },
-                    type = Type.Manual,
+                    settings = Playlist.Settings.ForPreview,
                 ),
                 showTooltip = false,
                 showDivider = true,
@@ -296,12 +301,13 @@ private fun PlaylistPreviewRowPreview(
                 modifier = Modifier.fillMaxWidth(),
             )
             PlaylistPreviewRow(
-                playlist = PlaylistPreview(
+                playlist = SmartPlaylistPreview(
                     uuid = "",
                     title = "Starred",
                     episodeCount = 328,
                     artworkPodcastUuids = List(4) { "podcast-uuid-$it" },
-                    type = Type.Smart,
+                    settings = Playlist.Settings.ForPreview,
+                    smartRules = SmartRules.Default,
                 ),
                 showTooltip = false,
                 showDivider = false,

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playlist/Playlist.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playlist/Playlist.kt
@@ -17,7 +17,15 @@ sealed interface Playlist {
         val sortType: PlaylistEpisodeSortType,
         val isAutoDownloadEnabled: Boolean,
         val autoDownloadLimit: Int,
-    )
+    ) {
+        companion object {
+            val ForPreview = Settings(
+                sortType = PlaylistEpisodeSortType.DragAndDrop,
+                isAutoDownloadEnabled = false,
+                autoDownloadLimit = 10,
+            )
+        }
+    }
 
     data class Metadata(
         val playbackDurationLeft: Duration,

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playlist/PlaylistManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playlist/PlaylistManagerImpl.kt
@@ -30,7 +30,6 @@ import au.com.shiftyjelly.pocketcasts.models.type.SmartRules.PodcastsRule
 import au.com.shiftyjelly.pocketcasts.models.type.SmartRules.ReleaseDateRule
 import au.com.shiftyjelly.pocketcasts.models.type.SmartRules.StarredRule
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
-import au.com.shiftyjelly.pocketcasts.repositories.playlist.Playlist.Type
 import au.com.shiftyjelly.pocketcasts.repositories.playlist.PlaylistManager.Companion.MANUAL_PLAYLIST_EPISODE_LIMIT
 import au.com.shiftyjelly.pocketcasts.repositories.playlist.PlaylistManager.Companion.PLAYLIST_ARTWORK_EPISODE_LIMIT
 import au.com.shiftyjelly.pocketcasts.repositories.playlist.PlaylistManager.Companion.SMART_PLAYLIST_EPISODE_LIMIT
@@ -382,12 +381,16 @@ class PlaylistManagerImpl(
         val podcastsFlow = manualPlaylistArtworkPodcastsFlow(playlist)
         val episodeMetadataFlow = playlistDao.manualPlaylistMetadataFlow(playlist.uuid)
         return combine(podcastsFlow, episodeMetadataFlow) { podcasts, metadata ->
-            PlaylistPreview(
+            ManualPlaylistPreview(
                 uuid = playlist.uuid,
                 title = playlist.title,
                 artworkPodcastUuids = podcasts,
                 episodeCount = metadata.episodeCount,
-                type = Type.Manual,
+                settings = Playlist.Settings(
+                    sortType = playlist.sortType,
+                    isAutoDownloadEnabled = playlist.autoDownload,
+                    autoDownloadLimit = playlist.autodownloadLimit,
+                ),
             )
         }
     }
@@ -395,13 +398,19 @@ class PlaylistManagerImpl(
     private fun smartPlaylistPreviewsFlow(playlist: PlaylistEntity): Flow<PlaylistPreview> {
         val podcastsFlow = smartPlaylistArtworkPodcastsFlow(playlist)
         val episodeMetadataFlow = playlistDao.smartPlaylistMetadataFlow(clock, playlist.smartRules)
+        val smartRules = playlist.smartRules
         return combine(podcastsFlow, episodeMetadataFlow) { podcasts, metadata ->
-            PlaylistPreview(
+            SmartPlaylistPreview(
                 uuid = playlist.uuid,
                 title = playlist.title,
                 artworkPodcastUuids = podcasts,
                 episodeCount = metadata.episodeCount,
-                type = Type.Smart,
+                settings = Playlist.Settings(
+                    sortType = playlist.sortType,
+                    isAutoDownloadEnabled = playlist.autoDownload,
+                    autoDownloadLimit = playlist.autodownloadLimit,
+                ),
+                smartRules = smartRules,
             )
         }
     }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playlist/PlaylistPreview.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playlist/PlaylistPreview.kt
@@ -1,9 +1,33 @@
 package au.com.shiftyjelly.pocketcasts.repositories.playlist
 
-data class PlaylistPreview(
-    val uuid: String,
-    val title: String,
-    val episodeCount: Int,
-    val artworkPodcastUuids: List<String>,
-    val type: Playlist.Type,
-)
+import au.com.shiftyjelly.pocketcasts.models.type.SmartRules
+
+sealed interface PlaylistPreview {
+    val uuid: String
+    val title: String
+    val episodeCount: Int
+    val artworkPodcastUuids: List<String>
+    val settings: Playlist.Settings
+    val type: Playlist.Type
+}
+
+data class SmartPlaylistPreview(
+    override val uuid: String,
+    override val title: String,
+    override val episodeCount: Int,
+    override val artworkPodcastUuids: List<String>,
+    override val settings: Playlist.Settings,
+    val smartRules: SmartRules,
+) : PlaylistPreview {
+    override val type get() = Playlist.Type.Smart
+}
+
+data class ManualPlaylistPreview(
+    override val uuid: String,
+    override val title: String,
+    override val episodeCount: Int,
+    override val artworkPodcastUuids: List<String>,
+    override val settings: Playlist.Settings,
+) : PlaylistPreview {
+    override val type get() = Playlist.Type.Manual
+}


### PR DESCRIPTION
## Description

This changes `PlaylistPreview` from a `data class` to a `sealed interface`. This change is needed to support controlling auto-downloads in different contexts as the podcast settings control needs to know whether is used in a playlist.

Relates to PCDROID-97

## Testing Instructions

Code review is fine.

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.