### PR TITLE
[CredentialManager] Use Google login on WearOS

### DIFF
--- a/wear/build.gradle.kts
+++ b/wear/build.gradle.kts
@@ -123,6 +123,9 @@ dependencies {
     implementation(libs.wear.remote.interactions)
     implementation(libs.wear.tooling.preview)
     implementation(libs.work.runtime)
+    implementation(libs.credentials)
+    implementation(libs.credentials.google.play)
+    implementation(libs.google.identity)
 
     implementation(projects.modules.features.account)
     implementation(projects.modules.features.player)

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/MainActivity.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/MainActivity.kt
@@ -1,11 +1,14 @@
 package au.com.shiftyjelly.pocketcasts.wear
 
+import android.content.Context
 import android.os.Bundle
+import android.util.Log
 import android.widget.Toast
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.viewModels
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -64,11 +67,14 @@ class MainActivity : ComponentActivity() {
             WearAppTheme {
                 val state by viewModel.state.collectAsState()
 
+                Log.i("===", "state = $state")
+
                 WearApp(
                     signInState = state.signInState,
                     showLoggingInScreen = state.showLoggingInScreen,
                     onShowLoginScreen = viewModel::onSignInConfirmationActionHandled,
                     signOut = viewModel::signOut,
+                    requestLogin = viewModel::tryCredentialsManager
                 )
             }
         }
@@ -86,17 +92,26 @@ private fun WearApp(
     showLoggingInScreen: Boolean,
     onShowLoginScreen: () -> Unit,
     signOut: () -> Unit,
+    requestLogin: (Context) -> Unit,
 ) {
     val navController = rememberSwipeDismissableNavController()
     val swipeToDismissState = rememberSwipeToDismissBoxState()
     val navState = rememberSwipeDismissableNavHostState(swipeToDismissState)
+    val context = LocalContext.current
 
     if (showLoggingInScreen) {
         navController.navigate(LoggingInScreen.ROUTE_WITH_DELAY)
         onShowLoginScreen()
     }
 
-    val userCanAccessWatch = signInState.isSignedInAsPlusOrPatron == true
+    val userCanAccessWatch = signInState.isSignedInAsPlusOrPatron
+
+    LaunchedEffect(signInState, context) {
+        Log.i("====", "launchedEffect, sst=$signInState, ctxt=$context")
+        if (signInState == SignInState.SignedOut) {
+            requestLogin(context)
+        }
+    }
 
     val waitingForSignIn = remember { mutableStateOf(false) }
     if (!userCanAccessWatch) {
@@ -401,5 +416,6 @@ private fun DefaultPreview() {
         showLoggingInScreen = false,
         onShowLoginScreen = {},
         signOut = {},
+        requestLogin = {}
     )
 }

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/MainActivity.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/MainActivity.kt
@@ -283,10 +283,10 @@ private fun WearApp(
                 onEmailSignInSuccess = {
                     navController.navigate(LoggingInScreen.ROUTE)
                 },
-                googleSignInSuccessScreen = { googleSignInAccount ->
+                googleSignInSuccessScreen = { googleAccount ->
                     LoggingInScreen(
-                        avatarUrl = googleSignInAccount?.photoUrl?.toString(),
-                        name = googleSignInAccount?.givenName,
+                        avatarUrl = googleAccount.avatarUrl,
+                        name = googleAccount.name,
                         onClose = {},
                     )
                 },

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/MainActivity.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/MainActivity.kt
@@ -1,14 +1,11 @@
 package au.com.shiftyjelly.pocketcasts.wear
 
-import android.content.Context
 import android.os.Bundle
-import android.util.Log
 import android.widget.Toast
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.viewModels
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -67,14 +64,11 @@ class MainActivity : ComponentActivity() {
             WearAppTheme {
                 val state by viewModel.state.collectAsState()
 
-                Log.i("===", "state = $state")
-
                 WearApp(
                     signInState = state.signInState,
                     showLoggingInScreen = state.showLoggingInScreen,
                     onShowLoginScreen = viewModel::onSignInConfirmationActionHandled,
                     signOut = viewModel::signOut,
-                    requestLogin = viewModel::tryCredentialsManager
                 )
             }
         }
@@ -92,12 +86,10 @@ private fun WearApp(
     showLoggingInScreen: Boolean,
     onShowLoginScreen: () -> Unit,
     signOut: () -> Unit,
-    requestLogin: (Context) -> Unit,
 ) {
     val navController = rememberSwipeDismissableNavController()
     val swipeToDismissState = rememberSwipeToDismissBoxState()
     val navState = rememberSwipeDismissableNavHostState(swipeToDismissState)
-    val context = LocalContext.current
 
     if (showLoggingInScreen) {
         navController.navigate(LoggingInScreen.ROUTE_WITH_DELAY)
@@ -105,13 +97,6 @@ private fun WearApp(
     }
 
     val userCanAccessWatch = signInState.isSignedInAsPlusOrPatron
-
-    LaunchedEffect(signInState, context) {
-        Log.i("====", "launchedEffect, sst=$signInState, ctxt=$context")
-        if (signInState == SignInState.SignedOut) {
-            requestLogin(context)
-        }
-    }
 
     val waitingForSignIn = remember { mutableStateOf(false) }
     if (!userCanAccessWatch) {
@@ -416,6 +401,5 @@ private fun DefaultPreview() {
         showLoggingInScreen = false,
         onShowLoginScreen = {},
         signOut = {},
-        requestLogin = {}
     )
 }

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/WearMainActivityViewModel.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/WearMainActivityViewModel.kt
@@ -1,33 +1,16 @@
 package au.com.shiftyjelly.pocketcasts.wear
 
 import android.content.Context
-import android.util.Log
-import androidx.credentials.CredentialManager
-import androidx.credentials.CustomCredential
-import androidx.credentials.GetCredentialRequest
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import au.com.shiftyjelly.pocketcasts.account.watchsync.WatchSync
-import au.com.shiftyjelly.pocketcasts.account.watchsync.WatchSyncAuthData
 import au.com.shiftyjelly.pocketcasts.models.type.SignInState
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
 import au.com.shiftyjelly.pocketcasts.repositories.refresh.RefreshPodcastsTask
-import au.com.shiftyjelly.pocketcasts.repositories.sync.LoginResult
-import au.com.shiftyjelly.pocketcasts.repositories.sync.SignInSource
-import au.com.shiftyjelly.pocketcasts.repositories.sync.SyncManager
 import au.com.shiftyjelly.pocketcasts.repositories.user.UserManager
-import au.com.shiftyjelly.pocketcasts.utils.extensions.isGooglePlayServicesAvailableSuccess
-import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
-import com.google.android.gms.common.GoogleApiAvailability
-import com.google.android.horologist.auth.data.tokenshare.TokenBundleRepository
-import com.google.android.libraries.identity.googleid.GetSignInWithGoogleOption
-import com.google.android.libraries.identity.googleid.GoogleIdTokenCredential
 import dagger.hilt.android.lifecycle.HiltViewModel
-import dagger.hilt.android.qualifiers.ActivityContext
 import dagger.hilt.android.qualifiers.ApplicationContext
-import java.util.UUID
 import javax.inject.Inject
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
@@ -42,20 +25,15 @@ import timber.log.Timber
 class WearMainActivityViewModel @Inject constructor(
     private val playbackManager: PlaybackManager,
     private val podcastManager: PodcastManager,
-    private val tokenBundleRepository: TokenBundleRepository<WatchSyncAuthData?>,
     private val userManager: UserManager,
     private val settings: Settings,
-    private val watchSync: WatchSync,
     @ApplicationContext private val context: Context,
-    private val syncManager: SyncManager
 ) : ViewModel() {
 
     data class State(
         val showLoggingInScreen: Boolean = false,
         val signInState: SignInState = SignInState.SignedOut,
     )
-
-    private val credentialManager: CredentialManager by lazy { CredentialManager.create(context) }
 
     private val _state = MutableStateFlow(State())
     val state = _state.asStateFlow()
@@ -68,87 +46,6 @@ class WearMainActivityViewModel @Inject constructor(
                 .collect { signInState ->
                     _state.update { it.copy(signInState = signInState) }
                 }
-        }
-    }
-
-    fun tryCredentialsManager(
-        @ActivityContext context: Context,
-    ) {
-        val isGoogleSignInAvailable = Settings.GOOGLE_SIGN_IN_SERVER_CLIENT_ID.isNotEmpty() &&
-            GoogleApiAvailability.getInstance().isGooglePlayServicesAvailableSuccess(context)
-
-        Log.d("===", "tryCredentialsManager ctxt=$context, isgoogleAvail=$isGoogleSignInAvailable")
-
-        if (isGoogleSignInAvailable) {
-            viewModelScope.launch {
-                try {
-                    val googleIdOption: GetSignInWithGoogleOption = GetSignInWithGoogleOption.Builder(
-                        serverClientId = Settings.GOOGLE_SIGN_IN_SERVER_CLIENT_ID,
-                    ).setNonce(UUID.randomUUID().toString()).build()
-
-                    val request: GetCredentialRequest = GetCredentialRequest.Builder()
-                        .addCredentialOption(googleIdOption)
-                        .build()
-
-                    val result = credentialManager.getCredential(
-                        request = request,
-                        context = context,
-                    )
-                    val credential = result.credential as CustomCredential
-                    if (credential.type == GoogleIdTokenCredential.TYPE_GOOGLE_ID_TOKEN_CREDENTIAL) {
-                        val googleIdTokenCredential = GoogleIdTokenCredential
-                            .createFrom(credential.data)
-
-                        signInWithGoogleToken(
-                            idToken = googleIdTokenCredential.idToken,
-                        )
-                    } else {
-                        Log.w("====", "else")
-                        LogBuffer.e(LogBuffer.TAG_INVALID_STATE, "Failed to sign in with Google One Tap")
-                        watchAuthTokenExchange()
-                    }
-                } catch (e: Exception) {
-                    Log.w("====", "error $e")
-                    LogBuffer.e(LogBuffer.TAG_CRASH, e, "Unable to sign in with Google One Tap")
-                    watchAuthTokenExchange()
-                }
-            }
-        } else {
-            watchAuthTokenExchange()
-        }
-    }
-
-    private suspend fun signInWithGoogleToken(
-        idToken: String,
-    ) {
-        val authResult = syncManager.loginWithGoogle(idToken = idToken, signInSource = SignInSource.UserInitiated.Onboarding)
-        onLoginFromPhoneResult(authResult)
-    }
-
-    private fun watchAuthTokenExchange() {
-        viewModelScope.launch {
-            tokenBundleRepository.flow
-                .collect { watchSyncAuthData ->
-                    watchSync.processAuthDataChange(watchSyncAuthData) {
-                        onLoginFromPhoneResult(it)
-                    }
-                }
-        }
-    }
-
-    private fun onLoginFromPhoneResult(loginResult: LoginResult) {
-        when (loginResult) {
-            is LoginResult.Failed -> { /* do nothing */
-            }
-
-            is LoginResult.Success -> {
-                viewModelScope.launch {
-                    podcastManager.refreshPodcastsAfterSignIn()
-                }
-                _state.update {
-                    it.copy(showLoggingInScreen = true)
-                }
-            }
         }
     }
 

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/authentication/AuthenticationNavGraph.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/authentication/AuthenticationNavGraph.kt
@@ -14,6 +14,7 @@ const val AUTHENTICATION_SUB_GRAPH = "authentication_graph"
 private object AuthenticationNavRoutes {
     const val LOGIN_SCREEN = "login_screen"
     const val LOGIN_WITH_GOOGLE = "login_with_google"
+    const val LOGIN_WITH_GOOGLE_LEGACY = "login_with_google_legacy"
     const val LOGIN_WITH_PHONE = "login_with_phone"
     const val LOGIN_WITH_EMAIL = "login_with_email"
 }
@@ -63,6 +64,20 @@ fun NavGraphBuilder.authenticationNavGraph(
             route = AuthenticationNavRoutes.LOGIN_WITH_GOOGLE,
         ) {
             LoginWithGoogleScreen(
+                onSuccess = {
+                    navController.popBackStack()
+                },
+                onError = {
+                    navController.popBackStack()
+                    navController.navigate(AuthenticationNavRoutes.LOGIN_WITH_GOOGLE_LEGACY)
+                }
+            )
+        }
+
+        composable(
+            route = AuthenticationNavRoutes.LOGIN_WITH_GOOGLE_LEGACY,
+        ) {
+            LegacyLoginWithGoogleScreen(
                 signInSuccessScreen = googleSignInSuccessScreen,
                 onCancel = { navController.popBackStack() },
             )

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/authentication/AuthenticationNavGraph.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/authentication/AuthenticationNavGraph.kt
@@ -7,7 +7,6 @@ import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.compose.navigation
 import androidx.wear.compose.navigation.composable
-import com.google.android.gms.auth.api.signin.GoogleSignInAccount
 
 const val AUTHENTICATION_SUB_GRAPH = "authentication_graph"
 
@@ -19,10 +18,15 @@ private object AuthenticationNavRoutes {
     const val LOGIN_WITH_EMAIL = "login_with_email"
 }
 
+data class GoogleAccountData(
+    val name: String,
+    val avatarUrl: String? = null,
+)
+
 fun NavGraphBuilder.authenticationNavGraph(
     navController: NavController,
     onEmailSignInSuccess: () -> Unit,
-    googleSignInSuccessScreen: @Composable (GoogleSignInAccount?) -> Unit,
+    googleSignInSuccessScreen: @Composable (GoogleAccountData) -> Unit,
 ) {
     navigation(
         startDestination = AuthenticationNavRoutes.LOGIN_SCREEN,
@@ -64,13 +68,13 @@ fun NavGraphBuilder.authenticationNavGraph(
             route = AuthenticationNavRoutes.LOGIN_WITH_GOOGLE,
         ) {
             LoginWithGoogleScreen(
-                onSuccess = {
-                    navController.popBackStack()
+                successContent = {
+                    googleSignInSuccessScreen(GoogleAccountData(name = it.name, avatarUrl = it.avatarUrl))
                 },
                 onError = {
                     navController.popBackStack()
                     navController.navigate(AuthenticationNavRoutes.LOGIN_WITH_GOOGLE_LEGACY)
-                }
+                },
             )
         }
 
@@ -78,7 +82,9 @@ fun NavGraphBuilder.authenticationNavGraph(
             route = AuthenticationNavRoutes.LOGIN_WITH_GOOGLE_LEGACY,
         ) {
             LegacyLoginWithGoogleScreen(
-                signInSuccessScreen = googleSignInSuccessScreen,
+                signInSuccessScreen = {
+                    googleSignInSuccessScreen(GoogleAccountData(name = it?.givenName.orEmpty(), avatarUrl = it?.photoUrl.toString()))
+                },
                 onCancel = { navController.popBackStack() },
             )
         }

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/authentication/LegacyLoginWithGoogleScreen.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/authentication/LegacyLoginWithGoogleScreen.kt
@@ -1,0 +1,59 @@
+@file:Suppress("DEPRECATION")
+
+package au.com.shiftyjelly.pocketcasts.wear.ui.authentication
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.hilt.navigation.compose.hiltViewModel
+import au.com.shiftyjelly.pocketcasts.compose.CallOnce
+import au.com.shiftyjelly.pocketcasts.utils.Network
+import au.com.shiftyjelly.pocketcasts.wear.ui.component.ErrorScreen
+import com.google.android.gms.auth.api.signin.GoogleSignInAccount
+import com.google.android.horologist.auth.ui.googlesignin.signin.GoogleSignInScreen
+import com.google.android.horologist.compose.layout.ScreenScaffold
+import timber.log.Timber
+import au.com.shiftyjelly.pocketcasts.localization.R as LR
+import com.google.android.horologist.auth.composables.R as HR
+
+@Composable
+fun LegacyLoginWithGoogleScreen(
+    onCancel: () -> Unit,
+    modifier: Modifier = Modifier,
+    viewModel: LegacyLoginWithGoogleScreenViewModel = hiltViewModel(),
+    signInSuccessScreen: @Composable (GoogleSignInAccount?) -> Unit,
+) {
+    ScreenScaffold(
+        modifier = modifier,
+    ) {
+        val state by viewModel.state.collectAsState()
+        val context = LocalContext.current
+
+        CallOnce {
+            // Allow the user to sign in with a different account
+            viewModel.clearPreviousSignIn()
+        }
+
+        GoogleSignInScreen(
+            viewModel = viewModel.googleSignInViewModel,
+            onAuthCancelled = {
+                Timber.i("Google sign in cancelled")
+                onCancel()
+            },
+            failedContent = {
+                val message = if (Network.isConnected(context)) {
+                    HR.string.horologist_auth_error_message
+                } else {
+                    LR.string.log_in_no_network
+                }
+                ErrorScreen(stringResource(message))
+            },
+            content = {
+                signInSuccessScreen(state.googleSignInAccount)
+            },
+        )
+    }
+}

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/authentication/LegacyLoginWithGoogleScreenViewModel.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/authentication/LegacyLoginWithGoogleScreenViewModel.kt
@@ -19,7 +19,7 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 
 @HiltViewModel
-class LoginWithGoogleScreenViewModel @Inject constructor(
+class LegacyLoginWithGoogleScreenViewModel @Inject constructor(
     googleSignInClient: GoogleSignInClient,
     private val podcastManager: PodcastManager,
     private val syncManager: SyncManager,

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/authentication/LoginWithGoogleScreen.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/authentication/LoginWithGoogleScreen.kt
@@ -2,18 +2,15 @@ package au.com.shiftyjelly.pocketcasts.wear.ui.authentication
 
 import androidx.activity.compose.LocalActivity
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
-import androidx.compose.ui.Modifier
 import androidx.hilt.navigation.compose.hiltViewModel
 import au.com.shiftyjelly.pocketcasts.compose.CallOnce
 
 @Composable
 fun LoginWithGoogleScreen(
-    onSuccess: () -> Unit,
     onError: () -> Unit,
-    modifier: Modifier = Modifier,
-    viewModel: LoginWithGoogleViewModel = hiltViewModel()
+    viewModel: LoginWithGoogleViewModel = hiltViewModel(),
+    successContent: @Composable (LoginWithGoogleViewModel.State.SignedInWithGoogle) -> Unit,
 ) {
     val state = viewModel.state.collectAsState().value
     val context = LocalActivity.current
@@ -24,11 +21,11 @@ fun LoginWithGoogleScreen(
         } ?: onError()
     }
 
-    LaunchedEffect(state) {
-        when (state) {
-            is LoginWithGoogleViewModel.State.Failed -> onError()
-            is LoginWithGoogleViewModel.State.SignedInWithGoogle -> onSuccess()
-            is LoginWithGoogleViewModel.State.Idle -> Unit
+    when (state) {
+        is LoginWithGoogleViewModel.State.Failed -> onError()
+        is LoginWithGoogleViewModel.State.SignedInWithGoogle -> {
+            successContent(state)
         }
+        is LoginWithGoogleViewModel.State.Idle -> Unit
     }
 }

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/authentication/LoginWithGoogleScreen.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/authentication/LoginWithGoogleScreen.kt
@@ -1,59 +1,34 @@
-@file:Suppress("DEPRECATION")
-
 package au.com.shiftyjelly.pocketcasts.wear.ui.authentication
 
+import androidx.activity.compose.LocalActivity
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
-import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.res.stringResource
 import androidx.hilt.navigation.compose.hiltViewModel
 import au.com.shiftyjelly.pocketcasts.compose.CallOnce
-import au.com.shiftyjelly.pocketcasts.utils.Network
-import au.com.shiftyjelly.pocketcasts.wear.ui.component.ErrorScreen
-import com.google.android.gms.auth.api.signin.GoogleSignInAccount
-import com.google.android.horologist.auth.ui.googlesignin.signin.GoogleSignInScreen
-import com.google.android.horologist.compose.layout.ScreenScaffold
-import timber.log.Timber
-import au.com.shiftyjelly.pocketcasts.localization.R as LR
-import com.google.android.horologist.auth.composables.R as HR
 
 @Composable
 fun LoginWithGoogleScreen(
-    onCancel: () -> Unit,
+    onSuccess: () -> Unit,
+    onError: () -> Unit,
     modifier: Modifier = Modifier,
-    viewModel: LoginWithGoogleScreenViewModel = hiltViewModel(),
-    signInSuccessScreen: @Composable (GoogleSignInAccount?) -> Unit,
+    viewModel: LoginWithGoogleViewModel = hiltViewModel()
 ) {
-    ScreenScaffold(
-        modifier = modifier,
-    ) {
-        val state by viewModel.state.collectAsState()
-        val context = LocalContext.current
+    val state = viewModel.state.collectAsState().value
+    val context = LocalActivity.current
 
-        CallOnce {
-            // Allow the user to sign in with a different account
-            viewModel.clearPreviousSignIn()
+    CallOnce {
+        context?.let {
+            viewModel.tryCredentialsManager(context)
+        } ?: onError()
+    }
+
+    LaunchedEffect(state) {
+        when (state) {
+            is LoginWithGoogleViewModel.State.Failed -> onError()
+            is LoginWithGoogleViewModel.State.SignedInWithGoogle -> onSuccess()
+            is LoginWithGoogleViewModel.State.Idle -> Unit
         }
-
-        GoogleSignInScreen(
-            viewModel = viewModel.googleSignInViewModel,
-            onAuthCancelled = {
-                Timber.i("Google sign in cancelled")
-                onCancel()
-            },
-            failedContent = {
-                val message = if (Network.isConnected(context)) {
-                    HR.string.horologist_auth_error_message
-                } else {
-                    LR.string.log_in_no_network
-                }
-                ErrorScreen(stringResource(message))
-            },
-            content = {
-                signInSuccessScreen(state.googleSignInAccount)
-            },
-        )
     }
 }

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/authentication/LoginWithGoogleViewModel.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/authentication/LoginWithGoogleViewModel.kt
@@ -1,0 +1,115 @@
+package au.com.shiftyjelly.pocketcasts.wear.ui.authentication
+
+import android.content.Context
+import android.util.Log
+import androidx.credentials.CredentialManager
+import androidx.credentials.CustomCredential
+import androidx.credentials.GetCredentialRequest
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import au.com.shiftyjelly.pocketcasts.preferences.Settings
+import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
+import au.com.shiftyjelly.pocketcasts.repositories.sync.LoginResult
+import au.com.shiftyjelly.pocketcasts.repositories.sync.SignInSource
+import au.com.shiftyjelly.pocketcasts.repositories.sync.SyncManager
+import au.com.shiftyjelly.pocketcasts.utils.extensions.isGooglePlayServicesAvailableSuccess
+import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
+import com.google.android.gms.common.GoogleApiAvailability
+import com.google.android.libraries.identity.googleid.GetSignInWithGoogleOption
+import com.google.android.libraries.identity.googleid.GoogleIdTokenCredential
+import dagger.hilt.android.lifecycle.HiltViewModel
+import dagger.hilt.android.qualifiers.ActivityContext
+import dagger.hilt.android.qualifiers.ApplicationContext
+import java.util.UUID
+import javax.inject.Inject
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+
+@HiltViewModel
+class LoginWithGoogleViewModel @Inject constructor(
+    private val podcastManager: PodcastManager,
+    private val syncManager: SyncManager,
+    @ApplicationContext context: Context,
+) : ViewModel() {
+
+    sealed interface State {
+        data object Idle : State
+        data class SignedInWithGoogle(
+            val token: String,
+        ) : State
+        data object Failed : State
+    }
+
+    private val credentialManager: CredentialManager by lazy { CredentialManager.create(context) }
+
+    private val _state = MutableStateFlow<State>(State.Idle)
+    val state = _state.asStateFlow()
+
+    fun tryCredentialsManager(
+        @ActivityContext context: Context,
+    ) {
+        val isGoogleSignInAvailable = Settings.GOOGLE_SIGN_IN_SERVER_CLIENT_ID.isNotEmpty() &&
+            GoogleApiAvailability.getInstance().isGooglePlayServicesAvailableSuccess(context)
+
+        if (isGoogleSignInAvailable) {
+            viewModelScope.launch {
+                try {
+                    val googleIdOption: GetSignInWithGoogleOption = GetSignInWithGoogleOption.Builder(
+                        serverClientId = Settings.GOOGLE_SIGN_IN_SERVER_CLIENT_ID,
+                    ).setNonce(UUID.randomUUID().toString()).build()
+
+                    val request: GetCredentialRequest = GetCredentialRequest.Builder()
+                        .addCredentialOption(googleIdOption)
+                        .build()
+
+                    val result = credentialManager.getCredential(
+                        request = request,
+                        context = context,
+                    )
+                    val credential = result.credential as CustomCredential
+                    if (credential.type == GoogleIdTokenCredential.TYPE_GOOGLE_ID_TOKEN_CREDENTIAL) {
+                        val googleIdTokenCredential = GoogleIdTokenCredential
+                            .createFrom(credential.data)
+
+                        signInWithGoogleToken(
+                            idToken = googleIdTokenCredential.idToken,
+                        )
+                    } else {
+                        Log.w("====", "else")
+                        LogBuffer.e(LogBuffer.TAG_INVALID_STATE, "Failed to sign in with Google One Tap")
+                        _state.value = State.Failed
+                    }
+                } catch (e: Exception) {
+                    Log.w("====", "error $e")
+                    LogBuffer.e(LogBuffer.TAG_CRASH, e, "Unable to sign in with Google One Tap")
+                    _state.value = State.Failed
+                }
+            }
+        } else {
+            _state.value = State.Failed
+        }
+    }
+
+    private suspend fun signInWithGoogleToken(
+        idToken: String,
+    ) {
+        val authResult = syncManager.loginWithGoogle(idToken = idToken, signInSource = SignInSource.UserInitiated.Onboarding)
+        onLoginFromPhoneResult(authResult)
+    }
+
+    private fun onLoginFromPhoneResult(loginResult: LoginResult) {
+        when (loginResult) {
+            is LoginResult.Failed -> {
+                _state.value = State.Failed
+            }
+
+            is LoginResult.Success -> {
+                viewModelScope.launch {
+                    podcastManager.refreshPodcastsAfterSignIn()
+                }
+                _state.value = State.SignedInWithGoogle(token = loginResult.result.token.value)
+            }
+        }
+    }
+}

--- a/wear/src/test/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/authentication/LoginWithGoogleScreenViewModelTest.kt
+++ b/wear/src/test/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/authentication/LoginWithGoogleScreenViewModelTest.kt
@@ -34,12 +34,12 @@ class LoginWithGoogleScreenViewModelTest {
 
     @Mock
     private lateinit var syncManager: SyncManager
-    private lateinit var testSubject: LoginWithGoogleScreenViewModel
+    private lateinit var testSubject: LegacyLoginWithGoogleScreenViewModel
 
     @Before
     fun setup() {
         MockitoAnnotations.openMocks(this)
-        testSubject = LoginWithGoogleScreenViewModel(
+        testSubject = LegacyLoginWithGoogleScreenViewModel(
             googleSignInClient = googleSignInClient,
             podcastManager = podcastManager,
             syncManager = syncManager,


### PR DESCRIPTION
## Description
Adds Google login via CredentialManager on WearOS.
The old horologist-based login is still in place.
For Google login, we're now trying CredentialManager APIs first. If they fail, we fall back to horologist's Google login.

Fixes https://linear.app/a8c/issue/PCDROID-167/use-credentialmanager-on-wearos-for-google-login

## Testing Instructions
1. Build WearOS app and install on your watch
2. Launch the app, make sure the phone app doesn't run on the phone paired with the watch (otherwise horologist's token exchange migth kick in and log you in automatically)
3. Tap "Log in"
4. Select "Google" option
- [ ] CredentialManager presents the account selector
5. Select a google account you want to sign in with
- [ ] After successful sign in, you see the Welcome screen
- [ ] After a short delay you see the landing page on watch (podcasts)

Please consider testing other, more complicated login scenarios as well.

## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] ~I have considered whether it makes sense to add tests for my changes~
- [ ] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [ ] ~Any jetpack compose components I added or changed are covered by compose previews~
- [ ] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~
 