### PR TITLE
Improve playlist's time left calculation

### DIFF
--- a/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/repositories/playlist/PlaylistManagerManualTest.kt
+++ b/app/src/androidTest/java/au/com/shiftyjelly/pocketcasts/repositories/playlist/PlaylistManagerManualTest.kt
@@ -5,6 +5,7 @@ import au.com.shiftyjelly.pocketcasts.models.entity.PlaylistEntity.Companion.SYN
 import au.com.shiftyjelly.pocketcasts.models.entity.PodcastEpisode
 import au.com.shiftyjelly.pocketcasts.models.type.PlaylistEpisodeSortType
 import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
@@ -873,6 +874,53 @@ class PlaylistManagerManualTest {
                 ),
                 awaitItem(),
             )
+        }
+    }
+
+    @Test
+    fun computeTotalPlaybackDurationLeft() = dsl.test {
+        insertManualPlaylist(index = 0)
+        insertPodcast(index = 0)
+        repeat(6) { index ->
+            insertManualEpisode(index = index, podcastIndex = 0, playlistIndex = 0)
+        }
+
+        manager.manualPlaylistFlow("playlist-id-0").test {
+            assertEquals(0.seconds, awaitItem()?.metadata?.playbackDurationLeft)
+
+            insertPodcastEpisode(index = 0, podcastIndex = 0) {
+                it.copy(duration = 0.0)
+            }
+            assertEquals(0.seconds, awaitItem()?.metadata?.playbackDurationLeft)
+
+            insertPodcastEpisode(index = 1, podcastIndex = 0) {
+                it.copy(duration = 20.0)
+            }
+            assertEquals(20.seconds, awaitItem()?.metadata?.playbackDurationLeft)
+
+            insertPodcastEpisode(index = 2, podcastIndex = 0) {
+                it.copy(duration = 15.0)
+            }
+            assertEquals(35.seconds, awaitItem()?.metadata?.playbackDurationLeft)
+
+            insertPodcastEpisode(index = 3, podcastIndex = 0) {
+                it.copy(duration = 15.0, playedUpTo = 10.0)
+            }
+            assertEquals(40.seconds, awaitItem()?.metadata?.playbackDurationLeft)
+
+            // Check when the duration is unknown and playedUpTo can get above it
+            insertPodcastEpisode(index = 4, podcastIndex = 0) {
+                it.copy(duration = 0.0, playedUpTo = 10.0)
+            }
+            assertEquals(40.seconds, awaitItem()?.metadata?.playbackDurationLeft)
+
+            insertPodcastEpisode(index = 5, podcastIndex = 0) {
+                it.copy(duration = 5.0, isArchived = true)
+            }
+            assertEquals(40.seconds, awaitItem()?.metadata?.playbackDurationLeft)
+
+            manager.toggleShowArchived("playlist-id-0")
+            assertEquals(45.seconds, awaitItem()?.metadata?.playbackDurationLeft)
         }
     }
 }

--- a/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/PlaylistDao.kt
+++ b/modules/services/model/src/main/java/au/com/shiftyjelly/pocketcasts/models/db/dao/PlaylistDao.kt
@@ -207,7 +207,13 @@ abstract class PlaylistDao {
         SELECT
           COUNT(*) AS episode_count,
           SUM(IFNULL(podcastEpisode.archived, 0)) AS archived_episode_count,
-          SUM(MAX(0, IFNULL(podcastEpisode.duration, 0) - IFNULL(podcastEpisode.played_up_to, 0))) AS time_left
+          SUM(
+            CASE
+              WHEN playlist.showArchivedEpisodes != 0 OR podcastEpisode.archived = 0
+              THEN MAX(0, IFNULL(podcastEpisode.duration, 0) - IFNULL(podcastEpisode.played_up_to, 0))
+              ELSE 0
+            END
+          ) AS time_left
         FROM playlists AS playlist
         JOIN manual_playlist_episodes AS playlistEpisode ON playlistEpisode.playlist_uuid IS playlist.uuid
         LEFT JOIN podcast_episodes AS podcastEpisode ON podcastEpisode.uuid IS playlistEpisode.episode_uuid


### PR DESCRIPTION
## Description

This PR adds support for excluding or including archived episodes when computing playlist time left duration.

## Testing Instructions

1. Create a Manual Playlist.
2. Add some episodes to it.
3. Archive a couple of episodes.
4. Toggle show archived state.
5. Notice that the playback duration responds to the archived state.

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.