### PR TITLE
Fix Discover collection missing analytic

### DIFF
--- a/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/DiscoverAdapter.kt
+++ b/modules/features/discover/src/main/java/au/com/shiftyjelly/pocketcasts/discover/view/DiscoverAdapter.kt
@@ -1074,6 +1074,8 @@ internal class DiscoverAdapter(
                             val collectionPodcasts: List<CollectionPodcast> = podcasts.map { podcast -> CollectionPodcast(podcast) }
 
                             holder.adapter.submitPodcastList(collectionPodcasts, collectionHeader) { onRestoreInstanceState(holder) }
+
+                            row.listUuid?.let { listUuid -> trackListImpression(listUuid) }
                         },
                     )
                 }


### PR DESCRIPTION
## Description

Em was checking how successful one of the Discover lists was performing and realised that the analytics didn't seem to be working. This change fixes that. The issue was that the new collection design wasn't sending the impression analytics. 

Internal reference: p1758547003969589-slack-C06EHRAPW12

**Before**
	
```
Tracked: discover_list_impression, Properties: {"list_id":"0bc68241-2658-45fd-b241-cbc2eac2cd06", ...
Tracked: discover_list_impression, Properties: {"list_id":"82a5225d-ec62-485b-be4b-94ac5232d1e4", ...
Tracked: discover_list_impression, Properties: {"list_id":"shelf-talk", ...
Tracked: discover_list_impression, Properties: {"list_id":"comedians-who-podcast", ...
```

**After**
	
```
Tracked: discover_list_impression, Properties: {"list_id":"0bc68241-2658-45fd-b241-cbc2eac2cd06",  ...
Tracked: discover_list_impression, Properties: {"list_id":"82a5225d-ec62-485b-be4b-94ac5232d1e4", ...
Tracked: discover_list_impression, Properties: {"list_id":"bbc-2025", ...
Tracked: discover_list_impression, Properties: {"list_id":"sitrick-hofmeister", ...
Tracked: discover_list_impression, Properties: {"list_id":"shelf-talk", ...
Tracked: discover_list_impression, Properties: {"list_id":"comedians-who-podcast", ...
```

## Testing Instructions

1. Use the `debugProd` variant
2. Filter logcat by `Tracked`
3. Go to the Discover section
4. ✅ Verify the `bbc-2025` impression is recorded

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 