### PR TITLE
Update account creation encouragement screen

### DIFF
--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/AccountBenefitsPage.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/AccountBenefitsPage.kt
@@ -28,6 +28,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.layout.SubcomposeLayout
 import androidx.compose.ui.res.painterResource
@@ -63,6 +64,8 @@ internal fun AccountBenefitsPage(
     onClose: () -> Unit,
     onShowBenefit: (AccountBenefit) -> Unit,
     modifier: Modifier = Modifier,
+    mainCtaLabel: String = stringResource(LR.string.onboarding_get_started),
+    mainCtaColor: Color = MaterialTheme.theme.colors.primaryText01,
 ) {
     Column(
         horizontalAlignment = Alignment.CenterHorizontally,
@@ -80,6 +83,8 @@ internal fun AccountBenefitsPage(
         )
 
         ActionButtons(
+            mainCtaColor = mainCtaColor,
+            mainCtaLabel = mainCtaLabel,
             onGetStartedClick = onGetStartedClick,
             onLogIn = onLogIn,
             modifier = Modifier.padding(
@@ -150,6 +155,8 @@ private fun HeaderText(
 
 @Composable
 private fun ActionButtons(
+    mainCtaColor: Color,
+    mainCtaLabel: String,
     onGetStartedClick: () -> Unit,
     onLogIn: () -> Unit,
     modifier: Modifier = Modifier,
@@ -158,9 +165,9 @@ private fun ActionButtons(
         modifier = modifier,
     ) {
         RowTextButton(
-            text = stringResource(LR.string.onboarding_get_started),
+            text = mainCtaLabel,
             colors = ButtonDefaults.buttonColors(
-                backgroundColor = MaterialTheme.theme.colors.primaryText01,
+                backgroundColor = mainCtaColor,
                 contentColor = MaterialTheme.theme.colors.primaryUi01,
             ),
             includePadding = false,


### PR DESCRIPTION
## Description
This PR adds the encourage acct creation screen to the new onboarding flow in sync with the slack discussion:
p1758148136582399-slack-C0932TFPUDC

We've made tweaks on the screen, the CTA color and the labels have been updated.

## Testing Instructions
1. To trigger account encouragement, apply [always_show_encouragement.patch](https://github.com/user-attachments/files/22426242/always_show_encouragement.patch)
2. Build app
3. Complete onboarding without signing in / up
4. Kill app
5. Relaunch it
- [ ] encouragment is displayed
- [ ] Create Account cta takes you to new onboarding's create account page.

## Screenshots or Screencast 

https://github.com/user-attachments/assets/051f7265-f04e-4eb5-a74c-1cd61976ab1c

## Checklist
- [ ] ~If this is a user-facing change, I have added an entry in CHANGELOG.md~
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] ~I have considered whether it makes sense to add tests for my changes~
- [ ] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [ ] ~Any jetpack compose components I added or changed are covered by compose previews~
- [ ] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~
 