### PR TITLE
Update Tasker to use playlists

### DIFF
--- a/modules/features/taskerplugin/src/main/AndroidManifest.xml
+++ b/modules/features/taskerplugin/src/main/AndroidManifest.xml
@@ -67,7 +67,7 @@
         </intent-filter>
     </activity>
     <activity
-        android:name=".queryUpNext.config.ActivityConfigQueryUpNext"
+        android:name=".queryupnext.config.ActivityConfigQueryUpNext"
         android:exported="true"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/pocket_casts_query_up_next_episodes">

--- a/modules/features/taskerplugin/src/main/java/au/com/shiftyjelly/pocketcasts/taskerplugin/addtoupnext/config/ActivityConfigAddToUpNext.kt
+++ b/modules/features/taskerplugin/src/main/java/au/com/shiftyjelly/pocketcasts/taskerplugin/addtoupnext/config/ActivityConfigAddToUpNext.kt
@@ -1,40 +1,10 @@
 package au.com.shiftyjelly.pocketcasts.taskerplugin.addtoupnext.config
 
 import androidx.activity.viewModels
-import androidx.compose.runtime.Composable
-import androidx.compose.ui.tooling.preview.Preview
-import au.com.shiftyjelly.pocketcasts.compose.AppTheme
-import au.com.shiftyjelly.pocketcasts.localization.R
 import au.com.shiftyjelly.pocketcasts.taskerplugin.base.ActivityConfigBase
-import au.com.shiftyjelly.pocketcasts.taskerplugin.base.ComposableTaskerInputFieldList
-import au.com.shiftyjelly.pocketcasts.taskerplugin.base.TaskerInputFieldState
-import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import dagger.hilt.android.AndroidEntryPoint
-import kotlinx.coroutines.flow.MutableStateFlow
-import au.com.shiftyjelly.pocketcasts.images.R as RD
 
 @AndroidEntryPoint
 class ActivityConfigAddToUpNext : ActivityConfigBase<ViewModelConfigAddToUpNext>() {
     override val viewModel: ViewModelConfigAddToUpNext by viewModels()
-}
-
-@Preview(showBackground = true)
-@Composable
-private fun ComposableConfigAddToUpNextPreview() {
-    AppTheme(Theme.ThemeType.CLASSIC_LIGHT) {
-        ComposableTaskerInputFieldList(
-            listOf(
-                TaskerInputFieldState.Content(
-                    MutableStateFlow("All About Android"),
-                    R.string.episode_ids,
-                    RD.drawable.ic_upnext,
-                    MutableStateFlow(true),
-                    {},
-                    listOf("%test"),
-                    MutableStateFlow(listOf("New Releases", "Up Next")),
-                ),
-            ),
-            onFinish = {},
-        )
-    }
 }

--- a/modules/features/taskerplugin/src/main/java/au/com/shiftyjelly/pocketcasts/taskerplugin/base/ComposableBase.kt
+++ b/modules/features/taskerplugin/src/main/java/au/com/shiftyjelly/pocketcasts/taskerplugin/base/ComposableBase.kt
@@ -5,8 +5,11 @@ import androidx.annotation.StringRes
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.imePadding
+import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.requiredSizeIn
+import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
@@ -195,7 +198,10 @@ fun ComposableTaskerInputFieldList(
     Box(
         modifier = modifier
             .padding(8.dp)
-            .fillMaxHeight(),
+            .fillMaxHeight()
+            .imePadding()
+            .statusBarsPadding()
+            .navigationBarsPadding(),
     ) {
         LazyColumn {
             fieldContents.forEach { content ->

--- a/modules/features/taskerplugin/src/main/java/au/com/shiftyjelly/pocketcasts/taskerplugin/base/Extensions.kt
+++ b/modules/features/taskerplugin/src/main/java/au/com/shiftyjelly/pocketcasts/taskerplugin/base/Extensions.kt
@@ -4,10 +4,13 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
+import au.com.shiftyjelly.pocketcasts.repositories.playlist.PlaylistManager
 import java.text.SimpleDateFormat
-import java.util.*
+import java.util.Date
+import kotlinx.coroutines.flow.first
 
 val String?.nullIfEmpty get() = if (isNullOrEmpty()) null else this
+
 fun <T> tryOrNull(handleError: ((Throwable) -> T?)? = null, block: () -> T?): T? = try {
     block()
 } catch (t: Throwable) {
@@ -25,4 +28,7 @@ val screenSize
     }
 
 val Date.formattedForTasker get() = SimpleDateFormat("yyyy-MM-dd HH:mm:ss").format(this)
+
 val String.formattedForTasker get() = replace(",", "")
+
+internal suspend fun PlaylistManager.findPlaylist(uuid: String) = smartPlaylistFlow(uuid).first() ?: manualPlaylistFlow(uuid).first()

--- a/modules/features/taskerplugin/src/main/java/au/com/shiftyjelly/pocketcasts/taskerplugin/base/hilt/HiltEntryPoints.kt
+++ b/modules/features/taskerplugin/src/main/java/au/com/shiftyjelly/pocketcasts/taskerplugin/base/hilt/HiltEntryPoints.kt
@@ -2,11 +2,10 @@ package au.com.shiftyjelly.pocketcasts.taskerplugin.base.hilt
 
 import android.content.Context
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
-import au.com.shiftyjelly.pocketcasts.repositories.download.DownloadManager
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
+import au.com.shiftyjelly.pocketcasts.repositories.playlist.PlaylistManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
-import au.com.shiftyjelly.pocketcasts.repositories.podcast.SmartPlaylistManager
 import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import dagger.hilt.EntryPoint
 import dagger.hilt.InstallIn
@@ -15,50 +14,18 @@ import dagger.hilt.components.SingletonComponent
 
 @InstallIn(SingletonComponent::class)
 @EntryPoint
-interface ThemeEntryPoint {
+interface TaskerEntryPoint {
     fun getTheme(): Theme
-}
-
-@InstallIn(SingletonComponent::class)
-@EntryPoint
-interface PlaybackManagerEntryPoint {
-    fun getPlaybackManager(): PlaybackManager
-}
-
-@InstallIn(SingletonComponent::class)
-@EntryPoint
-interface SmartPlaylistManagerEntryPoint {
-    fun getSmartPlaylistManager(): SmartPlaylistManager
-}
-
-@InstallIn(SingletonComponent::class)
-@EntryPoint
-interface EpisodeManagerEntryPoint {
-    fun getEpisodeManager(): EpisodeManager
-}
-
-@InstallIn(SingletonComponent::class)
-@EntryPoint
-interface SettingsEntryPoint {
     fun getSettings(): Settings
-}
-
-@InstallIn(SingletonComponent::class)
-@EntryPoint
-interface PodcastManagerEntryPoint {
+    fun getPlaybackManager(): PlaybackManager
     fun getPodcastManager(): PodcastManager
+    fun getEpisodeManager(): EpisodeManager
+    fun getPlaylistManager(): PlaylistManager
 }
 
-@InstallIn(SingletonComponent::class)
-@EntryPoint
-interface DownloadManagerEntryPoint {
-    fun getDownloadManager(): DownloadManager
-}
-
-val Context.appTheme get() = EntryPointAccessors.fromApplication(applicationContext, ThemeEntryPoint::class.java).getTheme()
-val Context.playbackManager get() = EntryPointAccessors.fromApplication(applicationContext, PlaybackManagerEntryPoint::class.java).getPlaybackManager()
-val Context.smartPlaylistManager get() = EntryPointAccessors.fromApplication(applicationContext, SmartPlaylistManagerEntryPoint::class.java).getSmartPlaylistManager()
-val Context.episodeManager get() = EntryPointAccessors.fromApplication(applicationContext, EpisodeManagerEntryPoint::class.java).getEpisodeManager()
-val Context.podcastManager get() = EntryPointAccessors.fromApplication(applicationContext, PodcastManagerEntryPoint::class.java).getPodcastManager()
-val Context.downloadManager get() = EntryPointAccessors.fromApplication(applicationContext, DownloadManagerEntryPoint::class.java).getDownloadManager()
-val Context.settings get() = EntryPointAccessors.fromApplication(applicationContext, SettingsEntryPoint::class.java).getSettings()
+val Context.appTheme get() = EntryPointAccessors.fromApplication(applicationContext, TaskerEntryPoint::class.java).getTheme()
+val Context.playbackManager get() = EntryPointAccessors.fromApplication(applicationContext, TaskerEntryPoint::class.java).getPlaybackManager()
+val Context.playlistManager get() = EntryPointAccessors.fromApplication(applicationContext, TaskerEntryPoint::class.java).getPlaylistManager()
+val Context.episodeManager get() = EntryPointAccessors.fromApplication(applicationContext, TaskerEntryPoint::class.java).getEpisodeManager()
+val Context.podcastManager get() = EntryPointAccessors.fromApplication(applicationContext, TaskerEntryPoint::class.java).getPodcastManager()
+val Context.settings get() = EntryPointAccessors.fromApplication(applicationContext, TaskerEntryPoint::class.java).getSettings()

--- a/modules/features/taskerplugin/src/main/java/au/com/shiftyjelly/pocketcasts/taskerplugin/controlplayback/config/ActivityConfigControlPlayback.kt
+++ b/modules/features/taskerplugin/src/main/java/au/com/shiftyjelly/pocketcasts/taskerplugin/controlplayback/config/ActivityConfigControlPlayback.kt
@@ -1,49 +1,10 @@
 package au.com.shiftyjelly.pocketcasts.taskerplugin.controlplayback.config
 
 import androidx.activity.viewModels
-import androidx.compose.runtime.Composable
-import androidx.compose.ui.tooling.preview.Preview
-import au.com.shiftyjelly.pocketcasts.compose.AppTheme
-import au.com.shiftyjelly.pocketcasts.localization.R
 import au.com.shiftyjelly.pocketcasts.taskerplugin.base.ActivityConfigBase
-import au.com.shiftyjelly.pocketcasts.taskerplugin.base.ComposableTaskerInputFieldList
-import au.com.shiftyjelly.pocketcasts.taskerplugin.base.TaskerInputFieldState
-import au.com.shiftyjelly.pocketcasts.taskerplugin.controlplayback.InputControlPlayback
-import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import dagger.hilt.android.AndroidEntryPoint
-import kotlinx.coroutines.flow.MutableStateFlow
-import au.com.shiftyjelly.pocketcasts.images.R as RD
 
 @AndroidEntryPoint
 class ActivityConfigControlPlayback : ActivityConfigBase<ViewModelConfigControlPlayback>() {
     override val viewModel: ViewModelConfigControlPlayback by viewModels()
-}
-
-@Preview(showBackground = true)
-@Composable
-private fun ComposableConfigControlPlaybackPreview() {
-    AppTheme(Theme.ThemeType.CLASSIC_LIGHT) {
-        ComposableTaskerInputFieldList(
-            listOf(
-                TaskerInputFieldState.Content(
-                    MutableStateFlow(InputControlPlayback.PlaybackCommand.SkipToTime.name),
-                    R.string.playback_command,
-                    RD.drawable.filter_play,
-                    MutableStateFlow(true),
-                    {},
-                    listOf("%test"),
-                    MutableStateFlow(InputControlPlayback.PlaybackCommand.values().toList()),
-                ),
-                TaskerInputFieldState.Content(
-                    MutableStateFlow("60"),
-                    R.string.time_to_skip_to_seconds,
-                    RD.drawable.filter_time,
-                    MutableStateFlow(true),
-                    {},
-                    listOf("%test"),
-                ),
-            ),
-            onFinish = {},
-        )
-    }
 }

--- a/modules/features/taskerplugin/src/main/java/au/com/shiftyjelly/pocketcasts/taskerplugin/playplaylist/ActionRunnerPlayPlaylist.kt
+++ b/modules/features/taskerplugin/src/main/java/au/com/shiftyjelly/pocketcasts/taskerplugin/playplaylist/ActionRunnerPlayPlaylist.kt
@@ -3,14 +3,17 @@ package au.com.shiftyjelly.pocketcasts.taskerplugin.playplaylist
 import android.content.Context
 import au.com.shiftyjelly.pocketcasts.analytics.SourceView
 import au.com.shiftyjelly.pocketcasts.localization.R
-import au.com.shiftyjelly.pocketcasts.taskerplugin.base.hilt.episodeManager
+import au.com.shiftyjelly.pocketcasts.models.to.PlaylistEpisode
+import au.com.shiftyjelly.pocketcasts.taskerplugin.base.findPlaylist
 import au.com.shiftyjelly.pocketcasts.taskerplugin.base.hilt.playbackManager
-import au.com.shiftyjelly.pocketcasts.taskerplugin.base.hilt.smartPlaylistManager
+import au.com.shiftyjelly.pocketcasts.taskerplugin.base.hilt.playlistManager
 import com.joaomgcd.taskerpluginlibrary.action.TaskerPluginRunnerActionNoOutput
 import com.joaomgcd.taskerpluginlibrary.input.TaskerInput
 import com.joaomgcd.taskerpluginlibrary.runner.TaskerPluginResult
 import com.joaomgcd.taskerpluginlibrary.runner.TaskerPluginResultError
 import com.joaomgcd.taskerpluginlibrary.runner.TaskerPluginResultSucess
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
 
 private const val ERROR_NO_TITLE_PROVIDED = 1
 private const val ERROR_PLAYLIST_NOT_FOUND = 2
@@ -21,16 +24,24 @@ class ActionRunnerPlayPlaylist : TaskerPluginRunnerActionNoOutput<InputPlayPlayl
     override fun run(context: Context, input: TaskerInput<InputPlayPlaylist>): TaskerPluginResult<Unit> {
         val title = input.regular.title ?: return TaskerPluginResultError(ERROR_NO_TITLE_PROVIDED, context.getString(R.string.must_provide_filter_name))
         val playbackManager = context.playbackManager
-        val playlistManager = context.smartPlaylistManager
-        val episodeManager = context.episodeManager
+        val playlistManager = context.playlistManager
+
+        val playlistPreviews = runBlocking { playlistManager.playlistPreviewsFlow().first() }
+        val playlistPreview = playlistPreviews.find { it.title.equals(title, ignoreCase = true) }
+        if (playlistPreview == null) {
+            return TaskerPluginResultError(ERROR_PLAYLIST_NOT_FOUND, context.getString(R.string.filter_x_not_found, title))
+        }
+        val playlist = runBlocking { playlistManager.findPlaylist(playlistPreview.uuid) }
+        if (playlist == null) {
+            return TaskerPluginResultError(ERROR_PLAYLIST_NOT_FOUND, context.getString(R.string.filter_x_not_found, title))
+        }
+
+        val episodes = playlist.episodes.mapNotNull(PlaylistEpisode::toPodcastEpisode)
+        if (episodes.isEmpty()) {
+            return TaskerPluginResultError(ERROR_PLAYLIST_NO_EPISODES, context.getString(R.string.no_episodes_in_filter_x, title))
+        }
 
         playbackManager.upNextQueue.removeAll()
-
-        val playlist = playlistManager.findFirstByTitleBlocking(title) ?: return TaskerPluginResultError(ERROR_PLAYLIST_NOT_FOUND, context.getString(R.string.filter_x_not_found, title))
-
-        val episodes = playlistManager.findEpisodesBlocking(playlist, episodeManager, playbackManager)
-        if (episodes.isEmpty()) return TaskerPluginResultError(ERROR_PLAYLIST_NO_EPISODES, context.getString(R.string.no_episodes_in_filter_x, title))
-
         playbackManager.playEpisodes(episodes, SourceView.TASKER)
         return TaskerPluginResultSucess()
     }

--- a/modules/features/taskerplugin/src/main/java/au/com/shiftyjelly/pocketcasts/taskerplugin/playplaylist/config/ActivityConfigPlayPlaylist.kt
+++ b/modules/features/taskerplugin/src/main/java/au/com/shiftyjelly/pocketcasts/taskerplugin/playplaylist/config/ActivityConfigPlayPlaylist.kt
@@ -1,40 +1,10 @@
 package au.com.shiftyjelly.pocketcasts.taskerplugin.playplaylist.config
 
 import androidx.activity.viewModels
-import androidx.compose.runtime.Composable
-import androidx.compose.ui.tooling.preview.Preview
-import au.com.shiftyjelly.pocketcasts.compose.AppTheme
-import au.com.shiftyjelly.pocketcasts.localization.R
 import au.com.shiftyjelly.pocketcasts.taskerplugin.base.ActivityConfigBase
-import au.com.shiftyjelly.pocketcasts.taskerplugin.base.ComposableTaskerInputFieldList
-import au.com.shiftyjelly.pocketcasts.taskerplugin.base.TaskerInputFieldState
-import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import dagger.hilt.android.AndroidEntryPoint
-import kotlinx.coroutines.flow.MutableStateFlow
-import au.com.shiftyjelly.pocketcasts.images.R as RD
 
 @AndroidEntryPoint
 class ActivityConfigPlayPlaylist : ActivityConfigBase<ViewModelConfigPlayPlaylist>() {
     override val viewModel: ViewModelConfigPlayPlaylist by viewModels()
-}
-
-@Preview(showBackground = true)
-@Composable
-private fun ComposableConfigPlayPlaylistPreview() {
-    AppTheme(Theme.ThemeType.CLASSIC_LIGHT) {
-        ComposableTaskerInputFieldList(
-            listOf(
-                TaskerInputFieldState.Content(
-                    MutableStateFlow("New Release"),
-                    R.string.filters_filter_name,
-                    RD.drawable.filter_bullet,
-                    MutableStateFlow(true),
-                    {},
-                    listOf("%test"),
-                    MutableStateFlow(listOf("New Releases", "Up Next")),
-                ),
-            ),
-            onFinish = {},
-        )
-    }
 }

--- a/modules/features/taskerplugin/src/main/java/au/com/shiftyjelly/pocketcasts/taskerplugin/playplaylist/config/ViewModelConfigPlayPlaylist.kt
+++ b/modules/features/taskerplugin/src/main/java/au/com/shiftyjelly/pocketcasts/taskerplugin/playplaylist/config/ViewModelConfigPlayPlaylist.kt
@@ -5,7 +5,7 @@ import androidx.annotation.DrawableRes
 import androidx.annotation.StringRes
 import au.com.shiftyjelly.pocketcasts.localization.R
 import au.com.shiftyjelly.pocketcasts.taskerplugin.base.ViewModelBase
-import au.com.shiftyjelly.pocketcasts.taskerplugin.base.hilt.smartPlaylistManager
+import au.com.shiftyjelly.pocketcasts.taskerplugin.base.hilt.playlistManager
 import au.com.shiftyjelly.pocketcasts.taskerplugin.playplaylist.ActionHelperPlayPlaylist
 import au.com.shiftyjelly.pocketcasts.taskerplugin.playplaylist.InputPlayPlaylist
 import com.joaomgcd.taskerpluginlibrary.config.TaskerPluginConfig
@@ -24,8 +24,8 @@ class ViewModelConfigPlayPlaylist @Inject constructor(
 
     private inner class InputField constructor(@StringRes labelResId: Int, @DrawableRes iconResId: Int, valueGetter: InputPlayPlaylist.() -> String?, valueSetter: InputPlayPlaylist.(String?) -> Unit) : InputFieldBase<String>(labelResId, iconResId, valueGetter, valueSetter) {
         override val askFor get() = true
-        override fun getPossibleValues(): Flow<List<String>>? {
-            return context.smartPlaylistManager.findAllFlow().map { playlist -> playlist.map { it.title } }
+        override fun getPossibleValues(): Flow<List<String>> {
+            return context.playlistManager.playlistPreviewsFlow().map { playlist -> playlist.map { it.title } }
         }
     }
 

--- a/modules/features/taskerplugin/src/main/java/au/com/shiftyjelly/pocketcasts/taskerplugin/queryfilterepisodes/ActionRunnerQueryFilterEpisodes.kt
+++ b/modules/features/taskerplugin/src/main/java/au/com/shiftyjelly/pocketcasts/taskerplugin/queryfilterepisodes/ActionRunnerQueryFilterEpisodes.kt
@@ -1,25 +1,33 @@
 package au.com.shiftyjelly.pocketcasts.taskerplugin.queryfilterepisodes
 
 import android.content.Context
+import au.com.shiftyjelly.pocketcasts.models.to.PlaylistEpisode
 import au.com.shiftyjelly.pocketcasts.taskerplugin.base.OutputQueryEpisodes
-import au.com.shiftyjelly.pocketcasts.taskerplugin.base.hilt.episodeManager
-import au.com.shiftyjelly.pocketcasts.taskerplugin.base.hilt.playbackManager
-import au.com.shiftyjelly.pocketcasts.taskerplugin.base.hilt.smartPlaylistManager
+import au.com.shiftyjelly.pocketcasts.taskerplugin.base.findPlaylist
+import au.com.shiftyjelly.pocketcasts.taskerplugin.base.hilt.playlistManager
 import au.com.shiftyjelly.pocketcasts.taskerplugin.base.nullIfEmpty
 import com.joaomgcd.taskerpluginlibrary.action.TaskerPluginRunnerAction
 import com.joaomgcd.taskerpluginlibrary.input.TaskerInput
 import com.joaomgcd.taskerpluginlibrary.runner.TaskerPluginResult
 import com.joaomgcd.taskerpluginlibrary.runner.TaskerPluginResultSucess
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
 
 class ActionRunnerQueryFilterEpisodes : TaskerPluginRunnerAction<InputQueryFilterEpisodes, Array<OutputQueryEpisodes>>() {
 
     override fun run(context: Context, input: TaskerInput<InputQueryFilterEpisodes>): TaskerPluginResult<Array<OutputQueryEpisodes>> {
-        val playlistManager = context.smartPlaylistManager
-        val titleOrId = input.regular.titleOrId.nullIfEmpty ?: return TaskerPluginResultSucess()
+        val playlistManager = context.playlistManager
+        val titleOrId = input.regular.titleOrId?.trim().nullIfEmpty ?: return TaskerPluginResultSucess()
 
-        val playlist = playlistManager.findAllBlocking().firstOrNull { it.title.lowercase().contains(titleOrId.trim().lowercase()) || it.uuid == titleOrId } ?: return TaskerPluginResultSucess(arrayOf())
-        val episodes = playlistManager.findEpisodesBlocking(playlist, context.episodeManager, context.playbackManager).take(50)
-        val output = episodes.map { OutputQueryEpisodes(it) }.toTypedArray()
+        val playlistPreviews = runBlocking { playlistManager.playlistPreviewsFlow().first() }
+        val playlistPreview = playlistPreviews.find { it.uuid.equals(titleOrId, ignoreCase = true) || it.title.contains(titleOrId, ignoreCase = true) } ?: return TaskerPluginResultSucess(arrayOf())
+        val playlist = runBlocking { playlistManager.findPlaylist(playlistPreview.uuid) } ?: return TaskerPluginResultSucess(arrayOf())
+
+        val output = playlist.episodes
+            .mapNotNull(PlaylistEpisode::toPodcastEpisode)
+            .take(50)
+            .map { OutputQueryEpisodes(it) }
+            .toTypedArray()
         return TaskerPluginResultSucess(output)
     }
 }

--- a/modules/features/taskerplugin/src/main/java/au/com/shiftyjelly/pocketcasts/taskerplugin/queryfilterepisodes/config/ActivityConfigQueryFilterEpisodes.kt
+++ b/modules/features/taskerplugin/src/main/java/au/com/shiftyjelly/pocketcasts/taskerplugin/queryfilterepisodes/config/ActivityConfigQueryFilterEpisodes.kt
@@ -1,40 +1,10 @@
 package au.com.shiftyjelly.pocketcasts.taskerplugin.queryfilterepisodes.config
 
 import androidx.activity.viewModels
-import androidx.compose.runtime.Composable
-import androidx.compose.ui.tooling.preview.Preview
-import au.com.shiftyjelly.pocketcasts.compose.AppTheme
-import au.com.shiftyjelly.pocketcasts.localization.R
 import au.com.shiftyjelly.pocketcasts.taskerplugin.base.ActivityConfigBase
-import au.com.shiftyjelly.pocketcasts.taskerplugin.base.ComposableTaskerInputFieldList
-import au.com.shiftyjelly.pocketcasts.taskerplugin.base.TaskerInputFieldState
-import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import dagger.hilt.android.AndroidEntryPoint
-import kotlinx.coroutines.flow.MutableStateFlow
-import au.com.shiftyjelly.pocketcasts.images.R as RD
 
 @AndroidEntryPoint
 class ActivityConfigQueryFilterEpisodes : ActivityConfigBase<ViewModelConfigQueryFilterEpisodes>() {
     override val viewModel: ViewModelConfigQueryFilterEpisodes by viewModels()
-}
-
-@Preview(showBackground = true)
-@Composable
-private fun ComposableConfigQueryFilterEpisodesPreview() {
-    AppTheme(Theme.ThemeType.CLASSIC_LIGHT) {
-        ComposableTaskerInputFieldList(
-            listOf(
-                TaskerInputFieldState.Content(
-                    MutableStateFlow("All About Android"),
-                    R.string.podcast_id_or_title,
-                    RD.drawable.auto_tab_podcasts,
-                    MutableStateFlow(true),
-                    {},
-                    listOf("%test"),
-                    MutableStateFlow(listOf("New Releases", "Up Next")),
-                ),
-            ),
-            onFinish = {},
-        )
-    }
 }

--- a/modules/features/taskerplugin/src/main/java/au/com/shiftyjelly/pocketcasts/taskerplugin/queryfilterepisodes/config/ViewModelConfigQueryFilterEpisodes.kt
+++ b/modules/features/taskerplugin/src/main/java/au/com/shiftyjelly/pocketcasts/taskerplugin/queryfilterepisodes/config/ViewModelConfigQueryFilterEpisodes.kt
@@ -6,7 +6,7 @@ import androidx.annotation.StringRes
 import au.com.shiftyjelly.pocketcasts.localization.R
 import au.com.shiftyjelly.pocketcasts.taskerplugin.base.OutputQueryEpisodes
 import au.com.shiftyjelly.pocketcasts.taskerplugin.base.ViewModelBase
-import au.com.shiftyjelly.pocketcasts.taskerplugin.base.hilt.smartPlaylistManager
+import au.com.shiftyjelly.pocketcasts.taskerplugin.base.hilt.playlistManager
 import au.com.shiftyjelly.pocketcasts.taskerplugin.queryfilterepisodes.ActionHelperQueryFilterEpisodes
 import au.com.shiftyjelly.pocketcasts.taskerplugin.queryfilterepisodes.InputQueryFilterEpisodes
 import com.joaomgcd.taskerpluginlibrary.config.TaskerPluginConfig
@@ -26,7 +26,7 @@ class ViewModelConfigQueryFilterEpisodes @Inject constructor(
     private inner class InputField constructor(@StringRes labelResId: Int, @DrawableRes iconResId: Int, valueGetter: InputQueryFilterEpisodes.() -> String?, valueSetter: InputQueryFilterEpisodes.(String?) -> Unit) : InputFieldBase<String>(labelResId, iconResId, valueGetter, valueSetter) {
         override val askFor get() = true
         override fun getPossibleValues(): Flow<List<String>> {
-            return context.smartPlaylistManager.findAllFlow().map { podcast -> podcast.map { it.title } }
+            return context.playlistManager.playlistPreviewsFlow().map { playlist -> playlist.map { it.title } }
         }
     }
 

--- a/modules/features/taskerplugin/src/main/java/au/com/shiftyjelly/pocketcasts/taskerplugin/queryfilters/ActionRunnerQueryFilters.kt
+++ b/modules/features/taskerplugin/src/main/java/au/com/shiftyjelly/pocketcasts/taskerplugin/queryfilters/ActionRunnerQueryFilters.kt
@@ -1,19 +1,20 @@
 package au.com.shiftyjelly.pocketcasts.taskerplugin.queryfilters
 
 import android.content.Context
-import au.com.shiftyjelly.pocketcasts.taskerplugin.base.hilt.smartPlaylistManager
+import au.com.shiftyjelly.pocketcasts.taskerplugin.base.hilt.playlistManager
 import com.joaomgcd.taskerpluginlibrary.action.TaskerPluginRunnerAction
 import com.joaomgcd.taskerpluginlibrary.input.TaskerInput
 import com.joaomgcd.taskerpluginlibrary.runner.TaskerPluginResult
 import com.joaomgcd.taskerpluginlibrary.runner.TaskerPluginResultSucess
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
 
 class ActionRunnerQueryFilters : TaskerPluginRunnerAction<InputQueryFilters, Array<OutputQueryFilters>>() {
 
     override fun run(context: Context, input: TaskerInput<InputQueryFilters>): TaskerPluginResult<Array<OutputQueryFilters>> {
-        val playlistManager = context.smartPlaylistManager
-        val output = playlistManager.findAllBlocking().map {
-            OutputQueryFilters(it.uuid, it.title)
-        }.toTypedArray()
+        val playlistManager = context.playlistManager
+        val playlists = runBlocking { playlistManager.playlistPreviewsFlow().first() }
+        val output = playlists.map { OutputQueryFilters(it.uuid, it.title) }.toTypedArray()
         return TaskerPluginResultSucess(output)
     }
 }

--- a/modules/features/taskerplugin/src/main/java/au/com/shiftyjelly/pocketcasts/taskerplugin/querypodcastepisodes/config/ActivityConfigQueryPodcastEpisodes.kt
+++ b/modules/features/taskerplugin/src/main/java/au/com/shiftyjelly/pocketcasts/taskerplugin/querypodcastepisodes/config/ActivityConfigQueryPodcastEpisodes.kt
@@ -1,40 +1,10 @@
 package au.com.shiftyjelly.pocketcasts.taskerplugin.querypodcastepisodes.config
 
 import androidx.activity.viewModels
-import androidx.compose.runtime.Composable
-import androidx.compose.ui.tooling.preview.Preview
-import au.com.shiftyjelly.pocketcasts.compose.AppTheme
-import au.com.shiftyjelly.pocketcasts.localization.R
 import au.com.shiftyjelly.pocketcasts.taskerplugin.base.ActivityConfigBase
-import au.com.shiftyjelly.pocketcasts.taskerplugin.base.ComposableTaskerInputFieldList
-import au.com.shiftyjelly.pocketcasts.taskerplugin.base.TaskerInputFieldState
-import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import dagger.hilt.android.AndroidEntryPoint
-import kotlinx.coroutines.flow.MutableStateFlow
-import au.com.shiftyjelly.pocketcasts.images.R as RD
 
 @AndroidEntryPoint
 class ActivityConfigQueryPodcastEpisodes : ActivityConfigBase<ViewModelConfigQueryPodcastEpisodes>() {
     override val viewModel: ViewModelConfigQueryPodcastEpisodes by viewModels()
-}
-
-@Preview(showBackground = true)
-@Composable
-private fun ComposableConfigQueryPodcastEpisodesPreview() {
-    AppTheme(Theme.ThemeType.CLASSIC_LIGHT) {
-        ComposableTaskerInputFieldList(
-            listOf(
-                TaskerInputFieldState.Content(
-                    MutableStateFlow("All About Android"),
-                    R.string.podcast_id_or_title,
-                    RD.drawable.auto_tab_podcasts,
-                    MutableStateFlow(true),
-                    {},
-                    listOf("%test"),
-                    MutableStateFlow(listOf("New Releases", "Up Next")),
-                ),
-            ),
-            onFinish = {},
-        )
-    }
 }

--- a/modules/features/taskerplugin/src/main/java/au/com/shiftyjelly/pocketcasts/taskerplugin/queryupnext/ActionHelperQueryUpNext.kt
+++ b/modules/features/taskerplugin/src/main/java/au/com/shiftyjelly/pocketcasts/taskerplugin/queryupnext/ActionHelperQueryUpNext.kt
@@ -1,4 +1,4 @@
-package au.com.shiftyjelly.pocketcasts.taskerplugin.queryUpNext
+package au.com.shiftyjelly.pocketcasts.taskerplugin.queryupnext
 
 import au.com.shiftyjelly.pocketcasts.taskerplugin.base.OutputQueryEpisodes
 import com.joaomgcd.taskerpluginlibrary.config.TaskerPluginConfig

--- a/modules/features/taskerplugin/src/main/java/au/com/shiftyjelly/pocketcasts/taskerplugin/queryupnext/ActionRunnerQueryUpNext.kt
+++ b/modules/features/taskerplugin/src/main/java/au/com/shiftyjelly/pocketcasts/taskerplugin/queryupnext/ActionRunnerQueryUpNext.kt
@@ -1,4 +1,4 @@
-package au.com.shiftyjelly.pocketcasts.taskerplugin.queryUpNext
+package au.com.shiftyjelly.pocketcasts.taskerplugin.queryupnext
 
 import android.content.Context
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode

--- a/modules/features/taskerplugin/src/main/java/au/com/shiftyjelly/pocketcasts/taskerplugin/queryupnext/InputQueryUpNext.kt
+++ b/modules/features/taskerplugin/src/main/java/au/com/shiftyjelly/pocketcasts/taskerplugin/queryupnext/InputQueryUpNext.kt
@@ -1,4 +1,4 @@
-package au.com.shiftyjelly.pocketcasts.taskerplugin.queryUpNext
+package au.com.shiftyjelly.pocketcasts.taskerplugin.queryupnext
 
 import com.joaomgcd.taskerpluginlibrary.input.TaskerInputRoot
 

--- a/modules/features/taskerplugin/src/main/java/au/com/shiftyjelly/pocketcasts/taskerplugin/queryupnext/config/ActivityConfigQueryUpNext.kt
+++ b/modules/features/taskerplugin/src/main/java/au/com/shiftyjelly/pocketcasts/taskerplugin/queryupnext/config/ActivityConfigQueryUpNext.kt
@@ -1,41 +1,11 @@
-package au.com.shiftyjelly.pocketcasts.taskerplugin.queryUpNext.config
+package au.com.shiftyjelly.pocketcasts.taskerplugin.queryupnext.config
 
 import androidx.activity.viewModels
-import androidx.compose.runtime.Composable
-import androidx.compose.ui.tooling.preview.Preview
-import au.com.shiftyjelly.pocketcasts.compose.AppTheme
-import au.com.shiftyjelly.pocketcasts.localization.R
 import au.com.shiftyjelly.pocketcasts.taskerplugin.base.ActivityConfigBase
-import au.com.shiftyjelly.pocketcasts.taskerplugin.base.ComposableTaskerInputFieldList
-import au.com.shiftyjelly.pocketcasts.taskerplugin.base.TaskerInputFieldState
-import au.com.shiftyjelly.pocketcasts.ui.theme.Theme
 import dagger.hilt.android.AndroidEntryPoint
-import kotlinx.coroutines.flow.MutableStateFlow
-import au.com.shiftyjelly.pocketcasts.images.R as RD
 
 @AndroidEntryPoint
 class ActivityConfigQueryUpNext : ActivityConfigBase<ViewModelConfigQueryUpNext>() {
     override val viewModel: ViewModelConfigQueryUpNext by viewModels()
     override val finishForTaskerRightAway get() = true
-}
-
-@Preview(showBackground = true)
-@Composable
-private fun ComposableConfigQueryUpNextPreview() {
-    AppTheme(Theme.ThemeType.CLASSIC_LIGHT) {
-        ComposableTaskerInputFieldList(
-            listOf(
-                TaskerInputFieldState.Content(
-                    MutableStateFlow("All About Android"),
-                    R.string.podcast_id_or_title,
-                    RD.drawable.auto_tab_podcasts,
-                    MutableStateFlow(true),
-                    {},
-                    listOf("%test"),
-                    MutableStateFlow(listOf("New Releases", "Up Next")),
-                ),
-            ),
-            onFinish = {},
-        )
-    }
 }

--- a/modules/features/taskerplugin/src/main/java/au/com/shiftyjelly/pocketcasts/taskerplugin/queryupnext/config/ViewModelConfigQueryUpNext.kt
+++ b/modules/features/taskerplugin/src/main/java/au/com/shiftyjelly/pocketcasts/taskerplugin/queryupnext/config/ViewModelConfigQueryUpNext.kt
@@ -1,10 +1,10 @@
-package au.com.shiftyjelly.pocketcasts.taskerplugin.queryUpNext.config
+package au.com.shiftyjelly.pocketcasts.taskerplugin.queryupnext.config
 
 import android.app.Application
 import au.com.shiftyjelly.pocketcasts.taskerplugin.base.OutputQueryEpisodes
 import au.com.shiftyjelly.pocketcasts.taskerplugin.base.ViewModelBase
-import au.com.shiftyjelly.pocketcasts.taskerplugin.queryUpNext.ActionHelperQueryUpNext
-import au.com.shiftyjelly.pocketcasts.taskerplugin.queryUpNext.InputQueryUpNext
+import au.com.shiftyjelly.pocketcasts.taskerplugin.queryupnext.ActionHelperQueryUpNext
+import au.com.shiftyjelly.pocketcasts.taskerplugin.queryupnext.InputQueryUpNext
 import com.joaomgcd.taskerpluginlibrary.config.TaskerPluginConfig
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -892,7 +892,7 @@
     <string name="filters_create_filter_by">FILTER BY</string>
     <string name="filters_create_filter_details">Filter details</string>
     <string name="filters_create_name">NAME</string>
-    <string name="filters_filter_name">Filter Name</string>
+    <string name="filters_filter_name">Playlist Name</string>
     <string name="filters_create_options">Filter options</string>
     <string name="filters_create_save_filter">Save filter</string>
     <string name="filters_create_select_criteria">Select your filter criteria using these buttons to create an up to date smart playlist of episodes.</string>
@@ -2302,9 +2302,9 @@
 
     <!--    Tasker Plugin-->
 
-    <string name="must_provide_filter_name">Must provide filter name</string>
-    <string name="filter_x_not_found">Filter %1$s not found</string>
-    <string name="no_episodes_in_filter_x">No episodes in Filter %1$s</string>
+    <string name="must_provide_filter_name">Must provide playlist name</string>
+    <string name="filter_x_not_found">Playlist %1$s not found</string>
+    <string name="no_episodes_in_filter_x">No episodes in Playlist %1$s</string>
     <string name="must_provide_command_name">Must provide command name</string>
     <string name="command_x_not_valid">Command %1$s not valid</string>
     <string name="playback_command">Playback Command</string>
@@ -2321,13 +2321,13 @@
     <string name="time_to_skip_to_not_valid">Time to skip to %1$s not valid</string>
     <string name="time_to_skip_not_valid">Time to skip %1$s not valid</string>
     <string name="playback_speed_not_valid">Playback Speed %1$s not valid</string>
-    <string name="pocket_casts_play_filter">Pocket Casts Play Filter</string>
+    <string name="pocket_casts_play_filter">Pocket Casts Play Playlist</string>
     <string name="pocket_casts_control_playback">Pocket Casts Control Playback</string>
     <string name="pocket_casts_query_podcasts">Pocket Casts Query Podcasts</string>
     <string name="pocket_casts_query_podcast_episodes">Pocket Casts Query Podcast Episodes</string>
     <string name="pocket_casts_add_to_up_next">Pocket Casts Add To Up Next</string>
-    <string name="pocket_casts_query_filters">Pocket Casts Query Filters</string>
-    <string name="pocket_casts_query_filter_episodes">Pocket Casts Query Filter Episodes</string>
+    <string name="pocket_casts_query_filters">Pocket Casts Query Playlists</string>
+    <string name="pocket_casts_query_filter_episodes">Pocket Casts Query Playlist Episodes</string>
     <string name="pocket_casts_query_up_next_episodes">Pocket Casts Query Up Next Episodes</string>
     <string name="set_playback_speed">Set Playback Speed</string>
     <string name="playback_speed_between_values">Playback Speed (between 0.5 and 3)</string>
@@ -2368,10 +2368,10 @@
     <string name="no_episode_ids_provided">No episode IDs provided</string>
     <string name="no_episodes_found_for_episode_ids_x">No episodes found for episode IDs %1$s</string>
     <string name="episode_count">Episode Count</string>
-    <string name="filter_id">Filter ID</string>
-    <string name="filter_id_description">An unique ID that represents the filter. Can be used on the \'Query Filter Episodes\' action.</string>
-    <string name="filter_title">Filter Title</string>
-    <string name="filter_id_or_title">Filter ID or Title</string>
+    <string name="filter_id">Playlist ID</string>
+    <string name="filter_id_description">An unique ID that represents the playlist. Can be used on the \'Query Playlist Episodes\' action.</string>
+    <string name="filter_title">Playlist Title</string>
+    <string name="filter_id_or_title">Playlist ID or Title</string>
     <string name="error_opening_links_activity_not_found">Looks like you don\'t have an app capable of viewing this content.</string>
 
     <!-- Wear -->


### PR DESCRIPTION
## Description

This updates Tasker integration to use `PlaylistManager` instead of `SmartPlaylistManager`. I didn't do text copies switching based on the feature flag value. I don't think there's much value in doing this for a 3rd party integration and we develop playlists in the open anyway.

I removed a lot of Compose previews since they didn't showcase anything really and were showing Tasker's UI.

## Testing Instructions

If you don't have Tasker you can expense it. If you have Tasker check if the integrations old Filter integrations still work, and if the nomenclature uses Playlists instead of Filters.

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.