### PR TITLE
[Dependency Analysis] Add Missing Ignored Variants

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -26,4 +26,4 @@ org.gradle.caching=true
 org.gradle.configuration-cache=true
 
 # Dependency Analysis Plugin
-dependency.analysis.android.ignored.variants=release
+dependency.analysis.android.ignored.variants=release,prototype,debugProd


### PR DESCRIPTION
Closes: [AINFRA-1323](https://linear.app/a8c/issue/AINFRA-1323)

---

## Description
<!-- Please include a summary of what this PR is changing and why these changes are needed. -->

Although `release` was already defined as an ignored variant, `debugProd` and the newly added `prototype` (#4518) variants aren't yet. This change makes sure that only the `debug` variant is active for dependency analysis purposes, which also makes the `buildHealth` run faster without the need to analyze those extra variants.

FYI: And actually, the `prototype` variant is also causing failures on CI due the `google-services.json` file missing ([build](https://buildkite.com/automattic/pocket-casts-android/builds/13706/steps/canvas?sid=01998d9f-9241-46a9-a5f0-8794cfa3c193#01998d9f-9505-4af3-b073-97a42f709313/218-2067)). This change fixes that.

```

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':app:processPrototypeGoogleServices'.
> File google-services.json is missing.
   The Google Services Plugin cannot function without it.
   Searched locations: ...
```

---

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Tap on the Filters tab -->
<!-- 2. Tap on a filter -->
<!-- 3. etc. -->

1. Run `./gradlew buildHealth` and verify that everything works as expected.
2. Check the manually triggered [scheduled build](https://buildkite.com/automattic/pocket-casts-android/builds/13726/steps/canvas) and verify everything works as expected.

---

## Checklist `N/A`

#### I have tested any UI changes... `N/A`