### PR TITLE
Do not remove episodes from Up Next when downloaded file is deleted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
         ([#4523](https://github.com/Automattic/pocket-casts-android/pull/4523))
     *   Use CredentialManager on WearOS for Google login
         ([#4528](https://github.com/Automattic/pocket-casts-android/pull/4528))
+    *   Do not remove episodes from Up Next when downloaded file is deleted.
+        ([#4528](https://github.com/Automattic/pocket-casts-android/pull/4528))
 
 7.98
 -----

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/PlayerViewModel.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/PlayerViewModel.kt
@@ -541,7 +541,7 @@ class PlayerViewModel @Inject constructor(
         if (episode.episodeStatus != EpisodeStatusEnum.NOT_DOWNLOADED) {
             onDeleteStart.invoke()
             launch {
-                episodeManager.deleteEpisodeFile(episode, playbackManager, disableAutoDownload = false, removeFromUpNext = episode.episodeStatus == EpisodeStatusEnum.DOWNLOADED)
+                episodeManager.deleteEpisodeFile(episode, playbackManager, disableAutoDownload = false)
             }
         } else {
             onDownloadStart.invoke()

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/episode/EpisodeFragmentViewModel.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/episode/EpisodeFragmentViewModel.kt
@@ -191,7 +191,7 @@ class EpisodeFragmentViewModel @Inject constructor(
     fun deleteDownloadedEpisode() {
         episode?.let {
             launch {
-                episodeManager.deleteEpisodeFile(it, playbackManager, disableAutoDownload = true, removeFromUpNext = true)
+                episodeManager.deleteEpisodeFile(it, playbackManager, disableAutoDownload = true)
                 episodeAnalytics.trackEvent(
                     event = AnalyticsEvent.EPISODE_DOWNLOAD_DELETED,
                     source = source,

--- a/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManager.kt
+++ b/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/podcast/EpisodeManager.kt
@@ -112,7 +112,7 @@ interface EpisodeManager {
     suspend fun deleteEpisodesWithoutSync(episodes: List<PodcastEpisode>, playbackManager: PlaybackManager)
 
     fun deleteEpisodeWithoutSyncBlocking(episode: PodcastEpisode?, playbackManager: PlaybackManager)
-    suspend fun deleteEpisodeFile(episode: BaseEpisode?, playbackManager: PlaybackManager?, disableAutoDownload: Boolean, updateDatabase: Boolean = true, removeFromUpNext: Boolean = true, shouldShuffleUpNext: Boolean = false)
+    suspend fun deleteEpisodeFile(episode: BaseEpisode?, playbackManager: PlaybackManager?, disableAutoDownload: Boolean, updateDatabase: Boolean = true)
 
     /** Utility methods  */
     suspend fun countEpisodes(): Int

--- a/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/episode/EpisodeViewModel.kt
+++ b/wear/src/main/kotlin/au/com/shiftyjelly/pocketcasts/wear/ui/episode/EpisodeViewModel.kt
@@ -305,7 +305,6 @@ class EpisodeViewModel @Inject constructor(
                         episode,
                         playbackManager,
                         disableAutoDownload = true,
-                        removeFromUpNext = true,
                     )
                 }
 


### PR DESCRIPTION
## Description

As the title says

Closes PCDROID-177

## Testing Instructions

1. Add episodes to Up Next.
2. Download them.
3. Wait for the downloads to complete.
4. Delete episode files from different contexts like episode details or multi-select toolbar.
5. Episodes should stay in the queue.
6. Archive some episodes.
7. They should be removed from the queue.

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.