### PR TITLE
Add auto downloads Compose UI

### DIFF
--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/AutoDownloadSettingsFragment.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/AutoDownloadSettingsFragment.kt
@@ -456,7 +456,7 @@ class AutoDownloadSettingsFragment :
     }
 
     private fun updateOnFollowSummary() {
-        val limitDownloads = AutoDownloadLimitSetting.getNumberOfEpisodes(viewModel.getLimitDownload())
+        val limitDownloads = viewModel.getLimitDownload().episodeCount
 
         val localizedLimitDownloads = when (limitDownloads) {
             2 -> resources.getString(LR.string.number_two)

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/AutoDownloadSettingsHomePage.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/AutoDownloadSettingsHomePage.kt
@@ -1,0 +1,238 @@
+package au.com.shiftyjelly.pocketcasts.settings
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.selection.toggleable
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.pluralStringResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewParameter
+import au.com.shiftyjelly.pocketcasts.compose.AppThemeWithBackground
+import au.com.shiftyjelly.pocketcasts.compose.PreviewRegularDevice
+import au.com.shiftyjelly.pocketcasts.compose.components.SettingRow
+import au.com.shiftyjelly.pocketcasts.compose.components.SettingRowToggle
+import au.com.shiftyjelly.pocketcasts.compose.components.SettingSection
+import au.com.shiftyjelly.pocketcasts.compose.preview.ThemePreviewParameterProvider
+import au.com.shiftyjelly.pocketcasts.models.type.AutoDownloadLimitSetting
+import au.com.shiftyjelly.pocketcasts.settings.viewmodel.AutoDownloadSettingsViewModel.UiState
+import au.com.shiftyjelly.pocketcasts.ui.theme.Theme.ThemeType
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
+import au.com.shiftyjelly.pocketcasts.localization.R as LR
+
+@Composable
+internal fun AutoDownloadSettingsHomePage(
+    uiState: UiState,
+    onChangeUpNextDownload: (Boolean) -> Unit,
+    onChangeNewEpisodesDownload: (Boolean) -> Unit,
+    onChangePodcastsSetting: () -> Unit,
+    onChangeOnFollowDownload: (Boolean) -> Unit,
+    onChangeAutoDownloadLimitSetting: () -> Unit,
+    onChangePlaylistsSetting: () -> Unit,
+    onChangeOnUnmeteredDownload: (Boolean) -> Unit,
+    onChangeOnlyWhenChargingDownload: (Boolean) -> Unit,
+    onStopAllDownloads: () -> Unit,
+    onClearDownloadErrors: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val enabledPodcastsCount = remember(uiState.podcasts) {
+        uiState.podcasts.count { it.isAutoDownloadNewEpisodes }
+    }
+    val enabledPlaylistsCount = remember(uiState.playlists) {
+        uiState.playlists.count { it.settings.isAutoDownloadEnabled }
+    }
+
+    Column(
+        modifier = modifier
+            .verticalScroll(rememberScrollState())
+            .fillMaxSize(),
+    ) {
+        SettingSection(
+            heading = stringResource(LR.string.up_next),
+        ) {
+            SettingRow(
+                primaryText = stringResource(LR.string.settings_auto_download_up_next),
+                toggle = SettingRowToggle.Switch(
+                    checked = uiState.isUpNextDownloadEnabled,
+                ),
+                modifier = Modifier.toggleable(
+                    value = uiState.isUpNextDownloadEnabled,
+                    role = Role.Switch,
+                    onValueChange = onChangeUpNextDownload,
+                ),
+            )
+        }
+        SettingSection(
+            heading = stringResource(LR.string.podcasts),
+        ) {
+            Column {
+                SettingRow(
+                    primaryText = stringResource(LR.string.settings_auto_download_new_episodes),
+                    secondaryText = stringResource(LR.string.settings_auto_download_new_episodes_description),
+                    toggle = SettingRowToggle.Switch(
+                        checked = uiState.isNewEpisodesDownloadEnabled,
+                    ),
+                    modifier = Modifier.toggleable(
+                        value = uiState.isNewEpisodesDownloadEnabled,
+                        role = Role.Switch,
+                        onValueChange = onChangeNewEpisodesDownload,
+                    ),
+                )
+                AnimatedVisibility(
+                    visible = uiState.isNewEpisodesDownloadEnabled,
+                ) {
+                    SettingRow(
+                        primaryText = stringResource(LR.string.settings_choose_podcasts),
+                        secondaryText = when (enabledPodcastsCount) {
+                            uiState.podcasts.size -> stringResource(LR.string.podcasts_selected_all)
+                            else -> pluralStringResource(LR.plurals.podcasts_selected_count, enabledPodcastsCount, enabledPodcastsCount)
+                        },
+                        modifier = Modifier.clickable(
+                            role = Role.Button,
+                            onClick = onChangePodcastsSetting,
+                        ),
+                    )
+                }
+                SettingRow(
+                    primaryText = stringResource(LR.string.settings_auto_download_on_follow_podcast),
+                    secondaryText = pluralStringResource(
+                        LR.plurals.settings_auto_download_on_follow_podcast_description,
+                        uiState.autoDownloadLimit.episodeCount,
+                        stringResource(uiState.autoDownloadLimit.episodeCountRes),
+                    ),
+                    toggle = SettingRowToggle.Switch(
+                        checked = uiState.isOnFollowDownloadEnabled,
+                    ),
+                    modifier = Modifier.toggleable(
+                        value = uiState.isOnFollowDownloadEnabled,
+                        role = Role.Switch,
+                        onValueChange = onChangeOnFollowDownload,
+                    ),
+                )
+                SettingRow(
+                    primaryText = stringResource(LR.string.settings_auto_download_limit),
+                    secondaryText = stringResource(uiState.autoDownloadLimit.titleRes),
+                    modifier = Modifier.clickable(
+                        role = Role.Button,
+                        onClick = onChangeAutoDownloadLimitSetting,
+                    ),
+                )
+            }
+        }
+        val usePlaylists = FeatureFlag.isEnabled(Feature.PLAYLISTS_REBRANDING, immutable = true)
+        SettingSection(
+            heading = if (usePlaylists) {
+                stringResource(LR.string.playlists)
+            } else {
+                stringResource(LR.string.filters)
+            },
+        ) {
+            SettingRow(
+                primaryText = if (usePlaylists) {
+                    stringResource(LR.string.settings_auto_download_filters_episodes)
+                } else {
+                    stringResource(LR.string.settings_choose_playlists)
+                },
+                secondaryText = if (usePlaylists) {
+                    when (enabledPlaylistsCount) {
+                        uiState.playlists.size -> stringResource(LR.string.playlists_selected_all)
+                        else -> pluralStringResource(LR.plurals.playlists_selected_count, enabledPlaylistsCount, enabledPlaylistsCount)
+                    }
+                } else {
+                    when (enabledPlaylistsCount) {
+                        1 -> stringResource(LR.string.filters_chosen_singular)
+                        else -> stringResource(LR.string.filters_chosen_plural, enabledPlaylistsCount)
+                    }
+                },
+                modifier = Modifier.clickable(
+                    role = Role.Button,
+                    onClick = onChangePlaylistsSetting,
+                ),
+            )
+        }
+        SettingSection(
+            heading = stringResource(LR.string.settings),
+        ) {
+            SettingRow(
+                primaryText = stringResource(LR.string.settings_auto_download_unmetered),
+                secondaryText = stringResource(LR.string.settings_auto_download_unmetered_summary),
+                toggle = SettingRowToggle.Switch(
+                    checked = uiState.isOnUnmeteredDownloadEnabled,
+                ),
+                modifier = Modifier.toggleable(
+                    value = uiState.isOnUnmeteredDownloadEnabled,
+                    role = Role.Switch,
+                    onValueChange = onChangeOnUnmeteredDownload,
+                ),
+            )
+            SettingRow(
+                primaryText = stringResource(LR.string.settings_auto_download_charging),
+                toggle = SettingRowToggle.Switch(
+                    checked = uiState.isOnlyWhenChargingDownloadEnabled,
+                ),
+                modifier = Modifier.toggleable(
+                    value = uiState.isOnlyWhenChargingDownloadEnabled,
+                    role = Role.Switch,
+                    onValueChange = onChangeOnlyWhenChargingDownload,
+                ),
+            )
+        }
+        SettingSection(
+            heading = stringResource(LR.string.downloads),
+        ) {
+            SettingRow(
+                primaryText = stringResource(LR.string.settings_auto_download_stop_all),
+                modifier = Modifier.clickable(
+                    role = Role.Button,
+                    onClick = onStopAllDownloads,
+                ),
+            )
+            SettingRow(
+                primaryText = stringResource(LR.string.settings_auto_download_clear_errors),
+                modifier = Modifier.clickable(
+                    role = Role.Button,
+                    onClick = onClearDownloadErrors,
+                ),
+            )
+        }
+    }
+}
+
+@PreviewRegularDevice
+@Composable
+private fun AutoDownloadSettingsHomePagePreview(
+    @PreviewParameter(ThemePreviewParameterProvider::class) themeType: ThemeType,
+) {
+    AppThemeWithBackground(themeType) {
+        AutoDownloadSettingsHomePage(
+            uiState = UiState(
+                isUpNextDownloadEnabled = true,
+                isNewEpisodesDownloadEnabled = true,
+                isOnFollowDownloadEnabled = true,
+                autoDownloadLimit = AutoDownloadLimitSetting.TEN_LATEST_EPISODE,
+                isOnUnmeteredDownloadEnabled = true,
+                isOnlyWhenChargingDownloadEnabled = true,
+                podcasts = emptyList(),
+                playlists = emptyList(),
+            ),
+            onChangeUpNextDownload = {},
+            onChangeNewEpisodesDownload = {},
+            onChangePodcastsSetting = {},
+            onChangeOnFollowDownload = {},
+            onChangeAutoDownloadLimitSetting = {},
+            onChangePlaylistsSetting = {},
+            onChangeOnUnmeteredDownload = {},
+            onChangeOnlyWhenChargingDownload = {},
+            onStopAllDownloads = {},
+            onClearDownloadErrors = {},
+        )
+    }
+}

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/AutoDownloadSettingsPlaylistsPage.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/AutoDownloadSettingsPlaylistsPage.kt
@@ -1,0 +1,246 @@
+package au.com.shiftyjelly.pocketcasts.settings
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.selection.toggleable
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.Checkbox
+import androidx.compose.material.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.pluralStringResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.PreviewParameter
+import androidx.compose.ui.unit.dp
+import au.com.shiftyjelly.pocketcasts.compose.AppThemeWithBackground
+import au.com.shiftyjelly.pocketcasts.compose.PreviewRegularDevice
+import au.com.shiftyjelly.pocketcasts.compose.components.FadedLazyColumn
+import au.com.shiftyjelly.pocketcasts.compose.components.HorizontalDivider
+import au.com.shiftyjelly.pocketcasts.compose.components.PlaylistArtwork
+import au.com.shiftyjelly.pocketcasts.compose.components.TextH40
+import au.com.shiftyjelly.pocketcasts.compose.components.TextP50
+import au.com.shiftyjelly.pocketcasts.compose.preview.ThemePreviewParameterProvider
+import au.com.shiftyjelly.pocketcasts.compose.theme
+import au.com.shiftyjelly.pocketcasts.models.to.PlaylistIcon
+import au.com.shiftyjelly.pocketcasts.models.type.SmartRules
+import au.com.shiftyjelly.pocketcasts.models.type.SmartRules.PodcastsRule
+import au.com.shiftyjelly.pocketcasts.repositories.extensions.drawableId
+import au.com.shiftyjelly.pocketcasts.repositories.playlist.Playlist
+import au.com.shiftyjelly.pocketcasts.repositories.playlist.PlaylistPreview
+import au.com.shiftyjelly.pocketcasts.repositories.playlist.SmartPlaylistPreview
+import au.com.shiftyjelly.pocketcasts.ui.extensions.getColor
+import au.com.shiftyjelly.pocketcasts.ui.theme.Theme.ThemeType
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
+import au.com.shiftyjelly.pocketcasts.localization.R as LR
+
+@Composable
+internal fun AutoDownloadSettingsPlaylistsPage(
+    playlists: List<PlaylistPreview>,
+    onChangePlaylist: (String, Boolean) -> Unit,
+    onChangeAllPlaylists: (Boolean) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val usePlaylists = FeatureFlag.isEnabled(Feature.PLAYLISTS_REBRANDING, immutable = true)
+    val enabledPlaylistsCount = remember(playlists) {
+        playlists.count { it.settings.isAutoDownloadEnabled }
+    }
+
+    Column(
+        modifier = modifier.fillMaxSize(),
+    ) {
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(start = 16.dp, end = 8.dp, top = 4.dp, bottom = 4.dp),
+        ) {
+            TextP50(
+                text = if (usePlaylists) {
+                    pluralStringResource(LR.plurals.playlists_selected_count, enabledPlaylistsCount, enabledPlaylistsCount)
+                } else {
+                    when (enabledPlaylistsCount) {
+                        0 -> stringResource(LR.string.filters_chosen_none)
+                        1 -> stringResource(LR.string.filters_chosen_singular)
+                        else -> stringResource(LR.string.filters_chosen_plural, enabledPlaylistsCount)
+                    }
+                },
+                color = MaterialTheme.theme.colors.primaryText02,
+                modifier = Modifier.weight(1f),
+            )
+            Spacer(
+                modifier = Modifier.width(12.dp),
+            )
+            TextP50(
+                text = if (playlists.size == enabledPlaylistsCount) {
+                    stringResource(LR.string.select_none)
+                } else {
+                    stringResource(LR.string.select_all)
+                },
+                fontWeight = FontWeight.Medium,
+                color = MaterialTheme.theme.colors.primaryIcon01,
+                modifier = Modifier
+                    .clip(RoundedCornerShape(4.dp))
+                    .clickable(
+                        role = Role.Button,
+                        onClick = {
+                            val enable = playlists.size != enabledPlaylistsCount
+                            onChangeAllPlaylists(enable)
+                        },
+                    )
+                    .padding(8.dp),
+            )
+        }
+
+        Spacer(
+            modifier = Modifier.height(16.dp),
+        )
+        FadedLazyColumn(
+            modifier = Modifier.weight(1f),
+        ) {
+            itemsIndexed(
+                items = playlists,
+                key = { _, playlist -> playlist.uuid },
+            ) { index, playlist ->
+                PlaylistRow(
+                    playlist = playlist,
+                    isSelected = playlist.settings.isAutoDownloadEnabled,
+                    showDivider = index != playlists.lastIndex,
+                    usePlaylists = usePlaylists,
+                    modifier = Modifier.toggleable(
+                        role = Role.Checkbox,
+                        value = playlist.settings.isAutoDownloadEnabled,
+                        onValueChange = { value -> onChangePlaylist(playlist.uuid, value) },
+                    ),
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun PlaylistRow(
+    playlist: PlaylistPreview,
+    isSelected: Boolean,
+    showDivider: Boolean,
+    usePlaylists: Boolean,
+    modifier: Modifier = Modifier,
+) {
+    if (usePlaylists) {
+        Column(
+            modifier = modifier,
+        ) {
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp, vertical = 12.dp),
+            ) {
+                PlaylistArtwork(
+                    podcastUuids = playlist.artworkPodcastUuids,
+                    artworkSize = 56.dp,
+                )
+                Spacer(
+                    modifier = Modifier.width(16.dp),
+                )
+                Column(
+                    modifier = Modifier.weight(1f),
+                ) {
+                    TextH40(
+                        text = playlist.title,
+                    )
+                    TextP50(
+                        text = stringResource(LR.string.smart_playlist),
+                        color = MaterialTheme.theme.colors.primaryText02,
+                    )
+                }
+                Spacer(
+                    modifier = Modifier.width(16.dp),
+                )
+                Checkbox(
+                    checked = isSelected,
+                    onCheckedChange = null,
+                )
+            }
+            if (showDivider) {
+                HorizontalDivider(startIndent = 16.dp)
+            }
+        }
+    } else {
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp, vertical = 12.dp),
+        ) {
+            Image(
+                painter = painterResource(playlist.icon.drawableId),
+                colorFilter = ColorFilter.tint(Color(playlist.icon.getColor(LocalContext.current))),
+                contentDescription = null,
+                modifier = Modifier.size(32.dp),
+            )
+            Spacer(
+                modifier = Modifier.width(16.dp),
+            )
+            TextH40(
+                text = playlist.title,
+                modifier = Modifier.weight(1f),
+            )
+            Spacer(
+                modifier = Modifier.width(16.dp),
+            )
+            Checkbox(
+                checked = isSelected,
+                onCheckedChange = null,
+            )
+        }
+    }
+}
+
+@PreviewRegularDevice
+@Composable
+private fun AutoDownloadSettingsPlaylistsPagePreview(
+    @PreviewParameter(ThemePreviewParameterProvider::class) themeType: ThemeType,
+) {
+    AppThemeWithBackground(themeType) {
+        AutoDownloadSettingsPlaylistsPage(
+            playlists = List(3) { index ->
+                SmartPlaylistPreview(
+                    uuid = "playlist-uuid-$index",
+                    title = "Playlist $index",
+                    episodeCount = 0,
+                    artworkPodcastUuids = emptyList(),
+                    settings = Playlist.Settings.ForPreview.copy(
+                        isAutoDownloadEnabled = index % 2 == 0,
+                    ),
+                    smartRules = SmartRules.Default.copy(
+                        podcasts = PodcastsRule.Selected(uuids = setOf("podcast-uuid-$index")),
+                    ),
+                    icon = PlaylistIcon(0),
+                )
+            },
+            onChangePlaylist = { _, _ -> },
+            onChangeAllPlaylists = {},
+        )
+    }
+}

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/AutoDownloadSettingsPodcastsPage.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/AutoDownloadSettingsPodcastsPage.kt
@@ -1,0 +1,182 @@
+package au.com.shiftyjelly.pocketcasts.settings
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.selection.toggleable
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.Checkbox
+import androidx.compose.material.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.res.pluralStringResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.PreviewParameter
+import androidx.compose.ui.unit.dp
+import au.com.shiftyjelly.pocketcasts.compose.AppThemeWithBackground
+import au.com.shiftyjelly.pocketcasts.compose.PreviewRegularDevice
+import au.com.shiftyjelly.pocketcasts.compose.components.FadedLazyColumn
+import au.com.shiftyjelly.pocketcasts.compose.components.HorizontalDivider
+import au.com.shiftyjelly.pocketcasts.compose.components.PodcastImage
+import au.com.shiftyjelly.pocketcasts.compose.components.TextH40
+import au.com.shiftyjelly.pocketcasts.compose.components.TextP50
+import au.com.shiftyjelly.pocketcasts.compose.preview.ThemePreviewParameterProvider
+import au.com.shiftyjelly.pocketcasts.compose.theme
+import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
+import au.com.shiftyjelly.pocketcasts.ui.theme.Theme.ThemeType
+import au.com.shiftyjelly.pocketcasts.localization.R as LR
+
+@Composable
+internal fun AutoDownloadSettingsPodcastsPage(
+    podcasts: List<Podcast>,
+    onChangePodcast: (String, Boolean) -> Unit,
+    onChangeAllPodcasts: (Boolean) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val enabledPodcastsCount = remember(podcasts) {
+        podcasts.count { it.isAutoDownloadNewEpisodes }
+    }
+
+    Column(
+        modifier = modifier.fillMaxSize(),
+    ) {
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(start = 16.dp, end = 8.dp, top = 4.dp, bottom = 4.dp),
+        ) {
+            TextP50(
+                text = pluralStringResource(LR.plurals.podcasts_selected_count, enabledPodcastsCount, enabledPodcastsCount),
+                color = MaterialTheme.theme.colors.primaryText02,
+                modifier = Modifier.weight(1f),
+            )
+            Spacer(
+                modifier = Modifier.width(12.dp),
+            )
+            TextP50(
+                text = if (podcasts.size == enabledPodcastsCount) {
+                    stringResource(LR.string.select_none)
+                } else {
+                    stringResource(LR.string.select_all)
+                },
+                fontWeight = FontWeight.Medium,
+                color = MaterialTheme.theme.colors.primaryIcon01,
+                modifier = Modifier
+                    .clip(RoundedCornerShape(4.dp))
+                    .clickable(
+                        role = Role.Button,
+                        onClick = {
+                            val enable = podcasts.size != enabledPodcastsCount
+                            onChangeAllPodcasts(enable)
+                        },
+                    )
+                    .padding(8.dp),
+            )
+        }
+
+        Spacer(
+            modifier = Modifier.height(16.dp),
+        )
+        FadedLazyColumn(
+            modifier = Modifier.weight(1f),
+        ) {
+            itemsIndexed(
+                items = podcasts,
+                key = { _, podcast -> podcast.uuid },
+            ) { index, podcast ->
+                PodcastRow(
+                    podcast = podcast,
+                    isSelected = podcast.isAutoDownloadNewEpisodes,
+                    showDivider = index != podcasts.lastIndex,
+                    modifier = Modifier.toggleable(
+                        role = Role.Checkbox,
+                        value = podcast.isAutoDownloadNewEpisodes,
+                        onValueChange = { value -> onChangePodcast(podcast.uuid, value) },
+                    ),
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun PodcastRow(
+    podcast: Podcast,
+    isSelected: Boolean,
+    showDivider: Boolean,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier,
+    ) {
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp, vertical = 12.dp),
+        ) {
+            PodcastImage(
+                uuid = podcast.uuid,
+                imageSize = 56.dp,
+            )
+            Spacer(
+                modifier = Modifier.width(16.dp),
+            )
+            Column(
+                modifier = Modifier.weight(1f),
+            ) {
+                TextH40(
+                    text = podcast.title,
+                )
+                TextP50(
+                    text = podcast.author,
+                    color = MaterialTheme.theme.colors.primaryText02,
+                )
+            }
+            Spacer(
+                modifier = Modifier.width(16.dp),
+            )
+            Checkbox(
+                checked = isSelected,
+                onCheckedChange = null,
+            )
+        }
+        if (showDivider) {
+            HorizontalDivider(startIndent = 16.dp)
+        }
+    }
+}
+
+@PreviewRegularDevice
+@Composable
+private fun AutoDownloadSettingsPlaylistsPagePreview(
+    @PreviewParameter(ThemePreviewParameterProvider::class) themeType: ThemeType,
+) {
+    AppThemeWithBackground(themeType) {
+        AutoDownloadSettingsPodcastsPage(
+            podcasts = List(3) { index ->
+                Podcast(
+                    uuid = "podcast-uuid-$index",
+                    title = "Podcast $index",
+                    author = "Podcast author $index",
+                    autoDownloadStatus = if (index % 2 == 0) Podcast.AUTO_DOWNLOAD_OFF else Podcast.AUTO_DOWNLOAD_NEW_EPISODES,
+                )
+            },
+            onChangePodcast = { _, _ -> },
+            onChangeAllPodcasts = {},
+        )
+    }
+}

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/viewmodel/AutoDownloadSettingsViewModel.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/viewmodel/AutoDownloadSettingsViewModel.kt
@@ -7,6 +7,7 @@ import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.type.AutoDownloadLimitSetting
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.repositories.download.DownloadManager
+import au.com.shiftyjelly.pocketcasts.repositories.playlist.PlaylistPreview
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
 import dagger.hilt.android.lifecycle.HiltViewModel
 import io.reactivex.Single
@@ -78,7 +79,7 @@ class AutoDownloadSettingsViewModel @Inject constructor(
 
         analyticsTracker.track(
             AnalyticsEvent.SETTINGS_AUTO_DOWNLOAD_LIMIT_DOWNLOADS_CHANGED,
-            mapOf("value" to AutoDownloadLimitSetting.getNumberOfEpisodes(value)),
+            mapOf("value" to value.episodeCount),
         )
     }
 
@@ -124,6 +125,17 @@ class AutoDownloadSettingsViewModel @Inject constructor(
     fun countPodcasts(): Single<Int> = podcastManager.countSubscribedRxSingle()
         .observeOn(AndroidSchedulers.mainThread())
         .subscribeOn(Schedulers.io())
+
+    data class UiState(
+        val isUpNextDownloadEnabled: Boolean,
+        val isNewEpisodesDownloadEnabled: Boolean,
+        val isOnFollowDownloadEnabled: Boolean,
+        val autoDownloadLimit: AutoDownloadLimitSetting,
+        val isOnUnmeteredDownloadEnabled: Boolean,
+        val isOnlyWhenChargingDownloadEnabled: Boolean,
+        val podcasts: List<Podcast>,
+        val playlists: List<PlaylistPreview>,
+    )
 }
 
 fun Boolean.toAutoDownloadStatus(): Int = when (this) {

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -596,6 +596,11 @@
         <item quantity="one">%d podcast</item>
         <item quantity="other">%d podcasts</item>
     </plurals>
+    <string name="podcasts_selected_all">All podcasts selected</string>
+    <plurals name="podcasts_selected_count">
+        <item quantity="one">%1$d podcast selected</item>
+        <item quantity="other">%1$d podcasts selected</item>
+    </plurals>
     <string name="podcast_archive_all">Archive all</string>
     <string name="podcast_archive_all_played">Archive all played</string>
     <string name="podcast_archive_played">You should only do this if you don\'t want to see them anymore.</string>
@@ -1007,6 +1012,7 @@
     <string name="playlists_onboarding_playlist_title">Introducing Playlists</string>
     <string name="playlists_onboarding_smart_playlist_description">They still work exactly the same, using rules to auto-add your episodes. All your existing Filters are right here, nothing’s changed but the name.</string>
     <string name="playlists_onboarding_smart_playlist_title">Filters are now Smart Playlists</string>
+    <string name="playlists_selected_all">All playlists selected</string>
     <plurals name="playlists_selected_count">
         <item quantity="one">%1$d playlist selected</item>
         <item quantity="other">%1$d playlists selected</item>
@@ -1420,6 +1426,7 @@
     <string name="settings_auto_download_charging">Only when charging</string>
     <string name="settings_auto_download_clear_errors">Clear all download errors</string>
     <string name="settings_auto_download_clearing_errors">Clearing all download errors</string>
+    <string name="settings_auto_download_playlists">Auto download playlists</string>
     <string name="settings_auto_download_filters">Auto download filters</string>
     <string name="settings_auto_download_filters_episodes">All filter episodes</string>
     <string name="settings_auto_download_new_episodes">New episodes</string>
@@ -1430,6 +1437,7 @@
         <item quantity="other">Automatically download the latest %s episodes from new shows you follow.</item>
     </plurals>
 
+    <string name="number_one">one</string>
     <string name="number_two">two</string>
     <string name="number_three">three</string>
     <string name="number_five">five</string>
@@ -1463,6 +1471,7 @@
     <string name="settings_battery_learn_more_url" translatable="false">https://support.pocketcasts.com/article/playback-pausing-randomly-or-when-screen-is-locked/</string>
     <string name="settings_select_filters">Select filters</string>
     <string name="settings_choose_podcasts">Choose podcasts</string>
+    <string name="settings_choose_playlists">Choose playlists</string>
     <string name="settings_close_upgrade_offer">close upgrade offer</string>
     <string name="settings_customize_buttons_displayed_in_android_13_notification_and_android_auto">Customize the buttons displayed in Android 13+ playback notifications and Android Auto.</string>
     <string name="settings_developer">Developer</string>

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/type/AutoDownloadLimitSetting.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/type/AutoDownloadLimitSetting.kt
@@ -5,32 +5,43 @@ import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 enum class AutoDownloadLimitSetting(
     val id: Int,
+    val episodeCount: Int,
     @StringRes val titleRes: Int,
+    @StringRes val episodeCountRes: Int,
 ) {
     LATEST_EPISODE(
         id = 1,
+        episodeCount = 1,
         titleRes = LR.string.settings_auto_download_limit_latest_episode,
+        episodeCountRes = LR.string.number_one,
     ),
     TWO_LATEST_EPISODE(
         id = 2,
+        episodeCount = 2,
         titleRes = LR.string.settings_auto_download_limit_two_latest_episode,
+        episodeCountRes = LR.string.number_two,
     ),
     THREE_LATEST_EPISODE(
         id = 3,
+        episodeCount = 3,
         titleRes = LR.string.settings_auto_download_limit_three_latest_episode,
+        episodeCountRes = LR.string.number_three,
     ),
     FIVE_LATEST_EPISODE(
         id = 4,
+        episodeCount = 5,
         titleRes = LR.string.settings_auto_download_limit_five_latest_episode,
+        episodeCountRes = LR.string.number_five,
     ),
     TEN_LATEST_EPISODE(
         id = 5,
+        episodeCount = 10,
         titleRes = LR.string.settings_auto_download_limit_ten_latest_episode,
+        episodeCountRes = LR.string.number_ten,
     ),
     ;
 
     companion object {
-
         fun fromPreferenceString(stringValue: String): AutoDownloadLimitSetting? {
             return try {
                 val intValue = stringValue.toInt()
@@ -41,13 +52,5 @@ enum class AutoDownloadLimitSetting(
         }
 
         fun fromInt(id: Int) = (AutoDownloadLimitSetting.entries.firstOrNull { it.id == id })
-
-        fun getNumberOfEpisodes(setting: AutoDownloadLimitSetting): Int = when (setting) {
-            LATEST_EPISODE -> 1
-            TWO_LATEST_EPISODE -> 2
-            THREE_LATEST_EPISODE -> 3
-            FIVE_LATEST_EPISODE -> 5
-            TEN_LATEST_EPISODE -> 10
-        }
     }
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PodcastManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/PodcastManagerImpl.kt
@@ -666,7 +666,7 @@ class PodcastManagerImpl @Inject constructor(
             }
 
             val currentDownloadCount = podcastUuidToDownloadCount.getOrDefault(episode.podcastUuid, 0)
-            if (currentDownloadCount >= AutoDownloadLimitSetting.getNumberOfEpisodes(settings.autoDownloadLimit.value)) {
+            if (currentDownloadCount >= settings.autoDownloadLimit.value.episodeCount) {
                 continue // Skip to the next episode since it already downloaded the limit of episodes for this podcast
             }
 

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/SubscribeManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/SubscribeManager.kt
@@ -112,7 +112,7 @@ class SubscribeManager @Inject constructor(
                 if (canDownloadEpisodesAfterFollowPodcast(subscribed, shouldAutoDownload)) {
                     podcastDao.findByUuidBlocking(podcastUuid)?.let { podcast ->
                         val episodes = episodeManager.findEpisodesByPodcastOrderedByPublishDateBlocking(podcast)
-                        val numberOfEpisodes = AutoDownloadLimitSetting.getNumberOfEpisodes(settings.autoDownloadLimit.value)
+                        val numberOfEpisodes = settings.autoDownloadLimit.value.episodeCount
 
                         episodes.take(numberOfEpisodes).forEach { episode ->
                             if (episode.isQueued || episode.isDownloaded || episode.isDownloading || episode.isExemptFromAutoDownload) {


### PR DESCRIPTION
## Description

This adds UI I'll for the auto downloads management. I'm making this a separate PR as adding more logic would blow this PR out of proportions.

Relates to PCDROID-98

## Testing Instructions

Nothing to test as the code isn't connected to anything. Review should be enough.

## Screenshots or Screencast 

<img width="1346" height="1476" alt="SCR-20250924-ktuw" src="https://github.com/user-attachments/assets/dde081bb-1a82-4fa2-99dd-45271af3ae15" />

<img width="1237" height="1117" alt="SCR-20250924-kubt" src="https://github.com/user-attachments/assets/5e2744be-426d-44a9-8ddd-6ca4a8e60a9d" />

<img width="1582" height="1315" alt="SCR-20250924-ldue" src="https://github.com/user-attachments/assets/1542a163-a956-42e9-aafa-79209d07f8cc" />

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.