### PR TITLE
Fix swipe crashing before Android 12

### DIFF
--- a/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/swipe/SwipeButton.kt
+++ b/modules/services/views/src/main/java/au/com/shiftyjelly/pocketcasts/views/swipe/SwipeButton.kt
@@ -12,6 +12,7 @@ import android.widget.FrameLayout
 import androidx.annotation.ColorInt
 import androidx.annotation.DrawableRes
 import androidx.appcompat.content.res.AppCompatResources
+import androidx.core.content.res.use
 import androidx.core.view.isVisible
 import androidx.core.view.updateLayoutParams
 import androidx.core.widget.ImageViewCompat


### PR DESCRIPTION
## Description

A new error has [appeared in Sentry](https://a8c.sentry.io/issues/6916081511/?notification_uuid=0c72da56-7e67-4e5b-a209-142e315a0241&project=6711064). 

Release: 7.99-rc-1 (9374)
OS: Android 11 - 92%, Android 10 - 8%

```
InflateException

Binary XML file line #6 in au.com.shiftyjelly.pocketcasts:layout/adapter_episode: Binary XML file line #6 in au.com.shiftyjelly.pocketcasts:layout/adapter_episode: Error inflating class au.com.shiftyjelly.pocketcasts.views.swipe.SwipeRowLayout

java.lang.ClassCastException: android.content.res.TypedArray cannot be cast to java.lang.AutoCloseable
    at au.com.shiftyjelly.pocketcasts.views.swipe.SwipeButton.<init>(SwipeButton.kt:64)
    at java.lang.reflect.Constructor.newInstance0(Constructor.java)
```

This is happening because `TypedArray` did not become `AutoCloseable` until Android 12. There's an easy fix of using a core ktx `use` function instead.

https://developer.android.com/reference/kotlin/androidx/core/content/res/package-summary#(android.content.res.TypedArray).use(kotlin.Function1)

## Testing Instructions

1. Start an Android 11 emulator
2. Go to a podcast page
3. ✅ Verify the app doesn't crash

## Checklist
- [x] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [x] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [x] I have considered whether it makes sense to add tests for my changes
- [x] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [x] Any jetpack compose components I added or changed are covered by compose previews
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
 