### PR TITLE
Add user memebership

### DIFF
--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/repositories/playlist/PlaylistManagerDsl.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/repositories/playlist/PlaylistManagerDsl.kt
@@ -17,6 +17,7 @@ import au.com.shiftyjelly.pocketcasts.models.entity.PlaylistEntity
 import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.models.to.PlaylistEpisode
+import au.com.shiftyjelly.pocketcasts.models.type.Membership
 import au.com.shiftyjelly.pocketcasts.models.type.PlaylistEpisodeSortType
 import au.com.shiftyjelly.pocketcasts.models.type.PodcastsSortType
 import au.com.shiftyjelly.pocketcasts.models.type.SmartRules
@@ -143,11 +144,14 @@ class PlaylistManagerDsl : TestWatcher() {
     }
 
     fun setNoSubscription() {
-        settings.cachedSubscription.set(null, updateModifiedAt = false)
+        settings.cachedMembership.set(Membership.Empty, updateModifiedAt = false)
     }
 
     fun setPlusSubscription() {
-        settings.cachedSubscription.set(Subscription.PlusPreview, updateModifiedAt = false)
+        settings.cachedMembership.set(
+            Membership.Empty.copy(subscription = Subscription.PlusPreview),
+            updateModifiedAt = false,
+        )
     }
 
     fun cleanData() {

--- a/app/src/main/java/au/com/shiftyjelly/pocketcasts/PocketCastsApplication.kt
+++ b/app/src/main/java/au/com/shiftyjelly/pocketcasts/PocketCastsApplication.kt
@@ -45,6 +45,7 @@ import au.com.shiftyjelly.pocketcasts.widget.PlayerWidgetManager
 import coil.Coil
 import coil.ImageLoader
 import com.google.firebase.FirebaseApp
+import com.squareup.moshi.Moshi
 import dagger.hilt.android.HiltAndroidApp
 import java.io.File
 import java.util.concurrent.Executors
@@ -71,6 +72,8 @@ class PocketCastsApplication :
     Configuration.Provider {
 
     @Inject lateinit var appLifecycleObserver: AppLifecycleObserver
+
+    @Inject lateinit var moshi: Moshi
 
     @Inject lateinit var statsManager: StatsManager
 
@@ -251,8 +254,9 @@ class PocketCastsApplication :
                 }
 
                 VersionMigrationsWorker.performMigrations(
-                    settings = settings,
                     context = this@PocketCastsApplication,
+                    settings = settings,
+                    moshi = moshi,
                 )
 
                 // check that we have .nomedia files in existing folders

--- a/automotive/src/main/java/au/com/shiftyjelly/pocketcasts/AutomotiveApplication.kt
+++ b/automotive/src/main/java/au/com/shiftyjelly/pocketcasts/AutomotiveApplication.kt
@@ -27,6 +27,7 @@ import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
 import au.com.shiftyjelly.pocketcasts.utils.log.RxJavaUncaughtExceptionHandling
 import com.google.android.gms.common.ConnectionResult
 import com.google.android.gms.common.GoogleApiAvailability
+import com.squareup.moshi.Moshi
 import dagger.hilt.android.HiltAndroidApp
 import java.io.File
 import java.util.concurrent.Executors
@@ -42,6 +43,8 @@ import timber.log.Timber
 class AutomotiveApplication :
     Application(),
     Configuration.Provider {
+
+    @Inject lateinit var moshi: Moshi
 
     @Inject lateinit var podcastManager: PodcastManager
 
@@ -100,8 +103,9 @@ class AutomotiveApplication :
             }
 
             VersionMigrationsWorker.performMigrations(
-                settings = settings,
                 context = this@AutomotiveApplication,
+                settings = settings,
+                moshi = moshi,
             )
         }
 

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/OnboardingCreateAccountViewModel.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/OnboardingCreateAccountViewModel.kt
@@ -91,7 +91,7 @@ class OnboardingCreateAccountViewModel @Inject constructor(
             )
         }
 
-        subscriptionManager.clearCachedSubscription()
+        subscriptionManager.clearCachedMembership()
 
         viewModelScope.launch {
             val result = syncManager.createUserWithEmailAndPassword(

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/OnboardingLogInViewModel.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/OnboardingLogInViewModel.kt
@@ -93,7 +93,7 @@ class OnboardingLogInViewModel @Inject constructor(
             )
         }
 
-        subscriptionManager.clearCachedSubscription()
+        subscriptionManager.clearCachedMembership()
 
         viewModelScope.launch {
             val result = syncManager.loginWithEmailAndPassword(

--- a/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/SignInViewModel.kt
+++ b/modules/features/account/src/main/java/au/com/shiftyjelly/pocketcasts/account/viewmodel/SignInViewModel.kt
@@ -69,7 +69,7 @@ class SignInViewModel
         }
         signInState.postValue(SignInState.Loading)
 
-        subscriptionManager.clearCachedSubscription()
+        subscriptionManager.clearCachedMembership()
         viewModelScope.launch {
             val result = syncManager.loginWithEmailAndPassword(
                 email = emailString,

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/type/MembershipFeature.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/type/MembershipFeature.kt
@@ -27,14 +27,17 @@ data class Membership(
 @JsonClass(generateAdapter = false)
 enum class MembershipFeature {
     NoBannerAds,
+    NoDiscoverAds,
 }
 
 private fun SubscriptionTier.hasFeature(feature: MembershipFeature) = when (this) {
     SubscriptionTier.Plus -> when (feature) {
         MembershipFeature.NoBannerAds -> true
+        MembershipFeature.NoDiscoverAds -> true
     }
 
     SubscriptionTier.Patron -> when (feature) {
         MembershipFeature.NoBannerAds -> true
+        MembershipFeature.NoDiscoverAds -> true
     }
 }

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/type/MembershipFeature.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/type/MembershipFeature.kt
@@ -1,0 +1,40 @@
+package au.com.shiftyjelly.pocketcasts.models.type
+
+import au.com.shiftyjelly.pocketcasts.payment.SubscriptionTier
+import com.squareup.moshi.JsonClass
+import java.time.Instant
+
+@JsonClass(generateAdapter = true)
+data class Membership(
+    val subscription: Subscription?,
+    val createdAt: Instant?,
+    val features: List<MembershipFeature>,
+) {
+    fun hasFeature(feature: MembershipFeature): Boolean {
+        val isSubscriptionFeature = subscription?.tier?.hasFeature(feature) == true
+        return isSubscriptionFeature || feature in features
+    }
+
+    companion object {
+        val Empty = Membership(
+            subscription = null,
+            createdAt = null,
+            features = emptyList(),
+        )
+    }
+}
+
+@JsonClass(generateAdapter = false)
+enum class MembershipFeature {
+    NoBannerAds,
+}
+
+private fun SubscriptionTier.hasFeature(feature: MembershipFeature) = when (this) {
+    SubscriptionTier.Plus -> when (feature) {
+        MembershipFeature.NoBannerAds -> true
+    }
+
+    SubscriptionTier.Patron -> when (feature) {
+        MembershipFeature.NoBannerAds -> true
+    }
+}

--- a/modules/services/model/src/test/java/au/com/shiftyjelly/pocketcasts/models/type/MembershipTest.kt
+++ b/modules/services/model/src/test/java/au/com/shiftyjelly/pocketcasts/models/type/MembershipTest.kt
@@ -1,0 +1,82 @@
+package au.com.shiftyjelly.pocketcasts.models.type
+
+import au.com.shiftyjelly.pocketcasts.payment.BillingCycle
+import au.com.shiftyjelly.pocketcasts.payment.SubscriptionTier
+import java.time.Instant
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.experimental.runners.Enclosed
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
+
+@RunWith(Enclosed::class)
+class MembershipTest {
+    class NoSubscriptionWithFeatures {
+        @Test
+        fun `feature list is respected`() {
+            val membership = Membership(
+                subscription = null,
+                createdAt = null,
+                features = listOf(MembershipFeature.NoBannerAds),
+            )
+
+            assertTrue(membership.hasFeature(MembershipFeature.NoBannerAds))
+        }
+    }
+
+    @RunWith(Parameterized::class)
+    class TierPerFeature(
+        private val feature: MembershipFeature,
+        private val tier: SubscriptionTier?,
+    ) {
+        private val membership = Membership(
+            subscription = if (tier != null) {
+                Subscription(
+                    tier = tier,
+                    billingCycle = BillingCycle.Monthly,
+                    platform = SubscriptionPlatform.Android,
+                    expiryDate = Instant.MAX,
+                    isAutoRenewing = true,
+                    giftDays = 0,
+                )
+            } else {
+                null
+            },
+            createdAt = null,
+            features = emptyList(),
+        )
+
+        @Test
+        fun `feature availability per tier`() {
+            val hasFeature = membership.hasFeature(feature)
+
+            val expected = when (tier) {
+                SubscriptionTier.Plus -> when (feature) {
+                    MembershipFeature.NoBannerAds -> true
+                }
+
+                SubscriptionTier.Patron -> when (feature) {
+                    MembershipFeature.NoBannerAds -> true
+                }
+
+                null -> when (feature) {
+                    MembershipFeature.NoBannerAds -> false
+                }
+            }
+
+            assertEquals(expected, hasFeature)
+        }
+
+        companion object {
+            @JvmStatic
+            @Parameterized.Parameters(name = "Feature: {0}, Tier: {1}")
+            fun params() = MembershipFeature.entries.flatMap { feature ->
+                val tiers = (SubscriptionTier.entries + null)
+                tiers.map { tier ->
+                    arrayOf(feature, tier)
+                }
+            }
+        }
+    }
+}

--- a/modules/services/model/src/test/java/au/com/shiftyjelly/pocketcasts/models/type/MembershipTest.kt
+++ b/modules/services/model/src/test/java/au/com/shiftyjelly/pocketcasts/models/type/MembershipTest.kt
@@ -4,6 +4,7 @@ import au.com.shiftyjelly.pocketcasts.payment.BillingCycle
 import au.com.shiftyjelly.pocketcasts.payment.SubscriptionTier
 import java.time.Instant
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.experimental.runners.Enclosed
@@ -22,6 +23,7 @@ class MembershipTest {
             )
 
             assertTrue(membership.hasFeature(MembershipFeature.NoBannerAds))
+            assertFalse(membership.hasFeature(MembershipFeature.NoDiscoverAds))
         }
     }
 
@@ -54,14 +56,17 @@ class MembershipTest {
             val expected = when (tier) {
                 SubscriptionTier.Plus -> when (feature) {
                     MembershipFeature.NoBannerAds -> true
+                    MembershipFeature.NoDiscoverAds -> true
                 }
 
                 SubscriptionTier.Patron -> when (feature) {
                     MembershipFeature.NoBannerAds -> true
+                    MembershipFeature.NoDiscoverAds -> true
                 }
 
                 null -> when (feature) {
                     MembershipFeature.NoBannerAds -> false
+                    MembershipFeature.NoDiscoverAds -> false
                 }
             }
 

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/Settings.kt
@@ -9,6 +9,7 @@ import au.com.shiftyjelly.pocketcasts.models.to.PlaybackEffects
 import au.com.shiftyjelly.pocketcasts.models.to.PodcastGrouping
 import au.com.shiftyjelly.pocketcasts.models.to.RefreshState
 import au.com.shiftyjelly.pocketcasts.models.type.AutoDownloadLimitSetting
+import au.com.shiftyjelly.pocketcasts.models.type.Membership
 import au.com.shiftyjelly.pocketcasts.models.type.PodcastsSortType
 import au.com.shiftyjelly.pocketcasts.models.type.Subscription
 import au.com.shiftyjelly.pocketcasts.preferences.model.AppIconSetting
@@ -445,7 +446,8 @@ interface Settings {
     val cloudAutoUpload: UserSetting<Boolean>
     val cloudAutoDownload: UserSetting<Boolean>
     val cloudDownloadOnlyOnWifi: UserSetting<Boolean>
-    val cachedSubscription: UserSetting<Subscription?>
+    val cachedMembership: UserSetting<Membership>
+    val cachedSubscription: ReadSetting<Subscription?>
 
     val upgradeProfileClosed: UserSetting<Boolean>
     fun getUpgradeClosedAddFile(): Boolean

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/SettingsImpl.kt
@@ -13,8 +13,8 @@ import au.com.shiftyjelly.pocketcasts.models.to.PlaybackEffects
 import au.com.shiftyjelly.pocketcasts.models.to.PodcastGrouping
 import au.com.shiftyjelly.pocketcasts.models.to.RefreshState
 import au.com.shiftyjelly.pocketcasts.models.type.AutoDownloadLimitSetting
+import au.com.shiftyjelly.pocketcasts.models.type.Membership
 import au.com.shiftyjelly.pocketcasts.models.type.PodcastsSortType
-import au.com.shiftyjelly.pocketcasts.models.type.Subscription
 import au.com.shiftyjelly.pocketcasts.models.type.TrimMode
 import au.com.shiftyjelly.pocketcasts.preferences.Settings.Companion.DEFAULT_MAX_AUTO_ADD_LIMIT
 import au.com.shiftyjelly.pocketcasts.preferences.Settings.Companion.GLOBAL_AUTO_DOWNLOAD_NONE
@@ -1075,24 +1075,26 @@ class SettingsImpl @Inject constructor(
         sharedPrefs = sharedPreferences,
     )
 
-    private val subscriptionAdapter = moshi.adapter(Subscription::class.java)
+    private val membershipAdapter = moshi.adapter(Membership::class.java)
 
-    override val cachedSubscription = UserSetting.PrefFromString<Subscription?>(
-        sharedPrefKey = "user_subscription",
-        defaultValue = null,
+    override val cachedMembership = UserSetting.PrefFromString(
+        sharedPrefKey = "user_membership",
+        defaultValue = Membership.Empty,
         sharedPrefs = privatePreferences,
         fromString = { value ->
             value
                 .takeIf(String::isNotEmpty)
                 ?.let(::decrypt)
-                ?.let { decryptedValue -> runCatching { subscriptionAdapter.fromJson(decryptedValue) }.getOrNull() }
+                ?.let { decryptedValue -> runCatching { membershipAdapter.fromJson(decryptedValue) } }
+                ?.getOrNull()
+                ?: Membership.Empty
         },
-        toString = { value ->
-            value
-                ?.let(subscriptionAdapter::toJson)
-                ?.let(::encrypt)
-                .orEmpty()
-        },
+        toString = { value -> encrypt(membershipAdapter.toJson(value)) },
+    )
+
+    override val cachedSubscription = DelegatedSetting(
+        delegate = cachedMembership,
+        mapper = { membership -> membership.subscription },
     )
 
     override val headphoneControlsNextAction = HeadphoneActionUserSetting(

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/subscription/ServerPurchaseApprover.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/subscription/ServerPurchaseApprover.kt
@@ -7,7 +7,7 @@ import au.com.shiftyjelly.pocketcasts.payment.PurchaseApprover
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.repositories.sync.SyncManager
 import au.com.shiftyjelly.pocketcasts.servers.sync.SubscriptionPurchaseRequest
-import au.com.shiftyjelly.pocketcasts.servers.sync.toSubscription
+import au.com.shiftyjelly.pocketcasts.servers.sync.toMembership
 import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
 import javax.inject.Inject
 import kotlinx.coroutines.CancellationException
@@ -19,8 +19,8 @@ class ServerPurchaseApprover @Inject constructor(
     override suspend fun approve(purchase: Purchase): PaymentResult<Purchase> {
         return runCatching {
             val request = SubscriptionPurchaseRequest(purchase.token, purchase.productIds.first())
-            val subscription = syncManager.subscriptionPurchase(request).toSubscription()
-            settings.cachedSubscription.set(subscription, updateModifiedAt = false)
+            val membership = syncManager.subscriptionPurchase(request).toMembership()
+            settings.cachedMembership.set(membership, updateModifiedAt = false)
             PaymentResult.Success(purchase)
         }.getOrElse { error ->
             if (error is CancellationException) {

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/subscription/SubscriptionManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/subscription/SubscriptionManager.kt
@@ -5,5 +5,5 @@ import au.com.shiftyjelly.pocketcasts.models.type.Subscription
 interface SubscriptionManager {
     suspend fun fetchFreshSubscription(): Subscription?
 
-    fun clearCachedSubscription()
+    fun clearCachedMembership()
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/subscription/SubscriptionManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/subscription/SubscriptionManagerImpl.kt
@@ -1,10 +1,11 @@
 package au.com.shiftyjelly.pocketcasts.repositories.subscription
 
+import au.com.shiftyjelly.pocketcasts.models.type.Membership
 import au.com.shiftyjelly.pocketcasts.models.type.Subscription
 import au.com.shiftyjelly.pocketcasts.models.type.SubscriptionPlatform
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.repositories.sync.SyncManager
-import au.com.shiftyjelly.pocketcasts.servers.sync.toSubscription
+import au.com.shiftyjelly.pocketcasts.servers.sync.toMembership
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -14,16 +15,19 @@ class SubscriptionManagerImpl @Inject constructor(
     private val settings: Settings,
 ) : SubscriptionManager {
     override suspend fun fetchFreshSubscription(): Subscription? {
-        return runCatching { syncManager.subscriptionStatus().toSubscription() }
-            .onSuccess { subscription ->
-                settings.cachedSubscription.set(subscription, updateModifiedAt = false)
+        return runCatching { syncManager.subscriptionStatus().toMembership() }
+            .onSuccess { membership ->
+                val subscription = membership.subscription
+                settings.cachedMembership.set(membership, updateModifiedAt = false)
                 if (subscription != null && !subscription.isChampion && subscription.platform == SubscriptionPlatform.Gift) {
                     settings.setTrialFinishedSeen(false)
                 }
-            }.getOrNull()
+            }
+            .map { membership -> membership.subscription }
+            .getOrNull()
     }
 
-    override fun clearCachedSubscription() {
-        settings.cachedSubscription.set(null, updateModifiedAt = false)
+    override fun clearCachedMembership() {
+        settings.cachedMembership.set(Membership.Empty, updateModifiedAt = false)
     }
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/user/UserManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/user/UserManager.kt
@@ -17,7 +17,6 @@ import au.com.shiftyjelly.pocketcasts.repositories.notification.NotificationSche
 import au.com.shiftyjelly.pocketcasts.repositories.notification.TrendingAndRecommendationsNotificationType
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
 import au.com.shiftyjelly.pocketcasts.repositories.playback.UpNextQueue
-import au.com.shiftyjelly.pocketcasts.repositories.playlist.DefaultPlaylistsInitializater
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.FolderManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
@@ -132,7 +131,7 @@ class UserManagerImpl @Inject constructor(
     override fun signOut(playbackManager: PlaybackManager, wasInitiatedByUser: Boolean) {
         if (wasInitiatedByUser || !settings.getFullySignedOut()) {
             LogBuffer.i(LogBuffer.TAG_BACKGROUND_TASKS, "Signing out")
-            subscriptionManager.clearCachedSubscription()
+            subscriptionManager.clearCachedMembership()
             syncManager.signOut {
                 applicationScope.launch {
                     settings.clearPlusPreferences()

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/SubscriptionModel.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/SubscriptionModel.kt
@@ -1,5 +1,7 @@
 package au.com.shiftyjelly.pocketcasts.servers.sync
 
+import au.com.shiftyjelly.pocketcasts.models.type.Membership
+import au.com.shiftyjelly.pocketcasts.models.type.MembershipFeature
 import au.com.shiftyjelly.pocketcasts.models.type.Subscription
 import au.com.shiftyjelly.pocketcasts.models.type.SubscriptionPlatform
 import au.com.shiftyjelly.pocketcasts.payment.BillingCycle
@@ -21,6 +23,8 @@ data class SubscriptionStatusResponse(
     @Json(name = "type") val type: Int,
     @Json(name = "tier") val tier: String?,
     @Json(name = "index") val index: Int,
+    @Json(name = "createdAt") val createdAt: Instant?,
+    @Json(name = "features") val features: SubscriptionFeatures?,
 )
 
 @JsonClass(generateAdapter = true)
@@ -34,9 +38,20 @@ data class SubscriptionResponse(
     @Json(name = "giftDays") val giftDays: Int,
 )
 
-fun SubscriptionStatusResponse.toSubscription(): Subscription? {
+@JsonClass(generateAdapter = true)
+data class SubscriptionFeatures(
+    @Json(name = "removeBannerAds") val removeBannerAds: Boolean,
+)
+
+fun SubscriptionStatusResponse.toMembership(): Membership {
+    val membershipFeatures = features?.toMembershipFeatures().orEmpty()
+
     if (paid == 0) {
-        return null
+        return Membership(
+            subscription = null,
+            createdAt = createdAt,
+            features = membershipFeatures,
+        )
     }
 
     val subscriptionResponse = subscriptions?.getOrNull(index) ?: fallbackSubscription
@@ -44,31 +59,39 @@ fun SubscriptionStatusResponse.toSubscription(): Subscription? {
     // In these cases, the correct tier is only available at the top-level subscription status object.
     //
     // Therefore, we need to explicitly fall back to the top level object.
-    val tier = subscriptionResponse.tier
+    val rawTier = subscriptionResponse.tier
         ?.takeUnless(String::isNullOrBlank)
         ?: fallbackSubscription.tier
+    val tier = when (rawTier?.lowercase()) {
+        "plus" -> SubscriptionTier.Plus
+        "patron" -> SubscriptionTier.Patron
+        else -> null
+    }
+    val subscription = tier?.let {
+        Subscription(
+            tier = tier,
+            billingCycle = when (subscriptionResponse.frequency) {
+                1 -> BillingCycle.Monthly
+                2 -> BillingCycle.Yearly
+                else -> null
+            },
+            platform = when (subscriptionResponse.platform) {
+                1 -> SubscriptionPlatform.iOS
+                2 -> SubscriptionPlatform.Android
+                3 -> SubscriptionPlatform.Web
+                4 -> SubscriptionPlatform.Gift
+                else -> SubscriptionPlatform.Unknown
+            },
+            expiryDate = subscriptionResponse.expiryDate?.toInstant() ?: Instant.MAX,
+            isAutoRenewing = subscriptionResponse.autoRenewing,
+            giftDays = subscriptionResponse.giftDays,
+        )
+    }
 
-    return Subscription(
-        tier = when (tier?.lowercase()) {
-            "plus" -> SubscriptionTier.Plus
-            "patron" -> SubscriptionTier.Patron
-            else -> return null
-        },
-        billingCycle = when (subscriptionResponse.frequency) {
-            1 -> BillingCycle.Monthly
-            2 -> BillingCycle.Yearly
-            else -> null
-        },
-        platform = when (subscriptionResponse.platform) {
-            1 -> SubscriptionPlatform.iOS
-            2 -> SubscriptionPlatform.Android
-            3 -> SubscriptionPlatform.Web
-            4 -> SubscriptionPlatform.Gift
-            else -> SubscriptionPlatform.Unknown
-        },
-        expiryDate = subscriptionResponse.expiryDate?.toInstant() ?: Instant.MAX,
-        isAutoRenewing = subscriptionResponse.autoRenewing,
-        giftDays = subscriptionResponse.giftDays,
+    return Membership(
+        subscription = subscription,
+        createdAt = createdAt,
+        features = membershipFeatures,
     )
 }
 
@@ -82,3 +105,9 @@ private val SubscriptionStatusResponse.fallbackSubscription
         autoRenewing = autoRenewing,
         giftDays = giftDays,
     )
+
+private fun SubscriptionFeatures.toMembershipFeatures() = buildList {
+    if (removeBannerAds) {
+        add(MembershipFeature.NoBannerAds)
+    }
+}

--- a/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/SubscriptionModel.kt
+++ b/modules/services/servers/src/main/java/au/com/shiftyjelly/pocketcasts/servers/sync/SubscriptionModel.kt
@@ -41,6 +41,7 @@ data class SubscriptionResponse(
 @JsonClass(generateAdapter = true)
 data class SubscriptionFeatures(
     @Json(name = "removeBannerAds") val removeBannerAds: Boolean,
+    @Json(name = "removeDiscoverAds") val removeDiscoverAds: Boolean,
 )
 
 fun SubscriptionStatusResponse.toMembership(): Membership {
@@ -109,5 +110,8 @@ private val SubscriptionStatusResponse.fallbackSubscription
 private fun SubscriptionFeatures.toMembershipFeatures() = buildList {
     if (removeBannerAds) {
         add(MembershipFeature.NoBannerAds)
+    }
+    if (removeDiscoverAds) {
+        add(MembershipFeature.NoDiscoverAds)
     }
 }

--- a/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/extensions/Flow.kt
+++ b/modules/services/utils/src/main/java/au/com/shiftyjelly/pocketcasts/utils/extensions/Flow.kt
@@ -1,7 +1,9 @@
 package au.com.shiftyjelly.pocketcasts.utils.extensions
 
+import kotlinx.coroutines.ExperimentalForInheritanceCoroutinesApi
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.FlowCollector
+import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.combine as kotlinCombine
 
@@ -63,3 +65,38 @@ fun <T> Flow<T>.windowed(size: Int) = flow {
         }
     }
 }
+
+// Source: https://github.com/Kotlin/kotlinx.coroutines/issues/2631#issuecomment-2812699291
+@OptIn(ExperimentalForInheritanceCoroutinesApi::class)
+fun <T, R> StateFlow<T>.mapState(transform: (T) -> R): StateFlow<R> = object : StateFlow<R> {
+    override val replayCache: List<R> get() = listOf(value)
+
+    override suspend fun collect(collector: FlowCollector<R>): Nothing {
+        var lastEmittedValue: Any? = nullSurrogate
+        this@mapState.collect { newValue ->
+            val transformedValue = transform(newValue)
+            if (transformedValue != lastEmittedValue) {
+                lastEmittedValue = transformedValue
+                collector.emit(transformedValue)
+            }
+        }
+    }
+
+    private var lastUpstreamValue = this@mapState.value
+
+    override var value: R = transform(lastUpstreamValue)
+        private set
+        get() {
+            val currentUpstreamValue: T = this@mapState.value
+            if (currentUpstreamValue == lastUpstreamValue) {
+                return field
+            }
+
+            val newValue = transform(currentUpstreamValue)
+            field = newValue
+            lastUpstreamValue = currentUpstreamValue
+            return newValue
+        }
+}
+
+private val nullSurrogate = Any()

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/PocketCastsWearApplication.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/PocketCastsWearApplication.kt
@@ -24,6 +24,7 @@ import au.com.shiftyjelly.pocketcasts.utils.TimberDebugTree
 import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
 import au.com.shiftyjelly.pocketcasts.utils.log.RxJavaUncaughtExceptionHandling
 import com.google.firebase.FirebaseApp
+import com.squareup.moshi.Moshi
 import dagger.hilt.android.HiltAndroidApp
 import java.io.File
 import java.util.concurrent.Executors
@@ -37,6 +38,8 @@ import timber.log.Timber
 class PocketCastsWearApplication :
     Application(),
     Configuration.Provider {
+
+    @Inject lateinit var moshi: Moshi
 
     @Inject lateinit var appLifecycleObserver: AppLifecycleObserver
 
@@ -113,8 +116,9 @@ class PocketCastsWearApplication :
             }
 
             VersionMigrationsWorker.performMigrations(
-                settings = settings,
                 context = this@PocketCastsWearApplication,
+                settings = settings,
+                moshi = moshi,
             )
         }
 


### PR DESCRIPTION
## Description

This ads `Membership` type that has features from the backend attached to it. 

Closes PCDROID-173

## Testing Instructions

### Migration test

1. Install the app from the `release/7.98` branch.
2. Sign in with a Plus account.
3. Enabled airplane mode.
4. Install the app from this branch.
5. Open the app.
6. You should still see your subscription and no Plus incentives.

### Membership test

1. Install the staging `debug` app.
2. Start the app and do not sign in.
3. You should see banner ads.
4. Sign in with this user. p1758782139774569-slack-C08U02AG7C5
5. You should not see the ads.

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.