### PR TITLE
Clean up legacy filters logic

### DIFF
--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/repositories/playlist/PlaylistManagerSmartTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/repositories/playlist/PlaylistManagerSmartTest.kt
@@ -12,7 +12,6 @@ import au.com.shiftyjelly.pocketcasts.models.entity.PlaylistEntity.Companion.LAS
 import au.com.shiftyjelly.pocketcasts.models.entity.PlaylistEntity.Companion.LAST_MONTH
 import au.com.shiftyjelly.pocketcasts.models.entity.PlaylistEntity.Companion.LAST_WEEK
 import au.com.shiftyjelly.pocketcasts.models.entity.PlaylistEntity.Companion.SYNC_STATUS_NOT_SYNCED
-import au.com.shiftyjelly.pocketcasts.models.entity.PlaylistEntity.Companion.SYNC_STATUS_SYNCED
 import au.com.shiftyjelly.pocketcasts.models.to.PlaylistEpisode
 import au.com.shiftyjelly.pocketcasts.models.type.EpisodePlayingStatus
 import au.com.shiftyjelly.pocketcasts.models.type.PlaylistEpisodeSortType
@@ -198,7 +197,7 @@ class PlaylistManagerSmartTest {
                     filterHours = LAST_2_WEEKS,
                     iconId = 10,
                     sortPosition = 0,
-                    syncStatus = SYNC_STATUS_SYNCED,
+                    syncStatus = SYNC_STATUS_NOT_SYNCED,
                 )
             },
         )
@@ -219,7 +218,7 @@ class PlaylistManagerSmartTest {
                     finished = false,
                     iconId = 23,
                     sortPosition = 0,
-                    syncStatus = SYNC_STATUS_SYNCED,
+                    syncStatus = SYNC_STATUS_NOT_SYNCED,
                 )
             },
         )

--- a/app/src/main/java/au/com/shiftyjelly/pocketcasts/PocketCastsApplication.kt
+++ b/app/src/main/java/au/com/shiftyjelly/pocketcasts/PocketCastsApplication.kt
@@ -26,7 +26,6 @@ import au.com.shiftyjelly.pocketcasts.repositories.playback.SleepTimerRestartWhe
 import au.com.shiftyjelly.pocketcasts.repositories.playlist.PlaylistInteractionNotifier
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
-import au.com.shiftyjelly.pocketcasts.repositories.podcast.SmartPlaylistManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.UserEpisodeManager
 import au.com.shiftyjelly.pocketcasts.repositories.shortcuts.DynamicShortcutsSynchronizer
 import au.com.shiftyjelly.pocketcasts.repositories.support.DatabaseExportHelper
@@ -85,8 +84,6 @@ class PocketCastsApplication :
     @Inject lateinit var settings: Settings
 
     @Inject lateinit var fileStorage: FileStorage
-
-    @Inject lateinit var smartPlaylistManager: SmartPlaylistManager
 
     @Inject lateinit var playbackManager: PlaybackManager
 
@@ -206,7 +203,7 @@ class PocketCastsApplication :
 
             withContext(Dispatchers.Default) {
                 playbackManager.setup()
-                downloadManager.setup(episodeManager, podcastManager, smartPlaylistManager, playbackManager)
+                downloadManager.setup(episodeManager, podcastManager, playbackManager)
 
                 val isRestoreFromBackup = settings.isRestoreFromBackup()
                 // as this may be a different device clear the storage location on a restore

--- a/automotive/src/main/java/au/com/shiftyjelly/pocketcasts/AutomotiveApplication.kt
+++ b/automotive/src/main/java/au/com/shiftyjelly/pocketcasts/AutomotiveApplication.kt
@@ -17,10 +17,8 @@ import au.com.shiftyjelly.pocketcasts.repositories.jobs.VersionMigrationsWorker
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
-import au.com.shiftyjelly.pocketcasts.repositories.podcast.SmartPlaylistManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.UserEpisodeManager
 import au.com.shiftyjelly.pocketcasts.repositories.refresh.RefreshPodcastsTask
-import au.com.shiftyjelly.pocketcasts.repositories.sync.SyncManager
 import au.com.shiftyjelly.pocketcasts.repositories.user.UserManager
 import au.com.shiftyjelly.pocketcasts.utils.TimberDebugTree
 import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
@@ -50,8 +48,6 @@ class AutomotiveApplication :
 
     @Inject lateinit var episodeManager: EpisodeManager
 
-    @Inject lateinit var smartPlaylistManager: SmartPlaylistManager
-
     @Inject lateinit var playbackManager: PlaybackManager
 
     @Inject lateinit var downloadManager: DownloadManager
@@ -69,8 +65,6 @@ class AutomotiveApplication :
     @Inject lateinit var analyticsTracker: AnalyticsTracker
 
     @Inject lateinit var experimentProvider: ExperimentProvider
-
-    @Inject lateinit var syncManager: SyncManager
 
     @Inject @ApplicationScope
     lateinit var applicationScope: CoroutineScope
@@ -98,7 +92,7 @@ class AutomotiveApplication :
         runBlocking {
             withContext(Dispatchers.Default) {
                 playbackManager.setup()
-                downloadManager.setup(episodeManager, podcastManager, smartPlaylistManager, playbackManager)
+                downloadManager.setup(episodeManager, podcastManager, playbackManager)
                 RefreshPodcastsTask.runNow(this@AutomotiveApplication, applicationScope)
             }
 

--- a/automotive/src/main/java/au/com/shiftyjelly/pocketcasts/AutomotiveSettingsFragment.kt
+++ b/automotive/src/main/java/au/com/shiftyjelly/pocketcasts/AutomotiveSettingsFragment.kt
@@ -31,7 +31,6 @@ import au.com.shiftyjelly.pocketcasts.repositories.playback.UpNextQueue
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.FolderManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
-import au.com.shiftyjelly.pocketcasts.repositories.podcast.SmartPlaylistManager
 import au.com.shiftyjelly.pocketcasts.repositories.searchhistory.SearchHistoryManager
 import au.com.shiftyjelly.pocketcasts.repositories.sync.SyncManager
 import au.com.shiftyjelly.pocketcasts.repositories.user.UserManager
@@ -64,9 +63,6 @@ class AutomotiveSettingsFragment : BaseFragment() {
 
     @Inject
     lateinit var folderManager: FolderManager
-
-    @Inject
-    lateinit var smartPlaylistManager: SmartPlaylistManager
 
     @Inject
     lateinit var searchHistoryManager: SearchHistoryManager
@@ -172,7 +168,6 @@ class AutomotiveSettingsFragment : BaseFragment() {
                     userManager.signOutAndClearData(
                         playbackManager = playbackManager,
                         upNextQueue = upNextQueue,
-                        smartPlaylistManager = smartPlaylistManager,
                         folderManager = folderManager,
                         searchHistoryManager = searchHistoryManager,
                         episodeManager = episodeManager,

--- a/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/AccountDetailsFragment.kt
+++ b/modules/features/profile/src/main/java/au/com/shiftyjelly/pocketcasts/profile/AccountDetailsFragment.kt
@@ -30,7 +30,6 @@ import au.com.shiftyjelly.pocketcasts.repositories.playback.UpNextQueue
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.FolderManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
-import au.com.shiftyjelly.pocketcasts.repositories.podcast.SmartPlaylistManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.UserEpisodeManager
 import au.com.shiftyjelly.pocketcasts.repositories.searchhistory.SearchHistoryManager
 import au.com.shiftyjelly.pocketcasts.repositories.sync.SyncManager
@@ -67,8 +66,6 @@ class AccountDetailsFragment : BaseFragment() {
     @Inject lateinit var episodeManager: EpisodeManager
 
     @Inject lateinit var folderManager: FolderManager
-
-    @Inject lateinit var smartPlaylistManager: SmartPlaylistManager
 
     @Inject lateinit var playbackManager: PlaybackManager
 
@@ -269,7 +266,6 @@ class AccountDetailsFragment : BaseFragment() {
         userManager.signOutAndClearData(
             playbackManager = playbackManager,
             upNextQueue = upNextQueue,
-            smartPlaylistManager = smartPlaylistManager,
             folderManager = folderManager,
             searchHistoryManager = searchHistoryManager,
             episodeManager = episodeManager,

--- a/modules/services/localization/src/main/res/values/strings.xml
+++ b/modules/services/localization/src/main/res/values/strings.xml
@@ -936,7 +936,7 @@
     <string name="filters_time_anytime">Any time</string>
     <string name="filters_time_month">Last month</string>
     <string name="filters_time_week">Last week</string>
-    <string name="filters_title_in_progress" translatable="false">@string/in_progress</string>
+    <string name="filters_title_in_progress" translatable="false">@string/in_progress_uppercase</string>
     <string name="filters_title_new_releases">New Releases</string>
     <string name="filters_title_starred" translatable="false">@string/starred</string>
     <string name="filters_warning_delete_button" translatable="false">@string/filters_options_delete</string>

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/PlaylistDao.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/PlaylistDao.kt
@@ -177,6 +177,9 @@ abstract class PlaylistDao {
     @Query("DELETE FROM playlists WHERE deleted = 1")
     abstract suspend fun deleteMarkedPlaylists()
 
+    @Query("DELETE FROM playlists")
+    abstract suspend fun deleteAllPlaylists()
+
     @Query("DELETE FROM playlists WHERE uuid IN (:uuids)")
     protected abstract suspend fun deleteAllPlaylistsInUnsafe(uuids: Collection<String>)
 

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/download/DownloadManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/download/DownloadManager.kt
@@ -7,8 +7,6 @@ import au.com.shiftyjelly.pocketcasts.models.entity.BaseEpisode
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
-import au.com.shiftyjelly.pocketcasts.repositories.podcast.SmartPlaylistManager
-import io.reactivex.subjects.Subject
 import kotlinx.coroutines.flow.Flow
 
 interface DownloadManager {
@@ -20,7 +18,7 @@ interface DownloadManager {
 
     fun episodeDownloadProgressFlow(episodeUuid: String): Flow<DownloadProgressUpdate>
 
-    fun setup(episodeManager: EpisodeManager, podcastManager: PodcastManager, smartPlaylistManager: SmartPlaylistManager, playbackManager: PlaybackManager)
+    fun setup(episodeManager: EpisodeManager, podcastManager: PodcastManager, playbackManager: PlaybackManager)
     fun beginMonitoringWorkManager(context: Context)
     fun hasPendingOrRunningDownloads(): Boolean
     fun addEpisodeToQueue(episode: BaseEpisode, from: String, fireEvent: Boolean, source: SourceView)

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/download/DownloadManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/download/DownloadManagerImpl.kt
@@ -36,7 +36,6 @@ import au.com.shiftyjelly.pocketcasts.repositories.notification.NotificationOpen
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
-import au.com.shiftyjelly.pocketcasts.repositories.podcast.SmartPlaylistManager
 import au.com.shiftyjelly.pocketcasts.repositories.refresh.RefreshPodcastsThread
 import au.com.shiftyjelly.pocketcasts.utils.AppPlatform
 import au.com.shiftyjelly.pocketcasts.utils.Network
@@ -56,7 +55,6 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.mapNotNull
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
@@ -89,7 +87,6 @@ class DownloadManagerImpl @Inject constructor(
     private var notificationBuilder: NotificationCompat.Builder? = null
     private lateinit var podcastManager: PodcastManager
     private lateinit var episodeManager: EpisodeManager
-    private lateinit var smartPlaylistManager: SmartPlaylistManager
     private lateinit var playbackManager: PlaybackManager
 
     private val pendingQueue = HashMap<String, DownloadingInfo>()
@@ -114,10 +111,9 @@ class DownloadManagerImpl @Inject constructor(
 
     private var sourceView: SourceView = SourceView.UNKNOWN
 
-    override fun setup(episodeManager: EpisodeManager, podcastManager: PodcastManager, smartPlaylistManager: SmartPlaylistManager, playbackManager: PlaybackManager) {
+    override fun setup(episodeManager: EpisodeManager, podcastManager: PodcastManager, playbackManager: PlaybackManager) {
         this.episodeManager = episodeManager
         this.podcastManager = podcastManager
-        this.smartPlaylistManager = smartPlaylistManager
         this.playbackManager = playbackManager
 
         launch {

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playback/PlaybackManager.kt
@@ -48,10 +48,10 @@ import au.com.shiftyjelly.pocketcasts.repositories.notification.NotificationOpen
 import au.com.shiftyjelly.pocketcasts.repositories.notification.OnboardingNotificationType
 import au.com.shiftyjelly.pocketcasts.repositories.playback.LocalPlayer.Companion.VOLUME_DUCK
 import au.com.shiftyjelly.pocketcasts.repositories.playback.LocalPlayer.Companion.VOLUME_NORMAL
+import au.com.shiftyjelly.pocketcasts.repositories.playlist.PlaylistManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.ChapterManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
-import au.com.shiftyjelly.pocketcasts.repositories.podcast.SmartPlaylistManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.UserEpisodeManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.toServerPostFile
 import au.com.shiftyjelly.pocketcasts.repositories.shownotes.ShowNotesManager
@@ -121,7 +121,7 @@ open class PlaybackManager @Inject constructor(
     private val playerManager: PlayerFactory,
     private var castManager: CastManager,
     @ApplicationContext private val application: Context,
-    private val smartPlaylistManager: SmartPlaylistManager,
+    private val playlistManager: PlaylistManager,
     private val downloadManager: DownloadManager,
     val upNextQueue: UpNextQueue,
     private val notificationHelper: NotificationHelper,
@@ -213,7 +213,7 @@ open class PlaybackManager @Inject constructor(
         playbackManager = this,
         podcastManager = podcastManager,
         episodeManager = episodeManager,
-        smartPlaylistManager = smartPlaylistManager,
+        playlistManager = playlistManager,
         settings = settings,
         context = application,
         episodeAnalytics = episodeAnalytics,

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playlist/DefaultPlaylistsInitializer.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playlist/DefaultPlaylistsInitializer.kt
@@ -1,22 +1,30 @@
 package au.com.shiftyjelly.pocketcasts.repositories.playlist
 
+import android.content.Context
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
+import dagger.hilt.android.qualifiers.ApplicationContext
 import javax.inject.Inject
 import javax.inject.Singleton
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
+import au.com.shiftyjelly.pocketcasts.localization.R as LR
 
 @Singleton
 class DefaultPlaylistsInitializer @Inject constructor(
     private val settings: Settings,
     private val playlistManager: PlaylistManager,
+    @ApplicationContext private val context: Context,
 ) {
     private val mutex = Mutex()
 
     suspend fun initialize(force: Boolean = false) = mutex.withLock {
         if (force || !settings.getBooleanForKey(CREATED_DEFAULT_PLAYLISTS_KEY, false)) {
-            playlistManager.createSmartPlaylist(SmartPlaylistDraft.InProgress)
-            playlistManager.createSmartPlaylist(SmartPlaylistDraft.NewReleases)
+            val inProgressUuid = playlistManager.createSmartPlaylist(SmartPlaylistDraft.InProgress)
+            playlistManager.updateName(inProgressUuid, context.getString(LR.string.filters_title_in_progress))
+
+            val newReleasesUuid = playlistManager.createSmartPlaylist(SmartPlaylistDraft.NewReleases)
+            playlistManager.updateName(newReleasesUuid, context.getString(LR.string.filters_title_new_releases))
+
             settings.setBooleanForKey(CREATED_DEFAULT_PLAYLISTS_KEY, true)
         }
     }

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playlist/PlaylistManagerImpl.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/playlist/PlaylistManagerImpl.kt
@@ -16,7 +16,6 @@ import au.com.shiftyjelly.pocketcasts.models.entity.PlaylistEntity.Companion.LAS
 import au.com.shiftyjelly.pocketcasts.models.entity.PlaylistEntity.Companion.LAST_MONTH
 import au.com.shiftyjelly.pocketcasts.models.entity.PlaylistEntity.Companion.LAST_WEEK
 import au.com.shiftyjelly.pocketcasts.models.entity.PlaylistEntity.Companion.SYNC_STATUS_NOT_SYNCED
-import au.com.shiftyjelly.pocketcasts.models.entity.PlaylistEntity.Companion.SYNC_STATUS_SYNCED
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.models.to.PlaylistEpisode
 import au.com.shiftyjelly.pocketcasts.models.to.PlaylistEpisodeMetadata
@@ -547,12 +546,7 @@ private fun SmartPlaylistDraft.toPlaylistEntity() = PlaylistEntity(
     manual = false,
     draft = false,
     deleted = false,
-    // We use referential equality so only predefined playlists are synced by default
-    syncStatus = if (this === SmartPlaylistDraft.NewReleases || this === SmartPlaylistDraft.InProgress) {
-        SYNC_STATUS_SYNCED
-    } else {
-        SYNC_STATUS_NOT_SYNCED
-    },
+    syncStatus = SYNC_STATUS_NOT_SYNCED,
 ).applySmartRules(rules)
 
 private fun PlaylistEntity.applySmartRules(rules: SmartRules) = copy(

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/support/Support.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/support/Support.kt
@@ -25,8 +25,6 @@ import au.com.shiftyjelly.pocketcasts.repositories.playback.UpNextQueue
 import au.com.shiftyjelly.pocketcasts.repositories.playlist.PlaylistManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
-import au.com.shiftyjelly.pocketcasts.repositories.podcast.SmartPlaylistManager
-import au.com.shiftyjelly.pocketcasts.repositories.subscription.SubscriptionManager
 import au.com.shiftyjelly.pocketcasts.repositories.sync.SyncManager
 import au.com.shiftyjelly.pocketcasts.utils.FileUtil
 import au.com.shiftyjelly.pocketcasts.utils.Network

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/PocketCastsWearApplication.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/PocketCastsWearApplication.kt
@@ -15,8 +15,6 @@ import au.com.shiftyjelly.pocketcasts.repositories.notification.NotificationHelp
 import au.com.shiftyjelly.pocketcasts.repositories.playback.PlaybackManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.EpisodeManager
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
-import au.com.shiftyjelly.pocketcasts.repositories.podcast.SmartPlaylistManager
-import au.com.shiftyjelly.pocketcasts.repositories.sync.SyncManager
 import au.com.shiftyjelly.pocketcasts.repositories.user.UserManager
 import au.com.shiftyjelly.pocketcasts.shared.AppLifecycleObserver
 import au.com.shiftyjelly.pocketcasts.shared.DownloadStatisticsReporter
@@ -51,11 +49,7 @@ class PocketCastsWearApplication :
 
     @Inject lateinit var playbackManager: PlaybackManager
 
-    @Inject lateinit var smartPlaylistManager: SmartPlaylistManager
-
     @Inject lateinit var podcastManager: PodcastManager
-
-    @Inject lateinit var syncManager: SyncManager
 
     @Inject lateinit var settings: Settings
 
@@ -100,7 +94,7 @@ class PocketCastsWearApplication :
 
             withContext(Dispatchers.Default) {
                 playbackManager.setup()
-                downloadManager.setup(episodeManager, podcastManager, smartPlaylistManager, playbackManager)
+                downloadManager.setup(episodeManager, podcastManager, playbackManager)
 
                 val storageChoice = settings.getStorageChoice()
                 if (storageChoice == null) {


### PR DESCRIPTION
## Description

This removes usage of old playlist manager in some of the places to make the future transition when we remove playlists feature flag smoother. I also adjusted a couple of things:

1. Defaults playlists titles are now localized.
2. Default playlists are now marked as not synced.

## Testing Instructions

1. Change device's language to some other one supported by our app.
2. Install the app.
3. Open it.
4. Go to playlists.
5. The titles should be localized.

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.