### PR TITLE
Enable stored passwords on WearOS to sign in with

### DIFF
--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/authentication/LoginWithGoogleViewModel.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/authentication/LoginWithGoogleViewModel.kt
@@ -5,6 +5,8 @@ import android.content.Context
 import androidx.credentials.CredentialManager
 import androidx.credentials.CustomCredential
 import androidx.credentials.GetCredentialRequest
+import androidx.credentials.GetPasswordOption
+import androidx.credentials.PasswordCredential
 import androidx.credentials.exceptions.NoCredentialException
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
@@ -17,7 +19,6 @@ import au.com.shiftyjelly.pocketcasts.utils.extensions.isGooglePlayServicesAvail
 import au.com.shiftyjelly.pocketcasts.utils.log.LogBuffer
 import com.google.android.gms.common.GoogleApiAvailability
 import com.google.android.libraries.identity.googleid.GetGoogleIdOption
-import com.google.android.libraries.identity.googleid.GetSignInWithGoogleOption
 import com.google.android.libraries.identity.googleid.GoogleIdTokenCredential
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
@@ -69,28 +70,43 @@ class LoginWithGoogleViewModel @Inject constructor(
 
                     val request: GetCredentialRequest = GetCredentialRequest.Builder()
                         .addCredentialOption(googleIdOption)
+                        .addCredentialOption(GetPasswordOption())
                         .build()
 
                     val result = credentialManager.getCredential(
                         request = request,
                         context = activity,
                     )
-                    val credential = result.credential as CustomCredential
-                    if (credential.type == GoogleIdTokenCredential.TYPE_GOOGLE_ID_TOKEN_CREDENTIAL) {
-                        val googleIdTokenCredential = GoogleIdTokenCredential
-                            .createFrom(credential.data)
+                    val credential = result.credential
+                    when (credential) {
+                        is CustomCredential -> {
+                            if (credential.type == GoogleIdTokenCredential.TYPE_GOOGLE_ID_TOKEN_CREDENTIAL) {
+                                val googleIdTokenCredential = GoogleIdTokenCredential
+                                    .createFrom(credential.data)
 
-                        _state.value = State.SignedInWithGoogle(
-                            name = googleIdTokenCredential.givenName.orEmpty(),
-                            avatarUrl = googleIdTokenCredential.profilePictureUri?.toString(),
-                        )
+                                _state.value = State.SignedInWithGoogle(
+                                    name = googleIdTokenCredential.givenName.orEmpty(),
+                                    avatarUrl = googleIdTokenCredential.profilePictureUri?.toString(),
+                                )
 
-                        signInWithGoogleToken(
-                            idToken = googleIdTokenCredential.idToken,
-                        )
-                    } else {
-                        LogBuffer.e(LogBuffer.TAG_INVALID_STATE, "Failed to sign in with Google One Tap")
-                        _state.value = State.Failed.Other
+                                signInWithGoogleToken(
+                                    idToken = googleIdTokenCredential.idToken,
+                                )
+                            } else {
+                                LogBuffer.e(LogBuffer.TAG_INVALID_STATE, "Failed to sign in with GetGoogleIdOption")
+                                _state.value = State.Failed.Other
+                            }
+                        }
+                        is PasswordCredential -> {
+                            signInWithPassword(
+                                email = credential.id,
+                                password = credential.password,
+                            )
+                        }
+                        else -> {
+                            LogBuffer.e(LogBuffer.TAG_INVALID_STATE, "Failed to sign in with Google One Tap")
+                            _state.value = State.Failed.Other
+                        }
                     }
                 }.onFailure {
                     LogBuffer.e(LogBuffer.TAG_CRASH, it, "Unable to sign in with Google One Tap")
@@ -111,12 +127,26 @@ class LoginWithGoogleViewModel @Inject constructor(
     ) {
         val loginResult = syncManager.loginWithGoogle(idToken, SignInSource.UserInitiated.Watch)
         when (loginResult) {
+            is LoginResult.Success -> {
+                podcastManager.refreshPodcastsAfterSignIn()
+            }
             is LoginResult.Failed -> {
                 LogBuffer.i(LogBuffer.TAG_BACKGROUND_TASKS, "Failed to login with Google: ${loginResult.message}")
             }
+        }
+    }
 
+    private suspend fun signInWithPassword(
+        email: String,
+        password: String,
+    ) {
+        val loginResult = syncManager.loginWithEmailAndPassword(email = email, password = password, signInSource = SignInSource.UserInitiated.Watch)
+        when (loginResult) {
             is LoginResult.Success -> {
                 podcastManager.refreshPodcastsAfterSignIn()
+            }
+            is LoginResult.Failed -> {
+                LogBuffer.i(LogBuffer.TAG_BACKGROUND_TASKS, "Failed to login with email and password: ${loginResult.message}")
             }
         }
     }


### PR DESCRIPTION
## Description
This PR adds the password option during WearOS login.
When the user has any passwords saved on their Google account, they can now select them for login.
Credits due to @geekygecko 🙇 

## Testing Instructions
1. Clean install app on WearOS
2. Launch it, make sure your phone app doesn't run
3. Tap Log In
4. Select Google
5. Check Sign In Options to see if you have a password saved
6. Select password when so
- [ ] You're able to log in with Google


## Checklist
- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [ ] ~I have considered whether it makes sense to add tests for my changes~
- [ ] ~All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`~
- [ ] ~Any jetpack compose components I added or changed are covered by compose previews~
- [ ] ~I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.~
 