### PR TITLE
Fix freeCompilerArgs build warning

### DIFF
--- a/wear/build.gradle.kts
+++ b/wear/build.gradle.kts
@@ -1,3 +1,6 @@
+import org.jetbrains.kotlin.gradle.dsl.KotlinJvmCompilerOptions
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompilationTask
+
 plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.kotlin.android)
@@ -41,13 +44,15 @@ android {
         compose = true
     }
 
-    kotlinOptions {
-        // Allow for widescale experimental APIs in Alpha libraries we build upon
-        freeCompilerArgs += "-opt-in=com.google.android.horologist.annotations.ExperimentalHorologistApi"
-    }
-
     lint {
         checkDependencies = false
+    }
+}
+
+tasks.withType<KotlinCompilationTask<KotlinJvmCompilerOptions>>().configureEach {
+    compilerOptions {
+        // Allow for widescale experimental APIs in Alpha libraries we build upon
+        freeCompilerArgs.add("-opt-in=com.google.android.horologist.annotations.ExperimentalHorologistApi")
     }
 }
 


### PR DESCRIPTION
## Description

This is only a minor change to fix the following build warning by switching to the `compilerOptions` DSL.
```
w: ./pocket-casts-android/wear/build.gradle.kts:46:9: 'freeCompilerArgs: List<String>' is deprecated. 
  Please migrate to the compilerOptions DSL. More details are here: https://kotl.in/u1r8ln
```

Without this flag the following error happens:
```
e: ./pocket-casts-android/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/settings/WearAboutScreen.kt:35:27
  Horologist API is experimental. The API may be changed in the future.
```

## Testing Instructions

A successful build should be enough.

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 