### PR TITLE
Use playlists nomenclature in the whole app

### DIFF
--- a/app/src/main/java/au/com/shiftyjelly/pocketcasts/PocketCastsApplication.kt
+++ b/app/src/main/java/au/com/shiftyjelly/pocketcasts/PocketCastsApplication.kt
@@ -23,6 +23,7 @@ import au.com.shiftyjelly.pocketcasts.repositories.notification.NotificationHelp
 import au.com.shiftyjelly.pocketcasts.repositories.notification.NotificationManager
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
 import au.com.shiftyjelly.pocketcasts.repositories.playback.SleepTimerRestartWhenShakingDevice
+import au.com.shiftyjelly.pocketcasts.repositories.playlist.PlaylistInteractionNotifier
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.SmartPlaylistManager
@@ -131,6 +132,8 @@ class PocketCastsApplication :
     @Inject lateinit var notificationManager: NotificationManager
 
     @Inject lateinit var shortcutsSynchronizer: DynamicShortcutsSynchronizer
+
+    @Inject lateinit var playlistInteractionNotifier: PlaylistInteractionNotifier
 
     override fun onCreate() {
         if (BuildConfig.DEBUG) {
@@ -277,6 +280,7 @@ class PocketCastsApplication :
         CuratedPodcastsSyncWorker.enqueuePeriodicWork(this)
         engageSdkBridge.registerIntegration()
         shortcutsSynchronizer.keepShortcutsInSync()
+        playlistInteractionNotifier.monitorPlaylistsInteraction()
 
         keepPlayerWidgetsUpdated()
 

--- a/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/status/StatusViewModel.kt
+++ b/modules/features/settings/src/main/java/au/com/shiftyjelly/pocketcasts/settings/status/StatusViewModel.kt
@@ -8,6 +8,8 @@ import androidx.lifecycle.viewModelScope
 import au.com.shiftyjelly.pocketcasts.repositories.support.Support
 import au.com.shiftyjelly.pocketcasts.settings.status.ServiceStatusChecker.Check.Internet
 import au.com.shiftyjelly.pocketcasts.settings.status.ServiceStatusChecker.Check.Urls
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
 import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
 import au.com.shiftyjelly.pocketcasts.views.helper.UiUtil
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -48,7 +50,11 @@ class StatusViewModel @Inject constructor(
         ),
         Service(
             title = LR.string.settings_status_service_account,
-            summary = LR.string.settings_status_service_account_summary,
+            summary = if (FeatureFlag.isEnabled(Feature.PLAYLISTS_REBRANDING, immutable = true)) {
+                LR.string.settings_status_service_account_summary_2
+            } else {
+                LR.string.settings_status_service_account_summary
+            },
             help = LR.string.settings_status_service_ad_blocker_help_singular,
             helpArgs = listOf("api.pocketcasts.com"),
             check = Urls(listOf("https://api.pocketcasts.com/health")),

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -1789,6 +1789,7 @@
     <string name="settings_status_service_refresh_summary">The service used to find new episodes.</string>
     <string name="settings_status_service_account">Account Service</string>
     <string name="settings_status_service_account_summary">The service used to store episode progress, podcasts you follow, filters, etc.</string>
+    <string name="settings_status_service_account_summary_2">The service used to store episode progress, podcasts you follow, playlists, etc.</string>
     <string name="settings_status_service_discover"><![CDATA[Discover & Search]]></string>
     <string name="settings_status_service_discover_summary">The discover section of the app, including podcast search.</string>
     <string name="settings_status_service_ad_blocker_help_singular">The most common cause is that you have an ad-blocker configured on your phone or network. You’ll need to unblock the domain %s</string>
@@ -2577,6 +2578,7 @@
     <string name="notification_up_next_message">Build a playback queue and say goodbye to jumping around between episodes.</string>
     <string name="notification_filters_title">Organize your episodes</string>
     <string name="notification_filters_message">Create smart filters to organize your episodes.</string>
+    <string name="notification_filters_message_2">Create playlists to organize your episodes.</string>
     <string name="notification_themes_title">Time for a new look</string>
     <string name="notification_themes_message">Browse our themes and find the one that suits your style.</string>
     <string name="notification_staff_picks_title">Explore our Staff Picks</string>

--- a/modules/services/repositories/src/main/AndroidManifest.xml
+++ b/modules/services/repositories/src/main/AndroidManifest.xml
@@ -16,7 +16,7 @@
             android:exported="false"
             tools:node="merge">
             <meta-data
-                android:name="au.com.shiftyjelly.pocketcasts.repositories.playlist.DefaultPlaylistsStartupInitializater"
+                android:name="au.com.shiftyjelly.pocketcasts.repositories.playlist.DefaultPlaylistsStartupInitializer"
                 android:value="androidx.startup" />
         </provider>
 

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/di/InitializerEntryPoint.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/di/InitializerEntryPoint.kt
@@ -1,7 +1,7 @@
 package au.com.shiftyjelly.pocketcasts.repositories.di
 
 import android.content.Context
-import au.com.shiftyjelly.pocketcasts.repositories.playlist.DefaultPlaylistsStartupInitializater
+import au.com.shiftyjelly.pocketcasts.repositories.playlist.DefaultPlaylistsStartupInitializer
 import dagger.hilt.EntryPoint
 import dagger.hilt.InstallIn
 import dagger.hilt.android.EntryPointAccessors
@@ -10,7 +10,7 @@ import dagger.hilt.components.SingletonComponent
 @EntryPoint
 @InstallIn(SingletonComponent::class)
 interface InitializerEntryPoint {
-    fun inject(initializer: DefaultPlaylistsStartupInitializater)
+    fun inject(initializer: DefaultPlaylistsStartupInitializer)
 }
 
 internal fun Context.initialzierEntryPoint() = EntryPointAccessors.fromApplication<InitializerEntryPoint>(this)

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/di/InitializerEntryPoint.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/di/InitializerEntryPoint.kt
@@ -13,4 +13,4 @@ interface InitializerEntryPoint {
     fun inject(initializer: DefaultPlaylistsStartupInitializer)
 }
 
-internal fun Context.initialzierEntryPoint() = EntryPointAccessors.fromApplication<InitializerEntryPoint>(this)
+internal fun Context.initializerEntryPoint() = EntryPointAccessors.fromApplication<InitializerEntryPoint>(this)

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/notification/NotificationType.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/notification/NotificationType.kt
@@ -17,6 +17,8 @@ import au.com.shiftyjelly.pocketcasts.deeplink.TrendingDeepLink
 import au.com.shiftyjelly.pocketcasts.deeplink.UpsellDeepLink
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.preferences.Settings.NotificationId
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.Feature
+import au.com.shiftyjelly.pocketcasts.utils.featureflag.FeatureFlag
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 sealed interface NotificationType {
@@ -62,9 +64,9 @@ sealed class OnboardingNotificationType(
     override val subcategory: String,
     override val analyticsType: String,
     @StringRes override val titleRes: Int,
-    @StringRes override val messageRes: Int,
     val dayOffset: Int,
 ) : NotificationType {
+    abstract override val messageRes: Int
 
     override fun isSettingsToggleOn(settings: Settings): Boolean {
         return settings.dailyRemindersNotification.value
@@ -76,10 +78,11 @@ sealed class OnboardingNotificationType(
         notificationId = NotificationId.ONBOARDING_SYNC.value,
         subcategory = SUBCATEGORY_SYNC,
         titleRes = LR.string.notification_sync_title,
-        messageRes = LR.string.notification_sync_message,
         dayOffset = 0,
         analyticsType = "onboardingSignUp",
     ) {
+        override val messageRes get() = LR.string.notification_sync_message
+
         override fun toIntent(context: Context) = CreateAccountDeepLink.toIntent(context)
     }
 
@@ -87,10 +90,11 @@ sealed class OnboardingNotificationType(
         notificationId = NotificationId.ONBOARDING_IMPORT.value,
         subcategory = SUBCATEGORY_IMPORT,
         titleRes = LR.string.notification_import_title,
-        messageRes = LR.string.notification_import_message,
         dayOffset = 1,
         analyticsType = "onboardingImport",
     ) {
+        override val messageRes get() = LR.string.notification_import_message
+
         override fun toIntent(context: Context) = ImportDeepLink.toIntent(context)
     }
 
@@ -98,10 +102,11 @@ sealed class OnboardingNotificationType(
         notificationId = NotificationId.ONBOARDING_UPNEXT.value,
         subcategory = SUBCATEGORY_UP_NEXT,
         titleRes = LR.string.notification_up_next_title,
-        messageRes = LR.string.notification_up_next_message,
         dayOffset = 2,
         analyticsType = "onboardingUpNext",
     ) {
+        override val messageRes get() = LR.string.notification_up_next_message
+
         override fun toIntent(context: Context) = ShowUpNextTabDeepLink.toIntent(context)
     }
 
@@ -109,10 +114,15 @@ sealed class OnboardingNotificationType(
         notificationId = NotificationId.ONBOARDING_FILTERS.value,
         subcategory = SUBCATEGORY_FILTERS,
         titleRes = LR.string.notification_filters_title,
-        messageRes = LR.string.notification_filters_message,
         dayOffset = 3,
         analyticsType = "onboardingFilters",
     ) {
+        override val messageRes get() = if (FeatureFlag.isEnabled(Feature.PLAYLISTS_REBRANDING, immutable = true)) {
+            LR.string.notification_filters_message_2
+        } else {
+            LR.string.notification_filters_message
+        }
+
         override fun toIntent(context: Context) = ShowFiltersDeepLink.toIntent(context)
     }
 
@@ -120,10 +130,11 @@ sealed class OnboardingNotificationType(
         notificationId = NotificationId.ONBOARDING_THEMES.value,
         subcategory = SUBCATEGORY_THEMES,
         titleRes = LR.string.notification_themes_title,
-        messageRes = LR.string.notification_themes_message,
         dayOffset = 4,
         analyticsType = "onboardingThemes",
     ) {
+        override val messageRes get() = LR.string.notification_themes_message
+
         override fun toIntent(context: Context) = ThemesDeepLink.toIntent(context)
     }
 
@@ -131,10 +142,11 @@ sealed class OnboardingNotificationType(
         notificationId = NotificationId.ONBOARDING_STAFF_PICKS.value,
         subcategory = SUBCATEGORY_STAFF_PICKS,
         titleRes = LR.string.notification_staff_picks_title,
-        messageRes = LR.string.notification_staff_picks_message,
         dayOffset = 5,
         analyticsType = "onboardingStaffPicks",
     ) {
+        override val messageRes get() = LR.string.notification_staff_picks_message
+
         override fun toIntent(context: Context) = StaffPicksDeepLink.toIntent(context)
     }
 
@@ -142,10 +154,11 @@ sealed class OnboardingNotificationType(
         notificationId = NotificationId.ONBOARDING_UPSELL.value,
         subcategory = SUBCATEGORY_PLUS_UP_SELL,
         titleRes = LR.string.notification_plus_upsell_title,
-        messageRes = LR.string.notification_plus_upsell_message,
         dayOffset = 6,
         analyticsType = "onboardingUpsell",
     ) {
+        override val messageRes get() = LR.string.notification_plus_upsell_message
+
         override fun toIntent(context: Context) = UpsellDeepLink.toIntent(context)
     }
 

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playlist/DefaultPlaylistsInitializer.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playlist/DefaultPlaylistsInitializer.kt
@@ -7,7 +7,7 @@ import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 
 @Singleton
-class DefaultPlaylistsInitializater @Inject constructor(
+class DefaultPlaylistsInitializer @Inject constructor(
     private val settings: Settings,
     private val playlistManager: PlaylistManager,
 ) {

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playlist/DefaultPlaylistsStartupInitializer.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playlist/DefaultPlaylistsStartupInitializer.kt
@@ -9,8 +9,8 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.launch
 
-class DefaultPlaylistsStartupInitializater : Initializer<Unit> {
-    @Inject lateinit var initializater: DefaultPlaylistsInitializater
+class DefaultPlaylistsStartupInitializer : Initializer<Unit> {
+    @Inject lateinit var initializer: DefaultPlaylistsInitializer
 
     @Inject @ApplicationScope
     lateinit var applicationScope: CoroutineScope
@@ -18,7 +18,7 @@ class DefaultPlaylistsStartupInitializater : Initializer<Unit> {
     override fun create(context: Context) {
         context.initialzierEntryPoint().inject(this)
         applicationScope.launch(NonCancellable) {
-            initializater.initialize()
+            initializer.initialize()
         }
     }
 

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playlist/DefaultPlaylistsStartupInitializer.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playlist/DefaultPlaylistsStartupInitializer.kt
@@ -3,7 +3,7 @@ package au.com.shiftyjelly.pocketcasts.repositories.playlist
 import android.content.Context
 import androidx.startup.Initializer
 import au.com.shiftyjelly.pocketcasts.repositories.di.ApplicationScope
-import au.com.shiftyjelly.pocketcasts.repositories.di.initialzierEntryPoint
+import au.com.shiftyjelly.pocketcasts.repositories.di.initializerEntryPoint
 import javax.inject.Inject
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.NonCancellable
@@ -16,7 +16,7 @@ class DefaultPlaylistsStartupInitializer : Initializer<Unit> {
     lateinit var applicationScope: CoroutineScope
 
     override fun create(context: Context) {
-        context.initialzierEntryPoint().inject(this)
+        context.initializerEntryPoint().inject(this)
         applicationScope.launch(NonCancellable) {
             initializer.initialize()
         }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playlist/Playlist.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playlist/Playlist.kt
@@ -56,6 +56,8 @@ sealed interface Playlist {
     companion object {
         const val NEW_RELEASES_UUID = "2797DCF8-1C93-4999-B52A-D1849736FA2C"
         const val IN_PROGRESS_UUID = "D89A925C-5CE1-41A4-A879-2751838CE5CE"
+
+        val PREDEFINED_UUIDS = setOf(NEW_RELEASES_UUID, IN_PROGRESS_UUID)
     }
 }
 

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playlist/PlaylistInteractionNotifier.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playlist/PlaylistInteractionNotifier.kt
@@ -1,0 +1,45 @@
+package au.com.shiftyjelly.pocketcasts.repositories.playlist
+
+import au.com.shiftyjelly.pocketcasts.models.db.dao.PlaylistDao
+import au.com.shiftyjelly.pocketcasts.models.entity.PlaylistEntity
+import au.com.shiftyjelly.pocketcasts.repositories.di.ApplicationScope
+import au.com.shiftyjelly.pocketcasts.repositories.notification.NotificationManager
+import au.com.shiftyjelly.pocketcasts.repositories.notification.OnboardingNotificationType
+import java.util.concurrent.atomic.AtomicBoolean
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.takeWhile
+import kotlinx.coroutines.launch
+
+@Singleton
+class PlaylistInteractionNotifier @Inject constructor(
+    @ApplicationScope private val scope: CoroutineScope,
+    private val playlistDao: PlaylistDao,
+    private val notificationManager: NotificationManager,
+) {
+    private val isMonitoring = AtomicBoolean()
+
+    fun monitorPlaylistsInteraction() {
+        if (!isMonitoring.getAndSet(true)) {
+            scope.launch {
+                if (notificationManager.hasUserInteractedWithFeature(OnboardingNotificationType.Filters)) {
+                    return@launch
+                }
+                awaitNewPlaylist()
+                notificationManager.updateUserFeatureInteraction(OnboardingNotificationType.Filters)
+            }
+        }
+    }
+
+    suspend fun awaitNewPlaylist() {
+        playlistDao.allPlaylistsFlow()
+            .takeWhile(::hasOnlyDefaultPlaylists)
+            .collect()
+    }
+
+    private fun hasOnlyDefaultPlaylists(playlists: List<PlaylistEntity>) = playlists.all { playlist ->
+        playlist.uuid in Playlist.PREDEFINED_UUIDS
+    }
+}

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/SmartPlaylistManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/SmartPlaylistManager.kt
@@ -33,7 +33,6 @@ interface SmartPlaylistManager {
     fun updateBlocking(playlist: PlaylistEntity, userPlaylistUpdate: UserPlaylistUpdate?, isCreatingFilter: Boolean = false)
 
     fun updateAutoDownloadStatus(playlist: PlaylistEntity, autoDownloadEnabled: Boolean)
-    fun updateAutoDownloadStatusRxCompletable(playlist: PlaylistEntity, autoDownloadEnabled: Boolean): Completable
 
     fun deleteBlocking(playlist: PlaylistEntity)
     suspend fun resetDb()

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/SmartPlaylistManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/SmartPlaylistManagerImpl.kt
@@ -1,6 +1,5 @@
 package au.com.shiftyjelly.pocketcasts.repositories.podcast
 
-import android.content.Context
 import au.com.shiftyjelly.pocketcasts.models.db.AppDatabase
 import au.com.shiftyjelly.pocketcasts.models.entity.PlaylistEntity
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
@@ -9,13 +8,11 @@ import au.com.shiftyjelly.pocketcasts.models.type.EpisodeStatusEnum
 import au.com.shiftyjelly.pocketcasts.models.type.PlaylistEpisodeSortType
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.repositories.di.ApplicationScope
-import au.com.shiftyjelly.pocketcasts.repositories.download.DownloadManager
 import au.com.shiftyjelly.pocketcasts.repositories.notification.NotificationManager
 import au.com.shiftyjelly.pocketcasts.repositories.notification.OnboardingNotificationType
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
-import au.com.shiftyjelly.pocketcasts.repositories.playlist.DefaultPlaylistsInitializater
+import au.com.shiftyjelly.pocketcasts.repositories.playlist.DefaultPlaylistsInitializer
 import au.com.shiftyjelly.pocketcasts.repositories.sync.SyncManager
-import dagger.hilt.android.qualifiers.ApplicationContext
 import io.reactivex.Completable
 import io.reactivex.Flowable
 import io.reactivex.Maybe
@@ -29,13 +26,11 @@ import timber.log.Timber
 
 class SmartPlaylistManagerImpl @Inject constructor(
     private val settings: Settings,
-    private val downloadManager: DownloadManager,
     private val playlistUpdateAnalytics: PlaylistUpdateAnalytics,
     private val syncManager: SyncManager,
     private val notificationManager: NotificationManager,
-    @ApplicationContext private val context: Context,
     appDatabase: AppDatabase,
-    private val playlistsInitializater: DefaultPlaylistsInitializater,
+    private val playlistsInitializer: DefaultPlaylistsInitializer,
     @ApplicationScope private val scope: CoroutineScope,
 ) : SmartPlaylistManager {
 
@@ -161,10 +156,6 @@ class SmartPlaylistManagerImpl @Inject constructor(
         playlist.autoDownload = autoDownloadEnabled
     }
 
-    override fun updateAutoDownloadStatusRxCompletable(playlist: PlaylistEntity, autoDownloadEnabled: Boolean): Completable {
-        return Completable.fromAction { updateAutoDownloadStatus(playlist, autoDownloadEnabled) }
-    }
-
     override fun createPlaylistBlocking(name: String, iconId: Int, draft: Boolean): PlaylistEntity {
         val playlist = PlaylistEntity(
             uuid = UUID.randomUUID().toString(),
@@ -203,7 +194,7 @@ class SmartPlaylistManagerImpl @Inject constructor(
 
     override suspend fun resetDb() {
         playlistDao.deleteAll()
-        playlistsInitializater.initialize(force = true)
+        playlistsInitializer.initialize(force = true)
     }
 
     override suspend fun deleteSynced(playlist: PlaylistEntity) {

--- a/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/SmartPlaylistManagerImplTest.kt
+++ b/modules/services/repositories/src/test/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/SmartPlaylistManagerImplTest.kt
@@ -1,11 +1,9 @@
 package au.com.shiftyjelly.pocketcasts.repositories.podcast
 
-import android.content.Context
 import au.com.shiftyjelly.pocketcasts.models.db.AppDatabase
 import au.com.shiftyjelly.pocketcasts.models.db.dao.SmartPlaylistDao
 import au.com.shiftyjelly.pocketcasts.models.entity.PlaylistEntity
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
-import au.com.shiftyjelly.pocketcasts.repositories.download.DownloadManager
 import au.com.shiftyjelly.pocketcasts.repositories.notification.NotificationManager
 import au.com.shiftyjelly.pocketcasts.repositories.notification.OnboardingNotificationType
 import au.com.shiftyjelly.pocketcasts.repositories.sync.SyncManager
@@ -26,11 +24,9 @@ class SmartPlaylistManagerImplTest {
     private val dispatcher = StandardTestDispatcher()
 
     private val settings: Settings = mock()
-    private val downloadManager: DownloadManager = mock()
     private val playlistUpdateAnalytics: PlaylistUpdateAnalytics = mock()
     private val syncManager: SyncManager = mock()
     private val notificationManager: NotificationManager = mock()
-    private val context: Context = mock()
     private val appDatabase: AppDatabase = mock()
     private val smartPlaylistDao: SmartPlaylistDao = mock()
 
@@ -71,13 +67,11 @@ class SmartPlaylistManagerImplTest {
 
         return SmartPlaylistManagerImpl(
             settings = settings,
-            downloadManager = downloadManager,
             playlistUpdateAnalytics = playlistUpdateAnalytics,
             syncManager = syncManager,
             notificationManager = notificationManager,
-            context = context,
             appDatabase = appDatabase,
-            playlistsInitializater = mock(),
+            playlistsInitializer = mock(),
             scope = CoroutineScope(dispatcher),
         )
     }


### PR DESCRIPTION
## Description

This is some minor cleanup and updates to text copies that do not use "playlists" wording.

Closes PCDROID-96

## Testing Instructions

Code review should be enough.

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.