### PR TITLE
Fix done button overlapping with navigation bars

### DIFF
--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/folders/FolderChooserPage.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/folders/FolderChooserPage.kt
@@ -1,17 +1,23 @@
 package au.com.shiftyjelly.pocketcasts.podcasts.view.folders
 
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.safeContentPadding
+import androidx.compose.foundation.layout.safeDrawing
+import androidx.compose.foundation.layout.safeDrawingPadding
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
-import androidx.compose.material.Card
 import androidx.compose.material.Icon
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Surface
@@ -50,8 +56,18 @@ fun FolderChooserPage(
     modifier: Modifier = Modifier,
 ) {
     val state: FolderEditViewModel.State by viewModel.state.collectAsState()
-    Surface(modifier = modifier.nestedScroll(rememberViewInteropNestedScrollConnection())) {
-        Column {
+    Surface(
+        modifier = modifier
+            .nestedScroll(rememberViewInteropNestedScrollConnection()),
+    ) {
+        Column(
+            modifier = Modifier
+                .windowInsetsPadding(
+                    WindowInsets.safeDrawing.only(
+                        WindowInsetsSides.Horizontal + WindowInsetsSides.Bottom,
+                    ),
+                ),
+        ) {
             BottomSheetAppBar(
                 title = null,
                 navigationButton = NavigationButton.Close,
@@ -69,15 +85,12 @@ fun FolderChooserPage(
                 onNewFolderClick = onNewFolderClick,
                 modifier = Modifier.weight(1f),
             )
-            Card(
-                elevation = if (isSystemInDarkTheme()) 0.dp else 8.dp,
-                backgroundColor = Color.Transparent,
-            ) {
-                RowButton(
-                    text = stringResource(LR.string.done),
-                    onClick = { onCloseClick() },
-                )
-            }
+            RowButton(
+                modifier = Modifier
+                    .navigationBarsPadding(),
+                text = stringResource(LR.string.done),
+                onClick = { onCloseClick() },
+            )
         }
     }
 }


### PR DESCRIPTION
## Description

Fixes #4510 by by adding proper window insets handling to the FolderChooserPage screen.
- Added `navigationBarsPadding()` to the "Done" button to prevent it from overlapping with system navigation bars.
- Added `windowInsetsPadding(WindowInsets.safeDrawing.only(WindowInsetsSides.Horizontal + WindowInsetsSides.Bottom))` to the root Column to handle horizontal and bottom insets — ensuring proper layout in landscape without introducing unnecessary top padding in portrait.
- Removed the unnecessary Card wrapper around the button row. The card’s elevation was causing an inconsistent shadow appearance in light mode, so removing it results in a cleaner and more visually consistent layout.

## Testing Instructions

1. Open any podcast.
2. Tap the folder icon to open the "Choose Folder" screen.
3. Verify that the "Done" button no longer overlaps with the navigation bar.
4. Rotate the device to landscape — the layout should still respect system insets (including notches).

## Screenshots or Screencast 

Portrait:

<img width="361" height="777" alt="Screenshot 2025-10-01 at 12 15 42 AM" src="https://github.com/user-attachments/assets/52787d01-2353-4114-8fb4-93dd98797fac" />
<img width="364" height="782" alt="Screenshot 2025-10-01 at 12 15 55 AM" src="https://github.com/user-attachments/assets/7dc81bdf-d95c-42f5-8e36-1359da56964c" />

Landscape: (Notch present but not visible in screenshot)

<img width="1170" height="540" alt="image" src="https://github.com/user-attachments/assets/c340a8a6-17b9-4af4-830e-40d1cf48be71" />

## Checklist

- [ ] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...

- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack
