### PR TITLE
Fix transcript button incorrectly disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 *   Bug Fixes
     *   Fix done button overlapping with navigation bars
         ([#4553](https://github.com/Automattic/pocket-casts-android/pull/4553))
+    *   Fix transcript button incorrectly disabled
+        ([#4555](https://github.com/Automattic/pocket-casts-android/pull/4555))
 
 7.99
 -----

--- a/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/ShelfSharedViewModel.kt
+++ b/modules/features/player/src/main/java/au/com/shiftyjelly/pocketcasts/player/viewmodel/ShelfSharedViewModel.kt
@@ -37,11 +37,9 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.mapNotNull
-import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.rx2.asFlow
-import timber.log.Timber
 
 @OptIn(ExperimentalCoroutinesApi::class)
 @HiltViewModel


### PR DESCRIPTION
## Description

It's possible to open the full-screen player with an episode that should have a transcript, but the transcript button is incorrectly disabled. The issue was that the Observable had a distinct on it. So if the current playing episode changed, that would not be classed as a change. I've modified it so that it also considers the UUID of the playing episode. 

Fixes PCDROID-92

## Testing Instructions

1. Clear your Up Next
2. Restart the app
3. Create an Up Next using some old episodes that don’t have transcripts. For example The Daily episodes from 2024
4. Now play an episode with a transcript for example the most recent The Daily episode
5. Open the full screen player
6. ✅  Verify the transcript button isn't greyed out

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack
