### PR TITLE
Add auto play to playlists

### DIFF
--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/PlaylistFragment.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/PlaylistFragment.kt
@@ -119,6 +119,11 @@ class PlaylistFragment :
         return binding.root
     }
 
+    override fun onResume() {
+        super.onResume()
+        viewModel.updateAutoPlaySource()
+    }
+
     private fun PlaylistFragmentBinding.setupContent() {
         val headerAdapter = createHeaderAdapter(this)
         val episodesAdapter = createEpisodesAdapter(this)

--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/PlaylistViewModel.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/PlaylistViewModel.kt
@@ -9,6 +9,7 @@ import au.com.shiftyjelly.pocketcasts.compose.text.SearchFieldState
 import au.com.shiftyjelly.pocketcasts.models.to.toPodcastEpisodes
 import au.com.shiftyjelly.pocketcasts.models.type.PlaylistEpisodeSortType
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
+import au.com.shiftyjelly.pocketcasts.preferences.model.AutoPlaySource
 import au.com.shiftyjelly.pocketcasts.repositories.download.DownloadManager
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
 import au.com.shiftyjelly.pocketcasts.repositories.playlist.Playlist
@@ -324,6 +325,10 @@ class PlaylistViewModel @AssistedInject constructor(
 
     fun trackShowArchivedCtaTapped() {
         analyticsTracker.track(AnalyticsEvent.FILTER_SHOW_ARCHIVED_CTA_EMPTY_TAPPED)
+    }
+
+    fun updateAutoPlaySource() {
+        settings.trackingAutoPlaySource.set(AutoPlaySource.fromId(playlistUuid), updateModifiedAt = false)
     }
 
     data class UiState(

--- a/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/model/AutoPlaySource.kt
+++ b/modules/services/preferences/src/main/java/au/com/shiftyjelly/pocketcasts/preferences/model/AutoPlaySource.kt
@@ -4,30 +4,36 @@ import java.util.UUID
 
 sealed interface AutoPlaySource {
     val id: String
-
-    // We can safely use the ID as server ID. Keeping it if need to make changes in the future.
-    val serverId: String get() = id
+    val analyticsValue: String
 
     data class PodcastOrFilter(
         val uuid: String,
     ) : AutoPlaySource {
         override val id get() = uuid
+
+        override val analyticsValue: String
+            get() = "podcast_or_filter_$uuid"
     }
 
     enum class Predefined(
         override val id: String,
+        override val analyticsValue: String,
     ) : AutoPlaySource {
         Downloads(
             id = "downloads",
+            analyticsValue = "downloads",
         ),
         Files(
             id = "files",
+            analyticsValue = "files",
         ),
         Starred(
             id = "starred",
+            analyticsValue = "starred",
         ),
         None(
             id = "",
+            analyticsValue = "none",
         ),
     }
 
@@ -37,7 +43,5 @@ sealed interface AutoPlaySource {
             .recover { Predefined.entries.find { it.id == id } }
             .getOrNull()
             ?: Predefined.None
-
-        fun fromServerId(id: String) = fromId(id)
     }
 }

--- a/modules/services/preferences/src/test/kotlin/au/com/shiftyjelly/pocketcasts/preferences/model/AutoPlaySourceTest.kt
+++ b/modules/services/preferences/src/test/kotlin/au/com/shiftyjelly/pocketcasts/preferences/model/AutoPlaySourceTest.kt
@@ -43,43 +43,4 @@ class AutoPlaySourceTest {
 
         assertEquals(AutoPlaySource.Predefined.Starred, source)
     }
-
-    @Test
-    fun `create PodcastOrFilter from uuid server ID`() {
-        val uuid = UUID.randomUUID().toString()
-
-        val source = AutoPlaySource.fromServerId(uuid)
-
-        assertEquals(AutoPlaySource.PodcastOrFilter(uuid), source)
-    }
-
-    @Test
-    fun `create None from malformed uuid server ID`() {
-        val malformedUuid = UUID.randomUUID().toString().replace("-", "")
-
-        val source = AutoPlaySource.fromServerId(malformedUuid)
-
-        assertEquals(AutoPlaySource.Predefined.None, source)
-    }
-
-    @Test
-    fun `create Files from server ID`() {
-        val source = AutoPlaySource.fromServerId("files")
-
-        assertEquals(AutoPlaySource.Predefined.Files, source)
-    }
-
-    @Test
-    fun `create Downloads from server ID`() {
-        val source = AutoPlaySource.fromServerId("downloads")
-
-        assertEquals(AutoPlaySource.Predefined.Downloads, source)
-    }
-
-    @Test
-    fun `create Starred from server ID`() {
-        val source = AutoPlaySource.fromServerId("starred")
-
-        assertEquals(AutoPlaySource.Predefined.Starred, source)
-    }
 }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/AutoPlaySelector.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/AutoPlaySelector.kt
@@ -1,0 +1,117 @@
+package au.com.shiftyjelly.pocketcasts.repositories.playback
+
+import android.content.Context
+import au.com.shiftyjelly.pocketcasts.models.entity.BaseEpisode
+import au.com.shiftyjelly.pocketcasts.models.entity.Podcast
+import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
+import au.com.shiftyjelly.pocketcasts.models.entity.UserEpisode
+import au.com.shiftyjelly.pocketcasts.models.to.PlaylistEpisode
+import au.com.shiftyjelly.pocketcasts.models.to.PodcastGrouping
+import au.com.shiftyjelly.pocketcasts.models.type.EpisodePlayingStatus
+import au.com.shiftyjelly.pocketcasts.models.type.EpisodeStatusEnum
+import au.com.shiftyjelly.pocketcasts.preferences.Settings
+import au.com.shiftyjelly.pocketcasts.preferences.model.AutoPlaySource
+import au.com.shiftyjelly.pocketcasts.repositories.file.CloudFilesManager
+import au.com.shiftyjelly.pocketcasts.repositories.playlist.PlaylistManager
+import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
+import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
+import dagger.hilt.android.qualifiers.ApplicationContext
+import javax.inject.Inject
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.reactive.awaitFirst
+import kotlinx.coroutines.withContext
+
+class AutoPlaySelector @Inject constructor(
+    @ApplicationContext private val context: Context,
+    private val settings: Settings,
+    private val podcastManager: PodcastManager,
+    private val episodeManager: EpisodeManager,
+    private val playlistManager: PlaylistManager,
+    private val cloudFilesManager: CloudFilesManager,
+) {
+    suspend fun selectNextEpisode(currentEpisodeUuid: String?): Pair<BaseEpisode, AutoPlaySource>? {
+        val source = settings.lastAutoPlaySource.value
+        val episodes = when (source) {
+            is AutoPlaySource.PodcastOrFilter -> {
+                val podcast = podcastManager.findPodcastByUuid(uuid = source.uuid)
+                if (podcast != null) {
+                    findPodcastEpisodes(podcast, currentEpisodeUuid)
+                } else {
+                    findPlaylistEpisodes(source.uuid)
+                }
+            }
+            AutoPlaySource.Predefined.Downloads -> findDownloadedEpisodes()
+            AutoPlaySource.Predefined.Files -> findUserEpisodes()
+            AutoPlaySource.Predefined.Starred -> findStarredEpisodes()
+            AutoPlaySource.Predefined.None -> emptyList()
+        }
+        val episode = if (currentEpisodeUuid == null) {
+            episodes.firstOrNull()
+        } else {
+            val currentEpisodeIndex = episodes.indexOfFirst { it.uuid == currentEpisodeUuid }
+            episodes.getOrNull(currentEpisodeIndex + 1) ?: episodes.firstOrNull()?.takeIf { it.uuid != currentEpisodeUuid }
+        }
+
+        return episode?.let { it to source }
+    }
+
+    private suspend fun findPodcastEpisodes(
+        podcast: Podcast,
+        currentEpisodeUuid: String?,
+    ): List<PodcastEpisode> {
+        val episodes = episodeManager
+            .findEpisodesByPodcastOrderedSuspend(podcast)
+            .filterNot(PodcastEpisode::isArchived)
+
+        return withContext(Dispatchers.Default) {
+            val modifiedEpisodes = when (podcast.grouping) {
+                PodcastGrouping.None, PodcastGrouping.Starred, PodcastGrouping.Season -> episodes
+
+                PodcastGrouping.Downloaded -> episodes.map { episode ->
+                    if (episode.uuid == currentEpisodeUuid) {
+                        episode.copy(episodeStatus = EpisodeStatusEnum.DOWNLOADED)
+                    } else {
+                        episode
+                    }
+                }
+
+                PodcastGrouping.Unplayed -> episodes.map { episode ->
+                    if (episode.uuid == currentEpisodeUuid) {
+                        episode.copy(playingStatus = EpisodePlayingStatus.NOT_PLAYED)
+                    } else {
+                        episode
+                    }
+                }
+            }
+
+            podcast.grouping
+                .formGroups(modifiedEpisodes, podcast, context.resources)
+                .flatten()
+        }
+    }
+
+    private suspend fun findPlaylistEpisodes(playlistUuid: String): List<PodcastEpisode> {
+        val smartPlaylist = playlistManager.smartPlaylistFlow(playlistUuid).first()
+        val playlist = smartPlaylist ?: playlistManager.manualPlaylistFlow(playlistUuid).first()
+
+        return withContext(Dispatchers.Default) {
+            playlist?.episodes
+                ?.mapNotNull(PlaylistEpisode::toPodcastEpisode)
+                ?.filterNot(PodcastEpisode::isArchived)
+                .orEmpty()
+        }
+    }
+
+    private suspend fun findDownloadedEpisodes(): List<PodcastEpisode> {
+        return episodeManager.findDownloadedEpisodesRxFlowable().awaitFirst()
+    }
+
+    private suspend fun findUserEpisodes(): List<UserEpisode> {
+        return cloudFilesManager.sortedCloudFiles.first()
+    }
+
+    private suspend fun findStarredEpisodes(): List<PodcastEpisode> {
+        return episodeManager.findStarredEpisodes()
+    }
+}


### PR DESCRIPTION
## Description

Current playlists interactions do not support auto play. This adds it.

## Testing Instructions

1. Have an empty queue.
2. Create a manual playlists.
3. Add episodes to it.
4. Play a single episode from it.
5. Fast forward to the end.
6. A next episode from the playlist should start playing.

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.