### PR TITLE
[CredentialManager Migration] Migrate from GoogleSingIn on phone

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -48,6 +48,9 @@
         <meta-data android:name="com.google.android.wearable.media.theme"
                    android:resource="@style/WearMediaTheme"/>
 
+        <meta-data android:name="asset_statements"
+            android:resource="@string/asset_statements" />
+
         <!-- Main activity. Uses standard launch mode as if you go into a episode list and then exit the app, then open using recents the back button was broken. Also when on the updates tab if you click a notification and then you have to back twice. -->
         <activity
                 android:name=".ui.MainActivity"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="asset_statements" translatable="false">
+[{
+  \"include\": \"https://pocketcasts.com/.well-known/assetlinks.json\"
+}]
+</string>
+</resources>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -58,6 +58,8 @@ wear-compose = "1.4.1"
 webkit = "1.14.0"
 wordpress-lint = "2.2.0"
 work = "2.10.0"
+credentials = "1.5.0"
+google-id = "1.1.1"
 
 [libraries]
 # About Libraries
@@ -251,6 +253,11 @@ androidx-webkit = { group = "androidx.webkit", name = "webkit", version.ref = "w
 work-runtime = { module = "androidx.work:work-runtime-ktx", version.ref = "work" }
 work-rx2 = { module = "androidx.work:work-rxjava2", version.ref = "work" }
 work-test = { module = "androidx.work:work-testing", version.ref = "work" }
+
+# Credentials
+credentials = { module = "androidx.credentials:credentials", version.ref = "credentials" }
+credentials-google-play = { module = "androidx.credentials:credentials-play-services-auth", version.ref = "credentials" }
+google-identity = { module = "com.google.android.libraries.identity.googleid:googleid", version.ref = "google-id"}
 
 # Other dependencies
 androidx-annotation = "androidx.annotation:annotation:1.9.1"

--- a/modules/features/account/build.gradle.kts
+++ b/modules/features/account/build.gradle.kts
@@ -67,7 +67,7 @@ dependencies {
     implementation(libs.navigation.compose)
     implementation(libs.navigation.fragment.ktx)
     implementation(libs.navigation.ui.ktx)
-    implementation(libs.play.auth)
+    // implementation(libs.play.auth)
     implementation(libs.play.cast)
     implementation(libs.retrofit)
     implementation(libs.rx2.android)
@@ -75,6 +75,9 @@ dependencies {
     implementation(libs.rx2.kotlin)
     implementation(libs.rx2.relay)
     implementation(libs.timber)
+    implementation(libs.credentials)
+    implementation(libs.credentials.google.play)
+    implementation(libs.google.identity)
 
     implementation(projects.modules.features.cartheme)
     implementation(projects.modules.services.images)

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/components/ContinueWithGoogleButton.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/components/ContinueWithGoogleButton.kt
@@ -1,8 +1,6 @@
 package au.com.shiftyjelly.pocketcasts.account.onboarding.components
 
 import android.widget.Toast
-import androidx.activity.compose.rememberLauncherForActivityResult
-import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.material.ButtonDefaults
 import androidx.compose.material.MaterialTheme
@@ -53,40 +51,11 @@ fun ContinueWithGoogleButton(
         Toast.makeText(context, errorMessage, Toast.LENGTH_LONG).show()
     }
 
-    // request legacy Google Sign-In and process the result
-    val googleLegacySignInLauncher = rememberLauncherForActivityResult(ActivityResultContracts.StartIntentSenderForResult()) { result ->
-        viewModel.onGoogleLegacySignInResult(
-            result = result,
-            onSuccess = onComplete,
-            onError = showError,
-        )
-    }
-
-    // request Google One Tap Sign-In and process the result
-    val googleOneTapSignInLauncher = rememberLauncherForActivityResult(ActivityResultContracts.StartIntentSenderForResult()) { result ->
-        viewModel.onGoogleOneTapSignInResult(
-            result = result,
-            onSuccess = onComplete,
-            onError = {
-                viewModel.startGoogleLegacySignIn(
-                    onSuccess = { request -> googleLegacySignInLauncher.launch(request) },
-                    onError = showError,
-                )
-            },
-        )
-    }
-
     val onSignInClick = {
         viewModel.startGoogleOneTapSignIn(
             flow = flow,
-//            onSuccess = { request -> googleOneTapSignInLauncher.launch(request) },
             onSuccess = onComplete,
-            onError = {
-                viewModel.startGoogleLegacySignIn(
-                    onSuccess = { request -> googleLegacySignInLauncher.launch(request) },
-                    onError = showError,
-                )
-            },
+            onError = showError,
             event = event,
         )
     }

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/components/ContinueWithGoogleButton.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/onboarding/components/ContinueWithGoogleButton.kt
@@ -79,7 +79,8 @@ fun ContinueWithGoogleButton(
     val onSignInClick = {
         viewModel.startGoogleOneTapSignIn(
             flow = flow,
-            onSuccess = { request -> googleOneTapSignInLauncher.launch(request) },
+//            onSuccess = { request -> googleOneTapSignInLauncher.launch(request) },
+            onSuccess = onComplete,
             onError = {
                 viewModel.startGoogleLegacySignIn(
                     onSuccess = { request -> googleLegacySignInLauncher.launch(request) },

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/GoogleSignInButtonViewModel.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/GoogleSignInButtonViewModel.kt
@@ -1,10 +1,9 @@
 package au.com.shiftyjelly.pocketcasts.account.viewmodel
 
 import android.content.Context
-import androidx.activity.result.ActivityResult
-import androidx.activity.result.IntentSenderRequest
 import androidx.credentials.CredentialManager
 import androidx.credentials.CustomCredential
+import androidx.credentials.GetCredentialRequest
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
@@ -21,20 +20,13 @@ import au.com.shiftyjelly.pocketcasts.utils.Util
 import au.com.shiftyjelly.pocketcasts.utils.extensions.isGooglePlayServicesAvailableSuccess
 import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
 import com.google.android.gms.common.GoogleApiAvailability
-import com.google.android.gms.common.api.ApiException
-import com.google.android.gms.common.api.CommonStatusCodes
-import com.google.android.libraries.identity.googleid.GetGoogleIdOption
+import com.google.android.libraries.identity.googleid.GetSignInWithGoogleOption
+import com.google.android.libraries.identity.googleid.GoogleIdTokenCredential
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
 import java.util.UUID
 import javax.inject.Inject
 import kotlinx.coroutines.launch
-import androidx.credentials.GetCredentialRequest
-import androidx.credentials.exceptions.GetCredentialException
-import com.google.android.libraries.identity.googleid.GetSignInWithGoogleOption
-import com.google.android.libraries.identity.googleid.GoogleIdTokenCredential
-import com.google.android.libraries.identity.googleid.GoogleIdTokenParsingException
-import timber.log.Timber
 
 @HiltViewModel
 class GoogleSignInButtonViewModel @Inject constructor(
@@ -54,11 +46,9 @@ class GoogleSignInButtonViewModel @Inject constructor(
 
     /**
      * Try to sign in with Google One Tap.
-     * It's common for the One Tap to fail so then try the legacy Google Sign-In.
      */
     fun startGoogleOneTapSignIn(
         flow: OnboardingFlow?,
-        //onSuccess: (IntentSenderRequest) -> Unit,
         onSuccess: (GoogleSignInState, Subscription?) -> Unit,
         onError: suspend () -> Unit,
         event: AnalyticsEvent = AnalyticsEvent.SETUP_ACCOUNT_BUTTON_TAPPED,
@@ -80,7 +70,7 @@ class GoogleSignInButtonViewModel @Inject constructor(
         viewModelScope.launch {
             try {
                 val googleIdOption: GetSignInWithGoogleOption = GetSignInWithGoogleOption.Builder(
-                    serverClientId = Settings.GOOGLE_SIGN_IN_SERVER_CLIENT_ID
+                    serverClientId = Settings.GOOGLE_SIGN_IN_SERVER_CLIENT_ID,
                 ).setNonce(UUID.randomUUID().toString()).build()
 
                 val request: GetCredentialRequest = GetCredentialRequest.Builder()
@@ -91,144 +81,25 @@ class GoogleSignInButtonViewModel @Inject constructor(
                     request = request,
                     context = context,
                 )
-                when (val credential = result.credential) {
-                    is CustomCredential -> {
-                        if (credential.type == GoogleIdTokenCredential.TYPE_GOOGLE_ID_TOKEN_CREDENTIAL) {
-                            try {
-                                val googleIdTokenCredential = GoogleIdTokenCredential
-                                    .createFrom(credential.data)
+                val credential = result.credential as CustomCredential
+                if (credential.type == GoogleIdTokenCredential.TYPE_GOOGLE_ID_TOKEN_CREDENTIAL) {
+                    val googleIdTokenCredential = GoogleIdTokenCredential
+                        .createFrom(credential.data)
 
-                                // TODO do magic here!
-                                signInWithGoogleToken(
-                                    idToken = googleIdTokenCredential.idToken,
-                                    onSuccess = onSuccess,
-                                    onError = onError
-                                )
-
-                            } catch (e: GoogleIdTokenParsingException) {
-                                LogBuffer.e(LogBuffer.TAG_CRASH, "Received an invalid google id token response", e)
-                            }
-                        } else {
-                            // Catch any unrecognized custom credential type here.
-                        }
-                    }
-
-                    else -> {}
+                    signInWithGoogleToken(
+                        idToken = googleIdTokenCredential.idToken,
+                        onSuccess = onSuccess,
+                        onError = onError,
+                    )
+                } else {
+                    LogBuffer.e(LogBuffer.TAG_INVALID_STATE, "Failed to sign in with Google One Tap")
+                    onError()
                 }
-//                val beginSignInRequest = BeginSignInRequest.GoogleIdTokenRequestOptions.builder()
-//                    .setSupported(true)
-//                    // use the Google Cloud credentials OAuth Server Client ID, not the Android Client ID.
-//                    .setServerClientId(Settings.GOOGLE_SIGN_IN_SERVER_CLIENT_ID)
-//                    // don't just show accounts previously used to sign in.
-//                    .setFilterByAuthorizedAccounts(false)
-//                    .build()
-//                val signInRequest = BeginSignInRequest.builder()
-//                    .setGoogleIdTokenRequestOptions(beginSignInRequest)
-//                    .build()
-//                val result = Identity.getSignInClient(context).beginSignIn(signInRequest).await()
-//                val intentRequest = IntentSenderRequest.Builder(result.pendingIntent).build()
-//                onSuccess(intentRequest)
             } catch (e: Exception) {
                 LogBuffer.e(LogBuffer.TAG_CRASH, e, "Unable to sign in with Google One Tap")
                 onError()
             }
         }
-    }
-
-    /**
-     * Try to sign in with the legacy Google Sign-In.
-     */
-    fun startGoogleLegacySignIn(
-        onSuccess: (IntentSenderRequest) -> Unit,
-        onError: () -> Unit,
-    ) {
-        viewModelScope.launch {
-            try {
-                Timber.i("Using legacy Google Sign-In")
-//                val lastSignedInAccount = GoogleSignIn.getLastSignedInAccount(context)
-//                val idToken = lastSignedInAccount?.idToken
-//                val email = lastSignedInAccount?.email
-//                if (idToken == null || email == null) {
-//                    val request = GetSignInIntentRequest.builder().setServerClientId(Settings.GOOGLE_SIGN_IN_SERVER_CLIENT_ID).build()
-//                    val signInIntent = Identity.getSignInClient(context).getSignInIntent(request).await()
-//                    val intentSenderRequest = IntentSenderRequest.Builder(signInIntent.intentSender).build()
-//                    onSuccess(intentSenderRequest)
-//                } else {
-//                    signInWithGoogleToken(
-//                        idToken = idToken,
-//                        onSuccess = { _, _ -> },
-//                        onError = onError,
-//                    )
-//                }
-            } catch (ex: Exception) {
-                LogBuffer.e(LogBuffer.TAG_CRASH, ex, "Unable to sign in with legacy Google Sign-In")
-                onError()
-            }
-        }
-    }
-
-    /**
-     * Handle the response from the Google One Tap intent to sign in.
-     */
-    fun onGoogleOneTapSignInResult(
-        result: ActivityResult,
-        onSuccess: (GoogleSignInState, Subscription?) -> Unit,
-        onError: suspend () -> Unit,
-    ) {
-        viewModelScope.launch {
-            try {
-                onGoogleSignInResult(
-                    result = result,
-                    onSuccess = onSuccess,
-                    onError = {
-                        onError()
-                    },
-                )
-            } catch (e: Exception) {
-                if (e is ApiException && e.statusCode == CommonStatusCodes.CANCELED) {
-                    // user declined to sign in
-                    return@launch
-                }
-                LogBuffer.e(LogBuffer.TAG_CRASH, e, "Unable to get sign in credentials from Google One Tap result.")
-                onError()
-            }
-        }
-    }
-
-    /**
-     * Handle the response from the legacy Google Sign-In intent.
-     */
-    fun onGoogleLegacySignInResult(result: ActivityResult, onSuccess: (GoogleSignInState, Subscription?) -> Unit, onError: () -> Unit) {
-        viewModelScope.launch {
-            try {
-                onGoogleSignInResult(
-                    result = result,
-                    onSuccess = onSuccess,
-                    onError = onError,
-                )
-            } catch (e: Exception) {
-                LogBuffer.e(
-                    LogBuffer.TAG_CRASH,
-                    e,
-                    "Unable to get sign in credentials from legacy Google Sign-In result.",
-                )
-                onError()
-            }
-        }
-    }
-
-    private suspend fun onGoogleSignInResult(
-        result: ActivityResult,
-        onSuccess: (GoogleSignInState, Subscription?) -> Unit,
-        onError: suspend () -> Unit,
-    ) {
-//        val credential = Identity.getSignInClient(context).getSignInCredentialFromIntent(result.data)
-//        val idToken = credential.googleIdToken ?: throw Exception("Unable to sign in because no token was returned.")
-//        signInWithGoogleToken(
-//            idToken = idToken,
-//            onSuccess = onSuccess,
-//            onError = onError,
-//        )
     }
 
     private suspend fun signInWithGoogleToken(
@@ -238,8 +109,8 @@ class GoogleSignInButtonViewModel @Inject constructor(
     ) = when (val authResult = syncManager.loginWithGoogle(idToken = idToken, signInSource = SignInSource.UserInitiated.Onboarding)) {
         is LoginResult.Success -> {
             podcastManager.refreshPodcastsAfterSignIn()
-            val subscritpion = subscriptionManager.fetchFreshSubscription()
-            onSuccess(GoogleSignInState(isNewAccount = authResult.result.isNewAccount), subscritpion)
+            val subscription = subscriptionManager.fetchFreshSubscription()
+            onSuccess(GoogleSignInState(isNewAccount = authResult.result.isNewAccount), subscription)
         }
 
         is LoginResult.Failed -> {

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/GoogleSignInButtonViewModel.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/GoogleSignInButtonViewModel.kt
@@ -3,6 +3,8 @@ package au.com.shiftyjelly.pocketcasts.account.viewmodel
 import android.content.Context
 import androidx.activity.result.ActivityResult
 import androidx.activity.result.IntentSenderRequest
+import androidx.credentials.CredentialManager
+import androidx.credentials.CustomCredential
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
@@ -18,18 +20,20 @@ import au.com.shiftyjelly.pocketcasts.settings.onboarding.OnboardingFlow
 import au.com.shiftyjelly.pocketcasts.utils.Util
 import au.com.shiftyjelly.pocketcasts.utils.extensions.isGooglePlayServicesAvailableSuccess
 import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
-import com.google.android.gms.auth.api.identity.BeginSignInRequest
-import com.google.android.gms.auth.api.identity.GetSignInIntentRequest
-import com.google.android.gms.auth.api.identity.Identity
-import com.google.android.gms.auth.api.signin.GoogleSignIn
 import com.google.android.gms.common.GoogleApiAvailability
 import com.google.android.gms.common.api.ApiException
 import com.google.android.gms.common.api.CommonStatusCodes
+import com.google.android.libraries.identity.googleid.GetGoogleIdOption
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
+import java.util.UUID
 import javax.inject.Inject
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.tasks.await
+import androidx.credentials.GetCredentialRequest
+import androidx.credentials.exceptions.GetCredentialException
+import com.google.android.libraries.identity.googleid.GetSignInWithGoogleOption
+import com.google.android.libraries.identity.googleid.GoogleIdTokenCredential
+import com.google.android.libraries.identity.googleid.GoogleIdTokenParsingException
 import timber.log.Timber
 
 @HiltViewModel
@@ -40,6 +44,8 @@ class GoogleSignInButtonViewModel @Inject constructor(
     private val syncManager: SyncManager,
     private val subscriptionManager: SubscriptionManager,
 ) : ViewModel() {
+
+    private val credentialManager: CredentialManager by lazy { CredentialManager.create(context) }
 
     companion object {
         fun showContinueWithGoogleButton(context: Context) = Settings.GOOGLE_SIGN_IN_SERVER_CLIENT_ID.isNotEmpty() &&
@@ -52,7 +58,8 @@ class GoogleSignInButtonViewModel @Inject constructor(
      */
     fun startGoogleOneTapSignIn(
         flow: OnboardingFlow?,
-        onSuccess: (IntentSenderRequest) -> Unit,
+        //onSuccess: (IntentSenderRequest) -> Unit,
+        onSuccess: (GoogleSignInState, Subscription?) -> Unit,
         onError: suspend () -> Unit,
         event: AnalyticsEvent = AnalyticsEvent.SETUP_ACCOUNT_BUTTON_TAPPED,
     ) {
@@ -72,19 +79,55 @@ class GoogleSignInButtonViewModel @Inject constructor(
 
         viewModelScope.launch {
             try {
-                val beginSignInRequest = BeginSignInRequest.GoogleIdTokenRequestOptions.builder()
-                    .setSupported(true)
-                    // use the Google Cloud credentials OAuth Server Client ID, not the Android Client ID.
-                    .setServerClientId(Settings.GOOGLE_SIGN_IN_SERVER_CLIENT_ID)
-                    // don't just show accounts previously used to sign in.
-                    .setFilterByAuthorizedAccounts(false)
+                val googleIdOption: GetSignInWithGoogleOption = GetSignInWithGoogleOption.Builder(
+                    serverClientId = Settings.GOOGLE_SIGN_IN_SERVER_CLIENT_ID
+                ).setNonce(UUID.randomUUID().toString()).build()
+
+                val request: GetCredentialRequest = GetCredentialRequest.Builder()
+                    .addCredentialOption(googleIdOption)
                     .build()
-                val signInRequest = BeginSignInRequest.builder()
-                    .setGoogleIdTokenRequestOptions(beginSignInRequest)
-                    .build()
-                val result = Identity.getSignInClient(context).beginSignIn(signInRequest).await()
-                val intentRequest = IntentSenderRequest.Builder(result.pendingIntent).build()
-                onSuccess(intentRequest)
+
+                val result = credentialManager.getCredential(
+                    request = request,
+                    context = context,
+                )
+                when (val credential = result.credential) {
+                    is CustomCredential -> {
+                        if (credential.type == GoogleIdTokenCredential.TYPE_GOOGLE_ID_TOKEN_CREDENTIAL) {
+                            try {
+                                val googleIdTokenCredential = GoogleIdTokenCredential
+                                    .createFrom(credential.data)
+
+                                // TODO do magic here!
+                                signInWithGoogleToken(
+                                    idToken = googleIdTokenCredential.idToken,
+                                    onSuccess = onSuccess,
+                                    onError = onError
+                                )
+
+                            } catch (e: GoogleIdTokenParsingException) {
+                                LogBuffer.e(LogBuffer.TAG_CRASH, "Received an invalid google id token response", e)
+                            }
+                        } else {
+                            // Catch any unrecognized custom credential type here.
+                        }
+                    }
+
+                    else -> {}
+                }
+//                val beginSignInRequest = BeginSignInRequest.GoogleIdTokenRequestOptions.builder()
+//                    .setSupported(true)
+//                    // use the Google Cloud credentials OAuth Server Client ID, not the Android Client ID.
+//                    .setServerClientId(Settings.GOOGLE_SIGN_IN_SERVER_CLIENT_ID)
+//                    // don't just show accounts previously used to sign in.
+//                    .setFilterByAuthorizedAccounts(false)
+//                    .build()
+//                val signInRequest = BeginSignInRequest.builder()
+//                    .setGoogleIdTokenRequestOptions(beginSignInRequest)
+//                    .build()
+//                val result = Identity.getSignInClient(context).beginSignIn(signInRequest).await()
+//                val intentRequest = IntentSenderRequest.Builder(result.pendingIntent).build()
+//                onSuccess(intentRequest)
             } catch (e: Exception) {
                 LogBuffer.e(LogBuffer.TAG_CRASH, e, "Unable to sign in with Google One Tap")
                 onError()
@@ -102,21 +145,21 @@ class GoogleSignInButtonViewModel @Inject constructor(
         viewModelScope.launch {
             try {
                 Timber.i("Using legacy Google Sign-In")
-                val lastSignedInAccount = GoogleSignIn.getLastSignedInAccount(context)
-                val idToken = lastSignedInAccount?.idToken
-                val email = lastSignedInAccount?.email
-                if (idToken == null || email == null) {
-                    val request = GetSignInIntentRequest.builder().setServerClientId(Settings.GOOGLE_SIGN_IN_SERVER_CLIENT_ID).build()
-                    val signInIntent = Identity.getSignInClient(context).getSignInIntent(request).await()
-                    val intentSenderRequest = IntentSenderRequest.Builder(signInIntent.intentSender).build()
-                    onSuccess(intentSenderRequest)
-                } else {
-                    signInWithGoogleToken(
-                        idToken = idToken,
-                        onSuccess = { _, _ -> },
-                        onError = onError,
-                    )
-                }
+//                val lastSignedInAccount = GoogleSignIn.getLastSignedInAccount(context)
+//                val idToken = lastSignedInAccount?.idToken
+//                val email = lastSignedInAccount?.email
+//                if (idToken == null || email == null) {
+//                    val request = GetSignInIntentRequest.builder().setServerClientId(Settings.GOOGLE_SIGN_IN_SERVER_CLIENT_ID).build()
+//                    val signInIntent = Identity.getSignInClient(context).getSignInIntent(request).await()
+//                    val intentSenderRequest = IntentSenderRequest.Builder(signInIntent.intentSender).build()
+//                    onSuccess(intentSenderRequest)
+//                } else {
+//                    signInWithGoogleToken(
+//                        idToken = idToken,
+//                        onSuccess = { _, _ -> },
+//                        onError = onError,
+//                    )
+//                }
             } catch (ex: Exception) {
                 LogBuffer.e(LogBuffer.TAG_CRASH, ex, "Unable to sign in with legacy Google Sign-In")
                 onError()
@@ -179,13 +222,13 @@ class GoogleSignInButtonViewModel @Inject constructor(
         onSuccess: (GoogleSignInState, Subscription?) -> Unit,
         onError: suspend () -> Unit,
     ) {
-        val credential = Identity.getSignInClient(context).getSignInCredentialFromIntent(result.data)
-        val idToken = credential.googleIdToken ?: throw Exception("Unable to sign in because no token was returned.")
-        signInWithGoogleToken(
-            idToken = idToken,
-            onSuccess = onSuccess,
-            onError = onError,
-        )
+//        val credential = Identity.getSignInClient(context).getSignInCredentialFromIntent(result.data)
+//        val idToken = credential.googleIdToken ?: throw Exception("Unable to sign in because no token was returned.")
+//        signInWithGoogleToken(
+//            idToken = idToken,
+//            onSuccess = onSuccess,
+//            onError = onError,
+//        )
     }
 
     private suspend fun signInWithGoogleToken(
@@ -198,6 +241,7 @@ class GoogleSignInButtonViewModel @Inject constructor(
             val subscritpion = subscriptionManager.fetchFreshSubscription()
             onSuccess(GoogleSignInState(isNewAccount = authResult.result.isNewAccount), subscritpion)
         }
+
         is LoginResult.Failed -> {
             onError()
         }


### PR DESCRIPTION
## Description
This PR replaces the existing GoogleSignIn methods with the preferred CredentialManager APIs.

Fixes https://linear.app/a8c/issue/PCDROID-164/migrate-from-googlesignin-to-credentialmanagers-on-phone

## Testing Instructions
1. Clean install app on a real device
2. During onboarding tap Get started
3. Tap 'Continue with Google'
4. Select an account
- [ ] account gets created / signed in 

## Screenshots or Screencast 

https://github.com/user-attachments/assets/bfabcd04-c19e-4591-9b00-6520d4180256


## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] ~I have considered whether it makes sense to add tests for my changes~
- [ ] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [ ] ~Any jetpack compose components I added or changed are covered by compose previews~
- [ ] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~
 