### PR TITLE
Fix shared list under the mini player

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 *   Bug Fixes
     *   Fix done button overlapping with navigation bars
         ([#4553](https://github.com/Automattic/pocket-casts-android/pull/4553))
+    *   Fix shared list under the mini player
+        ([#4560](https://github.com/Automattic/pocket-casts-android/pull/4560))
     *   Fix transcript button incorrectly disabled
         ([#4555](https://github.com/Automattic/pocket-casts-android/pull/4555))
 

--- a/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/share/ShareListIncomingFragment.kt
+++ b/modules/features/podcasts/src/main/java/au/com/shiftyjelly/pocketcasts/podcasts/view/share/ShareListIncomingFragment.kt
@@ -5,7 +5,11 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.core.os.bundleOf
+import androidx.core.view.updatePadding
 import androidx.fragment.app.viewModels
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import au.com.shiftyjelly.pocketcasts.analytics.AnalyticsEvent
@@ -15,17 +19,17 @@ import au.com.shiftyjelly.pocketcasts.podcasts.databinding.FragmentShareIncoming
 import au.com.shiftyjelly.pocketcasts.podcasts.view.podcast.PodcastFragment
 import au.com.shiftyjelly.pocketcasts.preferences.Settings
 import au.com.shiftyjelly.pocketcasts.repositories.podcast.PodcastManager
-import au.com.shiftyjelly.pocketcasts.ui.extensions.getThemeTintedDrawable
 import au.com.shiftyjelly.pocketcasts.ui.helper.FragmentHostListener
 import au.com.shiftyjelly.pocketcasts.views.dialog.OptionsDialog
 import au.com.shiftyjelly.pocketcasts.views.extensions.hide
+import au.com.shiftyjelly.pocketcasts.views.extensions.setup
 import au.com.shiftyjelly.pocketcasts.views.extensions.show
 import au.com.shiftyjelly.pocketcasts.views.fragments.BaseFragment
+import au.com.shiftyjelly.pocketcasts.views.helper.NavigationIcon
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
-import au.com.shiftyjelly.pocketcasts.images.R as IR
+import kotlinx.coroutines.launch
 import au.com.shiftyjelly.pocketcasts.localization.R as LR
-import au.com.shiftyjelly.pocketcasts.ui.R as UR
 
 @AndroidEntryPoint
 class ShareListIncomingFragment :
@@ -91,12 +95,7 @@ class ShareListIncomingFragment :
         recyclerView.adapter = adapter
         recyclerView.layoutManager = LinearLayoutManager(context, RecyclerView.VERTICAL, false)
 
-        val toolbar = binding.toolbar
-        toolbar.setNavigationOnClickListener {
-            @Suppress("DEPRECATION")
-            activity?.onBackPressed()
-        }
-        toolbar.navigationIcon = context.getThemeTintedDrawable(IR.drawable.ic_cancel, UR.attr.secondary_icon_01)
+        binding.toolbar.setup(navigationIcon = NavigationIcon.Close, activity = activity, theme = theme, includeStatusBarPadding = false)
 
         viewModel.share.observe(viewLifecycleOwner) { share ->
             when (share) {
@@ -120,6 +119,15 @@ class ShareListIncomingFragment :
 
         if (!viewModel.isFragmentChangingConfigurations) {
             viewModel.trackShareEvent(AnalyticsEvent.INCOMING_SHARE_LIST_SHOWN, mapOf("source" to source.analyticsValue))
+        }
+
+        // add bottom padding to make sure the content isn't hidden by the mini player
+        viewLifecycleOwner.lifecycleScope.launch {
+            viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
+                settings.bottomInset.collect {
+                    binding.recyclerView.updatePadding(bottom = it)
+                }
+            }
         }
     }
 

--- a/modules/features/podcasts/src/main/res/layout/fragment_share_incoming.xml
+++ b/modules/features/podcasts/src/main/res/layout/fragment_share_incoming.xml
@@ -1,48 +1,59 @@
 <?xml version="1.0" encoding="utf-8"?>
-<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:background="?attr/primary_ui_01"
-    android:fitsSystemWindows="true">
+    android:orientation="vertical"
+    android:background="?attr/primary_ui_01">
 
-    <androidx.coordinatorlayout.widget.CoordinatorLayout
-        android:id="@+id/main_content"
+    <au.com.shiftyjelly.pocketcasts.views.component.StatusBarSpacer
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:background="?attr/secondary_ui_01" />
+
+    <FrameLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent">
 
-        <androidx.recyclerview.widget.RecyclerView
-            android:id="@+id/recyclerView"
+        <androidx.coordinatorlayout.widget.CoordinatorLayout
+            android:id="@+id/main_content"
             android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:clipToPadding="false"
-            android:paddingTop="8dp"
-            android:paddingBottom="8dp"
-            app:layout_behavior="@string/appbar_scrolling_view_behavior" />
+            android:layout_height="match_parent">
 
-        <com.google.android.material.appbar.AppBarLayout
-            android:id="@+id/appbar"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content">
-
-            <androidx.appcompat.widget.Toolbar
-                android:id="@+id/toolbar"
+            <androidx.recyclerview.widget.RecyclerView
+                android:id="@+id/recyclerView"
                 android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:background="?attr/secondary_ui_01"
-                android:minHeight="?android:attr/actionBarSize"
-                app:layout_scrollFlags="scroll|enterAlways"
-                app:title="@string/podcasts_share_list" />
+                android:layout_height="match_parent"
+                android:clipToPadding="false"
+                android:paddingTop="8dp"
+                android:paddingBottom="8dp"
+                app:layout_behavior="@string/appbar_scrolling_view_behavior" />
 
-        </com.google.android.material.appbar.AppBarLayout>
+            <com.google.android.material.appbar.AppBarLayout
+                android:id="@+id/appbar"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content">
 
-    </androidx.coordinatorlayout.widget.CoordinatorLayout>
+                <androidx.appcompat.widget.Toolbar
+                    android:id="@+id/toolbar"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:background="?attr/secondary_ui_01"
+                    android:minHeight="?android:attr/actionBarSize"
+                    app:layout_scrollFlags="scroll|enterAlways"
+                    app:title="@string/podcasts_share_list" />
 
-    <ProgressBar
-        android:id="@+id/progressCircle"
-        style="?android:attr/progressBarStyleLarge"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_gravity="center" />
+            </com.google.android.material.appbar.AppBarLayout>
 
-</FrameLayout>
+        </androidx.coordinatorlayout.widget.CoordinatorLayout>
+
+        <ProgressBar
+            android:id="@+id/progressCircle"
+            style="?android:attr/progressBarStyleLarge"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center" />
+
+    </FrameLayout>
+
+</LinearLayout>


### PR DESCRIPTION
## Description

When you open a shared list of podcasts and you have the mini player open, you can't get to the bottom of the list.

Fixes PCDROID-135

## Testing Instructions

1. Click on this list https://lists.pocketcasts.com/strange-tales
2. Try to scroll to the bottom of the page

## Screenshots 

| Before | After |
| --- | --- |
| <img width="1198" height="2531" alt="Screenshot_20251001_172552" src="https://github.com/user-attachments/assets/065d8cb0-7c75-4d29-b811-48cea7fa1e8c" /> | <img width="1198" height="2531" alt="Screenshot_20251001_170013" src="https://github.com/user-attachments/assets/2bf02ec4-890c-46ac-bccb-84613fd1e549" /> | 
| <img width="1198" height="2531" alt="Screenshot_20251001_172620" src="https://github.com/user-attachments/assets/94cb73e4-44ea-4e49-9d11-fee2fdd48810" /> | <img width="1198" height="2531" alt="Screenshot_20251001_170727" src="https://github.com/user-attachments/assets/b6fe89fd-d1ff-4596-9b4f-296ceb08092d" /> | 
| <img width="1198" height="2531" alt="Screenshot_20251001_172629" src="https://github.com/user-attachments/assets/ae4ad3e5-4808-4313-b9cb-3542ad790546" /> | <img width="1198" height="2531" alt="Screenshot_20251001_170735" src="https://github.com/user-attachments/assets/1352904a-493a-40b0-a53d-f6d1849197bf" /> | 

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 
#### I have tested any UI changes...
<!-- If this PR does not contain UI changes, ignore these items -->
- [x] with different themes
- [x] with a landscape orientation
- [x] with the device set to have a large display and font size
- [x] for accessibility with TalkBack
