### PR TITLE
Fix playlist empty search state

### DIFF
--- a/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/PlaylistFragment.kt
+++ b/modules/features/filters/src/main/java/au/com/shiftyjelly/pocketcasts/playlists/PlaylistFragment.kt
@@ -233,7 +233,7 @@ class PlaylistFragment :
                     contentState = when (uiState.playlist?.episodes?.size) {
                         null -> ContentState.Uninitialized
 
-                        0 -> if (uiState.playlist.metadata.archivedEpisodeCount == 0) {
+                        0 -> if (uiState.playlist.metadata.totalEpisodeCount == 0) {
                             ContentState.HasNoEpisodes
                         } else {
                             ContentState.HasEpisode


### PR DESCRIPTION
## Description

When determining content state I incorrectly used `archivedEpisodeCount` instead of `totalEpisodeCount`. This resulted in the empty state being shown instead of the empty search results.

## Testing Instructions

1. Create a playlists.
2. Do not have any archived episodes in it.
3. Search for an arbitrary episode that doesn't yield any results.
4. You should see no episodes found state.

## Screenshots or Screencast 

<img width="540" alt="image" src="https://github.com/user-attachments/assets/41755aa8-fa09-43bd-99b9-1312eb18b99c" />

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.